### PR TITLE
daemon(T2.4): RequestMeta validation middleware (reject empty request_id)

### DIFF
--- a/packages/daemon/src/rpc/__tests__/integration.spec.ts
+++ b/packages/daemon/src/rpc/__tests__/integration.spec.ts
@@ -16,6 +16,14 @@
 // Connect protocol is being served (route path
 // `/ccsm.v1.SessionService/Hello`). Any other unary would do; Hello
 // is documented as forever-stable in spec ch04 §3.
+//
+// Note on RequestMeta: every call below supplies a valid
+// `meta.requestId` because T2.4 (#37) wires the
+// `requestMetaInterceptor` into `createDaemonNodeAdapter` — an empty
+// meta would now be rejected with `InvalidArgument` BEFORE the router
+// reaches its `Unimplemented` stub. The integration test asserts the
+// downstream Unimplemented behavior, so it intentionally clears the
+// meta-validation gate first.
 
 import { afterEach, describe, expect, it } from 'vitest';
 import { Code, ConnectError, createClient } from '@connectrpc/connect';
@@ -31,6 +39,12 @@ import { makeRouterBindHook } from '../bind.js';
 import type { BindDescriptor } from '../../listeners/types.js';
 
 const isWin = platform() === 'win32';
+
+/** A canonical UUIDv4 used for the integration calls — passes
+ * `requestMetaInterceptor` so the test can assert the next ring
+ * (Unimplemented) rather than tripping on missing meta. */
+const VALID_REQUEST_ID = '7f3c1d8e-2b94-4f01-a5c6-d9e8b2a107c4';
+const validHello = { meta: { requestId: VALID_REQUEST_ID } } as const;
 
 interface Cleanup {
   closeServer?: () => Promise<void>;
@@ -78,7 +92,7 @@ describe('router bind hook — over-the-wire Unimplemented', () => {
 
     let captured: unknown = null;
     try {
-      await client.hello({});
+      await client.hello(validHello);
     } catch (err) {
       captured = err;
     }
@@ -105,7 +119,7 @@ describe('router bind hook — over-the-wire Unimplemented', () => {
 
     let captured: unknown = null;
     try {
-      await client.hello({});
+      await client.hello(validHello);
     } catch (err) {
       captured = err;
     }

--- a/packages/daemon/src/rpc/middleware/request-meta.ts
+++ b/packages/daemon/src/rpc/middleware/request-meta.ts
@@ -1,0 +1,233 @@
+// RequestMeta validation interceptor — rejects RPCs whose `RequestMeta.request_id`
+// is empty / whitespace-only with `ConnectError(InvalidArgument)` carrying an
+// `ErrorDetail{code: "request.missing_id"}` outgoing detail.
+//
+// Spec refs:
+//   - ch04 §2 — RequestMeta semantics. Forever-stable: every RPC carries a
+//     `RequestMeta meta = 1` whose `request_id` is a client-generated UUIDv4.
+//   - F7 (closes R4 P1) — daemon MUST validate `request_id` is non-empty on
+//     every RPC. Daemon MUST NOT silently synthesize a substitute (would
+//     break client-side correlation logs and hide a misbehaving client).
+//
+// SRP: this module is a pure *decider*. Inputs (the inbound message's
+// `meta.requestId`) → decision (accept | reject). No I/O, no logging, no
+// synthesis. Synthesis is explicitly forbidden by F7; the only "side effect"
+// is the throw, which Connect translates into the wire error envelope.
+//
+// Why an interceptor (not per-handler validation): the validation rule is
+// uniform across every RPC in `@ccsm/proto` (every Request message has a
+// `RequestMeta meta = 1` field by ch04 §2 contract). Encoding the rule
+// once in the router pipeline guarantees no future RPC can ship without
+// the check — a per-handler `validateMeta(req.meta)` call would be a
+// reviewer-grep-only invariant, not a mechanical one. This matches the
+// existing `peerCredAuthInterceptor` pattern in `src/auth/interceptor.ts`
+// (single decider, runs before any handler).
+//
+// Layer 1 — alternatives checked:
+//   - Validate at the proto layer via a custom option / `optional` keyword:
+//     rejected by `request-id-roundtrip.spec.ts` (T0.12) which pins that
+//     the wire MUST allow empty `request_id` so middleware can observe and
+//     reject. Adding `optional` would bypass this code path.
+//   - Validate inside each handler: scope-creeps every L3+ handler PR.
+//     Reviewers would have to grep for `meta.requestId` in every diff. An
+//     interceptor is the standard Connect-ES seam for cross-cutting checks.
+//   - Use `connect-validate` / `protovalidate-es`: heavyweight dep for a
+//     single rule (non-empty trim) on a single field. v0.4 may revisit if
+//     the rule set grows; v0.3 keeps it 30 LOC and dep-free.
+//
+// Streaming RPCs: `RequestMeta` lives on the FIRST inbound message. We wrap
+// the request's `message` AsyncIterable so the first emitted value is
+// validated before being forwarded to the handler. If validation fails the
+// wrapped iterable throws on its first `.next()`, which surfaces to the
+// handler as the same `ConnectError(InvalidArgument)` clients of unary RPCs
+// see — uniform wire shape. We do not buffer subsequent messages; the
+// iterable is a thin pass-through after the first message.
+
+import {
+  Code,
+  ConnectError,
+  type Interceptor,
+  type StreamRequest,
+  type UnaryRequest,
+} from '@connectrpc/connect';
+import {
+  ErrorDetailSchema,
+  RequestMetaSchema,
+  type RequestMeta,
+} from '@ccsm/proto';
+
+/**
+ * The forever-stable ErrorDetail.code emitted on rejection. Pinned by the
+ * `error-detail-roundtrip.spec.ts` contract test (T0.12) — drift here MUST
+ * be reflected in that fixture and in every client-side error handler.
+ */
+export const REQUEST_MISSING_ID_CODE = 'request.missing_id';
+
+/**
+ * Forever-stable rejection message attached to the ConnectError. Matches
+ * the fixture in `request-id-roundtrip.spec.ts` so contract drift is a
+ * mechanical test failure rather than a silent UX change.
+ */
+export const REQUEST_MISSING_ID_MESSAGE =
+  'request_id is required and must be a non-empty UUIDv4.';
+
+/**
+ * Pure decider: returns `true` iff `requestId` is a non-empty, non-whitespace
+ * string. Exported separately so tests can exercise the predicate without
+ * going through the Connect interceptor plumbing.
+ */
+export function isValidRequestId(requestId: string | undefined | null): boolean {
+  if (typeof requestId !== 'string') return false;
+  // F7: trim before measuring length so a whitespace-only id (e.g. "  ")
+  // is rejected the same as "". Clients that legitimately want an opaque
+  // id can use UUIDv4 (the spec's recommended shape) which never trims to
+  // empty. We do NOT enforce UUIDv4 syntax here — the rule from ch04 §2
+  // is "non-empty"; UUIDv4 is the recommended client-side convention,
+  // not a daemon-side validator (over-validation would reject clients
+  // that legitimately use other id schemes the spec hasn't yet blessed).
+  return requestId.trim().length > 0;
+}
+
+/**
+ * Build the canonical "request.missing_id" ConnectError. Exported so tests
+ * can compare against the exact shape the interceptor throws.
+ */
+export function makeMissingRequestIdError(): ConnectError {
+  return new ConnectError(
+    REQUEST_MISSING_ID_MESSAGE,
+    Code.InvalidArgument,
+    undefined,
+    [
+      {
+        desc: ErrorDetailSchema,
+        value: {
+          code: REQUEST_MISSING_ID_CODE,
+          message: REQUEST_MISSING_ID_MESSAGE,
+          extra: {},
+        },
+      },
+    ],
+  );
+}
+
+/**
+ * Extract the `RequestMeta` from a v0.3 request message. By ch04 §2 every
+ * Request message carries `RequestMeta meta = 1`, surfaced in the
+ * generated TS as `meta?: RequestMeta`. We probe duck-typed because the
+ * interceptor receives `MessageShape<DescMessage>` (the open union over
+ * every request type) — an exhaustive switch on every Request type would
+ * couple this file to every service in `@ccsm/proto` and break the
+ * "additive without code edits" promise of new RPCs.
+ *
+ * Returns `undefined` if the message has no `meta` field (which itself is
+ * a contract violation — handled by the caller as a missing request_id).
+ */
+function extractMeta(message: unknown): RequestMeta | undefined {
+  if (typeof message !== 'object' || message === null) return undefined;
+  const meta = (message as { meta?: unknown }).meta;
+  if (typeof meta !== 'object' || meta === null) return undefined;
+  // Duck-type check: a generated RequestMeta has $typeName === RequestMetaSchema.typeName.
+  // We don't import `isMessage` from @bufbuild/protobuf because the duck
+  // check below is sufficient and avoids a runtime dep on the registry.
+  const typeName = (meta as { $typeName?: unknown }).$typeName;
+  if (typeName === RequestMetaSchema.typeName) {
+    return meta as RequestMeta;
+  }
+  // Tolerate plain-object meta shapes (test harness convenience): if it
+  // has a `requestId` string field we treat it as a meta. The interceptor
+  // is a decider over `requestId`; further structural assertions belong
+  // in the contract tests, not here.
+  if (typeof (meta as { requestId?: unknown }).requestId === 'string') {
+    return meta as RequestMeta;
+  }
+  return undefined;
+}
+
+/**
+ * Validate a single inbound message's `RequestMeta.request_id`. Throws
+ * `ConnectError(InvalidArgument)` with the canonical ErrorDetail if the
+ * id is empty / whitespace / missing. F7: never synthesizes a substitute.
+ */
+export function validateRequestMeta(message: unknown): void {
+  const meta = extractMeta(message);
+  if (!meta || !isValidRequestId(meta.requestId)) {
+    throw makeMissingRequestIdError();
+  }
+}
+
+/**
+ * Wrap a streaming request's `message` AsyncIterable so the first emitted
+ * value is validated before being forwarded. Subsequent values pass
+ * through unchanged. If the first value fails validation, the wrapped
+ * iterable throws on its first `.next()` — Connect surfaces this to the
+ * client as the same InvalidArgument ConnectError unary RPCs see.
+ *
+ * The handler never observes a synthesized id: if the source iterable
+ * yields nothing (zero-message stream), nothing is emitted and validation
+ * never runs. v0.3 has no zero-message client streaming RPCs (every
+ * streaming method is server-streaming with a single request message,
+ * see ch04 §3-§6), so this is the correct conservative choice.
+ */
+function validatedAsyncIterable<T>(
+  source: AsyncIterable<T>,
+): AsyncIterable<T> {
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<T> {
+      const inner = source[Symbol.asyncIterator]();
+      let validated = false;
+      return {
+        async next(): Promise<IteratorResult<T>> {
+          const result = await inner.next();
+          if (!validated && !result.done) {
+            validateRequestMeta(result.value);
+            validated = true;
+          }
+          return result;
+        },
+        async return(value?: unknown): Promise<IteratorResult<T>> {
+          if (typeof inner.return === 'function') {
+            return inner.return(value);
+          }
+          return { done: true, value: undefined as never };
+        },
+        async throw(err?: unknown): Promise<IteratorResult<T>> {
+          if (typeof inner.throw === 'function') {
+            return inner.throw(err);
+          }
+          throw err;
+        },
+      };
+    },
+  };
+}
+
+/**
+ * The Connect interceptor. Composed into the router's interceptor list
+ * (see `router.ts` `createDaemonNodeAdapter`); runs BEFORE any handler so
+ * a missing/empty `request_id` never reaches application code.
+ *
+ * Order vs. `peerCredAuthInterceptor`: the spec does not pin a strict
+ * ordering between the two, but the chosen wiring (auth first, then
+ * meta-validation) means an unauthenticated caller sees `Unauthenticated`
+ * rather than `InvalidArgument` — matching the "auth is the outer ring"
+ * convention. Both checks are cheap; the relative order does not affect
+ * security (the daemon rejects either way before any handler runs).
+ */
+export const requestMetaInterceptor: Interceptor = (next) => async (req) => {
+  if (!req.stream) {
+    // Unary: the single request message is already materialized; validate
+    // synchronously, then forward unchanged.
+    validateRequestMeta((req as UnaryRequest).message);
+    return next(req);
+  }
+  // Streaming: wrap the message iterable so validation runs on the first
+  // emitted value. We intentionally construct a new request object via
+  // spread (the `message` field is `readonly`) and forward it — Connect
+  // accepts any object that satisfies the `StreamRequest` shape.
+  const streamReq = req as StreamRequest;
+  const wrapped: StreamRequest = {
+    ...streamReq,
+    message: validatedAsyncIterable(streamReq.message),
+  };
+  return next(wrapped);
+};

--- a/packages/daemon/src/rpc/router.ts
+++ b/packages/daemon/src/rpc/router.ts
@@ -59,6 +59,8 @@ import {
   SupervisorService,
 } from '@ccsm/proto';
 
+import { requestMetaInterceptor } from './middleware/request-meta.js';
+
 /**
  * Stable enumeration of every v0.3 Connect service from `@ccsm/proto`.
  *
@@ -136,12 +138,31 @@ export type DaemonNodeHandler = ReturnType<typeof connectNodeAdapter>;
  * function shape works for both — connect-node abstracts the
  * difference internally). Listener A wires this into its
  * `http2.createServer({ ... }, handler)` call.
+ *
+ * Interceptor wiring: T2.4 (#37) — `requestMetaInterceptor` is prepended
+ * to whatever interceptor list the caller supplies, so it runs FIRST in
+ * the chain and rejects empty / whitespace-only `RequestMeta.request_id`
+ * before any handler sees the call. Caller-supplied interceptors run
+ * AFTER (e.g. T1.3 `peerCredAuthInterceptor` deposited by `makeListenerA`,
+ * which prepends auth in front of meta-validation when it builds its own
+ * interceptor list — see `bind.ts`). Order is enforced here rather than
+ * in `makeListenerA` so any future call site that reaches
+ * `createDaemonNodeAdapter` directly still inherits the meta-validation
+ * (the alternative — relying on every caller to remember to push the
+ * interceptor — is a documentation-only invariant the F7 spec rule
+ * forbids).
  */
 export function createDaemonNodeAdapter(
   options: CreateDaemonNodeAdapterOptions = {},
 ): DaemonNodeHandler {
+  const { interceptors: callerInterceptors, ...rest } = options;
+  const interceptors = [
+    requestMetaInterceptor,
+    ...(callerInterceptors ?? []),
+  ];
   return connectNodeAdapter({
-    ...options,
+    ...rest,
+    interceptors,
     routes: stubRoutes,
   });
 }

--- a/packages/daemon/test/rpc/middleware/request-meta.spec.ts
+++ b/packages/daemon/test/rpc/middleware/request-meta.spec.ts
@@ -1,0 +1,352 @@
+// T2.4 (#37) — RequestMeta validation interceptor tests.
+//
+// Spec refs: ch04 §2 (RequestMeta semantics), F7 (no silent synthesis,
+// canonical ErrorDetail.code = "request.missing_id"). The middleware
+// itself is documented in `src/rpc/middleware/request-meta.ts`.
+//
+// Pure decider test style — we drive the interceptor with synthetic
+// UnaryRequest / StreamRequest skeletons and a mock `next` to assert:
+//
+//   1. Empty `request_id` rejects with InvalidArgument + canonical
+//      ErrorDetail; handler is NEVER called (no synthesis).
+//   2. Whitespace-only `request_id` rejects identically (F7's "non-empty"
+//      rule means "non-empty after trim", per the docstring on
+//      `isValidRequestId`).
+//   3. A valid (non-empty) `request_id` passes through; handler runs;
+//      `meta.request_id` is unmodified (no rewrite).
+//   4. A request with no `meta` at all rejects (contract violation —
+//      every v0.3 Request message carries `RequestMeta meta = 1`).
+//   5. Streaming requests: validation runs on the FIRST emitted message;
+//      the wrapped iterable forwards subsequent messages unchanged.
+//   6. The pure `isValidRequestId` predicate covers the boundary cases
+//      (empty, whitespace, valid) without going through the interceptor.
+
+import { describe, expect, it, vi } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  createContextValues,
+  type StreamRequest,
+  type StreamResponse,
+  type UnaryRequest,
+  type UnaryResponse,
+} from '@connectrpc/connect';
+import {
+  ErrorDetailSchema,
+  RequestMetaSchema,
+  HelloRequestSchema,
+  WatchSessionsRequestSchema,
+} from '@ccsm/proto';
+
+import {
+  REQUEST_MISSING_ID_CODE,
+  REQUEST_MISSING_ID_MESSAGE,
+  isValidRequestId,
+  makeMissingRequestIdError,
+  requestMetaInterceptor,
+  validateRequestMeta,
+} from '../../../src/rpc/middleware/request-meta.js';
+
+// ---- Pure decider: isValidRequestId ----------------------------------------
+
+describe('isValidRequestId (pure predicate)', () => {
+  it('returns false for empty string (F7 non-empty rule)', () => {
+    expect(isValidRequestId('')).toBe(false);
+  });
+
+  it('returns false for whitespace-only strings (trim before measure)', () => {
+    expect(isValidRequestId(' ')).toBe(false);
+    expect(isValidRequestId('   ')).toBe(false);
+    expect(isValidRequestId('\t\n')).toBe(false);
+    expect(isValidRequestId(' ')).toBe(false); // NBSP
+  });
+
+  it('returns false for null / undefined / non-string types', () => {
+    expect(isValidRequestId(null)).toBe(false);
+    expect(isValidRequestId(undefined)).toBe(false);
+    expect(isValidRequestId(123 as unknown as string)).toBe(false);
+  });
+
+  it('returns true for a canonical UUIDv4', () => {
+    expect(isValidRequestId('7f3c1d8e-2b94-4f01-a5c6-d9e8b2a107c4')).toBe(true);
+  });
+
+  it('returns true for any non-whitespace string (no UUID syntax enforcement)', () => {
+    // F7 says "non-empty"; we deliberately do NOT enforce UUIDv4 syntax
+    // (over-validation would reject clients using other id schemes).
+    expect(isValidRequestId('req-1')).toBe(true);
+    expect(isValidRequestId('a')).toBe(true);
+  });
+});
+
+// ---- makeMissingRequestIdError: canonical error shape ----------------------
+
+describe('makeMissingRequestIdError (canonical ConnectError shape)', () => {
+  it('uses Code.InvalidArgument', () => {
+    const err = makeMissingRequestIdError();
+    expect(err).toBeInstanceOf(ConnectError);
+    expect(err.code).toBe(Code.InvalidArgument);
+  });
+
+  it('carries the canonical ErrorDetail with code "request.missing_id"', () => {
+    const err = makeMissingRequestIdError();
+    const details = err.findDetails(ErrorDetailSchema);
+    expect(details).toHaveLength(1);
+    expect(details[0]?.code).toBe(REQUEST_MISSING_ID_CODE);
+    expect(details[0]?.message).toBe(REQUEST_MISSING_ID_MESSAGE);
+  });
+
+  it('uses the canonical human-readable rejection message', () => {
+    const err = makeMissingRequestIdError();
+    expect(err.rawMessage).toBe(REQUEST_MISSING_ID_MESSAGE);
+  });
+});
+
+// ---- validateRequestMeta: standalone decider over a message ----------------
+
+describe('validateRequestMeta (standalone decider)', () => {
+  it('throws on a request with empty request_id', () => {
+    const msg = create(HelloRequestSchema, {
+      meta: create(RequestMetaSchema, { requestId: '' }),
+      clientKind: 'electron',
+    });
+    expect(() => validateRequestMeta(msg)).toThrow(ConnectError);
+  });
+
+  it('throws on a request with whitespace-only request_id', () => {
+    const msg = create(HelloRequestSchema, {
+      meta: create(RequestMetaSchema, { requestId: '   ' }),
+      clientKind: 'electron',
+    });
+    expect(() => validateRequestMeta(msg)).toThrow(ConnectError);
+  });
+
+  it('does not throw on a valid request_id', () => {
+    const msg = create(HelloRequestSchema, {
+      meta: create(RequestMetaSchema, { requestId: 'abc' }),
+      clientKind: 'electron',
+    });
+    expect(() => validateRequestMeta(msg)).not.toThrow();
+  });
+
+  it('throws on a message with no meta field at all (contract violation)', () => {
+    expect(() => validateRequestMeta({ clientKind: 'electron' })).toThrow(
+      ConnectError,
+    );
+  });
+
+  it('throws on null / non-object messages', () => {
+    expect(() => validateRequestMeta(null)).toThrow(ConnectError);
+    expect(() => validateRequestMeta(undefined)).toThrow(ConnectError);
+    expect(() => validateRequestMeta('not-a-message')).toThrow(ConnectError);
+  });
+});
+
+// ---- requestMetaInterceptor: end-to-end behavior ---------------------------
+
+type AnyReq = UnaryRequest | StreamRequest;
+type AnyResp = UnaryResponse | StreamResponse;
+
+function makeUnaryNext(): ReturnType<typeof vi.fn<(r: AnyReq) => Promise<AnyResp>>> {
+  return vi.fn(
+    async (r: AnyReq): Promise<AnyResp> => ({
+      stream: false,
+      service: r.service,
+      method: r.method as UnaryResponse['method'],
+      header: new Headers(),
+      trailer: new Headers(),
+      message: {} as never,
+    }),
+  );
+}
+
+/** Build a synthetic UnaryRequest carrying the supplied request message.
+ * The interceptor only reads `req.message` and `req.stream`; other fields
+ * are placeholder-typed to satisfy the Connect type and are never read. */
+function makeUnaryReq(message: object): UnaryRequest {
+  return {
+    stream: false,
+    contextValues: createContextValues(),
+    header: new Headers(),
+    service: {} as UnaryRequest['service'],
+    method: {} as UnaryRequest['method'],
+    requestMethod: 'POST',
+    url: 'http://test/x',
+    signal: new AbortController().signal,
+    message: message as never,
+  };
+}
+
+describe('requestMetaInterceptor — unary RPCs', () => {
+  it('rejects empty request_id with InvalidArgument + ErrorDetail; handler not called', async () => {
+    const req = makeUnaryReq(
+      create(HelloRequestSchema, {
+        meta: create(RequestMetaSchema, { requestId: '' }),
+        clientKind: 'electron',
+      }),
+    );
+    const next = makeUnaryNext();
+
+    await expect(requestMetaInterceptor(next)(req)).rejects.toMatchObject({
+      code: Code.InvalidArgument,
+    });
+    expect(next).not.toHaveBeenCalled();
+
+    // Re-throw to inspect the ErrorDetail attachment.
+    let captured: ConnectError | undefined;
+    try {
+      await requestMetaInterceptor(next)(req);
+    } catch (err) {
+      captured = err as ConnectError;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    const details = captured!.findDetails(ErrorDetailSchema);
+    expect(details).toHaveLength(1);
+    expect(details[0]?.code).toBe(REQUEST_MISSING_ID_CODE);
+  });
+
+  it('rejects whitespace-only request_id (trim before measure)', async () => {
+    const req = makeUnaryReq(
+      create(HelloRequestSchema, {
+        meta: create(RequestMetaSchema, { requestId: '\t  \n' }),
+        clientKind: 'electron',
+      }),
+    );
+    const next = makeUnaryNext();
+
+    await expect(requestMetaInterceptor(next)(req)).rejects.toMatchObject({
+      code: Code.InvalidArgument,
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('passes a valid request_id through to the handler unchanged (no synthesis)', async () => {
+    const req = makeUnaryReq(
+      create(HelloRequestSchema, {
+        meta: create(RequestMetaSchema, {
+          requestId: '7f3c1d8e-2b94-4f01-a5c6-d9e8b2a107c4',
+        }),
+        clientKind: 'electron',
+      }),
+    );
+    const next = makeUnaryNext();
+
+    await requestMetaInterceptor(next)(req);
+    expect(next).toHaveBeenCalledTimes(1);
+    // F7: the interceptor MUST NOT synthesize / rewrite the id.
+    const forwarded = next.mock.calls[0]![0] as UnaryRequest;
+    const meta = (forwarded.message as unknown as { meta: { requestId: string } }).meta;
+    expect(meta.requestId).toBe('7f3c1d8e-2b94-4f01-a5c6-d9e8b2a107c4');
+  });
+
+  it('rejects a request with no meta field (contract violation)', async () => {
+    // Synthesize a message-shaped object with no `meta` (impossible from
+    // a real generated codec, but defensive against handler-side mistakes
+    // / future RPCs that forget to include RequestMeta).
+    const req = makeUnaryReq({ clientKind: 'electron' });
+    const next = makeUnaryNext();
+
+    await expect(requestMetaInterceptor(next)(req)).rejects.toMatchObject({
+      code: Code.InvalidArgument,
+    });
+    expect(next).not.toHaveBeenCalled();
+  });
+});
+
+// ---- requestMetaInterceptor: streaming RPCs --------------------------------
+
+function makeStreamReq(messages: AsyncIterable<unknown>): StreamRequest {
+  return {
+    stream: true,
+    contextValues: createContextValues(),
+    header: new Headers(),
+    service: {} as StreamRequest['service'],
+    method: {} as StreamRequest['method'],
+    requestMethod: 'POST',
+    url: 'http://test/x',
+    signal: new AbortController().signal,
+    message: messages as AsyncIterable<never>,
+  };
+}
+
+async function* yieldAll<T>(items: T[]): AsyncIterable<T> {
+  for (const item of items) yield item;
+}
+
+/** Mock streaming `next` that drains the request iterable into an array
+ * before resolving — mirrors what a real handler would do, lets the test
+ * inspect what the interceptor actually forwarded. */
+function makeStreamNext(
+  collected: unknown[],
+): ReturnType<typeof vi.fn<(r: AnyReq) => Promise<AnyResp>>> {
+  return vi.fn(async (r: AnyReq): Promise<AnyResp> => {
+    if (r.stream) {
+      for await (const m of (r as StreamRequest).message) {
+        collected.push(m);
+      }
+    }
+    return {
+      stream: true,
+      service: r.service,
+      method: r.method as StreamResponse['method'],
+      header: new Headers(),
+      trailer: new Headers(),
+      message: yieldAll([]) as AsyncIterable<never>,
+    };
+  });
+}
+
+describe('requestMetaInterceptor — streaming RPCs', () => {
+  it('rejects on first message when request_id is empty (handler iterable throws)', async () => {
+    const collected: unknown[] = [];
+    const next = makeStreamNext(collected);
+    const req = makeStreamReq(
+      yieldAll([
+        create(WatchSessionsRequestSchema, {
+          meta: create(RequestMetaSchema, { requestId: '' }),
+        }),
+      ]),
+    );
+
+    await expect(requestMetaInterceptor(next)(req)).rejects.toMatchObject({
+      code: Code.InvalidArgument,
+    });
+    // The handler was invoked (Connect cannot rewind a stream interceptor),
+    // but the wrapped iterable threw on its FIRST .next(), so no message
+    // ever reached the handler's collection logic.
+    expect(collected).toEqual([]);
+  });
+
+  it('forwards a valid first message to the handler unchanged', async () => {
+    const collected: unknown[] = [];
+    const next = makeStreamNext(collected);
+    const valid = create(WatchSessionsRequestSchema, {
+      meta: create(RequestMetaSchema, {
+        requestId: '7f3c1d8e-2b94-4f01-a5c6-d9e8b2a107c4',
+      }),
+    });
+    const req = makeStreamReq(yieldAll([valid]));
+
+    await requestMetaInterceptor(next)(req);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(collected).toEqual([valid]);
+  });
+
+  it('rejects whitespace-only request_id on streaming first message', async () => {
+    const collected: unknown[] = [];
+    const next = makeStreamNext(collected);
+    const req = makeStreamReq(
+      yieldAll([
+        create(WatchSessionsRequestSchema, {
+          meta: create(RequestMetaSchema, { requestId: '  ' }),
+        }),
+      ]),
+    );
+
+    await expect(requestMetaInterceptor(next)(req)).rejects.toMatchObject({
+      code: Code.InvalidArgument,
+    });
+    expect(collected).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Task

Task #37 — T2.4 RequestMeta validation middleware. Spec
`docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md` ch04 §2,
F7 (no silent synthesis of `request_id`).

## Summary

- Adds `requestMetaInterceptor` (`packages/daemon/src/rpc/middleware/request-meta.ts`):
  inbound-RPC Connect-ES interceptor that validates `RequestMeta.request_id`.
- Empty / whitespace-only / missing → `ConnectError(InvalidArgument)` with
  outgoing `ErrorDetail{code: "request.missing_id"}` (forever-stable code
  pinned by `proto/test/contract/error-detail-roundtrip.spec.ts`).
- Valid id → forwards unchanged; **never** synthesizes a substitute (F7).
- Wired into `createDaemonNodeAdapter` (T2.2 PR #918): runs FIRST in the
  interceptor chain so the check applies uniformly to every service in
  `@ccsm/proto` (Session/Pty/Crash/Settings/Notify/Draft/Supervisor),
  including the current Unimplemented stubs and every future handler.
- Streaming RPCs handled by wrapping `req.message` in a validated
  AsyncIterable that throws on the first emitted value when the meta is
  empty — same wire shape as the unary rejection.

## Layer 1 — alternatives checked

- Validate at the proto layer (`optional`): rejected by the T0.12
  contract test `request-id-roundtrip.spec.ts` which pins that the wire
  MUST allow empty `request_id` so middleware can observe + reject.
- Per-handler `validateMeta(req.meta)`: scope-creeps every L3+ handler
  PR; reviewers would have to grep every diff. Interceptor is the
  standard Connect-ES seam for cross-cutting checks (matches the
  existing `peerCredAuthInterceptor` pattern in `src/auth/interceptor.ts`).
- `connect-validate` / `protovalidate-es`: heavyweight dep for one rule
  on one field. v0.4 may revisit; v0.3 stays dep-free.

## Test plan

`packages/daemon/test/rpc/middleware/request-meta.spec.ts` — 20 pure
decider tests:

- `isValidRequestId` predicate: empty, whitespace (space / tab / newline
  / NBSP), null, undefined, non-string, valid UUIDv4, opaque short id.
- `makeMissingRequestIdError`: code = InvalidArgument; detail =
  canonical `request.missing_id`; rawMessage matches contract fixture.
- `validateRequestMeta`: empty / whitespace / valid / missing-meta /
  null / non-object.
- `requestMetaInterceptor` unary: empty + whitespace reject (handler
  never called, ErrorDetail attached); valid passes through unchanged
  (no synthesis); missing-meta rejects.
- `requestMetaInterceptor` streaming: empty + whitespace on first
  message reject (handler iterable yields nothing); valid first message
  forwards unchanged.

## Local validation

```
$ cd packages/daemon && npx vitest run test/rpc/middleware
 Test Files  1 passed (1)
      Tests  20 passed (20)

$ npx vitest run src/rpc test/rpc
 Test Files  3 passed (3)
      Tests  54 passed | 1 skipped (55)
   (1 skipped is the POSIX-only UDS integration on Windows)

$ pnpm lint        -> clean
$ pnpm typecheck   -> clean
```

## Notes

- `src/rpc/__tests__/integration.spec.ts` was updated to supply
  `meta.requestId = "<uuid>"` on its `client.hello(...)` calls so the
  test continues to assert the downstream Unimplemented behavior rather
  than tripping on the new meta-validation gate. Rationale documented
  in the file's leading comment.
- Interceptor order is `[requestMetaInterceptor, ...callerInterceptors]`
  (validation prepends caller list). Intent: future call sites that
  reach `createDaemonNodeAdapter` directly inherit the F7 check
  unconditionally; relying on every caller to remember the prepend
  would be a documentation-only invariant the F7 spec rule forbids.