### PR TITLE
daemon(T2.3): Hello RPC + version negotiation + listener_id

### DIFF
--- a/packages/daemon/src/rpc/bind.ts
+++ b/packages/daemon/src/rpc/bind.ts
@@ -55,7 +55,9 @@ import {
  * Build a `BindHook` that:
  *   1. Constructs a Node http2 server whose request listener is the
  *      Connect-router stub handler (every v0.3 service registered with
- *      `Unimplemented`-by-default).
+ *      `Unimplemented`-by-default). When `routerOptions.helloDeps` is
+ *      supplied (T2.3), the real `SessionService.Hello` handler is
+ *      installed on top of the stub baseline.
  *   2. Delegates the OS-level bind to the right T1.5 adapter for the
  *      planned `BindDescriptor.kind`.
  *   3. Returns a `BoundTransport` whose `descriptor` reflects the

--- a/packages/daemon/src/rpc/hello.ts
+++ b/packages/daemon/src/rpc/hello.ts
@@ -1,0 +1,340 @@
+// SessionService.Hello handler — version negotiation + listener-id surfacing.
+// Spec ch04 §3 (Hello{Request,Response} shape) + ch02 §6 (one-directional
+// version negotiation) + ch04 §2 (ErrorDetail on rejection).
+//
+// T2.3 scope: replace the T2.2 empty `{}` stub for SessionService.Hello with
+// a real handler. Three responsibilities:
+//   1. validate `RequestMeta.request_id` is non-empty (ch04 §2 — F7 rule
+//      "Daemon MUST NOT silently synthesize"); reject with INVALID_ARGUMENT
+//      and ErrorDetail.code = "request.missing_id";
+//   2. validate the client's `proto_min_version` is <= the daemon's
+//      `PROTO_VERSION`; reject too-old clients with FAILED_PRECONDITION and
+//      ErrorDetail.code = "version.client_too_old", carrying
+//      extra["daemon_proto_version"] so the client can decide whether to
+//      upgrade (ch02 §6 + ch04 §3);
+//   3. surface the daemon-derived `listener_id` ("A" for Listener A on
+//      v0.3) and the per-call `Principal` echo onto the HelloResponse.
+//
+// SRP layering — three roles, kept separate:
+//   - decider: `decideHello(req, ctx)` — pure function `(req, ctx) → verdict`.
+//     No I/O, no Connect plumbing, no `ConnectError`. Returns a tagged-union
+//     verdict so callers (and unit tests) can introspect the decision
+//     before any side effect. Spec test ref `proto/proto-min-version-truth-table.spec.ts`
+//     exercises this directly via the truth table.
+//   - sink:    `makeHelloHandler(deps)` — wraps the decider in the Connect
+//     handler signature `(req, handlerContext) → HelloResponse | throws
+//     ConnectError`. The only place `ConnectError` is constructed.
+//   - producer: caller (router wiring in `./router.ts`) supplies the
+//     `HelloDeps` (daemonVersion / protoVersion / listenerId / Listener-A
+//     descriptor accessor / boot-id reader). Producer composition is the
+//     daemon-startup wiring's responsibility (T1.7), not this module's.
+//
+// What this file is NOT:
+//   - principal-derivation: that is `auth/interceptor.ts`'s
+//     `peerCredAuthInterceptor`, which deposits the `Principal` under
+//     `PRINCIPAL_KEY` BEFORE this handler runs. The handler reads the
+//     deposited principal and translates it to the proto `Principal`
+//     oneof shape.
+//   - boot_id surfacing: the spec ch03 §3.3 "Hello-echo boot_id" mechanism
+//     references a `boot_id` field that does NOT exist on the current
+//     `HelloResponse` proto (fields 1-5: meta / daemon_version /
+//     proto_version / principal / listener_id — no boot_id slot, no
+//     `reserved 6`). The forever-stable `session.proto` would need a
+//     coordinated additive bump (lock.json + PROTO_VERSION + electron
+//     client mirror) to add it; that is its own task and is intentionally
+//     out of scope here. See PR body for the push-back.
+//
+// Layer 1 — alternatives checked:
+//   - We could thread `(daemonVersion, protoVersion, listenerId)` as
+//     plain function args into a single closure. Rejected: the daemon's
+//     version + proto version are process-global constants
+//     (`PROTO_VERSION` from `@ccsm/proto`, daemon semver from package
+//     metadata), but the listener-id and the future boot-id are
+//     descriptor-level — bundling all four into a `HelloDeps` shape
+//     keeps the call site (router wiring) symmetric with the other RPC
+//     handlers that will land in T3.x / T4.x.
+//   - We could read `PROTO_VERSION` directly inside the decider. Rejected:
+//     the decider must be pure — taking it as a context arg lets unit
+//     tests pin a specific version without monkey-patching the @ccsm/proto
+//     re-export.
+//   - The Connect router's "unimplemented for absent method" behavior
+//     (ch04 §3 footnote) means this handler simply replaces the empty
+//     stub `{}` for SessionService.Hello in `./router.ts`'s opt-in
+//     `makeDaemonRoutes(deps)` factory. The plain `stubRoutes` (no deps)
+//     remains untouched so the T2.2 `router.spec.ts` and
+//     `__tests__/integration.spec.ts` over-the-wire Unimplemented assertions
+//     still hold.
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type HandlerContext,
+  type ServiceImpl,
+} from '@connectrpc/connect';
+
+import {
+  ErrorDetailSchema,
+  HelloResponseSchema,
+  LocalUserSchema,
+  PrincipalSchema,
+  RequestMetaSchema,
+  SessionService,
+  type HelloRequest,
+  type HelloResponse,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, type Principal as AuthPrincipal } from '../auth/index.js';
+
+/**
+ * Stable per-listener identifier surfaced on `HelloResponse.listener_id`.
+ * Spec ch04 §3 + the schema migration table row "HelloResponse.listener_id
+ * string values" — v0.3 always emits `"A"`; v0.4 Listener B emits `"B"`.
+ * Open string set on the wire; clients tolerate unknown values.
+ *
+ * Exported as a typed constant (not a magic string) so the call-site
+ * wiring in `./router.ts` and the daemon-startup composition (T1.7) both
+ * read from one place. This is also the value the daemon writes into
+ * `listener-a.json`'s analogous fields (descriptor's `listener_addr` is
+ * the bind address, not the id; the id discriminates which listener
+ * handled the call when v0.4 ships Listener B).
+ */
+export const LISTENER_A_HELLO_ID = 'A' as const;
+
+/**
+ * Inputs the Hello handler needs to assemble a response. Pure-data shape
+ * (no functions) so unit tests can construct it inline without mocks.
+ *
+ * Field semantics:
+ *   - `daemonVersion` — daemon semver string surfaced on
+ *     `HelloResponse.daemon_version`. Spec ch04 §3 — informational, the
+ *     wire-stable contract is `proto_version`, not this string.
+ *   - `protoVersion` — daemon's current `PROTO_VERSION` (`@ccsm/proto`).
+ *     Used both as the negotiation ceiling (decider compares
+ *     `client.proto_min_version <= protoVersion`) and as the value
+ *     surfaced on `HelloResponse.proto_version`.
+ *   - `listenerId` — which listener answered; v0.3 Listener A always
+ *     passes `LISTENER_A_HELLO_ID` (`"A"`).
+ */
+export interface HelloDeps {
+  readonly daemonVersion: string;
+  readonly protoVersion: number;
+  readonly listenerId: string;
+}
+
+/**
+ * Decider verdict — discriminated union so unit tests can assert on the
+ * chosen branch without parsing a `ConnectError` shape (the sink layer's
+ * concern). Three terminals:
+ *
+ *   - `kind: 'ok'`   — accept; `response` is the full `HelloResponse`
+ *                      ready for wire encode.
+ *   - `kind: 'invalid_argument'` — reject; `code` / `message` populate
+ *                      the `ErrorDetail` and the ConnectError text. v0.3
+ *                      uses this exclusively for the request_id missing
+ *                      check (`code: "request.missing_id"`).
+ *   - `kind: 'failed_precondition'` — reject; ditto for the version
+ *                      negotiation (`code: "version.client_too_old"`),
+ *                      with an `extra` map carrying the daemon's
+ *                      `proto_version` so the client can tell the user
+ *                      to upgrade.
+ *
+ * Why three branches, not one "reject with code" branch: the Connect
+ * status code (`INVALID_ARGUMENT` vs `FAILED_PRECONDITION`) is a wire
+ * decision per spec ch04 §3 wording — encoding it in the verdict's
+ * discriminant keeps the sink mechanical (`switch (verdict.kind)` →
+ * `Code.X`) and pushes the choice into the decider where it belongs.
+ */
+export type HelloVerdict =
+  | { readonly kind: 'ok'; readonly response: HelloResponse }
+  | {
+      readonly kind: 'invalid_argument';
+      readonly code: 'request.missing_id';
+      readonly message: string;
+      readonly extra: Readonly<Record<string, string>>;
+    }
+  | {
+      readonly kind: 'failed_precondition';
+      readonly code: 'version.client_too_old';
+      readonly message: string;
+      readonly extra: Readonly<Record<string, string>>;
+    };
+
+/**
+ * Pure decider. No I/O, no `ConnectError`, no contextValues access — the
+ * `principal` is passed in (the sink reads `PRINCIPAL_KEY` and threads it
+ * here). Spec refs: ch04 §3 (negotiation contract) + ch02 §6 (one-directional
+ * negotiation: daemon does NOT push a `min_compatible_client` value back).
+ *
+ * Validation ordering matches the spec test suite expectations:
+ *   1. `meta.request_id` non-empty — F7 universal rule, applied to every
+ *      RPC. Empty `request_id` is the FIRST gate so a malformed client
+ *      never reaches the version-negotiation branch and confuses the
+ *      operator about which contract was violated.
+ *   2. `proto_min_version <= protoVersion` — too-old clients are rejected
+ *      with the structured `version.client_too_old` detail. The strictly
+ *      `>` comparison surfaces the "client wants a newer proto than the
+ *      daemon speaks" case as the rejection. Older clients (lower
+ *      `proto_min_version`) are accepted — the daemon supports back-compat
+ *      as long as its current `protoVersion` meets the client's floor.
+ *   3. otherwise — accept; build `HelloResponse` echoing meta, populating
+ *      daemon_version / proto_version / listener_id, and translating the
+ *      in-process `AuthPrincipal` into the proto `Principal` oneof.
+ */
+export function decideHello(
+  req: HelloRequest,
+  ctx: HelloDeps & { readonly principal: AuthPrincipal },
+): HelloVerdict {
+  const requestId = req.meta?.requestId ?? '';
+  if (requestId.length === 0) {
+    return {
+      kind: 'invalid_argument',
+      code: 'request.missing_id',
+      message:
+        'HelloRequest.meta.request_id MUST be a non-empty client-generated UUIDv4 (spec ch04 §2)',
+      extra: {},
+    };
+  }
+
+  if (req.protoMinVersion > ctx.protoVersion) {
+    return {
+      kind: 'failed_precondition',
+      code: 'version.client_too_old',
+      message:
+        `client requires proto_min_version=${req.protoMinVersion} but ` +
+        `daemon speaks proto_version=${ctx.protoVersion} ` +
+        '(spec ch02 §6 + ch04 §3 — version negotiation is one-directional; ' +
+        'client decides upgrade based on daemon_proto_version)',
+      // Spec ch04 §3 names the key explicitly: `extra["daemon_proto_version"]
+      // = <int>`. Stringify because `ErrorDetail.extra` is `map<string, string>`.
+      extra: { daemon_proto_version: String(ctx.protoVersion) },
+    };
+  }
+
+  const response = create(HelloResponseSchema, {
+    // Echo `meta` so the client's request/response correlation in
+    // structured logs lines up. We forward the full RequestMeta fields
+    // we observed (request_id is the only one daemon validates; client_version
+    // and client_send_unix_ms are observability echoes).
+    meta: create(RequestMetaSchema, {
+      requestId,
+      clientVersion: req.meta?.clientVersion ?? '',
+      clientSendUnixMs: req.meta?.clientSendUnixMs ?? 0n,
+    }),
+    daemonVersion: ctx.daemonVersion,
+    protoVersion: ctx.protoVersion,
+    principal: authPrincipalToProto(ctx.principal),
+    listenerId: ctx.listenerId,
+  });
+
+  return { kind: 'ok', response };
+}
+
+/**
+ * Translate the in-process `AuthPrincipal` (`auth/principal.ts`) into the
+ * proto `Principal` oneof shape (`@ccsm/proto`'s `LocalUser local_user = 1`
+ * variant). v0.3 only ships `local-user`; the switch-default throws so a
+ * future v0.4 `cf-access` variant on the in-process side without a
+ * matching update here fails loud.
+ */
+function authPrincipalToProto(p: AuthPrincipal): ReturnType<typeof create<typeof PrincipalSchema>> {
+  switch (p.kind) {
+    case 'local-user': {
+      return create(PrincipalSchema, {
+        kind: {
+          case: 'localUser',
+          value: create(LocalUserSchema, {
+            uid: p.uid,
+            displayName: p.displayName,
+          }),
+        },
+      });
+    }
+    default: {
+      const _exhaustive: never = p.kind;
+      throw new Error(
+        `unhandled AuthPrincipal kind in Hello handler: ${String(_exhaustive)}`,
+      );
+    }
+  }
+}
+
+/**
+ * Build the Connect `ServiceImpl<typeof SessionService>['hello']` handler
+ * — the sink layer. Reads `PRINCIPAL_KEY` from the `HandlerContext` (the
+ * `peerCredAuthInterceptor` deposited it before this runs); throws
+ * `Unauthenticated` if the interceptor wiring is missing (defensive — the
+ * spec ch05 §2 invariant is "every handler reads `ctx.principal` and
+ * assumes it is set", and the missing-principal sentinel is `null` per
+ * `auth/interceptor.ts`).
+ *
+ * The decider's verdict is mapped to wire shapes here:
+ *   - `ok`                     → return `HelloResponse`
+ *   - `invalid_argument`       → throw `ConnectError(INVALID_ARGUMENT)`
+ *                                with an `ErrorDetail` outgoing detail
+ *   - `failed_precondition`    → throw `ConnectError(FAILED_PRECONDITION)`
+ *                                with an `ErrorDetail` outgoing detail
+ *
+ * Outgoing details use the `{ desc, value }` shape Connect-ES v2 expects
+ * for server-side error details (see `ConnectError` constructor signature
+ * in `@connectrpc/connect/dist/esm/connect-error.d.ts`).
+ */
+export function makeHelloHandler(
+  deps: HelloDeps,
+): ServiceImpl<typeof SessionService>['hello'] {
+  return (req: HelloRequest, handlerContext: HandlerContext): HelloResponse => {
+    const principal = handlerContext.values.get(PRINCIPAL_KEY);
+    if (principal === null) {
+      // Defensive — the peerCredAuthInterceptor MUST have run and set
+      // PRINCIPAL_KEY before this handler executes. If we observe `null`,
+      // the interceptor was not installed in the chain (a wiring bug,
+      // not an auth failure of the caller). We surface as Internal so
+      // operators see a daemon-side bug indicator rather than the client
+      // being told they are unauthenticated.
+      throw new ConnectError(
+        'Hello handler invoked without peerCredAuthInterceptor in chain ' +
+          '(PRINCIPAL_KEY=null) — daemon wiring bug',
+        Code.Internal,
+      );
+    }
+
+    const verdict = decideHello(req, { ...deps, principal });
+    switch (verdict.kind) {
+      case 'ok':
+        return verdict.response;
+      case 'invalid_argument':
+        throw new ConnectError(verdict.message, Code.InvalidArgument, undefined, [
+          {
+            desc: ErrorDetailSchema,
+            value: {
+              code: verdict.code,
+              message: verdict.message,
+              extra: { ...verdict.extra },
+            },
+          },
+        ]);
+      case 'failed_precondition':
+        throw new ConnectError(
+          verdict.message,
+          Code.FailedPrecondition,
+          undefined,
+          [
+            {
+              desc: ErrorDetailSchema,
+              value: {
+                code: verdict.code,
+                message: verdict.message,
+                extra: { ...verdict.extra },
+              },
+            },
+          ],
+        );
+      default: {
+        const _exhaustive: never = verdict;
+        throw new Error(
+          `unhandled HelloVerdict kind: ${String((_exhaustive as { kind: string }).kind)}`,
+        );
+      }
+    }
+  };
+}

--- a/packages/daemon/src/rpc/router.ts
+++ b/packages/daemon/src/rpc/router.ts
@@ -59,6 +59,7 @@ import {
   SupervisorService,
 } from '@ccsm/proto';
 
+import { makeHelloHandler, type HelloDeps } from './hello.js';
 import { requestMetaInterceptor } from './middleware/request-meta.js';
 
 /**
@@ -108,15 +109,74 @@ export const stubRoutes = (router: ConnectRouter): void => {
 };
 
 /**
+ * Opt-in registration of the real T2.3 SessionService.Hello handler on
+ * top of the T2.2 stub baseline. Other services remain stub
+ * (`Unimplemented`) — those handlers land in their respective tasks
+ * (T3.x session, T4.x pty, etc.) and will follow the same pattern of an
+ * additive registration over the stubs.
+ *
+ * Why "register on top" instead of editing `STUB_SERVICES`: the T2.2
+ * stub coverage spec (`__tests__/router.spec.ts`) iterates EVERY method
+ * on EVERY service expecting `Unimplemented`. Removing SessionService
+ * from `STUB_SERVICES` would also strip the stub for the eight other
+ * SessionService RPCs (ListSessions / GetSession / ...) that have NOT
+ * yet landed, regressing them from `Unimplemented` to `404 Not Found`.
+ * The Connect router's `service(desc, impl)` accepts a partial impl
+ * and falls back to `Unimplemented` for absent methods — so
+ * registering `{ hello }` alongside the prior empty `{}` is the
+ * documented additive path.
+ *
+ * Per Connect-ES `ConnectRouter.service` semantics, calling `service`
+ * twice for the same descriptor REPLACES the prior registration (the
+ * router is a path-keyed map keyed on `service.typeName + method.name`).
+ * Order therefore matters: `registerStubServices(router)` first, then
+ * the real-handler overlay so the partial `{ hello }` impl supplants
+ * the stub `{}` for SessionService while every other service keeps the
+ * stub.
+ */
+export function registerHelloHandler(
+  router: ConnectRouter,
+  deps: HelloDeps,
+): ConnectRouter {
+  router.service(SessionService, { hello: makeHelloHandler(deps) });
+  return router;
+}
+
+/**
+ * Bundled routes callback that installs stubs for every service AND the
+ * real T2.3 Hello handler on SessionService. Use this from the daemon's
+ * production startup wiring (T1.7) — pass through to
+ * `createDaemonNodeAdapter({ helloDeps: ... })`. Unit tests that want
+ * pure stubs (no real handlers) keep using `stubRoutes`.
+ */
+export function makeDaemonRoutes(
+  helloDeps: HelloDeps,
+): (router: ConnectRouter) => void {
+  return (router: ConnectRouter): void => {
+    registerStubServices(router);
+    registerHelloHandler(router, helloDeps);
+  };
+}
+
+/**
  * Adapter-construction options. We accept the same shape as
  * `ConnectRouterOptions` (gRPC / gRPC-Web / Connect protocol toggles)
  * plus an optional `requestPathPrefix` that the listener layer may
  * supply if it wants to mount the router under a sub-path (the v0.3
  * Listener A serves the router at the root, so the default is empty).
+ *
+ * `helloDeps` (T2.3) — when provided, the adapter installs the real
+ * `SessionService.Hello` handler in addition to the stub baseline. When
+ * omitted (the default), every service responds with `Unimplemented`
+ * exactly like the T2.2 baseline. The omit-default keeps the T2.2
+ * `__tests__/router.spec.ts` and `__tests__/integration.spec.ts`
+ * over-the-wire Unimplemented assertions intact.
  */
 export interface CreateDaemonNodeAdapterOptions extends ConnectRouterOptions {
   /** Optional URL prefix; default `""` (mount at root). */
   readonly requestPathPrefix?: string;
+  /** When set, installs the T2.3 Hello handler on top of the stubs. */
+  readonly helloDeps?: HelloDeps;
 }
 
 /**
@@ -155,7 +215,9 @@ export type DaemonNodeHandler = ReturnType<typeof connectNodeAdapter>;
 export function createDaemonNodeAdapter(
   options: CreateDaemonNodeAdapterOptions = {},
 ): DaemonNodeHandler {
-  const { interceptors: callerInterceptors, ...rest } = options;
+  const { helloDeps, interceptors: callerInterceptors, ...rest } = options;
+  const routes =
+    helloDeps !== undefined ? makeDaemonRoutes(helloDeps) : stubRoutes;
   const interceptors = [
     requestMetaInterceptor,
     ...(callerInterceptors ?? []),
@@ -163,6 +225,6 @@ export function createDaemonNodeAdapter(
   return connectNodeAdapter({
     ...rest,
     interceptors,
-    routes: stubRoutes,
+    routes,
   });
 }

--- a/packages/daemon/test/rpc/hello.spec.ts
+++ b/packages/daemon/test/rpc/hello.spec.ts
@@ -1,0 +1,307 @@
+// SessionService.Hello handler — T2.3 spec.
+//
+// Covers:
+//   - happy path: client_api_version compatible (proto_min_version <=
+//     daemon's PROTO_VERSION) -> response with listener_id + principal
+//     + meta echo + daemon_version + proto_version.
+//   - too-old client: client.proto_min_version > daemon.PROTO_VERSION
+//     -> ConnectError(FailedPrecondition) with ErrorDetail
+//     code = "version.client_too_old" and extra["daemon_proto_version"]
+//     = String(daemon.PROTO_VERSION).
+//   - request_id missing: empty meta.request_id -> ConnectError(InvalidArgument)
+//     with ErrorDetail code = "request.missing_id" (spec ch04 §2 F7).
+//   - pure-decider tests: drive `decideHello(req, ctx)` directly with
+//     synthesized `(req, ctx)` shapes; no Connect plumbing, no I/O.
+//   - over-the-wire (in-process router transport): drives the bound
+//     handler through `createRouterTransport` to verify the
+//     `ConnectError` shape (code + ErrorDetail attached) survives the
+//     decider->sink->wire conversion. Real http2 socket coverage is
+//     deferred to the `__tests__/integration.spec.ts` end-to-end tests
+//     in T2.x integration scope (T2.3 ships the handler; T2.4+ cover
+//     the wire integration matrix).
+//
+// Why under `test/rpc/` (not `src/rpc/__tests__/`): per
+// `packages/daemon/vitest.config.ts` the `test/**/*.spec.ts` glob is the
+// out-of-tree integration / contract layer; the cross-module fixtures
+// here (proto schemas + auth Principal type + Connect router transport)
+// match that layer's purpose. Pure-source unit specs co-locate as
+// `__tests__/` next to source — those would be appropriate if the
+// decider lived in isolation, but the spec-mandated test name is
+// `packages/daemon/test/rpc/hello.spec.ts` (manager prompt) so we
+// honor that path verbatim.
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  createClient,
+  createRouterTransport,
+} from '@connectrpc/connect';
+import { describe, expect, it } from 'vitest';
+
+import {
+  ErrorDetailSchema,
+  HelloRequestSchema,
+  PROTO_VERSION,
+  RequestMetaSchema,
+  SessionService,
+  type ErrorDetail,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, type Principal as AuthPrincipal } from '../../src/auth/index.js';
+import {
+  LISTENER_A_HELLO_ID,
+  decideHello,
+  makeHelloHandler,
+  type HelloDeps,
+} from '../../src/rpc/hello.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const TEST_DAEMON_VERSION = '0.3.0-test';
+
+const TEST_PRINCIPAL: AuthPrincipal = {
+  kind: 'local-user',
+  uid: '1000',
+  displayName: 'alice',
+};
+
+const BASE_DEPS: HelloDeps = {
+  daemonVersion: TEST_DAEMON_VERSION,
+  protoVersion: PROTO_VERSION,
+  listenerId: LISTENER_A_HELLO_ID,
+};
+
+function makeReq(overrides: {
+  readonly requestId?: string;
+  readonly clientKind?: string;
+  readonly protoMinVersion?: number;
+  readonly clientVersion?: string;
+  readonly clientSendUnixMs?: bigint;
+}): ReturnType<typeof create<typeof HelloRequestSchema>> {
+  return create(HelloRequestSchema, {
+    meta: create(RequestMetaSchema, {
+      requestId: overrides.requestId ?? '11111111-2222-3333-4444-555555555555',
+      clientVersion: overrides.clientVersion ?? '0.3.0',
+      clientSendUnixMs: overrides.clientSendUnixMs ?? 1_700_000_000_000n,
+    }),
+    clientKind: overrides.clientKind ?? 'electron',
+    protoMinVersion: overrides.protoMinVersion ?? PROTO_VERSION,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Pure-decider tests — no I/O, no Connect plumbing
+// ---------------------------------------------------------------------------
+
+describe('decideHello — pure decider', () => {
+  it('happy path: returns ok verdict with full HelloResponse', () => {
+    const req = makeReq({ protoMinVersion: PROTO_VERSION });
+    const verdict = decideHello(req, { ...BASE_DEPS, principal: TEST_PRINCIPAL });
+
+    expect(verdict.kind).toBe('ok');
+    if (verdict.kind !== 'ok') return; // type narrow
+    expect(verdict.response.daemonVersion).toBe(TEST_DAEMON_VERSION);
+    expect(verdict.response.protoVersion).toBe(PROTO_VERSION);
+    expect(verdict.response.listenerId).toBe(LISTENER_A_HELLO_ID);
+
+    // Meta echo — request_id matches, optional fields preserved.
+    expect(verdict.response.meta?.requestId).toBe(
+      '11111111-2222-3333-4444-555555555555',
+    );
+    expect(verdict.response.meta?.clientVersion).toBe('0.3.0');
+    expect(verdict.response.meta?.clientSendUnixMs).toBe(1_700_000_000_000n);
+
+    // Principal echo — proto Principal oneof carries LocalUser variant.
+    expect(verdict.response.principal?.kind?.case).toBe('localUser');
+    if (verdict.response.principal?.kind?.case !== 'localUser') return;
+    expect(verdict.response.principal.kind.value.uid).toBe('1000');
+    expect(verdict.response.principal.kind.value.displayName).toBe('alice');
+  });
+
+  it('older client (proto_min_version < daemon proto_version) is accepted', () => {
+    // Spec ch02 §6: only the strictly-greater client floor is rejected.
+    // A client whose floor is BELOW the daemon's current version is the
+    // common back-compat path.
+    const req = makeReq({ protoMinVersion: 0 });
+    const verdict = decideHello(req, { ...BASE_DEPS, principal: TEST_PRINCIPAL });
+    expect(verdict.kind).toBe('ok');
+  });
+
+  it('exact-match (proto_min_version === daemon proto_version) is accepted', () => {
+    const req = makeReq({ protoMinVersion: PROTO_VERSION });
+    const verdict = decideHello(req, { ...BASE_DEPS, principal: TEST_PRINCIPAL });
+    expect(verdict.kind).toBe('ok');
+  });
+
+  it('too-old client: returns failed_precondition + version.client_too_old', () => {
+    const req = makeReq({ protoMinVersion: PROTO_VERSION + 1 });
+    const verdict = decideHello(req, { ...BASE_DEPS, principal: TEST_PRINCIPAL });
+
+    expect(verdict.kind).toBe('failed_precondition');
+    if (verdict.kind !== 'failed_precondition') return;
+    expect(verdict.code).toBe('version.client_too_old');
+    expect(verdict.extra.daemon_proto_version).toBe(String(PROTO_VERSION));
+  });
+
+  it('empty request_id: returns invalid_argument + request.missing_id', () => {
+    const req = makeReq({ requestId: '' });
+    const verdict = decideHello(req, { ...BASE_DEPS, principal: TEST_PRINCIPAL });
+
+    expect(verdict.kind).toBe('invalid_argument');
+    if (verdict.kind !== 'invalid_argument') return;
+    expect(verdict.code).toBe('request.missing_id');
+  });
+
+  it('open-set client_kind values are accepted unmodified', () => {
+    // Spec ch04 §3 + ch15 §3: daemon MUST tolerate any UTF-8 string in
+    // client_kind and MUST NOT branch behavior on it. Here we exercise
+    // a value outside the v0.3 published `{electron, web, ios}` set.
+    const req = makeReq({ clientKind: 'rust-cli' });
+    const verdict = decideHello(req, { ...BASE_DEPS, principal: TEST_PRINCIPAL });
+    expect(verdict.kind).toBe('ok');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sink wiring tests — through the in-process Connect router transport
+// ---------------------------------------------------------------------------
+
+/**
+ * Build an in-process Connect transport whose `SessionService.Hello`
+ * runs the T2.3 handler with `BASE_DEPS`. A SERVER-side interceptor
+ * deposits `principal` under `PRINCIPAL_KEY` before the handler runs,
+ * mirroring what `peerCredAuthInterceptor` does on a real connection.
+ *
+ * Server-side interceptors live under the router options
+ * (`{ router: { interceptors: [...] } }`) because `ConnectRouterOptions
+ * extends Partial<UniversalHandlerOptions>` which carries the
+ * server-installed interceptor chain. Client-side `transport.interceptors`
+ * fire on the request producer side and never reach the handler's
+ * `HandlerContext.values`.
+ */
+function makeBoundTransport(principal: AuthPrincipal | null = TEST_PRINCIPAL) {
+  return createRouterTransport(
+    (router) => {
+      router.service(SessionService, { hello: makeHelloHandler(BASE_DEPS) });
+    },
+    {
+      router: {
+        interceptors: [
+          (next) => async (req) => {
+            req.contextValues.set(PRINCIPAL_KEY, principal);
+            return next(req);
+          },
+        ],
+      },
+    },
+  );
+}
+
+describe('SessionService.Hello — in-process router transport', () => {
+  it('happy path: returns HelloResponse with listener_id "A"', async () => {
+    const transport = makeBoundTransport();
+    const client = createClient(SessionService, transport);
+
+    const resp = await client.hello({
+      meta: {
+        requestId: 'aaaa-bbbb',
+        clientVersion: '0.3.0',
+        clientSendUnixMs: 0n,
+      },
+      clientKind: 'electron',
+      protoMinVersion: PROTO_VERSION,
+    });
+
+    expect(resp.listenerId).toBe(LISTENER_A_HELLO_ID);
+    expect(resp.daemonVersion).toBe(TEST_DAEMON_VERSION);
+    expect(resp.protoVersion).toBe(PROTO_VERSION);
+    expect(resp.principal?.kind?.case).toBe('localUser');
+  });
+
+  it('too-old client: throws ConnectError(FailedPrecondition) + ErrorDetail', async () => {
+    const transport = makeBoundTransport();
+    const client = createClient(SessionService, transport);
+
+    let captured: unknown = null;
+    try {
+      await client.hello({
+        meta: {
+          requestId: 'aaaa-bbbb',
+          clientVersion: '0.3.0',
+          clientSendUnixMs: 0n,
+        },
+        clientKind: 'electron',
+        protoMinVersion: PROTO_VERSION + 1,
+      });
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(ConnectError);
+    const ce = captured as ConnectError;
+    expect(ce.code).toBe(Code.FailedPrecondition);
+
+    const details = ce.findDetails(ErrorDetailSchema) as ErrorDetail[];
+    expect(details.length).toBeGreaterThanOrEqual(1);
+    expect(details[0].code).toBe('version.client_too_old');
+    expect(details[0].extra.daemon_proto_version).toBe(String(PROTO_VERSION));
+  });
+
+  it('missing request_id: throws ConnectError(InvalidArgument) + ErrorDetail', async () => {
+    const transport = makeBoundTransport();
+    const client = createClient(SessionService, transport);
+
+    let captured: unknown = null;
+    try {
+      await client.hello({
+        meta: {
+          requestId: '',
+          clientVersion: '0.3.0',
+          clientSendUnixMs: 0n,
+        },
+        clientKind: 'electron',
+        protoMinVersion: PROTO_VERSION,
+      });
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(ConnectError);
+    const ce = captured as ConnectError;
+    expect(ce.code).toBe(Code.InvalidArgument);
+
+    const details = ce.findDetails(ErrorDetailSchema) as ErrorDetail[];
+    expect(details.length).toBeGreaterThanOrEqual(1);
+    expect(details[0].code).toBe('request.missing_id');
+  });
+
+  it('handler missing peer-cred wiring: throws Internal (defensive)', async () => {
+    // Simulate the wiring bug where peerCredAuthInterceptor never ran:
+    // PRINCIPAL_KEY is the null sentinel default.
+    const transport = createRouterTransport((router) => {
+      router.service(SessionService, { hello: makeHelloHandler(BASE_DEPS) });
+    });
+    const client = createClient(SessionService, transport);
+
+    let captured: unknown = null;
+    try {
+      await client.hello({
+        meta: {
+          requestId: 'aaaa-bbbb',
+          clientVersion: '0.3.0',
+          clientSendUnixMs: 0n,
+        },
+        clientKind: 'electron',
+        protoMinVersion: PROTO_VERSION,
+      });
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(ConnectError);
+    expect((captured as ConnectError).code).toBe(Code.Internal);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the T2.2 empty stub for `SessionService.Hello` with a real handler that:

1. **Validates** `RequestMeta.request_id` is non-empty — empty rejected with `ConnectError(InvalidArgument)` + `ErrorDetail.code = "request.missing_id"` (spec ch04 §2 F7 universal rule).
2. **Negotiates** protocol version (one-directional, spec ch02 §6) — accepts when `client.proto_min_version <= daemon.PROTO_VERSION`; rejects too-old clients with `ConnectError(FailedPrecondition)` + `ErrorDetail.code = "version.client_too_old"` carrying `extra["daemon_proto_version"] = String(daemon.PROTO_VERSION)`.
3. **Surfaces** `listener_id` (`"A"` for v0.3 Listener A), `daemon_version`, `proto_version`, `principal` (translated from `auth/PRINCIPAL_KEY` to the proto `Principal` oneof), and the request-meta echo on the `HelloResponse`.

### Architecture (SRP three-roles)

- **Decider** — `decideHello(req, ctx)`: pure function `(HelloRequest, HelloDeps & {principal}) -> HelloVerdict`. No I/O, no `ConnectError`, no Connect-ES plumbing. The discriminated-union verdict (`'ok' | 'invalid_argument' | 'failed_precondition'`) lets unit tests assert on the decision before any side effect.
- **Sink** — `makeHelloHandler(deps)`: wraps the decider in the Connect handler signature; reads `PRINCIPAL_KEY` from `HandlerContext.values`; only place `ConnectError` is constructed.
- **Producer** — caller (router wiring) supplies `HelloDeps`. Production composition lands in T1.7 daemon-startup.

### Wiring (opt-in over T2.2)

- `stubRoutes` (T2.2) is unchanged — still registers every service with `{}` so `Unimplemented`-by-default holds.
- New `registerHelloHandler(router, deps)` overlays the real handler on top of the stub `SessionService` (Connect's `service(desc, partial-impl)` keeps absent methods as `Unimplemented`).
- New `makeDaemonRoutes(helloDeps)` is the bundled routes callback used by `createDaemonNodeAdapter({ helloDeps })`.
- The default `createDaemonNodeAdapter()` (no `helloDeps`) keeps the prior stubs-only behavior so `src/rpc/__tests__/router.spec.ts` and `src/rpc/__tests__/integration.spec.ts` over-the-wire `Unimplemented` assertions stay green.

### Out of scope: `boot_id`

The manager prompt asked to surface `boot_id` from the descriptor. Investigation found the proto `HelloResponse` carries fields 1-5 (`meta`, `daemon_version`, `proto_version`, `principal`, `listener_id`) with no `boot_id` slot and no `reserved 6` — adding `boot_id` requires a coordinated proto edit + `lock.json` bump + `PROTO_VERSION` bump, which crosses the forever-stable wire boundary and is a separate task.

Manager ruled (in-flight): spec ch03 §3.3 wording "Hello echoes boot_id" is a drafting error. The renderer-side boot_id verification actually goes through the descriptor JSON (PR #922 / T6.7), not the Hello RPC. A spec-clarification follow-up task is queued to reconcile ch03 §3.3 wording with the actual proto + renderer implementation.

## Test plan

- [x] `cd packages/daemon && npx vitest run test/rpc/hello.spec.ts` — 10/10 pass:
  - 6 pure-decider tests (happy / older-client accepted / exact-match / too-old rejected / empty-request_id rejected / open-set client_kind tolerated).
  - 4 wire tests through the in-process `createRouterTransport` (happy + listener_id="A" / too-old + ErrorDetail roundtrip / missing request_id + ErrorDetail roundtrip / defensive Internal when peer-cred wiring is missing).
- [x] `cd packages/daemon && npx vitest run src/rpc/__tests__/router.spec.ts src/rpc/__tests__/integration.spec.ts` — 34 pass / 1 skip (T2.2 baseline preserved).
- [x] `cd packages/daemon && pnpm lint` — clean.
- [x] `cd packages/daemon && pnpm typecheck` — clean (both `tsconfig.json` and `tsconfig.test.json`).

### Local test output

```
 RUN  v4.1.5 C:/Users/jiahuigu/ccsm-worktrees/pool-7/packages/daemon

 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  15:31:57
   Duration  4.18s
```

```
 Test Files  2 passed (2)
      Tests  34 passed | 1 skipped (35)
   Duration  2.85s
```

> Note: full daemon test suite has 47 unrelated failures from `better-sqlite3` native binding mismatch (NODE_MODULE_VERSION 145 vs 137) on this Windows worktree — preexisting environmental issue not caused by this PR. RPC and auth tests all pass.

## Spec refs

- ch04 §3 — `Hello{Request,Response}` message shape
- ch02 §6 — one-directional version negotiation
- ch04 §2 — `ErrorDetail` on rejection (forever-stable)
- ch04 §3 + ch15 §3 — `client_kind` open-set tolerance (covered by decider test)

## Closes

- Task #33 (T2.3)

Builds on PR #918 (T2.2 stub router) and PR #863 (T1.6 descriptor writer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)