### PR TITLE
fix(daemon): unify ccsm.db path between T5.1 openDatabase + T5.7 recovery

### DIFF
--- a/packages/daemon/src/db/__tests__/recovery.spec.ts
+++ b/packages/daemon/src/db/__tests__/recovery.spec.ts
@@ -26,7 +26,7 @@ describe('checkAndRecover (T5.7 — ch07 §6)', () => {
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'ccsm-daemon-recovery-'));
-    dbPath = join(tmpDir, 'sessions.db');
+    dbPath = join(tmpDir, 'ccsm.db');
     crashRawPath = join(tmpDir, 'crash-raw.ndjson');
   });
 

--- a/packages/daemon/src/db/recovery.ts
+++ b/packages/daemon/src/db/recovery.ts
@@ -128,7 +128,7 @@ export function makeRecoveryFlag(): RecoveryFlag {
 
 export interface CheckAndRecoverOpts {
   /**
-   * Absolute path to the SQLite DB file (typically `statePaths().sessionsDb`).
+   * Absolute path to the SQLite DB file (typically `statePaths().db`).
    */
   readonly dbPath: string;
   /**

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -30,7 +30,7 @@
 // when they land).
 
 import { mkdirSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname } from 'node:path';
 
 import { runMigrations } from './db/migrations/runner.js';
 import { checkAndRecover, makeRecoveryFlag, type RecoveryFlag } from './db/recovery.js';
@@ -92,7 +92,7 @@ export async function runStartup(
   // pins the DB and crash-raw filenames to this module's constants.
   const sp = statePaths();
   const recovery = checkAndRecover({
-    dbPath: sp.sessionsDb,
+    dbPath: sp.db,
     crashRawPath: sp.crashRaw,
     flag: recoveryFlag,
   });
@@ -102,7 +102,7 @@ export async function runStartup(
     );
   }
 
-  const dbPath = join(env.paths.stateDir, 'ccsm.db');
+  const dbPath = sp.db;
   // Ensure parent dir exists — installer normally creates stateDir, but
   // dev/smoke runs may point CCSM_STATE_DIR at a brand-new tmp dir.
   mkdirSync(dirname(dbPath), { recursive: true });

--- a/packages/daemon/src/state-dir/__tests__/paths.spec.ts
+++ b/packages/daemon/src/state-dir/__tests__/paths.spec.ts
@@ -31,7 +31,7 @@ describe('statePaths — per-OS layout (ch07 §2)', () => {
     expect(p.root).toBe('D:\\ProgramData\\ccsm');
     expect(p.descriptor).toBe('D:\\ProgramData\\ccsm\\listener-a.json');
     expect(p.descriptorsDir).toBe('D:\\ProgramData\\ccsm\\descriptors');
-    expect(p.sessionsDb).toBe('D:\\ProgramData\\ccsm\\sessions.db');
+    expect(p.db).toBe('D:\\ProgramData\\ccsm\\ccsm.db');
     expect(p.crashRaw).toBe('D:\\ProgramData\\ccsm\\crash-raw.ndjson');
   });
 
@@ -46,7 +46,7 @@ describe('statePaths — per-OS layout (ch07 §2)', () => {
     const env = {} as NodeJS.ProcessEnv;
     const p = statePaths('win32', env);
     expect(p.root).toBe('C:\\ProgramData\\ccsm');
-    expect(p.sessionsDb).toBe('C:\\ProgramData\\ccsm\\sessions.db');
+    expect(p.db).toBe('C:\\ProgramData\\ccsm\\ccsm.db');
     expect(p.crashRaw).toBe('C:\\ProgramData\\ccsm\\crash-raw.ndjson');
   });
 
@@ -55,7 +55,7 @@ describe('statePaths — per-OS layout (ch07 §2)', () => {
     expect(p.root).toBe('/Library/Application Support/ccsm');
     expect(p.descriptor).toBe('/Library/Application Support/ccsm/listener-a.json');
     expect(p.descriptorsDir).toBe('/Library/Application Support/ccsm/descriptors');
-    expect(p.sessionsDb).toBe('/Library/Application Support/ccsm/sessions.db');
+    expect(p.db).toBe('/Library/Application Support/ccsm/ccsm.db');
     expect(p.crashRaw).toBe('/Library/Application Support/ccsm/crash-raw.ndjson');
   });
 
@@ -65,7 +65,7 @@ describe('statePaths — per-OS layout (ch07 §2)', () => {
     expect(p.root).toBe('/var/lib/ccsm');
     expect(p.descriptor).toBe('/var/lib/ccsm/listener-a.json');
     expect(p.descriptorsDir).toBe('/var/lib/ccsm/descriptors');
-    expect(p.sessionsDb).toBe('/var/lib/ccsm/sessions.db');
+    expect(p.db).toBe('/var/lib/ccsm/ccsm.db');
     expect(p.crashRaw).toBe('/var/lib/ccsm/crash-raw.ndjson');
   });
 

--- a/packages/daemon/src/state-dir/paths.ts
+++ b/packages/daemon/src/state-dir/paths.ts
@@ -45,7 +45,7 @@ export interface StatePaths {
    */
   readonly descriptorsDir: string;
   /** SQLite database file (ch07 §2 — DB path column / §3 schema). */
-  readonly sessionsDb: string;
+  readonly db: string;
   /** Crash collector raw NDJSON file (ch07 §2 / ch09). */
   readonly crashRaw: string;
 }
@@ -81,7 +81,7 @@ export function statePaths(
     root,
     descriptor: join(root, 'listener-a.json'),
     descriptorsDir: join(root, 'descriptors'),
-    sessionsDb: join(root, 'sessions.db'),
+    db: join(root, 'ccsm.db'),
     crashRaw: join(root, 'crash-raw.ndjson'),
   });
 }
@@ -113,7 +113,7 @@ function stateRoot(platform: StateDirPlatform, env: NodeJS.ProcessEnv): string {
  * per ch10 §5 / ch07 §2). We still pass it for consistency.
  *
  * Returns the resolved StatePaths so callers can chain
- * `const paths = await ensureStateDir(); openDb(paths.sessionsDb);`.
+ * `const paths = await ensureStateDir(); openDb(paths.db);`.
  */
 export async function ensureStateDir(
   platform: StateDirPlatform = process.platform,

--- a/packages/daemon/src/supervisor/__tests__/server.spec.ts
+++ b/packages/daemon/src/supervisor/__tests__/server.spec.ts
@@ -356,7 +356,7 @@ describe('SupervisorServer — UDS / named-pipe bind + endpoints', () => {
   describe('GET /healthz — recovery_modal (ch07 §6)', () => {
     it('reflects pending=true after the recovery flag is set', async () => {
       const flag = makeRecoveryFlag();
-      flag.set(1700000099000, '/var/lib/ccsm/sessions.db.corrupt-1700000099000');
+      flag.set(1700000099000, '/var/lib/ccsm/ccsm.db.corrupt-1700000099000');
       server = build({ recoveryFlag: flag });
       await server.start();
 
@@ -365,7 +365,7 @@ describe('SupervisorServer — UDS / named-pipe bind + endpoints', () => {
       expect(body.recovery_modal).toEqual({
         pending: true,
         ts_ms: 1700000099000,
-        corrupt_path: '/var/lib/ccsm/sessions.db.corrupt-1700000099000',
+        corrupt_path: '/var/lib/ccsm/ccsm.db.corrupt-1700000099000',
       });
     });
 
@@ -389,7 +389,7 @@ describe('SupervisorServer — UDS / named-pipe bind + endpoints', () => {
       mockUid = 999;
       mockSid = SID_LOCAL_SERVICE;
       const flag = makeRecoveryFlag();
-      flag.set(1700000000000, '/var/lib/ccsm/sessions.db.corrupt-1700000000000');
+      flag.set(1700000000000, '/var/lib/ccsm/ccsm.db.corrupt-1700000000000');
       server = build({ recoveryFlag: flag });
       await server.start();
 
@@ -417,7 +417,7 @@ describe('SupervisorServer — UDS / named-pipe bind + endpoints', () => {
       mockUid = 1000; // not in {0, 999}
       mockSid = 'S-1-5-21-9-9-9-1001';
       const flag = makeRecoveryFlag();
-      flag.set(1700000000000, '/var/lib/ccsm/sessions.db.corrupt-1700000000000');
+      flag.set(1700000000000, '/var/lib/ccsm/ccsm.db.corrupt-1700000000000');
       server = build({ recoveryFlag: flag });
       await server.start();
 

--- a/packages/daemon/test/crash/crash-raw-recovery.spec.ts
+++ b/packages/daemon/test/crash/crash-raw-recovery.spec.ts
@@ -61,7 +61,7 @@ interface Fixture {
 function setup(): Fixture {
   const dir = mkdtempSync(path.join(tmpdir(), 'ccsm-crashraw-'));
   const ndjsonPath = path.join(dir, 'crash-raw.ndjson');
-  const dbPath = path.join(dir, 'sessions.db');
+  const dbPath = path.join(dir, 'ccsm.db');
   const db = openDatabase(dbPath);
   db.exec(CRASH_LOG_DDL);
   return { dir, ndjsonPath, dbPath, db };

--- a/packages/daemon/test/state-dir/paths.spec.ts
+++ b/packages/daemon/test/state-dir/paths.spec.ts
@@ -42,7 +42,7 @@ import { STATE_DIR_MODE, statePaths } from '../../src/state-dir/paths.js';
 //
 // These are the EXACT bytes daemon callers receive from `statePaths()` for
 // the corresponding `process.platform` value. If a future change alters any
-// path (e.g. moves descriptor under a subdir, renames `sessions.db`, switches
+// path (e.g. moves descriptor under a subdir, renames `ccsm.db`, switches
 // linux root off /var/lib/ccsm), this test fails — that is the contract.
 //
 // Note on win32: %PROGRAMDATA% is the OS-defined location of the per-machine
@@ -59,7 +59,7 @@ const LOCKED = {
       root: 'C:\\ProgramData\\ccsm',
       descriptor: 'C:\\ProgramData\\ccsm\\listener-a.json',
       descriptorsDir: 'C:\\ProgramData\\ccsm\\descriptors',
-      sessionsDb: 'C:\\ProgramData\\ccsm\\sessions.db',
+      db: 'C:\\ProgramData\\ccsm\\ccsm.db',
       crashRaw: 'C:\\ProgramData\\ccsm\\crash-raw.ndjson',
     },
   },
@@ -69,7 +69,7 @@ const LOCKED = {
       root: 'D:\\ProgramData\\ccsm',
       descriptor: 'D:\\ProgramData\\ccsm\\listener-a.json',
       descriptorsDir: 'D:\\ProgramData\\ccsm\\descriptors',
-      sessionsDb: 'D:\\ProgramData\\ccsm\\sessions.db',
+      db: 'D:\\ProgramData\\ccsm\\ccsm.db',
       crashRaw: 'D:\\ProgramData\\ccsm\\crash-raw.ndjson',
     },
   },
@@ -79,7 +79,7 @@ const LOCKED = {
       root: 'C:\\ProgramData\\ccsm',
       descriptor: 'C:\\ProgramData\\ccsm\\listener-a.json',
       descriptorsDir: 'C:\\ProgramData\\ccsm\\descriptors',
-      sessionsDb: 'C:\\ProgramData\\ccsm\\sessions.db',
+      db: 'C:\\ProgramData\\ccsm\\ccsm.db',
       crashRaw: 'C:\\ProgramData\\ccsm\\crash-raw.ndjson',
     },
   },
@@ -89,7 +89,7 @@ const LOCKED = {
       root: '/Library/Application Support/ccsm',
       descriptor: '/Library/Application Support/ccsm/listener-a.json',
       descriptorsDir: '/Library/Application Support/ccsm/descriptors',
-      sessionsDb: '/Library/Application Support/ccsm/sessions.db',
+      db: '/Library/Application Support/ccsm/ccsm.db',
       crashRaw: '/Library/Application Support/ccsm/crash-raw.ndjson',
     },
   },
@@ -99,7 +99,7 @@ const LOCKED = {
       root: '/var/lib/ccsm',
       descriptor: '/var/lib/ccsm/listener-a.json',
       descriptorsDir: '/var/lib/ccsm/descriptors',
-      sessionsDb: '/var/lib/ccsm/sessions.db',
+      db: '/var/lib/ccsm/ccsm.db',
       crashRaw: '/var/lib/ccsm/crash-raw.ndjson',
     },
   },


### PR DESCRIPTION
## Summary

Resolves spec inconsistency surfaced during PR #923 rebase. Two pieces of the daemon referred to the same logical SQLite file by different paths:

- **T5.7 corruption recovery** (`src/db/recovery.ts`, merged in #923): `checkAndRecover()` reads `statePaths().sessionsDb`, which resolved to `<root>/sessions.db`.
- **T5.1 better-sqlite3 wrapper** (`src/db/sqlite.ts` via `src/index.ts`, merged in #864): opened `<env.paths.stateDir>/ccsm.db`.

Result: recovery never inspected the file the daemon actually opened.

## Decision: option (a) — rename to `ccsm.db`

Spec ch07 §2 (state directory layout per OS) explicitly names the file `ccsm.db` on all three OS rows ("`state\ccsm.db`" / "`state/ccsm.db`"). The recovery module's own header comment (`recovery.ts:9`) also says `state/ccsm.db`. So `statePaths()` was the wrong producer.

Changes:
- `StatePaths.sessionsDb` → `StatePaths.db`
- resolved filename `sessions.db` → `ccsm.db`
- `src/index.ts`: pass `sp.db` to both `checkAndRecover()` and `openDatabase()` (was: hardcoded `join(env.paths.stateDir, 'ccsm.db')` for the second). Both call sites now flow through one accessor — they cannot diverge again.
- Tests updated to match.

Pre-release internal path; no migration needed (no users yet) per task brief.

## Out of scope (flagged for follow-up)

While investigating I noticed that `env.defaultStateDir()` adds a `/state` subdir on win32/darwin (`%PROGRAMDATA%/ccsm/state`) but NOT on linux (`/var/lib/ccsm`), while `statePaths().root` never adds `/state` on any OS. Spec ch07 §2 shows DB path as `state/ccsm.db` relative to root, so both layers may be off-by-one wrt the spec. That's a separate spec-conformance bug — this PR only fixes the T5.1 ↔ T5.7 mismatch by routing both through `statePaths().db`. File a follow-up if needed.

## Test plan

- [x] `pnpm typecheck` — no new errors (the existing `src/index.ts(234) push() on readonly` error is pre-existing on `working`, unrelated)
- [x] `pnpm lint` — no new errors (same pre-existing error)
- [x] Targeted suites green: `npx vitest run test/state-dir/ test/crash/ src/db/__tests__/ src/state-dir/__tests__/ src/supervisor/__tests__/server.spec.ts` → 115 passed, 3 skipped
- [x] Full daemon suite: 470 passed, 21 skipped, 5 todo. One failure (`test/descriptor/schema.spec.ts` golden bytes) reproduces on clean `working` HEAD — pre-existing Windows CRLF issue, unrelated.
- [x] Recovery + openDatabase verified to operate on the same path (single accessor `sp.db`).

Closes #182.

🤖 Generated with [Claude Code](https://claude.com/claude-code)