### PR TITLE
fix(daemon): T5.5 replace BetterQueue with hand-rolled setTimeout batcher (spec ch07 §5 16ms tick)

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@bufbuild/protobuf": "^2.12.0",
     "@connectrpc/connect": "^2.1.1",
-    "better-queue": "^3.8.12",
     "better-sqlite3": "^12.9.0"
   },
   "devDependencies": {
@@ -23,7 +22,6 @@
     "@ccsm/proto": "workspace:*",
     "@connectrpc/connect": "^2.1.1",
     "@connectrpc/connect-node": "^2.1.1",
-    "@types/better-queue": "^3.8.6",
     "@types/better-sqlite3": "^7.6.12",
     "ajv": "^8.20.0"
   }

--- a/packages/daemon/src/sqlite/coalescer.ts
+++ b/packages/daemon/src/sqlite/coalescer.ts
@@ -7,10 +7,22 @@
 // Topology (FOREVER-STABLE per spec):
 //   - One pty-host child process per session `postMessage`s deltas to the
 //     daemon main thread (this module is the receiving end).
-//   - Per-session `BetterQueue` instance batches enqueued deltas with a
-//     16 ms tick (`batchDelay = batchDelayTimeout = 16`). All deltas that
-//     arrive inside the window are flushed as one prepared-statement loop
+//   - Per-session hand-rolled `setTimeout(tickMs)` batcher accumulates
+//     enqueued deltas inside a 16 ms window. All deltas that arrive
+//     inside the window are flushed as one prepared-statement loop
 //     wrapped in a single SQLite IMMEDIATE transaction.
+//
+//     Why hand-rolled (replaces `better-queue` per Task #184): on Windows
+//     `better-queue` schedules its worker via a cascade
+//     `push → setTimeout(0) → setTimeout(batchDelay) → setImmediate` that
+//     adds 24-31 ms minimum on top of the configured batch delay (15.625 ms
+//     timer granularity). Under CI load on `windows-latest` this exceeds
+//     the test margin (`coalescer.spec.ts` 56 ms slack). Spec ch07 §5
+//     mandates an exact 16 ms tick + IMMEDIATE txn — the simplest scheduler
+//     that honors that on every platform is one `setTimeout(tickMs)` per
+//     session. The FOREVER-STABLE invariants ((a) 16 ms tick, (b) batched
+//     IMMEDIATE txn per session, (c) 8 MiB per-session cap, (d) 3-strike
+//     DEGRADED) are preserved; only the scheduler implementation changed.
 //   - Per-session pending-byte cap of 8 MiB. On overflow the enqueue call
 //     throws a Connect `ResourceExhausted` error so the caller (the
 //     pty-host bridge) can drop the snapshot/delta and write a
@@ -40,7 +52,6 @@
 import { EventEmitter } from 'node:events';
 
 import { Code, ConnectError } from '@connectrpc/connect';
-import BetterQueue from 'better-queue';
 
 import type { SqliteDatabase } from '../db/sqlite.js';
 
@@ -113,10 +124,20 @@ export type SessionHealth = 'healthy' | 'degraded';
 // ---------------------------------------------------------------------------
 
 interface SessionState {
-  /** BetterQueue handle that batches deltas with a 16 ms window. */
-  readonly queue: BetterQueue<DeltaWrite, void>;
+  /** In-memory queue of pending writes awaiting the next tick flush. */
+  pendingWrites: DeltaWrite[];
   /** Pending bytes already accepted into the queue (for the 8 MiB cap). */
   pendingBytes: number;
+  /** Active flush-tick timer; null when no tick is scheduled. */
+  flushTimer: ReturnType<typeof setTimeout> | null;
+  /** True while `flushBatch` is on the stack — gate against re-entry. */
+  flushing: boolean;
+  /**
+   * Resolvers waiting for the in-flight (or scheduled) flush to complete.
+   * Used by `destroy()` to await graceful drain. Cleared after each
+   * successful flush; `enqueueDelta` re-arms a new wait if needed.
+   */
+  drainWaiters: Array<() => void>;
   /** Consecutive disk-class failures for this session. */
   consecutiveFailures: number;
   /** Current health state — flipped on the 3rd consecutive failure. */
@@ -209,7 +230,7 @@ export class WriteCoalescer extends EventEmitter {
 
   /**
    * Enqueue a delta for batched write. Returns synchronously after the
-   * payload is accepted into the per-session BetterQueue; the actual
+   * payload is accepted into the per-session pending queue; the actual
    * SQLite write happens on the next 16 ms tick.
    *
    * Throws `ConnectError(RESOURCE_EXHAUSTED)` if the session's pending
@@ -229,7 +250,8 @@ export class WriteCoalescer extends EventEmitter {
       );
     }
     state.pendingBytes += size;
-    state.queue.push(write);
+    state.pendingWrites.push(write);
+    this.armFlushTimer(write.sessionId, state);
   }
 
   /**
@@ -291,12 +313,8 @@ export class WriteCoalescer extends EventEmitter {
     if (this.destroyed) return;
     this.destroyed = true;
     const drains: Promise<void>[] = [];
-    for (const state of this.sessions.values()) {
-      drains.push(
-        new Promise<void>((resolve) => {
-          state.queue.destroy(() => resolve());
-        }),
-      );
+    for (const [sessionId, state] of this.sessions) {
+      drains.push(this.drainSession(sessionId, state));
     }
     await Promise.all(drains);
     this.sessions.clear();
@@ -315,43 +333,12 @@ export class WriteCoalescer extends EventEmitter {
   private getOrCreateSession(sessionId: string): SessionState {
     let state = this.sessions.get(sessionId);
     if (state) return state;
-    const queue = new BetterQueue<DeltaWrite, void>(
-      (batch: DeltaWrite | DeltaWrite[], cb) => {
-        // BetterQueue's batching mode passes an array; non-batching mode
-        // would pass a single task. We always run in batching mode (size
-        // > 1) but normalize defensively.
-        const items = Array.isArray(batch) ? batch : [batch];
-        try {
-          this.flushBatch(sessionId, items);
-          cb(null);
-        } catch (err) {
-          cb(err);
-        }
-      },
-      {
-        // batchSize must be > 1 to enable batching mode. Set high enough
-        // that any realistic 16 ms window's worth of deltas batches into
-        // one transaction (chapter 06 §3: 16 KiB / 16 ms cap per delta;
-        // 8 MiB cap / smallest-realistic-delta is the upper bound on
-        // batch length but values >> than the cap-divided count never
-        // hurt — BetterQueue just flushes whatever's pending when the
-        // delay expires).
-        batchSize: 1_000_000,
-        // Both delays set to TICK_MS so the batch flushes on the tick
-        // regardless of whether more tasks arrive (`batchDelay`) or
-        // tasks stop arriving early (`batchDelayTimeout`).
-        batchDelay: this.tickMs,
-        batchDelayTimeout: this.tickMs,
-        // One worker — only the daemon main thread writes SQLite.
-        concurrent: 1,
-        // Surface processor exceptions as task failures (default false
-        // would swallow them).
-        failTaskOnProcessException: true,
-      },
-    );
     state = {
-      queue,
+      pendingWrites: [],
       pendingBytes: 0,
+      flushTimer: null,
+      flushing: false,
+      drainWaiters: [],
       consecutiveFailures: 0,
       health: 'healthy',
     };
@@ -359,10 +346,104 @@ export class WriteCoalescer extends EventEmitter {
     return state;
   }
 
-  private flushBatch(sessionId: string, batch: readonly DeltaWrite[]): void {
+  /**
+   * Arm a `setTimeout(tickMs)` for the session if one isn't already
+   * armed and a flush isn't currently in flight. The timer fires
+   * `runFlush` which drains every pending write into a single
+   * IMMEDIATE transaction (ch07 §5).
+   *
+   * No-op if a timer is already pending or `flushing` is true — in the
+   * latter case `runFlush` will reschedule itself if more writes
+   * arrived during the flush.
+   */
+  private armFlushTimer(sessionId: string, state: SessionState): void {
+    if (state.flushTimer !== null || state.flushing) return;
+    state.flushTimer = setTimeout(() => {
+      this.runFlush(sessionId, state);
+    }, this.tickMs);
+    // Do NOT call `.unref()` — graceful shutdown sequencing (T5.6) is
+    // responsible for keeping the daemon alive until destroy() drains.
+  }
+
+  /**
+   * Drain `state.pendingWrites` into one IMMEDIATE transaction. Called
+   * by the tick timer; safe re-entry is gated by `state.flushing`.
+   *
+   * Steps (per Task #184 design):
+   *  1. Clear `flushTimer`.
+   *  2. Capture pending into a local batch and zero the queue.
+   *  3. Run the transaction; on success/failure, decrement
+   *     `pendingBytes` by the captured total (drop semantics — spec
+   *     ch07 §5 does not retry).
+   *  4. Resolve any drain waiters.
+   *  5. If new writes arrived while the txn ran, re-arm a fresh tick.
+   */
+  private runFlush(sessionId: string, state: SessionState): void {
+    state.flushTimer = null;
+    if (state.pendingWrites.length === 0) {
+      this.resolveDrainWaiters(state);
+      return;
+    }
+    const batch = state.pendingWrites;
+    state.pendingWrites = [];
+    state.flushing = true;
+    try {
+      this.flushBatch(sessionId, state, batch);
+    } finally {
+      state.flushing = false;
+      this.resolveDrainWaiters(state);
+      // New writes that landed during the flush need their own tick.
+      if (state.pendingWrites.length > 0) {
+        this.armFlushTimer(sessionId, state);
+      }
+    }
+  }
+
+  private resolveDrainWaiters(state: SessionState): void {
+    if (state.drainWaiters.length === 0) return;
+    if (state.pendingWrites.length > 0 || state.flushing) return;
+    const waiters = state.drainWaiters;
+    state.drainWaiters = [];
+    for (const r of waiters) r();
+  }
+
+  /**
+   * Drive a session to fully drained state. If a tick is pending, fire
+   * it synchronously; if a flush is in-flight, wait for it. Iterates
+   * until no pending writes remain.
+   */
+  private drainSession(sessionId: string, state: SessionState): Promise<void> {
+    return new Promise<void>((resolve) => {
+      const tryDrain = (): void => {
+        if (state.pendingWrites.length === 0 && !state.flushing) {
+          if (state.flushTimer !== null) {
+            clearTimeout(state.flushTimer);
+            state.flushTimer = null;
+          }
+          resolve();
+          return;
+        }
+        // Either a flush is in flight or a tick is scheduled. Register
+        // a waiter; runFlush() will resolve us, then we re-check.
+        state.drainWaiters.push(() => tryDrain());
+        // If nothing is in flight and the timer hasn't fired yet, run
+        // the flush synchronously now to skip the remaining wait.
+        if (!state.flushing && state.flushTimer !== null) {
+          clearTimeout(state.flushTimer);
+          state.flushTimer = null;
+          this.runFlush(sessionId, state);
+        }
+      };
+      tryDrain();
+    });
+  }
+
+  private flushBatch(
+    sessionId: string,
+    state: SessionState,
+    batch: readonly DeltaWrite[],
+  ): void {
     if (batch.length === 0) return;
-    const state = this.sessions.get(sessionId);
-    if (!state) return; // session was destroyed mid-flight; drop silently
 
     let totalBytes = 0;
     for (const d of batch) totalBytes += d.payload.byteLength;
@@ -383,13 +464,11 @@ export class WriteCoalescer extends EventEmitter {
       this.emit('write-failed', sessionId, 'pty_delta', error);
       if (isDiskClassError(error)) {
         this.recordFailure(state, sessionId, error);
-      } else {
-        // Non-disk errors are programmer bugs (e.g. PK collision). Still
-        // drop the batch — the daemon does not retry, the spec is
-        // explicit — but propagate via `write-failed` so tests notice.
-        // Do NOT throw further: BetterQueue's failTaskOnProcessException
-        // would route into task_failed which we've not subscribed to.
       }
+      // Non-disk errors (programmer bugs, e.g. PK collision) still drop
+      // the batch — the daemon does not retry and the spec is explicit.
+      // We surface them via `write-failed` (above) and swallow rather
+      // than rethrow: the tick callback has no caller to propagate to.
     } finally {
       // The bytes are out of the queue regardless of outcome — the spec
       // drops the batch on disk-class failure rather than retrying.

--- a/packages/daemon/test/sqlite/coalescer.spec.ts
+++ b/packages/daemon/test/sqlite/coalescer.spec.ts
@@ -80,7 +80,7 @@ function makeSnapshot(sessionId: string, baseSeq: number, bytes: number): Snapsh
   };
 }
 
-/** Wait for the BetterQueue tick + an extra micro-margin. */
+/** Wait for the coalescer's tick + an extra micro-margin. */
 async function tick(extraMs = 40): Promise<void> {
   await new Promise((r) => setTimeout(r, TICK_MS + extraMs));
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,9 +237,6 @@ importers:
       '@connectrpc/connect':
         specifier: ^2.1.1
         version: 2.1.1(@bufbuild/protobuf@2.12.0)
-      better-queue:
-        specifier: ^3.8.12
-        version: 3.8.12
       better-sqlite3:
         specifier: ^12.9.0
         version: 12.9.0
@@ -250,9 +247,6 @@ importers:
       '@connectrpc/connect-node':
         specifier: ^2.1.1
         version: 2.1.1(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.12.0))
-      '@types/better-queue':
-        specifier: ^3.8.6
-        version: 3.8.6
       '@types/better-sqlite3':
         specifier: ^7.6.12
         version: 7.6.13
@@ -1978,9 +1972,6 @@ packages:
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
-  '@types/better-queue@3.8.6':
-    resolution: {integrity: sha512-iC8L2LmVwgA0lcfrw9bLt0qQ8BVs2HOK/c2vtUnqQvoltMGn1GQ4OQChZFLRSx9AXgtdF6FDVsGDqyaV/urChw==}
-
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
@@ -2565,12 +2556,6 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
-
-  better-queue-memory@1.0.4:
-    resolution: {integrity: sha512-SWg5wFIShYffEmJpI6LgbL8/3Dqhku7xI1oEiy6FroP9DbcZlG0ZDjxvPdP9t7hTGW40IpIcC6zVoGT1oxjOuA==}
-
-  better-queue@3.8.12:
-    resolution: {integrity: sha512-D9KZ+Us+2AyaCz693/9AyjTg0s8hEmkiM/MB3i09cs4MdK1KgTSGJluXRYmOulR69oLZVo2XDFtqsExDt8oiLA==}
 
   better-sqlite3@12.9.0:
     resolution: {integrity: sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==}
@@ -4433,9 +4418,6 @@ packages:
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
-  node-eta@0.9.0:
-    resolution: {integrity: sha512-mTCTZk29tmX1OGfVkPt63H3c3VqXrI2Kvua98S7iUIB/Gbp0MNw05YtUomxQIxnnKMyRIIuY9izPcFixzhSBrA==}
-
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
@@ -5618,11 +5600,6 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
-    hasBin: true
-
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
@@ -7805,10 +7782,6 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
-  '@types/better-queue@3.8.6':
-    dependencies:
-      '@types/node': 22.19.17
-
   '@types/better-sqlite3@7.6.13':
     dependencies:
       '@types/node': 22.19.17
@@ -8530,14 +8503,6 @@ snapshots:
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
-
-  better-queue-memory@1.0.4: {}
-
-  better-queue@3.8.12:
-    dependencies:
-      better-queue-memory: 1.0.4
-      node-eta: 0.9.0
-      uuid: 9.0.1
 
   better-sqlite3@12.9.0:
     dependencies:
@@ -10604,8 +10569,6 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  node-eta@0.9.0: {}
-
   node-exports-info@1.6.0:
     dependencies:
       array.prototype.flatmap: 1.3.3
@@ -11911,8 +11874,6 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@8.3.2: {}
-
-  uuid@9.0.1: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
## Summary

- Replaces `better-queue` in `packages/daemon/src/sqlite/coalescer.ts` with a hand-rolled `setTimeout(tickMs)` batcher (one timer per session that drains `pendingWrites` into a single IMMEDIATE transaction; re-arms a fresh tick if writes arrive during the flush).
- Removes `better-queue` and `@types/better-queue` from `packages/daemon/package.json` (sole consumer; verified via grep across `packages/`).
- Fixes Windows-only flake at `coalescer.spec.ts:253` ("frees pending bytes after a successful flush") root-caused in #179: BetterQueue's `setTimeout(0) → setTimeout(16) → setImmediate` cascade exceeds the test's 56 ms margin (16 ms TICK_MS + 40 ms slack) under CI contention on `windows-latest` (15.625 ms timer granularity).
- Spec ch07 §5 mandates exact 16 ms tick + IMMEDIATE txn — BetterQueue's scheduling guarantees do not match this on Windows. The spec's wording in line 1986 ("BetterQueue keyed by session") is implementation-suggestive, not normative; the FOREVER-STABLE invariants are the tick/txn/cap/DEGRADED behavior, all preserved.

## FOREVER-STABLE invariants preserved (per ch07 §5)

- 16 ms tick (configurable via `tickMs` constructor option)
- Batched IMMEDIATE txn per session via `db.transaction(...).immediate(batch)`
- 8 MiB per-session cap → throws `ConnectError(ResourceExhausted)` on overflow
- 3-strike DEGRADED with `session-degraded` / `session-recovered` events
- Snapshot writes still synchronous out-of-band
- `destroy()` drains pending writes; awaits in-flight flushes via `drainWaiters` list, then clears timers

## Test plan

- [x] `pnpm typecheck` — only pre-existing failures (src/index.ts:234 listener-tuple `.push`); no new errors from this change
- [x] `pnpm lint` — only pre-existing failure (same src/index.ts:234)
- [x] `npx vitest run test/sqlite/coalescer.spec.ts` — **30 / 30 PASS**
- [x] `npx vitest run` (full daemon suite) — coalescer 13/13 pass; only failing test is pre-existing `descriptor/schema.spec.ts` CRLF/LF golden mismatch (unrelated)

## Reverse-verify

Per dev.md §2 phase-4. Local environment: Windows 11, Node v24.14.1.

**Pre-fix isolated** (`vitest run test/sqlite/coalescer.spec.ts`, 30 runs):
```
30 passed, 0 failed
```
The flake does NOT reproduce on local Windows in isolation — consistent with #179 diagnosis (CI-machine contention dependent; local Windows lacks the contention level of `windows-latest` runners).

**Pre-fix under full-suite contention** (`vitest run` from packages/daemon, 1 sample run):
```
Tests  1 failed | 490 passed | 21 skipped | 5 todo (517)
FAIL  test/descriptor/schema.spec.ts  (unrelated; CRLF/LF golden mismatch)
test/sqlite/coalescer.spec.ts: 13/13 PASS
```
coalescer.spec.ts also passes locally pre-fix under contention — the flake is specific to `windows-latest` GitHub runners (heavier contention than developer laptops).

**Post-fix isolated** (30 runs):
```
30 passed, 0 failed
```

**Post-fix under full-suite contention** (10 runs):
```
Run 1:  Tests  1 failed | 510 passed  (descriptor/schema only)
Run 2:  Tests  1 failed | 510 passed  (descriptor/schema only)
Run 3:  Tests  1 failed | 510 passed  (descriptor/schema only)
Run 4:  Tests  1 failed | 510 passed  (descriptor/schema only)
Run 5:  Tests  1 failed | 510 passed  (descriptor/schema only)
Run 6:  Tests  1 failed | 510 passed  (descriptor/schema only)
Run 7:  Tests  2 failed | 509 passed  (descriptor/schema + 1 transient unrelated)
Run 8:  Tests  2 failed | 509 passed  (descriptor/schema + 1 transient unrelated)
Run 9:  Tests  1 failed | 510 passed  (descriptor/schema only)
Run 10: Tests  1 failed | 510 passed  (descriptor/schema only)
coalescer.spec.ts: 10/10 PASS in all 10 runs
```

True validation of the Windows CI flake will come from `windows-latest` matrix in PR #906.

## Implementation notes

Hand-rolled batcher per Task #184 design:

`enqueueDelta(write)`:
1. Cap check: if `pendingBytes + size > queueCapBytes` → throw `ConnectError(ResourceExhausted)`
2. `pendingBytes += size`; `pendingWrites.push(write)`
3. `armFlushTimer()`: if no timer pending and not flushing, `setTimeout(runFlush, tickMs)`

`runFlush()`:
1. Clear `flushTimer`
2. Capture `pendingWrites` into `batch`, zero the queue
3. Set `flushing = true`
4. Run `db.transaction(insertLoop).immediate(batch)`; on success → `recordSuccess`; on disk-class err → `recordFailure`
5. `finally`: `pendingBytes -= totalBytes`; `flushing = false`; resolve drain waiters; if new writes arrived during the txn, re-arm a fresh tick

`destroy()`:
1. Mark destroyed
2. For each session: if pending or in-flight, force-fire any pending timer synchronously and await drain via `drainWaiters` list
3. Clear `sessions` map

Closes #184. Unblocks #906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)