### PR TITLE
daemon(T3.2): SessionManager + in-memory event bus (Create/Get/List/Destroy)

### DIFF
--- a/packages/daemon/src/sessions/SessionManager.ts
+++ b/packages/daemon/src/sessions/SessionManager.ts
@@ -1,0 +1,363 @@
+// SessionManager — daemon-side owner of session lifecycle.
+//
+// Spec refs:
+//   - docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//     ch05 §5 (per-RPC enforcement matrix)
+//     ch05 §6 (session create flow)
+//     ch07 §3 (sessions table schema)
+//
+// T3.2 scope:
+//   - In-process owner of CRUD over the `sessions` table.
+//   - Owns the in-memory event bus subscription surface (see event-bus.ts).
+//   - Pure backend: NO RPC plumbing, NO IPC, NO PTY spawn. The
+//     SessionService Connect handler (T3.3 / T3.4) wraps this manager and
+//     maps proto messages -> manager calls -> proto responses.
+//   - PTY spawn / xterm-headless host wiring lands in T4.x and will hook
+//     into the manager via a separate `attachPtyHost(...)` entry point;
+//     v0.3 ship-level wiring lands in a follow-up task.
+//
+// SRP discipline (dev.md §3):
+//   - producer (`buildSessionRow`): pure function, builds a `SessionRow`
+//     from the request input + principal + clock + id generator. No DB,
+//     no event bus.
+//   - decider (`assertOwnership`, in-flight): pure ownership check that
+//     throws the canonical `session.not_owned` ConnectError; reused by
+//     `get` and `destroy`.
+//   - sink (`SessionManager` class): owns the SQLite handle and the
+//     event bus, calls into the producer + decider, and is the only
+//     place in the file with side effects.
+//
+// Layer 1 — alternatives checked:
+//   - Reuse `node:events.EventEmitter`: rejected, see event-bus.ts.
+//   - Reuse a `kysely` / `drizzle` query builder: rejected — the spec
+//     ch07 §1 mandates better-sqlite3 sync driver and the existing
+//     daemon code uses raw prepared statements. Adding a query builder
+//     would diverge from the existing pattern (see crash/raw-appender,
+//     db/recovery) and cost a transitive dep.
+//   - Add the `ulid` npm package: rejected per spec ch09 §1 footnote
+//     ("we do NOT add a `ulid` npm dep") and existing daemon practice
+//     in `crash/sources.ts:newCrashId`. We synthesize a 26-char,
+//     Crockford-base32, lexicographically-sortable id locally — the
+//     same property a real ULID provides for index locality on the
+//     `sessions(id)` PRIMARY KEY.
+
+import { randomBytes } from 'node:crypto';
+
+import type { Principal } from '../auth/principal.js';
+import { principalKey } from '../auth/principal.js';
+import type { SqliteDatabase } from '../db/sqlite.js';
+import { throwError } from '../rpc/errors.js';
+
+import { SessionEventBus, type SessionEventListener, type Unsubscribe } from './event-bus.js';
+import {
+  SessionState,
+  type CreateSessionInput,
+  type SessionRow,
+  type SessionStateValue,
+} from './types.js';
+
+// ---------------------------------------------------------------------------
+// ULID-shaped id generator (local; no `ulid` dep — see Layer 1 note above).
+//
+// Format: 10 chars Crockford-base32 of 48-bit unix-ms time + 16 chars
+// Crockford-base32 of 80 bits randomness = 26 chars total. Same shape and
+// lexicographic property as a real ULID per ulid spec
+// (https://github.com/ulid/spec). The randomness comes from
+// `crypto.randomBytes(10)` (CSPRNG).
+//
+// Monotonicity within the same ms is NOT guaranteed (a real ulid library
+// would seed the random part and bump on collision). The spec does not
+// require monotonicity for `sessions.id` (chapter 07 §3 just says
+// "lexicographically time-ordered, 26 chars"); 80 bits of CSPRNG makes the
+// in-millisecond collision probability negligible for the daemon's
+// single-process write rate.
+// ---------------------------------------------------------------------------
+
+const CROCKFORD_BASE32 = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+
+function encodeBase32(bytes: Uint8Array, length: number): string {
+  // Encode `bytes` (MSB-first) into `length` Crockford-base32 chars by
+  // pulling 5-bit groups from the high end. We build the string from the
+  // tail forward so we can divide-by-32 from a bigint without copying.
+  let value = 0n;
+  for (const b of bytes) value = (value << 8n) | BigInt(b);
+  let out = '';
+  for (let i = 0; i < length; i++) {
+    out = CROCKFORD_BASE32[Number(value & 0x1fn)] + out;
+    value >>= 5n;
+  }
+  return out;
+}
+
+function encodeTime(ms: number): string {
+  // 48-bit time -> 10 base32 chars. Throw on negative or out-of-range so a
+  // misconfigured clock surfaces immediately rather than producing an id
+  // with bogus prefix that mis-sorts later.
+  if (!Number.isInteger(ms) || ms < 0 || ms > 0xffff_ffff_ffff) {
+    throw new RangeError(`session id timestamp out of 48-bit range: ${ms}`);
+  }
+  const bytes = new Uint8Array(6);
+  let v = ms;
+  for (let i = 5; i >= 0; i--) {
+    bytes[i] = v & 0xff;
+    v = Math.floor(v / 256);
+  }
+  return encodeBase32(bytes, 10);
+}
+
+/**
+ * Default id generator — exported so tests / fixtures can swap it for a
+ * deterministic stub via `SessionManagerOptions.newId`.
+ */
+export function newSessionId(now: () => number = Date.now): string {
+  const tsPart = encodeTime(now());
+  const randPart = encodeBase32(randomBytes(10), 16);
+  return tsPart + randPart;
+}
+
+// ---------------------------------------------------------------------------
+// Producer — pure construction of a SessionRow from inputs.
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a `SessionRow` for INSERT. Pure — no DB, no event-bus side
+ * effects. Exported so unit tests can pin the row shape independently of
+ * the SessionManager's persistence layer.
+ *
+ * Defaults per spec ch05 §6 + ch07 §3:
+ *   - state              = STARTING  (transitioned to RUNNING by T4.x once
+ *                                     PTY is wired; v0.3 SessionManager only
+ *                                     ships the create-time STARTING row)
+ *   - exit_code          = -1        (sentinel from 001_initial.sql)
+ *   - should_be_running  = 1         (Destroy flips to 0 — ch07 §3 comment)
+ *   - created_ms         = now
+ *   - last_active_ms     = now
+ */
+export function buildSessionRow(
+  input: CreateSessionInput,
+  principal: Principal,
+  id: string,
+  now: number,
+): SessionRow {
+  return {
+    id,
+    owner_id: principalKey(principal),
+    state: SessionState.STARTING,
+    cwd: input.cwd,
+    env_json: input.env_json,
+    claude_args_json: input.claude_args_json,
+    geometry_cols: input.geometry_cols,
+    geometry_rows: input.geometry_rows,
+    exit_code: -1,
+    created_ms: now,
+    last_active_ms: now,
+    should_be_running: 1,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Decider — ownership check.
+// ---------------------------------------------------------------------------
+
+/**
+ * Throws `session.not_owned` (Code.PermissionDenied) if `caller` does not
+ * own `row`. Pure — does not log, does not metric. The interceptor / log
+ * appender (T9.x) attaches structured-log emission around the throw.
+ *
+ * Spec ch05 §4: "The check is NOT delegated to SQL — it is an explicit
+ * early return because (a) Listing RPCs filter by owner_id in SQL, but
+ * get/update/destroy RPCs take a session_id from the client; an SQL-only
+ * filter would return 'not found' instead of 'permission denied', and we
+ * want the distinction in logs."
+ */
+function assertRowOwned(caller: Principal, row: SessionRow): void {
+  const callerKey = principalKey(caller);
+  if (row.owner_id !== callerKey) {
+    throwError('session.not_owned', undefined, { session_id: row.id });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sink — the SessionManager class.
+// ---------------------------------------------------------------------------
+
+export interface SessionManagerOptions {
+  /** Override the wall clock — tests pass a controllable stub. */
+  readonly now?: () => number;
+  /** Override the id generator — tests pass a deterministic counter. */
+  readonly newId?: () => string;
+  /** Override the event-bus instance — tests inject a spy. */
+  readonly eventBus?: SessionEventBus;
+}
+
+/**
+ * Manager interface — exported so the SessionService handler (T3.3) can
+ * type-depend on the surface without taking a concrete-class import.
+ * Mirrors the v0.3 RPCs from spec ch05 §5 (Create / Get / List /
+ * Destroy / WatchSessions). WatchSessions is exposed here as
+ * `subscribe`; the handler adapts that into the gRPC server-streaming
+ * call.
+ */
+export interface ISessionManager {
+  create(input: CreateSessionInput, caller: Principal): SessionRow;
+  get(id: string, caller: Principal): SessionRow;
+  list(caller: Principal): readonly SessionRow[];
+  destroy(id: string, caller: Principal): SessionRow;
+  subscribe(caller: Principal, listener: SessionEventListener): Unsubscribe;
+}
+
+/**
+ * SQL fragments — kept as `const` so prepared statements are cached on
+ * the better-sqlite3 driver. Column order matches `SessionRow` so the
+ * INSERT bindings line up with the row shape.
+ */
+const SQL_INSERT = `INSERT INTO sessions (
+  id, owner_id, state, cwd, env_json, claude_args_json,
+  geometry_cols, geometry_rows, exit_code, created_ms, last_active_ms,
+  should_be_running
+) VALUES (
+  @id, @owner_id, @state, @cwd, @env_json, @claude_args_json,
+  @geometry_cols, @geometry_rows, @exit_code, @created_ms, @last_active_ms,
+  @should_be_running
+)`;
+
+const SQL_SELECT_BY_ID = `SELECT id, owner_id, state, cwd, env_json, claude_args_json,
+  geometry_cols, geometry_rows, exit_code, created_ms, last_active_ms,
+  should_be_running
+  FROM sessions WHERE id = ?`;
+
+const SQL_SELECT_BY_OWNER = `SELECT id, owner_id, state, cwd, env_json, claude_args_json,
+  geometry_cols, geometry_rows, exit_code, created_ms, last_active_ms,
+  should_be_running
+  FROM sessions WHERE owner_id = ? ORDER BY created_ms ASC, id ASC`;
+
+const SQL_UPDATE_DESTROY = `UPDATE sessions
+  SET state = @state, should_be_running = 0, last_active_ms = @last_active_ms
+  WHERE id = @id`;
+
+export class SessionManager implements ISessionManager {
+  private readonly db: SqliteDatabase;
+  private readonly now: () => number;
+  private readonly newId: () => string;
+  private readonly bus: SessionEventBus;
+
+  constructor(db: SqliteDatabase, options: SessionManagerOptions = {}) {
+    this.db = db;
+    this.now = options.now ?? Date.now;
+    this.newId = options.newId ?? (() => newSessionId(this.now));
+    this.bus = options.eventBus ?? new SessionEventBus();
+  }
+
+  /**
+   * Create a session for `caller`. Spec ch05 §6:
+   *   1. id := ULID()
+   *   2. owner_id := principalKey(principal)
+   *   3. INSERT row with state=STARTING.
+   *   4. emit `SessionEvent.created` on the bus.
+   *
+   * Returns the persisted row so the handler can render the proto
+   * `Session` immediately. PTY spawn + state transition to RUNNING is
+   * out of scope for this PR (T4.x).
+   */
+  create(input: CreateSessionInput, caller: Principal): SessionRow {
+    const now = this.now();
+    const id = this.newId();
+    const row = buildSessionRow(input, caller, id, now);
+    this.db.prepare(SQL_INSERT).run(row);
+    this.bus.publish({ kind: 'created', session: row });
+    return row;
+  }
+
+  /**
+   * Fetch a session by id. Spec ch05 §5: load by id; `assertOwnership`;
+   * then return. A missing row throws `Code.NotFound` so the caller can
+   * distinguish "no such session" from "not yours".
+   */
+  get(id: string, caller: Principal): SessionRow {
+    const row = this.loadRow(id);
+    assertRowOwned(caller, row);
+    return row;
+  }
+
+  /**
+   * List the caller's sessions. Spec ch05 §5: SQL `WHERE owner_id = ?`
+   * with `principalKey(ctx.principal)`; **no per-row check** because no
+   * row escapes the filter. The principalKey filter is unconditional
+   * (security boundary, per task constraints) — a future "admin
+   * cross-principal list" lands as a NEW method, not a flag here.
+   */
+  list(caller: Principal): readonly SessionRow[] {
+    const ownerKey = principalKey(caller);
+    return this.db.prepare(SQL_SELECT_BY_OWNER).all(ownerKey) as SessionRow[];
+  }
+
+  /**
+   * Destroy a session. Spec ch05 §5: load by id; `assertOwnership`; then
+   * delete + tear down PTY + kill claude CLI. PTY/CLI teardown lands in
+   * T4.x; T3.2 ships the row-state change + `should_be_running = 0` so
+   * the daemon's restore-on-boot loop skips it (ch05 §7), and emits
+   * `SessionEvent.destroyed`.
+   *
+   * The row is updated rather than deleted (chapter 07 §3 retains the
+   * row for crash-log / audit cross-reference; a future GC task may
+   * prune EXITED rows older than a retention window).
+   */
+  destroy(id: string, caller: Principal): SessionRow {
+    const row = this.loadRow(id);
+    assertRowOwned(caller, row);
+    const now = this.now();
+    const newState: SessionStateValue = SessionState.EXITED;
+    this.db.prepare(SQL_UPDATE_DESTROY).run({
+      id: row.id,
+      state: newState,
+      last_active_ms: now,
+    });
+    const destroyed: SessionRow = {
+      ...row,
+      state: newState,
+      should_be_running: 0,
+      last_active_ms: now,
+    };
+    this.bus.publish({ kind: 'destroyed', session: destroyed });
+    return destroyed;
+  }
+
+  /**
+   * Subscribe to lifecycle events scoped to `caller`. Returns an
+   * unsubscribe handle. The bus filters on `principalKey(caller)`
+   * before delivery — subscribers cannot observe other principals'
+   * events even if the predicate is buggy (security boundary).
+   */
+  subscribe(caller: Principal, listener: SessionEventListener): Unsubscribe {
+    return this.bus.subscribe(principalKey(caller), listener);
+  }
+
+  /**
+   * Test/observability hook: expose the underlying bus so a higher
+   * layer (T3.3 WatchSessions handler) can pass it through, and unit
+   * tests can assert listener counts. NOT part of the
+   * `ISessionManager` interface — handlers should go through
+   * `subscribe`, not the bus directly.
+   */
+  get eventBus(): SessionEventBus {
+    return this.bus;
+  }
+
+  /**
+   * Load a row by id, throwing `session.not_owned` when the row is
+   * absent. Spec ch05 §4 / §5: we deliberately do NOT distinguish
+   * "row missing" from "row owned by a different principal" at the
+   * RPC layer — leaking existence-of-id across principals would let
+   * one user enumerate another user's session ids by probing for
+   * Code.NotFound vs Code.PermissionDenied. Both paths emit
+   * `session.not_owned`. (If a v0.4 admin RPC needs the distinction,
+   * it lands as a separate method.)
+   */
+  private loadRow(id: string): SessionRow {
+    const row = this.db.prepare(SQL_SELECT_BY_ID).get(id) as SessionRow | undefined;
+    if (row === undefined) {
+      throwError('session.not_owned', undefined, { session_id: id });
+    }
+    return row;
+  }
+}

--- a/packages/daemon/src/sessions/event-bus.ts
+++ b/packages/daemon/src/sessions/event-bus.ts
@@ -1,0 +1,164 @@
+// In-memory, principal-scoped pub/sub bus for SessionEvent.
+//
+// Spec refs:
+//   - ch05 §5 — `WatchSessions` filters the in-memory event bus by
+//     `principalKey(ctx.principal)`; `WATCH_SCOPE_ALL` is rejected for
+//     non-admin principals.
+//   - ch05 §6 — Create flow emits `SessionEvent.created` after INSERT.
+//
+// SRP (dev.md §3): this module is a single SINK — it owns the
+// subscriber map and the fanout side effect. It has NO knowledge of DB,
+// proto, or transport. Producers call `publish`; consumers call
+// `subscribe`. Filtering is done HERE so subscribers cannot
+// accidentally see other principals' events even if they pass the wrong
+// predicate (security boundary, not perf hint — per task constraints).
+//
+// Layer 1 — alternatives checked:
+//   - `node:events.EventEmitter` would work, but it has no built-in
+//     per-subscriber filter and the listener-leak warning fires at 11
+//     listeners (the daemon may have N watchers per principal). A
+//     20-line bespoke bus is simpler than configuring EventEmitter.
+//   - RxJS / mitt / nanoevents: all are extra deps for what is a
+//     `Set<Listener>` + `for-of` loop. Not justified.
+//   - Connect-ES has no event-bus primitive; the WatchSessions handler
+//     will adapt this bus into a `ServerStreamingHandler` (T3.3).
+
+import type { SessionEvent } from './types.js';
+
+/**
+ * Event subscriber callback. Called synchronously from `publish` for
+ * every event whose `session.owner_id` matches the subscriber's
+ * `principalKey`. Listener exceptions are caught and reported via
+ * `onListenerError` (default: console.error) so a single buggy
+ * subscriber cannot prevent fanout to others or corrupt the publisher.
+ */
+export type SessionEventListener = (event: SessionEvent) => void;
+
+/**
+ * Unsubscribe handle returned by `subscribe`. Calling it removes the
+ * listener; calling it twice is a no-op (idempotent — common pattern
+ * for React effect cleanup / Connect handler abort).
+ */
+export type Unsubscribe = () => void;
+
+export interface SessionEventBusOptions {
+  /**
+   * Override for listener-error reporting. Default delegates to
+   * `console.error` with a stable prefix so daemon logs remain greppable.
+   * Tests pass a vi.fn() to assert the bus does NOT swallow errors
+   * silently (a regression here would mask broken subscribers).
+   */
+  readonly onListenerError?: (err: unknown, event: SessionEvent) => void;
+}
+
+/**
+ * Principal-scoped, in-memory pub/sub for `SessionEvent`.
+ *
+ * Fanout rule (security boundary): a listener subscribed with
+ * `principalKey = K` ONLY receives events whose `session.owner_id === K`.
+ * The check happens inside `publish`, BEFORE the listener is invoked —
+ * a buggy subscription predicate cannot leak cross-principal events.
+ *
+ * Concurrency: every operation is synchronous. better-sqlite3 is sync;
+ * the manager publishes inside the same call stack as the INSERT, so
+ * watchers observe the event after the transaction commits but before
+ * the RPC returns to the client. This matches the spec ch05 §6 sequence
+ * diagram (emit happens between UPDATE state=RUNNING and the response).
+ *
+ * Listener iteration is over a SNAPSHOT (Array.from) so a listener that
+ * unsubscribes itself during dispatch does not skip its peers.
+ */
+export class SessionEventBus {
+  /**
+   * Map of principalKey -> set of listeners. Map+Set avoids array
+   * `splice(indexOf)` on unsubscribe — O(1) add/remove, listener
+   * identity is the key so the same function can subscribe twice (rare,
+   * but allowed; both invocations fire on publish).
+   */
+  private readonly listenersByPrincipal = new Map<string, Set<SessionEventListener>>();
+  private readonly onListenerError: (err: unknown, event: SessionEvent) => void;
+
+  constructor(options: SessionEventBusOptions = {}) {
+    this.onListenerError =
+      options.onListenerError ??
+      ((err, event) => {
+        // Stable prefix for log-grep; deliberately not a structured-log
+        // call here — this bus has no logger dependency. The supervisor
+        // log appender (T9.x) can scope-watch on this string.
+        console.error(
+          '[ccsm-daemon] SessionEventBus listener threw',
+          { kind: event.kind, sessionId: event.session.id },
+          err,
+        );
+      });
+  }
+
+  /**
+   * Subscribe to events for a single principal. Returns an idempotent
+   * unsubscribe handle.
+   *
+   * The subscriber's `principalKey` is the SOLE filter — we do NOT
+   * accept arbitrary predicates because the security boundary belongs
+   * inside the bus. v0.4 admin-scope subscriptions will be a NEW
+   * method (`subscribeAll`), gated by an admin principal kind, rather
+   * than a parameter to this one (forces every cross-principal call
+   * site to surface to a reviewer).
+   */
+  subscribe(principalKey: string, listener: SessionEventListener): Unsubscribe {
+    if (typeof principalKey !== 'string' || principalKey.length === 0) {
+      throw new TypeError('principalKey must be a non-empty string');
+    }
+    let set = this.listenersByPrincipal.get(principalKey);
+    if (set === undefined) {
+      set = new Set<SessionEventListener>();
+      this.listenersByPrincipal.set(principalKey, set);
+    }
+    set.add(listener);
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      const current = this.listenersByPrincipal.get(principalKey);
+      if (current === undefined) return;
+      current.delete(listener);
+      if (current.size === 0) {
+        this.listenersByPrincipal.delete(principalKey);
+      }
+    };
+  }
+
+  /**
+   * Publish an event. Synchronously fans out to every listener whose
+   * subscription `principalKey` matches `event.session.owner_id`.
+   *
+   * Listener exceptions are caught — one buggy subscriber cannot break
+   * fanout to its peers. The exception is reported through
+   * `onListenerError`.
+   */
+  publish(event: SessionEvent): void {
+    const ownerKey = event.session.owner_id;
+    const set = this.listenersByPrincipal.get(ownerKey);
+    if (set === undefined || set.size === 0) return;
+    // Snapshot so a listener that unsubscribes (or subscribes another)
+    // during dispatch cannot skip peers.
+    const snapshot = Array.from(set);
+    for (const listener of snapshot) {
+      try {
+        listener(event);
+      } catch (err) {
+        this.onListenerError(err, event);
+      }
+    }
+  }
+
+  /**
+   * Test/observability helper: number of currently registered listeners
+   * for a principal. NOT used for control flow inside the daemon —
+   * exposed so unit tests can verify unsubscribe actually removed the
+   * entry, and so an admin diag RPC can report subscriber counts in
+   * v0.4 without reaching into private state.
+   */
+  listenerCount(principalKey: string): number {
+    return this.listenersByPrincipal.get(principalKey)?.size ?? 0;
+  }
+}

--- a/packages/daemon/src/sessions/types.ts
+++ b/packages/daemon/src/sessions/types.ts
@@ -1,0 +1,112 @@
+// In-process session types — INTERNAL to the daemon. NOT proto types.
+//
+// Spec refs:
+//   - docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//     ch05 §5 (per-RPC enforcement matrix), §6 (session create flow),
+//     ch07 §3 (sessions table schema).
+//
+// Design notes (T3.2 / Task #38):
+//   - These types model the SQLite `sessions` row 1:1 (chapter 07 §3 schema).
+//     The fields use snake_case to mirror the column names, so the
+//     better-sqlite3 prepared-statement bindings are positional and the
+//     `SELECT * FROM sessions` row maps trivially with no rename layer.
+//   - We deliberately do NOT import the proto-generated `Session` /
+//     `SessionEvent` messages here. The SessionManager owns DB rows and
+//     event-bus payloads; mapping the row to the proto `Session` happens at
+//     the RPC handler layer (T3.3 / T3.4) — keeps the manager free of proto
+//     plumbing per the SRP discipline (dev.md §3 "sink owns one side effect").
+//   - `SessionState` is a number that mirrors the proto `SessionState` enum
+//     int (chapter 07 §3 + common.proto: STARTING=1, RUNNING=2, EXITED=3,
+//     CRASHED=4). v0.3 SessionManager currently emits STARTING on create and
+//     transitions to a TERMINATED state on Destroy. Per spec ch05 §5 the
+//     enum order is forever-stable; "TERMINATED" is NOT a separate enum
+//     value — Destroy semantically maps to EXITED with `should_be_running=0`
+//     so the daemon's restore-on-boot loop (ch05 §7) skips the row.
+//   - `SessionEvent` is the in-memory union shape for the event bus. It is
+//     intentionally minimal: each variant carries the full SessionRow so
+//     subscribers (WatchSessions handler in T3.3) can render the proto
+//     `SessionEvent` without re-querying the DB. Principal-scoping is done
+//     by the bus before delivery — see event-bus.ts.
+
+/**
+ * Mirrors the proto `SessionState` enum int values from
+ * `packages/proto/src/ccsm/v1/common.proto`. Re-declared as a `const` enum
+ * here to keep the SessionManager free of proto imports (the proto value is
+ * the wire contract; this constant is its numeric image inside the daemon).
+ *
+ * Forever-stable ordering per spec ch05 + common.proto:
+ *   UNSPECIFIED=0, STARTING=1, RUNNING=2, EXITED=3, CRASHED=4
+ */
+export const SessionState = Object.freeze({
+  UNSPECIFIED: 0,
+  STARTING: 1,
+  RUNNING: 2,
+  EXITED: 3,
+  CRASHED: 4,
+} as const);
+
+export type SessionStateValue = (typeof SessionState)[keyof typeof SessionState];
+
+/**
+ * A row in the `sessions` table (chapter 07 §3 schema). Field names mirror
+ * the SQLite column names exactly — the SessionManager binds these into
+ * `INSERT INTO sessions (...) VALUES (...)` positionally, and `SELECT *`
+ * rows are returned as this shape with no renaming layer.
+ *
+ * `env_json` and `claude_args_json` are stored as TEXT in SQLite — we keep
+ * the raw JSON string here rather than a parsed object to avoid double-
+ * encoding round-trips and to keep the manager allocation-free on read.
+ * Callers that need parsed values do so at the RPC boundary.
+ *
+ * `owner_id` is `principalKey(principal)` — see ch05 §1. It is the security
+ * boundary on every Get/List/Destroy: the manager filters/asserts on this
+ * column unconditionally.
+ */
+export interface SessionRow {
+  readonly id: string;
+  readonly owner_id: string;
+  readonly state: SessionStateValue;
+  readonly cwd: string;
+  readonly env_json: string;
+  readonly claude_args_json: string;
+  readonly geometry_cols: number;
+  readonly geometry_rows: number;
+  readonly exit_code: number;
+  readonly created_ms: number;
+  readonly last_active_ms: number;
+  readonly should_be_running: 0 | 1;
+}
+
+/**
+ * Input shape for `SessionManager.create`. Everything the daemon needs from
+ * a `CreateSessionRequest` after the RPC layer has unpacked the proto. We
+ * do NOT take the proto type directly so the manager remains independent
+ * of `@ccsm/proto` and is unit-testable without a proto fixture.
+ *
+ * `env` and `claude_args` are normalised to strings (JSON-encoded) before
+ * being passed in; the producer (see `producer.ts`) handles the encode so
+ * the manager itself is allocation-light.
+ */
+export interface CreateSessionInput {
+  readonly cwd: string;
+  /** Pre-encoded JSON object string. */
+  readonly env_json: string;
+  /** Pre-encoded JSON array string. */
+  readonly claude_args_json: string;
+  readonly geometry_cols: number;
+  readonly geometry_rows: number;
+}
+
+/**
+ * In-process event bus payload. One discriminated union variant per
+ * lifecycle event. Each variant carries the full `SessionRow` so a
+ * subscriber can render the proto `SessionEvent` immediately without a
+ * DB round-trip.
+ *
+ * Spec ch05 §6 defines `created`; ch05 §5 (`DestroySession` row) defines
+ * `destroyed`. v0.4 may extend with `state-changed` etc.; new variants
+ * land as additional `kind` values without changing existing ones.
+ */
+export type SessionEvent =
+  | { readonly kind: 'created'; readonly session: SessionRow }
+  | { readonly kind: 'destroyed'; readonly session: SessionRow };

--- a/packages/daemon/test/sessions/SessionManager.spec.ts
+++ b/packages/daemon/test/sessions/SessionManager.spec.ts
@@ -1,0 +1,293 @@
+// Unit tests for SessionManager (T3.2 / Task #38).
+//
+// Spec refs:
+//   - ch05 §5 (per-RPC enforcement matrix: principal-scoped Get / List /
+//     Destroy; SQL filter for List; assertOwnership for Get / Destroy).
+//   - ch05 §6 (Create flow: ULID id, owner_id = principalKey, INSERT,
+//     emit `SessionEvent.created`).
+//   - ch07 §3 (sessions table schema).
+//
+// Tests use:
+//   - the real `openDatabase(':memory:')` wrapper (T5.1) and the real
+//     migration runner (T5.4) — anything else would diverge from the
+//     production schema and let a future column rename slip through.
+//   - the daemon's real Principal model from `src/auth/principal.ts`
+//     (T3.1) and the canonical `session.not_owned` ConnectError shape
+//     from `src/rpc/errors.ts` (T2.5).
+//
+// We deliberately do NOT mock the SQLite layer. The manager is so thin
+// that a pure-JS double would test the double, not the manager.
+
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { Code, ConnectError } from '@connectrpc/connect';
+import { ErrorDetailSchema } from '@ccsm/proto';
+
+import type { Principal } from '../../src/auth/principal.js';
+import { openDatabase, type SqliteDatabase } from '../../src/db/sqlite.js';
+import { runMigrations } from '../../src/db/migrations/runner.js';
+import { SessionEventBus } from '../../src/sessions/event-bus.js';
+import {
+  SessionManager,
+  buildSessionRow,
+  newSessionId,
+} from '../../src/sessions/SessionManager.js';
+import { SessionState, type SessionEvent } from '../../src/sessions/types.js';
+
+const ALICE: Principal = { kind: 'local-user', uid: '1000', displayName: 'alice' };
+const BOB: Principal = { kind: 'local-user', uid: '1001', displayName: 'bob' };
+
+function freshDb(): SqliteDatabase {
+  const db = openDatabase(':memory:');
+  runMigrations(db);
+  // sessions.owner_id has an FK to principals(id); insert both before any
+  // CreateSession call so the FK check passes. v0.3 daemon manages this
+  // table outside the SessionManager (peer-cred middleware upserts on
+  // connect — T1.3); for unit tests we synthesize the rows directly.
+  const insertPrincipal = db.prepare(
+    `INSERT INTO principals (id, kind, display_name, first_seen_ms, last_seen_ms)
+     VALUES (?, ?, ?, ?, ?)`,
+  );
+  insertPrincipal.run('local-user:1000', 'local-user', 'alice', 1, 1);
+  insertPrincipal.run('local-user:1001', 'local-user', 'bob', 1, 1);
+  return db;
+}
+
+function createInput(overrides: Partial<{ cwd: string; cols: number; rows: number }> = {}) {
+  return {
+    cwd: overrides.cwd ?? '/home/alice',
+    env_json: '{"FOO":"bar"}',
+    claude_args_json: '["--no-color"]',
+    geometry_cols: overrides.cols ?? 80,
+    geometry_rows: overrides.rows ?? 24,
+  };
+}
+
+describe('newSessionId', () => {
+  it('produces a 26-char Crockford-base32 string', () => {
+    const id = newSessionId(() => 1700000000000);
+    expect(id).toHaveLength(26);
+    expect(id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+  });
+
+  it('is lexicographically ordered by time', () => {
+    const idEarly = newSessionId(() => 1000);
+    const idLate = newSessionId(() => 2000);
+    expect(idEarly < idLate).toBe(true);
+  });
+
+  it('rejects negative or out-of-48-bit timestamps', () => {
+    expect(() => newSessionId(() => -1)).toThrow(RangeError);
+    expect(() => newSessionId(() => 0xffff_ffff_ffff + 1)).toThrow(RangeError);
+  });
+});
+
+describe('buildSessionRow (producer)', () => {
+  it('sets owner_id to principalKey(principal)', () => {
+    const row = buildSessionRow(createInput(), ALICE, 'ID00000000000000000000000A', 5);
+    expect(row.owner_id).toBe('local-user:1000');
+  });
+
+  it('defaults match spec ch05 §6 + ch07 §3 (state=STARTING, exit_code=-1, should_be_running=1)', () => {
+    const row = buildSessionRow(createInput(), ALICE, 'ID00000000000000000000000A', 7);
+    expect(row.state).toBe(SessionState.STARTING);
+    expect(row.exit_code).toBe(-1);
+    expect(row.should_be_running).toBe(1);
+    expect(row.created_ms).toBe(7);
+    expect(row.last_active_ms).toBe(7);
+  });
+});
+
+describe('SessionManager.create', () => {
+  let db: SqliteDatabase;
+  beforeEach(() => {
+    db = freshDb();
+  });
+
+  it('persists the row and returns it', () => {
+    let counter = 0;
+    const mgr = new SessionManager(db, {
+      now: () => 100,
+      newId: () => `ID${String(counter++).padStart(24, '0')}`,
+    });
+    const row = mgr.create(createInput(), ALICE);
+    expect(row.id).toBe('ID000000000000000000000000');
+    expect(row.owner_id).toBe('local-user:1000');
+
+    const persisted = db.prepare('SELECT * FROM sessions WHERE id = ?').get(row.id);
+    expect(persisted).toMatchObject({
+      id: row.id,
+      owner_id: 'local-user:1000',
+      state: SessionState.STARTING,
+      cwd: '/home/alice',
+      env_json: '{"FOO":"bar"}',
+      claude_args_json: '["--no-color"]',
+      geometry_cols: 80,
+      geometry_rows: 24,
+      exit_code: -1,
+      should_be_running: 1,
+    });
+  });
+
+  it('emits a SessionEvent.created on the bus, scoped to the owner principal', () => {
+    const bus = new SessionEventBus();
+    const events: SessionEvent[] = [];
+    bus.subscribe('local-user:1000', (e) => events.push(e));
+    const otherEvents: SessionEvent[] = [];
+    bus.subscribe('local-user:1001', (e) => otherEvents.push(e));
+
+    const mgr = new SessionManager(db, { eventBus: bus, now: () => 1, newId: () => 'X' });
+    const row = mgr.create(createInput(), ALICE);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: 'created', session: row });
+    expect(otherEvents).toHaveLength(0);
+  });
+});
+
+describe('SessionManager.get', () => {
+  it('returns the row when caller owns it', () => {
+    const db = freshDb();
+    const mgr = new SessionManager(db, { now: () => 1, newId: () => 'OWNED' });
+    const row = mgr.create(createInput(), ALICE);
+    expect(mgr.get(row.id, ALICE)).toEqual(row);
+  });
+
+  it('throws session.not_owned (PermissionDenied) when caller is a different principal', () => {
+    const db = freshDb();
+    const mgr = new SessionManager(db, { now: () => 1, newId: () => 'CROSS' });
+    const row = mgr.create(createInput(), ALICE);
+    try {
+      mgr.get(row.id, BOB);
+      expect.fail('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectError);
+      const ce = err as ConnectError;
+      expect(ce.code).toBe(Code.PermissionDenied);
+      const detail = ce.findDetails(ErrorDetailSchema)[0];
+      expect(detail?.code).toBe('session.not_owned');
+      expect(detail?.extra.session_id).toBe(row.id);
+    }
+  });
+
+  it('throws session.not_owned (not NotFound) when the row does not exist — prevents id enumeration', () => {
+    const db = freshDb();
+    const mgr = new SessionManager(db);
+    try {
+      mgr.get('does-not-exist', ALICE);
+      expect.fail('expected throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(ConnectError);
+      expect((err as ConnectError).code).toBe(Code.PermissionDenied);
+      const detail = (err as ConnectError).findDetails(ErrorDetailSchema)[0];
+      expect(detail?.code).toBe('session.not_owned');
+    }
+  });
+});
+
+describe('SessionManager.list', () => {
+  it("returns only the caller's sessions, ordered by created_ms then id", () => {
+    const db = freshDb();
+    let t = 100;
+    let n = 0;
+    const mgr = new SessionManager(db, {
+      now: () => t,
+      newId: () => `ID${String(n++).padStart(24, '0')}`,
+    });
+    t = 100; mgr.create(createInput({ cwd: '/a' }), ALICE);
+    t = 200; mgr.create(createInput({ cwd: '/b' }), BOB);
+    t = 300; mgr.create(createInput({ cwd: '/c' }), ALICE);
+
+    const aliceList = mgr.list(ALICE);
+    expect(aliceList.map((r) => r.cwd)).toEqual(['/a', '/c']);
+    expect(aliceList.every((r) => r.owner_id === 'local-user:1000')).toBe(true);
+
+    const bobList = mgr.list(BOB);
+    expect(bobList.map((r) => r.cwd)).toEqual(['/b']);
+  });
+
+  it('returns an empty array for a principal with no sessions', () => {
+    const db = freshDb();
+    const mgr = new SessionManager(db);
+    expect(mgr.list(ALICE)).toEqual([]);
+  });
+});
+
+describe('SessionManager.destroy', () => {
+  it('marks the row EXITED + should_be_running=0 and emits SessionEvent.destroyed', () => {
+    const db = freshDb();
+    const events: SessionEvent[] = [];
+    const bus = new SessionEventBus();
+    bus.subscribe('local-user:1000', (e) => events.push(e));
+
+    let t = 100;
+    const mgr = new SessionManager(db, {
+      now: () => t,
+      newId: () => 'TODESTROY',
+      eventBus: bus,
+    });
+    const row = mgr.create(createInput(), ALICE);
+    expect(events.at(-1)?.kind).toBe('created');
+
+    t = 500;
+    const destroyed = mgr.destroy(row.id, ALICE);
+    expect(destroyed.state).toBe(SessionState.EXITED);
+    expect(destroyed.should_be_running).toBe(0);
+    expect(destroyed.last_active_ms).toBe(500);
+
+    const persisted = db
+      .prepare('SELECT state, should_be_running, last_active_ms FROM sessions WHERE id = ?')
+      .get(row.id) as { state: number; should_be_running: number; last_active_ms: number };
+    expect(persisted).toEqual({
+      state: SessionState.EXITED,
+      should_be_running: 0,
+      last_active_ms: 500,
+    });
+
+    expect(events.at(-1)?.kind).toBe('destroyed');
+    expect(events.at(-1)?.session.id).toBe(row.id);
+  });
+
+  it('refuses cross-principal destroy with session.not_owned and leaves the row untouched', () => {
+    const db = freshDb();
+    const mgr = new SessionManager(db, { now: () => 1, newId: () => 'PROTECT' });
+    const row = mgr.create(createInput(), ALICE);
+
+    expect(() => mgr.destroy(row.id, BOB)).toThrow(ConnectError);
+
+    const persisted = db
+      .prepare('SELECT state, should_be_running FROM sessions WHERE id = ?')
+      .get(row.id) as { state: number; should_be_running: number };
+    expect(persisted).toEqual({ state: SessionState.STARTING, should_be_running: 1 });
+  });
+});
+
+describe('SessionManager.subscribe', () => {
+  it('delivers create + destroy events for the caller, scoped by principalKey', () => {
+    const db = freshDb();
+    const mgr = new SessionManager(db, { now: () => 1, newId: () => 'SUB1' });
+    const aliceSeen: SessionEvent[] = [];
+    const bobSeen: SessionEvent[] = [];
+    const unsub = mgr.subscribe(ALICE, (e) => aliceSeen.push(e));
+    mgr.subscribe(BOB, (e) => bobSeen.push(e));
+
+    const row = mgr.create(createInput(), ALICE);
+    mgr.destroy(row.id, ALICE);
+
+    expect(aliceSeen.map((e) => e.kind)).toEqual(['created', 'destroyed']);
+    expect(bobSeen).toEqual([]);
+
+    unsub();
+    expect(mgr.eventBus.listenerCount('local-user:1000')).toBe(0);
+  });
+
+  it("uses the caller's principalKey for filtering — a Bob subscriber sees nothing for Alice's session", () => {
+    const db = freshDb();
+    const mgr = new SessionManager(db, { now: () => 1, newId: () => 'SUB2' });
+    const seen = vi.fn();
+    mgr.subscribe(BOB, seen);
+
+    mgr.create(createInput(), ALICE);
+
+    expect(seen).not.toHaveBeenCalled();
+  });
+});

--- a/packages/daemon/test/sessions/event-bus.spec.ts
+++ b/packages/daemon/test/sessions/event-bus.spec.ts
@@ -1,0 +1,136 @@
+// Unit tests for the in-memory SessionEventBus (T3.2).
+//
+// Covers the security-critical guarantees:
+//   - principal-scoped fanout: subscribers ONLY see events whose
+//     `session.owner_id` matches their `principalKey`.
+//   - listener exception isolation: a throwing listener does not break
+//     fanout to its peers.
+//   - unsubscribe is idempotent and removes the listener.
+//   - listenerCount reflects subscribe/unsubscribe correctly.
+//
+// Spec refs: ch05 §5 (WatchSessions principal-scoped enforcement).
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { SessionEventBus } from '../../src/sessions/event-bus.js';
+import { SessionState, type SessionEvent, type SessionRow } from '../../src/sessions/types.js';
+
+function makeRow(owner: string, id = 'row-1'): SessionRow {
+  return {
+    id,
+    owner_id: owner,
+    state: SessionState.STARTING,
+    cwd: '/tmp',
+    env_json: '{}',
+    claude_args_json: '[]',
+    geometry_cols: 80,
+    geometry_rows: 24,
+    exit_code: -1,
+    created_ms: 1,
+    last_active_ms: 1,
+    should_be_running: 1,
+  };
+}
+
+function created(row: SessionRow): SessionEvent {
+  return { kind: 'created', session: row };
+}
+
+describe('SessionEventBus', () => {
+  it('delivers events only to subscribers whose principalKey matches event.session.owner_id', () => {
+    const bus = new SessionEventBus();
+    const aliceListener = vi.fn();
+    const bobListener = vi.fn();
+    bus.subscribe('local-user:alice', aliceListener);
+    bus.subscribe('local-user:bob', bobListener);
+
+    bus.publish(created(makeRow('local-user:alice', 'sess-a')));
+    bus.publish(created(makeRow('local-user:bob', 'sess-b')));
+
+    expect(aliceListener).toHaveBeenCalledTimes(1);
+    expect(aliceListener.mock.calls[0]?.[0].session.id).toBe('sess-a');
+    expect(bobListener).toHaveBeenCalledTimes(1);
+    expect(bobListener.mock.calls[0]?.[0].session.id).toBe('sess-b');
+  });
+
+  it('does not leak cross-principal events even when many subscribers share the bus', () => {
+    const bus = new SessionEventBus();
+    const owners = ['p:1', 'p:2', 'p:3', 'p:4'];
+    const listeners = new Map(owners.map((o) => [o, vi.fn()] as const));
+    for (const [owner, listener] of listeners) bus.subscribe(owner, listener);
+
+    bus.publish(created(makeRow('p:2', 'only-p2')));
+
+    for (const [owner, listener] of listeners) {
+      if (owner === 'p:2') expect(listener).toHaveBeenCalledTimes(1);
+      else expect(listener).not.toHaveBeenCalled();
+    }
+  });
+
+  it('unsubscribe removes the listener and is idempotent', () => {
+    const bus = new SessionEventBus();
+    const listener = vi.fn();
+    const unsub = bus.subscribe('local-user:alice', listener);
+
+    expect(bus.listenerCount('local-user:alice')).toBe(1);
+    unsub();
+    expect(bus.listenerCount('local-user:alice')).toBe(0);
+    // second call must be a no-op
+    expect(() => unsub()).not.toThrow();
+    expect(bus.listenerCount('local-user:alice')).toBe(0);
+
+    bus.publish(created(makeRow('local-user:alice')));
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('isolates listener exceptions: one throwing listener does not block its peers', () => {
+    const errors: unknown[] = [];
+    const bus = new SessionEventBus({
+      onListenerError: (err) => errors.push(err),
+    });
+    const thrower = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const survivor = vi.fn();
+    bus.subscribe('local-user:alice', thrower);
+    bus.subscribe('local-user:alice', survivor);
+
+    bus.publish(created(makeRow('local-user:alice')));
+
+    expect(thrower).toHaveBeenCalledTimes(1);
+    expect(survivor).toHaveBeenCalledTimes(1);
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toBe('boom');
+  });
+
+  it('snapshot iteration: a listener that unsubscribes during dispatch does not skip its peers', () => {
+    const bus = new SessionEventBus();
+    const calls: string[] = [];
+
+    let unsubA: () => void = () => {};
+    const a = vi.fn(() => {
+      calls.push('a');
+      unsubA();
+    });
+    const b = vi.fn(() => calls.push('b'));
+    unsubA = bus.subscribe('local-user:alice', a);
+    bus.subscribe('local-user:alice', b);
+
+    bus.publish(created(makeRow('local-user:alice')));
+
+    expect(calls).toEqual(['a', 'b']);
+    expect(bus.listenerCount('local-user:alice')).toBe(1);
+  });
+
+  it('publish with no subscribers is a no-op', () => {
+    const bus = new SessionEventBus();
+    expect(() => bus.publish(created(makeRow('nobody-listening')))).not.toThrow();
+  });
+
+  it('rejects empty / non-string principalKey on subscribe', () => {
+    const bus = new SessionEventBus();
+    expect(() => bus.subscribe('', vi.fn())).toThrow(TypeError);
+    // @ts-expect-error — runtime validation guard
+    expect(() => bus.subscribe(undefined, vi.fn())).toThrow(TypeError);
+  });
+});


### PR DESCRIPTION
Closes Task #38.

## Summary

In-process owner of the daemon's session lifecycle, per spec
`docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md` ch05 §5
(per-RPC enforcement matrix) + §6 (session create flow). Pure backend:
NO RPC plumbing, NO IPC, NO PTY spawn. T3.3/T3.4 will wire this manager
into the SessionService Connect handlers.

### Files

- `packages/daemon/src/sessions/types.ts` — internal `SessionRow`,
  `SessionState` mirror, `CreateSessionInput`, `SessionEvent` union.
  Deliberately NOT proto types — proto mapping is a handler-layer
  concern (SRP).
- `packages/daemon/src/sessions/event-bus.ts` — `SessionEventBus`,
  in-memory pub/sub keyed by `principalKey`. Filters BEFORE delivery
  (security boundary, not perf hint), isolates listener exceptions,
  snapshot-iterates so an unsubscribe during dispatch does not skip
  peers.
- `packages/daemon/src/sessions/SessionManager.ts`:
  - `SessionManager` (sink): CRUD on the `sessions` table via T5.1
    SQLite wrapper + emits on the bus.
  - `buildSessionRow` (producer): pure construction.
  - `assertRowOwned` (decider): private — throws the canonical
    `session.not_owned` ConnectError from T2.5.
  - `newSessionId`: 26-char Crockford-base32 (48-bit time prefix +
    80 bits CSPRNG), same lex-sort property as ULID without adding
    the `ulid` npm dep (consistent with `crash/sources.ts:newCrashId`).
- Tests under `packages/daemon/test/sessions/`.

### Enforcement matrix coverage (ch05 §5)

| RPC | Behavior |
| --- | --- |
| `Create` | INSERT row with `owner_id = principalKey(caller)`, state=STARTING; emit `created` |
| `Get` | load by id; `assertOwnership`; missing rows ALSO map to `session.not_owned` (prevents cross-principal id enumeration) |
| `List` | SQL `WHERE owner_id = ?` — unconditional principalKey filter |
| `Destroy` | load; `assertOwnership`; UPDATE state=EXITED + should_be_running=0; emit `destroyed`. Row preserved for crash-log cross-reference |
| `Subscribe` (WatchSessions wiring) | bus filters fanout by `principalKey(caller)` |

### Constraint check

1. ULID-shaped session IDs — yes, locally generated (no `ulid` dep).
2. `principalKey` filter is unconditional in List/Get — yes (security boundary).
3. Event bus filters by principalKey before delivery — yes; verified by tests.
4. Cross-principal access throws `throwError('session.not_owned', ...)` from `src/rpc/errors.ts` — yes.
5. SQLite via T5.1 `openDatabase` wrapper — yes; no raw `better-sqlite3`.
6. NO IPC, NO Connect plumbing in SessionManager — yes; verified by zero `@connectrpc/connect-node` / `@ccsm/proto` imports in `src/sessions/`.

## Test plan

- [x] `pnpm typecheck` — passes for the new files; one pre-existing
  error in `src/index.ts:234` (`push()` on `readonly Listener[]`) is
  unrelated and already fails on `origin/working` (verified with
  `git stash -u`).
- [x] `pnpm lint` — clean for the new files; same pre-existing
  `ccsm/no-listener-slot-mutation` error in `src/index.ts:234`.
- [x] `npx vitest run test/sessions/` — 23/23 pass (12 event-bus +
  11 SessionManager incl. principal-scoped fanout, cross-principal
  denial, missing-row enumeration guard, list ordering, destroy
  state flip, listener exception isolation).
- [x] `npx vitest run` — 533 pass, 1 pre-existing failure
  (`test/descriptor/schema.spec.ts` golden CRLF on Windows; verified
  fails on `origin/working` with the same Windows runner).

## Out of scope (explicit)

- ConnectRouter wiring — T3.3/T3.4.
- PTY spawn / xterm-headless host / claude CLI lifecycle — T4.x.
- Restore-on-boot loop (`should_be_running = 1` rows) — separate task.
- proto-`Session` row mapping — handler layer.