### PR TITLE
daemon(T5.12): crash retention pruner (10000 rows / 90 days / 6h cycle)

### DIFF
--- a/packages/daemon/src/crash/pruner-decider.ts
+++ b/packages/daemon/src/crash/pruner-decider.ts
@@ -1,0 +1,168 @@
+// packages/daemon/src/crash/pruner-decider.ts
+//
+// Pure decider for the crash retention pruner (Task #64 / T5.12).
+//
+// Spec refs:
+//   - docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//     ch09 §3 (rotation and capping):
+//       - Cap on entry count: default 10000 rows; exceeding → delete oldest by `ts_ms`.
+//       - Cap on age: default 90 days; exceeding → delete by `ts_ms < now - 90d`.
+//       - Both caps configurable via `Settings.crash_retention`; daemon
+//         enforces hard caps `max_entries ≤ 10000`, `max_age_days ≤ 90`.
+//       - Pruner runs at boot and every 6 hours.
+//   - ch07 §3 (`crash_log` schema; column `ts_ms`).
+//
+// SRP: this module is the **decider**. It is a pure function:
+//   `decidePrune(now, settings, stats) → PrunePlan`
+// No DB I/O, no clock, no logging. The sink (`pruner.ts`) supplies `now`
+// and `stats`, executes the SQL the plan emits, and writes the log line.
+//
+// Layer 1 — alternatives checked:
+//   - A single SQL `DELETE FROM crash_log WHERE ts_ms < ? OR id IN (...)`
+//     would conflate the two prune passes. We keep them separate so:
+//       (a) the log line cleanly attributes rows_deleted_age vs.
+//           rows_deleted_count (operators triaging "why is the log
+//           shrinking" need this distinction);
+//       (b) the count-cap pass operates on the post-age-cap row count,
+//           matching the spec's natural reading ("delete oldest beyond
+//           max_entries" is meaningful only after age-pruning).
+//   - Reading the cap defaults from a separate constants module: the
+//     hard caps ARE the defaults per spec ch09 §3 ("default 10000 /
+//     default 90"; "daemon enforces hard caps max_entries ≤ 10000,
+//     max_age_days ≤ 90"). Same value, single source of truth.
+
+/**
+ * Hard cap on `crash_log` row count. Spec ch09 §3.
+ * The DEFAULT and the HARD CAP are the same value per spec: a
+ * user-supplied value above this is silently clamped.
+ */
+export const MAX_ENTRIES_HARD_CAP = 10_000;
+
+/**
+ * Hard cap on `crash_log` row age in days. Spec ch09 §3. As above:
+ * default == hard cap; user-supplied above this is silently clamped.
+ */
+export const MAX_AGE_DAYS_HARD_CAP = 90;
+
+/** Milliseconds in a day. */
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/** User-supplied retention settings (sourced from `Settings.crash_retention`). */
+export interface CrashRetentionSettings {
+  /**
+   * Max retained rows. Undefined / non-positive / NaN → use the default
+   * (== hard cap). Values above the hard cap are silently clamped to it
+   * (with a warning emitted by the sink); the decider returns the
+   * clamped value in `effective` so the sink can log it.
+   */
+  readonly max_entries?: number;
+  /**
+   * Max retained age in days. Same defaulting + clamping rules as
+   * `max_entries`.
+   */
+  readonly max_age_days?: number;
+}
+
+/** Effective (post-defaulting, post-clamping) retention settings. */
+export interface EffectiveRetention {
+  readonly maxEntries: number;
+  readonly maxAgeDays: number;
+  /** True if the caller's `max_entries` was clamped down. */
+  readonly maxEntriesClamped: boolean;
+  /** True if the caller's `max_age_days` was clamped down. */
+  readonly maxAgeDaysClamped: boolean;
+}
+
+/**
+ * Resolve user-supplied settings into the effective values the pruner
+ * acts on. Pure function; no I/O. Exposed so the sink can log a single
+ * "settings clamped" warning at the start of each cycle.
+ */
+export function resolveRetention(s: CrashRetentionSettings): EffectiveRetention {
+  const me = clampPositive(s.max_entries, MAX_ENTRIES_HARD_CAP);
+  const md = clampPositive(s.max_age_days, MAX_AGE_DAYS_HARD_CAP);
+  return {
+    maxEntries: me.value,
+    maxAgeDays: md.value,
+    maxEntriesClamped: me.clamped,
+    maxAgeDaysClamped: md.clamped,
+  };
+}
+
+function clampPositive(
+  raw: number | undefined,
+  hardCap: number,
+): { value: number; clamped: boolean } {
+  // Undefined, non-finite, NaN, zero, or negative → fall back to default
+  // (== hard cap). Spec phrases the defaults as "default 10000 / default
+  // 90"; missing-or-bogus user input collapses to the same value.
+  if (raw === undefined || !Number.isFinite(raw) || raw <= 0) {
+    return { value: hardCap, clamped: false };
+  }
+  // SQLite ts_ms is an integer; round down a fractional max_age_days so
+  // the threshold maths stays in integer ms without truncation surprises.
+  const v = Math.floor(raw);
+  if (v > hardCap) {
+    return { value: hardCap, clamped: true };
+  }
+  return { value: v, clamped: false };
+}
+
+/**
+ * The two parameterised SQL statements that comprise one prune cycle.
+ * Each is a single statement with a single bound parameter. The sink
+ * runs both inside one `IMMEDIATE` transaction (spec ch09 §3 + ch07 §5
+ * write-coalescing: prune work is a writer-side concern).
+ *
+ * `ageDelete`     — delete rows older than `now - maxAgeDays * 86400000`.
+ * `countDelete`   — keep newest `maxEntries`; delete the rest by `ts_ms`.
+ *
+ * Note: both statements target `crash_log`. The table lives in
+ * `001_initial.sql` (T5.2 / Task #55) with column `ts_ms` (per spec
+ * ch07 §3).
+ */
+export interface PrunePlan {
+  readonly ageDelete: { readonly sql: string; readonly param: number };
+  readonly countDelete: { readonly sql: string; readonly param: number };
+  readonly effective: EffectiveRetention;
+  /** Cut-off in epoch ms (`now - maxAgeDays * 86400000`). Mirrored here
+   *  so tests can assert without re-deriving it from `now`. */
+  readonly ageCutoffMs: number;
+}
+
+/**
+ * Build the prune plan. Pure: same `(now, settings)` always yields the
+ * same SQL + params. The sink supplies a real `Date.now()` (or a fake
+ * clock under `vi.useFakeTimers`).
+ *
+ * The two statements are intentionally string-templated with the param
+ * separated: the sink uses `db.prepare(sql).run(param)` so SQLite still
+ * binds the value (no string-concat injection — `param` is always a
+ * number anyway, but the contract keeps prepared-statement caching
+ * intact).
+ */
+export function decidePrune(
+  now: number,
+  settings: CrashRetentionSettings,
+): PrunePlan {
+  const eff = resolveRetention(settings);
+  const ageCutoffMs = now - eff.maxAgeDays * MS_PER_DAY;
+  return {
+    ageDelete: {
+      sql: 'DELETE FROM crash_log WHERE ts_ms < ?',
+      param: ageCutoffMs,
+    },
+    countDelete: {
+      // Keep the newest `maxEntries` rows by ts_ms (tie-broken by id so
+      // the result is deterministic when many rows share a timestamp).
+      // We delete the complement: rows whose id is NOT in the top-N.
+      sql:
+        'DELETE FROM crash_log WHERE id NOT IN (' +
+        'SELECT id FROM crash_log ORDER BY ts_ms DESC, id DESC LIMIT ?' +
+        ')',
+      param: eff.maxEntries,
+    },
+    effective: eff,
+    ageCutoffMs,
+  };
+}

--- a/packages/daemon/src/crash/pruner.ts
+++ b/packages/daemon/src/crash/pruner.ts
@@ -1,0 +1,278 @@
+// packages/daemon/src/crash/pruner.ts
+//
+// Crash retention pruner — sink (Task #64 / T5.12).
+//
+// Spec refs:
+//   - docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//     ch09 §3 (rotation and capping; pruner runs at boot and every 6h).
+//   - ch07 §1 / §3 (`crash_log` schema + `better-sqlite3` wrapper).
+//   - ch07 §5 (write-coalescing — pruner mutations are writer-side).
+//   - ch02 §4 (graceful shutdown — caller's Shutdown ctx invokes `stop()`).
+//
+// SRP layering:
+//   - **decider** — `decidePrune` in `pruner-decider.ts` (pure; this
+//     module imports it).
+//   - **producer** — the schedule (timer). Implemented here as
+//     `defaultScheduler` so tests can swap `vi.useFakeTimers` via
+//     dependency injection (`schedulerFactory`).
+//   - **sink** — `CrashPruner.runOnce()` executes the decider's two
+//     SQL statements inside a single IMMEDIATE transaction and emits
+//     one log line per cycle.
+//
+// Boot wiring (see `index.ts`):
+//   1. open db + run migrations + recovery + shutdown installation
+//   2. construct `CrashPruner({ db, log, readSettings })`
+//   3. call `pruner.start()` → 30s warmup, then first run, then 6h cadence.
+//   4. register `pruner.stop` on the shutdown context.
+//
+// Layer 1 — alternatives checked:
+//   - `node-cron` / `cron` packages: overkill (we have one job; no
+//     crontab expressions). Adds a dep + parse step for what amounts to
+//     `setTimeout` + `setInterval`. Rejected.
+//   - Re-using a worker thread: pruning is two SQL statements inside
+//     one IMMEDIATE transaction. The write coalescer (T5.6) already
+//     serialises writers; running on the main thread in a 6h tick is
+//     fine and avoids a worker-message round trip.
+//   - Skipping the warmup: spec ch09 §3 only says "boot and every 6h".
+//     The 30s warmup is a defence-in-depth knob from the task brief —
+//     it keeps the pruner's first IMMEDIATE write off the boot critical
+//     path (recovery, migration, listener bind all complete in <30s on
+//     reference hardware).
+
+import type { SqliteDatabase } from '../db/sqlite.js';
+
+import {
+  decidePrune,
+  resolveRetention,
+  type CrashRetentionSettings,
+  type EffectiveRetention,
+} from './pruner-decider.js';
+
+/** Spec ch09 §3: pruner runs every 6h. */
+export const PRUNE_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+/**
+ * 30s startup warmup before the first prune run. The boot critical
+ * path (recovery → migrations → listener bind) finishes well within
+ * this on reference hardware; firing the pruner inside that window
+ * would race the migration runner's IMMEDIATE transaction.
+ */
+export const STARTUP_WARMUP_MS = 30_000;
+
+/** Per-cycle log payload. Surface-stable so tests can assert shape. */
+export interface PruneCycleResult {
+  readonly rowsDeletedAge: number;
+  readonly rowsDeletedCount: number;
+  readonly effective: EffectiveRetention;
+  readonly elapsedMs: number;
+}
+
+/** Minimal log surface (matches the entrypoint's logger shape). */
+export interface PrunerLogger {
+  info(line: string): void;
+  warn(line: string): void;
+}
+
+/**
+ * Reads the current `Settings.crash_retention`. Wired in T5-Settings
+ * later (Task #T5.x); v0.3 callers that don't yet have a SettingsRepo
+ * pass a constant `() => ({})` and the decider falls back to defaults.
+ */
+export type ReadCrashRetention = () => CrashRetentionSettings;
+
+/**
+ * Schedule producer — exposed for test stubbing. Default impl wraps
+ * `setTimeout` + `setInterval` (vitest's `useFakeTimers` swaps these
+ * globally so tests don't need a custom scheduler in most cases).
+ */
+export interface PrunerScheduler {
+  /** Schedule the first run after `delayMs`. Returns a canceller. */
+  setTimeout(fn: () => void, delayMs: number): () => void;
+  /** Schedule recurring runs every `periodMs`. Returns a canceller. */
+  setInterval(fn: () => void, periodMs: number): () => void;
+}
+
+const defaultScheduler: PrunerScheduler = {
+  setTimeout(fn, delayMs) {
+    const t = setTimeout(fn, delayMs);
+    // .unref() so the pruner timer alone never keeps the event loop
+    // alive — listener-A and the supervisor own that responsibility.
+    if (typeof t.unref === 'function') t.unref();
+    return () => clearTimeout(t);
+  },
+  setInterval(fn, periodMs) {
+    const t = setInterval(fn, periodMs);
+    if (typeof t.unref === 'function') t.unref();
+    return () => clearInterval(t);
+  },
+};
+
+export interface CrashPrunerOptions {
+  readonly db: SqliteDatabase;
+  readonly log: PrunerLogger;
+  /** Settings reader. Defaults to `() => ({})` (= use spec defaults). */
+  readonly readSettings?: ReadCrashRetention;
+  /** Clock injection for tests. Defaults to `Date.now`. */
+  readonly now?: () => number;
+  /** Scheduler injection for tests. Defaults to global timers. */
+  readonly scheduler?: PrunerScheduler;
+  /** Override the 30s warmup (tests). */
+  readonly warmupMs?: number;
+  /** Override the 6h cadence (tests). */
+  readonly intervalMs?: number;
+}
+
+/**
+ * Crash retention pruner. Construct once per daemon boot; call `start()`
+ * after migrations + recovery + Shutdown installation; call `stop()`
+ * during graceful shutdown (T1.8 step ordering — between RPC drain and
+ * WAL checkpoint is fine; the pruner is just a writer).
+ *
+ * Idempotent: a second `start()` is a no-op (warns); `stop()` after
+ * `stop()` is a no-op.
+ */
+export class CrashPruner {
+  private readonly db: SqliteDatabase;
+  private readonly log: PrunerLogger;
+  private readonly readSettings: ReadCrashRetention;
+  private readonly now: () => number;
+  private readonly scheduler: PrunerScheduler;
+  private readonly warmupMs: number;
+  private readonly intervalMs: number;
+
+  private cancelWarmup: (() => void) | null = null;
+  private cancelInterval: (() => void) | null = null;
+  private started = false;
+  private stopped = false;
+
+  constructor(opts: CrashPrunerOptions) {
+    this.db = opts.db;
+    this.log = opts.log;
+    this.readSettings = opts.readSettings ?? ((): CrashRetentionSettings => ({}));
+    this.now = opts.now ?? ((): number => Date.now());
+    this.scheduler = opts.scheduler ?? defaultScheduler;
+    this.warmupMs = opts.warmupMs ?? STARTUP_WARMUP_MS;
+    this.intervalMs = opts.intervalMs ?? PRUNE_INTERVAL_MS;
+  }
+
+  /**
+   * Schedule the first run after `warmupMs`, then every `intervalMs`.
+   * Safe to call once; calling again warns and is a no-op.
+   */
+  start(): void {
+    if (this.started) {
+      this.log.warn('crash-pruner: start() called twice; ignoring');
+      return;
+    }
+    if (this.stopped) {
+      this.log.warn('crash-pruner: start() after stop(); ignoring');
+      return;
+    }
+    this.started = true;
+
+    this.cancelWarmup = this.scheduler.setTimeout(() => {
+      this.cancelWarmup = null;
+      this.tick();
+      // Install the steady-state cadence AFTER the first run completes
+      // so a slow first run doesn't pile a second tick onto the same
+      // event loop turn.
+      this.cancelInterval = this.scheduler.setInterval(() => {
+        this.tick();
+      }, this.intervalMs);
+    }, this.warmupMs);
+  }
+
+  /**
+   * Cancel any pending timer. Idempotent. Does NOT run a final prune —
+   * shutdown ordering hands the WAL checkpoint to T1.8 step 6 right
+   * after this; running another prune here would race that.
+   */
+  stop(): void {
+    if (this.stopped) return;
+    this.stopped = true;
+    if (this.cancelWarmup !== null) {
+      this.cancelWarmup();
+      this.cancelWarmup = null;
+    }
+    if (this.cancelInterval !== null) {
+      this.cancelInterval();
+      this.cancelInterval = null;
+    }
+  }
+
+  /**
+   * Execute one prune cycle synchronously. Public so the entrypoint
+   * (or tests) can force a prune outside the cadence. Captures and
+   * logs all errors — never throws (the pruner must not crash the
+   * daemon over a transient SQLite error).
+   */
+  runOnce(): PruneCycleResult | null {
+    try {
+      return this.runOnceInner();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.log.warn(`crash-pruner: cycle failed: ${msg}`);
+      return null;
+    }
+  }
+
+  private tick(): void {
+    // tick() wraps runOnce() and is the only path the scheduler invokes.
+    // Pulled out so a thrown timer callback can't bubble into the global
+    // event loop (`runOnce` already swallows; this is belt + braces).
+    this.runOnce();
+  }
+
+  private runOnceInner(): PruneCycleResult {
+    const startedAt = this.now();
+    const settings = this.readSettings();
+
+    // Resolve early so we can warn ONCE per cycle if the user supplied
+    // out-of-range values (matches the task brief: "emit warning log
+    // on clamp").
+    const eff = resolveRetention(settings);
+    if (eff.maxEntriesClamped) {
+      this.log.warn(
+        `crash-pruner: max_entries clamped to hard cap ${eff.maxEntries} (user supplied higher)`,
+      );
+    }
+    if (eff.maxAgeDaysClamped) {
+      this.log.warn(
+        `crash-pruner: max_age_days clamped to hard cap ${eff.maxAgeDays} (user supplied higher)`,
+      );
+    }
+
+    const plan = decidePrune(startedAt, settings);
+    const ageStmt = this.db.prepare(plan.ageDelete.sql);
+    const countStmt = this.db.prepare(plan.countDelete.sql);
+
+    // Single IMMEDIATE transaction (spec ch09 §3 + ch07 §5). The
+    // wrapper from better-sqlite3's `db.transaction()` defaults to a
+    // DEFERRED transaction; we want IMMEDIATE so the writer lock is
+    // acquired before the age-pass DELETE so a concurrent reader
+    // (CrashService.GetCrashLog) can't slip a stale snapshot between
+    // the two passes.
+    const tx = this.db.transaction((): { age: number; count: number } => {
+      const age = ageStmt.run(plan.ageDelete.param).changes;
+      const count = countStmt.run(plan.countDelete.param).changes;
+      return { age, count };
+    });
+    // better-sqlite3: `.immediate()` requests `BEGIN IMMEDIATE`. The
+    // wrapped fn takes no args, so the variadic `.immediate(...args)`
+    // is invoked with none.
+    const { age, count } = tx.immediate();
+
+    const elapsedMs = this.now() - startedAt;
+    this.log.info(
+      `crash-pruner: rows_deleted_age=${age} rows_deleted_count=${count} ` +
+        `max_entries=${eff.maxEntries} max_age_days=${eff.maxAgeDays} ` +
+        `elapsed_ms=${elapsedMs}`,
+    );
+    return {
+      rowsDeletedAge: age,
+      rowsDeletedCount: count,
+      effective: eff,
+      elapsedMs,
+    };
+  }
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -35,6 +35,7 @@ import { dirname, join } from 'node:path';
 import { runMigrations } from './db/migrations/runner.js';
 import { checkAndRecover, makeRecoveryFlag, type RecoveryFlag } from './db/recovery.js';
 import { openDatabase, type SqliteDatabase } from './db/sqlite.js';
+import { CrashPruner } from './crash/pruner.js';
 import { buildDaemonEnv, type DaemonEnv } from './env.js';
 import { Lifecycle, Phase } from './lifecycle.js';
 import { makeListenerA } from './listeners/factory.js';
@@ -74,6 +75,8 @@ export async function runStartup(
 ): Promise<{
   readonly env: DaemonEnv;
   readonly listenerA: Listener | null;
+  readonly db: SqliteDatabase;
+  readonly crashPruner: CrashPruner;
 }> {
   lifecycle.onTransition((p) => log(`phase -> ${p}`));
 
@@ -130,6 +133,23 @@ export async function runStartup(
   lifecycle.advanceTo(Phase.RESTORING_SESSIONS);
   log('TODO(T3.4): re-spawn should-be-running sessions, orphan-uid check');
 
+  // T5.12 / Task #64 — crash retention pruner. Constructed AFTER
+  // openDatabase + runMigrations + recoveryFlag so the pruner's first
+  // (post-warmup) IMMEDIATE transaction can never race the migration
+  // runner. Caller (main / tests) calls `crashPruner.start()` after
+  // shutdown handlers are installed; `stop()` is invoked from the
+  // shutdown context in the entrypoint.
+  const crashPruner = new CrashPruner({
+    db,
+    log: {
+      info: (line) => log(line),
+      warn: (line) => log(line),
+    },
+    // Settings reader wires in with T5-Settings (later task); until
+    // then `() => ({})` collapses to the spec defaults (10000 / 90).
+    readSettings: () => ({}),
+  });
+
   // Phase: STARTING_LISTENERS  (T1.4 listener + T2.2 router)
   lifecycle.advanceTo(Phase.STARTING_LISTENERS);
   // The listener-slot assert (ch03 §1) is a one-liner we can do today even
@@ -161,7 +181,7 @@ export async function runStartup(
   lifecycle.advanceTo(Phase.READY);
   log('TODO(T1.7): flip Supervisor /healthz to 200');
 
-  return { env, listenerA };
+  return { env, listenerA, db, crashPruner };
 }
 
 /**
@@ -186,6 +206,7 @@ async function main(): Promise<void> {
   const lifecycle = new Lifecycle();
   let listenerA: Listener | null = null;
   let watchdog: SystemdWatchdogHandle | null = null;
+  let crashPruner: CrashPruner | null = null;
 
   // Build the shutdown orchestrator + a mutable context the future
   // T1.4 / T1.7 / T5.1 / T4.x wiring can populate as they land. We
@@ -211,6 +232,10 @@ async function main(): Promise<void> {
     // Stop the watchdog first so its keepalive timer doesn't pin the
     // event loop while shutdown.run drains in-flight RPCs.
     watchdog?.stop();
+    // Cancel the crash pruner timer BEFORE shutdown.run so its 6h
+    // tick can't sneak in a stray IMMEDIATE write between the WAL
+    // checkpoint (step 6) and db.close (step 7).
+    crashPruner?.stop();
     const r = await shutdown.run(ctxRef);
     // Exit code: clean drain + zero step errors → 0; otherwise 1.
     const exitCode = r.errors.length === 0 && r.inFlightAtBudgetExpiry <= 0 ? 0 : 1;
@@ -227,12 +252,19 @@ async function main(): Promise<void> {
   try {
     const result = await runStartup(lifecycle);
     listenerA = result.listenerA;
+    crashPruner = result.crashPruner;
     // Register the bound listener with the shutdown context so SIGTERM
-    // closes it during step 1 (stop accepting). T5.1 will register the
-    // db handle here too once it lands.
+    // closes it during step 1 (stop accepting). Register the db handle
+    // so the WAL checkpoint (step 6) + close (step 7) actually fire.
     if (listenerA !== null) {
       ctxRef.listeners.push(listenerA);
     }
+    ctxRef.db = result.db;
+    // Start the crash retention pruner AFTER shutdown handlers are
+    // installed (above) — a SIGTERM during the 30s warmup must still
+    // cancel the pending timer cleanly.
+    crashPruner.start();
+    log('crash-pruner: scheduled (30s warmup, then every 6h)');
     // Watchdog after READY — there is no point telling systemd we're alive
     // until the daemon is actually serving. systemd's `WatchdogSec=30s`
     // gives ~30s of boot slack before the first WATCHDOG=1 is required.
@@ -254,6 +286,7 @@ async function main(): Promise<void> {
     }
   } catch (err) {
     watchdog?.stop();
+    crashPruner?.stop();
     const error = err instanceof Error ? err : new Error(String(err));
     lifecycle.fail(error);
     log(`STARTUP FAILED at phase ${lifecycle.currentPhase()}: ${error.message}`);

--- a/packages/daemon/test/crash/pruner-decider.spec.ts
+++ b/packages/daemon/test/crash/pruner-decider.spec.ts
@@ -1,0 +1,111 @@
+// packages/daemon/test/crash/pruner-decider.spec.ts
+//
+// Pure decider tests for the crash retention pruner (Task #64 / T5.12).
+// No SQLite, no clock — verifies the (now, settings) → PrunePlan mapping
+// and the hard-cap clamping rules.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_AGE_DAYS_HARD_CAP,
+  MAX_ENTRIES_HARD_CAP,
+  decidePrune,
+  resolveRetention,
+} from '../../src/crash/pruner-decider.js';
+
+describe('resolveRetention (T5.12 — ch09 §3 defaults + clamping)', () => {
+  it('falls back to defaults when settings are empty', () => {
+    const r = resolveRetention({});
+    expect(r.maxEntries).toBe(MAX_ENTRIES_HARD_CAP);
+    expect(r.maxAgeDays).toBe(MAX_AGE_DAYS_HARD_CAP);
+    expect(r.maxEntriesClamped).toBe(false);
+    expect(r.maxAgeDaysClamped).toBe(false);
+  });
+
+  it('honours user-supplied values inside the hard cap', () => {
+    const r = resolveRetention({ max_entries: 500, max_age_days: 14 });
+    expect(r.maxEntries).toBe(500);
+    expect(r.maxAgeDays).toBe(14);
+    expect(r.maxEntriesClamped).toBe(false);
+    expect(r.maxAgeDaysClamped).toBe(false);
+  });
+
+  it('clamps user-supplied values above the hard cap and flags it', () => {
+    const r = resolveRetention({ max_entries: 50_000, max_age_days: 365 });
+    expect(r.maxEntries).toBe(MAX_ENTRIES_HARD_CAP);
+    expect(r.maxAgeDays).toBe(MAX_AGE_DAYS_HARD_CAP);
+    expect(r.maxEntriesClamped).toBe(true);
+    expect(r.maxAgeDaysClamped).toBe(true);
+  });
+
+  it('treats zero / negative / NaN as "use default" (not clamp)', () => {
+    const r = resolveRetention({ max_entries: 0, max_age_days: -5 });
+    expect(r.maxEntries).toBe(MAX_ENTRIES_HARD_CAP);
+    expect(r.maxAgeDays).toBe(MAX_AGE_DAYS_HARD_CAP);
+    expect(r.maxEntriesClamped).toBe(false);
+    expect(r.maxAgeDaysClamped).toBe(false);
+  });
+
+  it('floors fractional max_age_days', () => {
+    const r = resolveRetention({ max_age_days: 7.9 });
+    expect(r.maxAgeDays).toBe(7);
+  });
+
+  it('clamps a value EQUAL to the hard cap without flagging (no-op)', () => {
+    const r = resolveRetention({
+      max_entries: MAX_ENTRIES_HARD_CAP,
+      max_age_days: MAX_AGE_DAYS_HARD_CAP,
+    });
+    expect(r.maxEntries).toBe(MAX_ENTRIES_HARD_CAP);
+    expect(r.maxAgeDays).toBe(MAX_AGE_DAYS_HARD_CAP);
+    expect(r.maxEntriesClamped).toBe(false);
+    expect(r.maxAgeDaysClamped).toBe(false);
+  });
+});
+
+describe('decidePrune (T5.12 — ch09 §3 plan)', () => {
+  const NOW = 1_714_600_000_000; // arbitrary but stable
+  const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+  it('emits an age-cutoff = now - maxAgeDays * 86400000', () => {
+    const plan = decidePrune(NOW, { max_age_days: 30 });
+    expect(plan.ageCutoffMs).toBe(NOW - 30 * MS_PER_DAY);
+    expect(plan.ageDelete.param).toBe(NOW - 30 * MS_PER_DAY);
+  });
+
+  it('emits a count-cutoff = effective.maxEntries', () => {
+    const plan = decidePrune(NOW, { max_entries: 750 });
+    expect(plan.countDelete.param).toBe(750);
+  });
+
+  it('targets crash_log in both DELETEs', () => {
+    const plan = decidePrune(NOW, {});
+    expect(plan.ageDelete.sql).toMatch(/^DELETE FROM crash_log WHERE ts_ms < \?$/);
+    expect(plan.countDelete.sql).toContain('DELETE FROM crash_log');
+    // Order tie-break by id so the keep-set is deterministic when many
+    // rows share a ts_ms.
+    expect(plan.countDelete.sql).toContain('ORDER BY ts_ms DESC, id DESC');
+    expect(plan.countDelete.sql).toContain('LIMIT ?');
+  });
+
+  it('clamps a too-large max_entries and surfaces it via .effective', () => {
+    const plan = decidePrune(NOW, { max_entries: 99_999 });
+    expect(plan.effective.maxEntries).toBe(MAX_ENTRIES_HARD_CAP);
+    expect(plan.effective.maxEntriesClamped).toBe(true);
+    expect(plan.countDelete.param).toBe(MAX_ENTRIES_HARD_CAP);
+  });
+
+  it('uses defaults (10000 / 90) when settings are absent', () => {
+    const plan = decidePrune(NOW, {});
+    expect(plan.effective.maxEntries).toBe(10_000);
+    expect(plan.effective.maxAgeDays).toBe(90);
+    expect(plan.ageDelete.param).toBe(NOW - 90 * MS_PER_DAY);
+    expect(plan.countDelete.param).toBe(10_000);
+  });
+
+  it('is pure — same inputs always produce the same plan', () => {
+    const a = decidePrune(NOW, { max_entries: 100, max_age_days: 7 });
+    const b = decidePrune(NOW, { max_entries: 100, max_age_days: 7 });
+    expect(a).toEqual(b);
+  });
+});

--- a/packages/daemon/test/crash/pruner.spec.ts
+++ b/packages/daemon/test/crash/pruner.spec.ts
@@ -1,0 +1,307 @@
+// packages/daemon/test/crash/pruner.spec.ts
+//
+// Sink tests for the crash retention pruner (Task #64 / T5.12).
+//
+// Uses an in-memory DB seeded with the real `001_initial.sql` migration
+// so the `crash_log` schema matches production. Cadence + warmup tests
+// use `vi.useFakeTimers` — we do NOT actually wait 30s / 6h.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { openDatabase, type SqliteDatabase } from '../../src/db/sqlite.js';
+import { runMigrations } from '../../src/db/migrations/runner.js';
+import {
+  CrashPruner,
+  PRUNE_INTERVAL_MS,
+  STARTUP_WARMUP_MS,
+  type PrunerLogger,
+} from '../../src/crash/pruner.js';
+
+function makeDb(): SqliteDatabase {
+  const db = openDatabase(':memory:');
+  runMigrations(db);
+  return db;
+}
+
+interface CapturedLog {
+  info: string[];
+  warn: string[];
+}
+
+function makeLogger(): { log: PrunerLogger; captured: CapturedLog } {
+  const captured: CapturedLog = { info: [], warn: [] };
+  const log: PrunerLogger = {
+    info: (line) => captured.info.push(line),
+    warn: (line) => captured.warn.push(line),
+  };
+  return { log, captured };
+}
+
+interface SeedRow {
+  id: string;
+  tsMs: number;
+  source?: string;
+}
+
+function seedCrashes(db: SqliteDatabase, rows: ReadonlyArray<SeedRow>): void {
+  const stmt = db.prepare(
+    "INSERT INTO crash_log (id, ts_ms, source, summary, detail, labels_json, owner_id) " +
+      "VALUES (?, ?, ?, '', '', '{}', 'daemon-self')",
+  );
+  for (const r of rows) stmt.run(r.id, r.tsMs, r.source ?? 'test');
+}
+
+function countCrashes(db: SqliteDatabase): number {
+  const row = db.prepare('SELECT COUNT(*) AS n FROM crash_log').get() as {
+    n: number;
+  };
+  return row.n;
+}
+
+describe('CrashPruner.runOnce — age cap (T5.12 — ch09 §3)', () => {
+  let db: SqliteDatabase;
+  afterEach(() => db?.close());
+
+  it('deletes rows with ts_ms < (now - max_age_days*86400000)', () => {
+    db = makeDb();
+    const NOW = 1_714_600_000_000;
+    const MS_PER_DAY = 86_400_000;
+    seedCrashes(db, [
+      { id: '01-old', tsMs: NOW - 100 * MS_PER_DAY }, // older than 90d
+      { id: '02-old', tsMs: NOW - 91 * MS_PER_DAY }, // older than 90d
+      { id: '03-edge', tsMs: NOW - 90 * MS_PER_DAY }, // exactly at 90d boundary — kept (ts_ms < cutoff is strict)
+      { id: '04-recent', tsMs: NOW - 1 * MS_PER_DAY },
+      { id: '05-now', tsMs: NOW },
+    ]);
+    const { log, captured } = makeLogger();
+    const pruner = new CrashPruner({ db, log, now: () => NOW });
+    const r = pruner.runOnce();
+    expect(r).not.toBeNull();
+    expect(r!.rowsDeletedAge).toBe(2);
+    expect(r!.rowsDeletedCount).toBe(0);
+    // The boundary row (= cutoff) survives because the cap is strict (<).
+    expect(countCrashes(db)).toBe(3);
+    // Log line shape — operators grep for both fields.
+    expect(captured.info.some((l) => /rows_deleted_age=2/.test(l))).toBe(true);
+    expect(captured.info.some((l) => /rows_deleted_count=0/.test(l))).toBe(true);
+  });
+
+  it('honours a user-supplied max_age_days within the hard cap', () => {
+    db = makeDb();
+    const NOW = 2_000_000_000_000;
+    const MS_PER_DAY = 86_400_000;
+    seedCrashes(db, [
+      { id: 'a', tsMs: NOW - 8 * MS_PER_DAY }, // older than 7d
+      { id: 'b', tsMs: NOW - 1 * MS_PER_DAY },
+    ]);
+    const { log } = makeLogger();
+    const pruner = new CrashPruner({
+      db,
+      log,
+      now: () => NOW,
+      readSettings: () => ({ max_age_days: 7 }),
+    });
+    const r = pruner.runOnce()!;
+    expect(r.rowsDeletedAge).toBe(1);
+    expect(countCrashes(db)).toBe(1);
+  });
+});
+
+describe('CrashPruner.runOnce — count cap (T5.12 — ch09 §3)', () => {
+  let db: SqliteDatabase;
+  afterEach(() => db?.close());
+
+  it('deletes oldest rows beyond max_entries (after age pass)', () => {
+    db = makeDb();
+    const NOW = 1_700_000_000_000;
+    // Seed 5 recent rows; cap to 3 → expect oldest 2 deleted.
+    seedCrashes(db, [
+      { id: 'r1', tsMs: NOW - 5 },
+      { id: 'r2', tsMs: NOW - 4 },
+      { id: 'r3', tsMs: NOW - 3 },
+      { id: 'r4', tsMs: NOW - 2 },
+      { id: 'r5', tsMs: NOW - 1 },
+    ]);
+    const { log, captured } = makeLogger();
+    const pruner = new CrashPruner({
+      db,
+      log,
+      now: () => NOW,
+      readSettings: () => ({ max_entries: 3 }),
+    });
+    const r = pruner.runOnce()!;
+    expect(r.rowsDeletedAge).toBe(0);
+    expect(r.rowsDeletedCount).toBe(2);
+    expect(countCrashes(db)).toBe(3);
+    // The newest 3 survive.
+    const ids = (
+      db
+        .prepare('SELECT id FROM crash_log ORDER BY ts_ms DESC')
+        .all() as Array<{ id: string }>
+    ).map((r) => r.id);
+    expect(ids).toEqual(['r5', 'r4', 'r3']);
+    expect(captured.info.some((l) => /rows_deleted_count=2/.test(l))).toBe(true);
+  });
+
+  it('runs both passes in a single transaction (count pass sees post-age state)', () => {
+    db = makeDb();
+    const NOW = 1_700_000_000_000;
+    const MS_PER_DAY = 86_400_000;
+    // 2 ancient rows + 4 recent; max_age=90d cuts the ancient; max_entries=3
+    // then trims 1 of the recent — count pass MUST operate on post-age count.
+    seedCrashes(db, [
+      { id: 'old1', tsMs: NOW - 200 * MS_PER_DAY },
+      { id: 'old2', tsMs: NOW - 100 * MS_PER_DAY },
+      { id: 'r1', tsMs: NOW - 4 },
+      { id: 'r2', tsMs: NOW - 3 },
+      { id: 'r3', tsMs: NOW - 2 },
+      { id: 'r4', tsMs: NOW - 1 },
+    ]);
+    const { log } = makeLogger();
+    const pruner = new CrashPruner({
+      db,
+      log,
+      now: () => NOW,
+      readSettings: () => ({ max_entries: 3 }),
+    });
+    const r = pruner.runOnce()!;
+    expect(r.rowsDeletedAge).toBe(2);
+    expect(r.rowsDeletedCount).toBe(1); // r1 trimmed; r2/r3/r4 survive
+    expect(countCrashes(db)).toBe(3);
+  });
+
+  it('is a no-op when crash_log is empty', () => {
+    db = makeDb();
+    const { log } = makeLogger();
+    const pruner = new CrashPruner({ db, log, now: () => 1_700_000_000_000 });
+    const r = pruner.runOnce()!;
+    expect(r.rowsDeletedAge).toBe(0);
+    expect(r.rowsDeletedCount).toBe(0);
+  });
+});
+
+describe('CrashPruner.runOnce — clamp warnings (T5.12)', () => {
+  let db: SqliteDatabase;
+  afterEach(() => db?.close());
+
+  it('warns once per cycle when settings clamp', () => {
+    db = makeDb();
+    const { log, captured } = makeLogger();
+    const pruner = new CrashPruner({
+      db,
+      log,
+      now: () => 1_700_000_000_000,
+      readSettings: () => ({ max_entries: 99_999, max_age_days: 365 }),
+    });
+    pruner.runOnce();
+    expect(captured.warn.some((l) => /max_entries clamped/.test(l))).toBe(true);
+    expect(captured.warn.some((l) => /max_age_days clamped/.test(l))).toBe(true);
+  });
+
+  it('does not warn when settings are at-or-below the hard cap', () => {
+    db = makeDb();
+    const { log, captured } = makeLogger();
+    const pruner = new CrashPruner({
+      db,
+      log,
+      now: () => 1_700_000_000_000,
+      readSettings: () => ({ max_entries: 5000, max_age_days: 30 }),
+    });
+    pruner.runOnce();
+    expect(captured.warn).toEqual([]);
+  });
+});
+
+describe('CrashPruner.start/stop — cadence (T5.12 — 30s warmup + 6h cycle)', () => {
+  let db: SqliteDatabase;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    db = makeDb();
+  });
+  afterEach(() => {
+    db?.close();
+    vi.useRealTimers();
+  });
+
+  it('runs the first cycle after the 30s warmup, then every 6h', () => {
+    const NOW = 1_700_000_000_000;
+    vi.setSystemTime(NOW);
+    const { log } = makeLogger();
+    const pruner = new CrashPruner({ db, log });
+    const spy = vi.spyOn(pruner, 'runOnce');
+
+    pruner.start();
+    // No run during the warmup.
+    vi.advanceTimersByTime(STARTUP_WARMUP_MS - 1);
+    expect(spy).not.toHaveBeenCalled();
+    // First run lands at warmup boundary.
+    vi.advanceTimersByTime(1);
+    expect(spy).toHaveBeenCalledTimes(1);
+
+    // 6h later → second run.
+    vi.advanceTimersByTime(PRUNE_INTERVAL_MS);
+    expect(spy).toHaveBeenCalledTimes(2);
+    vi.advanceTimersByTime(PRUNE_INTERVAL_MS);
+    expect(spy).toHaveBeenCalledTimes(3);
+
+    pruner.stop();
+  });
+
+  it('stop() before warmup cancels the first run', () => {
+    const { log } = makeLogger();
+    const pruner = new CrashPruner({ db, log });
+    const spy = vi.spyOn(pruner, 'runOnce');
+    pruner.start();
+    pruner.stop();
+    vi.advanceTimersByTime(STARTUP_WARMUP_MS * 10);
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('stop() after warmup cancels the steady-state cadence', () => {
+    const { log } = makeLogger();
+    const pruner = new CrashPruner({ db, log });
+    const spy = vi.spyOn(pruner, 'runOnce');
+    pruner.start();
+    vi.advanceTimersByTime(STARTUP_WARMUP_MS);
+    expect(spy).toHaveBeenCalledTimes(1);
+    pruner.stop();
+    vi.advanceTimersByTime(PRUNE_INTERVAL_MS * 5);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('start() twice warns and is a no-op', () => {
+    const { log, captured } = makeLogger();
+    const pruner = new CrashPruner({ db, log });
+    const spy = vi.spyOn(pruner, 'runOnce');
+    pruner.start();
+    pruner.start();
+    expect(captured.warn.some((l) => /start\(\) called twice/.test(l))).toBe(
+      true,
+    );
+    vi.advanceTimersByTime(STARTUP_WARMUP_MS);
+    // Only one warmup timer fired.
+    expect(spy).toHaveBeenCalledTimes(1);
+    pruner.stop();
+  });
+
+  it('stop() is idempotent', () => {
+    const { log } = makeLogger();
+    const pruner = new CrashPruner({ db, log });
+    pruner.start();
+    pruner.stop();
+    expect(() => pruner.stop()).not.toThrow();
+  });
+});
+
+describe('CrashPruner.runOnce — error handling (T5.12)', () => {
+  it('captures and logs SQL errors without throwing', () => {
+    const db = makeDb();
+    db.exec('DROP TABLE crash_log');
+    const { log, captured } = makeLogger();
+    const pruner = new CrashPruner({ db, log });
+    expect(() => pruner.runOnce()).not.toThrow();
+    expect(captured.warn.some((l) => /cycle failed/.test(l))).toBe(true);
+    db.close();
+  });
+});


### PR DESCRIPTION
## Summary

Task #64 — implements ch09 §3 crash retention pruner for the daemon's `crash_log` SQLite table.

- **Decider** (`pruner-decider.ts`, pure): `(now, settings) -> { ageDelete, countDelete, effective }`. Hard-clamps `max_entries` to 10000 and `max_age_days` to 90; treats undefined/non-positive/NaN as "use default". Defaults equal the hard caps per spec ("default 10000 / default 90"; "daemon enforces hard caps max_entries <= 10000, max_age_days <= 90").
- **Sink** (`pruner.ts`, `CrashPruner`): runs both DELETE statements inside one IMMEDIATE transaction so a concurrent reader (`CrashService.GetCrashLog`) cannot slip a stale snapshot between passes. Emits one log line per cycle: `rows_deleted_age=N rows_deleted_count=M max_entries=... max_age_days=... elapsed_ms=...`. Warns once per cycle when settings clamp.
- **Producer** (schedule): 30s startup warmup, then every 6h via `setTimeout` -> `setInterval`. Cancellers stored on the instance; both timers `.unref()` so the pruner never alone keeps the event loop alive. Scheduler injectable for tests.

Wired into `runStartup` AFTER `openDatabase` + `runMigrations` + `recoveryFlag` and AFTER `Shutdown` handler installation (so a SIGTERM during the 30s warmup still cancels cleanly). `triggerShutdown` calls `crashPruner.stop()` before `shutdown.run` so the 6h tick cannot race the WAL checkpoint -> `db.close` pair.

Reuses landed work:
- T5.1 (#54): `openDatabase` + better-sqlite3 wrapper
- T5.2 (#55): `crash_log` schema (note: table name is `crash_log`, column is `ts_ms`)
- T5.10 (#59): NDJSON appender owns its own retention path; pruner only touches the SQLite table
- T1.8 (#25): Shutdown context + `installShutdownHandlers`

## SRP layering

- decider: `decidePrune` / `resolveRetention` — pure, no I/O, no clock
- producer: `PrunerScheduler` (default = unref'd `setTimeout`/`setInterval`)
- sink: `CrashPruner.runOnce` — runs decider, executes its SQL, emits log

## Test plan

- [x] `npx vitest run test/crash/` -> 66/66 pass (12 decider + 13 sink + 41 pre-existing)
- [x] Decider tests cover: defaults, clamping (above-cap), zero/negative/NaN -> default, fractional flooring, equal-to-cap (no flag), pure (same input -> same plan), SQL/param shape, ts_ms-DESC + id-DESC tie-break.
- [x] Sink tests with in-memory DB seeded via real `001_initial.sql` cover: age-pass strict `<` boundary, user-supplied max_age_days, count-pass keeps newest N, count-pass operates on post-age row count (single-IMMEDIATE-transaction semantics), empty-table no-op, clamp warning emitted iff above cap, no warning when at-or-below cap, SQL error swallowed (no crash).
- [x] Cadence tests use `vi.useFakeTimers`: no run during 30s warmup, first run at warmup boundary, every 6h after; `stop()` before warmup cancels first run; `stop()` after warmup cancels steady state; `start()` twice warns + no-op; `stop()` idempotent. No real waiting.
- [x] `pnpm typecheck` -> only the pre-existing baseline error (`src/index.ts` `listeners.push` on `readonly Listener[]`, line 260 here, line 234 before; same root cause). No new typecheck errors introduced.
- [x] `pnpm lint` -> only the pre-existing baseline error (same line, `ccsm/no-listener-slot-mutation`). No new lint errors.
- [x] Full daemon vitest suite -> 1 pre-existing failure (`test/descriptor/schema.spec.ts` golden bytes; verified failing on `working` HEAD via `git stash`); 535 pass.

## Spec refs

- `docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md` ch09 §3 (rotation), ch07 §3 (`crash_log` schema), ch07 §5 (write-coalescing), ch02 §4 (shutdown ordering).