### PR TITLE
electron(T6.8): daemon cold-start blocking modal (8s timeout + retry)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -58,6 +58,7 @@ export default [
         HTMLInputElement: 'readonly',
         HTMLTextAreaElement: 'readonly',
         HTMLButtonElement: 'readonly',
+        HTMLDialogElement: 'readonly',
         HTMLSpanElement: 'readonly',
         HTMLLIElement: 'readonly',
         Element: 'readonly',

--- a/packages/electron/src/renderer/components/DaemonNotRunningModal.tsx
+++ b/packages/electron/src/renderer/components/DaemonNotRunningModal.tsx
@@ -1,0 +1,224 @@
+// T6.8 — Daemon cold-start blocking modal.
+//
+// Spec ref: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+// chapter 08 §6.1 (Daemon cold-start UX).
+//
+// Surface: a real DOM modal (`<dialog open>`) layered over the renderer
+// tree when the renderer's first Hello has not succeeded within 8 s. The
+// modal:
+//
+//   - Cannot be dismissed by Esc / click-outside (we cancel the native
+//     `cancel` event). Disappears only when the connection state surfaced
+//     by T6.7's `useConnection()` flips to `connected`.
+//   - Carries one OS-specific troubleshooting hint (macOS launchd, Linux
+//     systemd, Windows Service) per spec §6.1 bullet "per-OS instructions".
+//   - Exposes a "Try again" button that calls the caller's `onRetry`. The
+//     wiring at the call site routes this to T6.7's `retryNow()`, which
+//     resets the backoff schedule and re-runs descriptor fetch + Hello.
+//
+// SRP: this file is a sink (renders DOM). It owns NO timer logic, NO
+// connection state, NO retry mechanism — those are wired by the caller
+// from `useConnection()` (T6.7). The 8-second cold-start budget that
+// decides whether `open=true` lives in `useDaemonColdStartModal.ts`
+// alongside this file. Splitting trigger-decision (decider) from render
+// (sink) keeps this component trivially testable: render with `open=true`
+// and any `platform`, assert text + button wiring.
+//
+// Constraint: T8.2 ESLint backstop bans `ipcMain` / `ipcRenderer` /
+// `contextBridge`. The per-OS troubleshooting hint surfaces a copy-pasteable
+// shell command inline (no link out, no IPC). That keeps the modal a pure
+// render-only component — no preload bridge, no `shell.openExternal` call.
+// We do NOT mount any new IPC.
+//
+// User-facing copy: locked by spec §6.1 (line 2325-2329). Sentence case
+// ("Try again", not "TRY AGAIN"). Strings deliberately do NOT mention
+// internals: no "UDS", no "boot_id", no "Hello RPC", no "descriptor". The
+// per-OS hint surfaces the user-runnable diagnostic command from spec
+// §6.1 bullet 2 verbatim.
+
+import * as React from 'react';
+
+/**
+ * The platform detector return values used by the modal. Values are the
+ * `process.platform` Node.js values surfaced through the renderer (Electron
+ * exposes `process.platform` even with `nodeIntegration:false` — T6.6 boot
+ * wiring confirms this is available without IPC).
+ *
+ * Other platform strings (`'aix'`, `'freebsd'`, `'openbsd'`, `'sunos'`,
+ * etc.) fall through to the generic hint — same 8-s symptom, but the
+ * spec §6.1 service-management commands are macOS / Linux / Windows only.
+ */
+export type DaemonModalPlatform =
+  | 'darwin'
+  | 'linux'
+  | 'win32'
+  | 'other';
+
+/** Public props. */
+export interface DaemonNotRunningModalProps {
+  /**
+   * When true, the dialog is rendered with the `open` attribute and is
+   * visible. When false, the underlying `<dialog>` is unmounted entirely
+   * (we do not lean on browser modal stacking — Electron's renderer is a
+   * single user-facing dialog at a time).
+   */
+  readonly open: boolean;
+  /**
+   * Click handler for the "Try again" button. The caller wires this to
+   * T6.7's `useConnection().retryNow`. The component does not call
+   * preventDefault — caller decides if it wants to disable the button
+   * during an in-flight attempt by passing `retryDisabled`.
+   */
+  readonly onRetry: () => void;
+  /**
+   * Platform string. Defaults to detecting via `process.platform`. Tests
+   * inject explicit values; production callers omit and let detection
+   * pick the user's OS.
+   */
+  readonly platform?: DaemonModalPlatform;
+  /**
+   * Disable the "Try again" button (e.g., while the caller is still
+   * inside the previous attempt's await chain). Default: false.
+   */
+  readonly retryDisabled?: boolean;
+}
+
+/**
+ * Detect the renderer's host OS. Pure function; safe to call during
+ * render (no I/O, no allocation beyond the string compare).
+ *
+ * `process.platform` is exposed on the renderer's `process` global by
+ * Electron even when `nodeIntegration` is off — same path the existing
+ * preload-free renderer uses for `process.versions.electron`.
+ */
+export function detectPlatform(): DaemonModalPlatform {
+  // Guard: in a pure-Node unit test (vitest `node` env without happy-dom
+  // shim) `process` is the Node process. In happy-dom + Electron renderer
+  // it's the same global. Either way, `process.platform` is the truth.
+  const proc = (globalThis as { process?: { platform?: string } }).process;
+  const p = proc?.platform;
+  if (p === 'darwin') return 'darwin';
+  if (p === 'linux') return 'linux';
+  if (p === 'win32') return 'win32';
+  return 'other';
+}
+
+/**
+ * Per-OS hint copy. Values are EXACT user-runnable commands from spec
+ * §6.1 bullet 2; do not paraphrase — operators may copy-paste these into
+ * a terminal during a support call.
+ */
+function platformHint(platform: DaemonModalPlatform): {
+  readonly label: string;
+  readonly command: string;
+  readonly description: string;
+} {
+  switch (platform) {
+    case 'darwin':
+      return {
+        label: 'macOS',
+        command: 'launchctl print system/com.ccsm.daemon',
+        description:
+          'Open Terminal and run the command above to check the ccsm service status.',
+      };
+    case 'linux':
+      return {
+        label: 'Linux',
+        command: 'systemctl status ccsm',
+        description:
+          'Open a terminal and run the command above to check the ccsm service status.',
+      };
+    case 'win32':
+      return {
+        label: 'Windows',
+        command: 'Get-Service ccsm',
+        description:
+          'Open PowerShell and run the command above to check the ccsm service status.',
+      };
+    case 'other':
+    default:
+      return {
+        label: 'Service status',
+        command: '',
+        description:
+          'Check that the ccsm background service is installed and running on your system.',
+      };
+  }
+}
+
+/**
+ * Blocking modal shown when the daemon has not responded within the
+ * cold-start budget. See file header.
+ *
+ * The dialog renders nothing when `open` is false — keeps the DOM clean
+ * for screen readers and avoids any chance of focus-trap leak when the
+ * connection is healthy.
+ */
+export function DaemonNotRunningModal(
+  props: DaemonNotRunningModalProps,
+): React.ReactElement | null {
+  const platform = props.platform ?? detectPlatform();
+  const hint = platformHint(platform);
+  const dialogRef = React.useRef<HTMLDialogElement | null>(null);
+
+  // Cancel the native dialog "cancel" event so Esc does not dismiss the
+  // modal. Per spec §6.1: "The modal is dismissible only by a successful
+  // Hello." Click-outside on a non-modal `<dialog open>` is already a
+  // no-op (only `showModal()` adds the backdrop + click-outside dismiss
+  // path); we deliberately use the `open` attribute path, NOT
+  // `showModal()`, so our render is the single source of truth and there
+  // is no imperative state to keep in sync.
+  React.useEffect(() => {
+    const dialog = dialogRef.current;
+    if (dialog === null) return undefined;
+    const onCancel = (event: Event): void => {
+      event.preventDefault();
+    };
+    dialog.addEventListener('cancel', onCancel);
+    return () => {
+      dialog.removeEventListener('cancel', onCancel);
+    };
+  }, [props.open]);
+
+  if (!props.open) return null;
+
+  return (
+    <dialog
+      ref={dialogRef}
+      open
+      role="alertdialog"
+      aria-labelledby="ccsm-daemon-not-running-title"
+      aria-describedby="ccsm-daemon-not-running-body"
+      data-testid="daemon-not-running-modal"
+    >
+      <h2 id="ccsm-daemon-not-running-title">ccsm daemon is not running.</h2>
+      <p id="ccsm-daemon-not-running-body">
+        The ccsm background service did not respond after 8 seconds. The
+        renderer will keep retrying in the background.
+      </p>
+      <section
+        aria-label="Service troubleshooting"
+        data-testid="daemon-modal-troubleshooting"
+      >
+        <h3>{hint.label}</h3>
+        <p>{hint.description}</p>
+        {hint.command !== '' ? (
+          <pre data-testid="daemon-modal-command">
+            <code>{hint.command}</code>
+          </pre>
+        ) : null}
+      </section>
+      <div data-testid="daemon-modal-actions">
+        <button
+          type="button"
+          onClick={props.onRetry}
+          disabled={props.retryDisabled === true}
+          data-testid="daemon-modal-retry"
+          autoFocus
+        >
+          Try again
+        </button>
+      </div>
+    </dialog>
+  );
+}

--- a/packages/electron/src/renderer/components/use-daemon-cold-start-modal.ts
+++ b/packages/electron/src/renderer/components/use-daemon-cold-start-modal.ts
@@ -1,0 +1,157 @@
+// T6.8 — Cold-start trigger decider for the daemon-not-running modal.
+//
+// Spec ref: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+// chapter 08 §6.1.
+//
+// Concern: decide WHEN to surface `<DaemonNotRunningModal>` as
+// `open={true}`, given the connection state surfaced by T6.7's
+// `useConnection()`. The spec rule (line 2323) is:
+//
+//   "If the renderer's first `Hello` does not succeed within 8 seconds
+//    (cold-start budget; covers daemon-still-starting on a slow VM), the
+//    renderer renders a blocking modal."
+//
+// Mapping onto T6.7's state machine (`use-connection.tsx` :: ConnectionState):
+//
+//   - `connecting` / `reconnecting` for >= 8000 ms after the cold-start
+//     timer was armed → open the modal.
+//   - `connected` → close the modal AND clear the timer (spec line 2333:
+//     "The modal is dismissible only by a successful `Hello`."). Once
+//     closed, a SUBSEQUENT drop is a steady-state reconnect and the §6
+//     "Reconnecting..." banner takes over — NOT this modal again. The
+//     modal is the cold-start UX, not a connection-loss UX.
+//   - `version-mismatch` → never open this modal. Version mismatch has
+//     its own dedicated UX (T6.7 surfaces the state; a separate component
+//     out of scope here renders it). Showing the cold-start modal there
+//     would mislead — the daemon IS running, just incompatible.
+//
+// SRP: pure decider with one timer side-effect. Producer = T6.7's
+// `useConnection().state`. Sink = the boolean returned to the modal
+// component. No DOM, no Connect, no fetch.
+//
+// Test seam: `nowMs` + `setTimeoutFn` + `clearTimeoutFn` are injectable
+// so unit tests can drive the 8s budget deterministically with vitest's
+// fake timers OR a hand-rolled clock. Production callers omit; defaults
+// resolve to `Date.now` + globals.
+
+import * as React from 'react';
+
+import {
+  useConnection,
+  type ConnectionState,
+} from '../connection/use-connection.js';
+
+/** Cold-start budget in milliseconds. Locked by spec §6.1. */
+export const COLD_START_BUDGET_MS = 8000 as const;
+
+/**
+ * Decide if the modal should be open RIGHT NOW given the wall-clock
+ * elapsed since the cold-start timer was armed and the current state.
+ *
+ * Pure function; exported for unit testing alongside the hook.
+ *
+ * - `connected` → never open (spec line 2333).
+ * - `version-mismatch` → never open (different UX, see file header).
+ * - `connecting` / `reconnecting` AND no successful Hello yet AND
+ *   `elapsedMs >= 8000` → open.
+ *
+ * `everConnected` is the latch that distinguishes the cold-start path
+ * from the steady-state reconnect path. Once we have seen `connected`
+ * even once, future `reconnecting` states are NOT cold-start — they get
+ * the §6 banner instead of the §6.1 modal.
+ */
+export function shouldShowColdStartModal(args: {
+  readonly state: ConnectionState;
+  readonly everConnected: boolean;
+  readonly elapsedMs: number;
+}): boolean {
+  if (args.everConnected) return false;
+  if (args.state.kind === 'connected') return false;
+  if (args.state.kind === 'version-mismatch') return false;
+  return args.elapsedMs >= COLD_START_BUDGET_MS;
+}
+
+/** Injectable timer surface for tests. */
+export interface ColdStartTimerDeps {
+  readonly nowMs?: () => number;
+  readonly setTimeoutFn?: (fn: () => void, ms: number) => unknown;
+  readonly clearTimeoutFn?: (handle: unknown) => void;
+}
+
+/** Public hook return. */
+export interface UseDaemonColdStartModalResult {
+  /** Whether the modal should be rendered with `open={true}`. */
+  readonly open: boolean;
+  /** Re-arm the connection (T6.7's `retryNow`). Pass to modal `onRetry`. */
+  readonly onRetry: () => void;
+}
+
+/**
+ * React hook that bridges T6.7's `useConnection()` state to the modal's
+ * `open` boolean. Arms an 8s timer on mount; flips `open` to true when
+ * the timer fires AND we have not yet observed a successful Hello.
+ *
+ * Once we have observed `connected` even once, the modal stays closed
+ * for the rest of the renderer's lifetime — subsequent drops are
+ * surfaced by the §6 reconnect banner (rendered by a sibling component
+ * not owned by this hook).
+ *
+ * Why a timer instead of a `nextDelayMs * attempt >= 8000` accumulator:
+ *   - The spec wording is wall-clock ("within 8 seconds"), not
+ *     attempt-based.
+ *   - A flaky transport that resolves Hello slowly (e.g., 7s on attempt
+ *     0) would skip the modal under an attempt-based rule but should
+ *     still be flagged under wall-clock.
+ *   - Single timer = one piece of state to abort on connect / unmount,
+ *     trivially testable with fake timers.
+ */
+export function useDaemonColdStartModal(
+  deps?: ColdStartTimerDeps,
+): UseDaemonColdStartModalResult {
+  const { state, retryNow } = useConnection();
+
+  const nowMs = deps?.nowMs ?? Date.now;
+  const setTimeoutFn =
+    deps?.setTimeoutFn ?? ((fn, ms) => setTimeout(fn, ms) as unknown);
+  const clearTimeoutFn =
+    deps?.clearTimeoutFn ?? ((h) => clearTimeout(h as ReturnType<typeof setTimeout>));
+
+  const armedAtRef = React.useRef<number | null>(null);
+  const [budgetExpired, setBudgetExpired] = React.useState<boolean>(false);
+  const [everConnected, setEverConnected] = React.useState<boolean>(false);
+
+  // Arm the cold-start timer once on mount. We do NOT re-arm on retry —
+  // the spec rule is "first Hello does not succeed within 8 s of boot",
+  // and a manual retry from inside the modal does not buy back that
+  // budget. The timer also does not fire if we have already connected.
+  React.useEffect(() => {
+    if (armedAtRef.current !== null) return undefined;
+    armedAtRef.current = nowMs();
+    const handle = setTimeoutFn(() => {
+      setBudgetExpired(true);
+    }, COLD_START_BUDGET_MS);
+    return () => {
+      clearTimeoutFn(handle);
+    };
+    // Mount-only: we capture the initial timer surface and never re-bind.
+    // Tests that want a different clock pass it on first render; passing
+    // a different clock later would break the cold-start semantics.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Latch `everConnected` so a mid-session daemon restart doesn't
+  // re-trigger the cold-start modal.
+  React.useEffect(() => {
+    if (state.kind === 'connected' && !everConnected) {
+      setEverConnected(true);
+    }
+  }, [state.kind, everConnected]);
+
+  const open = shouldShowColdStartModal({
+    state,
+    everConnected,
+    elapsedMs: budgetExpired ? COLD_START_BUDGET_MS : 0,
+  });
+
+  return { open, onRetry: retryNow };
+}

--- a/packages/electron/test/renderer/components/DaemonNotRunningModal.spec.tsx
+++ b/packages/electron/test/renderer/components/DaemonNotRunningModal.spec.tsx
@@ -1,0 +1,183 @@
+// T6.8 — DaemonNotRunningModal component tests.
+//
+// @vitest-environment happy-dom
+//
+// Spec ref: chapter 08 §6.1.
+
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  DaemonNotRunningModal,
+  detectPlatform,
+  type DaemonModalPlatform,
+} from '../../../src/renderer/components/DaemonNotRunningModal.js';
+
+afterEach(() => cleanup());
+
+describe('DaemonNotRunningModal — render gating', () => {
+  it('renders nothing when open=false', () => {
+    const { container } = render(
+      <DaemonNotRunningModal
+        open={false}
+        onRetry={() => undefined}
+        platform="linux"
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a real <dialog open> when open=true (blocking modal, not a banner)', () => {
+    render(
+      <DaemonNotRunningModal
+        open={true}
+        onRetry={() => undefined}
+        platform="linux"
+      />,
+    );
+    const modal = screen.getByTestId('daemon-not-running-modal');
+    expect(modal.tagName).toBe('DIALOG');
+    expect(modal.hasAttribute('open')).toBe(true);
+    expect(modal.getAttribute('role')).toBe('alertdialog');
+  });
+});
+
+describe('DaemonNotRunningModal — copy is user-facing (no internals leak)', () => {
+  it('uses the spec-locked status text and 8-second figure', () => {
+    render(
+      <DaemonNotRunningModal
+        open={true}
+        onRetry={() => undefined}
+        platform="linux"
+      />,
+    );
+    expect(screen.getByText('ccsm daemon is not running.')).toBeTruthy();
+    expect(
+      screen.getByText(/did not respond after 8 seconds/i),
+    ).toBeTruthy();
+  });
+
+  it('does NOT mention internals (UDS, boot_id, Hello, descriptor, RPC)', () => {
+    const { container } = render(
+      <DaemonNotRunningModal
+        open={true}
+        onRetry={() => undefined}
+        platform="linux"
+      />,
+    );
+    const text = container.textContent ?? '';
+    expect(text).not.toMatch(/UDS/i);
+    expect(text).not.toMatch(/boot[_ ]?id/i);
+    expect(text).not.toMatch(/\bHello\b/);
+    expect(text).not.toMatch(/descriptor/i);
+    expect(text).not.toMatch(/\bRPC\b/);
+  });
+});
+
+describe('DaemonNotRunningModal — per-OS troubleshooting hint', () => {
+  const cases: ReadonlyArray<{
+    platform: DaemonModalPlatform;
+    expectLabel: string;
+    expectCommand: string;
+  }> = [
+    {
+      platform: 'darwin',
+      expectLabel: 'macOS',
+      expectCommand: 'launchctl print system/com.ccsm.daemon',
+    },
+    {
+      platform: 'linux',
+      expectLabel: 'Linux',
+      expectCommand: 'systemctl status ccsm',
+    },
+    {
+      platform: 'win32',
+      expectLabel: 'Windows',
+      expectCommand: 'Get-Service ccsm',
+    },
+  ];
+
+  for (const c of cases) {
+    it(`renders ${c.platform} hint with command "${c.expectCommand}"`, () => {
+      render(
+        <DaemonNotRunningModal
+          open={true}
+          onRetry={() => undefined}
+          platform={c.platform}
+        />,
+      );
+      const section = screen.getByTestId('daemon-modal-troubleshooting');
+      expect(section.textContent ?? '').toContain(c.expectLabel);
+      const cmd = screen.getByTestId('daemon-modal-command');
+      expect(cmd.textContent).toBe(c.expectCommand);
+    });
+  }
+
+  it('renders a generic hint with no command for unknown platforms', () => {
+    render(
+      <DaemonNotRunningModal
+        open={true}
+        onRetry={() => undefined}
+        platform="other"
+      />,
+    );
+    expect(screen.queryByTestId('daemon-modal-command')).toBeNull();
+    const section = screen.getByTestId('daemon-modal-troubleshooting');
+    expect(section.textContent ?? '').toMatch(/ccsm background service/i);
+  });
+});
+
+describe('DaemonNotRunningModal — retry wiring', () => {
+  it('invokes onRetry when the "Try again" button is clicked', () => {
+    const onRetry = vi.fn();
+    render(
+      <DaemonNotRunningModal
+        open={true}
+        onRetry={onRetry}
+        platform="linux"
+      />,
+    );
+    fireEvent.click(screen.getByTestId('daemon-modal-retry'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the retry button when retryDisabled=true', () => {
+    const onRetry = vi.fn();
+    render(
+      <DaemonNotRunningModal
+        open={true}
+        onRetry={onRetry}
+        platform="linux"
+        retryDisabled
+      />,
+    );
+    const button = screen.getByTestId('daemon-modal-retry') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+});
+
+describe('DaemonNotRunningModal — Esc / cancel is suppressed (cannot dismiss)', () => {
+  it('preventDefaults the native dialog "cancel" event', () => {
+    render(
+      <DaemonNotRunningModal
+        open={true}
+        onRetry={() => undefined}
+        platform="linux"
+      />,
+    );
+    const dialog = screen.getByTestId('daemon-not-running-modal') as HTMLDialogElement;
+    const event = new Event('cancel', { cancelable: true });
+    const dispatched = dialog.dispatchEvent(event);
+    // dispatchEvent returns false iff a listener called preventDefault.
+    expect(dispatched).toBe(false);
+    expect(event.defaultPrevented).toBe(true);
+  });
+});
+
+describe('detectPlatform', () => {
+  it('returns one of the supported strings (smoke test)', () => {
+    const p = detectPlatform();
+    expect(['darwin', 'linux', 'win32', 'other']).toContain(p);
+  });
+});

--- a/packages/electron/test/renderer/components/use-daemon-cold-start-modal.spec.tsx
+++ b/packages/electron/test/renderer/components/use-daemon-cold-start-modal.spec.tsx
@@ -1,0 +1,264 @@
+// T6.8 — useDaemonColdStartModal trigger-decider tests.
+//
+// @vitest-environment happy-dom
+//
+// Spec ref: chapter 08 §6.1.
+
+import { create } from '@bufbuild/protobuf';
+import { type Transport } from '@connectrpc/connect';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { HelloResponseSchema } from '@ccsm/proto';
+
+import {
+  ConnectionProvider,
+} from '../../../src/renderer/connection/use-connection.js';
+import type { DescriptorV1 } from '../../../src/main/protocol-app.js';
+import {
+  COLD_START_BUDGET_MS,
+  shouldShowColdStartModal,
+  useDaemonColdStartModal,
+} from '../../../src/renderer/components/use-daemon-cold-start-modal.js';
+
+function descriptor(bootId: string): DescriptorV1 {
+  return {
+    version: 1,
+    transport: 'KIND_TCP_LOOPBACK_H2C',
+    address: '127.0.0.1:1',
+    tlsCertFingerprintSha256: null,
+    supervisorAddress: 'unused',
+    boot_id: bootId,
+    daemon_pid: 1,
+    listener_addr: '127.0.0.1:1',
+    protocol_version: 1,
+    bind_unix_ms: 0,
+  };
+}
+
+function transport(responder: () => unknown): Transport {
+  return {
+    async unary(method, _signal, _timeoutMs, _header, _input, _ctxValues) {
+      const r = responder();
+      if (r instanceof Error) throw r;
+      return {
+        service: method.parent,
+        method,
+        stream: false as const,
+        header: new Headers(),
+        message: r as never,
+        trailer: new Headers(),
+      };
+    },
+    async stream() {
+      throw new Error('stream not used');
+    },
+  };
+}
+
+function buildWrapper(opts: {
+  fetchDescriptor: () => Promise<DescriptorV1>;
+  buildTransport: () => Transport;
+}) {
+  const queryClient = new QueryClient();
+  const Wrapper = ({ children }: { children: React.ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      React.createElement(
+        ConnectionProvider,
+        {
+          fetchDescriptor: opts.fetchDescriptor,
+          buildTransport: opts.buildTransport,
+        },
+        children,
+      ),
+    );
+  return Wrapper;
+}
+
+describe('shouldShowColdStartModal — pure decider', () => {
+  it('stays closed when never connected and budget not yet elapsed', () => {
+    expect(
+      shouldShowColdStartModal({
+        state: { kind: 'connecting', attempt: 0 },
+        everConnected: false,
+        elapsedMs: 7000,
+      }),
+    ).toBe(false);
+  });
+
+  it('opens once budget elapsed AND state is connecting', () => {
+    expect(
+      shouldShowColdStartModal({
+        state: { kind: 'connecting', attempt: 3 },
+        everConnected: false,
+        elapsedMs: COLD_START_BUDGET_MS,
+      }),
+    ).toBe(true);
+  });
+
+  it('opens once budget elapsed AND state is reconnecting', () => {
+    expect(
+      shouldShowColdStartModal({
+        state: {
+          kind: 'reconnecting',
+          attempt: 1,
+          nextDelayMs: 200,
+          previousBootId: null,
+        },
+        everConnected: false,
+        elapsedMs: COLD_START_BUDGET_MS,
+      }),
+    ).toBe(true);
+  });
+
+  it('stays closed once connected (modal is dismissible only by Hello)', () => {
+    expect(
+      shouldShowColdStartModal({
+        state: {
+          kind: 'connected',
+          bootId: 'b',
+          daemonVersion: '0.3.0',
+          protoVersion: 1,
+          listenerId: 'A',
+        },
+        everConnected: true,
+        elapsedMs: COLD_START_BUDGET_MS * 10,
+      }),
+    ).toBe(false);
+  });
+
+  it('stays closed for version-mismatch (different UX path)', () => {
+    expect(
+      shouldShowColdStartModal({
+        state: {
+          kind: 'version-mismatch',
+          daemonProtoVersion: 0,
+          clientMinVersion: 1,
+        },
+        everConnected: false,
+        elapsedMs: COLD_START_BUDGET_MS,
+      }),
+    ).toBe(false);
+  });
+
+  it('stays closed if everConnected is true (steady-state reconnect, not cold-start)', () => {
+    expect(
+      shouldShowColdStartModal({
+        state: {
+          kind: 'reconnecting',
+          attempt: 5,
+          nextDelayMs: 1600,
+          previousBootId: 'b',
+        },
+        everConnected: true,
+        elapsedMs: COLD_START_BUDGET_MS * 10,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('useDaemonColdStartModal — integration with T6.7 ConnectionProvider', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('opens after 8s when daemon never responds', async () => {
+    // Transport that never resolves — emulates daemon-down. We can't await
+    // forever; instead we time-bound the assertion to "open=true within
+    // a few timer ticks past 8000ms".
+    const Wrapper = buildWrapper({
+      fetchDescriptor: () => new Promise(() => undefined), // never resolves
+      buildTransport: () => transport(() => new Error('unused')),
+    });
+
+    const { result, unmount } = renderHook(() => useDaemonColdStartModal(), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.open).toBe(false);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(COLD_START_BUDGET_MS + 50);
+    });
+
+    expect(result.current.open).toBe(true);
+    unmount();
+  });
+
+  it('does NOT open if Hello succeeds before the 8s budget elapses', async () => {
+    const helloResp = create(HelloResponseSchema, {
+      daemonVersion: '0.3.0',
+      protoVersion: 1,
+      listenerId: 'A',
+    });
+
+    const Wrapper = buildWrapper({
+      fetchDescriptor: async () => descriptor('boot-X'),
+      buildTransport: () => transport(() => helloResp),
+    });
+
+    const { result, unmount } = renderHook(() => useDaemonColdStartModal(), {
+      wrapper: Wrapper,
+    });
+
+    // Drain microtasks — connect resolves on tick 1.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(50);
+    });
+
+    // Now blow past the budget. Modal must still be closed.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(COLD_START_BUDGET_MS + 100);
+    });
+
+    expect(result.current.open).toBe(false);
+    unmount();
+  });
+
+});
+
+describe('useDaemonColdStartModal — retry proxies to ConnectionProvider.retryNow', () => {
+  it('triggers a fresh connect attempt when onRetry is invoked', async () => {
+    // Real timers for this test — `waitFor`'s polling collides with vitest
+    // fake timers and the never-resolving paths above leave dangling
+    // microtasks that crash the worker on shutdown.
+    const fetchDescriptor = vi.fn(async () => descriptor('boot-X'));
+    const helloResp = create(HelloResponseSchema, {
+      daemonVersion: '0.3.0',
+      protoVersion: 1,
+      listenerId: 'A',
+    });
+
+    const Wrapper = buildWrapper({
+      fetchDescriptor,
+      buildTransport: () => transport(() => helloResp),
+    });
+
+    const { result, unmount } = renderHook(() => useDaemonColdStartModal(), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(fetchDescriptor).toHaveBeenCalledTimes(1);
+    });
+
+    act(() => {
+      result.current.onRetry();
+    });
+
+    await waitFor(() => {
+      expect(fetchDescriptor).toHaveBeenCalledTimes(2);
+    });
+
+    // Tear down explicitly so the ConnectionProvider's retry loop is
+    // aborted before vitest tries to exit the worker.
+    unmount();
+  });
+});

--- a/packages/electron/vitest.config.ts
+++ b/packages/electron/vitest.config.ts
@@ -21,7 +21,9 @@ export default defineConfig({
     environment: 'node',
     include: [
       'src/**/*.spec.ts',
+      'src/**/*.spec.tsx',
       'test/**/*.spec.ts',
+      'test/**/*.spec.tsx',
     ],
     globals: false,
     // E2E specs spawn real Electron + daemon subprocesses (per-PR variant


### PR DESCRIPTION
## Summary

Lands the renderer-side blocking modal specified by ch08 §6.1 of the v0.3 daemon-split design. When the renderer's first Hello has not succeeded within 8 seconds, a real DOM `<dialog>` covers the UI with the spec-locked status copy, a per-OS troubleshooting hint with a copy-pasteable shell command, and a Try-again button wired to T6.7's `retryNow`. Modal cannot be dismissed by Esc / click-outside; it disappears only when `useConnection().state.kind === 'connected'`.

Slots into Task #75 / PR #922 (T6.7 — renderer Hello + boot_id verification + reconnect backoff). T6.7 already provides the `connecting | connected | reconnecting | version-mismatch` state machine; this PR adds the wall-clock decider that flips the modal open at the 8s mark.

## What lands

- `packages/electron/src/renderer/components/DaemonNotRunningModal.tsx` — render-only component, `<dialog open role="alertdialog">`, suppresses the native `cancel` event so Esc cannot dismiss.
- `packages/electron/src/renderer/components/use-daemon-cold-start-modal.ts` — pure decider `shouldShowColdStartModal` + `useDaemonColdStartModal()` hook bridging T6.7's `useConnection()` to the modal's `open` boolean. Latches `everConnected` so a later daemon restart routes to the §6 reconnect banner, not the §6.1 cold-start modal.
- Tests: `DaemonNotRunningModal.spec.tsx` (12 cases) + `use-daemon-cold-start-modal.spec.tsx` (9 cases). Decider matrix + integration with the real `ConnectionProvider`.

## Wiring fixes folded in (necessary for the new tests to actually run)

- `packages/electron/vitest.config.ts`: extend `include` with `*.spec.tsx`. T6.7's `use-connection.spec.tsx` (211 lines / 5 cases) had been silently excluded by the prior `*.spec.ts`-only pattern; this PR's run shows it now executes alongside the new files (3 → 5 test files in `test/renderer/`).
- `eslint.config.js`: add `HTMLDialogElement: 'readonly'` to renderer globals.

## Constraints honored

- No new IPC. T8.2 ESLint backstop still passes (6/6). No `ipcMain` / `ipcRenderer` / `contextBridge`; modal is a pure DOM component reading state from T6.7's hook.
- Real DOM modal (`<dialog open>`), not a hint banner.
- 8s budget enforced as wall-clock from mount (matches spec wording "first Hello does not succeed within 8 seconds"), not as a per-Hello timeout. T6.7's `runWithReconnect` retries forever in the background; this hook is the wall-clock decider that surfaces the modal at the 8s mark.
- User-facing copy: spec line 2325-2329 verbatim. Strings deliberately do NOT mention internals (no UDS, no boot_id, no Hello, no descriptor, no RPC) — asserted by a regex test.

## Test plan

- [x] `cd packages/electron && pnpm lint` → 0 errors
- [x] `cd packages/electron && pnpm typecheck` → 0 errors
- [x] `cd packages/electron && npx vitest run test/renderer/` → 5 files / 42 tests passed
- [x] `cd packages/electron && npx vitest run test/eslint-backstop/` → 6/6 passed (no IPC tokens introduced)
- [ ] CI green on `working` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)