### PR TITLE
fix(daemon/state-dir): unify defaultStateDir() vs statePaths() /state segment ownership

### DIFF
--- a/packages/daemon/src/env.ts
+++ b/packages/daemon/src/env.ts
@@ -8,6 +8,7 @@
 // without changing the entrypoint shape.
 
 import { bootId } from './boot-id.js';
+import { statePaths } from './state-dir/paths.js';
 
 /** Runtime mode — `service` is the installed system service shape (ch02 §2);
  * `dev` is `npx tsx` / smoke runs from a dev tree. */
@@ -26,7 +27,9 @@ export const RESERVED_FOR_LISTENER_B = Symbol.for('ccsm.listener.reserved-b');
 export type ReservedForListenerB = typeof RESERVED_FOR_LISTENER_B;
 
 export interface DaemonEnvPaths {
-  /** Durable state root (e.g. `/var/lib/ccsm`, `%PROGRAMDATA%/ccsm/state`). */
+  /** Durable state root (e.g. `%PROGRAMDATA%\ccsm`, `/var/lib/ccsm`,
+   * `/Library/Application Support/ccsm`). Mirrors `statePaths().root` from
+   * `state-dir/paths.ts` — same on-disk directory per spec ch07 §2. */
   stateDir: string;
   /** Listener-A descriptor file (`listener-a.json`) — see ch03 §3. */
   descriptorPath: string;
@@ -56,16 +59,14 @@ export interface DaemonEnv {
   readonly buildCommit: string;
 }
 
-function defaultStateDir(): string {
-  if (process.platform === 'win32') {
-    const programData = process.env.PROGRAMDATA ?? 'C:/ProgramData';
-    return `${programData}/ccsm/state`;
-  }
-  if (process.platform === 'darwin') {
-    return '/Library/Application Support/ccsm/state';
-  }
-  return '/var/lib/ccsm';
-}
+// `defaultStateDir` and the default descriptor path BOTH delegate to
+// `state-dir/paths.ts` so the per-OS layout has exactly one source of truth
+// (spec ch07 §2; FROZEN by `test/state-dir/paths.spec.ts` per T10.7 / Task
+// #122). Before this delegation, `env.ts` had its own per-OS branch that
+// appended `/state` on win32+darwin but NOT on linux — a per-OS off-by-one
+// that drifted from `statePaths().root`. Diagnosed out-of-scope while
+// reviewing PR #931 / Task #182. The `state-dir/paths.ts` module owns the
+// canonical layout; everyone else routes through it.
 
 function defaultListenerAddr(): string {
   if (process.platform === 'win32') {
@@ -92,10 +93,18 @@ function defaultSupervisorAddr(): string {
  * T1.1 — every field has a sensible default). */
 export function buildDaemonEnv(): DaemonEnv {
   const mode: RuntimeMode = process.env.CCSM_DAEMON_MODE === 'service' ? 'service' : 'dev';
-  const stateDir = process.env.CCSM_STATE_DIR ?? defaultStateDir();
+  // Single source of truth for per-OS layout — see `state-dir/paths.ts`
+  // and the comment block above the deleted `defaultStateDir`.
+  const sp = statePaths();
+  const stateDir = process.env.CCSM_STATE_DIR ?? sp.root;
   const listenerAddr = process.env.CCSM_LISTENER_A_ADDR ?? defaultListenerAddr();
   const supervisorAddr = process.env.CCSM_SUPERVISOR_ADDR ?? defaultSupervisorAddr();
-  const descriptorPath = process.env.CCSM_DESCRIPTOR_PATH ?? `${stateDir}/listener-a.json`;
+  // When CCSM_STATE_DIR overrides the root, derive the descriptor path
+  // under the override; otherwise reuse the canonical `sp.descriptor` so
+  // path-separator handling stays in one place (`path.win32.join` vs posix).
+  const descriptorPath =
+    process.env.CCSM_DESCRIPTOR_PATH ??
+    (stateDir === sp.root ? sp.descriptor : `${stateDir}/listener-a.json`);
   const version = process.env.CCSM_VERSION ?? '0.3.0-dev';
   const buildCommit = process.env.CCSM_BUILD_COMMIT ?? 'dev';
 

--- a/packages/daemon/test/state-dir/env-consistency.spec.ts
+++ b/packages/daemon/test/state-dir/env-consistency.spec.ts
@@ -1,0 +1,124 @@
+// packages/daemon/test/state-dir/env-consistency.spec.ts
+//
+// Cross-module consistency invariant: `buildDaemonEnv().paths.stateDir` MUST
+// equal `statePaths().root` for the running platform. The two paths are
+// independent code paths today (env.ts has its own `defaultStateDir()`), but
+// they describe the SAME directory on disk per spec ch07 §2 ("Daemon state
+// root" column). Drift between them is a per-OS off-by-one bug — exactly
+// what shipped in env.ts before this fix:
+//
+//   env.defaultStateDir()         statePaths().root
+//   ----------------------------  ------------------------------
+//   win32:  <PROGRAMDATA>/ccsm/state    <PROGRAMDATA>\ccsm
+//   darwin: /Library/.../ccsm/state    /Library/.../ccsm
+//   linux:  /var/lib/ccsm                /var/lib/ccsm
+//
+// (Per-OS off-by-one: linux is consistent, win32/darwin are NOT. Diagnosed
+// out-of-scope while reviewing PR #931 / Task #182.)
+//
+// `state-dir/paths.ts` is the file-layout module and its `statePaths()` is
+// the FROZEN single source of truth (test/state-dir/paths.spec.ts golden,
+// T10.7 / Task #122). env.ts MUST delegate to it; this spec is the gate.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { buildDaemonEnv } from '../../src/env.js';
+import { statePaths } from '../../src/state-dir/paths.js';
+
+const SAVED_ENV: Record<string, string | undefined> = {};
+const ENV_KEYS = ['CCSM_STATE_DIR', 'PROGRAMDATA'] as const;
+
+function saveEnv(): void {
+  for (const k of ENV_KEYS) {
+    SAVED_ENV[k] = process.env[k];
+  }
+}
+
+function restoreEnv(): void {
+  for (const k of Object.keys(SAVED_ENV)) {
+    const v = SAVED_ENV[k];
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
+  }
+  for (const k of Object.keys(SAVED_ENV)) {
+    delete SAVED_ENV[k];
+  }
+}
+
+function withPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform');
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  try {
+    return fn();
+  } finally {
+    if (original) {
+      Object.defineProperty(process, 'platform', original);
+    } else {
+      Object.defineProperty(process, 'platform', { value: process.platform, configurable: true });
+    }
+  }
+}
+
+describe('env.paths.stateDir vs statePaths().root — single source of truth (ch07 §2)', () => {
+  beforeEach(() => {
+    saveEnv();
+    // Force the default branch (no CCSM_STATE_DIR override) — we are
+    // testing the per-OS *default* resolution, which is where the off-by-
+    // one lived.
+    delete process.env.CCSM_STATE_DIR;
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  it('win32: env.paths.stateDir == statePaths().root (no /state off-by-one)', () => {
+    process.env.PROGRAMDATA = 'C:\\ProgramData';
+    withPlatform('win32', () => {
+      const env = buildDaemonEnv();
+      const sp = statePaths();
+      expect(env.paths.stateDir).toBe(sp.root);
+    });
+  });
+
+  it('darwin: env.paths.stateDir == statePaths().root (no /state off-by-one)', () => {
+    withPlatform('darwin', () => {
+      const env = buildDaemonEnv();
+      const sp = statePaths();
+      expect(env.paths.stateDir).toBe(sp.root);
+    });
+  });
+
+  it('linux: env.paths.stateDir == statePaths().root', () => {
+    withPlatform('linux', () => {
+      const env = buildDaemonEnv();
+      const sp = statePaths();
+      expect(env.paths.stateDir).toBe(sp.root);
+    });
+  });
+
+  it('descriptorPath default sits directly under statePaths().root (ch07 §2 — listener-a.json at root, NOT under /state)', () => {
+    delete process.env.CCSM_DESCRIPTOR_PATH;
+    for (const plat of ['win32', 'darwin', 'linux'] as const) {
+      if (plat === 'win32') process.env.PROGRAMDATA = 'C:\\ProgramData';
+      withPlatform(plat, () => {
+        const env = buildDaemonEnv();
+        const sp = statePaths();
+        // Descriptor path must be `<root>/listener-a.json` exactly — same
+        // root as the file-layout module owns.
+        expect(env.paths.descriptorPath).toBe(sp.descriptor);
+      });
+    }
+  });
+
+  it('CCSM_STATE_DIR override still wins (env shape preserved)', () => {
+    process.env.CCSM_STATE_DIR = '/tmp/ccsm-override';
+    withPlatform('linux', () => {
+      const env = buildDaemonEnv();
+      expect(env.paths.stateDir).toBe('/tmp/ccsm-override');
+    });
+  });
+});


### PR DESCRIPTION
## Task

Task #187 — fix per-OS off-by-one between `env.defaultStateDir()` and
`statePaths().root`.

## Diagnosis

Two independent paths described the same on-disk directory but disagreed:

| OS      | `env.defaultStateDir()`               | `statePaths().root`                  |
| ------- | ------------------------------------- | ------------------------------------ |
| win32   | `<PROGRAMDATA>/ccsm/state` (off-by-1) | `<PROGRAMDATA>\ccsm`                 |
| darwin  | `/Library/.../ccsm/state` (off-by-1)  | `/Library/.../ccsm`                  |
| linux   | `/var/lib/ccsm` (consistent)          | `/var/lib/ccsm`                      |

Spec ch07 §2 (FROZEN by `test/state-dir/paths.spec.ts` per T10.7 /
Task #122) names `state-dir/paths.ts` as the file-layout module that
owns the canonical per-OS root. The frozen golden carries no `/state`
segment for any of `db` / `crashRaw` / `descriptor` / `descriptorsDir`
on any OS. So the unifying answer is **drop `/state` from `env.ts`**,
not add it to `statePaths()`.

## Fix

`packages/daemon/src/env.ts`:

- `defaultStateDir()` deleted.
- `buildDaemonEnv()` calls `statePaths()` for the canonical root.
- Default `descriptorPath` reuses `statePaths().descriptor` so the
  win32 path-separator handling (`path.win32.join`) lives in exactly
  one place.
- `CCSM_STATE_DIR` / `CCSM_DESCRIPTOR_PATH` env overrides preserved.
- `DaemonEnvPaths.stateDir` jsdoc updated to match the actual values.

`statePaths()` and the frozen `test/state-dir/paths.spec.ts` are
**untouched** — the file-layout module already owns the canonical
layout; this PR just makes `env.ts` route through it.

## Reverse-verify

New invariant test: `packages/daemon/test/state-dir/env-consistency.spec.ts`.

Without the fix (`git stash` of `env.ts`):

```
 FAIL  test/state-dir/env-consistency.spec.ts > ... > win32: env.paths.stateDir == statePaths().root
   Expected: "C:\ProgramData\ccsm"
   Received: "C:\ProgramData/ccsm/state"

 FAIL  ... > darwin: env.paths.stateDir == statePaths().root
   Expected: "/Library/Application Support/ccsm"
   Received: "/Library/Application Support/ccsm/state"

 FAIL  ... > descriptorPath default sits directly under statePaths().root
   Expected: "C:\ProgramData\ccsm\listener-a.json"
   Received: "C:\ProgramData/ccsm/state/listener-a.json"

 Test Files  1 failed (1)
      Tests  3 failed | 2 passed (5)
```

Linux passes both runs — already consistent (the off-by-one was
win32+darwin only).

With the fix (`git stash pop`):

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

## Quality gates (ran locally on win32 host)

```
$ cd packages/daemon && npx vitest run test/state-dir
 Test Files  2 passed (2)
      Tests  21 passed (21)

$ npm run lint
 1 error  (src/index.ts:234 ccsm/no-listener-slot-mutation — PRE-EXISTING, OUT OF SCOPE per task brief)

$ npm run typecheck
 1 error  src/index.ts(234,24) Property 'push' does not exist on type 'readonly Listener[]' — same pre-existing OUT-OF-SCOPE error
```

No new lint or typecheck errors introduced. The pre-existing
`index.ts:234` failure is explicitly carved out by the task brief.

## Files

- `packages/daemon/src/env.ts` — fix
- `packages/daemon/test/state-dir/env-consistency.spec.ts` — new invariant