### PR TITLE
feat(daemon T3.3): SessionService.WatchSessions stream handler

### DIFF
--- a/packages/daemon/src/rpc/router.ts
+++ b/packages/daemon/src/rpc/router.ts
@@ -59,6 +59,11 @@ import {
   SupervisorService,
 } from '@ccsm/proto';
 
+import {
+  makeWatchSessionsHandler,
+  type WatchSessionsDeps,
+} from '../sessions/watch-sessions.js';
+
 import { makeHelloHandler, type HelloDeps } from './hello.js';
 import { requestMetaInterceptor } from './middleware/request-meta.js';
 
@@ -143,6 +148,36 @@ export function registerHelloHandler(
 }
 
 /**
+ * Register the v0.3 SessionService handlers that have landed so far —
+ * Hello (T2.3) and WatchSessions (T3.3) — under a SINGLE
+ * `router.service(SessionService, ...)` call.
+ *
+ * Why a combined registration (not two `service()` calls): per Connect-ES
+ * `ConnectRouter.service` semantics, calling `service(desc, impl)` twice
+ * for the same descriptor REPLACES the prior registration (the router
+ * is a path-keyed map). Registering Hello and then WatchSessions
+ * separately would silently drop Hello. The Hello-only path
+ * (`registerHelloHandler` above) is preserved for callers that have not
+ * yet wired a SessionManager (existing test fixtures); production
+ * startup wiring (T1.7) uses this combined form.
+ *
+ * Methods not yet implemented (ListSessions, GetSession, CreateSession,
+ * DestroySession, RenameSession, ...) remain `Unimplemented` per the
+ * Connect router's "absent method → Unimplemented" rule, exactly as in
+ * the stub-only path.
+ */
+export function registerSessionService(
+  router: ConnectRouter,
+  deps: { readonly helloDeps: HelloDeps; readonly watchSessionsDeps: WatchSessionsDeps },
+): ConnectRouter {
+  router.service(SessionService, {
+    hello: makeHelloHandler(deps.helloDeps),
+    watchSessions: makeWatchSessionsHandler(deps.watchSessionsDeps),
+  });
+  return router;
+}
+
+/**
  * Bundled routes callback that installs stubs for every service AND the
  * real T2.3 Hello handler on SessionService. Use this from the daemon's
  * production startup wiring (T1.7) — pass through to
@@ -151,10 +186,15 @@ export function registerHelloHandler(
  */
 export function makeDaemonRoutes(
   helloDeps: HelloDeps,
+  watchSessionsDeps?: WatchSessionsDeps,
 ): (router: ConnectRouter) => void {
   return (router: ConnectRouter): void => {
     registerStubServices(router);
-    registerHelloHandler(router, helloDeps);
+    if (watchSessionsDeps !== undefined) {
+      registerSessionService(router, { helloDeps, watchSessionsDeps });
+    } else {
+      registerHelloHandler(router, helloDeps);
+    }
   };
 }
 
@@ -177,6 +217,16 @@ export interface CreateDaemonNodeAdapterOptions extends ConnectRouterOptions {
   readonly requestPathPrefix?: string;
   /** When set, installs the T2.3 Hello handler on top of the stubs. */
   readonly helloDeps?: HelloDeps;
+  /**
+   * When set (and `helloDeps` is also set), installs the T3.3
+   * WatchSessions streaming handler in the same SessionService
+   * registration as Hello — see `registerSessionService` for the
+   * "registering a single descriptor twice replaces" caveat that forces
+   * the combined registration. v0.3 ships this when the daemon startup
+   * wiring (T1.7) constructs a `SessionManager`; tests that don't need
+   * a manager simply omit it (Hello-only path stays).
+   */
+  readonly watchSessionsDeps?: WatchSessionsDeps;
 }
 
 /**
@@ -215,9 +265,9 @@ export type DaemonNodeHandler = ReturnType<typeof connectNodeAdapter>;
 export function createDaemonNodeAdapter(
   options: CreateDaemonNodeAdapterOptions = {},
 ): DaemonNodeHandler {
-  const { helloDeps, interceptors: callerInterceptors, ...rest } = options;
+  const { helloDeps, watchSessionsDeps, interceptors: callerInterceptors, ...rest } = options;
   const routes =
-    helloDeps !== undefined ? makeDaemonRoutes(helloDeps) : stubRoutes;
+    helloDeps !== undefined ? makeDaemonRoutes(helloDeps, watchSessionsDeps) : stubRoutes;
   const interceptors = [
     requestMetaInterceptor,
     ...(callerInterceptors ?? []),

--- a/packages/daemon/src/sessions/watch-sessions.ts
+++ b/packages/daemon/src/sessions/watch-sessions.ts
@@ -1,0 +1,471 @@
+// SessionService.WatchSessions handler — server-streaming subscription to
+// the in-memory SessionEventBus, scoped to the caller's Principal.
+//
+// Spec refs:
+//   - docs/superpowers/specs/2026-05-02-final-architecture.md
+//     ch04 §3 (WatchScope enum: UNSPECIFIED == OWN, OWN, ALL)
+//     ch05 §5 (per-RPC enforcement matrix; WatchSessions is double-scoped:
+//             principal filter is unconditional, scope enum widens to ALL
+//             only for v0.4 admin principals; v0.3 daemon MUST reject ALL
+//             with PermissionDenied carrying ErrorDetail).
+//   - T2.5 (PR #926) — `throwError('session.not_owned', ...)` is the
+//             single source of truth for `Code.PermissionDenied + ErrorDetail`
+//             emission. WatchSessions reuses that mapping.
+//   - T3.2 (PR #933) — SessionManager exposes `subscribe(caller, listener)`
+//             which delegates to `SessionEventBus`; the bus does the
+//             principal-key fanout filter (security boundary).
+//
+// SRP layering — three roles, kept separate (dev.md §2):
+//   - decider:  `decideWatchScope(req)` — pure function, no I/O. Returns
+//               `{ kind: 'accept' } | { kind: 'reject_permission_denied' }`.
+//               UNSPECIFIED is treated as OWN per session.proto comment;
+//               OWN is accepted; ALL is rejected with PermissionDenied.
+//   - producer: `subscribeAsAsyncIterable(manager, principal, signal)` —
+//               adapts the manager's push-based `subscribe(listener)` API
+//               into the AsyncIterable<SessionEvent> shape Connect-ES v2
+//               server-streaming handlers must return. Bounded buffer per
+//               subscriber (slow-consumer protection); abort signal tears
+//               down the subscription deterministically.
+//   - sink:     `makeWatchSessionsHandler(deps)` — wraps the decider +
+//               producer into the Connect handler signature, reading
+//               `PRINCIPAL_KEY` from the HandlerContext (the
+//               peerCredAuthInterceptor deposited it before this handler
+//               runs), mapping each in-memory `SessionEvent` to the proto
+//               `SessionEvent` shape.
+//
+// Why we map to proto here (not in the manager):
+//   - The manager owns DB rows and is proto-agnostic by design (see
+//     `sessions/types.ts` header comment + dev.md §2 SRP — manager is a
+//     persistence sink, the RPC handler is a wire sink). Putting the
+//     row → proto translation in the handler keeps the manager's test
+//     fixtures free of @ccsm/proto and lets v0.4 add new fields to the
+//     proto Session without churning the manager.
+//
+// Layer 1 — alternatives checked:
+//   - Use `node:events.EventEmitter.on(emitter, evt, { signal })` (the
+//     stdlib's built-in EventEmitter -> AsyncIterable adapter). Rejected:
+//     SessionEventBus is NOT an EventEmitter (it's a 30-line bespoke bus
+//     with principal-key filtering — see `event-bus.ts` Layer 1 note).
+//     Wrapping the bus to look like an EventEmitter just to use the
+//     stdlib adapter is more code than the 25-line adapter below.
+//   - Use `rxjs` / `it-pushable` / `eventemitter3`: zero of these are
+//     daemon deps, and adding a dep for one adapter is the dep-creep
+//     anti-pattern dev.md §1 calls out.
+//   - Have the handler call `manager.list()` once and stream a synthetic
+//     "snapshot" set of `created` events before subscribing. Rejected:
+//     spec ch05 §5 wording is "the bus delivers post-subscribe events" —
+//     adding a snapshot would change the wire semantics from "events
+//     since subscribe" to "current state + tail". v0.4 may add an
+//     explicit `include_snapshot` field; v0.3 ships the tail-only shape.
+//   - Drop events when the buffer is full vs. error the stream. We choose
+//     ERROR (Code.ResourceExhausted via ConnectError) because a watcher
+//     that misses created/destroyed events without notice would silently
+//     desync the client's session list — worse than a loud disconnect
+//     that the client retries (the Electron Sidebar has reconnect logic
+//     in T8.x). Buffer size is generous (1024 events) so legitimate
+//     workloads never hit the limit.
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type HandlerContext,
+  type ServiceImpl,
+} from '@connectrpc/connect';
+
+import {
+  LocalUserSchema,
+  PrincipalSchema,
+  SessionEventSchema,
+  SessionSchema,
+  WatchScope,
+  type SessionEvent as ProtoSessionEvent,
+  type SessionService,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, type Principal as AuthPrincipal } from '../auth/index.js';
+import { throwError } from '../rpc/errors.js';
+
+import type { ISessionManager } from './SessionManager.js';
+import type { SessionEvent, SessionRow } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Decider
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated union representing the decider's verdict for a
+ * WatchSessions request. Pure data; the sink is the only layer that
+ * translates a `reject` verdict into a thrown ConnectError.
+ *
+ * `accept` is the v0.3 happy path — both `WATCH_SCOPE_UNSPECIFIED` and
+ * `WATCH_SCOPE_OWN` resolve here (per session.proto comment "default
+ * UNSPECIFIED == OWN"). The principal-key filter applied by the bus is
+ * the security boundary in either case.
+ *
+ * `reject_permission_denied` is `WATCH_SCOPE_ALL` on v0.3. The spec
+ * (ch05 §5 + session.proto F1) reserves `ALL` for v0.4 admin principals
+ * and REQUIRES v0.3 daemons to emit PermissionDenied with structured
+ * ErrorDetail so Electron / future iOS clients can branch deterministically
+ * on `(code, error_detail.code)` rather than parsing free-form strings.
+ */
+export type WatchScopeVerdict =
+  | { readonly kind: 'accept' }
+  | { readonly kind: 'reject_permission_denied' };
+
+/**
+ * Pure decider over `WatchScope`. v0.3 enum values:
+ *   - UNSPECIFIED (0) → accept (treated as OWN per session.proto)
+ *   - OWN         (1) → accept
+ *   - ALL         (2) → reject_permission_denied
+ *
+ * Unknown enum values (forward-compat) are rejected with
+ * `reject_permission_denied`: a future v0.4 client speaking a higher
+ * proto_version may send an enum value the v0.3 daemon does not know
+ * about. The conservative choice is "deny by default" rather than
+ * silently accepting and treating as OWN — the negotiation contract
+ * (Hello) already lets the client downgrade or refuse to connect, so a
+ * value the daemon cannot interpret is a contract violation.
+ */
+export function decideWatchScope(scope: WatchScope): WatchScopeVerdict {
+  switch (scope) {
+    case WatchScope.UNSPECIFIED:
+    case WatchScope.OWN:
+      return { kind: 'accept' };
+    case WatchScope.ALL:
+      return { kind: 'reject_permission_denied' };
+    default:
+      // Unknown enum — see Layer 1 note in the function doc.
+      return { kind: 'reject_permission_denied' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Row → proto mapper (sink helper, exported for unit tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a proto `Session` from an in-process `SessionRow` and the
+ * caller's principal. The principal's `LocalUser` shape is embedded in
+ * the proto `owner` oneof so a watcher receives the full attribution
+ * surface without an extra round-trip.
+ *
+ * Note: the proto `Session.owner` field is the SESSION's owner (which,
+ * per the principal-scoped subscription contract, equals the watching
+ * principal in v0.3 — the bus filter guarantees `row.owner_id ===
+ * principalKey(caller)` before any event reaches a listener). v0.4 admin
+ * subscriptions will be the only case where these can differ; until
+ * then we render from the watching principal's authoritative shape so
+ * `displayName` is populated (the row carries only `owner_id` =
+ * principalKey, which is `<kind>:<uid>` — no display_name column).
+ *
+ * `exit_code` is wire-optional via proto3 field-presence (`optional
+ * int32 exit_code = 7`). The DB row carries the sentinel `-1` for "not
+ * yet exited" (chapter 07 §3); we map -1 → unset and any other value
+ * through unchanged so `state == EXITED` rows preserve `0` correctly.
+ */
+export function sessionRowToProto(
+  row: SessionRow,
+  caller: AuthPrincipal,
+): ReturnType<typeof create<typeof SessionSchema>> {
+  const owner = create(PrincipalSchema, {
+    kind: {
+      case: 'localUser',
+      value: create(LocalUserSchema, {
+        uid: caller.uid,
+        displayName: caller.displayName,
+      }),
+    },
+  });
+  return create(SessionSchema, {
+    id: row.id,
+    owner,
+    state: row.state as unknown as number,
+    cwd: row.cwd,
+    createdUnixMs: BigInt(row.created_ms),
+    lastActiveUnixMs: BigInt(row.last_active_ms),
+    // Sentinel -1 means "not yet exited" — leave the optional field unset.
+    exitCode: row.exit_code === -1 ? undefined : row.exit_code,
+  });
+}
+
+/**
+ * Translate an in-memory `SessionEvent` (from the bus) into a wire
+ * `SessionEvent` proto. The proto shape is a oneof:
+ *   - `created`   carries the full `Session`
+ *   - `updated`   carries the full `Session` (state / exit_code change)
+ *   - `destroyed` carries just the `session_id` string
+ *
+ * v0.3 SessionManager emits only `created` and `destroyed`; an `updated`
+ * variant lands in T4.x when PTY state transitions wire in. The mapper
+ * is exhaustive over the in-memory union so a future variant added to
+ * `types.ts::SessionEvent` without an update here fails the TypeScript
+ * `never`-narrowing check.
+ */
+export function sessionEventToProto(
+  ev: SessionEvent,
+  caller: AuthPrincipal,
+): ProtoSessionEvent {
+  switch (ev.kind) {
+    case 'created':
+      return create(SessionEventSchema, {
+        kind: { case: 'created', value: sessionRowToProto(ev.session, caller) },
+      });
+    case 'destroyed':
+      // Wire shape carries only the id — clients use it to remove the
+      // session from their local cache without needing the row payload.
+      return create(SessionEventSchema, {
+        kind: { case: 'destroyed', value: ev.session.id },
+      });
+    default: {
+      const _exhaustive: never = ev;
+      throw new Error(
+        `unhandled SessionEvent kind: ${String((_exhaustive as { kind: string }).kind)}`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Producer — bus → AsyncIterable adapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Bounded buffer used by the bus → AsyncIterable adapter. 1024 events
+ * is generous: a session create/destroy happens at human interaction
+ * speed (multiple-of-seconds), so even a sluggish watcher should drain
+ * faster than the producer can fill. Hitting the limit is an indication
+ * of a stuck consumer; the adapter signals the stream as
+ * `Code.ResourceExhausted` so the client's reconnect path runs.
+ *
+ * Exported for unit tests so the slow-consumer scenario can be exercised
+ * without queuing 1025+ real events.
+ */
+export const DEFAULT_WATCH_BUFFER_SIZE = 1024;
+
+interface SubscribeAsAsyncIterableOptions {
+  /** Override the buffer size — tests use a small value to exercise overflow. */
+  readonly bufferSize?: number;
+  /**
+   * AbortSignal used to tear down the subscription. Connect-ES passes
+   * `HandlerContext.signal` which fires when the client disconnects or
+   * the server is shutting down. The adapter detaches its listener and
+   * resolves the iterator's pending `next()` with `done: true`.
+   */
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Adapt the manager's push-based `subscribe(caller, listener)` API into
+ * a pull-based `AsyncIterable<SessionEvent>` that Connect-ES v2's
+ * server-streaming handler can `yield*` over.
+ *
+ * The adapter uses a single-slot promise queue:
+ *   - the listener fires synchronously from `bus.publish` and either
+ *     fulfills a pending `next()` or appends to the buffer;
+ *   - `next()` either consumes a buffered event or installs the resolver
+ *     for the next `publish` to fire;
+ *   - the `signal`'s `abort` event detaches the listener and resolves
+ *     any pending `next()` with `done: true` so the for-await loop in
+ *     the handler exits cleanly.
+ *
+ * Buffer-full policy: throw a `ConnectError(ResourceExhausted)` from
+ * `next()`. The handler propagates it as the stream's terminal error so
+ * the client sees a structured failure rather than silent event loss.
+ *
+ * Exported separately from the handler so unit tests can drive the
+ * adapter against a stub `subscribe` function without building a full
+ * Connect transport.
+ */
+export function subscribeAsAsyncIterable(
+  manager: ISessionManager,
+  caller: AuthPrincipal,
+  options: SubscribeAsAsyncIterableOptions = {},
+): AsyncIterable<SessionEvent> {
+  const bufferSize = options.bufferSize ?? DEFAULT_WATCH_BUFFER_SIZE;
+  const signal = options.signal;
+
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<SessionEvent> {
+      // Pending events queued because no consumer was waiting at publish
+      // time. FIFO via Array.shift — fine at sub-1024-element scale.
+      const buffer: SessionEvent[] = [];
+      // Resolver installed by `next()` when the buffer is empty. Cleared
+      // before each fulfillment so a second publish enqueues instead of
+      // double-fulfilling a stale resolver.
+      let pendingResolve:
+        | ((value: IteratorResult<SessionEvent>) => void)
+        | null = null;
+      let pendingReject: ((reason: unknown) => void) | null = null;
+      let done = false;
+      // Sticky error: if the buffer overflows we record the error and
+      // surface it on the next `next()` call so the handler propagates a
+      // single, deterministic terminal status to the client.
+      let bufferError: ConnectError | null = null;
+
+      const unsubscribe = manager.subscribe(caller, (ev) => {
+        if (done) return;
+        if (pendingResolve !== null) {
+          const resolve = pendingResolve;
+          pendingResolve = null;
+          pendingReject = null;
+          resolve({ value: ev, done: false });
+          return;
+        }
+        if (buffer.length >= bufferSize) {
+          // Slow consumer — record terminal error; further events are
+          // dropped because we're about to terminate the stream anyway.
+          bufferError = new ConnectError(
+            `WatchSessions subscriber buffer overflow (>= ${bufferSize} events); ` +
+              'consumer is too slow — stream terminated so client retries.',
+            Code.ResourceExhausted,
+          );
+          done = true;
+          unsubscribe();
+          return;
+        }
+        buffer.push(ev);
+      });
+
+      const onAbort = (): void => {
+        if (done) return;
+        done = true;
+        unsubscribe();
+        if (pendingResolve !== null) {
+          const resolve = pendingResolve;
+          pendingResolve = null;
+          pendingReject = null;
+          resolve({ value: undefined as never, done: true });
+        }
+      };
+
+      if (signal !== undefined) {
+        if (signal.aborted) {
+          onAbort();
+        } else {
+          signal.addEventListener('abort', onAbort, { once: true });
+        }
+      }
+
+      const detachAbort = (): void => {
+        if (signal !== undefined) {
+          signal.removeEventListener('abort', onAbort);
+        }
+      };
+
+      return {
+        async next(): Promise<IteratorResult<SessionEvent>> {
+          if (buffer.length > 0) {
+            const value = buffer.shift() as SessionEvent;
+            return { value, done: false };
+          }
+          if (bufferError !== null) {
+            const err = bufferError;
+            bufferError = null;
+            detachAbort();
+            throw err;
+          }
+          if (done) {
+            detachAbort();
+            return { value: undefined as never, done: true };
+          }
+          return new Promise<IteratorResult<SessionEvent>>((resolve, reject) => {
+            pendingResolve = resolve;
+            pendingReject = reject;
+          });
+        },
+        async return(value?: unknown): Promise<IteratorResult<SessionEvent>> {
+          done = true;
+          unsubscribe();
+          detachAbort();
+          if (pendingReject !== null) {
+            // No-op resolver — `return()` semantically completes the
+            // iterator; the consumer's pending `next()` resolves to done.
+            const resolve = pendingResolve;
+            pendingResolve = null;
+            pendingReject = null;
+            resolve?.({ value: undefined as never, done: true });
+          }
+          return { value: value as never, done: true };
+        },
+        async throw(err?: unknown): Promise<IteratorResult<SessionEvent>> {
+          done = true;
+          unsubscribe();
+          detachAbort();
+          if (pendingReject !== null) {
+            const reject = pendingReject;
+            pendingResolve = null;
+            pendingReject = null;
+            reject(err);
+          }
+          throw err;
+        },
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sink — Connect handler
+// ---------------------------------------------------------------------------
+
+export interface WatchSessionsDeps {
+  readonly manager: ISessionManager;
+}
+
+/**
+ * Build the Connect `ServiceImpl<typeof SessionService>['watchSessions']`
+ * handler. Reads `PRINCIPAL_KEY` from the HandlerContext (the
+ * peerCredAuthInterceptor deposited it before the handler runs), runs
+ * the decider over the request's `scope`, then either subscribes to the
+ * principal-scoped event bus and yields proto events, or throws
+ * `Code.PermissionDenied` with the canonical `session.not_owned`
+ * ErrorDetail (T2.5 single source of truth).
+ *
+ * The handler returns an async generator (Connect-ES v2 server-streaming
+ * shape). The generator's lifetime is bound to the HandlerContext's
+ * `signal`: when the client disconnects or the server shuts down,
+ * Connect aborts the signal, the producer's `subscribeAsAsyncIterable`
+ * detaches the bus listener, and the generator returns cleanly.
+ */
+export function makeWatchSessionsHandler(
+  deps: WatchSessionsDeps,
+): ServiceImpl<typeof SessionService>['watchSessions'] {
+  return async function* watchSessions(
+    req,
+    handlerContext: HandlerContext,
+  ): AsyncGenerator<ProtoSessionEvent, void, undefined> {
+    const principal = handlerContext.values.get(PRINCIPAL_KEY);
+    if (principal === null) {
+      // Defensive — peerCredAuthInterceptor MUST have deposited the
+      // principal before this handler runs. Mirrors hello.ts's posture:
+      // surface as Internal so operators see a daemon-side wiring bug
+      // rather than the client being told they're unauthenticated.
+      throw new ConnectError(
+        'WatchSessions handler invoked without peerCredAuthInterceptor in chain ' +
+          '(PRINCIPAL_KEY=null) — daemon wiring bug',
+        Code.Internal,
+      );
+    }
+
+    const verdict = decideWatchScope(req.scope);
+    if (verdict.kind === 'reject_permission_denied') {
+      // Spec ch05 §5: WATCH_SCOPE_ALL is reserved for v0.4 admin
+      // principals; v0.3 daemons MUST reject with PermissionDenied +
+      // structured ErrorDetail.code = "session.not_owned" so the client
+      // can branch deterministically on the (Code, ErrorDetail.code)
+      // pair (T2.5 single source of truth).
+      throwError('session.not_owned', 'WATCH_SCOPE_ALL is not permitted on v0.3 (admin scope reserved for v0.4)', {
+        requested_scope: WatchScope[req.scope] ?? String(req.scope),
+      });
+    }
+
+    const events = subscribeAsAsyncIterable(deps.manager, principal, {
+      signal: handlerContext.signal,
+    });
+
+    for await (const ev of events) {
+      yield sessionEventToProto(ev, principal);
+    }
+  };
+}

--- a/packages/daemon/test/sessions/watch-sessions.spec.ts
+++ b/packages/daemon/test/sessions/watch-sessions.spec.ts
@@ -1,0 +1,434 @@
+// Unit tests for SessionService.WatchSessions handler (T3.3 / Task #34).
+//
+// Covers:
+//   - Decider (`decideWatchScope`): UNSPECIFIED / OWN → accept;
+//     ALL → reject_permission_denied; unknown enum value → reject (forward
+//     compat conservative default).
+//   - Producer (`subscribeAsAsyncIterable`): bus events arrive via the
+//     iterator; abort signal terminates cleanly; buffer overflow surfaces
+//     as ConnectError(ResourceExhausted).
+//   - Sink (handler) over the in-process Connect router transport:
+//       * happy path — OWN scope yields proto SessionEvent for created
+//         + destroyed events, scoped to the caller's principal (peer
+//         principal cannot see them);
+//       * permission denied — ALL scope throws
+//         ConnectError(PermissionDenied) with ErrorDetail.code =
+//         "session.not_owned" (T2.5 single source of truth);
+//       * UNSPECIFIED defaults to OWN.
+//
+// Spec refs:
+//   - ch04 §3 (WatchScope enum); ch05 §5 (per-RPC enforcement matrix).
+//   - T2.5 / PR #926 (`throwError('session.not_owned', ...)`).
+//   - T3.2 / PR #933 (SessionManager + SessionEventBus).
+//
+// SRP layering mirrored in the spec layout: separate describe blocks for
+// the decider (pure), producer (no Connect plumbing), and sink (full
+// in-process router transport).
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  createClient,
+  createRouterTransport,
+} from '@connectrpc/connect';
+import { describe, expect, it } from 'vitest';
+
+import {
+  ErrorDetailSchema,
+  RequestMetaSchema,
+  SessionService,
+  SessionState as ProtoSessionState,
+  WatchScope,
+  WatchSessionsRequestSchema,
+  type ErrorDetail,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, type Principal as AuthPrincipal } from '../../src/auth/index.js';
+import { openDatabase, type SqliteDatabase } from '../../src/db/sqlite.js';
+import { runMigrations } from '../../src/db/migrations/runner.js';
+import { SessionManager } from '../../src/sessions/SessionManager.js';
+import { SessionState, type SessionRow } from '../../src/sessions/types.js';
+import {
+  DEFAULT_WATCH_BUFFER_SIZE,
+  decideWatchScope,
+  makeWatchSessionsHandler,
+  sessionEventToProto,
+  sessionRowToProto,
+  subscribeAsAsyncIterable,
+} from '../../src/sessions/watch-sessions.js';
+
+const ALICE: AuthPrincipal = { kind: 'local-user', uid: '1000', displayName: 'alice' };
+const BOB: AuthPrincipal = { kind: 'local-user', uid: '1001', displayName: 'bob' };
+
+function freshDb(): SqliteDatabase {
+  const db = openDatabase(':memory:');
+  runMigrations(db);
+  // sessions.owner_id has an FK to principals(id) — see SessionManager.spec.ts.
+  const insertPrincipal = db.prepare(
+    `INSERT INTO principals (id, kind, display_name, first_seen_ms, last_seen_ms)
+     VALUES (?, ?, ?, ?, ?)`,
+  );
+  insertPrincipal.run('local-user:1000', 'local-user', 'alice', 1, 1);
+  insertPrincipal.run('local-user:1001', 'local-user', 'bob', 1, 1);
+  return db;
+}
+
+function createInput() {
+  return {
+    cwd: '/home/alice',
+    env_json: '{}',
+    claude_args_json: '[]',
+    geometry_cols: 80,
+    geometry_rows: 24,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Decider
+// ---------------------------------------------------------------------------
+
+describe('decideWatchScope — pure decider', () => {
+  it('accepts WATCH_SCOPE_UNSPECIFIED (treated as OWN per session.proto)', () => {
+    expect(decideWatchScope(WatchScope.UNSPECIFIED)).toEqual({ kind: 'accept' });
+  });
+
+  it('accepts WATCH_SCOPE_OWN', () => {
+    expect(decideWatchScope(WatchScope.OWN)).toEqual({ kind: 'accept' });
+  });
+
+  it('rejects WATCH_SCOPE_ALL with reject_permission_denied', () => {
+    expect(decideWatchScope(WatchScope.ALL)).toEqual({
+      kind: 'reject_permission_denied',
+    });
+  });
+
+  it('rejects unknown enum values (forward-compat conservative default)', () => {
+    // Cast a numeric value the v0.3 enum does not know about — simulates
+    // a v0.4+ client speaking a higher proto_version that adds enum
+    // entries the v0.3 daemon has not seen.
+    expect(decideWatchScope(99 as WatchScope)).toEqual({
+      kind: 'reject_permission_denied',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Row → proto mapper
+// ---------------------------------------------------------------------------
+
+describe('sessionRowToProto / sessionEventToProto', () => {
+  function makeRow(overrides: Partial<SessionRow> = {}): SessionRow {
+    return {
+      id: 'sess-001',
+      owner_id: 'local-user:1000',
+      state: SessionState.STARTING,
+      cwd: '/home/alice',
+      env_json: '{}',
+      claude_args_json: '[]',
+      geometry_cols: 80,
+      geometry_rows: 24,
+      exit_code: -1,
+      created_ms: 1_700_000_000_000,
+      last_active_ms: 1_700_000_000_500,
+      should_be_running: 1,
+      ...overrides,
+    };
+  }
+
+  it('renders the LocalUser owner from the watching principal', () => {
+    const proto = sessionRowToProto(makeRow(), ALICE);
+    expect(proto.id).toBe('sess-001');
+    expect(proto.cwd).toBe('/home/alice');
+    expect(proto.state).toBe(ProtoSessionState.STARTING);
+    expect(proto.createdUnixMs).toBe(1_700_000_000_000n);
+    expect(proto.lastActiveUnixMs).toBe(1_700_000_000_500n);
+    expect(proto.owner?.kind?.case).toBe('localUser');
+    if (proto.owner?.kind?.case !== 'localUser') return;
+    expect(proto.owner.kind.value.uid).toBe('1000');
+    expect(proto.owner.kind.value.displayName).toBe('alice');
+  });
+
+  it('omits exit_code when the row carries the -1 sentinel', () => {
+    const proto = sessionRowToProto(makeRow({ exit_code: -1 }), ALICE);
+    expect(proto.exitCode).toBeUndefined();
+  });
+
+  it('preserves a real exit_code (including 0) through the mapper', () => {
+    const proto = sessionRowToProto(
+      makeRow({ exit_code: 0, state: SessionState.EXITED }),
+      ALICE,
+    );
+    expect(proto.exitCode).toBe(0);
+    expect(proto.state).toBe(ProtoSessionState.EXITED);
+  });
+
+  it('renders a "created" SessionEvent with the full proto Session', () => {
+    const ev = sessionEventToProto({ kind: 'created', session: makeRow() }, ALICE);
+    expect(ev.kind.case).toBe('created');
+    if (ev.kind.case !== 'created') return;
+    expect(ev.kind.value.id).toBe('sess-001');
+  });
+
+  it('renders a "destroyed" SessionEvent carrying just the id string', () => {
+    const ev = sessionEventToProto(
+      { kind: 'destroyed', session: makeRow({ state: SessionState.EXITED }) },
+      ALICE,
+    );
+    expect(ev.kind.case).toBe('destroyed');
+    if (ev.kind.case !== 'destroyed') return;
+    expect(ev.kind.value).toBe('sess-001');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Producer — bus → AsyncIterable adapter
+// ---------------------------------------------------------------------------
+
+describe('subscribeAsAsyncIterable — producer adapter', () => {
+  it('delivers events published after subscribe to the iterator', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+
+    const iter = subscribeAsAsyncIterable(manager, ALICE);
+    const it = iter[Symbol.asyncIterator]();
+
+    const created = manager.create(createInput(), ALICE);
+    const next = await it.next();
+    expect(next.done).toBe(false);
+    expect(next.value.kind).toBe('created');
+    expect(next.value.session.id).toBe(created.id);
+
+    // Cleanly tear down so the unsubscribe path runs (otherwise the
+    // SessionManager retains the listener).
+    await it.return?.(undefined);
+  });
+
+  it('does NOT deliver events for sessions owned by a different principal', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+
+    const iter = subscribeAsAsyncIterable(manager, ALICE);
+    const it = iter[Symbol.asyncIterator]();
+
+    // Bob creates — alice is subscribed and MUST NOT see it (the bus's
+    // principalKey filter is the security boundary).
+    manager.create(createInput(), BOB);
+
+    // Race the iterator against a short timeout: if alice received bob's
+    // event, `it.next()` resolves first; otherwise the timeout wins.
+    const timeout = new Promise<'timeout'>((resolve) =>
+      setTimeout(() => resolve('timeout'), 30),
+    );
+    const winner = await Promise.race([it.next().then(() => 'next' as const), timeout]);
+    expect(winner).toBe('timeout');
+
+    await it.return?.(undefined);
+  });
+
+  it('terminates the iterator when the AbortSignal fires', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const ctrl = new AbortController();
+
+    const iter = subscribeAsAsyncIterable(manager, ALICE, { signal: ctrl.signal });
+    const it = iter[Symbol.asyncIterator]();
+
+    const pending = it.next();
+    ctrl.abort();
+    const result = await pending;
+    expect(result.done).toBe(true);
+    // Bus should have removed the listener.
+    expect(manager.eventBus.listenerCount('local-user:1000')).toBe(0);
+  });
+
+  it('exposes a reasonable default buffer size', () => {
+    expect(DEFAULT_WATCH_BUFFER_SIZE).toBeGreaterThanOrEqual(64);
+  });
+
+  it('throws ConnectError(ResourceExhausted) when the buffer overflows', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+
+    // Tiny buffer to exercise overflow without queuing 1024+ events.
+    const iter = subscribeAsAsyncIterable(manager, ALICE, { bufferSize: 2 });
+    const it = iter[Symbol.asyncIterator]();
+
+    // Publish 3 events (buffer holds 2) WITHOUT a pending consumer — the
+    // 3rd push records the overflow error.
+    manager.create(createInput(), ALICE);
+    manager.create(createInput(), ALICE);
+    manager.create(createInput(), ALICE);
+
+    // First two events drain normally...
+    expect((await it.next()).value.kind).toBe('created');
+    expect((await it.next()).value.kind).toBe('created');
+    // ...the third surfaces the overflow as a terminal ConnectError.
+    let captured: unknown = null;
+    try {
+      await it.next();
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    expect((captured as ConnectError).code).toBe(Code.ResourceExhausted);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sink — Connect handler over the in-process router transport
+// ---------------------------------------------------------------------------
+
+function makeBoundTransport(
+  manager: SessionManager,
+  principal: AuthPrincipal | null = ALICE,
+) {
+  return createRouterTransport(
+    (router) => {
+      router.service(SessionService, {
+        watchSessions: makeWatchSessionsHandler({ manager }),
+      });
+    },
+    {
+      router: {
+        interceptors: [
+          (next) => async (req) => {
+            req.contextValues.set(PRINCIPAL_KEY, principal);
+            return next(req);
+          },
+        ],
+      },
+    },
+  );
+}
+
+function newRequest(scope: WatchScope) {
+  return create(WatchSessionsRequestSchema, {
+    meta: create(RequestMetaSchema, {
+      requestId: '11111111-2222-3333-4444-555555555555',
+      clientVersion: '0.3.0-test',
+      clientSendUnixMs: 0n,
+    }),
+    scope,
+  });
+}
+
+describe('SessionService.WatchSessions — in-process router transport', () => {
+  it('OWN scope: yields proto SessionEvent for created + destroyed events', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const transport = makeBoundTransport(manager);
+    const client = createClient(SessionService, transport);
+
+    const stream = client.watchSessions(newRequest(WatchScope.OWN));
+
+    // Drive the manager AFTER the stream subscription is in place.
+    // setTimeout(0) gives the Connect router enough event-loop turns to
+    // construct the handler's async generator and reach its first
+    // `next()` (which is when subscribeAsAsyncIterable installs the bus
+    // listener). A pure microtask (Promise.resolve().then) is too eager
+    // — it fires before the handler runs.
+    setTimeout(() => {
+      const created = manager.create(createInput(), ALICE);
+      manager.destroy(created.id, ALICE);
+    }, 10);
+
+    const collected: string[] = [];
+    for await (const ev of stream) {
+      collected.push(ev.kind.case ?? '');
+      if (collected.length === 2) break; // close the iterator (calls return())
+    }
+
+    expect(collected).toEqual(['created', 'destroyed']);
+  });
+
+  it('UNSPECIFIED scope defaults to OWN', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const transport = makeBoundTransport(manager);
+    const client = createClient(SessionService, transport);
+
+    const stream = client.watchSessions(newRequest(WatchScope.UNSPECIFIED));
+    setTimeout(() => {
+      manager.create(createInput(), ALICE);
+    }, 10);
+
+    let firstKind: string | undefined;
+    for await (const ev of stream) {
+      firstKind = ev.kind.case;
+      break;
+    }
+    expect(firstKind).toBe('created');
+  });
+
+  it('does NOT leak events from a different principal (security boundary)', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const transport = makeBoundTransport(manager, ALICE);
+    const client = createClient(SessionService, transport);
+
+    const stream = client.watchSessions(newRequest(WatchScope.OWN));
+
+    // Bob creates; alice's stream MUST stay silent.
+    setTimeout(() => {
+      manager.create(createInput(), BOB);
+    }, 10);
+
+    const it = stream[Symbol.asyncIterator]();
+    const timeout = new Promise<'timeout'>((resolve) =>
+      setTimeout(() => resolve('timeout'), 30),
+    );
+    const winner = await Promise.race([
+      it.next().then(() => 'event' as const),
+      timeout,
+    ]);
+    expect(winner).toBe('timeout');
+    await it.return?.(undefined);
+  });
+
+  it('ALL scope: throws ConnectError(PermissionDenied) + ErrorDetail "session.not_owned"', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const transport = makeBoundTransport(manager);
+    const client = createClient(SessionService, transport);
+
+    const stream = client.watchSessions(newRequest(WatchScope.ALL));
+    let captured: unknown = null;
+    try {
+      for await (const _ev of stream) {
+        void _ev;
+      }
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(ConnectError);
+    const ce = captured as ConnectError;
+    expect(ce.code).toBe(Code.PermissionDenied);
+
+    const details = ce.findDetails(ErrorDetailSchema) as ErrorDetail[];
+    expect(details.length).toBeGreaterThanOrEqual(1);
+    expect(details[0].code).toBe('session.not_owned');
+    expect(details[0].extra.requested_scope).toBe('ALL');
+  });
+
+  it('returns Internal when PRINCIPAL_KEY is null (defensive wiring check)', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const transport = makeBoundTransport(manager, null);
+    const client = createClient(SessionService, transport);
+
+    const stream = client.watchSessions(newRequest(WatchScope.OWN));
+    let captured: unknown = null;
+    try {
+      for await (const _ev of stream) {
+        void _ev;
+      }
+    } catch (err) {
+      captured = err;
+    }
+
+    expect(captured).toBeInstanceOf(ConnectError);
+    expect((captured as ConnectError).code).toBe(Code.Internal);
+  });
+});


### PR DESCRIPTION
## Summary

Wire the v0.3 SessionService.WatchSessions Connect server-streaming RPC.

- **decider** (`decideWatchScope`): pure — `UNSPECIFIED` / `OWN` → accept; `ALL` → reject; unknown enum values → reject (forward-compat conservative default).
- **producer** (`subscribeAsAsyncIterable`): adapts the manager's push-based `subscribe(caller, listener)` API (T3.2 / PR #933) into an `AsyncIterable<SessionEvent>` with a bounded buffer (default 1024). Overflow → terminal `ConnectError(ResourceExhausted)` after the buffer drains. `AbortSignal` (Connect's `HandlerContext.signal`) tears the subscription down.
- **sink** (`makeWatchSessionsHandler`): reads `PRINCIPAL_KEY` from the HandlerContext, runs the decider, then either subscribes & yields proto `SessionEvent` (mapped via `sessionRowToProto`/`sessionEventToProto`) or rejects `WATCH_SCOPE_ALL` with `Code.PermissionDenied + ErrorDetail.code = "session.not_owned"` via the T2.5 `throwError` helper (PR #926).

Router wiring: `registerSessionService` combines `hello` + `watchSessions` in a single `router.service(SessionService, ...)` call (Connect-ES replaces on second registration, so a separate call would silently drop `hello`). `makeDaemonRoutes` / `createDaemonNodeAdapter` accept an optional `watchSessionsDeps`; existing hello-only callers (and the T2.2 stub-only path) are unchanged.

Spec refs: ch04 §3 (WatchScope enum), ch05 §5 (per-RPC enforcement matrix; double-scoped streams; v0.3 honors only OWN; ALL must surface PermissionDenied).

## Local test output

```
$ npx eslint src/sessions/watch-sessions.ts src/rpc/router.ts test/sessions/watch-sessions.spec.ts
(clean — no errors, no warnings)

$ npx tsc --noEmit
src/index.ts(260,24): error TS2339: Property 'push' does not exist on type 'readonly Listener[]'.
# (pre-existing on origin/working — verified via git stash before/after; unrelated to T3.3)

$ npx vitest run sessions/
 Test Files  3 passed (3)
      Tests  42 passed (42)

$ npx vitest run rpc/
 Test Files  6 passed (6)
      Tests  91 passed | 4 skipped (95)
```

## Test coverage

`packages/daemon/test/sessions/watch-sessions.spec.ts` — 19 tests across the SRP layers:

- **decider** (4): UNSPECIFIED/OWN accept; ALL reject; unknown enum reject.
- **row → proto mapper** (5): owner from caller principal; exit_code -1 sentinel → unset; non-sentinel preserved (incl. 0); created/destroyed event mapping.
- **producer** (5): events delivered post-subscribe; cross-principal events filtered (security boundary); AbortSignal terminates cleanly + bus listener removed; default buffer size sane; buffer overflow → `ConnectError(ResourceExhausted)` after drain.
- **sink** (5, in-process router transport with PRINCIPAL_KEY-injecting interceptor): OWN happy path (created + destroyed events); UNSPECIFIED defaults to OWN; cross-principal events not leaked; ALL → `PermissionDenied + ErrorDetail "session.not_owned"`; null PRINCIPAL_KEY → `Code.Internal` (defensive wiring check).

## Test plan

- [x] `npx eslint src/` clean for changed files.
- [x] `npx tsc --noEmit` no NEW errors (pre-existing src/index.ts error confirmed on origin/working).
- [x] `npx vitest run sessions/` 42/42 passing.
- [x] `npx vitest run rpc/` 91/91 passing (router wiring change is back-compat).

🤖 Generated with [Claude Code](https://claude.com/claude-code)