### PR TITLE
test(T10.3): listener array-shape runtime + type backstop

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,15 @@ import tseslint from '@typescript-eslint/eslint-plugin';
 import tsparser from '@typescript-eslint/parser';
 import react from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
+// Register the daemon-local `ccsm` plugin at the root so that root-level
+// `lint:app` (eslint . --ext .ts,.tsx) can resolve `ccsm/no-listener-slot-mutation`
+// when it sweeps `packages/daemon/**`. The rule definition still lives in
+// `packages/daemon/eslint-plugins/`; the per-package config (packages/daemon/
+// eslint.config.js) is what sets it to `error`. At the root layer we only
+// need the plugin loaded so that inline `eslint-disable ccsm/...` comments
+// in daemon source/test files do not produce "Definition for rule was not
+// found" errors. Spec ch03 §1 / ch11 §5 / Task #29 (PR #873) context.
+import ccsmDaemonPlugin from './packages/daemon/eslint-plugins/ccsm-no-listener-slot-mutation.js';
 
 export default [
   {
@@ -166,5 +175,19 @@ export default [
         URLSearchParams: 'readonly'
       }
     }
+  },
+  {
+    // Register the daemon-local `ccsm` plugin for files under
+    // packages/daemon/** so root-level `lint:app` can resolve
+    // `ccsm/no-listener-slot-mutation` references in inline
+    // eslint-disable comments. The rule remains gated to `error`
+    // by the per-package config (packages/daemon/eslint.config.js);
+    // here we register the plugin only (rules block intentionally
+    // empty — root sweep does NOT enforce the daemon-internal rule,
+    // it just needs the name to resolve).
+    files: ['packages/daemon/**/*.{ts,tsx}'],
+    plugins: {
+      ccsm: ccsmDaemonPlugin,
+    },
   }
 ];

--- a/packages/daemon/src/listeners/__tests__/array-shape.spec.ts
+++ b/packages/daemon/src/listeners/__tests__/array-shape.spec.ts
@@ -1,0 +1,121 @@
+// Runtime + type-level backstop for the closed 2-slot Listener tuple.
+// Spec ch15 §3 forbidden-pattern #6 (no listener-tuple growth) + #18
+// (typed sentinel pinned in slot 1 until v0.4 Listener B lands).
+//
+// Why this file exists alongside `array.spec.ts` and the merged
+// `shape-no-growth.spec.ts` (PR #906):
+//   - `array.spec.ts` exercises the `ListenerSlots` type + sentinel
+//     identity in isolation (synthetic tuples).
+//   - `shape-no-growth.spec.ts` is a SOURCE-TEXT scan of `index.ts`
+//     that catches mutating method names (push/pop/splice/...) at
+//     pre-commit time without instantiating the daemon.
+//   - THIS file is the RUNTIME + TYPE-LEVEL backstop: it builds a real
+//     `DaemonEnv` via `buildDaemonEnv()` and asserts the tuple shape
+//     after boot, AND uses `// @ts-expect-error` to prove tsc itself
+//     rejects `.push()` on the readonly tuple type.
+//
+// Three layers (compile-time / lint-time / runtime) by design — see
+// the comment block atop `array.ts` and `eslint-plugins/ccsm-no-
+// listener-slot-mutation.js`. This spec is the third leg.
+//
+// SRP: this module is a test (decider over the runtime shape). No I/O
+// beyond `buildDaemonEnv()`, which only reads process.env.
+//
+// Note on the type-level checks below: TypeScript `readonly`/tuple
+// constraints are purely compile-time — they do NOT freeze the array
+// at runtime. We therefore park every `@ts-expect-error` line inside a
+// function that is declared but NEVER CALLED, so tsc still typechecks
+// the body (and reports TS2578 "unused @ts-expect-error" if any line
+// would in fact compile cleanly), but vitest does not execute the
+// mutation. The runtime-shape `describe` block above stands on its own.
+
+import { describe, expect, it } from 'vitest';
+import { buildDaemonEnv, RESERVED_FOR_LISTENER_B } from '../../env.js';
+
+describe('DaemonEnv.listeners closed 2-slot tuple (spec ch15 §3 #6 + #18)', () => {
+  it('has length === 2 after buildDaemonEnv()', () => {
+    const env = buildDaemonEnv();
+    expect(env.listeners).toHaveLength(2);
+    expect(env.listeners.length).toBe(2);
+  });
+
+  it('pins slot 1 to RESERVED_FOR_LISTENER_B (identity, not just equality)', () => {
+    const env = buildDaemonEnv();
+    expect(env.listeners[1]).toBe(RESERVED_FOR_LISTENER_B);
+    // Sanity: the sentinel resolves to the canonical Symbol.for key
+    // (a typo in the env-side declaration would break the v0.4 swap).
+    expect(env.listeners[1]).toBe(Symbol.for('ccsm.listener.reserved-b'));
+  });
+
+  it('keeps slot 0 / slot 1 stable across repeated buildDaemonEnv() calls', () => {
+    // The sentinel is module-scope; rebuilding env must not mint a fresh
+    // symbol or rewrite the slot-1 reference. v0.4 Listener B replaces
+    // slot 1 in EXACTLY one place (the spec-blessed makeListenerB call);
+    // any other rewrite is a Layer 1 violation.
+    const a = buildDaemonEnv();
+    const b = buildDaemonEnv();
+    expect(a.listeners[1]).toBe(b.listeners[1]);
+    expect(a.listeners).toHaveLength(b.listeners.length);
+  });
+});
+
+// -----------------------------------------------------------------
+// Type-level backstop — tsc must reject every mutation below.
+// -----------------------------------------------------------------
+//
+// This function is intentionally never called. tsc still typechecks
+// its body when the file is part of the daemon `tsconfig` include set
+// (it is — `src/**/*` covers `__tests__`). Each `@ts-expect-error`
+// line here MUST suppress a real TS error; if the readonly tuple
+// constraint is ever weakened, tsc emits TS2578 ("Unused
+// '@ts-expect-error' directive") and the typecheck step fails.
+//
+// vitest does NOT run this function (it is not wrapped in `it`/`test`),
+// so the runtime mutation never fires. This sidesteps the fact that
+// TypeScript's `readonly` tuple is a compile-time-only constraint.
+//
+// Do NOT delete this function; do NOT call it. Reviewers: if you see
+// a PR removing the export-or-keep-alive trick below, reject it.
+function _typeOnly_listenerTupleIsReadonly(): void {
+  const env = buildDaemonEnv();
+
+  // The ccsm/no-listener-slot-mutation ESLint rule (T1.9) ALSO fires on
+  // every line below — that is the lint-time guard doing its job. We
+  // intentionally bypass it here because (a) this function is never
+  // called at runtime, and (b) the whole point of these lines is to
+  // make tsc reject them. The eslint-disable is the test seam, not a
+  // real escape hatch — keep it limited to this single function body.
+  /* eslint-disable ccsm/no-listener-slot-mutation */
+
+  // Compile-time: every mutating method on the readonly tuple is rejected.
+  // @ts-expect-error — readonly tuple has no .push().
+  env.listeners.push(null);
+  // @ts-expect-error — readonly tuple has no .pop().
+  env.listeners.pop();
+  // @ts-expect-error — readonly tuple has no .shift().
+  env.listeners.shift();
+  // @ts-expect-error — readonly tuple has no .unshift().
+  env.listeners.unshift(null);
+  // @ts-expect-error — readonly tuple has no .splice().
+  env.listeners.splice(0, 1);
+  // @ts-expect-error — readonly tuple has no .sort().
+  env.listeners.sort();
+  // @ts-expect-error — readonly tuple has no .reverse().
+  env.listeners.reverse();
+  // @ts-expect-error — readonly tuple has no .fill().
+  env.listeners.fill(null);
+  // @ts-expect-error — readonly tuple has no .copyWithin().
+  env.listeners.copyWithin(0, 1);
+
+  // Compile-time: slot-1 reassignment is rejected (slot is typed
+  // `ReservedForListenerB`, no other value is assignable).
+  // @ts-expect-error — slot 1 is `ReservedForListenerB`; null is not assignable.
+  env.listeners[1] = null;
+
+  /* eslint-enable ccsm/no-listener-slot-mutation */
+}
+
+// Keep tsc from pruning the function as dead code via re-export.
+// This is a no-op at runtime (the export is never imported) but it
+// guarantees the body remains in the typecheck graph.
+export const __typeOnlyListenerTupleProbe = _typeOnly_listenerTupleIsReadonly;


### PR DESCRIPTION
closes Task #118

## Summary

Adds `packages/daemon/src/listeners/__tests__/array-shape.spec.ts` — the
**runtime + type-level** backstop for the closed 2-slot Listener tuple
(spec ch15 §3 forbidden-pattern #6 + #18). Third leg of the guard set:

| layer        | guard                                          | source                       |
| ------------ | ---------------------------------------------- | ---------------------------- |
| compile-time | `ListenerSlots` readonly tuple type            | T1.2 / PR #860 (merged)      |
| lint-time    | `ccsm/no-listener-slot-mutation` ESLint rule   | T1.9 / PR #873 (merged)      |
| source-scan  | `shape-no-growth.spec.ts` (scans `index.ts`)   | PR #906 (open)               |
| runtime+type | `array-shape.spec.ts`                          | **THIS PR**                  |

## What this spec covers that the others don't

1. **Runtime end-to-end**: builds a real `DaemonEnv` via `buildDaemonEnv()`
   and asserts `env.listeners.length === 2`, `env.listeners[1] ===
   RESERVED_FOR_LISTENER_B` (identity), and stability across repeated
   builds. Catches the case where a future env-builder refactor silently
   produces a wrong-length array or mints a fresh sentinel symbol.

2. **Type-level**: every mutating method (`push` / `pop` / `shift` /
   `unshift` / `splice` / `sort` / `reverse` / `fill` / `copyWithin`)
   plus slot-1 reassignment is wrapped in `// @ts-expect-error` inside
   an unreached function. tsc must reject each line; if `readonly` is
   ever weakened on the tuple type, tsc emits **TS2578 "Unused
   `@ts-expect-error` directive"** and the typecheck step fails.

   The `@ts-expect-error` lines live inside a function declared but
   never called — TypeScript's `readonly` is purely compile-time, so
   executing those lines at runtime would actually mutate the array.
   Parking them in dead code keeps the type-level proof without the
   runtime side effect. The function is kept alive in the typecheck
   graph via a no-op re-export.

## Reverse-verify

Removed one `@ts-expect-error` directive locally and ran tsc:

```
src/listeners/__tests__/array-shape.spec.ts(84,17): error TS2339:
  Property 'push' does not exist on type 'readonly [unknown, unique symbol]'.
```

Restored — the directive is load-bearing.

## Local quality gate

- `npx vitest run packages/daemon/src/listeners/__tests__/`
  -> `Test Files 5 passed (5) | Tests 37 passed | 2 skipped (39)` (the
     new file contributes 3 passes in the runtime block)
- `pnpm --filter @ccsm/daemon exec tsc -p tsconfig.json --noEmit` on
  the new file: clean. Only baseline noise remains (see below).
- `pnpm --filter @ccsm/daemon run lint` on the new file: clean. The
  spec wraps the type-only block in `eslint-disable
  ccsm/no-listener-slot-mutation` because proving tsc rejects mutation
  requires writing the very source text the lint rule forbids; the
  disable scope is one function body.

## Pre-existing baseline noise (NOT introduced here)

`packages/daemon/src/index.ts:260` `ctxRef.listeners.push(listenerA)`
fails BOTH typecheck (TS2339) and lint (`ccsm/no-listener-slot-mutation`)
on `working` HEAD (15896af). PR #906 (open, `dev/t0.8-ci-matrix`)
rewrites that site to `listeners = [listenerA]` and adds the
`shape-no-growth.spec.ts` referenced in the table above. This PR does
NOT touch `index.ts` — Task #118 scope is the runtime+type spec only.

## Layer 1 push-back (resolved)

The task description originally asked for an "as-const tuple type"
declaration in `listeners/types.ts`. That work is ALREADY DONE in T1.2
/ PR #860 (merged):

- `ListenerSlots = readonly [Listener, Listener | ReservedForListenerB]`
  in `array.ts`
- `DaemonEnv.listeners: readonly [unknown, ReservedForListenerB]` in
  `env.ts`
- runtime builder: `[null, RESERVED_FOR_LISTENER_B] as const`

No new type code was needed; this PR is the missing runtime+type spec
only, per the task's "what's still missing" subsection.

## Test plan

- [x] runtime spec passes (`vitest run`)
- [x] type-level `@ts-expect-error` lines verified load-bearing via
      one-line removal -> tsc TS2339 -> restored
- [x] lint clean on the new file (baseline `index.ts:260` is PR #906)
- [x] does not duplicate `shape-no-growth.spec.ts` (source-scan vs
      runtime + type — both belong)