### PR TITLE
fix(t7.3): platform-guard sign-scripts.spec for per-OS tools

### DIFF
--- a/packages/daemon/build/__tests__/sign-scripts.spec.ts
+++ b/packages/daemon/build/__tests__/sign-scripts.spec.ts
@@ -105,7 +105,12 @@ describe('packages/daemon/build/sign-*.{sh,ps1} (spec ch10 §3, T7.3)', () => {
   });
 
   describe('placeholder-safe — dry-run + missing env exits 0', () => {
-    it('sign-mac.sh exits 0 with no env (non-darwin host) and prints WARN', () => {
+    // Cross-host placeholder-safe gate (runs on every platform per PR #942
+    // review): each script must WARN and exit 0 when invoked without the
+    // right env / on the wrong host. This contract is what allows local
+    // dogfood `npm run build` to succeed on any developer machine, and is
+    // what every CI matrix runner exercises before its host-specific job.
+    it('sign-mac.sh exits 0 with no env (cross-host placeholder gate)', () => {
       // We test this on whatever host runs the suite. On non-darwin it
       // hits the gate; on darwin it hits the missing-env gate. Either path
       // exits 0 with a WARN line. WARN goes to stderr; capture both.
@@ -116,7 +121,7 @@ describe('packages/daemon/build/sign-*.{sh,ps1} (spec ch10 §3, T7.3)', () => {
       expect(typeof out.toString()).toBe('string');
     });
 
-    it('sign-linux.sh exits 0 with no env and prints WARN', () => {
+    it('sign-linux.sh exits 0 with no env and prints WARN (cross-host placeholder gate)', () => {
       // WARN goes to stderr; merge by spawning bash -c to redirect.
       const out = execFileSync('bash', ['-c', `bash "${LINUX_SH}" 2>&1`], {
         env: { ...process.env, GPG_SIGNING_KEY: '', CCSM_SIGN_DRY_RUN: '' },
@@ -125,34 +130,49 @@ describe('packages/daemon/build/sign-*.{sh,ps1} (spec ch10 §3, T7.3)', () => {
       expect(out.toString()).toMatch(/WARN: GPG_SIGNING_KEY not set/);
     });
 
-    it('sign-mac.sh dry-run prints codesign + xcrun notarytool traces', () => {
-      const out = execFileSync('bash', [MAC_SH], {
-        env: {
-          ...process.env,
-          APPLE_TEAM_ID: 'XXXXXXXXXX',
-          APPLE_SIGNING_IDENTITY: 'Developer ID Application: Test (XXXXXXXXXX)',
-          APPLE_NOTARY_PROFILE: 'test-profile',
-          CCSM_SIGN_DRY_RUN: '1',
-        },
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
-      const text = out.toString();
-      expect(text).toMatch(/DRY-RUN.*codesign/);
-      expect(text).toMatch(/DRY-RUN.*xcrun notarytool submit/);
-      expect(text).toMatch(/DRY-RUN.*stapler staple/);
-      expect(text).toMatch(/DRY-RUN.*spctl --assess/);
-    });
+    // Per-OS tool-output assertions: only meaningful on the matching host.
+    // The cross-host placeholder-safe contract is covered by the
+    // "exits 0 with no env" tests above, which run on every platform.
+    // Background: PR #906 (T0.8 CI matrix) surfaced a regression where
+    // these dry-run tests ran on darwin runners that lack debsigs/rpm/gpg
+    // (and on linux runners that lack the mac toolchain) — the scripts
+    // themselves are placeholder-safe (exit 0 + WARN on wrong host), but
+    // the tests assert tool-trace output that the wrong host can't emit.
+    // skipIf keeps the assertion on the matching host only.
+    it.skipIf(process.platform !== 'darwin')(
+      'sign-mac.sh dry-run prints codesign + xcrun notarytool traces (darwin only)',
+      () => {
+        const out = execFileSync('bash', [MAC_SH], {
+          env: {
+            ...process.env,
+            APPLE_TEAM_ID: 'XXXXXXXXXX',
+            APPLE_SIGNING_IDENTITY: 'Developer ID Application: Test (XXXXXXXXXX)',
+            APPLE_NOTARY_PROFILE: 'test-profile',
+            CCSM_SIGN_DRY_RUN: '1',
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        const text = out.toString();
+        expect(text).toMatch(/DRY-RUN.*codesign/);
+        expect(text).toMatch(/DRY-RUN.*xcrun notarytool submit/);
+        expect(text).toMatch(/DRY-RUN.*stapler staple/);
+        expect(text).toMatch(/DRY-RUN.*spctl --assess/);
+      },
+    );
 
-    it('sign-linux.sh dry-run prints debsigs + rpm --addsign + gpg --detach-sign traces', () => {
-      const out = execFileSync('bash', [LINUX_SH, '/tmp/fake-binary', '/tmp/fake.deb', '/tmp/fake.rpm'], {
-        env: { ...process.env, GPG_SIGNING_KEY: '0xDEADBEEF', CCSM_SIGN_DRY_RUN: '1' },
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
-      const text = out.toString();
-      expect(text).toMatch(/DRY-RUN.*gpg.*--detach-sign/);
-      expect(text).toMatch(/DRY-RUN.*debsigs --sign=origin/);
-      expect(text).toMatch(/DRY-RUN.*rpm.*--addsign/);
-    });
+    it.skipIf(process.platform !== 'linux')(
+      'sign-linux.sh dry-run prints debsigs + rpm --addsign + gpg --detach-sign traces (linux only)',
+      () => {
+        const out = execFileSync('bash', [LINUX_SH, '/tmp/fake-binary', '/tmp/fake.deb', '/tmp/fake.rpm'], {
+          env: { ...process.env, GPG_SIGNING_KEY: '0xDEADBEEF', CCSM_SIGN_DRY_RUN: '1' },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        const text = out.toString();
+        expect(text).toMatch(/DRY-RUN.*gpg.*--detach-sign/);
+        expect(text).toMatch(/DRY-RUN.*debsigs --sign=origin/);
+        expect(text).toMatch(/DRY-RUN.*rpm.*--addsign/);
+      },
+    );
   });
 
   describe('build-sea pipeline hook (T7.1 -> T7.3)', () => {


### PR DESCRIPTION
## Summary

Task #197 follow-up to PR #942 (T7.3 per-OS signing scaffolding).

PR #906 (T0.8 CI matrix, sibling rebase) surfaced a regression on macOS
runners: `packages/daemon/build/__tests__/sign-scripts.spec.ts` invoked
`sign-linux.sh` (and equivalents) on the wrong host and asserted on
tool-trace output (`debsigs` / `rpm` / `gpg` / `xcrun`) that the wrong
host can't emit.

The `sign-*.sh` / `.ps1` scripts themselves are correctly placeholder-
safe (WARN + exit 0 on wrong host / missing env) — that contract from
the PR #942 review is intact. The bug was purely at the **test** layer:
the dry-run assertions exercised per-OS tooling that doesn't exist on
the wrong runner.

## Fix

- `it.skipIf(process.platform !== 'darwin')` around the mac dry-run
  trace assertion (codesign + xcrun notarytool + stapler + spctl).
- `it.skipIf(process.platform !== 'linux')` around the linux dry-run
  trace assertion (debsigs + rpm --addsign + gpg --detach-sign).
- The two **cross-host placeholder-safe gate** tests (mac.sh + linux.sh
  WARN-and-exit-0 with no env) are kept running on **every** platform —
  that's the contract test from PR #942 review and must stay cross-host.

Scope is intentionally tight per task #197 brief:
- Only `packages/daemon/build/__tests__/sign-scripts.spec.ts` changes.
- The shell scripts (`sign-mac.sh` / `sign-win.ps1` / `sign-linux.sh`)
  are unchanged.
- `build-sea.sh` / `build-sea.ps1` unchanged.
- `ci.yml` unchanged.

## Test plan

- [x] `cd packages/daemon && npx vitest run build/__tests__/sign-scripts.spec.ts` on win32 -> 13 passed | 2 skipped (15 total).
- [x] `npm run lint:app` -> 0 errors (pre-existing warnings only).
- [x] `git diff --name-only origin/working...HEAD` -> only `sign-scripts.spec.ts`.
- [ ] CI matrix (linux/mac/win) green — this is the regression PR #906 hit; expecting all three runners to now skip the foreign-host dry-run blocks while still running the cross-host placeholder gate.

Refs: PR #942 (Task #82, T7.3), PR #906 (Task #15, T0.8 CI matrix), Task #197.