### PR TITLE
fix(t5.10): crash-raw SIGKILL replay windows timeout

### DIFF
--- a/packages/daemon/test/crash/crash-raw-recovery.spec.ts
+++ b/packages/daemon/test/crash/crash-raw-recovery.spec.ts
@@ -107,6 +107,27 @@ function rowCount(db: SqliteDatabase): number {
 // ---------------------------------------------------------------------------
 
 describe('crash-raw appender + replay', () => {
+  // Per-test timeout: 30s. Justification (Windows CI I/O cost):
+  //
+  //   The child below performs 100 sequential open-write-fsync-close
+  //   cycles. `fsyncSync` on Windows maps to `FlushFileBuffers`, which on
+  //   GitHub-hosted `windows-latest` runners (Hyper-V virtualised storage)
+  //   measures ~50 ms per call. 100 iterations × 50 ms ≈ 5 s — right at
+  //   vitest's 5 s default test timeout. PR #906's matrix observed this
+  //   test taking 5416 ms on `windows-latest` and timing out, while local
+  //   Windows hosts finish the same loop in ~150 ms (~1.5 ms per fsync on
+  //   real NVMe). Linux/mac CI also pass comfortably in <2 s.
+  //
+  //   We MUST NOT reduce the iteration count: the spec acceptance criterion
+  //   is literally "100 entries → kill before flush → all 100 appear in
+  //   crash table once" (see the file-header docstring). We MUST NOT remove
+  //   the per-line `fsyncSync`: the durability invariant under test is that
+  //   each line is on stable storage before the next call returns, so
+  //   sibling cases (a) (d) (e) below — which exercise `appendCrashRaw`
+  //   directly with fsync per call — remain meaningful. The 100-fsync
+  //   wall-clock cost on slow virtualised storage is therefore inherent,
+  //   not a code defect; the timeout is widened to give 5x headroom over
+  //   the observed worst case.
   it('100 entries appended in a child SIGKILLed before normal exit replay into crash_log exactly once', () => {
     // The child writes 100 entries via the same `appendCrashRaw` we ship.
     // After write 100 it raises SIGKILL on itself — no `process.exit`,
@@ -173,7 +194,7 @@ describe('crash-raw appender + replay', () => {
     const r2 = replayCrashRawOnBoot({ path: fx.ndjsonPath, db: fx.db });
     expect(r2.inserted).toBe(0);
     expect(rowCount(fx.db)).toBe(100);
-  });
+  }, 30_000);
 
   // -------------------------------------------------------------------------
   // ch09 §6.2 case (a): partial line at EOF.


### PR DESCRIPTION
## Summary

Task #198 [FIX-T5.10-followup]. PR #906's windows-latest matrix surfaced
that `packages/daemon/test/crash/crash-raw-recovery.spec.ts` headline test
(\"100 entries appended in a child SIGKILLed before normal exit replay\")
times out at vitest's 5s default. Root cause is inherent I/O cost on GH
windows-latest virtualised storage, not a code defect: 100 sequential
`fsyncSync` calls × ~50ms each = ~5s, right at the timeout edge. Local
Windows NVMe runs the same loop in ~150ms.

Fix: per-test timeout widened to 30s with a comment explaining why the
iteration count (spec acceptance criterion: 100) and per-line fsync
(durability invariant the sibling cases (a)/(d)/(e) rely on) cannot be
reduced. No production code touched. Hotfile mutex with PR #906 honoured
(no edits to ci.yml / .gitattributes / .nvmrc / package.json scripts /
eslint.config.js).

## Phase 1 — Reproduce

CI evidence from PR #906 windows-latest run 25275891192:

```
× test/crash/crash-raw-recovery.spec.ts (9 tests | 1 failed) 8111ms
  × 100 entries appended in a child SIGKILLed before normal exit replay into crash_log exactly once 5416ms

FAIL  test/crash/crash-raw-recovery.spec.ts > crash-raw appender + replay > 100 entries appended in a child SIGKILLed before normal exit replay into crash_log exactly once
Error: Test timed out in 5000ms.
```

Local Windows desktop run on the same SHA (`c332a61`, origin/working) does
NOT repro — passes in <1s. Environment differs from GH-hosted Windows
runner (real NVMe vs Hyper-V virtualised storage).

## Phase 2 — Diagnose

Instrumented the child loop locally (off-tree benchmark): 100 iterations
of `openSync('a') / writeSync / fsyncSync / closeSync` complete in ~90ms
on local NVMe. The CI's 5416ms cost implies ~54ms per iteration on the
GH runner, dominated by `fsyncSync` (Windows `FlushFileBuffers` on
virtualised storage). 100 × 54ms = 5400ms, tripping the 5000ms vitest
default test timeout.

Ruled out:
- Test-side flush race: file is read in parent AFTER `spawnSync` has
  reaped the child. Each line was already fsynced before SIGKILL fired.
- File-handle lock: child closes its fd before SIGKILL; parent
  `readFileSync` succeeds.
- Production crash-raw appender bug: 8 sibling tests in the same file
  (which each call the production `appendCrashRaw`) all pass on
  windows-latest in ~600ms total. The slow path is the 100-iteration
  inline child, not the appender code.

Root cause: 100 sequential FlushFileBuffers calls on virtualised storage
are inherently ~5s. Not a code defect.

## Phase 3 — Fix

Per-test timeout bump: `it(..., 30_000)`. 5x headroom over the observed
5416ms worst case. Comment in the source explains:
- Why iteration count cannot be reduced (spec acceptance criterion).
- Why per-line fsync cannot be removed (durability invariant the sibling
  (a)/(d)/(e) cases rely on via `appendCrashRaw`).
- Why the cost is inherent to the platform.

Last-resort path per task brief, taken only after confirming the test
itself is correct and the production appender is correct. Other fix
shapes considered and rejected:
- Reduce N from 100 → breaks spec acceptance literal \"100 entries\".
- Single fsync at end of loop → breaks per-line durability invariant.
- `if (process.platform === 'win32') return` skip → forbidden by brief
  (\"Windows is a ship target\").

## Phase 4 — Reverse-verify

Reverse-verify done locally by injecting a 60ms-per-iteration busy-wait
into the test's child script (simulating GH-runner FlushFileBuffers cost
on real NVMe), so the timing regime matches the CI failure observed in
PR #906. The injection was applied to the test temporarily, NOT shipped.

**Without fix (timeout reverted to default 5s, slow-injection on):**
```
 ❯ test/crash/crash-raw-recovery.spec.ts (9 tests | 1 failed | 8 skipped) 6195ms
   × 100 entries appended in a child SIGKILLed before normal exit replay into crash_log exactly once 6193ms

 FAIL  test/crash/crash-raw-recovery.spec.ts > crash-raw appender + replay > 100 entries appended in a child SIGKILLed before normal exit replay into crash_log exactly once
Error: Test timed out in 5000ms.
 Test Files  1 failed (1)
      Tests  1 failed | 8 skipped (9)
   Duration  6.76s
```

**With fix (30s per-test timeout, slow-injection on):**
```
 RUN  v4.1.5
 Test Files  1 passed (1)
      Tests  1 passed | 8 skipped (9)
   Duration  6.76s (transform 70ms, setup 0ms, import 108ms, tests 6.20s)
```

**Final state (fix applied, slow-injection removed) — full file passes:**
```
 RUN  v4.1.5
 Test Files  1 passed (1)
      Tests  9 passed (9)
   Duration  892ms (tests 348ms)
```

## Quality gates

- `git ls-files --eol packages/daemon/test/crash/crash-raw-recovery.spec.ts` → `i/lf  w/lf` ✓
- `npm run lint:app` → 0 errors (95 pre-existing warnings, none new) ✓
- Full crash-raw-recovery.spec.ts passes locally on Windows (9/9) ✓

## Test plan
- [ ] CI windows-latest: crash-raw-recovery.spec.ts headline test passes in <30s
- [ ] CI ubuntu-latest / macos-latest: still pass in <2s (no regression)
- [ ] No edits in this PR's diff to ci.yml, .gitattributes, .nvmrc, package.json scripts, or eslint.config.js (hotfile mutex with PR #906)