### PR TITLE
wave2(#218): PR template — wire-up evidence section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## Wire-up evidence
+
+If this PR introduces new exports / classes / handlers / sinks, fill these. If it's pure refactor / fix / test, mark `[REFACTOR-ONLY]` and skip.
+
+- [ ] **Importers**: paste `grep -rn 'from.*<your-module>' apps/ packages/` output showing who imports each new export
+- [ ] **Startup wiring** (for listeners / sinks / services / capture sources): paste the `apps/daemon/src/index.ts` (or equivalent `runStartup`) lines that call into your new code
+- [ ] **Library-only marker**: if there is no startup wiring because this is a pure library task, write `[LIBRARY-ONLY]` and link the follow-up wire-up task #


### PR DESCRIPTION
Task #218 — implements plan §5.1.

## Summary
Adds a `Wire-up evidence` section to `.github/pull_request_template.md` (file did not previously exist; created with just this section).

## Why
Audit found a recurring "library ALIGNED + production unwired" pattern across 8 merged tasks: T1.3, T1.6, T1.7, T2.3, T3.2, T5.5, T5.10, T5.11 — code merged, no production caller imports it.

Root cause: PR review never asked "who imports this?" This template makes that question mandatory by requiring one of:
- importer grep output, OR
- startup-wiring lines from `apps/daemon/src/index.ts`, OR
- explicit `[LIBRARY-ONLY]` marker linking the follow-up wire-up task.

Pure refactor / fix / test PRs can mark `[REFACTOR-ONLY]` and skip.

## Scope
Single file. No existing template to preserve (newly created).