### PR TITLE
fix(#241): daemon index.ts:260 listener slot mutation

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -257,7 +257,11 @@ async function main(): Promise<void> {
     // closes it during step 1 (stop accepting). Register the db handle
     // so the WAL checkpoint (step 6) + close (step 7) actually fire.
     if (listenerA !== null) {
-      ctxRef.listeners.push(listenerA);
+      // Reconstruct the listeners array rather than mutating it in place
+      // — the `ccsm/no-listener-slot-mutation` ESLint rule (T1.9 #29)
+      // bans `.push()` / `.splice()` / etc. on listener-named arrays to
+      // protect the closed 2-slot tuple invariant (spec ch03 §1).
+      ctxRef.listeners = [...ctxRef.listeners, listenerA];
     }
     ctxRef.db = result.db;
     // Start the crash retention pruner AFTER shutdown handlers are


### PR DESCRIPTION
## Summary

Task #241 — fix the pre-existing `ccsm/no-listener-slot-mutation` lint failure at `packages/daemon/src/index.ts:260`. Reviewer #239 confirmed via `git show origin/working:packages/daemon/src/index.ts`.

## Root cause

- T1.1 #21 (the daemon entrypoint) wrote `ctxRef.listeners.push(listenerA)` before the listener tuple discipline existed.
- T1.2 #28 introduced the closed 2-slot tuple shape `readonly [Listener, Listener | ReservedForListenerB]` (`packages/daemon/src/listeners/array.ts`) with slot 1 pinned to the `RESERVED_FOR_LISTENER_B` sentinel.
- T1.9 #29 added the local ESLint rule `ccsm/no-listener-slot-mutation` that bans `.push() / .pop() / .shift() / .unshift() / .splice() / .fill() / .copyWithin() / .sort() / .reverse()` on any identifier whose name matches `/listener|slot/i`.
- The entrypoint was never updated, so working has been red on lint.

The rule exists to protect the Listener-A / Listener-B sentinel discipline (spec ch03 §1): slot 1 must remain `RESERVED_FOR_LISTENER_B` until v0.4 ships the real Listener B factory. Source-level mutation could silently break that invariant.

## Fix

Replace the `.push()` mutation with array reconstruction:

```diff
 if (listenerA !== null) {
-  ctxRef.listeners.push(listenerA);
+  // Reconstruct the listeners array rather than mutating it in place
+  // — the `ccsm/no-listener-slot-mutation` ESLint rule (T1.9 #29)
+  // bans `.push()` / `.splice()` / etc. on listener-named arrays to
+  // protect the closed 2-slot tuple invariant (spec ch03 §1).
+  ctxRef.listeners = [...ctxRef.listeners, listenerA];
 }
```

Notes:
- `ctxRef` is `{ -readonly [K in keyof ShutdownContext]: ShutdownContext[K] }`, so the property is reassignable; the source `ShutdownContext.listeners: ReadonlyArray<Listener>` is satisfied by the new array.
- This is the `ShutdownContext` listeners (a `ReadonlyArray<Listener>` collected for graceful shutdown), not the `ListenerSlots` tuple — runtime behavior is identical.
- Spread + reassign do not match the rule's `AssignmentExpression` (slot-1 access) or `CallExpression` (mutating-method) handlers.

## Verification

- `pnpm --filter @ccsm/daemon lint` → clean (no errors).
- `pnpm --filter @ccsm/daemon typecheck` → clean.
- `npx vitest run src/listeners src/shutdown.spec.ts` → 58 passed / 2 skipped (all listener + shutdown tests green).
- Full `pnpm --filter @ccsm/daemon test` shows pre-existing `better-sqlite3` NODE_MODULE_VERSION mismatch (Node 24 vs 22) unrelated to this change — same failures appear on origin/working.

## Constraints honored

- Minimal change, single file, single hunk.
- No refactor of the larger startup flow.
- No other files touched.

## Test plan

- [x] Lint passes
- [x] Typecheck passes
- [x] Listener + shutdown tests pass locally
- [ ] CI green
- [ ] Manual `gh pr merge --squash` after CI green (--auto disabled per task)