### PR TITLE
wave3(#227): spec text reconcile — turbo gen glob + proto paths + BoundAddress

### DIFF
--- a/docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+++ b/docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
@@ -305,7 +305,7 @@ export function makeListenerA(env: DaemonEnv): Listener {
   return {
     id: "A",
     bind: env.platform === "win32"
-      ? { kind: "KIND_NAMED_PIPE", path: `\\\\.\\pipe\\ccsm-${env.userSid}` }
+      ? { kind: "KIND_NAMED_PIPE", pipeName: `\\\\.\\pipe\\ccsm-${env.userSid}` }
       : { kind: "KIND_UDS", path: env.platform === "darwin"
           ? "/var/run/com.ccsm.daemon/daemon.sock"
           : "/run/ccsm/daemon.sock" },

--- a/docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+++ b/docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
@@ -283,14 +283,14 @@ The daemon owns a fixed-length array `listeners: [ListenerSlot, ListenerSlot]`. 
 | `BindDescriptor.kind` | `listener-a.json.transport` | Socket shape | Used by |
 | --- | --- | --- | --- |
 | `KIND_UDS` | `"KIND_UDS"` | `{ path: string }` (e.g., `/run/ccsm/daemon.sock`) | Listener A on linux/mac when the UDS spike passes |
-| `KIND_NAMED_PIPE` | `"KIND_NAMED_PIPE"` | `{ path: string }` (e.g., `\\.\pipe\ccsm-<sid>`) | Listener A on Windows when the named-pipe spike passes |
+| `KIND_NAMED_PIPE` | `"KIND_NAMED_PIPE"` | `{ pipeName: string }` (e.g., `\\.\pipe\ccsm-<sid>`) | Listener A on Windows when the named-pipe spike passes |
 | `KIND_TCP_LOOPBACK_H2C` | `"KIND_TCP_LOOPBACK_H2C"` | `{ host: "127.0.0.1", port: number }` | Listener A loopback fallback (h2c) |
 | `KIND_TCP_LOOPBACK_H2_TLS` | `"KIND_TCP_LOOPBACK_H2_TLS"` | `{ host: "127.0.0.1", port: number, certFingerprintSha256: string }` | Listener A loopback TLS+ALPN fallback |
 
 ```ts
 export type BindDescriptor =
   | { kind: "KIND_UDS"; path: string }
-  | { kind: "KIND_NAMED_PIPE"; path: string }
+  | { kind: "KIND_NAMED_PIPE"; pipeName: string }
   | { kind: "KIND_TCP_LOOPBACK_H2C"; host: "127.0.0.1"; port: number }
   | { kind: "KIND_TCP_LOOPBACK_H2_TLS"; host: "127.0.0.1"; port: number; certFingerprintSha256: string };
 ```
@@ -2684,11 +2684,11 @@ ccsm/                                # repo root
 ├── packages/
 │   ├── proto/
 │   │   ├── package.json             # name: "@ccsm/proto"
-│   │   ├── ccsm/v1/*.proto
+│   │   ├── src/ccsm/v1/*.proto      # proto sources; `buf.yaml` declares `modules.path: src`
 │   │   ├── buf.yaml
 │   │   ├── buf.gen.yaml
 │   │   ├── gen/                     # generated code; gitignored; built by `pnpm run gen`
-│   │   │   ├── ts/                  # connect-es output
+│   │   │   ├── ts/                  # protoc-gen-es output (messages + GenService descriptors)
 │   │   │   ├── go/                  # for v0.4 (placeholder dir; empty in v0.3)
 │   │   │   └── swift/               # for v0.4
 │   │   └── scripts/lock-buf-image.sh
@@ -2698,7 +2698,7 @@ ccsm/                                # repo root
 │   │   ├── src/
 │   │   │   ├── index.ts             # entrypoint -> bundle.js -> sea
 │   │   │   ├── listeners/           # chapter 03
-│   │   │   ├── rpc/                 # handlers; consumes @ccsm/proto/gen/ts
+│   │   │   ├── rpc/                 # handlers; consumes `@ccsm/proto` (re-exports `gen/ts/**`)
 │   │   │   ├── pty/                 # chapter 06
 │   │   │   ├── db/                  # chapter 07
 │   │   │   ├── crash/               # chapter 09
@@ -2713,7 +2713,7 @@ ccsm/                                # repo root
 │       ├── src/
 │       │   ├── main/                # minimal; chapter 08 §4
 │       │   ├── preload/             # 5 lines; chapter 08 §4
-│       │   └── renderer/            # React app; consumes @ccsm/proto/gen/ts
+│       │   └── renderer/            # React app; consumes `@ccsm/proto` (re-exports `gen/ts/**`)
 │       ├── electron-builder.yml
 │       ├── test/{unit,e2e}/
 │       └── dist/
@@ -2752,7 +2752,7 @@ ccsm/                                # repo root
 }
 ```
 
-pnpm symlinks `node_modules/@ccsm/proto` to `packages/proto`, which exposes its `gen/ts` output via its `package.json` `"exports"` field.
+pnpm symlinks `node_modules/@ccsm/proto` to `packages/proto`, which re-exports its generated `gen/ts/**` modules through `packages/proto/src/index.ts`; the `package.json` `"exports"` field points at that re-export so consumers can `import { SessionService } from '@ccsm/proto'` without reaching into the `gen/ts` path directly.
 
 #### 4. Proto codegen pipeline
 
@@ -2761,12 +2761,16 @@ packages/proto/buf.gen.yaml
 ---
 version: v2
 plugins:
-  - remote: buf.build/bufbuild/es:v1.10.0
+  # protoc-gen-es v2 generates both message types AND service descriptors
+  # (`GenService<...>` constants). Connect-RPC consumes those descriptors
+  # directly via `@connectrpc/connect` — no separate `connect-es` plugin
+  # is needed (the v1 `connectrpc/es` plugin was deprecated by upstream
+  # in favor of `protoc-gen-es` ≥ v2 emitting GenService).
+  - local: protoc-gen-es
     out: gen/ts
-    opt: target=ts,import_extension=js
-  - remote: buf.build/connectrpc/es:v1.4.0
-    out: gen/ts
-    opt: target=ts,import_extension=js
+    opt:
+      - target=ts
+      - import_extension=js
 # v0.4 will append:
 #  - remote: buf.build/connectrpc/go:v1.x
 #    out: gen/go

--- a/turbo.json
+++ b/turbo.json
@@ -8,7 +8,7 @@
       "inputs": [
         "buf.yaml",
         "buf.gen.yaml",
-        "ccsm/**/*.proto",
+        "**/*.proto",
         "lock.json",
         "scripts/**"
       ]


### PR DESCRIPTION
## Summary

Single PR fixing 3 spec-vs-code text drifts found in audit A (plan §6.5 / audit A2). Pure documentation + one turbo.json config fix; no runtime code changes.

## Drift 1 — `turbo.json` `gen` task input glob (audit A2)

**Before**

```json
"inputs": [
  "buf.yaml",
  "buf.gen.yaml",
  "ccsm/**/*.proto",
  "lock.json",
  "scripts/**"
]
```

**After**

```json
"inputs": [
  "buf.yaml",
  "buf.gen.yaml",
  "**/*.proto",
  "lock.json",
  "scripts/**"
]
```

**Why**: Proto sources live at `packages/proto/src/ccsm/v1/*.proto` (per `buf.yaml` `modules.path: src`). The `ccsm/**/*.proto` glob, evaluated relative to the proto package root, never matched any file, so `.proto` edits did NOT invalidate the gen cache. Replaced with the package-anchored `**/*.proto`.

**Cache invalidation test (local, Windows)**

| Step | Expected | Actual |
| --- | --- | --- |
| `pnpm gen` (cold) | miss | `cache miss, executing 412d33ce1ad2e753` |
| `pnpm gen` (warm) | hit | `cache hit … FULL TURBO`, 178ms |
| Append a real byte to `packages/proto/src/ccsm/v1/common.proto` + `pnpm gen` | miss | `cache miss, executing b00d0fe1f830827c` |
| Restore + `pnpm gen` | hit | `FULL TURBO` |

Direction: fix code (turbo config). Spec ch11 §4 was not specific about the inputs list, so spec did not need an edit on this drift.

## Drift 2 — Proto paths in spec ch11 §2 / §3 / §4

Direction: fix spec text (code is canonical for paths and toolchain).

| Location | Before | After |
| --- | --- | --- |
| §2 dir tree (line 2687) | `ccsm/v1/*.proto` | `src/ccsm/v1/*.proto      # proto sources; `buf.yaml` declares `modules.path: src`` |
| §2 dir tree (line 2691) | `gen/ts: # connect-es output` | `gen/ts: # protoc-gen-es output (messages + GenService descriptors)` |
| §2 dir tree (line 2701/2716) | `consumes @ccsm/proto/gen/ts` | `consumes `@ccsm/proto` (re-exports `gen/ts/**`)` |
| §3 (line 2755) | `exposes its `gen/ts` output via its `package.json` `"exports"` field` | rewritten to describe the actual `src/index.ts` re-export (`exports` field points at `./src/index.ts`, which re-exports `gen/ts/**`) |
| §4 (lines 2762-2774) `buf.gen.yaml` block | listed two remote plugins (`bufbuild/es:v1.10.0` + `connectrpc/es:v1.4.0`, both with `import_extension=js`) | replaced with the actual config: one `local: protoc-gen-es` plugin + comment explaining why `connectrpc/es` is no longer needed (protoc-gen-es ≥ v2 emits `GenService<…>` directly, consumed by `@connectrpc/connect` at runtime) |

## Drift 3 — `BindDescriptor` namedPipe field name (spec ch03 §1a)

Direction: fix spec text (code field name `pipeName` is more accurate than `path`).

| Location | Before | After |
| --- | --- | --- |
| §1a table row `KIND_NAMED_PIPE` (line 286) | `{ path: string }` (e.g., `\.\pipe\ccsm-<sid>`) | `{ pipeName: string }` (e.g., `\.\pipe\ccsm-<sid>`) |
| §1a TS code block (line 293) | `{ kind: "KIND_NAMED_PIPE"; path: string }` | `{ kind: "KIND_NAMED_PIPE"; pipeName: string }` |

**Why**: The example value already shows a Windows named-pipe identifier, not a filesystem path. Code (`packages/daemon/src/listeners/types.ts` and `packages/daemon/src/transport/types.ts`) has consistently used `pipeName: string` since T1.2 / T1.5. The discriminator (`kind`) was left untouched — that surface is owned by #224 / PR #950 and is out of scope here. No code touched on this drift.

## Constraints honored

- Did NOT touch `BindDescriptor.kind` (#224 PR #950 territory).
- Did NOT touch ch14 §1.A transport matrix (#950 territory).
- No follow-up drifts found while reading.

## Test plan

- [x] `pnpm gen` HIT/HIT on consecutive runs
- [x] `pnpm gen` MISS on real `.proto` content change
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` — pre-existing failure on `daemon/src/index.ts:260` (unrelated to this PR; reproduced on `origin/working` with my changes stashed)

References: plan §6.5, audit A2.