### PR TITLE
wave0c(#217): electron rewire — drop ipc halves of updater/notify/window

### DIFF
--- a/electron/__tests__/updater.test.ts
+++ b/electron/__tests__/updater.test.ts
@@ -2,51 +2,29 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EventEmitter } from 'events';
 
 // ----------------------------------------------------------------------------
-// Mocks
+// Wave 0c (#217): the renderer-facing IPC + broadcast surface was removed.
+// `installUpdater()` now only wires the autoUpdater event listeners + kicks
+// off the periodic check loop; `getUpdaterStatus()` exposes the latest
+// in-process state for diagnostics.
 //
 // We mock both 'electron' and 'electron-updater' because the real modules
 // can't run in Node (electron needs the binary; electron-updater probes the
-// runtime environment on import). The mocks preserve enough behavior to
-// verify our IPC wiring: handlers registered, status broadcasts emitted,
-// periodic check scheduled.
+// runtime environment on import).
 // ----------------------------------------------------------------------------
 
-type IpcHandler = (event: unknown, ...args: unknown[]) => unknown;
 type Listener = (payload: unknown) => void;
 
-const ipcHandlers = new Map<string, IpcHandler>();
-const webContentsSends: Array<{ channel: string; payload: unknown }> = [];
 const autoUpdaterEmitter = new EventEmitter();
 // Use a mutable object so the mock factories can close over a stable reference
-// across `vi.resetModules()` re-imports. Reassigning primitives like
-// `appIsPackaged = false` wouldn't take effect after reset, because the new
-// mock factory snapshots its own binding — but a property on a persistent
-// object works because the object identity survives.
+// across `vi.resetModules()` re-imports.
 const state = {
   appIsPackaged: true,
   appVersion: '0.1.2',
   appName: 'CCSM',
-  checkForUpdatesImpl: (async () => ({ updateInfo: {} })) as () => Promise<unknown>,
-  downloadUpdateImpl: (async () => undefined) as () => Promise<unknown>
+  checkForUpdatesImpl: (async () => ({ updateInfo: {} })) as () => Promise<unknown>
 };
-const quitAndInstallCalls: Array<{ isSilent: boolean; isForceRunAfter: boolean }> = [];
 
 vi.mock('electron', () => {
-  const ipcMain = {
-    handle: (channel: string, handler: IpcHandler) => {
-      ipcHandlers.set(channel, handler);
-    }
-  };
-  const BrowserWindow = {
-    getAllWindows: () => [
-      {
-        webContents: {
-          send: (channel: string, payload: unknown) =>
-            webContentsSends.push({ channel, payload })
-        }
-      }
-    ]
-  };
   const app = {
     get isPackaged() {
       return state.appIsPackaged;
@@ -54,7 +32,7 @@ vi.mock('electron', () => {
     getVersion: () => state.appVersion,
     getName: () => state.appName
   };
-  return { ipcMain, BrowserWindow, app };
+  return { app };
 });
 
 vi.mock('electron-updater', () => {
@@ -66,56 +44,30 @@ vi.mock('electron-updater', () => {
     on: (event: string, listener: Listener) => {
       autoUpdaterEmitter.on(event, listener);
     },
-    checkForUpdates: () => state.checkForUpdatesImpl(),
-    downloadUpdate: () => state.downloadUpdateImpl(),
-    quitAndInstall: (isSilent: boolean, isForceRunAfter: boolean) => {
-      quitAndInstallCalls.push({ isSilent, isForceRunAfter });
-    }
+    checkForUpdates: () => state.checkForUpdatesImpl()
   };
   return { autoUpdater };
 });
 
 function resetState() {
-  ipcHandlers.clear();
-  webContentsSends.length = 0;
   autoUpdaterEmitter.removeAllListeners();
-  quitAndInstallCalls.length = 0;
   state.appIsPackaged = true;
   state.appVersion = '0.1.2';
   state.appName = 'CCSM';
   state.checkForUpdatesImpl = async () => ({ updateInfo: {} });
-  state.downloadUpdateImpl = async () => undefined;
 }
 
 async function freshModule() {
   resetState();
   const mod = await import('../updater');
   mod.__resetUpdaterForTests();
-  mod.installUpdaterIpc();
+  mod.installUpdater();
   return mod;
 }
 
-function sendsFor(channel: string) {
-  return webContentsSends.filter((s) => s.channel === channel).map((s) => s.payload);
-}
-
-describe('updater: IPC wiring', () => {
+describe('updater (Wave 0c — shell-only, no renderer surface)', () => {
   beforeEach(async () => {
     await freshModule();
-  });
-
-  it('registers all expected ipc handlers', () => {
-    const expected = [
-      'updates:status',
-      'updates:check',
-      'updates:download',
-      'updates:install',
-      'updates:getAutoCheck',
-      'updates:setAutoCheck'
-    ];
-    for (const ch of expected) {
-      expect(ipcHandlers.has(ch), `missing handler: ${ch}`).toBe(true);
-    }
   });
 
   it('configures autoUpdater for autoDownload + autoInstallOnAppQuit', async () => {
@@ -126,134 +78,75 @@ describe('updater: IPC wiring', () => {
 
   it('leaves allowPrerelease=false for the prod variant (#891)', async () => {
     const { autoUpdater } = await import('electron-updater');
-    // Default reset state has appName='CCSM' so installUpdaterIpc must NOT
+    // Default reset state has appName='CCSM' so installUpdater must NOT
     // flip allowPrerelease — prod users only see stable releases.
     expect(autoUpdater.allowPrerelease).toBe(false);
   });
 
   it('flips allowPrerelease=true for the dev variant (#891)', async () => {
-    // Override appName before re-importing so the dual-install branch fires.
     state.appName = 'CCSM Dev';
     const mod = await import('../updater');
     mod.__resetUpdaterForTests();
-    // Reset the mock field too — module-scoped mock object survives across
-    // freshModule() calls in beforeEach, so the prior installUpdaterIpc may
-    // have left it at its default. Force a known starting point.
     const { autoUpdater } = await import('electron-updater');
     autoUpdater.allowPrerelease = false;
-    mod.installUpdaterIpc();
+    mod.installUpdater();
     expect(autoUpdater.allowPrerelease).toBe(true);
   });
 
-  it('broadcasts status on update-available and fires update:available channel', () => {
+  it('records status on update-available', async () => {
     autoUpdaterEmitter.emit('update-available', { version: '1.2.3', releaseDate: '2026-01-01' });
-
-    const statusSends = sendsFor('updates:status');
-    expect(statusSends).toContainEqual({
+    const mod = await import('../updater');
+    expect(mod.getUpdaterStatus()).toEqual({
       kind: 'available',
       version: '1.2.3',
       releaseDate: '2026-01-01'
     });
-
-    const availableSends = sendsFor('update:available');
-    expect(availableSends).toContainEqual({ version: '1.2.3', releaseDate: '2026-01-01' });
   });
 
-  it('broadcasts status on update-downloaded and fires update:downloaded channel', () => {
+  it('records status on update-downloaded', async () => {
     autoUpdaterEmitter.emit('update-downloaded', { version: '1.2.3' });
-
-    expect(sendsFor('updates:status')).toContainEqual({ kind: 'downloaded', version: '1.2.3' });
-    expect(sendsFor('update:downloaded')).toContainEqual({ version: '1.2.3' });
+    const mod = await import('../updater');
+    expect(mod.getUpdaterStatus()).toEqual({ kind: 'downloaded', version: '1.2.3' });
   });
 
-  it('broadcasts status on error and fires update:error channel', () => {
+  it('records status on error', async () => {
     autoUpdaterEmitter.emit('error', new Error('network down'));
-
-    expect(sendsFor('updates:status')).toContainEqual({ kind: 'error', message: 'network down' });
-    expect(sendsFor('update:error')).toContainEqual({ message: 'network down' });
+    const mod = await import('../updater');
+    expect(mod.getUpdaterStatus()).toEqual({ kind: 'error', message: 'network down' });
   });
 
-  it('updates:check returns not-available in dev (unpackaged) without calling autoUpdater', async () => {
-    // Switch to dev mode after the default freshModule() in beforeEach; the
-    // app.isPackaged getter reads state at call time so this takes effect.
+  it('records status on download-progress', async () => {
+    autoUpdaterEmitter.emit('download-progress', {
+      percent: 42,
+      transferred: 4200,
+      total: 10000
+    });
+    const mod = await import('../updater');
+    expect(mod.getUpdaterStatus()).toEqual({
+      kind: 'downloading',
+      percent: 42,
+      transferred: 4200,
+      total: 10000
+    });
+  });
+
+  it('initial periodic check sets `not-available` in dev (unpackaged)', async () => {
+    // Re-init in unpackaged mode and verify the safeCheck() shortcut fires.
     state.appIsPackaged = false;
-
-    let checkCalled = false;
-    state.checkForUpdatesImpl = async () => {
-      checkCalled = true;
-      return { updateInfo: {} };
-    };
-
-    const handler = ipcHandlers.get('updates:check')!;
-    const result = await handler({});
-    expect(result).toEqual({ kind: 'not-available', version: '0.1.2' });
-    expect(checkCalled).toBe(false);
+    const mod = await import('../updater');
+    mod.__resetUpdaterForTests();
+    mod.installUpdater();
+    // safeCheck() runs synchronously up to the first await — wait one tick.
+    await Promise.resolve();
+    expect(mod.getUpdaterStatus()).toEqual({ kind: 'not-available', version: '0.1.2' });
   });
 
-  it('updates:check surfaces autoUpdater errors through the status channel', async () => {
-    state.checkForUpdatesImpl = async () => {
-      throw new Error('boom');
-    };
-    const handler = ipcHandlers.get('updates:check')!;
-    const result = (await handler({})) as { kind: string; message: string };
-    expect(result.kind).toBe('error');
-    expect(result.message).toBe('boom');
-    expect(sendsFor('updates:status')).toContainEqual({ kind: 'error', message: 'boom' });
-  });
-
-  it('updates:install calls quitAndInstall with visible installer + relaunch', async () => {
-    // Defense-in-depth gate (#TBD): updates:install refuses unless
-    // lastStatus is `downloaded`. Drive the broadcast first so the
-    // handler can proceed.
-    autoUpdaterEmitter.emit('update-downloaded', { version: '0.1.3' });
-    const handler = ipcHandlers.get('updates:install')!;
-    const res = handler({});
-    expect(res).toEqual({ ok: true });
-    // quitAndInstall is scheduled via setImmediate — flush it.
-    await new Promise((r) => setImmediate(r));
-    expect(quitAndInstallCalls).toEqual([{ isSilent: false, isForceRunAfter: true }]);
-  });
-
-  it('updates:install refuses when no download has completed', () => {
-    // No `update-downloaded` event broadcast → lastStatus stays `idle`.
-    // The defense-in-depth gate must short-circuit before quitAndInstall.
-    const handler = ipcHandlers.get('updates:install')!;
-    const res = handler({});
-    expect(res).toEqual({ ok: false, reason: 'not-ready' });
-    expect(quitAndInstallCalls).toEqual([]);
-  });
-
-  it('updates:install refuses when not packaged', async () => {
-    state.appIsPackaged = false;
-    const handler = ipcHandlers.get('updates:install')!;
-    const res = handler({});
-    expect(res).toEqual({ ok: false, reason: 'not-packaged' });
-  });
-
-  it('updates:download proxies to autoUpdater.downloadUpdate()', async () => {
-    let called = false;
-    state.downloadUpdateImpl = async () => {
-      called = true;
-    };
-    const handler = ipcHandlers.get('updates:download')!;
-    const res = await handler({});
-    expect(res).toEqual({ ok: true });
-    expect(called).toBe(true);
-  });
-
-  it('updates:setAutoCheck toggles the preference', async () => {
-    const setHandler = ipcHandlers.get('updates:setAutoCheck')!;
-    const getHandler = ipcHandlers.get('updates:getAutoCheck')!;
-    expect(await getHandler({})).toBe(true);
-    expect(await setHandler({}, false)).toBe(false);
-    expect(await getHandler({})).toBe(false);
-    expect(await setHandler({}, true)).toBe(true);
-  });
-
-  it('updates:status returns the last broadcast status', async () => {
-    autoUpdaterEmitter.emit('update-available', { version: '9.9.9' });
-    const handler = ipcHandlers.get('updates:status')!;
-    const res = await handler({});
-    expect(res).toEqual({ kind: 'available', version: '9.9.9', releaseDate: undefined });
+  it('installUpdater() is idempotent — repeated calls do not double-register listeners', async () => {
+    const before = autoUpdaterEmitter.listenerCount('update-available');
+    const mod = await import('../updater');
+    mod.installUpdater();
+    mod.installUpdater();
+    const after = autoUpdaterEmitter.listenerCount('update-available');
+    expect(after).toBe(before);
   });
 });

--- a/electron/notify/sinks/__tests__/flashSink.test.ts
+++ b/electron/notify/sinks/__tests__/flashSink.test.ts
@@ -1,30 +1,25 @@
-// Tests for createFlashSink — the renderer-IPC sink in the notify pipeline.
+// Tests for createFlashSink — the in-process executor in the notify pipeline.
 //
 // The sink owns:
 //   1. A debounced timer per sid (re-flash resets duration).
 //   2. An in-memory `flashStates` map mirrored onto globalThis.__ccsmFlashStates
-//      for e2e probes.
-//   3. Outgoing `notify:flash` IPC sends to the main BrowserWindow.
+//      for e2e probes + in-process consumers.
 //
-// We assert real behavior end-to-end through a stub BrowserWindow that
-// records sends, plus fake timers to drive the debounce + auto-clear.
+// Wave 0c (#217): the renderer-IPC half (`notify:flash`) is removed. The sink
+// no longer pushes any IPC traffic; tests assert only the in-memory map and
+// the auto-clear timer. Wave 0d will add a daemon-RPC push back in.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createFlashSink, FLASH_DURATION_MS } from '../flashSink';
 import type { Decision } from '../../notifyDecider';
 
-interface SendCall {
-  channel: string;
-  payload: { sid: string; on: boolean };
-}
-
 function makeStubWin(opts: { destroyed?: boolean; webDestroyed?: boolean } = {}) {
-  const sends: SendCall[] = [];
+  const sends: Array<{ channel: string; payload: unknown }> = [];
   const win = {
     isDestroyed: () => Boolean(opts.destroyed),
     webContents: {
       isDestroyed: () => Boolean(opts.webDestroyed),
-      send: (channel: string, payload: { sid: string; on: boolean }) => {
+      send: (channel: string, payload: unknown) => {
         sends.push({ channel, payload });
       },
     },
@@ -53,35 +48,33 @@ describe('createFlashSink', () => {
     expect(sink._peek()).toEqual({});
   });
 
-  it('sends notify:flash with on=true and mirrors state to globalThis', () => {
+  it('records flash state and mirrors to globalThis (no IPC fan-out post-Wave-0c)', () => {
     const { win, sends } = makeStubWin();
     const sink = createFlashSink({ getMainWindow: () => win as never });
     sink.apply(dec('s1', true));
-    expect(sends).toEqual([{ channel: 'notify:flash', payload: { sid: 's1', on: true } }]);
+    expect(sends).toEqual([]);
     expect(sink._peek()).toEqual({ s1: true });
     const g = globalThis as unknown as { __ccsmFlashStates: Record<string, boolean> };
     expect(g.__ccsmFlashStates).toBeDefined();
     expect(g.__ccsmFlashStates.s1).toBe(true);
   });
 
-  it('auto-clears flash after durationMs and sends on=false', () => {
-    const { win, sends } = makeStubWin();
+  it('auto-clears flash after durationMs', () => {
+    const { win } = makeStubWin();
     const sink = createFlashSink({
       getMainWindow: () => win as never,
       durationMs: 100,
     });
     sink.apply(dec('s1', true));
-    expect(sends.length).toBe(1);
+    expect(sink._peek()).toEqual({ s1: true });
     vi.advanceTimersByTime(99);
-    expect(sends.length).toBe(1);
+    expect(sink._peek()).toEqual({ s1: true });
     vi.advanceTimersByTime(2);
-    expect(sends.length).toBe(2);
-    expect(sends[1]).toEqual({ channel: 'notify:flash', payload: { sid: 's1', on: false } });
     expect(sink._peek()).toEqual({});
   });
 
-  it('re-flash before clear resets the timer (debounce) without an extra on=true send', () => {
-    const { win, sends } = makeStubWin();
+  it('re-flash before clear resets the timer (debounce)', () => {
+    const { win } = makeStubWin();
     const sink = createFlashSink({
       getMainWindow: () => win as never,
       durationMs: 100,
@@ -90,20 +83,16 @@ describe('createFlashSink', () => {
     vi.advanceTimersByTime(80);
     sink.apply(dec('s1', true)); // re-flash extends timer
     vi.advanceTimersByTime(80); // total 160 from first apply but only 80 since reset
-    // Still no clear yet — only original on=true was sent.
-    expect(sends.length).toBe(1);
+    expect(sink._peek()).toEqual({ s1: true });
     vi.advanceTimersByTime(30); // crosses reset deadline
-    expect(sends.length).toBe(2);
-    expect(sends[1]!.payload).toEqual({ sid: 's1', on: false });
+    expect(sink._peek()).toEqual({});
   });
 
-  it('forget() clears state immediately and sends on=false', () => {
-    const { win, sends } = makeStubWin();
+  it('forget() clears state immediately', () => {
+    const { win } = makeStubWin();
     const sink = createFlashSink({ getMainWindow: () => win as never });
     sink.apply(dec('s1', true));
     sink.forget('s1');
-    expect(sends.length).toBe(2);
-    expect(sends[1]!.payload).toEqual({ sid: 's1', on: false });
     expect(sink._peek()).toEqual({});
   });
 
@@ -114,41 +103,32 @@ describe('createFlashSink', () => {
     expect(sends).toEqual([]);
   });
 
-  it('skips send when window is destroyed', () => {
-    const { win, sends } = makeStubWin({ destroyed: true });
+  it('still records state when window is destroyed (no IPC layer to skip)', () => {
+    const { win } = makeStubWin({ destroyed: true });
     const sink = createFlashSink({ getMainWindow: () => win as never });
     sink.apply(dec('s1', true));
-    expect(sends).toEqual([]);
-    // Local state still updated (so probes can still observe).
     expect(sink._peek()).toEqual({ s1: true });
   });
 
-  it('skips send when webContents is destroyed', () => {
-    const { win, sends } = makeStubWin({ webDestroyed: true });
-    const sink = createFlashSink({ getMainWindow: () => win as never });
-    sink.apply(dec('s1', true));
-    expect(sends).toEqual([]);
-  });
-
-  it('skips send when getMainWindow returns null', () => {
+  it('still records state when getMainWindow returns null', () => {
     const sink = createFlashSink({ getMainWindow: () => null });
-    // Just must not throw.
     expect(() => sink.apply(dec('s1', true))).not.toThrow();
+    expect(sink._peek()).toEqual({ s1: true });
   });
 
   it('uses default FLASH_DURATION_MS when durationMs not provided', () => {
     expect(FLASH_DURATION_MS).toBe(4_000);
-    const { win, sends } = makeStubWin();
+    const { win } = makeStubWin();
     const sink = createFlashSink({ getMainWindow: () => win as never });
     sink.apply(dec('s1', true));
     vi.advanceTimersByTime(FLASH_DURATION_MS - 1);
-    expect(sends.length).toBe(1);
+    expect(sink._peek()).toEqual({ s1: true });
     vi.advanceTimersByTime(2);
-    expect(sends.length).toBe(2);
+    expect(sink._peek()).toEqual({});
   });
 
   it('handles independent sids without cross-talk', () => {
-    const { win, sends } = makeStubWin();
+    const { win } = makeStubWin();
     const sink = createFlashSink({
       getMainWindow: () => win as never,
       durationMs: 50,
@@ -160,17 +140,14 @@ describe('createFlashSink', () => {
     expect(sink._peek()).toEqual({ s2: true });
     vi.advanceTimersByTime(60);
     expect(sink._peek()).toEqual({});
-    // 2 on=true + 1 forget(s1)on=false + 1 auto(s2)on=false = 4 sends.
-    expect(sends.length).toBe(4);
   });
 
   // Audit #876 cluster 1.14 / Task #884 — dispose() must clear ALL pending
-  // timers and the flash map. Reverse-verify: comment out the `clear(sid)`
-  // loop in dispose() and the timer-leak assertion below fails (the auto-
-  // fire would still happen + sends.length grows past expectation).
+  // timers and the flash map. (Wave 0c: assertions on IPC send count are gone
+  // because the sink no longer pushes IPC.)
   describe('dispose()', () => {
-    it('clears all pending timers + flash state and sends on=false for each active sid', () => {
-      const { win, sends } = makeStubWin();
+    it('clears all pending timers + flash state', () => {
+      const { win } = makeStubWin();
       const sink = createFlashSink({
         getMainWindow: () => win as never,
         durationMs: 1000,
@@ -179,30 +156,23 @@ describe('createFlashSink', () => {
       sink.apply(dec('s2', true));
       sink.apply(dec('s3', true));
       expect(sink._peek()).toEqual({ s1: true, s2: true, s3: true });
-      expect(sends.length).toBe(3); // 3 on=true
 
       sink.dispose();
 
-      // All three flash entries cleared + on=false sent for each.
       expect(sink._peek()).toEqual({});
-      expect(sends.length).toBe(6); // + 3 on=false
-      const offSids = sends.slice(3).map((s) => s.payload.sid).sort();
-      expect(offSids).toEqual(['s1', 's2', 's3']);
 
       // Timer leak check — advancing past the original duration must NOT
-      // fire any additional sends (timers were cleared).
+      // resurrect any state (timers were cleared).
       vi.advanceTimersByTime(2000);
-      expect(sends.length).toBe(6);
+      expect(sink._peek()).toEqual({});
     });
 
     it('is idempotent — second dispose is a no-op', () => {
-      const { win, sends } = makeStubWin();
+      const { win } = makeStubWin();
       const sink = createFlashSink({ getMainWindow: () => win as never });
       sink.apply(dec('s1', true));
       sink.dispose();
-      const sendsBefore = sends.length;
-      sink.dispose();
-      expect(sends.length).toBe(sendsBefore);
+      expect(() => sink.dispose()).not.toThrow();
     });
 
     it('dispose with no active flashes is safe', () => {

--- a/electron/notify/sinks/__tests__/pipeline.test.ts
+++ b/electron/notify/sinks/__tests__/pipeline.test.ts
@@ -79,10 +79,10 @@ describe('installNotifyPipeline (Task #743 orchestrator)', () => {
     expect(log![0]!.sid).toBe('s1');
     expect(onNotified).toHaveBeenCalledWith('s1');
 
-    // Flash sink fired notify:flash IPC.
-    const flashSends = sends.filter((s) => s.channel === 'notify:flash');
-    expect(flashSends.length).toBe(1);
-    expect(flashSends[0]!.payload).toEqual({ sid: 's1', on: true });
+    // Wave 0c (#217): flash sink no longer pushes IPC. Assert via the
+    // in-memory map instead.
+    expect(sends.filter((s) => s.channel === 'notify:flash')).toEqual([]);
+    expect(pipeline._internals().flash._peek()['s1']).toBe(true);
 
     pipeline.dispose();
   });
@@ -108,7 +108,7 @@ describe('installNotifyPipeline (Task #743 orchestrator)', () => {
   });
 
   it('markUserInput sticky-mutes the sid (no toast on subsequent run)', () => {
-    const { win, sends } = makeStubWin();
+    const { win } = makeStubWin();
     const onNotified = vi.fn();
     const pipeline = installNotifyPipeline({
       getMainWindow: () => win as never,
@@ -122,8 +122,8 @@ describe('installNotifyPipeline (Task #743 orchestrator)', () => {
     pipeline.feedChunk('s1', osc(IDLE_TITLE));
 
     expect(onNotified).not.toHaveBeenCalled();
-    // Mute (Rule 7) suppresses toast but still fires flash.
-    expect(sends.some((s) => s.channel === 'notify:flash')).toBe(true);
+    // Mute (Rule 7) suppresses toast but still records flash state in the map.
+    expect(pipeline._internals().flash._peek()['s1']).toBe(true);
     pipeline.dispose();
   });
 
@@ -219,6 +219,8 @@ describe('installNotifyPipeline (Task #743 orchestrator)', () => {
   // every still-flashing sid leaks its setTimeout closure past disposal.
   // Reverse-verify: drop the `flash.dispose()` call in pipeline.ts and
   // the `_peek()` empty assertion below fails.
+  // Wave 0c (#217): IPC send assertions removed — flash sink no longer
+  // pushes to webContents.
   it('dispose clears flash sink state (no leaked timers)', () => {
     vi.useFakeTimers();
     try {
@@ -237,16 +239,12 @@ describe('installNotifyPipeline (Task #743 orchestrator)', () => {
 
       pipeline.dispose();
 
-      // Flash map cleared; on=false IPC sent for both sids.
+      // Flash map cleared.
       expect(flash._peek()).toEqual({});
-      const offSends = sends.filter(
-        (s) =>
-          s.channel === 'notify:flash' &&
-          (s.payload as { on: boolean }).on === false,
-      );
-      expect(offSends.length).toBe(2);
 
-      // Advance well past FLASH_DURATION_MS — no late timer fires.
+      // Advance well past FLASH_DURATION_MS — no late timer fires anything
+      // observable through the IPC channel either (which has nothing to fire
+      // post-Wave-0c, but still: zero new sends).
       const sendsAfterDispose = sends.length;
       vi.advanceTimersByTime(10_000);
       expect(sends.length).toBe(sendsAfterDispose);

--- a/electron/notify/sinks/__tests__/toastSink.test.ts
+++ b/electron/notify/sinks/__tests__/toastSink.test.ts
@@ -3,8 +3,12 @@
 //   1. Resolves the user-visible name via getNameFn (placeholder/empty
 //      collapse to short sid prefix).
 //   2. Calls toastImpl.show with the i18n title/body + a click handler that
-//      focuses the window + sends 'session:activate'.
+//      focuses the window.
 //   3. Bumps the unread badge via onNotified.
+//
+// Wave 0c (#217): the click handler used to also fire a 'session:activate'
+// IPC message; that channel is gone, so the test only asserts focus side
+// effects now.
 //
 // We assert real behavior by injecting a recording toastImpl (no real
 // Notification spawn) and a stub BrowserWindow.
@@ -153,7 +157,7 @@ describe('createToastSink', () => {
     expect(calls[0]!.payload.body).not.toContain('  Trimmed');
   });
 
-  it('click handler focuses, restores when minimized, shows when hidden, and sends session:activate', () => {
+  it('click handler focuses, restores when minimized, shows when hidden (no IPC fan-out post-Wave-0c)', () => {
     const { impl, calls } = makeRecordingImpl();
     const win = makeStubWin({ visible: false, minimized: true });
     const sink = createToastSink({
@@ -166,7 +170,7 @@ describe('createToastSink', () => {
     expect(win.show).toHaveBeenCalledTimes(1);
     expect(win.restore).toHaveBeenCalledTimes(1);
     expect(win.focus).toHaveBeenCalledTimes(1);
-    expect(win.webContents.send).toHaveBeenCalledWith('session:activate', { sid: 's1' });
+    expect(win.webContents.send).not.toHaveBeenCalled();
   });
 
   it('click handler skips show/restore when window already visible+not-minimized', () => {

--- a/electron/notify/sinks/flashSink.ts
+++ b/electron/notify/sinks/flashSink.ts
@@ -1,8 +1,11 @@
 // Flash sink — single-responsibility executor that, given a Decision from
-// `notifyDecider.decide`, pushes a transient `flash` signal to the renderer
-// for the affected sid. AgentIcon ORs this against `state === 'waiting'` to
-// breathe an amber halo even on rules where the decider said "flash but no
-// toast" (Rule 2: foreground + active sid + short task).
+// `notifyDecider.decide`, records a transient `flash` signal for the
+// affected sid in an in-memory map (mirrored onto globalThis for e2e probes).
+//
+// Wave 0c (#217): the renderer-IPC half (`webContents.send('notify:flash', ...)`)
+// is removed. Wave 0d will let the daemon push this signal over its RPC
+// channel; until then the sink is in-process bookkeeping only — AgentIcon
+// in the renderer no longer receives flash events from the shell.
 //
 // Why a separate sink (vs. piggybacking on the existing 'session:state' IPC):
 //   * The existing state stream is sourced from the JSONL watcher and runs
@@ -16,13 +19,8 @@
 //     toast pipeline or require a new code path inside the watcher.
 //
 // Auto-clear: a flash is transient — we set `flashStates[sid] = true`,
-// then schedule a clear after FLASH_DURATION_MS so the halo doesn't stick
-// indefinitely. Repeated flashes reset the timer (debounce-style).
-//
-// IPC contract: main → renderer over channel `notify:flash` with payload
-// `{ sid: string, on: boolean }`. Renderer (App.tsx) subscribes via the
-// preload bridge `window.ccsmNotify.onFlash` and writes the zustand store
-// field `flashStates: Record<sid, boolean>`.
+// then schedule a clear after FLASH_DURATION_MS so the in-memory map doesn't
+// grow unbounded. Repeated flashes reset the timer (debounce-style).
 
 import type { BrowserWindow } from 'electron';
 import type { Decision } from '../notifyDecider';
@@ -65,15 +63,13 @@ export function createFlashSink(opts: FlashSinkOptions): FlashSink {
   (globalThis as unknown as { __ccsmFlashStates?: Record<string, boolean> }).__ccsmFlashStates =
     flashStates;
 
-  function send(sid: string, on: boolean): void {
-    const win = opts.getMainWindow();
-    if (!win || win.isDestroyed()) return;
-    if (win.webContents.isDestroyed()) return;
-    try {
-      win.webContents.send('notify:flash', { sid, on });
-    } catch (err) {
-      console.warn('[flashSink] send failed', err);
-    }
+  function send(_sid: string, _on: boolean): void {
+    // Wave 0c (#217): renderer 'notify:flash' IPC removed. Flash state
+    // remains tracked in `flashStates` (mirrored to globalThis for e2e
+    // probes) so the in-process pipeline + tests still observe it; the
+    // renderer no longer receives push events. Wave 0d will route this
+    // through the daemon RPC channel.
+    void opts.getMainWindow; // keep deps referenced for the future wire-up
   }
 
   function clear(sid: string): void {

--- a/electron/notify/sinks/toastSink.ts
+++ b/electron/notify/sinks/toastSink.ts
@@ -8,10 +8,15 @@
 //   decider   : notifyDecider.decide(event, ctx) (#687) → Decision | null
 //   sinks     : toastSink (this file) + flashSink (renderer push)
 //
+// Wave 0c (#217): the click handler used to fan out to the renderer via
+// `webContents.send('session:activate', { sid })`. That IPC channel is
+// gone — Wave 0d will let the daemon push session-activate via Connect-RPC.
+// For now the click handler still focuses the OS window so the user lands
+// in the app, just without renderer-side activation.
+//
 // The sink does NOT decide. It only:
 //   1. Builds the user-visible toast copy (title/body) via `getNameFn`.
-//   2. Calls `notifyImpl.show` with a click handler that focuses the window
-//      + sends 'session:activate' to the renderer.
+//   2. Calls `notifyImpl.show` with a click handler that focuses the window.
 //   3. Bumps the unread badge via the optional `onNotified` hook.
 //   4. Pushes a probe entry to `globalThis.__ccsmNotifyLog` when the
 //      `CCSM_NOTIFY_TEST_HOOK` env is set (e2e seam — the existing
@@ -65,7 +70,7 @@ function resolveName(name: string | null | undefined, sid: string): string {
   return trimmed;
 }
 
-function focusAndActivate(win: BrowserWindow | null, sid: string): void {
+function focusAndActivate(win: BrowserWindow | null, _sid: string): void {
   if (!win || win.isDestroyed()) return;
   try {
     if (!win.isVisible()) win.show();
@@ -74,13 +79,8 @@ function focusAndActivate(win: BrowserWindow | null, sid: string): void {
   } catch (err) {
     console.warn('[toastSink] focus failed', err);
   }
-  try {
-    if (!win.webContents.isDestroyed()) {
-      win.webContents.send('session:activate', { sid });
-    }
-  } catch (err) {
-    console.warn('[toastSink] session:activate send failed', err);
-  }
+  // Wave 0c (#217): renderer 'session:activate' IPC removed. Wave 0d will
+  // route this through the daemon RPC layer.
 }
 
 function makeElectronToastImpl(): ToastImpl {

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -1,9 +1,12 @@
-import { app, BrowserWindow, ipcMain } from 'electron';
+import { app } from 'electron';
 import { autoUpdater } from 'electron-updater';
 
-// All status updates flow through one channel so the renderer doesn't have to
-// subscribe to N separate event names. The shape mirrors electron-updater's
-// own emitter so future fields land naturally.
+// Wave 0c (#217): renderer surface removed. The shell-only auto-update
+// mechanism still runs (periodic check + autoDownload + install on quit),
+// but no IPC handlers, no `webContents.send` broadcasts, no renderer
+// status channel. v0.4 will reintroduce a renderer-facing surface via the
+// daemon-driven RPC layer; until then the updater is a self-contained
+// background module that writes its state to `lastStatus` for diagnostics.
 export type UpdateStatus =
   | { kind: 'idle' }
   | { kind: 'checking' }
@@ -23,32 +26,8 @@ let periodicHandle: ReturnType<typeof setInterval> | null = null;
 // without hammering GitHub releases.
 const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
 
-// Named event channels — requested in the release infra spec in addition to
-// the aggregated `updates:status` channel. Keeping both channels is cheap and
-// makes renderer code (e.g. "show a toast on downloaded") trivial.
-const CHAN_AVAILABLE = 'update:available';
-const CHAN_DOWNLOADED = 'update:downloaded';
-const CHAN_ERROR = 'update:error';
-const CHAN_STATUS = 'updates:status';
-
-function sendAll(channel: string, payload: unknown): void {
-  for (const win of BrowserWindow.getAllWindows()) {
-    win.webContents.send(channel, payload);
-  }
-}
-
-function broadcast(status: UpdateStatus): void {
+function record(status: UpdateStatus): void {
   lastStatus = status;
-  sendAll(CHAN_STATUS, status);
-  // Fan out to the specific channels too so renderer listeners that only
-  // care about one transition don't have to switch on kind themselves.
-  if (status.kind === 'available') {
-    sendAll(CHAN_AVAILABLE, { version: status.version, releaseDate: status.releaseDate });
-  } else if (status.kind === 'downloaded') {
-    sendAll(CHAN_DOWNLOADED, { version: status.version });
-  } else if (status.kind === 'error') {
-    sendAll(CHAN_ERROR, { message: status.message });
-  }
 }
 
 /**
@@ -58,13 +37,13 @@ function broadcast(status: UpdateStatus): void {
  */
 async function safeCheck(): Promise<void> {
   if (!app.isPackaged) {
-    broadcast({ kind: 'not-available', version: app.getVersion() });
+    record({ kind: 'not-available', version: app.getVersion() });
     return;
   }
   try {
     await autoUpdater.checkForUpdates();
   } catch (e) {
-    broadcast({ kind: 'error', message: (e as Error).message });
+    record({ kind: 'error', message: (e as Error).message });
   }
 }
 
@@ -88,12 +67,17 @@ function stopPeriodicChecks(): void {
   }
 }
 
-export function installUpdaterIpc(): void {
+/**
+ * Initialize the shell-only auto-updater. Wires `electron-updater` event
+ * listeners + kicks off the periodic check loop. No renderer surface — the
+ * updater downloads in the background and applies on quit.
+ */
+export function installUpdater(): void {
   if (installed) return;
   installed = true;
 
-  // electron-updater is noisy by default; quiet it down — we surface state
-  // through our own channel.
+  // electron-updater is noisy by default; quiet it down — we keep its state
+  // in `lastStatus` for in-process diagnostics only.
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
   autoUpdater.logger = null;
@@ -106,19 +90,19 @@ export function installUpdaterIpc(): void {
     autoUpdater.allowPrerelease = true;
   }
 
-  autoUpdater.on('checking-for-update', () => broadcast({ kind: 'checking' }));
+  autoUpdater.on('checking-for-update', () => record({ kind: 'checking' }));
   autoUpdater.on('update-available', (info) =>
-    broadcast({
+    record({
       kind: 'available',
       version: info.version,
       releaseDate: info.releaseDate
     })
   );
   autoUpdater.on('update-not-available', (info) =>
-    broadcast({ kind: 'not-available', version: info.version })
+    record({ kind: 'not-available', version: info.version })
   );
   autoUpdater.on('download-progress', (p) =>
-    broadcast({
+    record({
       kind: 'downloading',
       percent: p.percent,
       transferred: p.transferred,
@@ -126,75 +110,21 @@ export function installUpdaterIpc(): void {
     })
   );
   autoUpdater.on('update-downloaded', (info) =>
-    broadcast({ kind: 'downloaded', version: info.version })
+    record({ kind: 'downloaded', version: info.version })
   );
   autoUpdater.on('error', (err) =>
-    broadcast({ kind: 'error', message: err?.message ?? String(err) })
+    record({ kind: 'error', message: err?.message ?? String(err) })
   );
-
-  ipcMain.handle('updates:status', () => lastStatus);
-
-  ipcMain.handle('updates:check', async () => {
-    if (!app.isPackaged) {
-      const status: UpdateStatus = { kind: 'not-available', version: app.getVersion() };
-      broadcast(status);
-      return status;
-    }
-    try {
-      const res = await autoUpdater.checkForUpdates();
-      void res;
-      return lastStatus;
-    } catch (e) {
-      const status: UpdateStatus = { kind: 'error', message: (e as Error).message };
-      broadcast(status);
-      return status;
-    }
-  });
-
-  ipcMain.handle('updates:download', async () => {
-    if (!app.isPackaged) return { ok: false, reason: 'not-packaged' as const };
-    try {
-      await autoUpdater.downloadUpdate();
-      return { ok: true as const };
-    } catch (e) {
-      return { ok: false as const, reason: (e as Error).message };
-    }
-  });
-
-  ipcMain.handle('updates:install', () => {
-    if (!app.isPackaged) return { ok: false as const, reason: 'not-packaged' as const };
-    // Defense-in-depth: refuse to call quitAndInstall unless we've
-    // actually broadcast a `downloaded` event. Without this guard a
-    // misbehaving renderer (e.g. the user clicking the persistent toast
-    // after a stale state, or a future bug that wires the install button
-    // to a non-downloaded state) can trigger autoUpdater.quitAndInstall()
-    // mid-download — electron-updater handles that by force-killing the
-    // app, which the user reads as a crash. Returning `not-ready` lets
-    // the renderer surface a sane "still downloading" message instead.
-    if (lastStatus.kind !== 'downloaded') {
-      return { ok: false as const, reason: 'not-ready' as const };
-    }
-    // quitAndInstall: (isSilent, isForceRunAfter). We want a visible installer
-    // on Windows (isSilent=false) and to relaunch after install on all OSes.
-    setImmediate(() => autoUpdater.quitAndInstall(false, true));
-    return { ok: true as const };
-  });
-
-  ipcMain.handle('updates:getAutoCheck', () => autoCheckEnabled);
-  ipcMain.handle('updates:setAutoCheck', (_e, enabled: boolean) => {
-    autoCheckEnabled = !!enabled;
-    if (autoCheckEnabled) {
-      startPeriodicChecks();
-      void safeCheck();
-    } else {
-      stopPeriodicChecks();
-    }
-    return autoCheckEnabled;
-  });
 
   // Check once on ready + every 4h thereafter.
   void safeCheck();
   startPeriodicChecks();
+}
+
+// Exposed for tests + diagnostics — lets callers read the latest known state
+// without subscribing to events.
+export function getUpdaterStatus(): UpdateStatus {
+  return lastStatus;
 }
 
 // Exposed for tests — lets them reset module state between cases.

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -146,15 +146,13 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
     // not via Mica/transparency. The user explicitly does not want to see
     // the desktop through the window.
     backgroundColor: '#0B0B0C',
-    // macOS: hiddenInset titlebar with native traffic lights.
-    // Windows: fully frameless — we self-draw the three controls inside
-    //   the right pane (see WindowControls).
-    ...(process.platform === 'darwin'
-      ? {
-          titleBarStyle: 'hiddenInset' as const,
-          trafficLightPosition: { x: 16, y: 14 },
-        }
-      : { titleBarStyle: 'hidden' as const, frame: false }),
+    // Wave 0c (#217): frameless DISABLED for v0.3 — use the OS-default
+    // window chrome (title bar, resize handles, traffic lights / minimize-
+    // maximize-close controls). v0.2's self-drawn title bar relied on the
+    // preload IPC bridge to read maximize state and dispatch window
+    // commands; with the bridge gone we revert to native chrome rather
+    // than ship a half-wired custom one. Custom chrome may return in v0.4
+    // once the daemon-driven RPC layer can carry window-control intents.
     // Windows 11: ask DWM to round the outer corners so the window edge
     //   matches the radii of our internal panels. Without this the window
     //   is a sharp rectangle and rounded interior surfaces look clipped
@@ -162,8 +160,10 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
     roundedCorners: true,
     autoHideMenuBar: true,
     webPreferences: {
-      contextIsolation: true,
-      nodeIntegration: false,
+      // sandbox:true is the recommended Electron baseline. Wave 0b (#216)
+      // removed the preload, so there is no longer a sandboxed-require
+      // mismatch to worry about — flip it on.
+      sandbox: true,
       // Hidden-mode animation correctness: Chromium throttles rAF
       // for offscreen / hidden windows down to ~1Hz. dnd-kit's
       // dropAnimation (150ms) and other CSS transitions then never
@@ -177,21 +177,6 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
       // probes cannot accidentally pop a DevTools window (any explicit
       // openDevTools() call below is a no-op once this is false).
       devTools: !hiddenForE2E,
-      // sandbox:true is the recommended Electron baseline (forces the
-      // preload into a Chromium sandbox where Node built-ins are
-      // unavailable), but our preload's `require('@sentry/electron/preload')`
-      // can't be resolved by the sandboxed preload's restricted require —
-      // it only follows relative paths and a small whitelist. Enabling it
-      // results in: "Error: module not found: @sentry/electron/preload"
-      // and `window.ccsm` is never installed.
-      //
-      // Followup: bundle preload through webpack (or vendor the sentry
-      // preload into electron/) so the require resolves at build time, then
-      // flip this back to true. Tracked separately to keep this PR scoped
-      // to the IPC hardening fixes that don't require a build-pipeline
-      // change.
-      sandbox: false,
-      preload: path.join(__dirname, '..', 'preload', 'index.js'),
     },
   });
 
@@ -247,27 +232,22 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
   // bound a renderer here via `bindCliBridgeSender`; ptyHost now reaches
   // attached webContents directly through their per-session attach map,
   // so no explicit binding step is needed.)
-  win.on('show', () => {
-    // Reset the renderer's fade-opacity in case the window was just
-    // restored after a fade-to-hide (see `window:beforeHide` below).
-    if (!win.webContents.isDestroyed()) {
-      win.webContents.send('window:afterShow');
-    }
-  });
+  //
+  // Wave 0c (#217): the `window:afterShow` and `window:maximizedChanged`
+  // renderer broadcasts are gone — there is no preload bridge to receive
+  // them. Native chrome means the renderer doesn't need to draw its own
+  // maximize affordance, and the fade-on-restore animation is dropped
+  // alongside the fade-on-hide (see fadeThenHide below).
 
   win.on('focus', () => {
     deps.onFocusChange({ focused: true, activeSid: deps.getActiveSid() });
   });
 
-  const emitMax = () =>
-    win.webContents.send('window:maximizedChanged', win.isMaximized());
-  win.on('maximize', emitMax);
-  win.on('unmaximize', emitMax);
-
   // Close-button behaviour. Three modes — see getCloseAction() above:
   //   'quit' → don't preventDefault; let the window close, fall through to
   //            window-all-closed → before-quit → app exit.
-  //   'tray' → preventDefault + fade-to-hide (the original behaviour).
+  //   'tray' → preventDefault + hide (the original behaviour, minus the
+  //            fade now that we can no longer cue the renderer).
   //   'ask'  → preventDefault + native dialog with a "Don't ask again"
   //            checkbox; on confirm we persist the choice via setCloseAction
   //            so the next click goes straight to that branch.
@@ -275,29 +255,9 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
   // (tray menu Quit, app.before-quit safety net, electron-builder updater)
   // bypass everything.
   //
-  // Fade-to-hide: before actually calling `win.hide()` we send a
-  // `window:beforeHide` event so the renderer can run a short opacity
-  // fade-out. `HIDE_FADE_MS` matches `DURATION.standard` (180ms) from the
-  // shared motion tokens — kept short so closing still feels responsive.
-  // Guarded by `fadePending` so repeated Ctrl+W presses don't stack timers.
-  const HIDE_FADE_MS = 180;
-  let fadePending = false;
-  const fadeThenHide = () => {
-    if (fadePending) return;
-    fadePending = true;
-    try {
-      if (!win.webContents.isDestroyed()) {
-        win.webContents.send('window:beforeHide', { durationMs: HIDE_FADE_MS });
-      }
-    } catch {
-      /* renderer unreachable — fall through to immediate hide */
-    }
-    setTimeout(() => {
-      fadePending = false;
-      if (win.isDestroyed()) return;
-      win.hide();
-    }, HIDE_FADE_MS);
-  };
+  // Wave 0c (#217): the renderer-side fade-out animation is removed because
+  // we no longer have a `window:beforeHide` IPC channel to start it. We hide
+  // immediately instead. v0.4 will reintroduce the cue over the daemon RPC.
   win.on('close', (e) => {
     if (deps.getIsQuitting()) return;
     const pref = getCloseAction();
@@ -307,7 +267,7 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
     }
     e.preventDefault();
     if (pref === 'tray') {
-      fadeThenHide();
+      win.hide();
       return;
     }
     // pref === 'ask': prompt once. Showing the dialog is async, but
@@ -333,24 +293,19 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
           '[main] close-action dialog failed; falling back to tray',
           err,
         );
-        fadeThenHide();
+        win.hide();
         return;
       }
       const choice: CloseAction = result.response === 0 ? 'tray' : 'quit';
       if (result.checkboxChecked) setCloseAction(choice);
       if (choice === 'tray') {
-        fadeThenHide();
+        win.hide();
       } else {
         deps.setIsQuitting(true);
         app.quit();
       }
     })();
   });
-
-  // After the window is shown again (tray click, dock click on macOS) the
-  // renderer's opacity may still be 0 from the previous fade-out. The
-  // existing `win.on('show')` handler above dispatches `window:afterShow`
-  // to reset it.
 
   return win;
 }


### PR DESCRIPTION
Companion to wave0b(#216) (PR #948), which pure-deleted `electron/ipc/`,
`electron/preload/`, `ptyHost/ipcRegistrar.ts`, and the `main.ts` ipcMain
registrations. This wave handles the **REWIRE** files — modules that need
surgical edits, not deletion.

References: electron survey **a321fb44 §REWIRE**.

## Changes (per a321fb44 + manager decisions)

### `electron/updater.ts` — auto-updater renderer surface deferred to v0.4
- Removed all 6 `ipcMain.handle` calls (`updates:status` / `:check` / `:download` / `:install` / `:getAutoCheck` / `:setAutoCheck`).
- Removed the 4 `webContents.send` broadcasts (`updates:status`, `update:available`, `update:downloaded`, `update:error`).
- Kept `autoUpdater.on(...)` listeners + `safeCheck` + `startPeriodicChecks` so the **shell-only** auto-update keeps running (4h periodic check, autoDownload, autoInstallOnAppQuit).
- `installUpdaterIpc` → renamed to `installUpdater`.
- New `getUpdaterStatus()` exposes `lastStatus` for in-process diagnostics.

### `electron/notify/sinks/toastSink.ts`
- Dropped the `webContents.send('session:activate', { sid })` call from the click handler.
- Notification API + `onclick` + window focus/restore/show all preserved.

### `electron/notify/sinks/flashSink.ts`
- Dropped the `webContents.send('notify:flash', ...)` push.
- In-memory `flashStates` map (mirrored to `globalThis.__ccsmFlashStates` for e2e probes) still tracked.
- `getMainWindow` option kept on the API for the future Wave 0d daemon-RPC reroute.

### `electron/window/createWindow.ts` — frameless **DISABLED**
- Removed `titleBarStyle: 'hidden'` / `frame: false` / `hiddenInset` / `trafficLightPosition` so we get OS-default chrome on every platform.
- Stripped `preload` from `webPreferences` (preload no longer exists).
- Removed `contextIsolation: true` and `nodeIntegration: false` (defaults).
- Flipped `sandbox: true` (now safe with no preload to break).
- Dropped `window:beforeHide` / `window:afterShow` / `window:maximizedChanged` `webContents.send` calls.
- Dropped the fade-on-hide animation that depended on the `beforeHide` cue (immediate `win.hide()` instead).

### Tests updated
- `electron/__tests__/updater.test.ts` rewritten — asserts in-process status recording + idempotent install + autoUpdater config flags. No more IPC handler / broadcast assertions.
- `electron/notify/sinks/__tests__/flashSink.test.ts` — assertions converted from "sent `notify:flash` IPC" to "recorded in `flashStates` map".
- `electron/notify/sinks/__tests__/pipeline.test.ts` — same conversion at the orchestrator level.
- `electron/notify/sinks/__tests__/toastSink.test.ts` — click handler test no longer expects `session:activate` IPC.

## Verification (Windows local, pool-14)

- **Production-code IPC residue: zero**
  `grep -rn 'ipcMain|contextBridge|webContents\.send' electron/ --include='*.ts' | grep -v __tests__`
  returns **only doc-comments** referencing the removed channels by name.
- **`ipcGuards` old-path imports: zero** (Wave 0b rename verified — `grep -rn "from.*['\"].*ipcGuards['\"]" electron/ src/` → empty).
- `tsc --noEmit` (renderer): **clean**.
- `tsc --noEmit -p tsconfig.electron.json`: **clean**.
- `npm run lint:app`: **0 errors** (57 pre-existing warnings, none from changed files).
- `npm run build:app` (tsc + webpack production): **success**.
- Targeted `vitest` (5 files, **55 tests**): all pass.
- Require-load smoke on all four edited modules:
  ```
  node -e "require('./dist/electron/updater.js'); require('./dist/electron/notify/sinks/toastSink.js'); require('./dist/electron/notify/sinks/flashSink.js'); require('./dist/electron/window/createWindow.js'); console.log('OK')"
  → OK
  ```
  (no `ERR_REQUIRE_ESM`).

## Out of scope (per task description)

- `electron/sessionWatcher/`, `sessionTitles/`, `agent/`, `prefs/`, `import-scanner.ts`, `ptyHost/lifecycle/*` → Wave 0d (MOVE).
- `src/` renderer → Wave 0e (cutover). Renderer code still references the removed IPC channels via `window.ccsm.*`; those calls will no-op until Wave 0e replaces them with daemon-RPC clients. **The Electron window will load empty / blank when launched until Wave 0e lands.** That is the expected next step, not a regression introduced here.
- `pnpm lint:no-ipc` script → Wave 0f.

## Wire-up evidence

This PR is a **decoupling** wave — it removes wire-up rather than adding it. The next-wave wire-up (Wave 0d daemon push for flash + session-activate; Wave 0e renderer cutover from `window.ccsm.*` to daemon RPC) will provide the new evidence trail.

Note: `--auto` disabled on this repo per recent PRs; expect manual merge after CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)