### PR TITLE
wave2: #222 .v0.2-only-files + check-v02-shrinking.sh CI guard

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,4 @@ If this PR introduces new exports / classes / handlers / sinks, fill these. If i
 - [ ] **Importers**: paste `grep -rn 'from.*<your-module>' apps/ packages/` output showing who imports each new export
 - [ ] **Startup wiring** (for listeners / sinks / services / capture sources): paste the `apps/daemon/src/index.ts` (or equivalent `runStartup`) lines that call into your new code
 - [ ] **Library-only marker**: if there is no startup wiring because this is a pure library task, write `[LIBRARY-ONLY]` and link the follow-up wire-up task #
+- [ ] **v0.2-only growth**: if this PR modifies any file in `.v0.2-only-files`, explain why it grew (e.g. file moved, intermediate refactor) or confirm net shrink. CI guard `tools/check-v02-shrinking.sh` enforces this.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,23 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          # fetch-depth: 0 is required for tools/check-v02-shrinking.sh —
+          # it needs `git merge-base HEAD origin/main` (or merge-base with
+          # GITHUB_BASE_REF) to compare line counts of v0.2-only files
+          # against the base. A shallow checkout would leave merge-base
+          # unresolvable and the guard would no-op.
+          fetch-depth: 0
+
+      # Wave 2 §5.6 (Task #222) — mechanical guard: files listed in
+      # .v0.2-only-files are slated for deletion/shrinkage during the v0.3
+      # cutover. CI enforces line counts may shrink but not grow vs the
+      # merge-base. Linux-only because the check is git/wc/bash and the
+      # result is deterministic across OSes; running on the matrix would
+      # waste 2x runner time.
+      - name: Check v0.2-only files don't grow
+        if: matrix.os == 'ubuntu-latest'
+        run: bash tools/check-v02-shrinking.sh
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.v0.2-only-files
+++ b/.v0.2-only-files
@@ -1,0 +1,41 @@
+# .v0.2-only-files — Wave 2 §5.6 mechanical guard (Task #222)
+#
+# Files listed here are slated for deletion / shrinkage during Wave 0d /
+# Wave 3 cutover. CI enforces: line count may DECREASE but never INCREASE
+# vs the merge-base. This is a mechanical guard that complements reviewer
+# self-check ("does this PR add v0.2 cruft?").
+#
+# Format:
+#   - One path per line.
+#   - Lines starting with `#` are comments.
+#   - Blank lines are ignored.
+#   - Globs are supported (e.g. `electron/sessionWatcher/*`).
+#   - Missing files are skipped (file moved is OK).
+#
+# What does NOT belong here:
+#   - electron/db.ts — staying for v0.3 (per #249 deferred prefs decision).
+#   - electron/tray/*, electron/lifecycle/*, electron/branding/*,
+#     electron/sentry/* — KEEP-shell, not v0.2-only.
+#   - electron/window/closeAction.ts — stays in shell per design plan.
+#
+# When you legitimately need to grow a listed file (intermediate refactor,
+# file moved into shell), explain in the PR body. The Wire-up evidence
+# checklist has a checkbox for this.
+
+# Tier 2 — REWIRE / MOVE pending (must shrink, not grow)
+electron/main.ts
+electron/updater.ts
+electron/window/createWindow.ts
+electron/notify/sinks/toastSink.ts
+electron/notify/sinks/flashSink.ts
+electron/agent/read-default-model.ts
+electron/prefs/userCwds.ts
+electron/prefs/notifyEnabled.ts
+electron/prefs/crashReporting.ts
+src/components/settings/UpdatesPane.tsx
+src/terminal/xtermSingleton.ts
+src/stores/persist.ts
+src/terminal/usePtyAttach.ts
+src/stores/drafts.ts
+src/stores/slices/sessionCrudSlice.ts
+src/agent/lifecycle.ts

--- a/tools/check-v02-shrinking.sh
+++ b/tools/check-v02-shrinking.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# tools/check-v02-shrinking.sh — Wave 2 §5.6 mechanical guard (Task #222)
+#
+# For each path/glob listed in .v0.2-only-files, compare current line count
+# (HEAD) against the merge-base with origin/main (or $GITHUB_BASE_REF when
+# running in CI). Fails if any listed file/glob has GROWN.
+#
+# Semantics:
+#   - missing-at-head + present-at-base → OK (file moved/deleted).
+#   - missing-at-base + present-at-head → treated as base=0, so any growth
+#     fails. If you legitimately added a brand-new v0.2-only file, that
+#     means you should NOT have added it; either delete it or remove its
+#     line from .v0.2-only-files.
+#   - missing in both → silent skip.
+#   - glob: sum line counts across all currently-matching files vs sum
+#     across base-matching files (uses `git ls-tree` on the base sha to
+#     enumerate base-side matches).
+
+set -u
+
+# POSIX-bash; works on Linux, macOS, Git Bash on Windows.
+
+LIST_FILE=".v0.2-only-files"
+
+if [ ! -f "$LIST_FILE" ]; then
+  echo "check-v02-shrinking: no $LIST_FILE found at repo root, skipping" >&2
+  exit 0
+fi
+
+# Resolve base sha. Prefer GITHUB_BASE_REF in CI; fall back to merge-base
+# with origin/main locally. If neither resolves, fall back to HEAD~1 with a
+# warning (not fatal — this script is best-effort on shallow checkouts).
+base_sha=""
+if [ -n "${GITHUB_BASE_REF:-}" ]; then
+  # GITHUB_BASE_REF is the target branch name (e.g. "working"). Need the
+  # remote ref so we get the actual sha.
+  if git rev-parse --verify "origin/${GITHUB_BASE_REF}" >/dev/null 2>&1; then
+    base_sha=$(git merge-base HEAD "origin/${GITHUB_BASE_REF}" 2>/dev/null || true)
+  fi
+fi
+if [ -z "$base_sha" ]; then
+  if git rev-parse --verify origin/main >/dev/null 2>&1; then
+    base_sha=$(git merge-base HEAD origin/main 2>/dev/null || true)
+  fi
+fi
+if [ -z "$base_sha" ]; then
+  if git rev-parse --verify origin/working >/dev/null 2>&1; then
+    base_sha=$(git merge-base HEAD origin/working 2>/dev/null || true)
+  fi
+fi
+if [ -z "$base_sha" ]; then
+  echo "check-v02-shrinking: cannot resolve base sha (no GITHUB_BASE_REF, no origin/main, no origin/working). Skipping." >&2
+  exit 0
+fi
+
+echo "check-v02-shrinking: base = $base_sha"
+echo
+
+# count_head <pattern> → echoes total line count for currently-matching files
+count_head() {
+  pattern="$1"
+  total=0
+  # Use shell glob expansion. If no match, the pattern stays literal — we
+  # detect that by checking if the literal exists as a file.
+  # shellcheck disable=SC2086
+  set -- $pattern
+  if [ "$#" -eq 1 ] && [ "$1" = "$pattern" ] && [ ! -e "$1" ]; then
+    echo 0
+    return
+  fi
+  for f in "$@"; do
+    if [ -f "$f" ]; then
+      n=$(wc -l < "$f" 2>/dev/null || echo 0)
+      total=$((total + n))
+    fi
+  done
+  echo "$total"
+}
+
+# count_base <pattern> → echoes total line count for files matching pattern
+# at base_sha. For literal paths this is one git-show. For globs we enumerate
+# the base tree with git ls-tree and shell-glob-match.
+count_base() {
+  pattern="$1"
+  total=0
+  case "$pattern" in
+    *'*'*|*'?'*|*'['*)
+      # Glob: enumerate full base tree, filter by glob match in shell.
+      # Strip the trailing `/*` or similar to find a containing dir for ls-tree
+      # efficiency; if pattern has no `/` use the repo root.
+      dir=$(dirname "$pattern")
+      [ "$dir" = "." ] && dir=""
+      if [ -n "$dir" ]; then
+        files=$(git ls-tree -r --name-only "$base_sha" -- "$dir" 2>/dev/null || true)
+      else
+        files=$(git ls-tree -r --name-only "$base_sha" 2>/dev/null || true)
+      fi
+      # Match each against the glob
+      while IFS= read -r f; do
+        [ -z "$f" ] && continue
+        # Use case-pattern matching; pattern is shell-glob.
+        # shellcheck disable=SC2254
+        case "$f" in
+          $pattern)
+            n=$(git show "${base_sha}:${f}" 2>/dev/null | wc -l)
+            total=$((total + n))
+            ;;
+        esac
+      done <<EOF
+$files
+EOF
+      ;;
+    *)
+      # Literal path.
+      if git cat-file -e "${base_sha}:${pattern}" 2>/dev/null; then
+        n=$(git show "${base_sha}:${pattern}" 2>/dev/null | wc -l)
+        total=$n
+      fi
+      ;;
+  esac
+  echo "$total"
+}
+
+fail=0
+checked=0
+skipped=0
+
+# Read .v0.2-only-files line by line, strip comments + blanks.
+while IFS= read -r raw || [ -n "$raw" ]; do
+  # Strip leading/trailing whitespace.
+  line=$(printf '%s' "$raw" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
+  # Skip blank + comment.
+  case "$line" in
+    ''|'#'*) continue ;;
+  esac
+
+  head_count=$(count_head "$line")
+  base_count=$(count_base "$line")
+
+  if [ "$head_count" -eq 0 ] && [ "$base_count" -eq 0 ]; then
+    skipped=$((skipped + 1))
+    echo "SKIP: $line (missing in both base and head)"
+    continue
+  fi
+
+  checked=$((checked + 1))
+
+  if [ "$head_count" -gt "$base_count" ]; then
+    delta=$((head_count - base_count))
+    echo "GROW: $line (base=$base_count, head=$head_count, +$delta)"
+    fail=1
+  else
+    delta=$((base_count - head_count))
+    echo "OK:   $line (base=$base_count, head=$head_count, -$delta)"
+  fi
+done < "$LIST_FILE"
+
+echo
+echo "check-v02-shrinking: $checked checked, $skipped skipped"
+
+if [ "$fail" -ne 0 ]; then
+  echo
+  echo "FAIL: one or more .v0.2-only-files entries grew vs base."
+  echo "      If this is intentional (file moved into shell, intermediate refactor),"
+  echo "      explain in the PR body under 'Wire-up evidence' and ping reviewer."
+  exit 1
+fi
+
+echo "PASS: no v0.2-only file grew."
+exit 0


### PR DESCRIPTION
## Summary

Wave 2 §5.6 (Task #222) — mechanical guard. Lists files slated for deletion / shrinkage during v0.3 cutover; CI enforces line counts may DECREASE but never INCREASE vs merge-base. More reliable than reviewer self-check.

## Files added/modified

### `.v0.2-only-files` (new, repo root)
16 entries (Tier 2 REWIRE/MOVE pending), all verified to exist in `working`:

| path | base lines | head lines |
|---|---|---|
| electron/main.ts | 320 | 288 |
| electron/updater.ts | 206 | 200 |
| electron/window/createWindow.ts | 356 | 323 |
| electron/notify/sinks/toastSink.ts | 169 | 169 |
| electron/notify/sinks/flashSink.ts | 127 | 123 |
| electron/agent/read-default-model.ts | 50 | 4 |
| electron/prefs/userCwds.ts | 105 | 105 |
| electron/prefs/notifyEnabled.ts | 44 | 44 |
| electron/prefs/crashReporting.ts | 52 | 52 |
| src/components/settings/UpdatesPane.tsx | 188 | 188 |
| src/terminal/xtermSingleton.ts | 242 | 242 |
| src/stores/persist.ts | 120 | 120 |
| src/terminal/usePtyAttach.ts | 477 | 477 |
| src/stores/drafts.ts | 112 | 112 |
| src/stores/slices/sessionCrudSlice.ts | 420 | 420 |
| src/agent/lifecycle.ts | 111 | 111 |

Skipped (per spec): `electron/import-scanner.ts` does not exist post-Wave 0d.2 (`f8ccd8a` moved it to daemon).

Excluded by design (per anti-patterns):
- `electron/db.ts` — staying for v0.3 per #249 deferred-prefs decision
- `electron/tray/*`, `electron/lifecycle/*`, `electron/branding/*`, `electron/sentry/*` — KEEP-shell
- `electron/window/closeAction.ts` — stays in shell

### `tools/check-v02-shrinking.sh` (new)
POSIX bash. Compares HEAD line counts against merge-base.
- Base resolution: `origin/${GITHUB_BASE_REF}` → `origin/main` → `origin/working` fallback chain.
- Handles: literal paths, globs (via `git ls-tree` enumeration), missing-in-base (treated as 0 = any growth fails), missing-in-head (skip — file moved is OK), comments (`#`) and blank lines.
- Exit 1 if any GROW; exit 0 otherwise.

### `.github/workflows/ci.yml` (modified)
- Added `fetch-depth: 0` to `actions/checkout@v4` (required for `git merge-base`).
- Added step `Check v0.2-only files don't grow` to existing `lint-typecheck-test` job, gated `if: matrix.os == 'ubuntu-latest'` (deterministic check; no need to run cross-OS).

### `.github/pull_request_template.md` (modified)
Added checkbox under Wire-up evidence: `If this PR modifies any file in .v0.2-only-files, explain why it grew or confirm net shrink.`

## Local validation

### Clean baseline (PASS, exit 0)
```
check-v02-shrinking: base = 69a83b1b770032098c974bb8d46a7c7222795c99

OK:   electron/main.ts (base=320, head=288, -32)
OK:   electron/updater.ts (base=206, head=200, -6)
OK:   electron/window/createWindow.ts (base=356, head=323, -33)
... (all 16 OK)

check-v02-shrinking: 16 checked, 0 skipped
PASS: no v0.2-only file grew.
```

### Inject 50 grow lines into `electron/main.ts` (FAIL, exit 1)
Note on acceptance criteria #2/#3: spec says "inject 10 grow lines". Since `electron/main.ts` head (288) is already 32 lines below base (320) on `working`, +10 still leaves head < base and would correctly PASS. Used +50 to push head (338) above base (320) and trigger GROW:
```
GROW: electron/main.ts (base=320, head=338, +18)
... (others OK)

FAIL: one or more .v0.2-only-files entries grew vs base.
```
Exit code: `1`. After restore: PASS again.

### Bash + YAML syntax
- `bash -n tools/check-v02-shrinking.sh` → OK
- `python -c 'import yaml; yaml.safe_load(open(...))'` → OK

## CI step name
`Check v0.2-only files don't grow` (in `lint + typecheck + test (ubuntu-latest)` job).

## Out of scope
- Did NOT add to `lint:no-ipc` script (separate concern, per anti-patterns).
- Did NOT touch typecheck/lint/tests (no app code changed).

## Test plan
- [x] Script runs locally on clean checkout, exit 0
- [x] Inject growth → exit 1 with GROW message
- [x] Restore → exit 0 again
- [x] Bash + YAML syntax valid
- [ ] CI lint job picks up the new step (verify on this PR)
- [ ] Existing CI still green