### PR TITLE
wave0d.3: electron/db.ts path-injection prep (prefs move deferred to v0.4 settings-RPC)

### DIFF
--- a/electron/__tests__/db-hardening.test.ts
+++ b/electron/__tests__/db-hardening.test.ts
@@ -3,19 +3,17 @@ import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
 
-// Mirror db.test.ts: redirect electron's userData to a per-test tmp dir so
-// (a) we never touch the real app data and (b) each test gets a clean slate.
+// Wave 0d.3 (#249): db.ts no longer imports `electron`. Tests inject the
+// data dir directly via `initDb(dataDir)` instead of mocking `app.getPath`.
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-db-hardening-'));
 let tmpDir = tmpRoot;
-
-vi.mock('electron', () => ({
-  app: { getPath: () => tmpDir }
-}));
 
 async function freshDb() {
   const mod = await import('../db');
   mod.closeDb();
+  mod.__resetDataDirForTests();
   tmpDir = fs.mkdtempSync(path.join(tmpRoot, 'run-'));
+  mod.initDb(tmpDir);
   return mod;
 }
 
@@ -36,7 +34,7 @@ describe('db hardening: startup integrity check', () => {
 
     const err = vi.spyOn(console, 'error').mockImplementation(() => {});
     const { initDb, saveState, loadState } = mod;
-    expect(() => initDb()).not.toThrow();
+    expect(() => initDb(tmpDir)).not.toThrow();
 
     // Original file got renamed aside.
     const siblings = fs.readdirSync(tmpDir);
@@ -56,7 +54,7 @@ describe('db hardening: startup integrity check', () => {
 describe('db hardening: schema versioning', () => {
   it('stamps user_version=1 on a freshly-created database', async () => {
     const { initDb } = await freshDb();
-    const handle = initDb();
+    const handle = initDb(tmpDir);
     const v = handle.pragma('user_version', { simple: true }) as number;
     expect(v).toBe(1);
   });
@@ -84,6 +82,33 @@ describe('db hardening: prepared statement cache', () => {
     expect(spy.mock.calls.length).toBe(callsAfterFirst);
 
     spy.mockRestore();
+  });
+});
+
+describe('db hardening: dataDir injection (Wave 0d.3 / #249)', () => {
+  // Reverse-verifies the headless-ready refactor: db.ts no longer imports
+  // `electron`. Without an injected dataDir the singleton must refuse to
+  // boot loudly rather than silently writing somewhere wrong (cwd, $HOME,
+  // etc.). Pairs with `electron/main.ts` calling
+  // `initDb(app.getPath('userData'))` exactly once during boot.
+  it('opens the database under the injected dataDir, not app.getPath', async () => {
+    const mod = await import('../db');
+    mod.closeDb();
+    mod.__resetDataDirForTests();
+    const dir = fs.mkdtempSync(path.join(tmpRoot, 'inject-'));
+    mod.initDb(dir);
+    // Marker write so we can assert the file landed where we asked.
+    mod.saveState('marker', '1');
+    expect(fs.existsSync(path.join(dir, 'ccsm.db'))).toBe(true);
+  });
+
+  it('throws a clear error when no dataDir was ever injected', async () => {
+    // Force the worst-case shape: singleton dropped AND cache cleared, so
+    // the next initDb() with no arg has nothing to fall back to.
+    const mod = await import('../db');
+    mod.closeDb();
+    mod.__resetDataDirForTests();
+    expect(() => mod.initDb()).toThrow(/initDb\(\) called without a dataDir/);
   });
 });
 

--- a/electron/__tests__/db.test.ts
+++ b/electron/__tests__/db.test.ts
@@ -1,22 +1,21 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
 
-// `initDb` asks electron for the userData dir. Point it at a per-test tmp dir
-// so real app data isn't touched and each test gets a fresh database.
+// Wave 0d.3 (#249): db.ts no longer imports `electron`. Tests inject the
+// data dir directly via `initDb(dataDir)` instead of mocking `app.getPath`.
 const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'agentory-db-test-'));
 let tmpDir = tmpRoot;
 
-vi.mock('electron', () => ({
-  app: { getPath: () => tmpDir }
-}));
-
 async function freshDb() {
-  // Reset the module-local singleton between tests.
+  // Reset the module-local singleton AND the cached dataDir between tests
+  // so the next initDb() call binds to a brand-new tmp directory.
   const mod = await import('../db');
   mod.closeDb();
+  mod.__resetDataDirForTests();
   tmpDir = fs.mkdtempSync(path.join(tmpRoot, 'run-'));
+  mod.initDb(tmpDir);
   return mod;
 }
 

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -1,9 +1,20 @@
 import Database from 'better-sqlite3';
-import { app } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
 
+// Wave 0d.3 (#249): this module no longer imports `electron`. Callers MUST
+// pass the data dir to `initDb(dataDir)` once at boot — `electron/main.ts`
+// invokes it inside `app.whenReady()` with `app.getPath('userData')`. The
+// path is then cached so `getDb()` / `loadState()` / `saveState()` continue
+// to work without an explicit arg from prefs/* and the IPC handlers.
+//
+// Rationale: keeping the `app.getPath('userData')` call inside this module
+// pinned the file to the Electron main process. Headless-ready shape (no
+// `electron` import) is a prerequisite for any future move into a non-
+// Electron process; the move itself is deferred (see PR body for #249).
+
 let db: Database.Database | null = null;
+let dataDirCached: string | null = null;
 
 // Schema version for the on-disk SQLite layout. Bumped only when the table
 // shapes change in a way readers care about. Use `PRAGMA user_version` so
@@ -119,9 +130,23 @@ function ensureHealthyDb(file: string, current: Database.Database): Database.Dat
   return new Database(file);
 }
 
-export function initDb(): Database.Database {
+export function initDb(dataDir?: string): Database.Database {
   if (db) return db;
-  const dir = app.getPath('userData');
+  // Cache the dir on the first call so later getDb()/loadState()/saveState()
+  // calls (which don't carry the dir) can re-open if the singleton is dropped
+  // by a test. If the caller never injected one, fail loudly — silently
+  // falling back to cwd or os.homedir() would corrupt user data on a
+  // misconfigured boot.
+  if (dataDir !== undefined) {
+    dataDirCached = dataDir;
+  }
+  if (dataDirCached === null) {
+    throw new Error(
+      '[db] initDb() called without a dataDir before the singleton was primed. ' +
+        'electron/main.ts must call initDb(app.getPath("userData")) once during boot.',
+    );
+  }
+  const dir = dataDirCached;
   fs.mkdirSync(dir, { recursive: true });
   const file = path.join(dir, 'ccsm.db');
 
@@ -179,6 +204,13 @@ export function __setDbForTests(instance: Database.Database | null): void {
     instance.pragma('foreign_keys = ON');
     instance.exec(SCHEMA_SQL);
   }
+}
+
+// Test-only: forget the cached dataDir so the next `initDb()` requires an
+// explicit dir argument again. Pairs with `closeDb()` in test setup so each
+// test can point the singleton at a fresh tmp directory.
+export function __resetDataDirForTests(): void {
+  dataDirCached = null;
 }
 
 export function getDb(): Database.Database {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -183,7 +183,7 @@ app.whenReady().then(() => {
     app.setAppUserModelId(aumid);
   }
 
-  initDb();
+  initDb(app.getPath('userData'));
 
   // Wave 0e (#247): wire the spec ch08 §3.1 allowlisted IPC surfaces.
   // ORDER MATTERS — the broadcast hooks must be registered BEFORE


### PR DESCRIPTION
## Wave 0d.3 (#249) — REVISED SCOPE

**Original 0d.3 scope**: db.ts + prefs/* move to daemon.

**Revised scope**: db.ts path-injection only — prefs move deferred per spec line 2135 (`docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md`: settings unification = v0.4 `SettingsService` RPC). Avoids v0.3 zero-rework violation.

**Follow-up task** to be created by manager: `[V0.4-FOLLOWUP] prefs unification via SettingsService RPC` (blocked, not for v0.3).

## Why the scope shrank (push-back summary)

Two push-backs against the original spec, resolved by manager during dispatch:

1. **db.ts vs daemon's existing db is incompatible** (FOREVER-STABLE migration lock per ch07 §4 + different schema shape + different lifecycle ownership). Manager picked **Option C**: prefs migrate to daemon's `settings(scope, key, value)` table.

2. **Option C as stated produces a split-brain**: renderer `window.ccsm.saveState('notifyEnabled', 'true')` → IPC `db:save` → electron `app_state`, while moved-to-daemon `loadNotifyEnabled` would read from daemon `settings`. Settings toggles silently no-op. Two sub-options were unworkable for v0.3 (one violates the FOREVER-STABLE intent, the other introduces per-key IPC routing throwaway code). Manager picked **C1**: do the path-injection refactor only this wave, defer the prefs move to the v0.4 SettingsService work.

This PR ships the C1 refactor.

## Wire-up evidence — [REFACTOR-ONLY]

- `electron/db.ts`: dropped `import { app } from 'electron'`. `initDb(dataDir)` now takes the data dir explicitly. The dir is cached on the first call so existing call sites (`getDb()`, `loadState(key)`, `saveState(key, value)` — used by `electron/ipc/dbIpc.ts`, `electron/prefs/closeAction.ts`, `electron/prefs/userCwds.ts`, `electron/prefs/notifyEnabled.ts`, `electron/prefs/crashReporting.ts`) continue to work without an arg. If `initDb()` is called with no arg before the cache is primed, it throws a clear error rather than silently writing to cwd or `$HOME`.
- `electron/main.ts`: the one boot-time call inside `app.whenReady()` now passes `app.getPath('userData')` explicitly.
- `electron/__tests__/db.test.ts` + `db-hardening.test.ts`: dropped `vi.mock('electron', ...)`. Tests now inject the tmp directory directly via `initDb(tmpDir)`. New `__resetDataDirForTests()` test seam paired with `closeDb()` so each test rebinds the singleton to a fresh dir.
- New reverse-verified test block (`'db hardening: dataDir injection (Wave 0d.3 / #249)'`) — confirms (a) DB opens at the injected dir, not whatever `app.getPath` would return, and (b) `initDb()` with no prior injection throws.

## Acceptance criteria

```
$ grep -n "app\.getPath" electron/db.ts
7:// invokes it inside `app.whenReady()` with `app.getPath('userData')`. The
11:// Rationale: keeping the `app.getPath('userData')` call inside this module
146:        'electron/main.ts must call initDb(app.getPath("userData")) once during boot.',
```
→ 0 actual calls; only comment / error-message string mentions remain.

```
$ grep -nE "import.*['\"]electron['\"]" electron/db.ts
```
→ 0 matches. db.ts no longer imports `electron`.

```
$ grep -n "initDb" electron/main.ts
38:import { initDb, closeDb } from './db';
186:  initDb(app.getPath('userData'));
```
→ main.ts passes dataDir explicitly at the call site.

## Test results (local, Windows)

- `npm run typecheck` → green.
- `npm run lint:app` → 0 errors, 66 warnings (pre-existing).
- `bash tools/lint-no-ipc.sh` → PASS.
- `npm run build:app` → green.
- `npm run test:app` → **974 / 974 passed** (125 files), including the 10 db-hardening + db.test cases and the 2 new dataDir-injection cases.
- `node -e "require('./dist/electron/db.js'); console.log(Object.keys(require('./dist/electron/db.js')))"` → loads cleanly with no `ERR_REQUIRE_ESM`, exports `initDb / __setDbForTests / __resetDataDirForTests / getDb / loadState / saveState / closeDb`.

## Reverse-verify (mandatory for the new test block)

Stash the refactor, keep tests:
```
$ git stash push electron/db.ts electron/main.ts -m "rev-verify-stash"
$ npx vitest run electron/__tests__/db-hardening.test.ts -t "dataDir injection"
 Test Files  1 failed (1)
      Tests  2 failed | 7 skipped (9)
```
The 2 new tests FAIL without the refactor (db.ts still tries to `import { app } from 'electron'`, which throws inside Vitest with no Electron runtime).

Pop the stash:
```
$ git stash pop
$ npx vitest run electron/__tests__/db-hardening.test.ts -t "dataDir injection"
 Test Files  1 passed (1)
      Tests  2 passed | 7 skipped (9)
```
Both tests pass with the refactor. Reverse-verify clean.

## Shims (deleted in 0d.X)

None — this PR is a pure in-place refactor. No files were moved, no shims were introduced. db.ts stays at `electron/db.ts` for v0.3 (still owns electron's `app_state` table, still backs `db:save` / `db:load` IPC for the renderer's generic key/value surface, and still backs `electron/prefs/closeAction.ts` which stays in shell per design plan).

## db.ts reconciliation

**Not done in this PR.** Both push-backs converged on deferring the merge with daemon's existing db wrapper (`packages/daemon/src/db/sqlite.ts` + `packages/daemon/src/db/migrations/runner.ts`, locked SHA256s in `packages/daemon/src/db/locked.ts`) until the v0.4 `SettingsService` RPC arrives. The two wrappers stay separate for v0.3:

- electron `db.ts`: owns `app_state(key, value, updated_at)` for renderer-facing key/value (drafts, persist snapshots, prefs).
- daemon `db/sqlite.ts` + `001_initial.sql`: owns `principals / sessions / pty_* / crash_log / settings / cwd_state` for daemon-internal state (FOREVER-STABLE per ch07 §4).

The two write to different DB files in `userData` and never share a connection. This PR makes electron's wrapper headless-shape-compatible (no `electron` import) so the eventual unification is a refactor, not an architectural rewrite.

## What is NOT touched

Per task constraints:
- electron/notify/sinks/ (Wave 0c)
- electron/shared/, agent/, sessionTitles/, notify/{notifyDecider,...} (Wave 0d.1 #252 — touched there)
- electron/sessionWatcher/, electron/import-scanner.ts (Wave 0d.2 #250)
- electron/ptyHost/ (Wave 0d.4 #251)
- electron/ipc-allowlisted/, electron/main.ts allowlist wiring lines, electron/window/ (Wave 0e PREP #956)
- src/, tools/, root package.json, .github/
- electron/prefs/* (deferred to v0.4 SettingsService RPC follow-up)
- packages/daemon/src/db/* (no migration / lock / runner changes)

## Files changed

```
 electron/__tests__/db-hardening.test.ts | 41 ++++++++++++++++++++++++++-------
 electron/__tests__/db.test.ts           | 15 ++++++------
 electron/db.ts                          | 38 +++++++++++++++++++++++++++---
 electron/main.ts                        |  2 +-
 4 files changed, 76 insertions(+), 20 deletions(-)
```