### PR TITLE
wave1: T4.4 claude-sim Go module

### DIFF
--- a/tools/claude-sim/README.md
+++ b/tools/claude-sim/README.md
@@ -1,0 +1,74 @@
+# claude-sim
+
+Stand-in binary that pretends to be the `claude` CLI for CCSM's 1h pty
+soak test (Task #209 / #92, ship-gate (c)).
+
+It is **not** a mock of Claude's behaviour. It is a deterministic traffic
+generator whose patterns are chosen to exercise every interesting edge
+of the CCSM pty pipeline: chunked output, multi-KiB floods, ANSI escape
+passthrough, idle gaps, and fast bursts.
+
+## Build
+
+```bash
+cd tools/claude-sim
+go build -o claude-sim ./...
+```
+
+Or use the helper used by the soak harness:
+
+```bash
+tools/claude-sim/build.sh           # writes ./claude-sim
+tools/claude-sim/build.sh /tmp/out  # custom output path
+```
+
+Compiles on darwin / linux / windows; no third-party dependencies.
+
+## Use from pty-soak-1h
+
+The soak test (#209 / #92) spawns this binary in place of the real
+`claude` CLI and pipes synthetic prompts to it for one hour. Wire-up
+lives in those tasks; this PR only ships the binary
+([LIBRARY-ONLY]).
+
+Typical invocation:
+
+```bash
+go build -o claude-sim ./...
+CLAUDE_SIM_BURST_INTERVAL_MS=50 \
+CLAUDE_SIM_QUIET_MS=5000 \
+CLAUDE_SIM_FLOOD_BYTES=32768 \
+CLAUDE_SIM_FAST_BURST_COUNT=64 \
+  ./claude-sim
+```
+
+It prints `claude-sim ready` on startup. After each line read on stdin
+it emits one of five patterns, rotating deterministically:
+
+| step % 5 | pattern        | what it stresses                          |
+|----------|----------------|-------------------------------------------|
+| 0        | small chunked  | common case, line buffering               |
+| 1        | KiB-scale flood| ring buffer, backpressure, snapshot debounce |
+| 2        | ANSI escape    | passthrough (color, bold, cursor moves)   |
+| 3        | quiet idle     | snapshot scheduler idle path              |
+| 4        | fast burst     | write coalescing, throughput              |
+
+Stdin handling:
+
+- One line in -> one pattern out.
+- `quit\n` -> prints `bye` and exits 0.
+- EOF -> exits 0.
+
+Any non-zero exit is treated as a soak regression.
+
+## Env vars
+
+| Name                          | Default | Purpose                                         |
+|-------------------------------|---------|-------------------------------------------------|
+| `CLAUDE_SIM_BURST_INTERVAL_MS`| 50      | Sleep between writes inside a chunked burst.    |
+| `CLAUDE_SIM_QUIET_MS`         | 5000    | Length of the idle-gap pattern.                 |
+| `CLAUDE_SIM_FLOOD_BYTES`      | 32768   | Size of the flood pattern (rounded up to 1KiB). |
+| `CLAUDE_SIM_FAST_BURST_COUNT` | 64      | Lines written in a fast burst.                  |
+
+Invalid / negative values fall back to the default so the soak harness
+cannot accidentally produce zero-output runs.

--- a/tools/claude-sim/build.sh
+++ b/tools/claude-sim/build.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Compile claude-sim. Invoked by the pty-soak-1h harness (#209 / #92)
+# during test setup, so adding a dedicated CI workflow for a ~200-line
+# binary is unnecessary — if the soak harness ever runs in CI, this
+# script will fail loudly there.
+set -euo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+out="${1:-${here}/claude-sim}"
+
+cd "${here}"
+go build -trimpath -o "${out}" ./...
+echo "claude-sim built: ${out}"

--- a/tools/claude-sim/go.mod
+++ b/tools/claude-sim/go.mod
@@ -1,0 +1,3 @@
+module claude-sim
+
+go 1.21

--- a/tools/claude-sim/main.go
+++ b/tools/claude-sim/main.go
@@ -1,0 +1,148 @@
+// claude-sim is a stand-in binary that pretends to be the `claude` CLI.
+// It is consumed by the 1h pty-soak test (Task #209 / #92): the daemon's
+// pty host spawns this process instead of the real `claude` CLI, and the
+// test asserts that snapshot scheduling, backpressure, ANSI passthrough,
+// and idle handling all stay healthy across an hour of mixed traffic.
+//
+// Behaviour:
+//   - Reads stdin line-by-line. EOF or "quit\n" exits cleanly.
+//   - Each loop iteration emits one of four traffic patterns chosen
+//     deterministically by a counter so the soak run is reproducible:
+//       1. small chunked burst   — exercises the common path
+//       2. 16 KiB+ flood          — exercises ring-buffer / backpressure
+//       3. ANSI escape sequence  — exercises terminal passthrough
+//       4. quiet idle gap        — exercises snapshot scheduler idle path
+//   - Cadence is configurable via env vars so the soak harness can dial
+//     it up or down without rebuilding:
+//       CLAUDE_SIM_BURST_INTERVAL_MS  (default 50)   between writes inside a burst
+//       CLAUDE_SIM_QUIET_MS           (default 5000) length of idle gap pattern
+//       CLAUDE_SIM_FLOOD_BYTES        (default 32768) size of flood pattern
+//       CLAUDE_SIM_FAST_BURST_COUNT   (default 64)  writes in fast-burst pattern
+//
+// No third-party deps. Compiles on darwin / linux / windows.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type config struct {
+	burstIntervalMs int
+	quietMs         int
+	floodBytes      int
+	fastBurstCount  int
+}
+
+func loadConfig() config {
+	return config{
+		burstIntervalMs: envInt("CLAUDE_SIM_BURST_INTERVAL_MS", 50),
+		quietMs:         envInt("CLAUDE_SIM_QUIET_MS", 5000),
+		floodBytes:      envInt("CLAUDE_SIM_FLOOD_BYTES", 32*1024),
+		fastBurstCount:  envInt("CLAUDE_SIM_FAST_BURST_COUNT", 64),
+	}
+}
+
+func envInt(name string, def int) int {
+	v := os.Getenv(name)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return def
+	}
+	return n
+}
+
+// patterns rotate deterministically per stdin line so a soak run is
+// reproducible. Each pattern returns after writing and (where relevant)
+// sleeping for its idle/burst window.
+func smallChunked(out *bufio.Writer, c config) {
+	parts := []string{"Thinking", ".", ".", ".", " done.\n"}
+	for _, p := range parts {
+		_, _ = out.WriteString(p)
+		_ = out.Flush()
+		time.Sleep(time.Duration(c.burstIntervalMs) * time.Millisecond)
+	}
+}
+
+func flood(out *bufio.Writer, c config) {
+	// ASCII filler avoids accidental ANSI interpretation; one trailing
+	// newline so line-buffered consumers don't stall.
+	chunk := strings.Repeat("x", 1024)
+	written := 0
+	for written < c.floodBytes {
+		_, _ = out.WriteString(chunk)
+		written += len(chunk)
+	}
+	_, _ = out.WriteString("\n")
+	_ = out.Flush()
+}
+
+func ansiEscape(out *bufio.Writer, _ config) {
+	// Color + cursor moves. CCSM's pty pipeline is supposed to forward
+	// these untouched; if it ever rewrites them, this line will look wrong
+	// in soak diagnostics.
+	const esc = "\x1b"
+	seq := esc + "[31mred" + esc + "[0m " +
+		esc + "[1mbold" + esc + "[0m " +
+		esc + "[2A" + // cursor up 2
+		esc + "[K" + // erase line
+		"done\n"
+	_, _ = out.WriteString(seq)
+	_ = out.Flush()
+}
+
+func quietIdle(out *bufio.Writer, c config) {
+	_, _ = out.WriteString("(idle)\n")
+	_ = out.Flush()
+	time.Sleep(time.Duration(c.quietMs) * time.Millisecond)
+}
+
+func fastBurst(out *bufio.Writer, c config) {
+	for i := 0; i < c.fastBurstCount; i++ {
+		_, _ = fmt.Fprintf(out, "tick %d\n", i)
+	}
+	_ = out.Flush()
+}
+
+var patterns = []func(*bufio.Writer, config){
+	smallChunked,
+	flood,
+	ansiEscape,
+	quietIdle,
+	fastBurst,
+}
+
+func main() {
+	cfg := loadConfig()
+	out := bufio.NewWriterSize(os.Stdout, 64*1024)
+	in := bufio.NewScanner(os.Stdin)
+	// Allow long lines from the soak driver (e.g. paste-heavy prompts).
+	in.Buffer(make([]byte, 64*1024), 1024*1024)
+
+	// Greet so the harness can confirm the process is alive before sending
+	// the first prompt.
+	_, _ = out.WriteString("claude-sim ready\n")
+	_ = out.Flush()
+
+	step := 0
+	for in.Scan() {
+		line := in.Text()
+		if line == "quit" {
+			_, _ = out.WriteString("bye\n")
+			_ = out.Flush()
+			return
+		}
+		patterns[step%len(patterns)](out, cfg)
+		step++
+	}
+	// EOF or scanner error -> exit 0; the soak test treats non-zero exit
+	// as a regression.
+	_ = out.Flush()
+}


### PR DESCRIPTION
[LIBRARY-ONLY] new `tools/claude-sim/` binary for pty-soak-1h.

## What

Adds a small (~150 LOC) Go module under `tools/claude-sim/` that pretends
to be the `claude` CLI. It is consumed by the 1h pty-soak test
(Task #209 / #92, ship-gate (c)) — the daemon spawns it instead of the
real `claude` CLI and drives mixed traffic through the pty pipeline for
an hour.

The binary reads stdin line-by-line and emits five deterministic
patterns, rotating per line:

| step % 5 | pattern        | what it stresses                              |
|----------|----------------|-----------------------------------------------|
| 0        | small chunked  | line buffering / common path                  |
| 1        | KiB-scale flood| ring buffer, backpressure, snapshot debounce  |
| 2        | ANSI escape    | passthrough (color, bold, cursor moves)       |
| 3        | quiet idle     | snapshot scheduler idle path                  |
| 4        | fast burst     | write coalescing, throughput                  |

`quit\n` -> exits 0; EOF -> exits 0. Determinism so soak runs are
reproducible.

## Env vars (configurable cadence, no rebuild)

- `CLAUDE_SIM_BURST_INTERVAL_MS` (default 50)
- `CLAUDE_SIM_QUIET_MS` (default 5000)
- `CLAUDE_SIM_FLOOD_BYTES` (default 32768)
- `CLAUDE_SIM_FAST_BURST_COUNT` (default 64)

Invalid / negative values fall back to the default so the soak harness
can't accidentally produce zero-output runs.

## Forward-safe

New `tools/claude-sim/` directory only — no existing-source impact, no
existing CI workflow touched. Wire-up into pty-soak-1h is owned by
#209 / #92 ([LIBRARY-ONLY]).

## Files

- `tools/claude-sim/go.mod` — module `claude-sim`, go 1.21
- `tools/claude-sim/main.go` — ~150 LOC, stdlib only
- `tools/claude-sim/README.md` — patterns table, env vars, soak usage
- `tools/claude-sim/build.sh` — helper invoked by soak harness during
  test setup; deliberately no dedicated CI workflow for ~150 LOC

## Verification

`go` is not installed on this Windows dev machine, so local
`go build` / smoke run was not possible (documented per dev.md §3
"local無法復現的環境差異"). Verification path:

1. Source reviewed by eye — all imports used, all `Write` errors
   intentionally discarded (a non-zero exit on transient stdout
   close would itself trip the soak test, which we do not want),
   `Scanner.Buffer` raised to 1 MiB for paste-heavy prompts,
   pattern table indexed with `% len(patterns)` to stay panic-safe
   if patterns are ever extended.
2. The module is stdlib-only and well within Go 1.21's surface, so
   compile risk is low.
3. The soak harness setup (#209 / #92) will invoke
   `tools/claude-sim/build.sh` on a machine with Go installed; any
   compile breakage will fail loudly there, on the very lane that
   actually consumes the binary. This matches the task brief
   ("just compile-on-test-setup is fine").

If a reviewer with Go installed wants to spot-check:

```bash
cd tools/claude-sim
./build.sh
echo -e "hi\nhi\nhi\nhi\nhi\nquit" | ./claude-sim | head -20
```

## v0.3 zero-rework

Binary is generic (env-configurable cadence, deterministic patterns)
and stays useful for v0.4 soak / regression work without changes.

Closes Task #210.