### PR TITLE
wave1: T4.5 snapshot-codec package

### DIFF
--- a/packages/snapshot-codec/eslint.config.js
+++ b/packages/snapshot-codec/eslint.config.js
@@ -1,0 +1,35 @@
+// Per-package ESLint config. Inherits the repo root flat config and adds
+// boundary rules: snapshot-codec is a leaf library (no project deps), so
+// any cross-package import is a smell.
+import rootConfig from '../../eslint.config.js';
+
+export default [
+  ...rootConfig,
+  {
+    files: ['src/**/*.ts'],
+    languageOptions: {
+      globals: {
+        // Web platform encoders are part of the standard Node global scope
+        // since Node 11; the root config doesn't declare them but our
+        // tests and (future) consumers rely on them.
+        TextEncoder: 'readonly',
+        TextDecoder: 'readonly',
+      },
+    },
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          {
+            group: ['@ccsm/*'],
+            message:
+              '@ccsm/snapshot-codec is a leaf library — must not depend on other workspace packages. Codec primitives only (spec ch06 §2).',
+          },
+          {
+            group: ['electron', 'electron/*', 'react', 'react-dom'],
+            message: '@ccsm/snapshot-codec is a pure-Node library — UI deps forbidden.',
+          },
+        ],
+      }],
+    },
+  },
+];

--- a/packages/snapshot-codec/package.json
+++ b/packages/snapshot-codec/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@ccsm/snapshot-codec",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "CCSM SnapshotV1 codec layer (Task #207, T4.5). Provides synchronous encode/decode that prefixes a single codec byte (1 = zstd, 2 = gzip) to a compressed payload, per design spec ch06 §2 'Codec rules'. The full SnapshotV1Wire framing (CSS1 magic, reserved bytes, inner_len) is layered on top by the daemon snapshot serializer (T4.6/T4.7) — this package is intentionally the inner compression-dispatch primitive, nothing more.",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "engines": {
+    "node": ">=22.15.0 <23"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "lint": "eslint \"src/**/*.ts\"",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0"
+  }
+}

--- a/packages/snapshot-codec/src/__tests__/codec.spec.ts
+++ b/packages/snapshot-codec/src/__tests__/codec.spec.ts
@@ -1,0 +1,245 @@
+// Codec roundtrip + golden tests for @ccsm/snapshot-codec.
+//
+// What this suite locks down (spec ch06 §2 / spec ch15 §3 audit row 5):
+//   1. encode/decode are mutually inverse for both codecs.
+//   2. The first byte of the output is the codec byte (1 or 2).
+//   3. The compressed payload starts with the well-known frame magic of
+//      the chosen algorithm — pins the algorithm choice without coupling
+//      to zlib library version (which controls the rest of the bytes).
+//   4. encode is deterministic within a single Node process — same input
+//      twice MUST produce byte-identical output. v0.4 ship-gate (c)
+//      relies on this for cross-process snapshot byte-equality.
+//   5. decode of a hex-pinned golden blob reproduces a known plaintext
+//      for both codecs. Decode is portable across zlib versions because
+//      both gzip and zstd frame formats are spec'd; this test would
+//      catch a swap of the codec byte semantics or a regression in the
+//      underlying decompressor.
+//   6. decode rejects empty buffer and unknown codec bytes.
+
+import { describe, expect, it } from 'vitest';
+import {
+  CODEC_GZIP,
+  CODEC_ZSTD,
+  decode,
+  encode,
+  EmptyBufferError,
+  UnknownCodecError,
+} from '../index.js';
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// We use Node Buffer (which IS a Uint8Array) for string<->bytes conversion
+// rather than TextEncoder/TextDecoder so the spec runs cleanly under both
+// the package-local lint config and the repo-root lint sweep (which does
+// not whitelist the WHATWG encoder globals). The codec API itself is
+// Uint8Array-only — Buffer here is just test scaffolding.
+
+function bytesEq(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function hex(b: Uint8Array): string {
+  return Buffer.from(b).toString('hex');
+}
+
+function fromHex(s: string): Uint8Array {
+  return new Uint8Array(Buffer.from(s, 'hex'));
+}
+
+function utf8(s: string): Uint8Array {
+  return new Uint8Array(Buffer.from(s, 'utf8'));
+}
+
+function utf8Decode(b: Uint8Array): string {
+  return Buffer.from(b).toString('utf8');
+}
+
+// Inputs that exercise different shapes the codec is likely to see in
+// production: tiny ASCII, binary with all 0..255 bytes, repetitive text
+// (large compression ratio), and unicode (multibyte UTF-8).
+const TINY_ASCII = utf8('hello world');
+const REPETITIVE = utf8('a'.repeat(4096));
+const UNICODE = utf8('snapshot 快照 📸 ' + 'ñ'.repeat(100));
+const BINARY = (() => {
+  const b = new Uint8Array(512);
+  for (let i = 0; i < b.length; i++) b[i] = i & 0xff;
+  return b;
+})();
+const EMPTY = new Uint8Array(0);
+
+const FIXTURES: Array<{ name: string; bytes: Uint8Array }> = [
+  { name: 'tiny ascii', bytes: TINY_ASCII },
+  { name: 'repetitive', bytes: REPETITIVE },
+  { name: 'unicode', bytes: UNICODE },
+  { name: 'binary 0..255', bytes: BINARY },
+  { name: 'empty input', bytes: EMPTY },
+];
+
+// ---------------------------------------------------------------------------
+// roundtrip
+// ---------------------------------------------------------------------------
+
+describe('encode/decode roundtrip', () => {
+  for (const codec of [CODEC_ZSTD, CODEC_GZIP] as const) {
+    for (const f of FIXTURES) {
+      it(`codec=${codec} ${f.name}`, () => {
+        const encoded = encode(f.bytes, codec);
+        // first byte MUST be the codec id
+        expect(encoded[0]).toBe(codec);
+        const decoded = decode(encoded);
+        expect(bytesEq(decoded, f.bytes)).toBe(true);
+      });
+    }
+  }
+});
+
+// ---------------------------------------------------------------------------
+// frame-magic assertions: pin the algorithm choice, not the bytes
+// ---------------------------------------------------------------------------
+
+describe('frame magic', () => {
+  it('codec=1 emits a zstd frame (magic 0xfd2fb528 little-endian)', () => {
+    const out = encode(TINY_ASCII, CODEC_ZSTD);
+    // [codec, 28, b5, 2f, fd, ...]
+    expect(out[0]).toBe(1);
+    expect(out[1]).toBe(0x28);
+    expect(out[2]).toBe(0xb5);
+    expect(out[3]).toBe(0x2f);
+    expect(out[4]).toBe(0xfd);
+  });
+
+  it('codec=2 emits a gzip frame (magic 0x1f 0x8b 0x08)', () => {
+    const out = encode(TINY_ASCII, CODEC_GZIP);
+    // [codec, 1f, 8b, 08, ...]
+    expect(out[0]).toBe(2);
+    expect(out[1]).toBe(0x1f);
+    expect(out[2]).toBe(0x8b);
+    expect(out[3]).toBe(0x08);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// determinism (within a single process)
+// ---------------------------------------------------------------------------
+
+describe('encode determinism', () => {
+  for (const codec of [CODEC_ZSTD, CODEC_GZIP] as const) {
+    it(`codec=${codec} same input → byte-identical output`, () => {
+      const a = encode(REPETITIVE, codec);
+      const b = encode(REPETITIVE, codec);
+      expect(bytesEq(a, b)).toBe(true);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// golden decode: hex-pinned blobs MUST decode to known plaintext.
+//
+// The blobs were produced offline using `node:zlib` defaults and are kept
+// as exact byte sequences so any future codec swap (e.g., changing zstd
+// level, accidentally re-numbering CODEC_ZSTD/CODEC_GZIP) trips the test.
+// Decode is portable across zlib versions because both formats are
+// fully specified; encode output is NOT pinned here because Node's
+// bundled zlib/zstd library version controls the post-magic bytes.
+// ---------------------------------------------------------------------------
+
+describe('golden decode', () => {
+  it('codec=1 zstd golden → "hello world"', () => {
+    // codec(01) | zstd frame for "hello world" (level=default, no dict)
+    const golden = fromHex('0128b52ffd200b59000068656c6c6f20776f726c64');
+    expect(golden[0]).toBe(1);
+    const decoded = decode(golden);
+    expect(utf8Decode(decoded)).toBe('hello world');
+  });
+
+  it('codec=2 gzip golden → "hello world"', () => {
+    // codec(02) | gzip frame for "hello world" (level=default, mtime=0)
+    const golden = fromHex(
+      '021f8b080000000000000acb48cdc9c95728cf2fca49010085114a0d0b000000',
+    );
+    expect(golden[0]).toBe(2);
+    const decoded = decode(golden);
+    expect(utf8Decode(decoded)).toBe('hello world');
+  });
+
+  it('encode → golden-decode chain works end-to-end', () => {
+    // Belt-and-suspenders: a freshly-encoded buffer decodes back via the
+    // same decode() the goldens use, ensuring no encode/decode drift.
+    for (const codec of [CODEC_ZSTD, CODEC_GZIP] as const) {
+      const encoded = encode(TINY_ASCII, codec);
+      const decoded = decode(encoded);
+      expect(utf8Decode(decoded)).toBe('hello world');
+      // hex render is just for clear failure output if this ever breaks
+      expect(hex(encoded).startsWith(codec === 1 ? '0128b52ffd' : '021f8b08')).toBe(true);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// error paths
+// ---------------------------------------------------------------------------
+
+describe('decode error handling', () => {
+  it('rejects empty buffer', () => {
+    expect(() => decode(new Uint8Array(0))).toThrow(EmptyBufferError);
+  });
+
+  it('rejects unknown codec byte 0x00', () => {
+    expect(() => decode(new Uint8Array([0x00, 0xde, 0xad]))).toThrow(UnknownCodecError);
+  });
+
+  it('rejects unknown codec byte 0x03 (reserved for future use)', () => {
+    expect(() => decode(new Uint8Array([0x03, 0xde, 0xad]))).toThrow(UnknownCodecError);
+  });
+
+  it('rejects unknown codec byte 0xff', () => {
+    expect(() => decode(new Uint8Array([0xff, 0xde, 0xad]))).toThrow(UnknownCodecError);
+  });
+
+  it('UnknownCodecError carries the offending codec byte', () => {
+    try {
+      decode(new Uint8Array([0x42, 0x00]));
+      throw new Error('expected throw');
+    } catch (e) {
+      expect(e).toBeInstanceOf(UnknownCodecError);
+      expect((e as UnknownCodecError).codec).toBe(0x42);
+    }
+  });
+
+  it('propagates underlying zlib error on garbage zstd payload', () => {
+    // codec=1 followed by bytes that are not a valid zstd frame — the
+    // decompressor MUST surface a zlib error rather than silently
+    // returning an empty / partial buffer.
+    expect(() =>
+      decode(new Uint8Array([0x01, 0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe])),
+    ).toThrow();
+  });
+
+  it('propagates underlying zlib error on truncated gzip payload', () => {
+    // codec=2 followed by partial gzip magic — decompressor MUST throw.
+    expect(() => decode(new Uint8Array([0x02, 0x1f, 0x8b]))).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// API surface sanity
+// ---------------------------------------------------------------------------
+
+describe('API surface', () => {
+  it('exports CODEC_ZSTD = 1 and CODEC_GZIP = 2 with correct numeric type', () => {
+    expect(CODEC_ZSTD).toBe(1);
+    expect(CODEC_GZIP).toBe(2);
+  });
+
+  it('encode returns a fresh Uint8Array (not a view of the input)', () => {
+    const out = encode(TINY_ASCII, CODEC_ZSTD);
+    expect(out).toBeInstanceOf(Uint8Array);
+    // mutating output MUST NOT mutate input
+    out[0] = 0xff;
+    expect(TINY_ASCII[0]).toBe('h'.charCodeAt(0));
+  });
+});

--- a/packages/snapshot-codec/src/index.ts
+++ b/packages/snapshot-codec/src/index.ts
@@ -1,0 +1,156 @@
+// @ccsm/snapshot-codec — SnapshotV1 inner-codec layer.
+//
+// Per design spec ch06 §2 ("Codec rules"), SnapshotV1 wraps a compressed
+// payload behind a single `codec` byte that names the algorithm:
+//   1 = zstd (forever-stable v0.3 daemon default; empty zstd dictionary)
+//   2 = gzip (browser fallback via DecompressionStream("gzip"); v0.4 web
+//             client may emit/accept this when wasm zstd is unavailable)
+//
+// This package is INTENTIONALLY the inner compression-dispatch primitive
+// only. It does not produce the full SnapshotV1Wire frame (outer "CSS1"
+// magic, reserved bytes, inner_len prefix) — that framing is layered on
+// top by the daemon snapshot serializer (T4.6/T4.7) so the wire format
+// and the codec dispatch can evolve independently.
+//
+// Public shape:
+//   encode(buf, codec) -> Uint8Array
+//     [codec_byte] ++ compress(buf, codec)
+//   decode(buf) -> Uint8Array
+//     reads buf[0], dispatches to the matching decompressor
+//
+// Both functions are SYNCHRONOUS by design. `node:zlib` exposes synchronous
+// zstd and gzip primitives in Node >= 22.15 (engines.node enforces this);
+// callers can offload to a worker if they need to keep the event loop free
+// — that policy belongs to the call site, not to the codec.
+//
+// Forward-compat (v0.4): adding `codec = 3` (e.g., zstd-with-dictionary)
+// only requires extending the `Codec` union and the dispatch tables here;
+// no change to callers, no `schema_version` bump (spec ch06 §2 / ch15 §3).
+
+import {
+  zstdCompressSync,
+  zstdDecompressSync,
+  gzipSync,
+  gunzipSync,
+} from 'node:zlib';
+
+/**
+ * Codec identifiers carried in the leading byte of the encoded buffer.
+ *
+ * The numeric values are FOREVER-STABLE — they appear on disk inside
+ * persisted `pty_snapshot.payload` rows (spec ch07 §2) and on the wire
+ * inside `PtySnapshot.screen_state` frames. Renumbering breaks every
+ * historical snapshot, so we type the values as a literal union and the
+ * byte positions are the source of truth.
+ */
+export type Codec = 1 | 2;
+
+/** Spec ch06 §2: codec = 1 → zstd. */
+export const CODEC_ZSTD = 1 as const;
+/** Spec ch06 §2: codec = 2 → gzip. */
+export const CODEC_GZIP = 2 as const;
+
+/**
+ * Thrown when {@link decode} encounters a codec byte that this build does
+ * not understand. The thrown error carries the offending byte so callers
+ * (e.g. the daemon snapshot loader) can log telemetry without re-parsing.
+ */
+export class UnknownCodecError extends Error {
+  public readonly codec: number;
+  constructor(codec: number) {
+    super(
+      `@ccsm/snapshot-codec: unknown codec byte 0x${codec.toString(16).padStart(2, '0')} ` +
+        `(expected 0x01 zstd or 0x02 gzip per spec ch06 §2)`,
+    );
+    this.name = 'UnknownCodecError';
+    this.codec = codec;
+  }
+}
+
+/**
+ * Thrown when {@link decode} is called with an empty buffer — there is no
+ * codec byte to read, which is always a programmer error (a real
+ * SnapshotV1 inner payload is never zero-length).
+ */
+export class EmptyBufferError extends Error {
+  constructor() {
+    super('@ccsm/snapshot-codec: cannot decode empty buffer (codec byte missing)');
+    this.name = 'EmptyBufferError';
+  }
+}
+
+// `node:zlib`'s sync helpers accept any TypedArray / Buffer / ArrayBuffer and
+// return a Node Buffer (which IS a Uint8Array, just with extra methods). We
+// keep the public surface as plain `Uint8Array` so non-Node consumers (and
+// tests) don't have to import the Buffer type.
+
+function compress(buf: Uint8Array, codec: Codec): Uint8Array {
+  switch (codec) {
+    case CODEC_ZSTD:
+      return zstdCompressSync(buf);
+    case CODEC_GZIP:
+      return gzipSync(buf);
+    default: {
+      // Exhaustiveness guard: if `Codec` ever grows a value we forgot to
+      // handle, TypeScript flags `_exhaustive` as a never-mismatch error.
+      const _exhaustive: never = codec;
+      throw new UnknownCodecError(_exhaustive as unknown as number);
+    }
+  }
+}
+
+function decompress(payload: Uint8Array, codec: number): Uint8Array {
+  switch (codec) {
+    case CODEC_ZSTD:
+      return zstdDecompressSync(payload);
+    case CODEC_GZIP:
+      return gunzipSync(payload);
+    default:
+      throw new UnknownCodecError(codec);
+  }
+}
+
+/**
+ * Encode an inner snapshot payload by compressing it with `codec` and
+ * prefixing the resulting bytes with the single codec byte.
+ *
+ * Output layout: `[codec_byte][compressed_bytes...]`
+ *
+ * @param buf   Uncompressed inner-payload bytes (typically the
+ *              `SnapshotV1Inner` byte stream produced by the daemon
+ *              snapshot serializer; this layer is opaque to the codec).
+ * @param codec Compression algorithm identifier (1 = zstd, 2 = gzip).
+ * @returns     A fresh `Uint8Array` whose first byte is `codec` and whose
+ *              remaining bytes are the compressed `buf`.
+ */
+export function encode(buf: Uint8Array, codec: Codec): Uint8Array {
+  const compressed = compress(buf, codec);
+  const out = new Uint8Array(1 + compressed.byteLength);
+  out[0] = codec;
+  out.set(compressed, 1);
+  return out;
+}
+
+/**
+ * Decode an encoded inner snapshot payload by reading the leading codec
+ * byte and decompressing the remainder with the matching algorithm.
+ *
+ * @param buf  Encoded bytes produced by {@link encode} (or any peer that
+ *             follows the same `[codec_byte][compressed_bytes...]` shape).
+ * @returns    The original uncompressed payload.
+ * @throws     {@link EmptyBufferError} if `buf.byteLength === 0`.
+ * @throws     {@link UnknownCodecError} if the codec byte is not 1 or 2.
+ *             Underlying zlib errors (truncated payload, bad magic, etc.)
+ *             propagate unchanged so the daemon's existing zlib error
+ *             handling (spec ch06 §2 reader rules) keeps working.
+ */
+export function decode(buf: Uint8Array): Uint8Array {
+  if (buf.byteLength === 0) {
+    throw new EmptyBufferError();
+  }
+  const codec = buf[0]!;
+  // `subarray` shares the underlying ArrayBuffer (no copy) — safe because
+  // node:zlib reads but never mutates the input.
+  const payload = buf.subarray(1);
+  return decompress(payload, codec);
+}

--- a/packages/snapshot-codec/tsconfig.json
+++ b/packages/snapshot-codec/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "src/**/__tests__/**"]
+}

--- a/packages/snapshot-codec/vitest.config.ts
+++ b/packages/snapshot-codec/vitest.config.ts
@@ -1,0 +1,11 @@
+// Vitest config for @ccsm/snapshot-codec. Co-located `*.spec.ts` files
+// next to the source they cover (matches the @ccsm/daemon convention).
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.spec.ts'],
+    globals: false,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -337,6 +337,12 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.12.0))
 
+  packages/snapshot-codec:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.19.17
+
 packages:
 
   7zip-bin@5.2.0:


### PR DESCRIPTION
## [LIBRARY-ONLY] Task #207 / WAVE1-4.5

New leaf package `@ccsm/snapshot-codec` implementing the SnapshotV1
inner-codec layer per design spec ch06 §2 (`Codec rules`). No consumers
wired up — Wave 3 #44/#46 (T4.6/T4.7) owns that.

## Summary

- `encode(buf, codec)` -> `[codec_byte][compressed_bytes]` (sync)
- `decode(buf)` -> dispatches on leading byte; returns the decompressed payload
- Codec 1 = zstd, codec 2 = gzip
- Both codecs implemented via Node's built-in `node:zlib` sync helpers
  (`zstdCompressSync` / `zstdDecompressSync` / `gzipSync` / `gunzipSync`)
- **Zero runtime dependencies** — `engines.node` bumped to `>=22.15.0`
  in this package only (where the zstd helpers stabilized in Node 22)
- Public errors: `EmptyBufferError`, `UnknownCodecError`

## Why no third-party zstd dep

Manager spec listed `zstd-napi` / `@mongodb-js/zstd` as candidates. I
evaluated both — they are native modules (prebuild-install + `.node`
binaries) which add SEA-bundle complexity, async-only API
(`@mongodb-js/zstd`), and a postinstall step. Node 22.15+ exposes a
synchronous zstd in the standard library; using it gives:

- zero deps (matches dev protocol §2 "标准库一行能解决 → 不要包一层")
- sync API matches the task spec signature exactly
- no SEA bundling work for daemon (T7.1 already complex)
- forward-compat: swap to a native lib later only requires API
  preservation, no consumer change

If the daemon's bundled SEA Node ever lags behind 22.15, we can swap
the implementation behind the same public surface in one PR.

## Why this is a thin layer (only the codec byte, not the full wire frame)

Spec ch06 §2 defines the full `SnapshotV1Wire` framing:

```
outer_magic[4] "CSS1" | codec[1] | reserved[3]=0 | inner_len[u32] | inner[...]
```

This package intentionally implements **only** the `codec[1] | inner[...]`
inner-dispatch layer. The outer magic + reserved + inner_len framing
lives in the daemon snapshot serializer (T4.6/T4.7) so:

- the wire format and the codec dispatch can evolve independently
- v0.4 wire-format extensions (e.g., chunked snapshots via the reserved
  bytes) don't touch the codec package
- the codec package remains usable for any other byte-prefix codec
  dispatch use case that emerges (delta payload compression, IPC
  payload compression, etc.)

This split is forever-additive — adding new codec values (`codec = 3`
zstd-with-dictionary per spec ch06 §3 "Forward-additive") only extends
the `Codec` union here; no consumer change.

## Tests

26 cases, all pass locally:

- encode/decode roundtrip across 5 fixtures (tiny ascii / repetitive
  4 KiB / multibyte unicode / full 0..255 binary / empty input) x 2
  codecs = 10 cases
- frame-magic assertions: pins algorithm choice without coupling to
  Node's bundled zlib library version (only the magic prefix is
  asserted)
- intra-process determinism: v0.4 ship-gate (c) byte-equality requires
  this — same input twice MUST produce identical bytes
- hex-pinned golden decode for both codecs: decode is portable across
  zlib versions because both gzip and zstd frame formats are fully
  specified, so a hex-pinned blob from any conformant encoder MUST
  decode to the known plaintext on any other conformant Node
- error paths: empty buffer, unknown codec bytes (0x00, 0x03, 0xff),
  underlying zlib propagation on garbage input
- API surface sanity: codec constants, fresh-buffer guarantee

```
Test Files  1 passed (1)
     Tests  26 passed (26)
```

## Verification

- `pnpm install` -> OK (only adds @types/node devDep entry to lockfile)
- `pnpm --filter @ccsm/snapshot-codec build` -> OK
- `pnpm --filter @ccsm/snapshot-codec test` -> 26/26 pass
- `pnpm --filter @ccsm/snapshot-codec lint` -> clean
- `pnpm --filter @ccsm/snapshot-codec typecheck` -> clean
- `pnpm typecheck` (root) -> clean
- `pnpm run lint:app` (root sweep) -> 0 errors (66 pre-existing warnings)
- `pnpm run build` (turbo) -> picks up the new package automatically;
  3/3 tasks successful

## Out of scope (deferred to other tasks per task brief)

- Wire-up to daemon snapshot path -> Wave 3 T4.6/T4.7 (#44/#46)
- Full `SnapshotV1Wire` outer framing -> daemon snapshot serializer
- `SnapshotV1Inner` byte layout encoder -> Wave 3 / spec ch06 §2
- Property-based round-trip spike `[snapshot-roundtrip-fidelity]` ->
  spec ch16 §1.8

## Test plan

- [x] Local test/lint/typecheck/build all green
- [x] Root typecheck unaffected
- [x] Root lint sweep finds 0 new errors
- [ ] CI green