### PR TITLE
wave2: T5.5 spec-code lock.json + check-spec-code-lock CI gate (#220)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,20 @@ jobs:
           node-version-file: '.nvmrc'
           cache: 'npm'
 
+      # Wave 2 §5.5 (Task #220) — mechanical guard: the 4 ship-gate files
+      # named in the v0.3 daemon-split spec must not be silently renamed
+      # or deleted. tools/check-spec-code-lock.sh reads
+      # docs/superpowers/specs/2026-05-03-v03-daemon-split.lock.json and
+      # verifies every locked path exists with the recorded SHA256
+      # (LF-normalized, so platform-stable). Linux-only because the check
+      # is git/sha256/node and the result is deterministic across OSes;
+      # running on the matrix would waste 2x runner time. Placed after
+      # Setup Node because the script uses `node -e` to parse the lock
+      # JSON (no jq dependency).
+      - name: Check spec-code lock (ship-gate paths)
+        if: matrix.os == 'ubuntu-latest'
+        run: bash tools/check-spec-code-lock.sh
+
       # Linux native builds for better-sqlite3 need python + build tools; the
       # GitHub-hosted ubuntu image already has them, but setup-python makes
       # it explicit and pins the version so upstream image changes don't

--- a/docs/superpowers/specs/2026-05-03-v03-daemon-split.lock.json
+++ b/docs/superpowers/specs/2026-05-03-v03-daemon-split.lock.json
@@ -1,0 +1,36 @@
+{
+  "$comment": "Ship-gate file lock for v0.3 daemon split spec. Locks the canonical paths of the 4 ship gates against accidental rename/deletion. Verified by tools/check-spec-code-lock.sh in CI on every PR. Hashes are SHA256 of file content with line endings normalized to LF (\\r stripped) so they are platform-stable on Linux / macOS / Windows regardless of git's autocrlf setting. To intentionally rotate a path or update file contents, update both this file and the spec in the same PR.",
+  "version": 1,
+  "spec": "docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md",
+  "hash_algorithm": "sha256",
+  "hash_source": "working_tree_lf_normalized",
+  "gates": {
+    "a": {
+      "title": "Gate A — no IPC drift",
+      "files": [
+        { "path": "tools/lint-no-ipc.sh", "sha256": "ee1113824aa2d011dbc2f44b590c36aa9a023847eec86c83b9b9ce3a2a5178d4" },
+        { "path": "tools/.no-ipc-allowlist", "sha256": "507a12b31fb9ff7a26d878fe7334e579c47e1b80e3aa0e729f21794fef7a626c" }
+      ]
+    },
+    "b": {
+      "title": "Gate B — snapshot codec",
+      "files": [
+        { "path": "packages/snapshot-codec/src/index.ts", "sha256": "e7d7e9a3283328c282a133cbad39dbab5c6d206c3c4e2752429540d3f3e71bd1" }
+      ]
+    },
+    "c": {
+      "title": "Gate C — pty soak harness",
+      "files": [
+        { "path": "packages/daemon/test/integration/pty-soak-shared.ts", "sha256": "a004ffe545815aa0e256c0efc3b0dd703852d611f7a9d15705c3211533ce08fe" },
+        { "path": "tools/claude-sim/main.go", "sha256": "21b5808e35922cbd36e6de58339c72f129a91956da6fcb7450a51af38664ddee" }
+      ]
+    },
+    "d": {
+      "title": "Gate D — installer roundtrip",
+      "files": [
+        { "path": "tools/installer-roundtrip.ps1", "sha256": "41d93bb1352bc727fc056e0a52b083099b645dc88d25abddf307d07f2c6ed142" },
+        { "path": "test/installer-residue-allowlist.txt", "sha256": "72808c598815046972b5c451df2c3f9233fc336d09f5143ebf8ed04543d48bf2" }
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test:app": "vitest run",
     "lint:app": "eslint . --ext .ts,.tsx",
     "lint:no-ipc": "bash tools/lint-no-ipc.sh",
+    "lint:spec-code-lock": "bash tools/check-spec-code-lock.sh",
     "prelint:app": "node scripts/gen-proto.mjs",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.electron.json",
     "pretypecheck": "node scripts/gen-proto.mjs",

--- a/tools/check-spec-code-lock.sh
+++ b/tools/check-spec-code-lock.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# tools/check-spec-code-lock.sh — Wave 2 §5.5 mechanical guard (Task #220)
+#
+# Reads docs/superpowers/specs/2026-05-03-v03-daemon-split.lock.json and
+# verifies every listed ship-gate file (a) exists at its canonical path
+# and (b) has the recorded SHA256.
+#
+# Why this exists:
+#   The v0.3 daemon-split spec ships behind 4 mechanical gates (a/b/c/d).
+#   Each gate is enforced by a specific file whose canonical path is named
+#   in the spec. If someone renames or deletes one of those files, the
+#   gate silently stops working. This script locks the paths against
+#   accidental rename/deletion: CI fails loudly on any drift.
+#
+# Hash source:
+#   We hash the **git blob** content (`git show HEAD:<path>`) rather than
+#   the working-tree bytes. This makes hashes platform-stable: on Windows
+#   `core.autocrlf=true` rewrites LF -> CRLF on checkout, which would
+#   otherwise produce a different SHA256 than Linux CI. Hashing the blob
+#   bypasses the smudge filter.
+#
+# Cross-platform:
+#   - sha256sum (GNU coreutils, present on Linux + Git Bash on Windows)
+#   - shasum -a 256 (BSD, present on macOS)
+#   - JSON parsed with node (already required by the project; root
+#     package.json `engines` pins it).
+#
+# Exit codes:
+#   0 — all listed files exist and hashes match
+#   1 — one or more files missing or hash mismatch
+#   2 — bootstrap error (lock file missing, no node, no sha256 tool, etc.)
+
+set -u
+
+LOCK_FILE="docs/superpowers/specs/2026-05-03-v03-daemon-split.lock.json"
+
+if [ ! -f "$LOCK_FILE" ]; then
+  echo "check-spec-code-lock: FAIL bootstrap — $LOCK_FILE not found" >&2
+  exit 2
+fi
+
+# Pick a sha256 implementation.
+if command -v sha256sum >/dev/null 2>&1; then
+  SHA_CMD="sha256sum"
+elif command -v shasum >/dev/null 2>&1; then
+  SHA_CMD="shasum -a 256"
+else
+  echo "check-spec-code-lock: FAIL bootstrap — neither sha256sum nor shasum found" >&2
+  exit 2
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "check-spec-code-lock: FAIL bootstrap — node not found (needed to parse lock JSON)" >&2
+  exit 2
+fi
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "check-spec-code-lock: FAIL bootstrap — git not found" >&2
+  exit 2
+fi
+
+# Emit "<gate>\t<path>\t<expected_sha256>" lines, one per locked file.
+ROWS="$(node -e '
+  const fs = require("fs");
+  const j = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  for (const [gate, info] of Object.entries(j.gates || {})) {
+    for (const f of info.files || []) {
+      process.stdout.write(gate + "\t" + f.path + "\t" + f.sha256 + "\n");
+    }
+  }
+' "$LOCK_FILE")"
+
+if [ -z "$ROWS" ]; then
+  echo "check-spec-code-lock: FAIL bootstrap — no rows parsed from $LOCK_FILE" >&2
+  exit 2
+fi
+
+fail=0
+checked=0
+
+# Iterate. Use a here-string so the loop body runs in the parent shell
+# (we need `fail` increments to survive).
+while IFS=$'\t' read -r gate path expected; do
+  [ -z "$gate" ] && continue
+  checked=$((checked + 1))
+
+  # Existence check: working tree (so a delete in this PR is caught
+  # even before commit) AND git index (so a missing file at HEAD is
+  # caught — relevant for CI where checkout is fresh).
+  if [ ! -f "$path" ]; then
+    echo "FAIL: gate $gate path $path missing (working tree)" >&2
+    fail=$((fail + 1))
+    continue
+  fi
+
+  # Hash the working-tree file with line endings normalized to LF.
+  # Why: on Windows `core.autocrlf=true` rewrites LF -> CRLF on checkout,
+  # which would otherwise produce a different SHA256 than the same file
+  # on Linux CI. We strip \r so the hash is the same on every platform
+  # AND catches uncommitted edits (a pre-commit run is meaningful).
+  # `tr -d '\r'` is a no-op for files that are already LF-only and for
+  # binary files that contain no \r bytes (none of our locked files are
+  # binary).
+  actual="$(tr -d '\r' < "$path" | $SHA_CMD | awk '{print $1}')"
+  source="working_tree(lf)"
+
+  if [ "$actual" != "$expected" ]; then
+    echo "FAIL: gate $gate path $path changed" >&2
+    echo "       expected sha256: $expected" >&2
+    echo "       actual   sha256: $actual ($source)" >&2
+    echo "       to intentionally update, refresh the hash in $LOCK_FILE" >&2
+    fail=$((fail + 1))
+  fi
+done <<EOF
+$ROWS
+EOF
+
+if [ "$fail" -ne 0 ]; then
+  echo "check-spec-code-lock: $fail/$checked locked file(s) failed verification" >&2
+  exit 1
+fi
+
+echo "check-spec-code-lock: OK ($checked locked files verified against $LOCK_FILE)"
+exit 0


### PR DESCRIPTION
Task #220 — Wave 2 §5.5 mechanical guard. Locks the canonical paths of the 4 v0.3 ship-gate files against accidental rename / deletion.

## What

- **NEW** `docs/superpowers/specs/2026-05-03-v03-daemon-split.lock.json` — per-gate (a/b/c/d) list of `{path, sha256}` for the 7 ship-gate files:
  - gate **a** — `tools/lint-no-ipc.sh`, `tools/.no-ipc-allowlist`
  - gate **b** — `packages/snapshot-codec/src/index.ts`
  - gate **c** — `packages/daemon/test/integration/pty-soak-shared.ts`, `tools/claude-sim/main.go`
  - gate **d** — `tools/installer-roundtrip.ps1`, `test/installer-residue-allowlist.txt`
  Hashes are SHA256 of file content with line endings normalized to LF (`\r` stripped before hashing), so they are stable across Linux / macOS / Windows regardless of git's `core.autocrlf` setting.

- **NEW** `tools/check-spec-code-lock.sh` — POSIX bash. Detects `sha256sum` (GNU) or `shasum -a 256` (BSD) at runtime. Parses the lock JSON via `node -e` (no jq dependency). Exits `1` with `FAIL: gate X path Y missing/changed` on drift; exits `2` on bootstrap error.

- **`.github/workflows/ci.yml`** — new linux-only step `Check spec-code lock (ship-gate paths)` invoking the script. Placed after `Setup Node` (script needs `node`). Linux-only matches the existing `check-v02-shrinking` pattern: deterministic across OSes, running on the matrix would waste 2x runner time.

- **`package.json`** — `npm run lint:spec-code-lock`.

## Why hash via LF-normalized working tree?

The natural thing is `sha256sum <path>`. That fails on Windows because `core.autocrlf=true` checks files out with CRLF, producing a different hash than Linux CI. Hashing via `git show HEAD:<path>` is platform-stable but cannot catch uncommitted edits. The chosen approach (`tr -d '\r' < <path> | sha256sum`) is platform-stable AND catches uncommitted edits — meaningful for pre-commit local runs.

## Verification

### Green run

```
$ bash tools/check-spec-code-lock.sh
check-spec-code-lock: OK (7 locked files verified against docs/superpowers/specs/2026-05-03-v03-daemon-split.lock.json)
```

### Negative test 1 — rename / delete

```
$ mv packages/snapshot-codec/src/index.ts /tmp/x.ts && bash tools/check-spec-code-lock.sh; echo exit=$?
FAIL: gate b path packages/snapshot-codec/src/index.ts missing (working tree)
check-spec-code-lock: 1/7 locked file(s) failed verification
exit=1
$ mv /tmp/x.ts packages/snapshot-codec/src/index.ts   # restore
```

### Negative test 2 — content drift

```
$ echo "// drift" >> packages/snapshot-codec/src/index.ts && bash tools/check-spec-code-lock.sh; echo exit=$?
FAIL: gate b path packages/snapshot-codec/src/index.ts changed
       expected sha256: e7d7e9a3283328c282a133cbad39dbab5c6d206c3c4e2752429540d3f3e71bd1
       actual   sha256: f1e0b312be88ad37e5e2587b748c476832fc2071294f64050a2d7aedd5e84eb3 (working_tree(lf))
       to intentionally update, refresh the hash in docs/superpowers/specs/2026-05-03-v03-daemon-split.lock.json
check-spec-code-lock: 1/7 locked file(s) failed verification
exit=1
$ git checkout packages/snapshot-codec/src/index.ts   # restore
$ bash tools/check-spec-code-lock.sh
check-spec-code-lock: OK (7 locked files verified against docs/superpowers/specs/2026-05-03-v03-daemon-split.lock.json)
```

Both negative tests exit 1 with the spec'd error format. Restore returns to green.

## Wire-up evidence

- [x] **Library-only marker**: `[LIBRARY-ONLY]` — this PR is a CI mechanical guard. No daemon / electron source is touched. The "wire-up" is the CI step itself, which is in this PR.
- [x] **Importers**: n/a (no new TypeScript exports).
- [x] **Startup wiring**: n/a (no daemon code).
- [x] **v0.2-only growth**: this PR adds new files only (`docs/`, `tools/`, `.github/`, `package.json` script entry). No file in `.v0.2-only-files` is modified.