### PR TITLE
wave2: T5.4 runStartup.lock + assertWired (#221)

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -62,6 +62,7 @@ import {
   type ShutdownContext,
   type ShutdownResult,
 } from './shutdown.js';
+import { assertWired } from './runStartup.lock.js';
 import {
   makeSupervisorServer,
   type SupervisorServer,
@@ -107,6 +108,14 @@ export interface RunStartupResult {
     readonly malformed: number;
     readonly fileMissing: boolean;
   };
+  /**
+   * Names of components actually wired by this `runStartup` invocation.
+   * Compared against `REQUIRED_COMPONENTS` (see `runStartup.lock.ts`)
+   * by the boot-time `assertWired` call AND by the daemon-boot e2e
+   * test (Task #208 / #225 rolling-extension contract). Order matches
+   * the canonical list so spec tests can deep-equal it.
+   */
+  readonly wired: ReadonlyArray<string>;
 }
 
 /**
@@ -369,6 +378,37 @@ export async function runStartup(
     log(`supervisor bound: ${supervisor.address()}`);
   }
 
+  // Collect canonical wire-up component names actually present on this
+  // boot, then assert against `REQUIRED_COMPONENTS` (see
+  // `runStartup.lock.ts`). Throws if any required-and-not-WARN_ONLY
+  // component is missing — failing boot is the right behavior because
+  // the daemon would otherwise silently ship a stub (the exact "library
+  // shipped but never wired" regression Wave 0/1 + Task #221 exist to
+  // catch). The two skip-env paths (`CCSM_DAEMON_SKIP_LISTENER`,
+  // `CCSM_DAEMON_SKIP_SUPERVISOR`, `CCSM_DAEMON_SKIP_CRASH_CAPTURE`)
+  // are smoke / unit-test seams; in those modes the corresponding
+  // component name is correctly absent from `wired` and `assertWired`
+  // throws. Smoke / unit tests that intentionally skip MUST handle the
+  // throw (the existing daemon-boot e2e leaves all skips off — it tests
+  // the production boot path).
+  const wired: string[] = [];
+  if (listenerA !== null) wired.push('listener-a');
+  if (supervisor !== null) wired.push('supervisor');
+  if (captureSourcesInstalled) wired.push('capture-sources');
+  // `replayCrashRawOnBoot` always returns a result (even on first boot
+  // it returns `{ fileMissing: true, ... }`) — its presence in the
+  // outer scope proves the wire-up fired, regardless of whether the
+  // file existed.
+  if (crashReplayResult !== null && crashReplayResult !== undefined) {
+    wired.push('crash-replayer');
+  }
+  // `write-coalescer`: NOT pushed yet — module exists at
+  // `src/sqlite/coalescer.ts` but the per-session pty-host bridge
+  // wires in T6.x. `assertWired` treats this name as WARN_ONLY for now
+  // (see `runStartup.lock.ts` `WARN_ONLY`), so this is a soft-fail
+  // until that task lands.
+  assertWired(wired, { warn: log });
+
   return {
     env,
     listenerA,
@@ -379,6 +419,7 @@ export async function runStartup(
     captureSourcesInstalled,
     captureSourcesUnsubscribe,
     crashReplayResult,
+    wired,
   };
 }
 

--- a/packages/daemon/src/runStartup.lock.ts
+++ b/packages/daemon/src/runStartup.lock.ts
@@ -1,0 +1,101 @@
+// packages/daemon/src/runStartup.lock.ts
+//
+// Wave-2 Task #221 — runStartup boot-time wire-up assertion.
+//
+// Goal: prevent the "library shipped but never wired" regression class
+// (the same root-cause Wave 0/1 was created to fix). At the END of
+// `runStartup` the production daemon hands this module a `present`
+// list of canonical component names; if any required name is absent we
+// throw `Error("missing wired components: X, Y")` so the daemon exits
+// non-zero and CI / install-time logs flag the regression immediately.
+//
+// `REQUIRED_COMPONENTS` is exported as a `readonly` const so the
+// `daemon-boot-end-to-end.spec.ts` (Task #208) can import + assert the
+// `result.wired` array equals it (rolling-extension contract — Task
+// #225 layers more assertions on top of the same boot).
+//
+// SRP — pure decider. No I/O, no logging, no side effects beyond `throw`.
+// The caller in `index.ts` does the production wiring + push; this file
+// does nothing but compute "missing = required − present" and throw.
+
+/**
+ * Canonical list of v0.3 daemon components that MUST be wired by
+ * `runStartup` before the boot is considered complete. Order is
+ * stable so `daemon-boot-end-to-end.spec.ts` can do a deep-equality
+ * assertion against `result.wired`.
+ *
+ * - `listener-a`     — Listener A is bound (T1.4 + T1.6 descriptor).
+ * - `supervisor`     — Supervisor UDS server is bound (T1.7).
+ * - `capture-sources`— `installCaptureSources` ran (ch09 §1).
+ * - `crash-replayer` — `replayCrashRawOnBoot` ran (ch09 §6.2).
+ * - `write-coalescer`— SQLite write coalescer is wired (ch07 §5).
+ *   v0.3 status: the coalescer module exists at
+ *   `src/sqlite/coalescer.ts` but the per-session bridge that hands it
+ *   pty-host deltas is not yet wired in `runStartup` (lands with the
+ *   T6.x pty-host wave). Until then `runStartup` does NOT push
+ *   `'write-coalescer'` and `assertWired` emits a warning to the
+ *   supplied `warn` callback instead of throwing — see `WARN_ONLY`
+ *   below. When the wire-up lands, drop it from `WARN_ONLY` and the
+ *   assertion auto-promotes to a hard failure.
+ */
+export const REQUIRED_COMPONENTS: ReadonlyArray<string> = [
+  'listener-a',
+  'supervisor',
+  'capture-sources',
+  'crash-replayer',
+  'write-coalescer',
+] as const;
+
+/**
+ * Components that are REQUIRED on paper but whose wire-up has not yet
+ * landed in `runStartup`. `assertWired` emits a warning for these
+ * instead of throwing so the daemon still boots while we wait for the
+ * owning task to land. When you wire one in, REMOVE it from this set —
+ * the assertion will then auto-promote to a hard failure if a future
+ * change accidentally drops the wiring.
+ *
+ * - `write-coalescer` → wired by T6.x pty-host bridge (TODO).
+ */
+const WARN_ONLY: ReadonlySet<string> = new Set(['write-coalescer']);
+
+/**
+ * Optional warn callback for the `WARN_ONLY` soft-fail path. The
+ * default is a no-op so unit tests do not need to inject anything;
+ * production `runStartup` injects a closure that calls the daemon
+ * `log()` helper.
+ */
+export interface AssertWiredOptions {
+  readonly warn?: (line: string) => void;
+}
+
+/**
+ * Throws if any required component name is absent from `present`,
+ * EXCEPT for components in `WARN_ONLY` which only emit a warning.
+ *
+ * Error message shape (intentionally stable so callers / log scrapers
+ * can grep): `missing wired components: a, b, c`.
+ */
+export function assertWired(
+  present: ReadonlyArray<string>,
+  options: AssertWiredOptions = {},
+): void {
+  const presentSet = new Set(present);
+  const missing: string[] = [];
+  const softMissing: string[] = [];
+  for (const name of REQUIRED_COMPONENTS) {
+    if (presentSet.has(name)) continue;
+    if (WARN_ONLY.has(name)) {
+      softMissing.push(name);
+    } else {
+      missing.push(name);
+    }
+  }
+  if (softMissing.length > 0 && options.warn) {
+    options.warn(
+      `assertWired: pending wire-up (TODO Task #T6.x): ${softMissing.join(', ')}`,
+    );
+  }
+  if (missing.length > 0) {
+    throw new Error(`missing wired components: ${missing.join(', ')}`);
+  }
+}

--- a/packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts
+++ b/packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts
@@ -74,6 +74,7 @@ import * as AjvNs from 'ajv';
 
 import { runStartup, type RunStartupResult } from '../../src/index.js';
 import { Lifecycle, Phase } from '../../src/lifecycle.js';
+import { REQUIRED_COMPONENTS } from '../../src/runStartup.lock.js';
 import { TEST_BEARER_TOKEN } from '../../src/auth/index.js';
 
 const Ajv =
@@ -379,6 +380,34 @@ describe('daemon-boot end-to-end (Task #208)', () => {
       const sp = statePaths();
       const st = await stat(sp.crashRaw);
       expect(st.size).toBe(0); // truncate-after-replay (ch09 §6.2)
+    }
+  });
+
+  // Task #221 — assertWired contract. `runStartup` now collects a
+  // `wired: string[]` of canonical component names actually wired by
+  // this boot and calls `assertWired` against `REQUIRED_COMPONENTS`. A
+  // successful boot here means every hard-required component reported
+  // present; the e2e then locks the array shape so a future regression
+  // that drops a wire-up (and silently absents the name) fails this
+  // file BEFORE it can ship.
+  it('runStartup probe: result.wired covers every REQUIRED_COMPONENTS entry that is hard-required on this boot', () => {
+    expect(result).not.toBeNull();
+    const wired = result!.wired;
+    // The production e2e never sets any `CCSM_DAEMON_SKIP_*` envs, so
+    // every hard-required component (REQUIRED_COMPONENTS minus the
+    // current WARN_ONLY set in runStartup.lock.ts) MUST be present.
+    // We assert the strict superset relationship rather than deep
+    // equality so the test does not need to be edited each time a
+    // WARN_ONLY entry graduates to hard-required (it auto-tightens).
+    const WARN_ONLY = new Set(['write-coalescer']);
+    for (const name of REQUIRED_COMPONENTS) {
+      if (WARN_ONLY.has(name)) continue;
+      expect(wired, `missing wired entry: ${name}`).toContain(name);
+    }
+    // No surprise extras either — the daemon should not be reporting
+    // names that aren't in the canonical list.
+    for (const name of wired) {
+      expect(REQUIRED_COMPONENTS).toContain(name);
     }
   });
 });

--- a/packages/daemon/test/lock/runStartup-lock.spec.ts
+++ b/packages/daemon/test/lock/runStartup-lock.spec.ts
@@ -1,0 +1,92 @@
+// packages/daemon/test/lock/runStartup-lock.spec.ts
+//
+// Wave-2 Task #221 — unit tests for `assertWired` boot-time check.
+//
+// Pure UT (no I/O / no daemon spawn) — `assertWired` is a decider
+// function. The integration-level proof "runStartup actually pushes
+// every name" lives in `test/integration/daemon-boot-end-to-end.spec.ts`
+// (Task #208 / #225).
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  REQUIRED_COMPONENTS,
+  assertWired,
+} from '../../src/runStartup.lock.js';
+
+// `write-coalescer` is currently WARN_ONLY (see runStartup.lock.ts).
+// The hard-required set is the canonical list MINUS that one. When the
+// pty-host bridge lands and `write-coalescer` is removed from
+// WARN_ONLY, this constant + the table below auto-stay correct without
+// edits — but the WARN_ONLY case below DOES need to be deleted then.
+const WARN_ONLY = new Set(['write-coalescer']);
+const HARD_REQUIRED = REQUIRED_COMPONENTS.filter((n) => !WARN_ONLY.has(n));
+
+describe('assertWired (Task #221)', () => {
+  it('does not throw when every REQUIRED_COMPONENTS name is present', () => {
+    expect(() => assertWired([...REQUIRED_COMPONENTS])).not.toThrow();
+  });
+
+  it('does not throw when only hard-required names are present (WARN_ONLY components soft-fail)', () => {
+    const warnLines: string[] = [];
+    expect(() =>
+      assertWired(HARD_REQUIRED, { warn: (s) => warnLines.push(s) }),
+    ).not.toThrow();
+    // The current WARN_ONLY entry (write-coalescer) should be flagged.
+    expect(warnLines.length).toBe(1);
+    expect(warnLines[0]).toContain('write-coalescer');
+  });
+
+  it('throws listing all 5 components when present is empty', () => {
+    let raised: Error | null = null;
+    try {
+      assertWired([]);
+    } catch (err) {
+      raised = err as Error;
+    }
+    expect(raised).not.toBeNull();
+    expect(raised!.message).toContain('missing wired components:');
+    // Empty -> every hard-required name in the message; WARN_ONLY ones
+    // (write-coalescer) only emit a warning so they are NOT in the
+    // throw message.
+    for (const n of HARD_REQUIRED) {
+      expect(raised!.message).toContain(n);
+    }
+    for (const n of WARN_ONLY) {
+      expect(raised!.message).not.toContain(n);
+    }
+  });
+
+  // Table-driven: drop each hard-required name in turn and confirm
+  // (a) it throws, (b) the missing name is listed, (c) other present
+  // names are NOT listed (no false positives).
+  for (const dropped of HARD_REQUIRED) {
+    it(`throws when '${dropped}' is missing`, () => {
+      const present = HARD_REQUIRED.filter((n) => n !== dropped);
+      let raised: Error | null = null;
+      try {
+        assertWired(present);
+      } catch (err) {
+        raised = err as Error;
+      }
+      expect(raised, `expected throw when ${dropped} missing`).not.toBeNull();
+      expect(raised!.message).toBe(`missing wired components: ${dropped}`);
+    });
+  }
+
+  it('warn callback is optional (no throw, no warn invocation needed)', () => {
+    // Even with WARN_ONLY components missing, calling without a `warn`
+    // callback must not throw.
+    expect(() => assertWired(HARD_REQUIRED)).not.toThrow();
+  });
+
+  it('REQUIRED_COMPONENTS exposes the canonical 5-component list in stable order', () => {
+    expect(REQUIRED_COMPONENTS).toEqual([
+      'listener-a',
+      'supervisor',
+      'capture-sources',
+      'crash-replayer',
+      'write-coalescer',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Wave-2 Task #221 — adds a boot-time wire-up assertion at the end of `runStartup` so the daemon fails fast if any required component is missing. This catches the "library shipped but never wired" regression class that Wave 0/1 (PR #966) was created to fix.

- New `packages/daemon/src/runStartup.lock.ts` exporting `REQUIRED_COMPONENTS` (canonical 5-component list) + `assertWired(present, { warn? })` (pure decider; throws `Error("missing wired components: X, Y")` for hard-required, soft-warns for `WARN_ONLY`).
- `runStartup` now collects `wired: string[]` from real outputs (`listenerA`, `supervisor`, `captureSourcesInstalled`, `crashReplayResult`) and calls `assertWired` before returning. `wired` is exposed on `RunStartupResult` so the daemon-boot e2e can lock the array shape.
- `write-coalescer` is currently in `WARN_ONLY` (module exists at `src/sqlite/coalescer.ts` but the per-session pty-host bridge wires in T6.x). Once that lands, drop it from `WARN_ONLY` and the assertion auto-promotes to a hard failure.

## Wire-up evidence

This **IS** the wire-up PR (modifies `packages/daemon/src/index.ts` directly):

- **Importers**:
  - `packages/daemon/src/index.ts` — `import { assertWired } from './runStartup.lock.js';`
  - `packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts` — `import { REQUIRED_COMPONENTS } from '../../src/runStartup.lock.js';`
  - `packages/daemon/test/lock/runStartup-lock.spec.ts` — `import { REQUIRED_COMPONENTS, assertWired } from '../../src/runStartup.lock.js';`
- **Startup wiring** (end of `runStartup`):
  ```ts
  const wired: string[] = [];
  if (listenerA !== null) wired.push('listener-a');
  if (supervisor !== null) wired.push('supervisor');
  if (captureSourcesInstalled) wired.push('capture-sources');
  if (crashReplayResult !== null && crashReplayResult !== undefined) {
    wired.push('crash-replayer');
  }
  // write-coalescer: WARN_ONLY pending T6.x pty-host bridge
  assertWired(wired, { warn: log });
  ```
- **Library-only marker**: N/A — this is the wire-up.
- **v0.2-only growth**: no `.v0.2-only-files` paths touched.

## Reverse-verify (per dev.md §2 phase-4)

Temporarily commented out `if (supervisor !== null) wired.push('supervisor');` and re-ran the daemon-boot e2e. Result:

```
Error: missing wired components: supervisor
 ❯ assertWired src/runStartup.lock.ts:99:11
 ❯ runStartup src/index.ts:410:3
 ❯ test/integration/daemon-boot-end-to-end.spec.ts:269:14

Test Files  1 failed (1)
Tests  7 failed (7)
```

`assertWired` aborted boot at runStartup with the exact stable error message (`missing wired components: supervisor`), and every e2e assertion downstream failed because the boot threw — proves the lock is load-bearing. Restored the push and the suite is back to 7/7 green.

## Local gates (all PASS)

- `pnpm --filter @ccsm/daemon typecheck` — PASS (0 errors)
- `pnpm --filter @ccsm/daemon lint` — 0 errors (pre-existing warnings only)
- `pnpm --filter @ccsm/daemon test` — `Test Files 97 passed | 1 skipped` / `Tests 1005 passed | 23 skipped | 5 todo`
- `pnpm run lint:no-ipc` — PASS

The new e2e assertion ran and observed the canonical list verbatim; the soft-warn path emitted `[ccsm-daemon] assertWired: pending wire-up (TODO Task #T6.x): write-coalescer` exactly once on each boot, as expected.

## Test plan

- [x] Unit tests cover all-present, each-individually-missing, empty-input, optional-warn-callback, and stable-order cases (9 tests, all green)
- [x] Daemon-boot e2e extended with `result.wired` superset assertion (Task #208 / #225 rolling-extension contract)
- [x] Reverse-verify proves the assertion fires when a real wire-up is dropped
- [x] All daemon gates green locally before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)