### PR TITLE
feat(electron): grant clipboard-read perm for app:// origin (#266)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -33,7 +33,6 @@
 //     state for the dependency bags.
 //   * The `app.whenReady()` body that wires every subsystem together
 //     (db init, notify pipeline construction, sessionWatcher, eager scans).
-
 import { app, BrowserWindow, session, type Tray } from 'electron';
 import { initDb, closeDb } from './db';
 import { installClipboardPermissionHandlers } from './security/clipboardPermission';
@@ -185,16 +184,7 @@ app.whenReady().then(() => {
   }
 
   initDb(app.getPath('userData'));
-
-  // Task #266: install clipboard-read permission policy on the default
-  // session BEFORE any BrowserWindow is created, so the very first renderer
-  // load already sees the gated handler. Without this, the renderer's
-  // `navigator.clipboard.read*` calls return NotAllowedError under
-  // sandbox:true + contextIsolation:true. Allowlist is `app://` only (the
-  // T6.1 protocol.handle scheme — see packages/electron/src/main/
-  // protocol-app.ts); every other origin + every other permission is denied.
   installClipboardPermissionHandlers(session.defaultSession);
-
   // Wave 0e (#247): wire the spec ch08 §3.1 allowlisted IPC surfaces.
   // ORDER MATTERS — the broadcast hooks must be registered BEFORE
   // installUpdater() so the autoUpdater event listeners installed by

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -34,8 +34,9 @@
 //   * The `app.whenReady()` body that wires every subsystem together
 //     (db init, notify pipeline construction, sessionWatcher, eager scans).
 
-import { app, BrowserWindow, type Tray } from 'electron';
+import { app, BrowserWindow, session, type Tray } from 'electron';
 import { initDb, closeDb } from './db';
+import { installClipboardPermissionHandlers } from './security/clipboardPermission';
 import { buildTrayIcon } from './branding/icon';
 import { initSentry } from './sentry/init';
 import { createWindow as createMainWindowFactory } from './window/createWindow';
@@ -184,6 +185,15 @@ app.whenReady().then(() => {
   }
 
   initDb(app.getPath('userData'));
+
+  // Task #266: install clipboard-read permission policy on the default
+  // session BEFORE any BrowserWindow is created, so the very first renderer
+  // load already sees the gated handler. Without this, the renderer's
+  // `navigator.clipboard.read*` calls return NotAllowedError under
+  // sandbox:true + contextIsolation:true. Allowlist is `app://` only (the
+  // T6.1 protocol.handle scheme — see packages/electron/src/main/
+  // protocol-app.ts); every other origin + every other permission is denied.
+  installClipboardPermissionHandlers(session.defaultSession);
 
   // Wave 0e (#247): wire the spec ch08 §3.1 allowlisted IPC surfaces.
   // ORDER MATTERS — the broadcast hooks must be registered BEFORE

--- a/electron/security/__tests__/clipboardPermission.test.ts
+++ b/electron/security/__tests__/clipboardPermission.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isClipboardPermissionAllowed,
+  installClipboardPermissionHandlers,
+  type ClipboardPermissionSession,
+} from '../clipboardPermission';
+
+describe('isClipboardPermissionAllowed', () => {
+  it('grants clipboard-read for app:// origin', () => {
+    expect(isClipboardPermissionAllowed('clipboard-read', 'app://ccsm')).toBe(
+      true,
+    );
+    expect(
+      isClipboardPermissionAllowed(
+        'clipboard-read',
+        'app://ccsm/listener-descriptor.json',
+      ),
+    ).toBe(true);
+  });
+
+  it('denies clipboard-read for any non-app origin', () => {
+    expect(
+      isClipboardPermissionAllowed('clipboard-read', 'http://localhost:4100'),
+    ).toBe(false);
+    expect(isClipboardPermissionAllowed('clipboard-read', 'file://')).toBe(
+      false,
+    );
+    expect(
+      isClipboardPermissionAllowed('clipboard-read', 'https://evil.example'),
+    ).toBe(false);
+  });
+
+  it('denies any permission other than clipboard-read even from app://', () => {
+    for (const perm of [
+      'clipboard-write',
+      'notifications',
+      'geolocation',
+      'media',
+      'midi',
+      'fullscreen',
+    ]) {
+      expect(isClipboardPermissionAllowed(perm, 'app://ccsm')).toBe(false);
+    }
+  });
+
+  it('denies on malformed / empty requesting origin', () => {
+    expect(isClipboardPermissionAllowed('clipboard-read', '')).toBe(false);
+    expect(isClipboardPermissionAllowed('clipboard-read', 'not a url')).toBe(
+      false,
+    );
+  });
+});
+
+describe('installClipboardPermissionHandlers', () => {
+  function makeFakeSession(): {
+    session: ClipboardPermissionSession;
+    request: ReturnType<typeof vi.fn>;
+    check: ReturnType<typeof vi.fn>;
+  } {
+    const request = vi.fn();
+    const check = vi.fn();
+    return {
+      session: {
+        setPermissionRequestHandler: request,
+        setPermissionCheckHandler: check,
+      },
+      request,
+      check,
+    };
+  }
+
+  it('registers a request handler that grants clipboard-read for app:// only', () => {
+    const fake = makeFakeSession();
+    installClipboardPermissionHandlers(fake.session);
+    expect(fake.request).toHaveBeenCalledTimes(1);
+    const handler = fake.request.mock.calls[0][0] as (
+      wc: unknown,
+      perm: string,
+      cb: (granted: boolean) => void,
+      details: { requestingUrl?: string },
+    ) => void;
+
+    const grants: boolean[] = [];
+    handler({}, 'clipboard-read', (g) => grants.push(g), {
+      requestingUrl: 'app://ccsm',
+    });
+    handler({}, 'clipboard-read', (g) => grants.push(g), {
+      requestingUrl: 'http://localhost:4100',
+    });
+    handler({}, 'notifications', (g) => grants.push(g), {
+      requestingUrl: 'app://ccsm',
+    });
+    handler({}, 'clipboard-read', (g) => grants.push(g), {});
+    expect(grants).toEqual([true, false, false, false]);
+  });
+
+  it('registers a check handler that mirrors the request decider', () => {
+    const fake = makeFakeSession();
+    installClipboardPermissionHandlers(fake.session);
+    expect(fake.check).toHaveBeenCalledTimes(1);
+    const handler = fake.check.mock.calls[0][0] as (
+      wc: unknown,
+      perm: string,
+      origin: string,
+    ) => boolean;
+    expect(handler({}, 'clipboard-read', 'app://ccsm')).toBe(true);
+    expect(handler({}, 'clipboard-read', 'http://localhost:4100')).toBe(false);
+    expect(handler({}, 'notifications', 'app://ccsm')).toBe(false);
+  });
+});

--- a/electron/security/clipboardPermission.ts
+++ b/electron/security/clipboardPermission.ts
@@ -78,6 +78,14 @@ export interface ClipboardPermissionSession {
  * Install the permission request + check handlers on the supplied session.
  * Call once per session (typically `session.defaultSession`) at boot, after
  * `app.whenReady()` has resolved.
+ *
+ * Call this on the default session BEFORE any BrowserWindow is created, so
+ * the very first renderer load already sees the gated handler. Without this,
+ * the renderer's `navigator.clipboard.read*` calls return NotAllowedError
+ * under sandbox:true + contextIsolation:true. Allowlist is `app://` only
+ * (the T6.1 protocol.handle scheme — see
+ * packages/electron/src/main/protocol-app.ts); every other origin + every
+ * other permission is denied.
  */
 export function installClipboardPermissionHandlers(
   session: ClipboardPermissionSession,

--- a/electron/security/clipboardPermission.ts
+++ b/electron/security/clipboardPermission.ts
@@ -1,0 +1,93 @@
+// Clipboard permission policy for the renderer (Task #266).
+//
+// Why: xterm's keydown handler swallows the user-activation propagation
+// `navigator.clipboard.read*` requires under sandbox:true + contextIsolation:
+// true, so the renderer currently routes clipboard ops through a native
+// bridge (`window.ccsmPty.clipboard.*` per src/terminal/xtermSingleton.ts).
+// Once we register `setPermissionRequestHandler` + `setPermissionCheckHandler`
+// granting `clipboard-read` for our own `app://` origin (see T6.1 /
+// `packages/electron/src/main/protocol-app.ts`), the renderer can switch to
+// `navigator.clipboard.*` directly. The actual cutover at xtermSingleton.ts
+// is a separate downstream task — this module only installs the policy.
+//
+// Policy:
+//   * `clipboard-read` is GRANTED iff the requesting origin's scheme is
+//     `app:` (i.e. our own descriptor-served renderer per ch08 §4.1). All
+//     other origins (file://, http://localhost dev server, https://*, ...)
+//     and all other permissions (`notifications`, `geolocation`, `media`,
+//     ...) are DENIED.
+//   * `setPermissionCheckHandler` mirrors the same rule — Chromium consults
+//     it for synchronous permission queries (e.g. `navigator.permissions.
+//     query({ name: 'clipboard-read' })`) and we want both APIs to agree.
+//
+// Why not broaden to `clipboard-write`: writing to the clipboard does not
+// require a permission grant in Chromium when triggered by user activation;
+// the bridge today exposes both read + write but only read needed special
+// handling. Adding `clipboard-write` here would be inert and confuse a
+// future reader about which permissions actually go through this gate.
+
+/**
+ * Pure decider — exported for unit tests. Returns true iff the renderer
+ * should be allowed to use the requested permission from the given origin.
+ *
+ * `requestingOrigin` is the value Chromium hands the permission handler
+ * (e.g. `app://ccsm`, `http://localhost:4100`, `file://`). `permission` is
+ * the Electron permission string (e.g. `clipboard-read`, `notifications`).
+ */
+export function isClipboardPermissionAllowed(
+  permission: string,
+  requestingOrigin: string,
+): boolean {
+  if (permission !== 'clipboard-read') return false;
+  try {
+    const u = new URL(requestingOrigin);
+    return u.protocol === 'app:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Minimal structural shape of `Electron.Session` we depend on. Keeping this
+ * narrow lets the unit test fake a session without pulling in the full
+ * Electron type surface.
+ */
+export interface ClipboardPermissionSession {
+  setPermissionRequestHandler(
+    handler:
+      | ((
+          webContents: unknown,
+          permission: string,
+          callback: (granted: boolean) => void,
+          details: { requestingUrl?: string },
+        ) => void)
+      | null,
+  ): void;
+  setPermissionCheckHandler(
+    handler:
+      | ((
+          webContents: unknown,
+          permission: string,
+          requestingOrigin: string,
+        ) => boolean)
+      | null,
+  ): void;
+}
+
+/**
+ * Install the permission request + check handlers on the supplied session.
+ * Call once per session (typically `session.defaultSession`) at boot, after
+ * `app.whenReady()` has resolved.
+ */
+export function installClipboardPermissionHandlers(
+  session: ClipboardPermissionSession,
+): void {
+  session.setPermissionRequestHandler((_wc, permission, callback, details) => {
+    callback(
+      isClipboardPermissionAllowed(permission, details.requestingUrl ?? ''),
+    );
+  });
+  session.setPermissionCheckHandler((_wc, permission, requestingOrigin) =>
+    isClipboardPermissionAllowed(permission, requestingOrigin),
+  );
+}


### PR DESCRIPTION
## Summary

Task #266 followup. Install `session.setPermissionRequestHandler` + `session.setPermissionCheckHandler` on `session.defaultSession` at `app.whenReady()` time, granting `clipboard-read` for the `app://` origin only (the T6.1 `protocol.handle` scheme — see `packages/electron/src/main/protocol-app.ts`) and denying every other permission and every other origin.

This is forward-looking infra prep so that, once the renderer migrates from the `ccsmPty.clipboard.*` native bridge (currently used by `src/terminal/xtermSingleton.ts` because xterm's keydown handler swallows the user-activation propagation `navigator.clipboard.read*` requires under `sandbox:true` + `contextIsolation:true`) to `navigator.clipboard.*` directly, Chromium routes the read request through this gate and grants it. The actual cutover at `xtermSingleton.ts` is a separate downstream task post-#228 and is **intentionally not in this PR's scope**.

## Files

- `electron/security/clipboardPermission.ts` (new, ~70 LOC inc. comments) — pure decider `isClipboardPermissionAllowed(permission, requestingOrigin)` + `installClipboardPermissionHandlers(session)` registration helper. SRP: decider is a pure function, sink is the registration helper.
- `electron/main.ts` — import `session` from electron + the new helper, call `installClipboardPermissionHandlers(session.defaultSession)` inside `app.whenReady()` immediately after `initDb`, BEFORE any `BrowserWindow` is created so the very first renderer load already sees the gated handler.
- `electron/security/__tests__/clipboardPermission.test.ts` (new, 6 cases) — covers decider + handler wiring (grant on `app://`, deny on `http://localhost`, `file://`, `https://*`, deny non-`clipboard-read` permissions even from `app://`, deny on malformed origins, both request + check handler agree).

## Wire-up evidence

The handler lands on the same session every `BrowserWindow` uses by default, because `electron/window/createWindow.ts` does NOT set `webPreferences.partition` or `webPreferences.session` — Electron defaults to `session.defaultSession` in that case. Greppable proof:

```bash
$ grep -nE "partition|webPreferences\.session" electron/window/createWindow.ts
# (no matches — every BrowserWindow uses session.defaultSession)

$ grep -nE "session\.defaultSession|setPermissionRequestHandler|setPermissionCheckHandler" electron/
electron/main.ts:  installClipboardPermissionHandlers(session.defaultSession);
electron/security/clipboardPermission.ts:  session.setPermissionRequestHandler((_wc, permission, callback, details) => {
electron/security/clipboardPermission.ts:  session.setPermissionCheckHandler((_wc, permission, requestingOrigin) =>
```

## Test plan

- [x] `npx vitest run electron/security/__tests__/clipboardPermission.test.ts` → 6/6 pass
- [x] `npx tsc -p tsconfig.electron.json` → clean (no errors in changed files; pre-existing errors elsewhere are missing `protoc-gen-es` artefacts in this worktree env, unrelated to this PR)
- [x] `npx eslint electron/security/clipboardPermission.ts electron/security/__tests__/clipboardPermission.test.ts electron/main.ts` → clean
- [x] electron require-load smoke: `node -e "require('./dist/electron/security/clipboardPermission.js')"` → `require OK` (no `ERR_REQUIRE_ESM`)
- [ ] Manual smoke (deferred to renderer-cutover PR): until the renderer is loaded from `app://`, this handler's grant branch is never hit at runtime — the deny branch (current default behaviour) is what the existing renderer sees, which is unchanged. Manual smoke of the grant path requires the post-#228 cutover where `xtermSingleton.ts` calls `navigator.clipboard.readText()` from an `app://`-served renderer.

## Out of scope

- Switching `src/terminal/xtermSingleton.ts` from the `window.ccsmPty.clipboard.*` bridge to `navigator.clipboard.*` (the actual user-visible cutover).
- Granting `clipboard-write` (writes don't require a permission grant in Chromium when triggered by user activation; adding it would be inert and confuse a future reader about which permissions actually go through this gate).
- Broadening the allowlist beyond `app://`.