### PR TITLE
spec(ch07): drop crash_raw_offset sidecar clause, align with ch09 §2 truncate model (#281)

### DIFF
--- a/docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+++ b/docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
@@ -1999,7 +1999,7 @@ v0.3 has **no automated backup**. Recovery posture:
    - `fsync` the NDJSON file's directory.
    - **Set the daemon's `recovery_modal_pending` flag** (in-memory boolean exposed via `Supervisor /healthz` JSON `{ ..., "recovery_modal": { "pending": true, "ts_ms": <now>, "corrupt_path": "..." } }`). Electron polls `/healthz` on attach; if `recovery_modal.pending`, it shows a **blocking modal** (NOT a toast) on launch with copy: "ccsm detected database corruption at \<ts\>. Your sessions and crash history could not be recovered. The corrupted database has been preserved at \<path\> for diagnostics. A fresh database has been initialized." with an Acknowledge button that POSTs to Supervisor `/ack-recovery` to clear the flag.
 5. **Open** a fresh `state/ccsm.db` read-write; run `001_initial.sql`; record `schema_migrations.version = 1`.
-6. **Replay** any NDJSON lines from `state/crash-raw.ndjson` into the new `crash_log` table ([Chapter 09](#chapter-09--crash-collector) §3); leave the NDJSON file in place (it's append-only; the daemon tracks a `crash_raw_offset` in a sidecar `state/crash-raw.offset` file to avoid re-replaying on restart).
+6. **Replay** any NDJSON lines from `state/crash-raw.ndjson` into the new `crash_log` table ([Chapter 09](#chapter-09--crash-collector) §3); the file is truncated to 0 bytes after successful replay (see [Chapter 09](#chapter-09--crash-collector) §2 for the recovery side) so the next boot starts from an empty file and cannot re-replay already-imported entries.
 7. **Continue boot**.
 
 This ordering ensures that even if the new DB fails to open (e.g., disk full immediately after recovery), the corruption event is on disk in a human-readable text file. Step 6 is best-effort; if it fails, the NDJSON line stays unread and is retried on next successful boot.
@@ -2394,7 +2394,7 @@ For fatal sources where the daemon cannot guarantee a successful SQLite write be
 
 Session-attributable crashes that take the NDJSON path (rare — typically only `worker_exit` if SQLite is also down) carry the session's `principalKey` in `owner_id`. v0.4 may add principal-attributed sources additively without changing the line shape.
 
-On next successful daemon boot, the daemon scans `crash-raw.ndjson`, imports any entries not already in `crash_log` (by id), then truncates the file. This ensures fatal events that prevented SQLite writes still surface to the user post-recovery.
+On next successful daemon boot, the daemon scans `crash-raw.ndjson`, imports any entries not already in `crash_log` (by id), then truncates the file. This ensures fatal events that prevented SQLite writes still surface to the user post-recovery. See [Chapter 07](#chapter-07--data-and-state) §6 for the appender side (corrupt-DB recovery boot ordering that calls into this replay).
 
 #### 3. Rotation and capping
 


### PR DESCRIPTION
## Summary

Spec-only edit. Task #281 follow-up to Task #226's push-back: PR #966 shipped `installCaptureSources` / `replayCrashRawOnBoot` wire-up, and the implementation in `packages/daemon/src/crash/raw-appender.ts:303` follows ch09 §2's **truncate-after-replay** model (`truncateSync(path, 0)`). But ch07 §6 line 2002 still described an `crash_raw_offset` sidecar at `state/crash-raw.offset` — directly contradicting the shipped behavior.

This PR removes the offending clause (single concern, single sentence) and adds a bidirectional cross-ref between ch07 §6 (appender / boot ordering) and ch09 §2 (recovery / replay).

## Changes

- `docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md` line 2002 (ch07 §6 step 6): removed "tracks a `crash_raw_offset` in a sidecar `state/crash-raw.offset` file to avoid re-replaying on restart"; replaced with explicit truncate-to-0 wording and a forward link to ch09 §2.
- Same file line 2397 (ch09 §2): added back-ref "see Chapter 07 §6 for the appender side (corrupt-DB recovery boot ordering that calls into this replay)".

## Why this is forward-safe (zero rework)

- Code already implements truncate (raw-appender.ts:303). No production path reads or writes any `crash-raw.offset` file.
- Tests lock the truncate behavior in:
  - `packages/daemon/test/crash/crash-raw-recovery.spec.ts:190,303` ("File truncated to 0 bytes after successful import.")
  - `packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts:382` (`expect(st.size).toBe(0)`)
- Spec was the only artifact still describing the abandoned sidecar approach.

## Verification

`grep -n 'crash_raw_offset\|crash-raw.offset' docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md` → 0 matches (proof: ran post-edit, empty output).

`git status` post-edit shows only the one spec file modified — no code or test touches.

## Wire-up evidence

N/A — spec-only edit.

## Test plan

- [x] grep proves zero `crash_raw_offset` / `crash-raw.offset` mentions remain
- [x] `git status` confirms only the spec md modified
- [x] No code or test files touched (production code already correct per #226 / PR #966)