### PR TITLE
wave0e-1(#289): cut src/stores/persist.ts from window.ccsm.* to localStorage (e2e fix)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -89,6 +89,8 @@ export default [
         requestAnimationFrame: 'readonly',
         cancelAnimationFrame: 'readonly',
         ResizeObserver: 'readonly',
+        localStorage: 'readonly',
+        sessionStorage: 'readonly',
         // Web platform globals available in Node 22+ (used by daemon
         // RPC code, e.g. T1.3 auth interceptor) and the Electron main
         // process. Browser code already has these via the DOM lib.

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -1,9 +1,8 @@
+// v0.3 transitional: localStorage direct (Wave 0e-1, #289). When SettingsService
+// RPC ships (audit #228 sub-task 9), this module re-cuts to daemon RPC. See
+// docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md.
 import type { Group, Session } from '../types';
-import type {
-  Theme,
-  FontSize,
-  FontSizePx,
-} from './slices/types';
+import type { Theme, FontSize, FontSizePx } from './slices/types';
 
 export const STATE_KEY = 'main';
 
@@ -58,9 +57,9 @@ export interface PersistedState {
 }
 
 export async function loadPersisted(): Promise<PersistedState | null> {
-  if (!window.ccsm) return null;
+  if (typeof localStorage === 'undefined') return null;
   try {
-    const raw = await window.ccsm.loadState(STATE_KEY);
+    const raw = localStorage.getItem(STATE_KEY);
     if (!raw) return null;
     const parsed = JSON.parse(raw) as PersistedState;
     if (parsed.version !== 1) return null;
@@ -83,38 +82,38 @@ export function setPersistErrorHandler(handler: (err: unknown) => void): void {
   onPersistError = handler;
 }
 
+function commitSnapshot(snap: PersistedState): void {
+  try {
+    localStorage.setItem(STATE_KEY, JSON.stringify(snap));
+  } catch (err) {
+    if (onPersistError) onPersistError(err);
+  }
+}
+
 export function schedulePersist(state: PersistedState): void {
-  if (!window.ccsm) return;
+  if (typeof localStorage === 'undefined') return;
   pendingSnapshot = state;
   if (writeTimer) clearTimeout(writeTimer);
   writeTimer = setTimeout(() => {
     writeTimer = null;
     const snap = pendingSnapshot;
     pendingSnapshot = null;
-    if (!snap) return;
-    window.ccsm!.saveState(STATE_KEY, JSON.stringify(snap)).catch((err) => {
-      if (onPersistError) onPersistError(err);
-    });
+    if (snap) commitSnapshot(snap);
   }, WRITE_DEBOUNCE_MS);
 }
 
 /**
  * Synchronously dispatch any pending debounced write. Call from `beforeunload`
- * (renderer) so a quick quit doesn't lose the last 250 ms of changes. The
- * actual saveState IPC is fire-and-forget — Electron lets the in-flight IPC
- * complete during teardown, but we don't await it here because beforeunload
- * handlers can't reliably hold the page open across async work.
+ * (renderer) so a quick quit doesn't lose the last 250 ms of changes.
+ * localStorage.setItem is synchronous so the write completes before unload.
  */
 export function flushNow(): void {
-  if (!window.ccsm) return;
+  if (typeof localStorage === 'undefined') return;
   if (writeTimer) {
     clearTimeout(writeTimer);
     writeTimer = null;
   }
   const snap = pendingSnapshot;
   pendingSnapshot = null;
-  if (!snap) return;
-  window.ccsm.saveState(STATE_KEY, JSON.stringify(snap)).catch((err) => {
-    if (onPersistError) onPersistError(err);
-  });
+  if (snap) commitSnapshot(snap);
 }

--- a/tests/persist-shape.test.ts
+++ b/tests/persist-shape.test.ts
@@ -11,9 +11,16 @@ import { schedulePersist, type PersistedState } from '../src/stores/persist';
 
 describe('persist: curated snapshot payload', () => {
   it('only includes the curated subset of state when serialized', () => {
-    const saveState = vi.fn().mockResolvedValue(undefined);
-    (globalThis as unknown as { window?: unknown }).window = {
-      ccsm: { saveState }
+    // v0.3 transitional: persist.ts writes to localStorage directly
+    // (Wave 0e-1, #289) until SettingsService RPC ships.
+    const setItem = vi.fn();
+    (globalThis as unknown as { localStorage?: unknown }).localStorage = {
+      setItem,
+      getItem: () => null,
+      removeItem: () => {},
+      clear: () => {},
+      key: () => null,
+      length: 0,
     };
     vi.useFakeTimers();
     try {
@@ -29,8 +36,8 @@ describe('persist: curated snapshot payload', () => {
       };
       schedulePersist(snap);
       vi.advanceTimersByTime(500);
-      expect(saveState).toHaveBeenCalledTimes(1);
-      const [, payload] = saveState.mock.calls[0] as [string, string];
+      expect(setItem).toHaveBeenCalledTimes(1);
+      const [, payload] = setItem.mock.calls[0] as [string, string];
       const parsed = JSON.parse(payload);
       // Allowed top-level keys — exhaustive list. New persisted fields should
       // be added here AND to PersistedState; high-churn runtime state must


### PR DESCRIPTION
## Wave 0e-1 — first slice of renderer cutover

Wave 0b (PR #948) deleted `window.ccsm.loadState/saveState` from preload but the renderer cutover (Wave 0e) was [DEFERRED]. Result: every PR's e2e harness-ui run has been failing because the renderer keeps calling phantom IPCs. User overruled the deferral tonight — e2e must be fixed, not muted (PR #975 closed).

This PR is the **first slice**: persist.ts only. Sibling tasks for drafts.ts, xtermSingleton, usePtyAttach, UpdatesPane, sessionCrudSlice, AppearancePane, NotificationsPane are tracked separately and will land as their own PRs.

## Why localStorage and not daemon RPC

Per the rpc-stub-gap audit (`docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md`, #228 sub-task 9), SettingsService is a stub. v0.3 transitional posture: localStorage now, daemon RPC when SettingsService is real. A comment block at the top of `persist.ts` documents the cutover plan.

## Wire-up evidence (#218 PR template)

**Before** (broken since Wave 0b PR #948):
- `loadPersisted()` calls `window.ccsm.loadState(STATE_KEY)` — undefined → throws → returns null → app boots empty every time.
- `schedulePersist()` / `flushNow()` call `window.ccsm.saveState(...)` — undefined → unhandled rejection / silent persist loss.
- harness-ui `startup-paints-before-hydrate` reports `loadStateWrapped: false` (the harness's `originalLoad = ccsm.loadState` returns undefined, so its 800ms wrap is skipped).

**After** (this PR):
- `loadPersisted()` reads `localStorage.getItem(STATE_KEY)`, parses JSON, returns the curated `PersistedState`. Function still `async` so callers (`store.ts:hydrateStore`) are untouched.
- `schedulePersist()` / `flushNow()` write `localStorage.setItem(STATE_KEY, JSON.stringify(snap))`. `flushNow()` is now genuinely synchronous (sync setItem) — the old IPC race window where beforeunload couldn't await the IPC is gone.
- `setPersistErrorHandler` still fires on setItem throws (quota exceeded, private mode).

**Reverse-verify**: comment out the `localStorage.setItem` call in `commitSnapshot` → `tests/persist-shape.test.ts > only includes the curated subset of state when serialized` fails (`expected setItem to be called 1 times, but got 0`). Same logic flips the harness-ui case red on a real Electron run.

## Scope (kept tight)

- Touched: `src/stores/persist.ts` (6 hits of window.ccsm.* → 0), `tests/persist-shape.test.ts` (stub swapped from `window.ccsm.saveState` to `localStorage.setItem`; assertions on the curated payload shape unchanged).
- NOT touched: any other src/, electron/, packages/electron/*, harness-ui/* assertions, daemon RPC handlers.

## Expected e2e impact

- `startup-paints-before-hydrate` should flip green: persist no longer throws on the missing IPC, hydrate resolves, and `__ccsmHydrationTrace.hydrateDoneAt` populates correctly. Note: the harness's `loadState` wrap (800ms delay so the skeleton is observable) is now a no-op, but the case's primary assertion is `renderedAt <= hydrateStartedAt`, which the synchronous render path in `index.tsx` already satisfies.
- `theme-toggle` likely flips green too (theme is in PERSISTED_KEYS, so settings now actually round-trip).
- Other harness-ui failures (drafts, xterm, ttyd, settings panes) will need their sibling Wave 0e PRs to flip.

## Local checks

- `pnpm lint` — green (only pre-existing daemon `eslint-disable` warnings, cached from another worktree).
- `pnpm typecheck` — green.
- `pnpm vitest run tests/persist-shape.test.ts tests/app-effects/usePersistErrorBridge.test.tsx` — all green.
- `bash tools/check-v02-shrinking.sh` — `src/stores/persist.ts (base=120, head=119, -1)` PASS.
- `pnpm vitest run` (full) — only `electron-load-smoke.test.ts` fails (13/13 cases, expected: requires `dist/electron/*` from a build step, baseline-identical on `origin/working`).
- e2e harness-ui not runnable on Windows host (xvfb-required); relying on CI to confirm the case flips green.

## Forward-safe / wave-locked

Forward-safe — single file, browser-native, no daemon dependency, no shared state with sibling Wave 0e tasks. Sibling tasks can run in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)