### PR TITLE
wave3(#290): wire WatchSessions handler in production daemon startup (audit #228 sub-task 1)

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -54,6 +54,7 @@ import { writeDescriptor, type DescriptorV1 } from './listeners/descriptor.js';
 import type { Listener } from './listeners/types.js';
 import { LISTENER_A_HELLO_ID } from './rpc/hello.js';
 import { makeRouterBindHook } from './rpc/bind.js';
+import { SessionManager } from './sessions/SessionManager.js';
 import { statePaths } from './state-dir/paths.js';
 import {
   Shutdown,
@@ -304,9 +305,23 @@ export async function runStartup(
       protoVersion: PROTO_VERSION,
       listenerId: LISTENER_A_HELLO_ID,
     };
+    // Wave-3 #290 — wire SessionService.WatchSessions handler in
+    // production. `makeWatchSessionsHandler` (T3.3 / PR #939) is fully
+    // implemented but was never bound at boot, so the wire returned
+    // `Code.Unimplemented` despite the handler shipping. Construct the
+    // SessionManager off the same `db` handle the rest of startup uses
+    // (single owner of the sessions table; the T6.x pty-host bridge
+    // will reuse this same instance when it lands) and pass the deps
+    // through `makeRouterBindHook`. The bind hook in `rpc/router.ts`
+    // installs the combined Hello + WatchSessions registration on
+    // SessionService when both deps are present (see
+    // `registerSessionService` "twice replaces" caveat).
+    const sessionManager = new SessionManager(db);
+    const watchSessionsDeps = { manager: sessionManager };
     listenerA = makeListenerA(env, {
       bindHook: makeRouterBindHook({
         helloDeps,
+        watchSessionsDeps,
         // Order matters: bearer→PeerInfo deposit MUST run before
         // peerCredAuthInterceptor (which reads PEER_INFO_KEY and
         // derives Principal). `requestMetaInterceptor` is prepended by

--- a/packages/daemon/test/integration/watch-sessions-wired.spec.ts
+++ b/packages/daemon/test/integration/watch-sessions-wired.spec.ts
@@ -1,0 +1,226 @@
+// packages/daemon/test/integration/watch-sessions-wired.spec.ts
+//
+// Wave-3 Task #290 — production daemon-startup wire-up regression for
+// SessionService.WatchSessions.
+//
+// Audit reference: docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md
+// (sub-task #1, branch research/228-rpc-stub-audit fbb0d60).
+//
+// Background:
+//   - `makeWatchSessionsHandler` (T3.3 / PR #939) is fully implemented and
+//     unit-tested at `packages/daemon/test/sessions/watch-sessions.spec.ts`.
+//   - Until #290, `packages/daemon/src/index.ts` constructed
+//     `makeRouterBindHook({ helloDeps })` WITHOUT a `watchSessionsDeps`
+//     argument, so `rpc/router.ts:makeDaemonRoutes` fell to its
+//     Hello-only branch and SessionService.WatchSessions resolved to the
+//     T2.2 `Unimplemented` stub at boot — the exact "library shipped but
+//     never wired" regression class Wave 0/1 + Task #221 exist to catch.
+//   - This spec boots the production `runStartup` (no mocks, no harness
+//     bypass) and asserts the over-the-wire response to a
+//     `WatchSessions(OWN)` call is NOT `Code.Unimplemented`. Reverse
+//     verification: deleting the `watchSessionsDeps` line from
+//     `index.ts` flips this spec to expect-Unimplemented and it fails.
+//
+// Why a separate spec from `daemon-boot-end-to-end.spec.ts`:
+//   - The audit lists WatchSessions as one of FOUR independent stubs that
+//     each need their own wire-up + regression test (CrashService,
+//     PtyService, SettingsService, WatchSessions). One spec per gap keeps
+//     each PR single-concern; later sub-tasks add sibling specs of the
+//     same shape. The boot-end-to-end spec stays the cross-cutting
+//     "every component wired" assertion via `result.wired`.
+//
+// Transport choice:
+//   - Identical to daemon-boot-end-to-end.spec.ts:
+//     `CCSM_LISTENER_A_FORCE_LOOPBACK=1` keeps Listener A on the
+//     cross-OS h2c loopback transport so this spec runs on every CI leg
+//     without UDS / named-pipe gating.
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type Client,
+  createClient,
+} from '@connectrpc/connect';
+import { createConnectTransport } from '@connectrpc/connect-node';
+
+import {
+  RequestMetaSchema,
+  SessionService,
+  WatchScope,
+  WatchSessionsRequestSchema,
+} from '@ccsm/proto';
+
+import { runStartup, type RunStartupResult } from '../../src/index.js';
+import { Lifecycle } from '../../src/lifecycle.js';
+import { TEST_BEARER_TOKEN } from '../../src/auth/index.js';
+
+interface BootEnv {
+  readonly tmpRoot: string;
+  readonly origEnv: NodeJS.ProcessEnv;
+}
+
+async function setupBootEnv(): Promise<BootEnv> {
+  const origEnv = { ...process.env };
+  const tmpRoot = await mkdtemp(join(tmpdir(), 'ccsm-watch-sessions-wired-'));
+  process.env.CCSM_STATE_DIR = tmpRoot;
+  process.env.CCSM_DESCRIPTOR_PATH = join(tmpRoot, 'listener-a.json');
+  process.env.CCSM_LISTENER_A_ADDR = join(tmpRoot, 'daemon.sock');
+  process.env.CCSM_LISTENER_A_FORCE_LOOPBACK = '1';
+  if (process.platform === 'win32') {
+    process.env.PROGRAMDATA = tmpRoot;
+  }
+  process.env.CCSM_SUPERVISOR_ADDR =
+    process.platform === 'win32'
+      ? `\\\\.\\pipe\\ccsm-watch-sessions-wired-${process.pid}-${Date.now()}`
+      : join(tmpRoot, 'supervisor.sock');
+  process.env.CCSM_VERSION = '0.3.0-watch-sessions-wired-test';
+  return { tmpRoot, origEnv };
+}
+
+async function teardownBootEnv(setup: BootEnv): Promise<void> {
+  for (const k of Object.keys(process.env)) {
+    if (!(k in setup.origEnv)) delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(setup.origEnv)) {
+    process.env[k] = v;
+  }
+  await rm(setup.tmpRoot, { recursive: true, force: true }).catch(() => {
+    /* tmp cleanup best-effort */
+  });
+}
+
+async function stopBoot(result: RunStartupResult | null): Promise<void> {
+  if (result === null) return;
+  result.captureSourcesUnsubscribe?.();
+  await result.supervisor?.stop().catch(() => {});
+  await result.listenerA?.stop().catch(() => {});
+  result.crashPruner.stop();
+  try {
+    result.db.close();
+  } catch {
+    /* idempotent */
+  }
+}
+
+function makeSessionClient(baseUrl: string): Client<typeof SessionService> {
+  const transport = createConnectTransport({
+    httpVersion: '2',
+    baseUrl,
+    interceptors: [
+      (next) => async (req) => {
+        req.header.set('authorization', `Bearer ${TEST_BEARER_TOKEN}`);
+        return next(req);
+      },
+    ],
+  });
+  return createClient(SessionService, transport);
+}
+
+function newWatchRequest(scope: WatchScope) {
+  return create(WatchSessionsRequestSchema, {
+    meta: create(RequestMetaSchema, {
+      requestId: `wired-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      clientVersion: '0.3.0-watch-sessions-wired-test',
+      clientSendUnixMs: BigInt(Date.now()),
+    }),
+    scope,
+  });
+}
+
+describe('SessionService.WatchSessions production wire-up (Task #290)', () => {
+  let setup: BootEnv;
+  let lifecycle: Lifecycle;
+  let result: RunStartupResult | null = null;
+
+  beforeEach(async () => {
+    setup = await setupBootEnv();
+    lifecycle = new Lifecycle();
+    result = await runStartup(lifecycle);
+  });
+
+  afterEach(async () => {
+    await stopBoot(result);
+    result = null;
+    await teardownBootEnv(setup);
+  });
+
+  it('WatchSessions(OWN) over the production Listener A does NOT return Code.Unimplemented', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    expect(r.listenerA).not.toBeNull();
+    const desc = r.listenerA!.descriptor();
+    expect(desc.kind).toBe('KIND_TCP_LOOPBACK_H2C');
+    if (desc.kind !== 'KIND_TCP_LOOPBACK_H2C') return;
+    const baseUrl = `http://127.0.0.1:${desc.port}`;
+
+    // AbortController scopes the lifetime of the streaming call. After
+    // we have observed enough to make the wire-up assertion (either a
+    // terminal Unimplemented error or a "stream stayed open past the
+    // timeout"), we abort so the http2 stream tears down promptly and
+    // afterEach's `listenerA.stop()` does not race a still-open client.
+    const ac = new AbortController();
+    const client = makeSessionClient(baseUrl);
+    const stream = client.watchSessions(newWatchRequest(WatchScope.OWN), {
+      signal: ac.signal,
+    });
+
+    // The handler is server-streaming with no events queued — when
+    // wired, the iterator stays open waiting for the first event from
+    // the bus. When NOT wired (the pre-#290 regression), the Connect
+    // router responds immediately with Code.Unimplemented and the
+    // iterator throws on the first `next()`. Race the iterator's first
+    // tick against a short timeout: timeout-wins == handler wired,
+    // throw-wins == we caught Unimplemented.
+    const iterator = stream[Symbol.asyncIterator]();
+    const firstEvent = iterator.next();
+    const timeout = new Promise<{ kind: 'timeout' }>((resolve) =>
+      setTimeout(() => resolve({ kind: 'timeout' }), 250),
+    );
+
+    let raised: ConnectError | null = null;
+    let timedOut = false;
+    try {
+      const winner = await Promise.race([
+        firstEvent.then(() => ({ kind: 'event' as const })),
+        timeout,
+      ]);
+      timedOut = winner.kind === 'timeout';
+    } catch (err) {
+      raised = ConnectError.from(err);
+    } finally {
+      // Tear the streaming call down deterministically: abort the
+      // signal (cancels the underlying http2 stream) AND drain the
+      // iterator's `return` (closes the JS-side generator). Either alone
+      // can race teardown on Windows named-pipe / loopback transports.
+      ac.abort();
+      await iterator.return?.(undefined).catch(() => {});
+      // Swallow the cancellation that the still-pending firstEvent
+      // promise will throw once abort propagates — we already have our
+      // verdict from the race above.
+      await firstEvent.catch(() => {});
+    }
+
+    if (raised !== null) {
+      // The ONLY acceptable terminal error from this call is something
+      // OTHER than Unimplemented. The pre-#290 regression manifests
+      // exactly as Code.Unimplemented; a different code (e.g. Canceled
+      // from teardown) is fine for the wire-up assertion.
+      expect(
+        raised.code,
+        `WatchSessions returned Unimplemented — production wire-up regressed (audit #228 sub-task 1, message: ${raised.message})`,
+      ).not.toBe(Code.Unimplemented);
+    } else {
+      // Stream stayed open until our timeout — proves the handler is
+      // installed AND subscribed to the bus (an Unimplemented stub
+      // would have terminated the stream within the first event-loop
+      // turn, well before 250ms).
+      expect(timedOut).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Direct fix for the first sub-task of the [RPC stub gap audit (#228)](https://github.com/Jiahui-Gu/ccsm/blob/research/228-rpc-stub-audit/docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md) (branch `research/228-rpc-stub-audit` @ `fbb0d60`).

The T3.3 `makeWatchSessionsHandler` factory at `packages/daemon/src/sessions/watch-sessions.ts:431` was fully implemented and unit-tested in PR #939 (Task #34), but production startup (`packages/daemon/src/index.ts:308`) only ever passed `helloDeps` to `makeRouterBindHook`. With no `watchSessionsDeps`, `rpc/router.ts:makeDaemonRoutes` fell to its Hello-only branch and `SessionService.WatchSessions` resolved to the T2.2 `Unimplemented` stub on the wire — the exact "library shipped but never wired" regression class Wave 0/1 + Task #221 exist to catch.

## Wire-up evidence

- **Before:** `packages/daemon/src/index.ts:308` — `makeRouterBindHook({ helloDeps })`. `WatchSessions` returns `Code.Unimplemented` over Listener A.
- **After:** `packages/daemon/src/index.ts:308` — `makeRouterBindHook({ helloDeps, watchSessionsDeps })`, where `watchSessionsDeps = { manager: new SessionManager(db) }` is constructed off the same `db` handle the rest of startup uses (single owner; the T6.x pty-host bridge will reuse this instance).
- **Reverse-verify:** Commented out the new `watchSessionsDeps` line in `index.ts` and re-ran the new spec — it failed with:
  ```
  [unimplemented] ccsm.v1.SessionService.WatchSessions is not implemented
  expected 12 not to be 12 // Code.Unimplemented
  ```
  Restored before commit.

## Changes (single concern, additive only)

1. `packages/daemon/src/index.ts`:
   - Import `SessionManager` from `./sessions/SessionManager.js`.
   - Construct `sessionManager = new SessionManager(db)` and `watchSessionsDeps = { manager: sessionManager }` inside the `STARTING_LISTENERS` phase, AFTER `db` is opened and BEFORE `makeListenerA`.
   - Pass `watchSessionsDeps` to `makeRouterBindHook` alongside the existing `helloDeps`.
2. `packages/daemon/test/integration/watch-sessions-wired.spec.ts` (new, 1 spec):
   - Boots the production `runStartup` (no harness; real composition).
   - Opens a `WatchSessions(OWN)` stream over Listener A's loopback transport.
   - Asserts the response is NOT `Code.Unimplemented` (server-streaming with no events queued races the iterator's first tick against a 250ms timeout — timeout-wins == handler wired, throw-wins == we caught Unimplemented).
   - Uses `AbortController` to tear down the streaming call deterministically before `afterEach` calls `listenerA.stop()`.

## Out of scope (separate audit sub-tasks)

- CrashService stub
- PtyService stub
- SettingsService stub
- `watch-sessions.ts` handler implementation (already shipped in PR #939)
- `REQUIRED_COMPONENTS` (additive wire-up only — no boot-lock changes)
- electron/, src/, packages/proto/, packages/electron/

## Test plan

- [x] `pnpm -F @ccsm/daemon exec vitest run test/integration/watch-sessions-wired.spec.ts` — 1/1 passes locally
- [x] `pnpm -F @ccsm/daemon exec vitest run test/integration/daemon-boot-end-to-end.spec.ts` — 7/7 still pass (no regression to existing boot e2e)
- [x] `pnpm -F @ccsm/daemon lint` — 0 errors
- [x] `pnpm -F @ccsm/daemon typecheck` — clean
- [x] `pnpm lint:no-ipc` — pass
- [x] Reverse-verify: removing the wire-up flips the new spec to fail with the exact `Unimplemented` error from the regression
- [ ] All 5 required CI checks GREEN (e2e job will likely STILL be red on harness-ui — those failures are renderer-side, this PR is daemon-side, expected)

## Forward-safe

Yes — additive wire-up of an already-shipped handler. No existing call site changes shape; no existing test regresses.

References:
- Closes Task #290
- Audit Task #228 sub-task 1
- Implements wire-up that should have shipped with #34 / PR #939

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>