### PR TITLE
ci(#291): pick up tools/test/*.spec.ts in CI test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,23 @@ jobs:
       - name: Test
         run: npm run test:app
 
+      # Task #291 — pick up tools/**/*.spec.ts. The root vitest config
+      # restricts `include` to `tests/**` + `electron/**/__tests__/**`,
+      # so specs under tools/ (e.g. tools/test/check-v02-shrinking.spec.ts
+      # added by Task #279, tools/test/installer-roundtrip-allowlist.spec.ts
+      # added by Task T8.6, tools/spike-harness/snapshot-roundtrip.spec.ts
+      # pinned by ch14 §1.B) were never executed in CI. They live outside
+      # the root include on purpose (pure-node, no jsdom, no setup file)
+      # and ship their own minimal config at tools/vitest.config.ts.
+      # Wire-up extends the existing required `lint + typecheck + test`
+      # job rather than adding a new required check (branch protection
+      # is frozen). Linux-only because the assertions are git/fs/process
+      # behaviour with no platform-specific paths — running on the matrix
+      # would triple wall-clock with no signal gain.
+      - name: Test (tools/**/*.spec.ts)
+        if: matrix.os == 'ubuntu-latest'
+        run: npx vitest run --config tools/vitest.config.ts
+
       # Tech-debt R6 (Task #802) — coverage roll-out. Run only on Linux to
       # keep the matrix lean (coverage instrumentation roughly doubles
       # wall-clock; one OS is enough for the lcov artifact). Threshold

--- a/tools/vitest.config.ts
+++ b/tools/vitest.config.ts
@@ -27,5 +27,12 @@ export default defineConfig({
     // Keep this file FOREVER-MINIMAL. Tools specs must not need globals,
     // setup files, or coverage instrumentation.
     globals: false,
+    // Tools specs spawn many `git` invocations against tmp-dir fixtures
+    // (e.g. tools/test/check-v02-shrinking.spec.ts builds 4-6-commit
+    // branch histories per case). On Windows runners each `git` shell
+    // out costs 100-300ms; the default 5s testTimeout flakes the
+    // step-wise cases. 30s leaves comfortable headroom on every OS in
+    // the CI matrix while staying well under the 10-minute job cap.
+    testTimeout: 30000,
   },
 });


### PR DESCRIPTION
## Why

Coverage gap surfaced by Task #286 fix worker: `tools/test/check-v02-shrinking.spec.ts` (added by #279/PR #974, merged 0eae74e) is **never executed in CI**. The root `vitest.config.ts` restricts `include` to `tests/**` and `electron/**/__tests__/**`, so any spec under `tools/` falls outside the glob.

Audit found **3 orphan specs** total under `tools/`:

- `tools/test/check-v02-shrinking.spec.ts` (PR #974, Task #279)
- `tools/test/installer-roundtrip-allowlist.spec.ts` (PR #902, Task T8.6)
- `tools/spike-harness/snapshot-roundtrip.spec.ts` (PR #851, Task T9.15 / spec ch14 §1.B forever-stable contract)

## What

Two-line change. Branch protection on `working` is frozen — cannot add a new required check — so the wire-up extends the existing required `lint + typecheck + test` job rather than introducing a new job.

1. `.github/workflows/ci.yml` — new `Test (tools/**/*.spec.ts)` step (Linux-only) immediately after the existing `Test` step. Reuses the pre-existing `tools/vitest.config.ts` (added in PR #851), which already has `include: ['tools/**/*.spec.ts']`.
2. `tools/vitest.config.ts` — bump `testTimeout` from the 5s default to 30s. Step-wise cases in `check-v02-shrinking.spec.ts` build 4-6-commit git fixtures per case; on Windows-class git, 5s is not enough headroom even though Linux is fine.

Linux-only because the orphan tests are pure platform-deterministic (git/fs/process); running on the matrix would triple wall-clock with no signal gain. Same precedent as the existing `Check v0.2-only files don't grow` and `Coverage` steps in this job.

## Wire-up evidence

ci.yml diff:

- New step at `.github/workflows/ci.yml:158-174`, runs `npx vitest run --config tools/vitest.config.ts`
- Falls inside the `lint + typecheck + test` job which is on the required-checks list (frozen branch protection)

Specs that will now be exercised by CI:

- `tools/test/check-v02-shrinking.spec.ts` — 16 tests, exercises `tools/check-v02-shrinking.sh` against tmp-dir git fixtures
- `tools/test/installer-roundtrip-allowlist.spec.ts` — 11 tests, exercises forever-stable allowlist contract for ship-gate (d)
- `tools/spike-harness/snapshot-roundtrip.spec.ts` — 2 tests under `describe.skip` (TODO until T4.6 SnapshotV1 codec lands; see file header). Wiring it in now means the day T4.6 flips `describe.skip` to `describe`, the suite turns red automatically without further CI work. **Pre-existing** describe.skip — not introduced by this PR.

## Reverse-verify

Pushed throwaway branch `reverse-verify/291-tools-test-ci` (PR #978, now closed) with one extra commit injecting `expect('reverse-verify-sentinel').toBe('this-must-fail')` into `check-v02-shrinking.spec.ts`. Result on PR #978:

```
ubuntu-latest job step status (gh api .../jobs/74134617464):
  ✓ Test
  ✗ Test (tools/**/*.spec.ts)   ← deliberate sentinel caught here
  - Coverage (skipped)
```

All other steps (Lint, Typecheck, Build, root Test) passed; only the new step failed. Confirms the wire-up actually catches failures in tools/ orphan specs (not just no-op-passing because the glob still missed them). Branch + PR both deleted before this PR was opened.

## Local checks

- lint: ✓ (exit 0, FULL TURBO cache hit)
- typecheck: ✓ (exit 0, `tsc --noEmit && tsc --noEmit -p tsconfig.electron.json`)
- build: ✓ (n/a — no .ts/.tsx source touched; only ci.yml + tools/vitest.config.ts)
- unit tests: `npx vitest run --config tools/vitest.config.ts` →
  ```
   Test Files  4 passed | 1 skipped (5)
        Tests  27 passed | 2 skipped (29)
     Duration  38.10s
  ```
  (1 skipped file = pre-existing `snapshot-roundtrip.spec.ts` describe.skip; 2 skipped tests = the same.)
- e2e: n/a (CI workflow change, no electron / src code touched)

## Hot-file note

`ci.yml` was last touched by #279 (PR #974, merged `0eae74e`). One in-flight DRAFT PR also touches it — #906 `ci(T0.8): install + proto-gen-and-lint + test matrix` on `dev/t0.8-ci-matrix` — but it's still in DRAFT. No conflict expected at merge time; if #906 lands first, this PR will need a trivial rebase to add the new step alongside theirs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>