### PR TITLE
wave0e: #300 AppearancePane localStorage cutover

### DIFF
--- a/src/components/settings/AppearancePane.tsx
+++ b/src/components/settings/AppearancePane.tsx
@@ -66,13 +66,49 @@ export function AppearancePane() {
   );
 }
 
-// Close-button behaviour preference. Persisted via the existing `db:save` /
-// `db:load` IPC under the `closeAction` app_state key — main reads the same
-// key on every win.on('close') so the choice takes effect without a restart.
-// Default is platform-derived inside main (win/linux=ask, mac=tray); the
-// renderer mirrors that fallback so the segmented control reflects the
-// current effective value before the user ever picks a row.
+// Close-button behaviour preference. v0.3 transitional: persisted to
+// localStorage directly (Wave 0e, Task #300), mirroring the cutover applied
+// to src/stores/persist.ts in PR #976 (#289). The SettingsService RPC that
+// will own this key in v0.4 is still a stub (rpc-stub-gap audit #228
+// sub-task 9), so we stage on localStorage in the meantime. When
+// SettingsService ships, this re-cuts to daemon RPC.
+//
+// Wave 0b (PR #948) deleted the renderer load/save IPC pair this used to call.
+//
+// Note: the main process previously read the same `closeAction` app_state key
+// on every win.on('close'). Until SettingsService is wired the renderer is the
+// sole writer; main falls back to its platform default at startup.
+//
+// Default is platform-derived (win/linux=ask, mac=tray); the renderer mirrors
+// that fallback so the segmented control reflects the current effective value
+// before the user ever picks a row.
 type CloseBehavior = 'ask' | 'tray' | 'quit';
+
+const CLOSE_ACTION_KEY = 'closeAction';
+
+function loadCloseAction(): CloseBehavior | null {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(CLOSE_ACTION_KEY);
+    if (raw === 'ask' || raw === 'tray' || raw === 'quit') return raw;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function commitCloseAction(value: CloseBehavior, onError?: (err: unknown) => void): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(CLOSE_ACTION_KEY, value);
+  } catch (err) {
+    // Quota / disabled-storage path — mirror persist.ts's onPersistError seam
+    // so a full disk doesn't silently drop the user's choice.
+    if (onError) onError(err);
+    else console.error('[closeAction] saveState failed:', err);
+  }
+}
+
 function CloseBehaviorField() {
   const { t } = useTranslation('settings');
   const platformDefault: CloseBehavior =
@@ -81,24 +117,14 @@ function CloseBehaviorField() {
   const [hydrated, setHydrated] = useState(false);
 
   useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const raw = await window.ccsm?.loadState('closeAction');
-        if (cancelled) return;
-        if (raw === 'ask' || raw === 'tray' || raw === 'quit') setValue(raw);
-      } finally {
-        if (!cancelled) setHydrated(true);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
+    const raw = loadCloseAction();
+    if (raw) setValue(raw);
+    setHydrated(true);
   }, []);
 
   const onChange = (next: CloseBehavior) => {
     setValue(next);
-    void window.ccsm?.saveState('closeAction', next);
+    commitCloseAction(next);
   };
 
   return (


### PR DESCRIPTION
## Task #300 — Wave 0e AppearancePane.tsx cutover

`src/components/settings/AppearancePane.tsx:87,101` was calling the deleted
`window.ccsm.loadState/saveState` pair (Wave 0b PR #948 deleted them).
Cut to `localStorage` directly, mirroring the pattern from PR #976 (#289)
on `src/stores/persist.ts`.

### Changes
- `loadCloseAction()` — `localStorage.getItem('closeAction')` with shape guard
- `commitCloseAction()` — `localStorage.setItem` wrapped in try/catch with an
  `onError` seam preserving persist.ts's `onPersistError` quota-path
  behaviour (default: `console.error('[closeAction] saveState failed:', err)`)
- `useEffect` simplified: localStorage is synchronous, no async / cancellation
- Top-of-section comment block documents the v0.3 transitional posture and
  the main-process caveat (until SettingsService RPC ships, the renderer is
  the sole writer; main falls back to its platform default at startup)

### Acceptance
- [x] 0 hits of `window\.ccsm\.(loadState|saveState)` in `AppearancePane.tsx`
- [x] `tools/check-v02-shrinking.sh` PASS (16 checked, 0 grew)

### Local checks
- lint: ✓ (exit 0)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0; webpack + tsc -p tsconfig.electron.json + turbo packages all green)
- unit tests: 15 daemon test files / 93 tests fail. **Pre-existing on `origin/working`**
  (verified via `git stash` baseline run — same 15/93 failure profile). Not introduced
  by this PR; the renderer-only diff doesn't touch any daemon code path.
- e2e: skipped — Wave 0e systemic e2e fail is exactly what these cutovers
  (#297-300 sibling tasks) are meant to clear; running it pre-merge would
  re-test the regression we're fixing piece-by-piece. Will validate after
  all 4 sibling cutovers land.

### Sibling files surfaced
Same `window.ccsm.{loadState,saveState}` pattern still present in:
- `src/stores/drafts.ts:28,84`
- `src/components/settings/UpdatesPane.tsx:134,150`
- `src/components/settings/NotificationsPane.tsx:21,37`

These are the other 3 Wave 0e sibling cutovers (Tasks #297-299).