### PR TITLE
wave0e: #299 drafts.ts localStorage cutover

### DIFF
--- a/src/stores/drafts.ts
+++ b/src/stores/drafts.ts
@@ -1,9 +1,9 @@
 // Per-session composer drafts persisted across app restarts.
-//
-// Drafts live in the same `app_state` table as the main store snapshot but
-// under their own key (`drafts`) so they evolve independently and don't bloat
-// the main snapshot's debounced write path. Stored shape is just a flat
-// Record<sessionId, string>.
+// v0.3 transitional: localStorage direct (Wave 0e, #299), mirroring
+// persist.ts (#289). Drafts live under their own localStorage key
+// (`drafts`) so they evolve independently and don't bloat the main
+// snapshot's debounced write path. Stored shape is a flat
+// Record<sessionId, string>. Re-cuts to RPC when SettingsService ships (#228).
 //
 // Lifecycle:
 //   - hydrateDrafts() on app boot, before the InputBar mounts.
@@ -23,9 +23,9 @@ let writeTimer: ReturnType<typeof setTimeout> | null = null;
 export async function hydrateDrafts(): Promise<void> {
   if (hydrated) return;
   hydrated = true;
-  if (!window.ccsm) return;
+  if (typeof localStorage === 'undefined') return;
   try {
-    const raw = await window.ccsm.loadState(STATE_KEY);
+    const raw = localStorage.getItem(STATE_KEY);
     if (!raw) return;
     const parsed = JSON.parse(raw) as { version: 1; drafts: Record<string, string> };
     if (parsed.version !== 1 || !parsed.drafts) return;
@@ -75,17 +75,17 @@ export function deleteDrafts(sessionIds: string[]): void {
 }
 
 function schedulePersist(): void {
-  if (!window.ccsm) return;
+  if (typeof localStorage === 'undefined') return;
   if (writeTimer) clearTimeout(writeTimer);
   writeTimer = setTimeout(() => {
     writeTimer = null;
     const drafts: Record<string, string> = {};
     for (const [k, v] of cache.entries()) drafts[k] = v;
-    void window.ccsm!.saveState(STATE_KEY, JSON.stringify({ version: 1, drafts })).catch(
-      () => {
-        /* persist failures are non-fatal; we'll retry on the next edit */
-      }
-    );
+    try {
+      localStorage.setItem(STATE_KEY, JSON.stringify({ version: 1, drafts }));
+    } catch {
+      /* persist failures are non-fatal; we'll retry on the next edit */
+    }
   }, WRITE_DEBOUNCE_MS);
 }
 

--- a/tests/drafts.test.ts
+++ b/tests/drafts.test.ts
@@ -8,18 +8,25 @@ import {
   _resetForTests,
 } from '../src/stores/drafts';
 
-// Minimal fake of the IPC surface the drafts module touches: just
-// loadState/saveState scoped to a single in-memory blob.
-function installCCSM(initial?: string) {
+// v0.3 transitional: drafts.ts writes to localStorage directly
+// (Wave 0e, #299) until SettingsService RPC ships. Mirror persist-shape
+// test pattern from #289.
+function installLocalStorage(initial?: string) {
   const store = new Map<string, string>();
   if (initial) store.set('drafts', initial);
-  const loadState = vi.fn(async (k: string) => store.get(k) ?? null);
-  const saveState = vi.fn(async (k: string, v: string) => {
+  const getItem = vi.fn((k: string) => store.get(k) ?? null);
+  const setItem = vi.fn((k: string, v: string) => {
     store.set(k, v);
   });
-  // Cast through unknown — we're only exercising the two methods drafts.ts uses.
-  (window as unknown as { ccsm: unknown }).ccsm = { loadState, saveState };
-  return { store, loadState, saveState };
+  (globalThis as unknown as { localStorage?: unknown }).localStorage = {
+    getItem,
+    setItem,
+    removeItem: () => {},
+    clear: () => {},
+    key: () => null,
+    length: 0,
+  };
+  return { store, getItem, setItem };
 }
 
 beforeEach(() => {
@@ -29,67 +36,67 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
-  delete (window as unknown as { ccsm?: unknown }).ccsm;
+  delete (globalThis as unknown as { localStorage?: unknown }).localStorage;
 });
 
 async function flushPersist() {
-  // Drain the 250ms debounce + the awaited saveState promise.
+  // Drain the 250ms debounce + the synchronous setItem call.
   await vi.advanceTimersByTimeAsync(300);
   await Promise.resolve();
 }
 
 describe('drafts persistence', () => {
   it('hydrates an empty cache when no blob exists', async () => {
-    const { loadState } = installCCSM();
+    const { getItem } = installLocalStorage();
     await hydrateDrafts();
-    expect(loadState).toHaveBeenCalledWith('drafts');
+    expect(getItem).toHaveBeenCalledWith('drafts');
     expect(getDraft('s-1')).toBe('');
   });
 
   it('hydrates from a v1 blob', async () => {
-    installCCSM(JSON.stringify({ version: 1, drafts: { 's-1': 'hello', 's-2': 'world' } }));
+    installLocalStorage(JSON.stringify({ version: 1, drafts: { 's-1': 'hello', 's-2': 'world' } }));
     await hydrateDrafts();
     expect(getDraft('s-1')).toBe('hello');
     expect(getDraft('s-2')).toBe('world');
   });
 
   it('ignores blobs with the wrong version', async () => {
-    installCCSM(JSON.stringify({ version: 2, drafts: { 's-1': 'oops' } }));
+    installLocalStorage(JSON.stringify({ version: 2, drafts: { 's-1': 'oops' } }));
     await hydrateDrafts();
     expect(getDraft('s-1')).toBe('');
   });
 
   it('survives corrupt JSON without throwing', async () => {
-    installCCSM('{not json');
+    installLocalStorage('{not json');
     await expect(hydrateDrafts()).resolves.not.toThrow();
     expect(getDraft('s-1')).toBe('');
   });
 
-  it('writes via debounced saveState on setDraft', async () => {
-    const { saveState } = installCCSM();
+  it('writes via debounced setItem on setDraft', async () => {
+    const { setItem } = installLocalStorage();
     await hydrateDrafts();
     setDraft('s-1', 'half-typed');
-    expect(saveState).not.toHaveBeenCalled(); // debounced
+    expect(setItem).not.toHaveBeenCalled(); // debounced
     await flushPersist();
-    expect(saveState).toHaveBeenCalledTimes(1);
-    const [, blob] = saveState.mock.calls[0];
+    expect(setItem).toHaveBeenCalledTimes(1);
+    const [, blob] = setItem.mock.calls[0];
     expect(JSON.parse(blob as string)).toEqual({ version: 1, drafts: { 's-1': 'half-typed' } });
   });
 
   it('coalesces rapid edits into a single write', async () => {
-    const { saveState } = installCCSM();
+    const { setItem } = installLocalStorage();
     await hydrateDrafts();
     setDraft('s-1', 'a');
     setDraft('s-1', 'ab');
     setDraft('s-1', 'abc');
     await flushPersist();
-    expect(saveState).toHaveBeenCalledTimes(1);
-    const [, blob] = saveState.mock.calls[0];
+    expect(setItem).toHaveBeenCalledTimes(1);
+    const [, blob] = setItem.mock.calls[0];
     expect(JSON.parse(blob as string).drafts['s-1']).toBe('abc');
   });
 
   it('clearDraft removes the entry and persists the deletion', async () => {
-    const { saveState } = installCCSM(
+    const { setItem } = installLocalStorage(
       JSON.stringify({ version: 1, drafts: { 's-1': 'old' } })
     );
     await hydrateDrafts();
@@ -97,33 +104,33 @@ describe('drafts persistence', () => {
     clearDraft('s-1');
     await flushPersist();
     expect(getDraft('s-1')).toBe('');
-    const lastBlob = saveState.mock.calls.at(-1)?.[1] as string;
+    const lastBlob = setItem.mock.calls.at(-1)?.[1] as string;
     expect(JSON.parse(lastBlob).drafts).toEqual({});
   });
 
   it('deleteDrafts batches removals and only writes when something changed', async () => {
-    const { saveState } = installCCSM(
+    const { setItem } = installLocalStorage(
       JSON.stringify({ version: 1, drafts: { 's-1': 'a', 's-2': 'b' } })
     );
     await hydrateDrafts();
     deleteDrafts(['s-1', 's-3-never-existed']);
     await flushPersist();
-    expect(saveState).toHaveBeenCalledTimes(1);
-    const blob = JSON.parse(saveState.mock.calls.at(-1)?.[1] as string);
+    expect(setItem).toHaveBeenCalledTimes(1);
+    const blob = JSON.parse(setItem.mock.calls.at(-1)?.[1] as string);
     expect(blob.drafts).toEqual({ 's-2': 'b' });
-    saveState.mockClear();
+    setItem.mockClear();
     deleteDrafts(['s-already-gone']);
     await flushPersist();
-    expect(saveState).not.toHaveBeenCalled();
+    expect(setItem).not.toHaveBeenCalled();
   });
 
   it('preserves multiline / unicode / emoji content verbatim', async () => {
-    const { saveState } = installCCSM();
+    const { setItem } = installLocalStorage();
     await hydrateDrafts();
     const tricky = 'line1\nline2 <tag> `code` 🚀\n\tindented';
     setDraft('s-1', tricky);
     await flushPersist();
-    const blob = JSON.parse(saveState.mock.calls.at(-1)?.[1] as string);
+    const blob = JSON.parse(setItem.mock.calls.at(-1)?.[1] as string);
     expect(blob.drafts['s-1']).toBe(tricky);
   });
 });


### PR DESCRIPTION
Wave 0e cutover: replace removed `window.ccsm.loadState/saveState` in `src/stores/drafts.ts` with direct `localStorage` access, mirroring `src/stores/persist.ts` exactly (cut in #289 / commit 1ed581c).

v0.3 transitional posture per the rpc-stub-gap audit (#228 sub-task 9). When `SettingsService` RPC ships, this module re-cuts to daemon RPC.

## Scope

- `src/stores/drafts.ts`: hydrate via `localStorage.getItem`, debounced write via `localStorage.setItem`. Same 250ms debounce, same corrupt-blob / wrong-version guards. Public function signatures untouched (callers in `InputBar` / soft-delete undo path see no change).
- `tests/drafts.test.ts`: stub `globalThis.localStorage` instead of `window.ccsm`. Same 9 assertions on hydrate/debounce/coalesce/clear/delete/unicode payload shape -- only the IO mock changed. Mirrors `#289`'s `persist-shape.test.ts` pattern.

## Acceptance

- 0 hits of ``window\.ccsm\.(loadState|saveState)`` in `drafts.ts` (verified via grep).
- `tools/check-v02-shrinking.sh` PASS: `src/stores/drafts.ts` 112 -> 112 LoC (equal -- no growth).
- `pnpm vitest run tests/drafts.test.ts`: 9/9 PASS.
- `pnpm vitest run tests/persist-shape.test.ts` (sibling sanity): 1/1 PASS.

## Local checks

- lint: OK (exit 0, FULL TURBO cache hit on 3 tasks)
- typecheck: OK (exit 0, `tsc --noEmit && tsc --noEmit -p tsconfig.electron.json`)
- build: OK (exit 0, FULL TURBO)
- unit tests:
  ```
  Test Files  1 passed (1)
       Tests  9 passed (9)
    Duration  3.18s
  ```
- e2e: not run locally (no harness change; sibling Wave 0e cutovers haven't shipped, so a full e2e run on this branch alone would just exercise the same drafts paths the unit tests cover). CI will run.

## Sibling files surfaced

Wave 0e tasks still pending elsewhere (out of scope here, tracked separately):
- `src/terminal/xtermSingleton.ts`
- `src/terminal/usePtyAttach.ts`
- `src/components/settings/UpdatesPane.tsx`
- `src/stores/slices/sessionCrudSlice.ts`
- AppearancePane / NotificationsPane