### PR TITLE
wave0e: #297 NotificationsPane localStorage cutover

### DIFF
--- a/src/components/settings/NotificationsPane.tsx
+++ b/src/components/settings/NotificationsPane.tsx
@@ -4,37 +4,45 @@ import { Switch } from '../ui/Switch';
 import { useTranslation } from '../../i18n/useTranslation';
 import { Field } from './Field';
 
-// Desktop notifications mute toggle. Persisted via the existing
-// `db:save` / `db:load` IPC under the `notifyEnabled` app_state key — main
-// reads the same key on every sessionWatcher state event so the toggle
-// takes effect without a restart. Default is ON: a missing row means
-// notifications fire (the "fresh install ships with toasts on" experience).
+// Wave 0e (#297): localStorage cutover, mirrors src/stores/persist.ts (#289).
+// Default ON; missing key → on. Main-process gate still reads the DB row via
+// electron/prefs/notifyEnabled.ts (followup to cut that side too).
+export const NOTIFY_ENABLED_KEY = 'notifyEnabled';
+
+function loadNotifyEnabled(): boolean {
+  if (typeof localStorage === 'undefined') return true;
+  try {
+    const raw = localStorage.getItem(NOTIFY_ENABLED_KEY);
+    if (raw == null) return true;
+    return !(raw === 'false' || raw === '0');
+  } catch {
+    return true;
+  }
+}
+
+function commitSnapshot(value: boolean): void {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(NOTIFY_ENABLED_KEY, value ? 'true' : 'false');
+  } catch (err) {
+    // Quota/SecurityError: warn (mirrors persist.ts onPersistError, #289).
+    console.warn('[NotificationsPane] failed to persist notifyEnabled', err);
+  }
+}
+
 export function NotificationsPane() {
   const { t } = useTranslation('settings');
   const [enabled, setEnabled] = useState<boolean>(true);
   const [hydrated, setHydrated] = useState(false);
 
   useEffect(() => {
-    let cancelled = false;
-    void (async () => {
-      try {
-        const raw = await window.ccsm?.loadState('notifyEnabled');
-        if (cancelled) return;
-        // Missing row → default ON. Explicit 'false' / '0' → off.
-        if (raw == null) setEnabled(true);
-        else setEnabled(!(raw === 'false' || raw === '0'));
-      } finally {
-        if (!cancelled) setHydrated(true);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
+    setEnabled(loadNotifyEnabled());
+    setHydrated(true);
   }, []);
 
   const onChange = (next: boolean) => {
     setEnabled(next);
-    void window.ccsm?.saveState('notifyEnabled', next ? 'true' : 'false');
+    commitSnapshot(next);
   };
 
   return (

--- a/tests/settings/NotificationsPane.test.tsx
+++ b/tests/settings/NotificationsPane.test.tsx
@@ -3,25 +3,43 @@ import { render, screen, waitFor, act, fireEvent } from '@testing-library/react'
 import React from 'react';
 import { NotificationsPane } from '../../src/components/settings/NotificationsPane';
 
-// Stand-in for the preload bridge. Holds an in-memory record of saved keys
-// so the toggle's persistence path can be observed without a real DB.
-function makeCcsm(initial: Record<string, string | undefined> = {}) {
-  const store: Record<string, string | undefined> = { ...initial };
+// In-memory localStorage stand-in. Wave 0e cutover (#297) shifted the toggle
+// from window.ccsm.{loadState,saveState} to direct localStorage, mirroring
+// src/stores/persist.ts (#289) — same shape, same key.
+function makeStorage(initial: Record<string, string> = {}) {
+  const store: Record<string, string> = { ...initial };
   return {
-    loadState: vi.fn(async (key: string) => store[key]),
-    saveState: vi.fn(async (key: string, val: string) => {
-      store[key] = val;
+    getItem: vi.fn((key: string) => (key in store ? store[key] : null)),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
     }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      for (const k of Object.keys(store)) delete store[k];
+    }),
+    key: vi.fn(),
+    get length() {
+      return Object.keys(store).length;
+    },
     __store: store,
-  };
+  } as unknown as Storage & { __store: Record<string, string>; setItem: ReturnType<typeof vi.fn> };
 }
 
+let storage: ReturnType<typeof makeStorage>;
+
 beforeEach(() => {
-  (window as { ccsm?: unknown }).ccsm = makeCcsm() as unknown as Window['ccsm'];
+  storage = makeStorage();
+  Object.defineProperty(window, 'localStorage', {
+    value: storage,
+    configurable: true,
+    writable: true,
+  });
 });
 
 afterEach(() => {
-  delete (window as { ccsm?: unknown }).ccsm;
+  vi.restoreAllMocks();
 });
 
 describe('NotificationsPane', () => {
@@ -34,16 +52,13 @@ describe('NotificationsPane', () => {
       name: /show desktop notifications/i,
     });
     expect(toggle).toBeInTheDocument();
-    // Default is ON — empty store row → toggle reads checked=true after hydrate.
+    // Default is ON — empty store → toggle reads checked=true after hydrate.
     await waitFor(() => {
       expect(toggle.getAttribute('aria-checked')).toBe('true');
     });
   });
 
   it('persists notifyEnabled=false when the user turns the toggle off', async () => {
-    const ccsm = makeCcsm();
-    (window as { ccsm?: unknown }).ccsm = ccsm as unknown as Window['ccsm'];
-
     await act(async () => {
       render(<NotificationsPane />);
     });
@@ -51,20 +66,22 @@ describe('NotificationsPane', () => {
     const toggle = await screen.findByRole('switch', {
       name: /show desktop notifications/i,
     });
-    // Wait for hydration so the click is enabled.
     await waitFor(() => expect(toggle).not.toBeDisabled());
 
     await act(async () => {
       fireEvent.click(toggle);
     });
-    expect(ccsm.saveState).toHaveBeenCalledWith('notifyEnabled', 'false');
+    expect(storage.setItem).toHaveBeenCalledWith('notifyEnabled', 'false');
     expect(toggle.getAttribute('aria-checked')).toBe('false');
   });
 
   it('reflects a persisted "false" row by hydrating to OFF', async () => {
-    (window as { ccsm?: unknown }).ccsm = makeCcsm({
-      notifyEnabled: 'false',
-    }) as unknown as Window['ccsm'];
+    storage = makeStorage({ notifyEnabled: 'false' });
+    Object.defineProperty(window, 'localStorage', {
+      value: storage,
+      configurable: true,
+      writable: true,
+    });
 
     await act(async () => {
       render(<NotificationsPane />);


### PR DESCRIPTION
## Summary

Wave 0e cutover for `src/components/settings/NotificationsPane.tsx` (Task #297). Wave 0b deleted `window.ccsm.loadState`/`saveState`; this file was left calling those phantom IPCs at lines 21 and 37. Cuts to direct localStorage following the canonical Wave 0e shape from `src/stores/persist.ts` (PR #976, commit `1ed581c`, Task #289).

- `loadNotifyEnabled()`: `localStorage.getItem(NOTIFY_ENABLED_KEY)` wrapped in try/catch, default-ON semantics preserved.
- `commitSnapshot(value)`: `localStorage.setItem` wrapped in try/catch; on quota / SecurityError, `console.warn` so failure isn't silent (mirrors persist.ts `onPersistError` without coupling to the store-snapshot-scoped handler).
- Tests: stub `window.localStorage` instead of `window.ccsm`. Same 3 cases (default ON, persist OFF, hydrate from persisted `'false'`); only the IO mock changed.

Acceptance:
- 0 hits of `window.ccsm.(loadState|saveState)` in NotificationsPane.tsx (verified via grep).
- `tools/check-v02-shrinking.sh` PASS (file is not in `.v0.2-only-files`, but check passes overall).

## Followup surfaced (NOT in this PR scope)

`electron/prefs/notifyEnabled.ts` (main-process notify gate) still reads the DB row via `electron/db` `loadState`. Until that side also cuts to localStorage (or `SettingsService` RPC ships per #228 sub-task 9), the toggle flip in renderer only persists the renderer's view of the setting; the main process continues to consult the previously-written DB row when deciding whether to fire toasts. Worth a Wave 0e followup task to align both sides.

## Local checks
- lint: ✓ (exit 0, only pre-existing warnings)
- typecheck: ✓ (exit 0)
- build: ✓ (`npm run build:app`, webpack + tsc -p tsconfig.electron.json, exit 0)
- unit tests: ✓ `npx vitest run tests/settings/NotificationsPane.test.tsx` — Test Files 1 passed (1), Tests 3 passed (3), Duration 11.82s
- e2e: skipped — change is a pure renderer storage-IO swap covered by the file's own UT; no new electron/* code or new probe surface.