### PR TITLE
chore(#322): demote CI matrix to windows-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Task #322 — windows-only matrix. Round 1-7 of the v0.3 ship-gate
+        # PRs failed because the matrix ran ubuntu+macos+windows but none
+        # were `required` in branch protection, letting devs alibi as
+        # "Linux only / mac only / can't repro locally" through 6 rounds
+        # of speculative fixes (history: PR #986). All current devs work
+        # on Windows hosts; demoting to windows-only means local green ==
+        # CI green with no platform escape hatch. Linux-conditional
+        # guard steps below are migrated to windows-latest because their
+        # tooling (bash, sha256sum, node, npx vitest) is available via
+        # Git-for-Windows on the windows runner.
+        os: [windows-latest]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
@@ -58,11 +68,9 @@ jobs:
       # may shrink but never grow vs the merge-base AND must be step-wise
       # monotonic across every first-parent commit in this branch series
       # (so a file can't shrink in commit N then re-grow in commit N+1).
-      # Linux-only because the check is git/wc/bash and the result is
-      # deterministic across OSes; running on the matrix would waste 2x
-      # runner time.
+      # Was Linux-only pre-#322; runs on windows via Git-for-Windows bash
+      # since this is the only matrix entry now.
       - name: Check v0.2-only files don't grow (incl. step-wise)
-        if: matrix.os == 'ubuntu-latest'
         run: bash tools/check-v02-shrinking.sh
 
       - name: Setup Node
@@ -76,13 +84,11 @@ jobs:
       # or deleted. tools/check-spec-code-lock.sh reads
       # docs/superpowers/specs/2026-05-03-v03-daemon-split.lock.json and
       # verifies every locked path exists with the recorded SHA256
-      # (LF-normalized, so platform-stable). Linux-only because the check
-      # is git/sha256/node and the result is deterministic across OSes;
-      # running on the matrix would waste 2x runner time. Placed after
+      # (LF-normalized, so platform-stable). Was Linux-only pre-#322;
+      # runs on windows now via Git-for-Windows bash + node. Placed after
       # Setup Node because the script uses `node -e` to parse the lock
       # JSON (no jq dependency).
       - name: Check spec-code lock (ship-gate paths)
-        if: matrix.os == 'ubuntu-latest'
         run: bash tools/check-spec-code-lock.sh
 
       # Linux native builds for better-sqlite3 need python + build tools; the
@@ -165,27 +171,23 @@ jobs:
       # and ship their own minimal config at tools/vitest.config.ts.
       # Wire-up extends the existing required `lint + typecheck + test`
       # job rather than adding a new required check (branch protection
-      # is frozen). Linux-only because the assertions are git/fs/process
-      # behaviour with no platform-specific paths — running on the matrix
-      # would triple wall-clock with no signal gain.
+      # is frozen). Was Linux-only pre-#322; runs on windows now since
+      # the assertions are git/fs/process behaviour with no
+      # platform-specific paths.
       - name: Test (tools/**/*.spec.ts)
-        if: matrix.os == 'ubuntu-latest'
         run: npx vitest run --config tools/vitest.config.ts
 
-      # Tech-debt R6 (Task #802) — coverage roll-out. Run only on Linux to
-      # keep the matrix lean (coverage instrumentation roughly doubles
-      # wall-clock; one OS is enough for the lcov artifact). Threshold
-      # misses do NOT fail CI yet — this is the initial roll-out; we wrap
-      # with `continue-on-error: true` to keep CI green during the bake-in
+      # Tech-debt R6 (Task #802) — coverage roll-out. Threshold misses do
+      # NOT fail CI yet — this is the initial roll-out; we wrap with
+      # `continue-on-error: true` to keep CI green during the bake-in
       # period. Bump and enforce in a follow-up once we've watched a few
-      # PRs.
+      # PRs. Was Linux-only pre-#322; runs on windows now (single matrix
+      # entry, lcov artifact still produced).
       - name: Coverage
-        if: matrix.os == 'ubuntu-latest'
         run: npm run coverage
         continue-on-error: true
 
       - name: Upload coverage artifact
-        if: matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-lcov

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,7 +25,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Task #322 — windows-only matrix. Round 1-7 of the v0.3 ship-gate
+        # PRs ran ubuntu+macos+windows e2e but none were `required` in
+        # branch protection, so devs alibied as "Linux only / mac only /
+        # can't repro locally" through 6 rounds of speculative fixes.
+        # All current devs are on Windows hosts; demoting e2e to
+        # windows-only means local `npm run probe:e2e` green == CI green
+        # with no platform escape hatch.
+        os: [windows-latest]
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -99,8 +106,7 @@ jobs:
         run: npx electron-rebuild
       - name: Build
         run: npm run build:app
-      - name: Run e2e (Linux with xvfb)
-        if: runner.os == 'Linux'
+      - name: Run e2e
         # E2E_SKIP=harness-real-cli — public CI runners have no `claude`
         # CLI installed AND no Anthropic auth tokens, so every case in
         # harness-real-cli that calls waitForTerminalReady deterministically
@@ -109,11 +115,6 @@ jobs:
         # via `node scripts/harness-real-cli.mjs` (or `npm run probe:e2e`
         # without the env var) for the dev / dogfood loop, where the user's
         # ~/.claude is real. (#726)
-        run: xvfb-run -a npm run probe:e2e
-        env:
-          E2E_SKIP: harness-real-cli
-      - name: Run e2e (mac/win)
-        if: runner.os != 'Linux'
         run: npm run probe:e2e
         env:
           E2E_SKIP: harness-real-cli


### PR DESCRIPTION
## Why

Round 1-7 of the v0.3 ship-gate PRs ran ubuntu+macos+windows but none were `required` in branch protection. Devs alibied as "Linux only / mac only / can't repro locally" through 6 rounds of speculative fixes (history: PR #986). All current devs work on Windows hosts; demoting both `ci.yml` and `e2e.yml` matrices to `[windows-latest]` means **local green == CI green with no platform escape hatch**.

Manager will flip the required-check name to the new windows-only job via `gh api` separately — out of this PR's diff.

## What

- `.github/workflows/ci.yml` — matrix `[ubuntu-latest, macos-latest, windows-latest]` → `[windows-latest]`. Linux-conditional guard steps (`check-v02-shrinking`, `check-spec-code-lock`, `tools/**` vitest, coverage upload) migrated to run unconditionally on windows. Tooling (`bash`, `sha256sum`, `node`, `npx`) is available via Git-for-Windows on the windows runner.
- `.github/workflows/e2e.yml` — matrix `[ubuntu-latest, macos-latest, windows-latest]` → `[windows-latest]`. Collapsed the `xvfb-run` / non-xvfb split into a single `Run e2e` step.

## Local checks (host: windows-11, pool-2 worktree)

- lint: ✓ exit 0 — `0 errors and 64 warnings` (pre-existing warnings, unrelated)
- typecheck: ✓ exit 0 — `tsc --noEmit && tsc --noEmit -p tsconfig.electron.json` clean
- build: ✓ exit 0 — `webpack 5.106.2 compiled with 3 warnings in 16883 ms` (perf hints, pre-existing)
- unit tests: ✓ `Test Files  114 passed (114) | Tests  831 passed (831) | Duration 41.06s`
- e2e (full): ✗ **expected red this round** — `=== totals: 0 passed, 2 failed, 1 skipped, 3 total ===` (`harness-dnd` + `harness-ui` both fail with `ERR_DLOPEN_FAILED` on better-sqlite3 — local node-pty/electron ABI churn unrelated to this YAML-only change; will be addressed in a follow-up). Quoted failure tail:

  ```
  === E2E summary ===
  [XX] harness-dnd       failed   41857ms  exit=1
  [--] harness-real-cli  skipped      0ms  exit=0
  [XX] harness-ui        failed   17642ms  exit=1
  === totals: 0 passed, 2 failed, 1 skipped, 3 total ===
  ```

## Scope guard

Diff is YAML-only (2 files). No `.ts/.tsx` touched, no `package.json` touched. Branch-protection required-check rename is the manager's `gh api` step, not in this PR.