### PR TITLE
fix(#328): startup paints skeleton before hydrate

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -65,4 +65,18 @@ root.render(
     </RendererBoot>
   </ErrorBoundary>
 );
-void hydrateStore();
+// Defer hydration until after the browser has had a chance to paint the
+// pre-hydrate <AppSkeleton/> frame. React 18's `createRoot.render()` schedules
+// the initial commit through the concurrent scheduler — it is NOT guaranteed
+// to commit before `hydrateStore()` runs to its first real `await`. Pre-#289
+// this happened to work because `loadState` was a real IPC (truly async, the
+// renderer thread yielded long enough for React to commit + paint). Post-#289
+// `loadPersisted()` is `localStorage.getItem` (sync), and `hydrateDrafts()`
+// is the same — there is no real yield, so React would batch the skeleton
+// commit with the post-hydrate `setState({ hydrated: true })` and the
+// skeleton frame would never paint. `setTimeout(0)` queues a fresh macrotask;
+// by the time it fires, React's scheduler has already drained its initial
+// commit task and the skeleton is in the DOM. harness-ui
+// startup-paints-before-hydrate (and real users on cold launch) now actually
+// see the skeleton.
+setTimeout(() => void hydrateStore(), 0);


### PR DESCRIPTION
## Summary

Restore the `harness-ui` `startup-paints-before-hydrate` contract that
broke after PR #976 (Wave 0e localStorage cutover of `src/stores/persist.ts`).

Root cause: pre-#976, `hydrateStore()` awaited a real IPC
(`window.ccsm.loadState`) — the round-trip gave React's concurrent
scheduler enough wall time to commit + paint `<AppSkeleton/>` before the
post-hydrate `setState({ hydrated: true })` re-rendered the populated UI
on top. Post-#976, `loadPersisted()` is a synchronous `localStorage.getItem`
inside an `async` function. The microtask boundary from `await
hydrateDrafts()` / `await loadPersisted()` is NOT enough to make React 18's
concurrent scheduler commit the skeleton frame independently — it batches
the skeleton commit with the hydrate flip, so the skeleton frame is never
painted. Real users on cold launch see a blank white window during
localStorage parse instead of the content-shaped placeholder.

Fix: defer `hydrateStore()` one macrotask via `setTimeout(0)` in
`src/index.tsx`. By the time the timer callback fires, React's scheduler
has already drained its initial commit task and `<AppSkeleton/>` is in the
DOM. Tried `requestAnimationFrame` first but it does not fire reliably on
Electron BrowserWindows that have not been `show()`n yet (RAF is throttled
to ~0 Hz when the window is hidden, which is the e2e harness's default).

## Local checks (host: windows-11)

- lint: ok (exit 0; `npm run lint` background task)
- typecheck: ok (exit 0; `npm run typecheck` background task)
- build: ok (`webpack 5.106.2 compiled with 3 warnings in 16921 ms` + `tsc -p tsconfig.electron.json` clean)
- unit tests: pre-existing baseline failures in `@ccsm/daemon` (24 files / 58 tests) — confirmed identical when stashing this fix; not introduced here, out of scope. Renderer-side `tests/` not touched.
- e2e (full `npm run probe:e2e`):
  - `harness-dnd` PASS
  - `harness-real-cli` baseline timeout (windows preload wiring gap, unrelated)
  - `harness-ui`: 7 passed, 7 failed, 14 total — **`startup-paints-before-hydrate [OK] 1111ms`**, the case this PR targets. Other 6 failures (`settings-updates-pane`, `titlebar`, `theme-toggle`, `import-empty-groups`, `rename`, `move-to-group-excludes-own-group`, `sidebar-long-name-truncates`) are pre-existing on `origin/working` (88d44d8) — confirmed by stashing this fix and re-running, they fail identically. Each is owned by a separate Group-C task per the manager's split.

## Reverse-verify

stash fix, rebuild, run case:
```
[case=startup-paints-before-hydrate] FAIL: startup-paints-before-hydrate: pre-hydrate skeleton was never seen in the DOM (window.__ccsm584Skeleton is null) — the [data-testid=\"sidebar-skeleton\"] element did not render before hydrate flipped, or the skeleton path was removed entirely (#584). dbg={\"initRan\":1,\"observerInstalled\":true,\"hydrated\":true,\"loadStateWrapped\":true,\"hasSidebarSkeleton\":false}
=== totals: 0 passed, 1 failed, 0 skipped, 1 total ===
```

stash pop, rebuild, run case:
```
[case=startup-paints-before-hydrate] startup-paints-before-hydrate — renderedAt=1777871986274 hydrateStartedAt=1777871986318 hydrateDoneAt=1777871987118 hydratedFlag(early)=true skeleton=260x765 rows=3 mainLoading=true
[case=startup-paints-before-hydrate] OK
=== totals: 1 passed, 0 failed, 0 skipped, 1 total ===
```

Note: the harness's `addInitScript` injects an 800 ms spin-loop into
`localStorage.getItem('main')` to widen the `hydrated=false` window for
its `MutationObserver`. With the spin-loop in place, the post-fix run
shows `hydrateDoneAt - hydrateStartedAt ≈ 800 ms` (the artificial delay)
while `renderedAt < hydrateStartedAt`, proving render is no longer gated
on hydrate.

## Test plan

- [x] Local repro RED on windows-11 host (1.4 s, single-case harness)
- [x] Apply fix, local repro GREEN
- [x] Reverse-verify (stash → RED, stash pop → GREEN), both quoted above
- [x] Lint + typecheck + build clean
- [x] Full `harness-ui` shows the targeted case green; other failures pre-existing
- [ ] CI windows-latest passes the targeted case

🤖 Generated with [Claude Code](https://claude.com/claude-code)