### PR TITLE
fix(#327): theme-toggle initial dark theme

### DIFF
--- a/scripts/harness-ui.mjs
+++ b/scripts/harness-ui.mjs
@@ -555,8 +555,39 @@ async function caseThemeToggle({ win, log, registerDispose }) {
     });
   }
 
+  // Force a state transition so the subsequent setTheme('dark') is
+  // guaranteed to be a primitive *change* — otherwise zustand's Object.is
+  // short-circuit skips fan-out, App doesn't re-render, useThemeEffect
+  // doesn't re-run, and the html classes stay whatever the previous case
+  // left them as (e.g. residual theme-light from settings-updates-pane,
+  // or a DOM mutation from another case that didn't touch the store).
+  // The two setTheme calls live in *separate* `win.evaluate` blocks with
+  // a `waitForFunction` between them, so React processes the 'light'
+  // commit fully (effect runs, dataset.theme='light') before we issue the
+  // 'dark' update — otherwise React 18 batching could merge both into one
+  // re-render with the final value, and if that final value matches the
+  // current store value the effect never fires.
+  // Then poll for the .dark class to actually appear instead of relying
+  // on a fixed waitForTimeout(150) which races with React's effect
+  // scheduler on Windows after the previous case hid+showed the
+  // BrowserWindow.
+  await win.evaluate(() => { window.__ccsmStore.getState().setTheme('light'); });
+  await win.waitForFunction(
+    () => document.documentElement.dataset.theme === 'light'
+      && document.documentElement.classList.contains('theme-light'),
+    null,
+    { timeout: 3000 }
+  );
   await win.evaluate(() => { window.__ccsmStore.getState().setTheme('dark'); });
-  await win.waitForTimeout(150);
+  await win.waitForFunction(
+    () => {
+      const c = document.documentElement.classList;
+      return c.contains('dark') && !c.contains('theme-light')
+        && document.documentElement.dataset.theme === 'dark';
+    },
+    null,
+    { timeout: 3000 }
+  );
   const dark1 = await snapshot();
   if (!dark1.themeClassDark || dark1.themeClassLight) throw new Error(`expected initial dark theme classes, got ${JSON.stringify(dark1)}`);
   if (dark1.dataTheme !== 'dark') throw new Error(`html[data-theme] should be 'dark', got ${dark1.dataTheme}`);


### PR DESCRIPTION
## Summary

`caseThemeToggle` opens with `setTheme('dark')` then waits 150ms. When the
zustand store already holds `'dark'` (e.g. residual from a prior run that
ended on dark, or any preceding case that DOM-poked `theme-light` without
touching the store), the setter short-circuits via `Object.is`, App
doesn't re-render, `useThemeEffect` doesn't re-run, and the html classes
stay broken. CI then snapshots `{themeClassDark:false, themeClassLight:true, dataTheme:'light'}`
and throws `expected initial dark theme classes, got dataTheme:light`.

Fix is in the harness, not the product:
1. drive the store through `'light'` first (in its own `win.evaluate`),
2. wait via `waitForFunction` for `dataset.theme === 'light'` + `.theme-light`,
3. then `setTheme('dark')` (separate evaluate so React's batcher can't merge),
4. wait via `waitForFunction` for `.dark` + no `.theme-light` + `dataset.theme === 'dark'`.

The two evaluates with a waitForFunction between them are load-bearing —
collapsing them lets React 18 batch the two store updates into one
commit with the same final value, which still skips the effect.

## Reverse-verify

Built a temp probe `scripts/harness-repro.mjs` (deleted before commit)
that emulates the CI failure scenario: pre-set store theme to `'dark'`,
manually flip the html DOM to `theme-light` / `dataset.theme='light'`,
then run the case's first step.

Old logic (`setTheme('dark')` + `waitForTimeout(150)`):
```
[harness=repro] >>> case theme-init-noop-old-logic
[case=theme-init-noop-old-logic] SNAPSHOT: {"themeClassDark":false,"themeClassLight":true,"dataTheme":"light"}
[case=theme-init-noop-old-logic] FAIL: expected initial dark theme classes, got {"themeClassDark":false,"themeClassLight":true,"dataTheme":"light"}
=== totals: 0 passed, 1 failed, 0 skipped, 1 total ===
```

New logic (`setTheme('light')` → wait → `setTheme('dark')` → wait):
```
[harness=repro] >>> case theme-init-noop-new-logic
[case=theme-init-noop-new-logic] SNAPSHOT: {"themeClassDark":true,"themeClassLight":false,"dataTheme":"dark"}
[case=theme-init-noop-new-logic] OK
=== totals: 1 passed, 0 failed, 0 skipped, 1 total ===
```

Failure shape is byte-for-byte identical to the CI windows-latest log
quoted in the Task #327 brief.

## Local checks (host: windows-11)

- lint: PASS (exit 0, turbo full-cache)
- typecheck: PASS (exit 0, `tsc --noEmit && tsc --noEmit -p tsconfig.electron.json`)
- build: PASS (exit 0, webpack 5.106.2 compiled with 3 warnings — bundle size only)
- unit tests (vitest run, root): `Test Files 2 failed | 112 passed (114) / Tests 10 failed | 821 passed (831)`. **All 10 failures are pre-existing on `working` (88d44d8) — `electron/__tests__/db*.test.ts` only — verified via `git stash` round-trip on the same pool. Out of scope for #327.** Daemon workspace also fails 59 tests on base (same).
- e2e (full, `npm run probe:e2e`):
  - `harness-dnd`: PASS (1/1)
  - `harness-ui --only=theme-toggle`: PASS (`dark1=0.16 light=0.98 dark2=0.16`, 1418ms)
  - `harness-ui` full: theme-toggle still throws `waitForFunction Timeout 3000ms` on the new first wait, **but as a downstream casualty of upstream cases (`settings-updates-pane`, `titlebar`) crashing App into the ErrorBoundary** — diagnostic snapshot at the start of theme-toggle in full run shows `{appShellPresent:false, rootChildTags:["DIV.p-4 text-fg-tertiary"]}` (the ErrorBoundary fallback). With App unmounted, `useThemeEffect` cannot apply the class no matter what we do at the store layer.
  - Same 8 failures in `harness-ui` full run on base branch (88d44d8) before my change — verified via `git stash` round-trip. My fix does not introduce regressions; it cannot single-handedly green the full e2e because the theme-toggle case can only assert the theme switching mechanism when App is alive. Group A's `waitForFunction` fixes (per the Task #327 split brief) are required to clear the upstream ErrorBoundary contamination.
  - `harness-real-cli`: pre-existing 5min timeout on base, unrelated.

## Test plan

- [x] Local repro of CI failure shape via dedicated probe (RED quote above)
- [x] Same probe with fix applied → GREEN
- [x] `harness-ui --only=theme-toggle` PASS
- [ ] `harness-ui` full PASS — blocked on Group A's upstream fixes (settings-updates-pane / titlebar / startup-paints-before-hydrate). Verified in PR description that all 8 full-run failures pre-exist on `working@88d44d8` and my change is causally orthogonal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)