### PR TITLE
wave3(#229): wire CrashService.GetCrashLog handler in production daemon startup

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -318,10 +318,23 @@ export async function runStartup(
     // `registerSessionService` "twice replaces" caveat).
     const sessionManager = new SessionManager(db);
     const watchSessionsDeps = { manager: sessionManager };
+    // Wave-3 #229 — wire CrashService.GetCrashLog handler in production.
+    // Audit #228 sub-task 2 (docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md):
+    // pre-#229 the entire CrashService was a stub on the wire even though
+    // `crash_log` is populated end-to-end at boot (`replayCrashRawOnBoot`).
+    // We pass the SAME `db` handle the rest of startup uses (single owner
+    // of the SQLite file; the future #335 WatchCrashLog wave reuses this
+    // same instance for its event-bus subscription). The streaming siblings
+    // (#334 GetRawCrashLog, #335 WatchCrashLog) stay `Unimplemented` until
+    // their sub-tasks land — `registerCrashService` ships a partial impl
+    // with only `getCrashLog` and the router's "absent method ->
+    // Unimplemented" rule covers the rest.
+    const crashDeps = { getCrashLogDeps: { db } };
     listenerA = makeListenerA(env, {
       bindHook: makeRouterBindHook({
         helloDeps,
         watchSessionsDeps,
+        crashDeps,
         // Order matters: bearer→PeerInfo deposit MUST run before
         // peerCredAuthInterceptor (which reads PEER_INFO_KEY and
         // derives Principal). `requestMetaInterceptor` is prepended by
@@ -417,6 +430,14 @@ export async function runStartup(
   if (crashReplayResult !== null && crashReplayResult !== undefined) {
     wired.push('crash-replayer');
   }
+  // `crash-rpc`: bound to the Listener A Connect router via
+  // `makeRouterBindHook({ crashDeps })` above. Track it as wired iff
+  // Listener A actually bound — the test seam
+  // `CCSM_DAEMON_SKIP_LISTENER=1` short-circuits the listener bind, in
+  // which case the CrashService overlay never reaches the router and
+  // this name correctly stays absent from `wired` (assertWired then
+  // throws on the missing `listener-a` first).
+  if (listenerA !== null) wired.push('crash-rpc');
   // `write-coalescer`: NOT pushed yet — module exists at
   // `src/sqlite/coalescer.ts` but the per-session pty-host bridge
   // wires in T6.x. `assertWired` treats this name as WARN_ONLY for now

--- a/packages/daemon/src/rpc/crash/get-crash-log.ts
+++ b/packages/daemon/src/rpc/crash/get-crash-log.ts
@@ -1,0 +1,307 @@
+// packages/daemon/src/rpc/crash/get-crash-log.ts
+//
+// Wave-3 Task #229 (sub-task 2 of audit #228) — production CrashService.GetCrashLog
+// Connect handler.
+//
+// Audit reference: docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md
+// (sub-task #2). Pre-#229 the entire `CrashService` was registered as an
+// empty stub against the Connect router (`router.ts:STUB_SERVICES`),
+// returning Connect `Code.Unimplemented` for every method despite the
+// `crash_log` SQLite table being populated end-to-end at boot
+// (`replayCrashRawOnBoot` -> `crash_log`). This file ships the unary
+// `GetCrashLog` handler; sibling sub-tasks own the streaming RPCs
+// (#334 GetRawCrashLog, #335 WatchCrashLog).
+//
+// Spec refs:
+//   - packages/proto/src/ccsm/v1/crash.proto (forever-stable wire shape:
+//     `int32 limit` capped at 1000, `int64 since_unix_ms` is a >= floor,
+//     `OwnerFilter owner_filter` with UNSPECIFIED == OWN per the enum
+//     comment).
+//   - docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//     ch04 §5 (request shape + 1000-row server cap).
+//     ch07 §3 + db/migrations/001_initial.sql (crash_log table layout +
+//     `idx_crash_log_recent` and `idx_crash_log_owner_recent` indices we
+//     deliberately rely on for ts-DESC ordering).
+//     ch09 §1 (`'daemon-self'` owner sentinel; principalKey for
+//     session-attributable rows).
+//   - packages/daemon/test/integration/crash-getlog.spec.ts already
+//     pins the over-the-wire semantics this handler implements end-to-end
+//     against an in-memory store; this file is the production binding
+//     to the real SQLite-backed `crash_log` table that the e2e harness
+//     was holding the seat for.
+//
+// SRP layering — three roles kept separate (dev.md §2):
+//   * decider:  `decideGetCrashLogQuery(req)` — pure function that maps
+//               the wire request shape onto the in-process query plan
+//               (server-side limit cap, since-floor coercion). No DB
+//               access, no clocks, no principal lookup.
+//   * producer: `readCrashLog(deps, plan)` — single SQL statement that
+//               reads from `crash_log` honoring the decider's output.
+//               Owner filter is applied in SQL because both indexes
+//               (`idx_crash_log_recent` + `idx_crash_log_owner_recent`)
+//               are ts-DESC-sorted; pushing the filter into SQL lets
+//               the planner use `idx_crash_log_owner_recent` for OWN
+//               and the recent index for ALL.
+//   * sink:     `makeGetCrashLogHandler(deps)` — Connect handler that
+//               reads the principal, runs the decider, calls the
+//               producer, and maps each row into a proto `CrashEntry`.
+//
+// Layer 1 — alternatives checked:
+//   - "wrap an existing reader" (per the task brief): no reader exists
+//     today. `crash/raw-appender.ts` only WRITES to `crash_log` (boot
+//     replay path); `crash/pruner.ts` only DELETES (retention).
+//     Constructing the reader here is the smallest single-concern
+//     addition; once Wave-4 lands a `CrashStore` (proposed under #335
+//     for the WatchCrashLog stream that needs an event bus around the
+//     write path), this handler becomes a one-line delegate.
+//   - SQL pagination via `LIMIT ... OFFSET`: rejected — the request
+//     shape ships only `(since_unix_ms, limit)`. Spec ch04 §5 wording
+//     pins the `since_unix_ms`-as-cursor contract; OFFSET is forever
+//     forbidden by that wording (would change the wire semantics).
+//   - Server-side dropping of foreign-owner rows in TS rather than SQL:
+//     rejected — see producer note above. SQL-side filter is one less
+//     row over the wire from SQLite to Node and uses an index.
+//   - ULID generation / id-based filtering: out of scope. The wire shape
+//     does not expose row ids as cursor input; ULIDs land via the
+//     write path and are returned in the response unchanged.
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type HandlerContext,
+  type ServiceImpl,
+} from '@connectrpc/connect';
+
+import {
+  CrashEntrySchema,
+  type CrashService,
+  GetCrashLogResponseSchema,
+  OwnerFilter,
+  type GetCrashLogRequest,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, principalKey, type Principal } from '../../auth/index.js';
+import { DAEMON_SELF } from '../../crash/sources.js';
+import type { SqliteDatabase } from '../../db/sqlite.js';
+import { throwError } from '../errors.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Hard server-side cap on `limit` (spec ch04 §5 — forever-stable). */
+export const SERVER_LIMIT_CAP = 1000;
+
+// ---------------------------------------------------------------------------
+// Decider
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolved query plan after applying spec-mandated coercions to the wire
+ * request. Pure data; the producer turns this into one SQL statement.
+ *
+ * `effectiveLimit` is the post-cap value: spec ch04 §5 caps at 1000;
+ * additionally a non-positive `limit` (proto3 default `0` for `int32`)
+ * is normalised to the cap so a client that omits `limit` gets the
+ * largest legal page rather than zero rows. The behaviour matches the
+ * already-pinned integration spec (`crash-getlog.spec.ts:138-139`:
+ * `limit > 0 ? limit : SERVER_LIMIT_CAP`).
+ */
+export interface GetCrashLogPlan {
+  readonly sinceUnixMs: number;
+  readonly effectiveLimit: number;
+  readonly ownerFilter: OwnerFilter;
+}
+
+/**
+ * Pure decider over the wire request. Translates `int64`/`int32` wire
+ * fields into safe in-process JS numbers (the `crash_log.ts_ms` column
+ * is INTEGER; values are unix-ms which fit in Number precision until
+ * year 287396, far past v0.3's lifecycle).
+ *
+ * Out-of-range `limit` → cap. Negative `since_unix_ms` is coerced to 0
+ * (defensive — proto3 allows negative int64 but the column never holds
+ * a negative value).
+ */
+export function decideGetCrashLogQuery(req: GetCrashLogRequest): GetCrashLogPlan {
+  const rawLimit = req.limit;
+  const effectiveLimit =
+    rawLimit > 0 && rawLimit < SERVER_LIMIT_CAP ? rawLimit : SERVER_LIMIT_CAP;
+  const rawSince = Number(req.sinceUnixMs);
+  const sinceUnixMs = Number.isFinite(rawSince) && rawSince > 0 ? rawSince : 0;
+  return {
+    sinceUnixMs,
+    effectiveLimit,
+    ownerFilter: req.ownerFilter,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Producer — SQL reader
+// ---------------------------------------------------------------------------
+
+/**
+ * Row shape returned by `crash_log` SELECT. Mirrors the columns from
+ * `db/migrations/001_initial.sql` `crash_log` table; `labels_json` is a
+ * raw JSON string at this layer (parsed in the sink).
+ */
+interface CrashLogRow {
+  readonly id: string;
+  readonly ts_ms: number;
+  readonly source: string;
+  readonly summary: string;
+  readonly detail: string;
+  readonly labels_json: string;
+  readonly owner_id: string;
+}
+
+export interface GetCrashLogDeps {
+  /** Open `crash_log` SQLite handle. Same instance the rest of the
+   *  daemon uses (single owner of the DB; see `index.ts` runStartup). */
+  readonly db: SqliteDatabase;
+}
+
+/**
+ * Read at most `plan.effectiveLimit` rows from `crash_log` newer-than-or-equal
+ * to `plan.sinceUnixMs`, applying the owner filter.
+ *
+ * Owner filter mapping (spec ch04 §5 + crash.proto OwnerFilter comment):
+ *   - UNSPECIFIED (default) == OWN
+ *   - OWN  → rows where `owner_id` equals the caller's principalKey OR
+ *            equals the `'daemon-self'` sentinel.
+ *   - ALL  → no owner filter; v0.3 daemon's authorization layer SHOULD
+ *            restrict this to admin principals, but the wire shape allows
+ *            it. Until the admin-principal scaffolding lands (v0.4) we
+ *            honor the request as-is — the integration spec
+ *            `crash-getlog.spec.ts` "ALL filter is broader than OWN"
+ *            test pins this behavior.
+ */
+export function readCrashLog(
+  deps: GetCrashLogDeps,
+  plan: GetCrashLogPlan,
+  callerKey: string,
+): readonly CrashLogRow[] {
+  const widen = plan.ownerFilter === OwnerFilter.ALL;
+  // Two prepared shapes — separate so the planner picks the right
+  // index for each (`idx_crash_log_owner_recent` for OWN's
+  // `owner_id IN (...)` clause, `idx_crash_log_recent` for ALL).
+  if (widen) {
+    const stmt = deps.db.prepare<[number, number]>(
+      `SELECT id, ts_ms, source, summary, detail, labels_json, owner_id
+         FROM crash_log
+        WHERE ts_ms >= ?
+        ORDER BY ts_ms DESC, id DESC
+        LIMIT ?`,
+    );
+    return stmt.all(plan.sinceUnixMs, plan.effectiveLimit) as readonly CrashLogRow[];
+  }
+  const stmt = deps.db.prepare<[number, string, string, number]>(
+    `SELECT id, ts_ms, source, summary, detail, labels_json, owner_id
+       FROM crash_log
+      WHERE ts_ms >= ?
+        AND owner_id IN (?, ?)
+      ORDER BY ts_ms DESC, id DESC
+      LIMIT ?`,
+  );
+  return stmt.all(
+    plan.sinceUnixMs,
+    callerKey,
+    DAEMON_SELF,
+    plan.effectiveLimit,
+  ) as readonly CrashLogRow[];
+}
+
+// ---------------------------------------------------------------------------
+// Sink — Connect handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a SQL row into the proto `CrashEntry` shape. `labels_json` is
+ * stored as JSON text; we parse defensively (a corrupt row should not
+ * fail the whole page — surface an empty labels map and the row's
+ * other fields).
+ */
+function rowToProto(row: CrashLogRow): ReturnType<typeof create<typeof CrashEntrySchema>> {
+  let labels: Record<string, string> = {};
+  try {
+    const parsed = JSON.parse(row.labels_json);
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      labels = {};
+      for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof v === 'string') labels[k] = v;
+      }
+    }
+  } catch {
+    // Corrupt JSON — keep `labels` empty; the rest of the row is still
+    // useful for the operator viewing the crash log.
+  }
+  return create(CrashEntrySchema, {
+    id: row.id,
+    tsUnixMs: BigInt(row.ts_ms),
+    source: row.source,
+    summary: row.summary,
+    detail: row.detail,
+    labels,
+    ownerId: row.owner_id,
+  });
+}
+
+/**
+ * Build the Connect `ServiceImpl<typeof CrashService>['getCrashLog']`
+ * handler. Reads `PRINCIPAL_KEY` from the HandlerContext (the
+ * `peerCredAuthInterceptor` deposited it before the handler runs),
+ * runs the decider over the request, then queries `crash_log` and
+ * maps rows to the wire shape.
+ *
+ * Mirrors the posture of `sessions/watch-sessions.ts:makeWatchSessionsHandler`:
+ * a missing principal is a daemon wiring bug surfaced as `Internal`
+ * rather than `Unauthenticated` (the auth interceptor would have
+ * rejected the call before this handler ran if the caller were
+ * unauthenticated).
+ */
+export function makeGetCrashLogHandler(
+  deps: GetCrashLogDeps,
+): ServiceImpl<typeof CrashService>['getCrashLog'] {
+  return async function getCrashLog(
+    req,
+    ctx: HandlerContext,
+  ) {
+    const principal: Principal | null = ctx.values.get(PRINCIPAL_KEY);
+    if (principal === null) {
+      throw new ConnectError(
+        'GetCrashLog handler invoked without peerCredAuthInterceptor in chain ' +
+          '(PRINCIPAL_KEY=null) — daemon wiring bug',
+        Code.Internal,
+      );
+    }
+    const plan = decideGetCrashLogQuery(req);
+    // Defensive: reject unknown enum values rather than silently treating
+    // them as ALL or OWN. Mirrors the `decideWatchScope` posture in
+    // sessions/watch-sessions.ts (forward-compat: a v0.4 client speaking
+    // a higher proto_version may send an enum the v0.3 daemon does not
+    // know; conservative deny is the contract).
+    if (
+      plan.ownerFilter !== OwnerFilter.UNSPECIFIED &&
+      plan.ownerFilter !== OwnerFilter.OWN &&
+      plan.ownerFilter !== OwnerFilter.ALL
+    ) {
+      throwError(
+        'session.not_owned',
+        `unknown OwnerFilter enum value ${String(plan.ownerFilter)} — refusing to interpret`,
+        { requested_owner_filter: String(plan.ownerFilter) },
+      );
+    }
+    const callerKey = principalKey(principal);
+    const rows = readCrashLog(deps, plan, callerKey);
+    return create(GetCrashLogResponseSchema, {
+      // Echo the request meta back unchanged. The client correlates
+      // request_id round-trip per spec ch04 §2; mutating to a different
+      // id would break that contract. A test that needs to assert
+      // server-emitted meta should send a request meta with the
+      // expected fields.
+      meta: req.meta,
+      entries: rows.map(rowToProto),
+    });
+  };
+}

--- a/packages/daemon/src/rpc/crash/register.ts
+++ b/packages/daemon/src/rpc/crash/register.ts
@@ -1,0 +1,61 @@
+// packages/daemon/src/rpc/crash/register.ts
+//
+// Wave-3 Task #229 (sub-task 2 of audit #228) — register the v0.3
+// CrashService Connect handlers that have landed so far on top of the
+// T2.2 stub baseline.
+//
+// Mirrors the `registerSessionService` pattern in
+// `packages/daemon/src/rpc/router.ts:registerSessionService` (Wave-3
+// #290): the Connect router's `service(desc, impl)` REPLACES any prior
+// registration for the same descriptor (path-keyed map under the hood).
+// Calling `service` once for `getCrashLog` and again later for, say,
+// `watchCrashLog` would silently drop `getCrashLog`. So every CrashService
+// handler that ships in v0.3 lives in this single overlay registration —
+// downstream sub-tasks (#334 GetRawCrashLog, #335 WatchCrashLog) extend
+// the deps interface and the partial impl below; the wiring topology in
+// `router.ts` and `index.ts` does not change.
+//
+// Methods not yet implemented in v0.3 (`watchCrashLog`, `getRawCrashLog`)
+// remain Connect `Unimplemented` per the router's "absent method ->
+// Unimplemented" rule (Connect-ES contract; same way SessionService's
+// not-yet-landed methods stay stubbed).
+
+import type { ConnectRouter } from '@connectrpc/connect';
+
+import { CrashService } from '@ccsm/proto';
+
+import {
+  makeGetCrashLogHandler,
+  type GetCrashLogDeps,
+} from './get-crash-log.js';
+
+/**
+ * Aggregate deps for every CrashService handler that ships in v0.3.
+ * Today only `GetCrashLog` is wired; future overlays append fields here
+ * (`getRawCrashLogDeps`, `watchCrashLogDeps`) without changing the
+ * router-level signature in `router.ts:makeDaemonRoutes`.
+ */
+export interface CrashServiceDeps {
+  readonly getCrashLogDeps: GetCrashLogDeps;
+}
+
+/**
+ * Install the v0.3 CrashService handler overlay on top of the stub
+ * baseline (`registerStubServices` in `router.ts`). Returns the same
+ * router so callers may chain.
+ *
+ * Per Connect-ES `ConnectRouter.service` semantics, this REPLACES the
+ * prior `{}` stub registration for `CrashService` — the partial impl
+ * below installs `getCrashLog`, and the router's "absent method ->
+ * Unimplemented" fallback keeps `watchCrashLog` / `getRawCrashLog`
+ * returning `Code.Unimplemented` until their owning sub-tasks land.
+ */
+export function registerCrashService(
+  router: ConnectRouter,
+  deps: CrashServiceDeps,
+): ConnectRouter {
+  router.service(CrashService, {
+    getCrashLog: makeGetCrashLogHandler(deps.getCrashLogDeps),
+  });
+  return router;
+}

--- a/packages/daemon/src/rpc/router.ts
+++ b/packages/daemon/src/rpc/router.ts
@@ -64,6 +64,7 @@ import {
   type WatchSessionsDeps,
 } from '../sessions/watch-sessions.js';
 
+import { registerCrashService, type CrashServiceDeps } from './crash/register.js';
 import { makeHelloHandler, type HelloDeps } from './hello.js';
 import { requestMetaInterceptor } from './middleware/request-meta.js';
 
@@ -187,6 +188,7 @@ export function registerSessionService(
 export function makeDaemonRoutes(
   helloDeps: HelloDeps,
   watchSessionsDeps?: WatchSessionsDeps,
+  crashDeps?: CrashServiceDeps,
 ): (router: ConnectRouter) => void {
   return (router: ConnectRouter): void => {
     registerStubServices(router);
@@ -194,6 +196,15 @@ export function makeDaemonRoutes(
       registerSessionService(router, { helloDeps, watchSessionsDeps });
     } else {
       registerHelloHandler(router, helloDeps);
+    }
+    // CrashService overlay (Wave-3 #229 / audit #228 sub-task 2).
+    // `registerCrashService` REPLACES the stub registration for
+    // CrashService with a partial impl exposing `getCrashLog`; the
+    // router's "absent method -> Unimplemented" fallback keeps
+    // `watchCrashLog` / `getRawCrashLog` stubbed (separate sub-tasks).
+    // Same additive overlay shape as SessionService above.
+    if (crashDeps !== undefined) {
+      registerCrashService(router, crashDeps);
     }
   };
 }
@@ -227,6 +238,16 @@ export interface CreateDaemonNodeAdapterOptions extends ConnectRouterOptions {
    * a manager simply omit it (Hello-only path stays).
    */
   readonly watchSessionsDeps?: WatchSessionsDeps;
+  /**
+   * When set, installs the Wave-3 CrashService overlay (Task #229 /
+   * audit #228 sub-task 2) on top of the stubs. Today this binds
+   * `CrashService.GetCrashLog`; the streaming siblings
+   * (`GetRawCrashLog`, `WatchCrashLog`) stay `Unimplemented` until
+   * their sub-tasks land. Production startup wires this when
+   * `index.ts` constructs a `crashDeps` (the same `db` handle the
+   * rest of startup uses); tests omit it for the stub baseline.
+   */
+  readonly crashDeps?: CrashServiceDeps;
 }
 
 /**
@@ -265,9 +286,9 @@ export type DaemonNodeHandler = ReturnType<typeof connectNodeAdapter>;
 export function createDaemonNodeAdapter(
   options: CreateDaemonNodeAdapterOptions = {},
 ): DaemonNodeHandler {
-  const { helloDeps, watchSessionsDeps, interceptors: callerInterceptors, ...rest } = options;
+  const { helloDeps, watchSessionsDeps, crashDeps, interceptors: callerInterceptors, ...rest } = options;
   const routes =
-    helloDeps !== undefined ? makeDaemonRoutes(helloDeps, watchSessionsDeps) : stubRoutes;
+    helloDeps !== undefined ? makeDaemonRoutes(helloDeps, watchSessionsDeps, crashDeps) : stubRoutes;
   const interceptors = [
     requestMetaInterceptor,
     ...(callerInterceptors ?? []),

--- a/packages/daemon/src/runStartup.lock.ts
+++ b/packages/daemon/src/runStartup.lock.ts
@@ -28,6 +28,12 @@
  * - `supervisor`     — Supervisor UDS server is bound (T1.7).
  * - `capture-sources`— `installCaptureSources` ran (ch09 §1).
  * - `crash-replayer` — `replayCrashRawOnBoot` ran (ch09 §6.2).
+ * - `crash-rpc`      — `CrashService.GetCrashLog` Connect handler is
+ *   installed on Listener A (Wave-3 #229 / audit #228 sub-task 2).
+ *   Pre-#229 the entire `CrashService` returned `Unimplemented` despite
+ *   the `crash_log` table being populated; this name asserts the wire
+ *   handler is in the production overlay so a regression that drops
+ *   the `crashDeps` pass-through fails boot.
  * - `write-coalescer`— SQLite write coalescer is wired (ch07 §5).
  *   v0.3 status: the coalescer module exists at
  *   `src/sqlite/coalescer.ts` but the per-session bridge that hands it
@@ -43,6 +49,7 @@ export const REQUIRED_COMPONENTS: ReadonlyArray<string> = [
   'supervisor',
   'capture-sources',
   'crash-replayer',
+  'crash-rpc',
   'write-coalescer',
 ] as const;
 

--- a/packages/daemon/test/integration/crash-getlog-wired.spec.ts
+++ b/packages/daemon/test/integration/crash-getlog-wired.spec.ts
@@ -1,0 +1,208 @@
+// packages/daemon/test/integration/crash-getlog-wired.spec.ts
+//
+// Wave-3 Task #229 — production daemon-startup wire-up regression for
+// CrashService.GetCrashLog.
+//
+// Audit reference: docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md
+// (sub-task #2 of #228).
+//
+// Background:
+//   - `makeGetCrashLogHandler` (#229) reads from the `crash_log` SQLite
+//     table that boot already populates via `replayCrashRawOnBoot`.
+//   - Until #229, `packages/daemon/src/index.ts` constructed
+//     `makeRouterBindHook({ helloDeps, watchSessionsDeps })` WITHOUT
+//     a `crashDeps` argument, so `rpc/router.ts:makeDaemonRoutes` never
+//     called `registerCrashService` and `CrashService.GetCrashLog`
+//     resolved to the T2.2 `Unimplemented` stub at boot — the exact
+//     "library shipped but never wired" regression class Wave 0/1 +
+//     Task #221 exist to catch.
+//   - This spec boots the production `runStartup` (no mocks, no harness
+//     bypass) and asserts the over-the-wire response to a
+//     `GetCrashLog(OWN)` call is NOT `Code.Unimplemented`. Reverse
+//     verification: deleting the `crashDeps` line from `index.ts`
+//     flips this spec to expect-Unimplemented and it fails.
+//
+// Why a separate spec from `daemon-boot-end-to-end.spec.ts`:
+//   - The audit lists CrashService.GetCrashLog as one of FOUR
+//     independent stubs that each need their own wire-up + regression
+//     test (CrashService.GetCrashLog, GetRawCrashLog, WatchCrashLog,
+//     and the WatchSessions gap that #290 closed). One spec per gap
+//     keeps each PR single-concern and matches the precedent set by
+//     `watch-sessions-wired.spec.ts` (#290).
+//
+// Transport choice:
+//   - Identical to daemon-boot-end-to-end.spec.ts and
+//     watch-sessions-wired.spec.ts: `CCSM_LISTENER_A_FORCE_LOOPBACK=1`
+//     keeps Listener A on the cross-OS h2c loopback transport so this
+//     spec runs on every CI leg without UDS / named-pipe gating.
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type Client,
+  createClient,
+} from '@connectrpc/connect';
+import { createConnectTransport } from '@connectrpc/connect-node';
+
+import {
+  CrashService,
+  GetCrashLogRequestSchema,
+  OwnerFilter,
+  RequestMetaSchema,
+} from '@ccsm/proto';
+
+import { runStartup, type RunStartupResult } from '../../src/index.js';
+import { Lifecycle } from '../../src/lifecycle.js';
+import { TEST_BEARER_TOKEN } from '../../src/auth/index.js';
+
+interface BootEnv {
+  readonly tmpRoot: string;
+  readonly origEnv: NodeJS.ProcessEnv;
+}
+
+async function setupBootEnv(): Promise<BootEnv> {
+  const origEnv = { ...process.env };
+  const tmpRoot = await mkdtemp(join(tmpdir(), 'ccsm-crash-getlog-wired-'));
+  process.env.CCSM_STATE_DIR = tmpRoot;
+  process.env.CCSM_DESCRIPTOR_PATH = join(tmpRoot, 'listener-a.json');
+  process.env.CCSM_LISTENER_A_ADDR = join(tmpRoot, 'daemon.sock');
+  process.env.CCSM_LISTENER_A_FORCE_LOOPBACK = '1';
+  if (process.platform === 'win32') {
+    process.env.PROGRAMDATA = tmpRoot;
+  }
+  process.env.CCSM_SUPERVISOR_ADDR =
+    process.platform === 'win32'
+      ? `\\\\.\\pipe\\ccsm-crash-getlog-wired-${process.pid}-${Date.now()}`
+      : join(tmpRoot, 'supervisor.sock');
+  process.env.CCSM_VERSION = '0.3.0-crash-getlog-wired-test';
+  return { tmpRoot, origEnv };
+}
+
+async function teardownBootEnv(setup: BootEnv): Promise<void> {
+  for (const k of Object.keys(process.env)) {
+    if (!(k in setup.origEnv)) delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(setup.origEnv)) {
+    process.env[k] = v;
+  }
+  await rm(setup.tmpRoot, { recursive: true, force: true }).catch(() => {
+    /* tmp cleanup best-effort */
+  });
+}
+
+async function stopBoot(result: RunStartupResult | null): Promise<void> {
+  if (result === null) return;
+  result.captureSourcesUnsubscribe?.();
+  await result.supervisor?.stop().catch(() => {});
+  await result.listenerA?.stop().catch(() => {});
+  result.crashPruner.stop();
+  try {
+    result.db.close();
+  } catch {
+    /* idempotent */
+  }
+}
+
+function makeCrashClient(baseUrl: string): Client<typeof CrashService> {
+  const transport = createConnectTransport({
+    httpVersion: '2',
+    baseUrl,
+    interceptors: [
+      (next) => async (req) => {
+        req.header.set('authorization', `Bearer ${TEST_BEARER_TOKEN}`);
+        return next(req);
+      },
+    ],
+  });
+  return createClient(CrashService, transport);
+}
+
+function newGetRequest() {
+  return create(GetCrashLogRequestSchema, {
+    meta: create(RequestMetaSchema, {
+      requestId: `wired-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      clientVersion: '0.3.0-crash-getlog-wired-test',
+      clientSendUnixMs: BigInt(Date.now()),
+    }),
+    limit: 10,
+    sinceUnixMs: BigInt(0),
+    ownerFilter: OwnerFilter.OWN,
+  });
+}
+
+describe('CrashService.GetCrashLog production wire-up (Task #229)', () => {
+  let setup: BootEnv;
+  let lifecycle: Lifecycle;
+  let result: RunStartupResult | null = null;
+
+  beforeEach(async () => {
+    setup = await setupBootEnv();
+    lifecycle = new Lifecycle();
+    result = await runStartup(lifecycle);
+  });
+
+  afterEach(async () => {
+    await stopBoot(result);
+    result = null;
+    await teardownBootEnv(setup);
+  });
+
+  it('GetCrashLog over the production Listener A does NOT return Code.Unimplemented', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    expect(r.listenerA).not.toBeNull();
+    const desc = r.listenerA!.descriptor();
+    expect(desc.kind).toBe('KIND_TCP_LOOPBACK_H2C');
+    if (desc.kind !== 'KIND_TCP_LOOPBACK_H2C') return;
+    const baseUrl = `http://127.0.0.1:${desc.port}`;
+
+    const client = makeCrashClient(baseUrl);
+
+    let raised: ConnectError | null = null;
+    let entriesLength: number | null = null;
+    try {
+      const resp = await client.getCrashLog(newGetRequest());
+      // Wired path: handler executed, returned a (possibly empty)
+      // GetCrashLogResponse. The crash_log table on a fresh boot may
+      // or may not have rows depending on whether crash-replay
+      // ingested anything (test boot environments without a writable
+      // per-OS state dir take the `fileMissing` branch — empty page).
+      // Either way, an `entries` array means we got past Unimplemented.
+      entriesLength = resp.entries.length;
+    } catch (err) {
+      raised = ConnectError.from(err);
+    }
+
+    if (raised !== null) {
+      // The pre-#229 regression manifests EXACTLY as Code.Unimplemented;
+      // anything else (e.g. Internal from a malformed env, Unauthenticated
+      // from a missing token) is out of scope for this wire-up assertion
+      // but still indicates the overlay was reached.
+      expect(
+        raised.code,
+        `GetCrashLog returned Unimplemented — production wire-up regressed (audit #228 sub-task 2, message: ${raised.message})`,
+      ).not.toBe(Code.Unimplemented);
+    } else {
+      // Stream-less unary RPC — handler ran to completion. `entries`
+      // is a repeated field so `length` is always defined; an empty
+      // array (no rows yet) is a valid wired response.
+      expect(entriesLength).not.toBeNull();
+      expect(entriesLength).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('runStartup reports `crash-rpc` in `result.wired`', () => {
+    // Pins the `runStartup.lock.ts` REQUIRED_COMPONENTS contract: a
+    // future regression that drops the `crashDeps` pass-through in
+    // `index.ts` would make `assertWired` throw at boot AND this
+    // assertion fail.
+    expect(result).not.toBeNull();
+    expect(result!.wired).toContain('crash-rpc');
+  });
+});


### PR DESCRIPTION
Closes audit #228 sub-task 2 (`docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md`).
Sibling to PR #977 (#290 — closed sub-task 1 for `SessionService.WatchSessions`).

## Summary

- Pre-#229, `CrashService` was only registered as the empty T2.2 stub in
  `packages/daemon/src/rpc/router.ts:STUB_SERVICES`, so over-the-wire
  `GetCrashLog` returned `Code.Unimplemented` despite the `crash_log`
  SQLite table being populated end-to-end at boot via
  `replayCrashRawOnBoot` -> `INSERT OR IGNORE INTO crash_log`. Same
  "library shipped but never wired" regression class Wave 0/1 + Task #221
  exist to catch.
- This PR ships the production unary `GetCrashLog` handler under a new
  `packages/daemon/src/rpc/crash/` directory and wires it through
  `index.ts:308` (the same site #290 used for `WatchSessions`).
- Streaming siblings stay `Unimplemented` — `GetRawCrashLog` -> #334,
  `WatchCrashLog` -> #335 (blocked by #340 crash event-bus).

## Wire-up evidence

- New `makeGetCrashLogHandler` exported from
  `packages/daemon/src/rpc/crash/get-crash-log.ts`.
- `registerCrashService` overlay (`packages/daemon/src/rpc/crash/register.ts`)
  is imported by `packages/daemon/src/rpc/router.ts` and called from the
  new third arg of `makeDaemonRoutes(helloDeps, watchSessionsDeps, crashDeps)`.
- `packages/daemon/src/index.ts` (the production startup) constructs
  `crashDeps = { getCrashLogDeps: { db } }` off the same `db` handle
  the rest of startup uses and passes it through `makeRouterBindHook`
  alongside `helloDeps` + `watchSessionsDeps`.
- `packages/daemon/src/runStartup.lock.ts` adds `crash-rpc` to
  `REQUIRED_COMPONENTS` (NOT in `WARN_ONLY`), and `index.ts` pushes
  `crash-rpc` into `wired` iff Listener A bound. A future regression
  that drops the `crashDeps` pass-through fails boot via `assertWired`.
- `packages/daemon/test/integration/crash-getlog-wired.spec.ts` boots
  the production `runStartup` (no harness, no mocks) and asserts
  `GetCrashLog(OWN)` does NOT return `Code.Unimplemented`, plus pins
  `result.wired.includes('crash-rpc')`. Identical bring-up shape to
  `watch-sessions-wired.spec.ts` (#290).

## Reverse-verify (manual)

Commenting out the `crashDeps` line in `index.ts`:
- `assertWired` throws at boot: `missing wired components: crash-rpc`.
- Integration spec fails with `[unimplemented]
  ccsm.v1.CrashService.GetCrashLog is not implemented` +
  `Code.Unimplemented (12)`.

Restored before commit.

## Local checks (host: windows-11)

- lint: OK (exit 0; 52 pre-existing warnings, 0 errors)
- typecheck: OK (`tsc --noEmit` against both base and electron projects)
- `tools/check-v02-shrinking.sh`: PASS
- `tools/check-spec-code-lock.sh`: PASS
- `tools/lint-no-ipc.sh`: PASS
- daemon vitest: 1000 passed / 9 failed / 23 skipped. All 9 failures are
  pre-existing on this Windows host (better-sqlite3 native ABI rebuild
  artefacts + http2 `listener.stop()` hang affecting every
  `*-wired.spec.ts` and `daemon-boot-end-to-end.spec.ts` integration
  spec — verified by stashing this PR's diff and re-running against
  `origin/working`, same set fails). CI Linux matrix is the source of
  truth for the new spec.

## Out of scope

- `CrashService.GetRawCrashLog` (server-stream) -> #334
- `CrashService.WatchCrashLog` (server-stream) -> #335 (blocked by #340)

## Test plan

- [ ] CI lint, typecheck, build pass on all three OS legs.
- [ ] CI daemon vitest passes on Linux + macOS legs (Windows env hang
  is the pre-existing flake described above; check that
  `crash-getlog-wired.spec.ts > GetCrashLog ... does NOT return
  Code.Unimplemented` is green where the matching `watch-sessions-wired`
  spec is green).
- [ ] Reviewer confirms `index.ts` deltas are ONLY the additive
  `crashDeps` construction + pass-through (no other behavioural change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)