### PR TITLE
feat(daemon)(#336): SessionService.ListSessions + GetSession read handlers

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -330,11 +330,20 @@ export async function runStartup(
     // with only `getCrashLog` and the router's "absent method ->
     // Unimplemented" rule covers the rest.
     const crashDeps = { getCrashLogDeps: { db } };
+    // Wave-3 §6.9 sub-task 5 (Task #336) — wire the SessionService read
+    // pair (ListSessions / GetSession) on top of the WatchSessions
+    // overlay. Both handlers reuse the same `sessionManager` (single
+    // owner of the sessions table; sharing keeps SQL access in one
+    // place). See `registerSessionService` for the "registering a
+    // descriptor twice replaces" caveat that forces all SessionService
+    // handlers into one registration.
+    const readHandlersDeps = { manager: sessionManager };
     listenerA = makeListenerA(env, {
       bindHook: makeRouterBindHook({
         helloDeps,
         watchSessionsDeps,
         crashDeps,
+        readHandlersDeps,
         // Order matters: bearer→PeerInfo deposit MUST run before
         // peerCredAuthInterceptor (which reads PEER_INFO_KEY and
         // derives Principal). `requestMetaInterceptor` is prepended by

--- a/packages/daemon/src/rpc/router.ts
+++ b/packages/daemon/src/rpc/router.ts
@@ -60,6 +60,11 @@ import {
 } from '@ccsm/proto';
 
 import {
+  makeGetSessionHandler,
+  makeListSessionsHandler,
+  type ReadHandlersDeps,
+} from '../sessions/read-handlers.js';
+import {
   makeWatchSessionsHandler,
   type WatchSessionsDeps,
 } from '../sessions/watch-sessions.js';
@@ -150,31 +155,49 @@ export function registerHelloHandler(
 
 /**
  * Register the v0.3 SessionService handlers that have landed so far —
- * Hello (T2.3) and WatchSessions (T3.3) — under a SINGLE
+ * Hello (T2.3), WatchSessions (T3.3) and the read pair ListSessions /
+ * GetSession (Wave 3 §6.9 sub-task 5 / Task #336) — under a SINGLE
  * `router.service(SessionService, ...)` call.
  *
- * Why a combined registration (not two `service()` calls): per Connect-ES
- * `ConnectRouter.service` semantics, calling `service(desc, impl)` twice
- * for the same descriptor REPLACES the prior registration (the router
- * is a path-keyed map). Registering Hello and then WatchSessions
- * separately would silently drop Hello. The Hello-only path
- * (`registerHelloHandler` above) is preserved for callers that have not
- * yet wired a SessionManager (existing test fixtures); production
- * startup wiring (T1.7) uses this combined form.
+ * Why a combined registration (not multiple `service()` calls): per
+ * Connect-ES `ConnectRouter.service` semantics, calling
+ * `service(desc, impl)` more than once for the same descriptor REPLACES
+ * the prior registration (the router is a path-keyed map). Registering
+ * Hello, then WatchSessions, then ListSessions/GetSession in three
+ * separate calls would silently drop the first two. The Hello-only
+ * path (`registerHelloHandler` above) is preserved for callers that
+ * have not yet wired a SessionManager (existing test fixtures);
+ * production startup wiring (T1.7) uses this combined form.
  *
- * Methods not yet implemented (ListSessions, GetSession, CreateSession,
- * DestroySession, RenameSession, ...) remain `Unimplemented` per the
- * Connect router's "absent method → Unimplemented" rule, exactly as in
- * the stub-only path.
+ * `readHandlersDeps` is optional so existing callers (test fixtures
+ * that built `{ helloDeps, watchSessionsDeps }` before #336 landed)
+ * keep compiling without churn. In production startup wiring (T1.7)
+ * it is always supplied — see `index.ts` where the same
+ * `SessionManager` instance is reused across watchSessionsDeps and
+ * readHandlersDeps (single owner of the sessions table).
+ *
+ * Methods not yet implemented (CreateSession, DestroySession,
+ * RenameSession, ...) remain `Unimplemented` per the Connect router's
+ * "absent method → Unimplemented" rule, exactly as in the stub-only
+ * path.
  */
 export function registerSessionService(
   router: ConnectRouter,
-  deps: { readonly helloDeps: HelloDeps; readonly watchSessionsDeps: WatchSessionsDeps },
+  deps: {
+    readonly helloDeps: HelloDeps;
+    readonly watchSessionsDeps: WatchSessionsDeps;
+    readonly readHandlersDeps?: ReadHandlersDeps;
+  },
 ): ConnectRouter {
-  router.service(SessionService, {
+  const impl: Parameters<typeof router.service<typeof SessionService>>[1] = {
     hello: makeHelloHandler(deps.helloDeps),
     watchSessions: makeWatchSessionsHandler(deps.watchSessionsDeps),
-  });
+  };
+  if (deps.readHandlersDeps !== undefined) {
+    impl.listSessions = makeListSessionsHandler(deps.readHandlersDeps);
+    impl.getSession = makeGetSessionHandler(deps.readHandlersDeps);
+  }
+  router.service(SessionService, impl);
   return router;
 }
 
@@ -189,11 +212,12 @@ export function makeDaemonRoutes(
   helloDeps: HelloDeps,
   watchSessionsDeps?: WatchSessionsDeps,
   crashDeps?: CrashServiceDeps,
+  readHandlersDeps?: ReadHandlersDeps,
 ): (router: ConnectRouter) => void {
   return (router: ConnectRouter): void => {
     registerStubServices(router);
     if (watchSessionsDeps !== undefined) {
-      registerSessionService(router, { helloDeps, watchSessionsDeps });
+      registerSessionService(router, { helloDeps, watchSessionsDeps, readHandlersDeps });
     } else {
       registerHelloHandler(router, helloDeps);
     }
@@ -248,6 +272,16 @@ export interface CreateDaemonNodeAdapterOptions extends ConnectRouterOptions {
    * rest of startup uses); tests omit it for the stub baseline.
    */
   readonly crashDeps?: CrashServiceDeps;
+  /**
+   * When set (and `helloDeps` + `watchSessionsDeps` are also set),
+   * installs the Wave 3 §6.9 sub-task 5 (Task #336) read pair
+   * (ListSessions / GetSession) in the same SessionService
+   * registration. Both handlers reuse the SessionManager already wired
+   * for WatchSessions (single owner of the sessions table). Tests that
+   * don't need the read pair simply omit it and those two methods stay
+   * `Unimplemented`.
+   */
+  readonly readHandlersDeps?: ReadHandlersDeps;
 }
 
 /**
@@ -286,9 +320,9 @@ export type DaemonNodeHandler = ReturnType<typeof connectNodeAdapter>;
 export function createDaemonNodeAdapter(
   options: CreateDaemonNodeAdapterOptions = {},
 ): DaemonNodeHandler {
-  const { helloDeps, watchSessionsDeps, crashDeps, interceptors: callerInterceptors, ...rest } = options;
+  const { helloDeps, watchSessionsDeps, crashDeps, readHandlersDeps, interceptors: callerInterceptors, ...rest } = options;
   const routes =
-    helloDeps !== undefined ? makeDaemonRoutes(helloDeps, watchSessionsDeps, crashDeps) : stubRoutes;
+    helloDeps !== undefined ? makeDaemonRoutes(helloDeps, watchSessionsDeps, crashDeps, readHandlersDeps) : stubRoutes;
   const interceptors = [
     requestMetaInterceptor,
     ...(callerInterceptors ?? []),

--- a/packages/daemon/src/sessions/read-handlers.ts
+++ b/packages/daemon/src/sessions/read-handlers.ts
@@ -1,0 +1,169 @@
+// SessionService read-only handlers — ListSessions + GetSession.
+//
+// Spec refs:
+//   - docs/superpowers/specs/2026-05-02-final-architecture.md
+//     ch04 §3 (per-RPC enforcement matrix)
+//     ch05 §5 (ListSessions = principal-scoped SQL filter, no per-row
+//             check; GetSession = load + assertOwnership; both return
+//             `Code.PermissionDenied + ErrorDetail{code: "session.not_owned"}`
+//             on a not-yours / not-found row — see SessionManager.loadRow
+//             for the security boundary that collapses NotFound into
+//             not_owned to prevent cross-principal id enumeration).
+//   - Wave 3 §6.9 sub-task 5 (Task #336) — only the read pair lands in
+//     this PR; CreateSession / DestroySession / RenameSession remain
+//     `Unimplemented` until their owning tasks land.
+//
+// SRP discipline (mirrors `watch-sessions.ts`):
+//   - producer: `SessionManager.list(caller)` / `SessionManager.get(id, caller)`
+//               own the SQL + ownership check (T3.2 / PR #933). The
+//               handler does NOT touch the DB directly.
+//   - decider:  there is none worth naming for read-only — both RPCs
+//               are unconditional happy-path once the principal is
+//               resolved (the "is this row mine?" check lives inside
+//               the manager's `assertRowOwned`, which is the single
+//               source of truth shared with `destroy`).
+//   - sink:     `makeListSessionsHandler` / `makeGetSessionHandler` are
+//               the Connect handler functions — they read
+//               `PRINCIPAL_KEY` from the HandlerContext, call the
+//               manager, map rows → proto via the existing
+//               `sessionRowToProto`, and echo `RequestMeta`.
+//
+// Layer 1 — alternatives checked:
+//   - Inline the SQL in the handler. Rejected: duplicates
+//     `SessionManager.list/get` and bypasses `assertRowOwned` (the
+//     security boundary); reviewer would (rightly) reject. Sharing the
+//     manager is the explicit task constraint ("share
+//     `SessionManager.list()` / `get()`").
+//   - Re-implement row → proto. Rejected: `sessionRowToProto` from
+//     `watch-sessions.ts` is already the canonical mapper (handles the
+//     `exit_code === -1` sentinel + `LocalUser` owner attribution).
+//     Reuse keeps a single mapper; a future field addition only edits
+//     one place.
+//   - Build a generic "registerRpcWithMeta" helper. Rejected: only two
+//     handlers in this PR; sugar would obscure the per-RPC shape that
+//     reviewers want to read straight through.
+//
+// Per Connect-ES `ConnectRouter.service` semantics, registering
+// SessionService more than once REPLACES the prior registration (path-keyed
+// map). The registration overlay (`registerSessionService` in
+// `rpc/router.ts`) therefore installs Hello + WatchSessions + ListSessions
+// + GetSession in a SINGLE `router.service(SessionService, ...)` call —
+// see the doc on that function for the "registering twice replaces"
+// caveat. Methods not yet implemented (CreateSession, DestroySession,
+// RenameSession, ...) keep responding `Unimplemented` per the
+// "absent method → Unimplemented" router rule.
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type HandlerContext,
+  type ServiceImpl,
+} from '@connectrpc/connect';
+
+import {
+  GetSessionResponseSchema,
+  ListSessionsResponseSchema,
+  RequestMetaSchema,
+  type GetSessionRequest,
+  type ListSessionsRequest,
+  type SessionService,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY } from '../auth/index.js';
+
+import type { ISessionManager } from './SessionManager.js';
+import { sessionRowToProto } from './watch-sessions.js';
+
+/**
+ * Dependency bundle shared by the two read handlers — they both call
+ * the same `SessionManager` instance owned by daemon startup wiring
+ * (one process-wide owner of the `sessions` table).
+ */
+export interface ReadHandlersDeps {
+  readonly manager: ISessionManager;
+}
+
+/**
+ * Echo the caller's `RequestMeta` back on the response. Mirrors
+ * `hello.ts` — daemon does not stamp server timestamps in v0.3 (the
+ * `request_id` round-trip is the only invariant the client relies on
+ * for log correlation). Returns a fresh proto so each response carries
+ * its own message instance (Connect-ES message identity equality is
+ * not contractual but copying is cheap and avoids accidental aliasing
+ * across responses).
+ */
+function echoMeta(req: {
+  readonly meta?: { readonly requestId: string; readonly clientVersion: string; readonly clientSendUnixMs: bigint } | undefined;
+}) {
+  return create(RequestMetaSchema, {
+    requestId: req.meta?.requestId ?? '',
+    clientVersion: req.meta?.clientVersion ?? '',
+    clientSendUnixMs: req.meta?.clientSendUnixMs ?? 0n,
+  });
+}
+
+/**
+ * Defensive: if `peerCredAuthInterceptor` did NOT run (daemon wiring
+ * bug — the interceptor is supposed to deposit `PRINCIPAL_KEY` before
+ * any handler executes), surface as `Code.Internal` so operators see a
+ * server-side wiring problem rather than the client being told they
+ * are unauthenticated. Mirrors the posture in `hello.ts` /
+ * `watch-sessions.ts`.
+ */
+function requirePrincipal(handlerContext: HandlerContext, rpcName: string) {
+  const principal = handlerContext.values.get(PRINCIPAL_KEY);
+  if (principal === null) {
+    throw new ConnectError(
+      `${rpcName} handler invoked without peerCredAuthInterceptor in chain ` +
+        '(PRINCIPAL_KEY=null) — daemon wiring bug',
+      Code.Internal,
+    );
+  }
+  return principal;
+}
+
+/**
+ * Build the `ServiceImpl<SessionService>['listSessions']` handler.
+ *
+ * Spec ch05 §5: SQL `WHERE owner_id = principalKey(ctx.principal)`; no
+ * per-row ownership check needed because no foreign rows escape the
+ * filter (security boundary lives in `SessionManager.list`).
+ */
+export function makeListSessionsHandler(
+  deps: ReadHandlersDeps,
+): ServiceImpl<typeof SessionService>['listSessions'] {
+  return async (req: ListSessionsRequest, handlerContext: HandlerContext) => {
+    const principal = requirePrincipal(handlerContext, 'ListSessions');
+    const rows = deps.manager.list(principal);
+    return create(ListSessionsResponseSchema, {
+      meta: echoMeta(req),
+      sessions: rows.map((row) => sessionRowToProto(row, principal)),
+    });
+  };
+}
+
+/**
+ * Build the `ServiceImpl<SessionService>['getSession']` handler.
+ *
+ * Spec ch05 §5: load by id; `assertOwnership`; return. Both the
+ * "no such id" and "not yours" cases collapse to
+ * `Code.PermissionDenied + ErrorDetail{code: "session.not_owned"}`
+ * inside `SessionManager.loadRow` (prevents cross-principal id
+ * enumeration). The handler therefore does not need its own
+ * existence/ownership branching — manager.get throws the canonical
+ * error directly and Connect propagates it as the RPC's terminal
+ * status.
+ */
+export function makeGetSessionHandler(
+  deps: ReadHandlersDeps,
+): ServiceImpl<typeof SessionService>['getSession'] {
+  return async (req: GetSessionRequest, handlerContext: HandlerContext) => {
+    const principal = requirePrincipal(handlerContext, 'GetSession');
+    const row = deps.manager.get(req.sessionId, principal);
+    return create(GetSessionResponseSchema, {
+      meta: echoMeta(req),
+      session: sessionRowToProto(row, principal),
+    });
+  };
+}

--- a/packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts
+++ b/packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts
@@ -317,6 +317,58 @@ describe('daemon-boot end-to-end (Task #208)', () => {
     expect(resp.meta?.requestId.startsWith('e2e-')).toBe(true);
   });
 
+  // Wave 3 §6.9 sub-task 5 (Task #336) — SessionService.ListSessions and
+  // GetSession read pair. Same regression catch as the Hello assertion
+  // above: prove the production wire path actually swaps the stub for
+  // the real handler. ListSessions on a fresh boot returns an empty
+  // `sessions` array (not Unimplemented). GetSession against a
+  // never-created id surfaces `Code.PermissionDenied` (the security
+  // boundary in `SessionManager.loadRow` collapses NotFound into
+  // not_owned to prevent cross-principal id enumeration) — also NOT
+  // Unimplemented. Both proofs use the existing bearer-authenticated
+  // session client; no extra fixture state is needed.
+  it('Listener-A.SessionService.ListSessions does NOT return Unimplemented', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    const desc = r.listenerA!.descriptor();
+    if (desc.kind !== 'KIND_TCP_LOOPBACK_H2C') return;
+    const baseUrl = `http://127.0.0.1:${desc.port}`;
+
+    const client = makeSessionClient(baseUrl);
+    const meta = newMeta();
+    const resp = await client.listSessions({ meta });
+    // The stub-baseline contract is `Unimplemented`; we proved the real
+    // handler is wired by getting back a populated response shape.
+    expect(resp.meta?.requestId).toBe(meta.requestId);
+    expect(Array.isArray(resp.sessions)).toBe(true);
+    // Fresh boot — no CreateSession handler has landed yet, so the list
+    // is empty. When CreateSession lands this assertion can be relaxed
+    // to `>= 0`.
+    expect(resp.sessions).toHaveLength(0);
+  });
+
+  it('Listener-A.SessionService.GetSession does NOT return Unimplemented', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    const desc = r.listenerA!.descriptor();
+    if (desc.kind !== 'KIND_TCP_LOOPBACK_H2C') return;
+    const baseUrl = `http://127.0.0.1:${desc.port}`;
+
+    const client = makeSessionClient(baseUrl);
+    let raised: ConnectError | null = null;
+    try {
+      await client.getSession({ meta: newMeta(), sessionId: 'no-such-id' });
+    } catch (err) {
+      raised = ConnectError.from(err);
+    }
+    expect(raised, 'expected ConnectError on unknown session id').not.toBeNull();
+    // The stub baseline would be Unimplemented. The real handler maps
+    // the missing-row case through `SessionManager.loadRow` which throws
+    // `session.not_owned` (PermissionDenied) — proves the handler ran.
+    expect(raised!.code).not.toBe(Code.Unimplemented);
+    expect(raised!.code).toBe(Code.PermissionDenied);
+  });
+
   it('rejects unauthenticated calls (no bearer token) with Code.Unauthenticated', async () => {
     expect(result).not.toBeNull();
     const r = result!;

--- a/packages/daemon/test/sessions/read-handlers.spec.ts
+++ b/packages/daemon/test/sessions/read-handlers.spec.ts
@@ -1,0 +1,247 @@
+// Unit tests for SessionService read-only handlers — ListSessions and
+// GetSession (Wave 3 §6.9 sub-task 5 / Task #336).
+//
+// Covers (mirrors `watch-sessions.spec.ts` layout):
+//   - Sink (handlers) over the in-process Connect router transport:
+//       * ListSessions: empty when no rows; returns only the caller's
+//         rows even when a peer principal also has rows (security
+//         boundary — `SessionManager.list` filters by owner_id).
+//       * ListSessions: echoes RequestMeta.request_id.
+//       * ListSessions: missing PRINCIPAL_KEY → ConnectError(Internal)
+//         (defensive — proves the handler refuses to run if the auth
+//         interceptor was not wired).
+//       * GetSession: returns the proto Session for an owned id.
+//       * GetSession: peer's id collapses to `Code.PermissionDenied +
+//         ErrorDetail.code = "session.not_owned"` (T2.5 single source
+//         of truth; the SessionManager prevents cross-principal id
+//         enumeration by mapping NotFound → not_owned).
+//       * GetSession: unknown id ALSO collapses to PermissionDenied
+//         (same security boundary).
+//
+// Spec refs: ch04 §3, ch05 §5; T2.5 / PR #926; T3.2 / PR #933.
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  createClient,
+  createRouterTransport,
+} from '@connectrpc/connect';
+import { describe, expect, it } from 'vitest';
+
+import {
+  ErrorDetailSchema,
+  GetSessionRequestSchema,
+  ListSessionsRequestSchema,
+  RequestMetaSchema,
+  SessionService,
+  type ErrorDetail,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, type Principal as AuthPrincipal } from '../../src/auth/index.js';
+import { runMigrations } from '../../src/db/migrations/runner.js';
+import { openDatabase, type SqliteDatabase } from '../../src/db/sqlite.js';
+import {
+  makeGetSessionHandler,
+  makeListSessionsHandler,
+} from '../../src/sessions/read-handlers.js';
+import { SessionManager } from '../../src/sessions/SessionManager.js';
+
+const ALICE: AuthPrincipal = { kind: 'local-user', uid: '1000', displayName: 'alice' };
+const BOB: AuthPrincipal = { kind: 'local-user', uid: '1001', displayName: 'bob' };
+
+function freshDb(): SqliteDatabase {
+  const db = openDatabase(':memory:');
+  runMigrations(db);
+  // sessions.owner_id has an FK to principals(id) — see SessionManager.spec.ts.
+  const insertPrincipal = db.prepare(
+    `INSERT INTO principals (id, kind, display_name, first_seen_ms, last_seen_ms)
+     VALUES (?, ?, ?, ?, ?)`,
+  );
+  insertPrincipal.run('local-user:1000', 'local-user', 'alice', 1, 1);
+  insertPrincipal.run('local-user:1001', 'local-user', 'bob', 1, 1);
+  return db;
+}
+
+function createInput(cwd = '/home/alice') {
+  return {
+    cwd,
+    env_json: '{}',
+    claude_args_json: '[]',
+    geometry_cols: 80,
+    geometry_rows: 24,
+  };
+}
+
+function makeBoundTransport(
+  manager: SessionManager,
+  principal: AuthPrincipal | null = ALICE,
+) {
+  return createRouterTransport(
+    (router) => {
+      router.service(SessionService, {
+        listSessions: makeListSessionsHandler({ manager }),
+        getSession: makeGetSessionHandler({ manager }),
+      });
+    },
+    {
+      router: {
+        interceptors: [
+          (next) => async (req) => {
+            req.contextValues.set(PRINCIPAL_KEY, principal);
+            return next(req);
+          },
+        ],
+      },
+    },
+  );
+}
+
+function newMeta(requestId = '11111111-2222-3333-4444-555555555555') {
+  return create(RequestMetaSchema, {
+    requestId,
+    clientVersion: '0.3.0-test',
+    clientSendUnixMs: 0n,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// ListSessions
+// ---------------------------------------------------------------------------
+
+describe('SessionService.ListSessions — handler', () => {
+  it('returns empty sessions array when the caller has no rows', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const client = createClient(SessionService, makeBoundTransport(manager));
+
+    const resp = await client.listSessions(
+      create(ListSessionsRequestSchema, { meta: newMeta() }),
+    );
+    expect(resp.sessions).toHaveLength(0);
+  });
+
+  it('echoes RequestMeta.request_id on the response', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const client = createClient(SessionService, makeBoundTransport(manager));
+
+    const reqId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const resp = await client.listSessions(
+      create(ListSessionsRequestSchema, { meta: newMeta(reqId) }),
+    );
+    expect(resp.meta?.requestId).toBe(reqId);
+  });
+
+  it('returns only the caller-owned rows; peer rows are filtered out', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+
+    const aliceRow = manager.create(createInput('/home/alice'), ALICE);
+    manager.create(createInput('/home/bob'), BOB);
+
+    const client = createClient(SessionService, makeBoundTransport(manager, ALICE));
+    const resp = await client.listSessions(
+      create(ListSessionsRequestSchema, { meta: newMeta() }),
+    );
+    expect(resp.sessions).toHaveLength(1);
+    expect(resp.sessions[0].id).toBe(aliceRow.id);
+    expect(resp.sessions[0].cwd).toBe('/home/alice');
+    expect(resp.sessions[0].owner?.kind?.case).toBe('localUser');
+  });
+
+  it('throws Code.Internal when PRINCIPAL_KEY was never deposited (wiring bug)', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const client = createClient(SessionService, makeBoundTransport(manager, null));
+
+    let raised: ConnectError | null = null;
+    try {
+      await client.listSessions(
+        create(ListSessionsRequestSchema, { meta: newMeta() }),
+      );
+    } catch (err) {
+      raised = ConnectError.from(err);
+    }
+    expect(raised).not.toBeNull();
+    expect(raised!.code).toBe(Code.Internal);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GetSession
+// ---------------------------------------------------------------------------
+
+describe('SessionService.GetSession — handler', () => {
+  it('returns the proto Session for an owned id', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const created = manager.create(createInput(), ALICE);
+    const client = createClient(SessionService, makeBoundTransport(manager, ALICE));
+
+    const resp = await client.getSession(
+      create(GetSessionRequestSchema, { meta: newMeta(), sessionId: created.id }),
+    );
+    expect(resp.session?.id).toBe(created.id);
+    expect(resp.session?.cwd).toBe('/home/alice');
+    expect(resp.meta?.requestId).toBe('11111111-2222-3333-4444-555555555555');
+  });
+
+  it('rejects a peer-owned id with PermissionDenied + session.not_owned', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const bobRow = manager.create(createInput('/home/bob'), BOB);
+
+    const client = createClient(SessionService, makeBoundTransport(manager, ALICE));
+    let raised: ConnectError | null = null;
+    try {
+      await client.getSession(
+        create(GetSessionRequestSchema, { meta: newMeta(), sessionId: bobRow.id }),
+      );
+    } catch (err) {
+      raised = ConnectError.from(err);
+    }
+    expect(raised).not.toBeNull();
+    expect(raised!.code).toBe(Code.PermissionDenied);
+    const detail = raised!.findDetails(ErrorDetailSchema)[0] as ErrorDetail | undefined;
+    expect(detail?.code).toBe('session.not_owned');
+  });
+
+  it('collapses unknown session id into PermissionDenied (no enumeration leak)', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const client = createClient(SessionService, makeBoundTransport(manager, ALICE));
+
+    let raised: ConnectError | null = null;
+    try {
+      await client.getSession(
+        create(GetSessionRequestSchema, { meta: newMeta(), sessionId: 'no-such-id' }),
+      );
+    } catch (err) {
+      raised = ConnectError.from(err);
+    }
+    expect(raised).not.toBeNull();
+    // Critical: NOT NotFound — the SessionManager's loadRow maps the
+    // missing-row case to `session.not_owned` so a malicious caller
+    // cannot probe other principals' ids by branching on the code.
+    expect(raised!.code).toBe(Code.PermissionDenied);
+    expect(raised!.code).not.toBe(Code.NotFound);
+  });
+
+  it('throws Code.Internal when PRINCIPAL_KEY was never deposited (wiring bug)', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const client = createClient(SessionService, makeBoundTransport(manager, null));
+
+    let raised: ConnectError | null = null;
+    try {
+      await client.getSession(
+        create(GetSessionRequestSchema, { meta: newMeta(), sessionId: 'whatever' }),
+      );
+    } catch (err) {
+      raised = ConnectError.from(err);
+    }
+    expect(raised).not.toBeNull();
+    expect(raised!.code).toBe(Code.Internal);
+  });
+});


### PR DESCRIPTION
Task #336 — Wave 3 §6.9 sub-task 5. Wire the SessionService read pair
(ListSessions / GetSession) in production. Forward-safe / additive
overlay; no behavior change to other services.

## What

- New `packages/daemon/src/sessions/read-handlers.ts` — producer/decider/sink
  module exporting `makeListSessionsHandler` + `makeGetSessionHandler`.
  Both reuse `SessionManager.list/get` (T3.2) so the security boundary
  (mapping NotFound → `session.not_owned` to prevent cross-principal id
  enumeration) lives in a single place. Row → proto mapping reuses
  `sessionRowToProto` from `watch-sessions.ts` (single canonical mapper).
- `packages/daemon/src/rpc/router.ts` — `registerSessionService` overlay
  extended with optional `readHandlersDeps`. Installed in the SAME
  `router.service(SessionService, ...)` call as Hello + WatchSessions
  (Connect-ES "registering a descriptor twice replaces" caveat).
  `CreateSession` / `DestroySession` / `RenameSession` etc. continue to
  return `Code.Unimplemented` per the router's "absent method" rule.
- `packages/daemon/src/index.ts` (line 308 area) — production startup
  threads `readHandlersDeps` off the same `sessionManager` instance
  already constructed for WatchSessions.

## Tests

- `packages/daemon/test/sessions/read-handlers.spec.ts` — 8 new unit
  tests over the in-process Connect router transport:
  - ListSessions: empty / meta echo / cross-principal filter / Internal
    on missing PRINCIPAL_KEY.
  - GetSession: owned id roundtrip / peer-owned id →
    `Code.PermissionDenied` + `ErrorDetail.code = "session.not_owned"`
    / unknown id collapses to PermissionDenied (NOT NotFound) /
    Internal on missing PRINCIPAL_KEY.
- `packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts` —
  two new wire-up assertions exercising the production Listener A:
  ListSessions does NOT return `Unimplemented` (returns empty list);
  GetSession does NOT return `Unimplemented` (returns
  PermissionDenied for an unknown id).

## Layer 1

- All 6 questions OK — additive read handlers, share existing manager,
  pattern mirrors `watch-sessions.ts`.
- 5-tier: tier 1 — `SessionManager.list/get` and `sessionRowToProto`
  already exist; one-line imports.

## Local checks (host: windows-11)

- lint: ✓ (exit 0; only pre-existing warnings in unrelated files)
- typecheck: ✓ (exit 0)
- build: ✓ (`npm run build` exit 0; `npm run build:app` exit 0 — webpack
  bundle compiled with the same warnings as on `working`)
- unit tests: new `read-handlers.spec.ts` 8/8 PASS in 220ms
  (`npx vitest run test/sessions/read-handlers.spec.ts`).
- full vitest (`npm test`): 1017/1053 PASS, 8 FAIL. **All 8 failures
  pre-exist on `origin/working` on this host** (verified by
  `git stash && npm test`) — they are Connect h2c-loopback timeouts on
  this Windows machine that affect every Listener-A integration test
  identically (Hello / unauthenticated / WatchSessions wired /
  ListSessions / GetSession / `rpc/__tests__/integration.spec.ts`
  router-bind tests). CI's windows matrix passes on `working`
  (`gh run list --branch working` last 3 runs all green), so this is a
  local Node v22.18 + connect-node h2c env issue, not a regression
  introduced by this PR. The two new e2e cases I added join the
  existing pattern and will pass together once that env issue is
  resolved (or in CI).