### PR TITLE
T7.9(#80): tools/verify-signing.{sh,ps1} per-OS signature verification

### DIFF
--- a/tools/test/verify-signing.spec.ts
+++ b/tools/test/verify-signing.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * tools/test/verify-signing.spec.ts
+ *
+ * Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md ch10 §7.
+ * Task #80 (T7.9) — per-OS signature verification scripts (companion to
+ * Task #82 / T7.3 sign-* scripts).
+ *
+ * Forever-stable shape gate for tools/verify-signing.{sh,ps1}. We assert:
+ *
+ *   1. Both files exist at the spec-pinned paths (ch10 §7 last paragraph
+ *      and ch11 §2 directory layout pin them under tools/).
+ *   2. Each script invokes the verification tools the spec pins per OS:
+ *        - mac:   codesign --verify --deep --strict + spctl --assess
+ *        - linux: dpkg-sig --verify (GOODSIG) + rpm --checksig + gpg --verify
+ *        - win:   Get-AuthenticodeSignature + Status -eq 'Valid'
+ *                 + TimeStamperCertificate
+ *   3. The forever-stable env contract appears in each script:
+ *        - CCSM_VERIFY_SIGNING_STRICT (placeholder-safe vs CI-strict toggle)
+ *        - CCSM_EXPECTED_CERT_CN      (cert pinning hook)
+ *   4. Cross-host placeholder-safe behavior: the bash script invoked with
+ *      no inputs and no STRICT env exits 0 with a WARN (does not break
+ *      local dogfood `npm run build` smoke).
+ *
+ * Heavy real-cert / real-MSI verification lives in CI release jobs; this
+ * spec is the cheapest forever-stable contract per dev §2 quality gates.
+ *
+ * Run with:
+ *   npx vitest run --config tools/vitest.config.ts \
+ *     tools/test/verify-signing.spec.ts
+ */
+
+import { execFileSync, spawnSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const SH = join(REPO_ROOT, 'tools', 'verify-signing.sh');
+const PS1 = join(REPO_ROOT, 'tools', 'verify-signing.ps1');
+
+function read(p: string): string {
+  return readFileSync(p, 'utf8');
+}
+
+describe('tools/verify-signing.{sh,ps1} (spec ch10 §7, T7.9)', () => {
+  describe('files exist at spec-pinned paths', () => {
+    it('tools/verify-signing.sh present', () => {
+      expect(existsSync(SH)).toBe(true);
+    });
+    it('tools/verify-signing.ps1 present', () => {
+      expect(existsSync(PS1)).toBe(true);
+    });
+  });
+
+  describe('per-OS verification tool pins (spec ch10 §7)', () => {
+    it('verify-signing.sh mac branch invokes codesign --verify + spctl --assess', () => {
+      const src = read(SH);
+      expect(src).toMatch(/codesign --verify --deep --strict --verbose=4/);
+      expect(src).toMatch(/spctl --assess --type/);
+      // Spec asserts output contains "accepted".
+      expect(src).toMatch(/"accepted"/);
+    });
+
+    it('verify-signing.sh linux branch invokes dpkg-sig + rpm --checksig + gpg --verify', () => {
+      const src = read(SH);
+      expect(src).toMatch(/dpkg-sig --verify/);
+      // Spec literal: GOODSIG.
+      expect(src).toContain('GOODSIG');
+      expect(src).toMatch(/rpm --checksig -v/);
+      // Spec literals: "Header SHA256 digest: OK" and the "Header V4 .../SHA256 Signature, key ID ...: OK" line.
+      expect(src).toContain('Header SHA256 digest: OK');
+      expect(src).toMatch(/Header V4.*SHA256 Signature.*key ID.*OK/);
+      expect(src).toMatch(/gpg --verify/);
+    });
+
+    it('verify-signing.ps1 invokes Get-AuthenticodeSignature with Status/TimeStamper assertions', () => {
+      const src = read(PS1);
+      expect(src).toMatch(/Get-AuthenticodeSignature/);
+      // Spec assertions.
+      expect(src).toMatch(/Status\s*-ne\s*'Valid'|Status\s*-eq\s*'Valid'/);
+      expect(src).toMatch(/TimeStamperCertificate/);
+      expect(src).toMatch(/SignerCertificate\.Subject/);
+    });
+  });
+
+  describe('forever-stable env contract', () => {
+    it('verify-signing.sh references CCSM_VERIFY_SIGNING_STRICT + CCSM_EXPECTED_CERT_CN', () => {
+      const src = read(SH);
+      expect(src).toContain('CCSM_VERIFY_SIGNING_STRICT');
+      expect(src).toContain('CCSM_EXPECTED_CERT_CN');
+    });
+
+    it('verify-signing.ps1 references CCSM_VERIFY_SIGNING_STRICT + CCSM_EXPECTED_CERT_CN', () => {
+      const src = read(PS1);
+      expect(src).toContain('CCSM_VERIFY_SIGNING_STRICT');
+      expect(src).toContain('CCSM_EXPECTED_CERT_CN');
+    });
+  });
+
+  describe('placeholder-safe — exits 0 + WARN with no env / no inputs', () => {
+    // Cross-host placeholder gate: every CI matrix runner exercises this
+    // before its host-specific job. Mirrors the contract from
+    // packages/daemon/build/__tests__/sign-scripts.spec.ts (Task #82).
+    it('verify-signing.sh exits 0 + prints WARN when no artifacts and STRICT unset', () => {
+      const proc = spawnSync(
+        'bash',
+        ['-c', `bash "${SH}" --binary /nonexistent-${Date.now()} --native /nonexistent-${Date.now()} 2>&1`],
+        {
+          env: {
+            ...process.env,
+            CCSM_VERIFY_SIGNING_STRICT: '',
+            CCSM_EXPECTED_CERT_CN: '',
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      );
+      const out = (proc.stdout?.toString() ?? '') + (proc.stderr?.toString() ?? '');
+      expect(proc.status, `expected exit 0, got ${proc.status}. output:\n${out}`).toBe(0);
+      expect(out).toMatch(/WARN:/);
+    });
+
+    it('verify-signing.sh STRICT=1 hard-fails (exit 30) when no artifacts present', () => {
+      const proc = spawnSync(
+        'bash',
+        ['-c', `bash "${SH}" --binary /nonexistent-${Date.now()} --native /nonexistent-${Date.now()} 2>&1`],
+        {
+          env: {
+            ...process.env,
+            CCSM_VERIFY_SIGNING_STRICT: '1',
+            CCSM_EXPECTED_CERT_CN: '',
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        },
+      );
+      const out = (proc.stdout?.toString() ?? '') + (proc.stderr?.toString() ?? '');
+      // Strict mode must surface a non-zero exit; 30 is the documented
+      // "missing tooling / wrong host / missing input" code.
+      expect(proc.status, `expected non-zero exit, got ${proc.status}. output:\n${out}`).not.toBe(0);
+      expect(out).toMatch(/FAIL:/);
+    });
+  });
+
+  describe('CI invocation site (spec ch10 §7)', () => {
+    // The spec pins these scripts as gating in package-* jobs. The actual
+    // wiring lives in the future T0.9 / package-* CI jobs (mutex-blocked
+    // per sign-mac.sh comment). The forever-stable contract this test
+    // protects is just that the scripts exist with executable shebangs so
+    // a `run: bash tools/verify-signing.sh` step works in any matrix.
+    it('verify-signing.sh has bash shebang', () => {
+      const src = read(SH);
+      expect(src.split('\n')[0]).toBe('#!/usr/bin/env bash');
+    });
+  });
+});

--- a/tools/verify-signing.ps1
+++ b/tools/verify-signing.ps1
@@ -1,0 +1,179 @@
+# tools/verify-signing.ps1
+#
+# Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+#       chapter 10 §7 (per-OS signature verification — Windows branch).
+#
+# Task #80 (T7.9) — Windows Authenticode verifier. Companion to T7.3 / #82
+# `packages/daemon/build/sign-win.ps1`. Invoked in the `package-win-msi`
+# CI job AFTER signtool sign and BEFORE artifact upload.
+#
+# Per ch10 §7 row "Windows":
+#   For each of {ccsm-daemon.exe, native\*.node, ccsm-setup-*.msi}:
+#     Get-AuthenticodeSignature <path>
+#   Assert:
+#     .Status                       -eq 'Valid'
+#     .SignerCertificate.Subject    -match 'CN=<expected EV CN>'
+#     .TimeStamperCertificate       -ne $null
+#   Fail the job if any path is NotSigned / HashMismatch / UnknownError.
+#
+# Placeholder-safe (project_v03_ship_intent): on a non-Windows host or
+# when no artifacts are found, the script logs WARN and exits 0 so local
+# dogfood `npm run build` smoke does not break. CI release jobs MUST set
+# CCSM_VERIFY_SIGNING_STRICT=1, which flips every "skipped because tool/
+# host/env missing" gate into a hard failure. A REAL bad-signature finding
+# ALWAYS exits non-zero regardless of strict mode.
+#
+# Env contract (forever-stable):
+#   CCSM_VERIFY_SIGNING_STRICT  if "1", missing tooling / wrong host /
+#                               missing inputs are HARD FAILURES (exit 30).
+#                               Default 0 = placeholder-safe (exit 0+WARN).
+#   CCSM_EXPECTED_CERT_CN       optional substring expected in
+#                               SignerCertificate.Subject, e.g. "CCSM Inc".
+#                               When unset only Status + TimeStamper checks
+#                               run (cert pinning skipped). Set in CI to
+#                               pin the release cert against substitution.
+#
+# Inputs (parameters):
+#   -BinaryPath  ccsm-daemon.exe (default: packages\daemon\dist\ccsm-daemon.exe)
+#   -NativeDir   native\ dir to scan for *.node (default: <pkg>\dist\native)
+#   -MsiPath     optional .msi to verify
+#
+# Exit codes:
+#   0   all verified / placeholder-safe skip (non-strict)
+#   20  bad signature found (always hard failure regardless of strict)
+#   30  strict mode + missing tooling / wrong host / missing input
+
+[CmdletBinding()]
+param(
+  [string] $BinaryPath = '',
+  [string] $NativeDir  = '',
+  [string] $MsiPath    = ''
+)
+
+# Do NOT use $ErrorActionPreference = 'Stop' — we want to handle each
+# Get-AuthenticodeSignature failure ourselves so we can collect ALL bad
+# artifacts before exiting (better CI signal than first-fail-stop).
+
+$Strict       = ($env:CCSM_VERIFY_SIGNING_STRICT -eq '1')
+$ExpectedCN   = $env:CCSM_EXPECTED_CERT_CN
+
+$Here     = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = (Resolve-Path (Join-Path $Here '..')).Path
+
+if (-not $BinaryPath) {
+  $BinaryPath = Join-Path $RepoRoot 'packages\daemon\dist\ccsm-daemon.exe'
+}
+if (-not $NativeDir) {
+  $NativeDir = Join-Path $RepoRoot 'packages\daemon\dist\native'
+}
+
+function Write-Info($msg) { Write-Host "[verify-signing] $msg" }
+function Write-Warn($msg) { Write-Warning "[verify-signing] $msg" }
+function Write-Fail($msg) {
+  # Use Write-Host to stderr-equivalent so the FAIL line renders cleanly in
+  # CI logs without the ScriptStackTrace wrapper that Write-Error injects.
+  [Console]::Error.WriteLine("[verify-signing] FAIL: $msg")
+}
+
+# soft-skip: placeholder-safe in dev, hard-fail in CI strict mode.
+function Invoke-SoftSkip($reason) {
+  if ($Strict) {
+    Write-Fail "$reason (CCSM_VERIFY_SIGNING_STRICT=1)"
+    exit 30
+  }
+  Write-Warn $reason
+  Write-Warn 'skipping — placeholder-safe (set CCSM_VERIFY_SIGNING_STRICT=1 in CI to enforce).'
+  exit 0
+}
+
+# Cross-host gate. Get-AuthenticodeSignature only exists on Windows
+# PowerShell + pwsh-on-Windows (uses Win32 WinVerifyTrust under the hood).
+if ($IsLinux -or $IsMacOS) {
+  Invoke-SoftSkip 'non-Windows host; Get-AuthenticodeSignature unavailable.'
+}
+
+if (-not (Get-Command Get-AuthenticodeSignature -ErrorAction SilentlyContinue)) {
+  # Microsoft.PowerShell.Security usually autoloads, but constrained-mode
+  # or pwsh-on-non-Windows sessions may not. Try one explicit import before
+  # giving up.
+  Import-Module Microsoft.PowerShell.Security -ErrorAction SilentlyContinue
+}
+if (-not (Get-Command Get-AuthenticodeSignature -ErrorAction SilentlyContinue)) {
+  Invoke-SoftSkip 'Get-AuthenticodeSignature cmdlet not available.'
+}
+
+# Build the artifact list.
+$artifacts = New-Object System.Collections.Generic.List[string]
+
+if (Test-Path -LiteralPath $BinaryPath) {
+  $artifacts.Add((Resolve-Path -LiteralPath $BinaryPath).Path)
+}
+
+if (Test-Path -LiteralPath $NativeDir) {
+  Get-ChildItem -LiteralPath $NativeDir -Filter '*.node' -Recurse -ErrorAction SilentlyContinue |
+    ForEach-Object { $artifacts.Add($_.FullName) }
+}
+
+if ($MsiPath) {
+  if (Test-Path -LiteralPath $MsiPath) {
+    $artifacts.Add((Resolve-Path -LiteralPath $MsiPath).Path)
+  } else {
+    Write-Fail "missing --MsiPath input: $MsiPath"
+    exit 20
+  }
+}
+
+if ($artifacts.Count -eq 0) {
+  Invoke-SoftSkip "no signed artifacts found (looked for $BinaryPath, $NativeDir\*.node, -MsiPath)"
+}
+
+Write-Info ("verifying {0} Windows artifact(s)" -f $artifacts.Count)
+
+$bad = @()
+foreach ($art in $artifacts) {
+  Write-Info "  Get-AuthenticodeSignature $art"
+  $sig = $null
+  try {
+    $sig = Get-AuthenticodeSignature -LiteralPath $art -ErrorAction Stop
+  } catch {
+    Write-Fail "Get-AuthenticodeSignature threw for ${art}: $($_.Exception.Message)"
+    $bad += $art
+    continue
+  }
+
+  # Per spec: Status must be Valid.
+  if ($sig.Status -ne 'Valid') {
+    Write-Fail "$art -> Status=$($sig.Status) (expected Valid). StatusMessage=$($sig.StatusMessage)"
+    $bad += $art
+    continue
+  }
+
+  # Per spec: TimeStamperCertificate must be non-null (RFC3161 timestamp
+  # required so the signature outlives the signing cert's expiry).
+  if ($null -eq $sig.TimeStamperCertificate) {
+    Write-Fail "$art -> missing RFC3161 timestamp (TimeStamperCertificate is null)"
+    $bad += $art
+    continue
+  }
+
+  # Per spec: SignerCertificate.Subject must match expected EV CN.
+  # Skipped when CCSM_EXPECTED_CERT_CN is unset (dev / no-pin builds).
+  if ($ExpectedCN) {
+    $subject = $sig.SignerCertificate.Subject
+    if ($subject -notmatch [regex]::Escape($ExpectedCN)) {
+      Write-Fail "$art -> SignerCertificate.Subject='$subject' does not contain '$ExpectedCN'"
+      $bad += $art
+      continue
+    }
+  }
+
+  Write-Info ("    OK Status=Valid Subject={0}" -f $sig.SignerCertificate.Subject)
+}
+
+if ($bad.Count -gt 0) {
+  Write-Fail ("{0} artifact(s) failed verification:`n  {1}" -f $bad.Count, ($bad -join "`n  "))
+  exit 20
+}
+
+Write-Info ("OK -- {0} Windows artifact(s) verified" -f $artifacts.Count)
+exit 0

--- a/tools/verify-signing.sh
+++ b/tools/verify-signing.sh
@@ -1,0 +1,338 @@
+#!/usr/bin/env bash
+# tools/verify-signing.sh
+#
+# Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+#       chapter 10 §7 (per-OS signature verification).
+#
+# Task #80 (T7.9) — per-OS signing VERIFIER. The companion to T7.3 (#82)
+# which produces the signatures. Invoked in each `package-{mac-pkg,
+# linux-deb,linux-rpm}` CI job AFTER signing and BEFORE artifact upload
+# (see ch10 §7 last paragraph). Windows uses verify-signing.ps1 (sibling).
+#
+# Per ch10 §7:
+#
+#   - macOS:   for each of {ccsm-daemon, native/*.node, *.app, *.pkg}:
+#                codesign --verify --deep --strict --verbose=4 <path>
+#                AND spctl --assess --type install --verbose <path>
+#                     (or --type execute for the bare binary)
+#              Assert exit 0 AND output contains 'accepted' / 'valid on disk'.
+#
+#   - Linux:   .deb         -> dpkg-sig --verify <path>; assert GOODSIG.
+#              .rpm         -> rpm --checksig -v <path>; assert
+#                                "(sha256) Header SHA256 digest: OK"
+#                                AND "Header V4 RSA/SHA256 Signature, key ID ...: OK".
+#              bare binary  -> gpg --verify ccsm-daemon.sig ccsm-daemon.
+#
+# Placeholder-safe (project_v03_ship_intent): on a non-target host or when
+# verifier tooling is missing, the script logs WARN and exits 0 so local
+# dogfood `npm run build` smoke does not break. CI release jobs MUST set
+# CCSM_VERIFY_SIGNING_STRICT=1, which flips every "skipped because tool/
+# host/env missing" gate into a hard failure (exit 30+). A REAL bad-
+# signature finding ALWAYS exits non-zero regardless of strict mode —
+# strict only governs the should-have-run-but-couldn't class.
+#
+# Env contract (forever-stable):
+#   CCSM_VERIFY_SIGNING_STRICT  if "1", missing tooling / wrong host /
+#                               missing inputs are HARD FAILURES (exit 30).
+#                               Default 0 = placeholder-safe (exit 0+WARN).
+#   CCSM_EXPECTED_CERT_CN       optional substring expected in the signer
+#                               Subject (mac codesign authority + linux
+#                               key-id check). When unset the check is
+#                               skipped (only signature validity is
+#                               asserted). Set in CI to pin the release
+#                               cert against substitution.
+#
+# Inputs (flags, all optional — only verifies what is provided / found):
+#   --binary <path>     bare daemon binary (default: packages/daemon/dist/ccsm-daemon)
+#   --native <dir>      native/ dir to scan for *.node (default: <pkg>/dist/native)
+#   --pkg <path>        macOS .pkg installer
+#   --app <path>        macOS .app bundle (fallback path per ch10 §1)
+#   --deb <path>        Linux .deb package
+#   --rpm <path>        Linux .rpm package
+#   --sig <path>        detached signature for --binary (default: <binary>.sig)
+#   -h | --help         print usage and exit 0.
+
+set -uo pipefail
+
+# Exit codes:
+#   0   all verified / placeholder-safe skip (non-strict)
+#   20  bad signature found (always hard failure regardless of strict)
+#   30  strict mode + missing tooling / wrong host / missing input
+
+STRICT="${CCSM_VERIFY_SIGNING_STRICT:-0}"
+EXPECTED_CN="${CCSM_EXPECTED_CERT_CN:-}"
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+DEFAULT_BIN="$REPO_ROOT/packages/daemon/dist/ccsm-daemon"
+DEFAULT_NATIVE="$REPO_ROOT/packages/daemon/dist/native"
+
+BINARY=""
+NATIVE_DIR=""
+PKG_PATH=""
+APP_PATH=""
+DEB_PATH=""
+RPM_PATH=""
+SIG_PATH=""
+
+usage() {
+  sed -n '2,55p' "$0"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --binary) BINARY="${2:-}"; shift 2 ;;
+    --native) NATIVE_DIR="${2:-}"; shift 2 ;;
+    --pkg)    PKG_PATH="${2:-}"; shift 2 ;;
+    --app)    APP_PATH="${2:-}"; shift 2 ;;
+    --deb)    DEB_PATH="${2:-}"; shift 2 ;;
+    --rpm)    RPM_PATH="${2:-}"; shift 2 ;;
+    --sig)    SIG_PATH="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "[verify-signing] unknown arg: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[[ -z "$BINARY"     ]] && BINARY="$DEFAULT_BIN"
+[[ -z "$NATIVE_DIR" ]] && NATIVE_DIR="$DEFAULT_NATIVE"
+[[ -z "$SIG_PATH"   ]] && SIG_PATH="${BINARY}.sig"
+
+log()  { echo "[verify-signing] $*"; }
+warn() { echo "[verify-signing] WARN: $*" >&2; }
+fail() { echo "[verify-signing] FAIL: $*" >&2; }
+
+# soft_skip <reason> — placeholder-safe skip in non-strict, hard fail in strict.
+soft_skip() {
+  local reason="$1"
+  if [[ "$STRICT" == "1" ]]; then
+    fail "$reason (CCSM_VERIFY_SIGNING_STRICT=1)"
+    exit 30
+  fi
+  warn "$reason"
+  warn "skipping — placeholder-safe (set CCSM_VERIFY_SIGNING_STRICT=1 in CI to enforce)."
+  exit 0
+}
+
+OS="$(uname -s 2>/dev/null || echo Unknown)"
+
+# Track whether any verification actually ran.
+verified_count=0
+
+# ---- helpers ----
+
+assert_contains() {
+  # assert_contains <haystack> <needle> <context>
+  if ! grep -qF -- "$2" <<<"$1"; then
+    fail "$3: expected output to contain '$2'"
+    return 1
+  fi
+  return 0
+}
+
+# ---- macOS branch ----
+verify_mac_path() {
+  # $1 = path, $2 = spctl --type (execute|install)
+  local path="$1" type="$2"
+  if [[ ! -e "$path" ]]; then
+    fail "missing artifact: $path"
+    return 1
+  fi
+  log "  codesign --verify --deep --strict --verbose=4 $path"
+  local cs_out
+  if ! cs_out="$(codesign --verify --deep --strict --verbose=4 "$path" 2>&1)"; then
+    fail "codesign verify failed: $path"
+    echo "$cs_out" >&2
+    return 1
+  fi
+  # codesign --verify success: stderr typically contains "valid on disk".
+  if ! grep -qE "valid on disk|satisfies its Designated Requirement" <<<"$cs_out"; then
+    # Some codesign versions print nothing on success — accept exit 0 alone
+    # but warn so a future regression where Apple changes the message is
+    # surfaced.
+    warn "codesign succeeded but did not print 'valid on disk' for $path"
+  fi
+
+  log "  spctl --assess --type $type --verbose $path"
+  local sp_out
+  if ! sp_out="$(spctl --assess --type "$type" --verbose "$path" 2>&1)"; then
+    fail "spctl assess failed: $path"
+    echo "$sp_out" >&2
+    return 1
+  fi
+  assert_contains "$sp_out" "accepted" "spctl $path" || return 1
+
+  if [[ -n "$EXPECTED_CN" ]]; then
+    # codesign -dvv prints "Authority=..." lines; the leaf authority
+    # carries the EV CN.
+    local auth_out
+    auth_out="$(codesign -dvv "$path" 2>&1 || true)"
+    if ! grep -qF "$EXPECTED_CN" <<<"$auth_out"; then
+      fail "expected cert CN '$EXPECTED_CN' not found in codesign authority for $path"
+      echo "$auth_out" >&2
+      return 1
+    fi
+  fi
+  return 0
+}
+
+run_mac() {
+  for tool in codesign spctl; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      soft_skip "$tool not on PATH (need macOS Xcode command-line tools)"
+    fi
+  done
+
+  local targets=()
+  [[ -e "$BINARY" ]] && targets+=("execute|$BINARY")
+
+  if [[ -d "$NATIVE_DIR" ]]; then
+    while IFS= read -r f; do
+      [[ -n "$f" ]] && targets+=("execute|$f")
+    done < <(find "$NATIVE_DIR" -type f -name '*.node' 2>/dev/null || true)
+  fi
+
+  [[ -n "$APP_PATH" && -e "$APP_PATH" ]] && targets+=("execute|$APP_PATH")
+  [[ -n "$PKG_PATH" && -e "$PKG_PATH" ]] && targets+=("install|$PKG_PATH")
+
+  if [[ ${#targets[@]} -eq 0 ]]; then
+    soft_skip "no signed artifacts found (looked for $BINARY, $NATIVE_DIR/*.node, --app, --pkg)"
+  fi
+
+  log "verifying ${#targets[@]} macOS artifact(s)"
+  local rc=0
+  for t in "${targets[@]}"; do
+    local type="${t%%|*}" path="${t#*|}"
+    if verify_mac_path "$path" "$type"; then
+      verified_count=$((verified_count + 1))
+    else
+      rc=20
+    fi
+  done
+  if [[ $rc -ne 0 ]]; then exit $rc; fi
+  log "OK — $verified_count macOS artifact(s) verified"
+}
+
+# ---- Linux branch ----
+verify_linux_deb() {
+  local deb="$1"
+  if ! command -v dpkg-sig >/dev/null 2>&1; then
+    soft_skip "dpkg-sig not on PATH (apt-get install dpkg-sig)"
+  fi
+  log "  dpkg-sig --verify $deb"
+  local out
+  if ! out="$(dpkg-sig --verify "$deb" 2>&1)"; then
+    fail "dpkg-sig verify failed: $deb"
+    echo "$out" >&2
+    return 1
+  fi
+  assert_contains "$out" "GOODSIG" "dpkg-sig $deb" || return 1
+  if [[ -n "$EXPECTED_CN" ]] && ! grep -qF "$EXPECTED_CN" <<<"$out"; then
+    fail "expected key id '$EXPECTED_CN' not found in dpkg-sig output for $deb"
+    echo "$out" >&2
+    return 1
+  fi
+  return 0
+}
+
+verify_linux_rpm() {
+  local rpm="$1"
+  if ! command -v rpm >/dev/null 2>&1; then
+    soft_skip "rpm not on PATH (yum/apt install rpm)"
+  fi
+  log "  rpm --checksig -v $rpm"
+  local out
+  if ! out="$(rpm --checksig -v "$rpm" 2>&1)"; then
+    fail "rpm --checksig failed: $rpm"
+    echo "$out" >&2
+    return 1
+  fi
+  # Per spec: assert both lines.
+  assert_contains "$out" "Header SHA256 digest: OK" "rpm checksig $rpm" || return 1
+  if ! grep -qE "Header V4 (RSA|DSA|EdDSA)/SHA256 Signature, key ID .*: OK" <<<"$out"; then
+    fail "rpm checksig: missing 'Header V4 RSA/SHA256 Signature, key ID ...: OK' for $rpm"
+    echo "$out" >&2
+    return 1
+  fi
+  if [[ -n "$EXPECTED_CN" ]] && ! grep -qF "$EXPECTED_CN" <<<"$out"; then
+    fail "expected key id '$EXPECTED_CN' not found in rpm checksig output for $rpm"
+    echo "$out" >&2
+    return 1
+  fi
+  return 0
+}
+
+verify_linux_binary() {
+  local bin="$1" sig="$2"
+  if ! command -v gpg >/dev/null 2>&1; then
+    soft_skip "gpg not on PATH"
+  fi
+  if [[ ! -e "$sig" ]]; then
+    soft_skip "detached signature missing: $sig (expected from sign-linux.sh detach-sign step)"
+  fi
+  log "  gpg --verify $sig $bin"
+  local out
+  if ! out="$(gpg --verify "$sig" "$bin" 2>&1)"; then
+    fail "gpg --verify failed: $bin"
+    echo "$out" >&2
+    return 1
+  fi
+  # gpg --verify success line: "Good signature from ...".
+  assert_contains "$out" "Good signature" "gpg verify $bin" || return 1
+  if [[ -n "$EXPECTED_CN" ]] && ! grep -qF "$EXPECTED_CN" <<<"$out"; then
+    fail "expected key id '$EXPECTED_CN' not found in gpg verify output for $bin"
+    echo "$out" >&2
+    return 1
+  fi
+  return 0
+}
+
+run_linux() {
+  local rc=0 did=0
+
+  if [[ -n "$DEB_PATH" ]]; then
+    if [[ ! -e "$DEB_PATH" ]]; then
+      fail "missing .deb: $DEB_PATH"
+      rc=20
+    elif verify_linux_deb "$DEB_PATH"; then
+      verified_count=$((verified_count + 1)); did=1
+    else
+      rc=20
+    fi
+  fi
+
+  if [[ -n "$RPM_PATH" ]]; then
+    if [[ ! -e "$RPM_PATH" ]]; then
+      fail "missing .rpm: $RPM_PATH"
+      rc=20
+    elif verify_linux_rpm "$RPM_PATH"; then
+      verified_count=$((verified_count + 1)); did=1
+    else
+      rc=20
+    fi
+  fi
+
+  if [[ -e "$BINARY" || -e "$SIG_PATH" ]]; then
+    if [[ ! -e "$BINARY" ]]; then
+      fail "missing binary: $BINARY"
+      rc=20
+    elif verify_linux_binary "$BINARY" "$SIG_PATH"; then
+      verified_count=$((verified_count + 1)); did=1
+    else
+      rc=20
+    fi
+  fi
+
+  if [[ $did -eq 0 && $rc -eq 0 ]]; then
+    soft_skip "no signed artifacts found (pass --deb, --rpm, or place $BINARY + $SIG_PATH)"
+  fi
+
+  if [[ $rc -ne 0 ]]; then exit $rc; fi
+  log "OK — $verified_count Linux artifact(s) verified"
+}
+
+# ---- dispatch ----
+case "$OS" in
+  Darwin) run_mac ;;
+  Linux)  run_linux ;;
+  *)      soft_skip "unsupported host OS: $OS (use verify-signing.ps1 on Windows)" ;;
+esac


### PR DESCRIPTION
## Summary

Implements **Task #80 (T7.9)** per spec ch10 §7 — per-OS signature verifier scripts that run in `package-{win-msi,mac-pkg,linux-deb,linux-rpm}` CI jobs AFTER signing and BEFORE artifact upload. Companion to T7.3 (#82, merged) which produces the signatures.

### Per-OS coverage (spec ch10 §7)

| OS | Tools |
|----|-------|
| macOS | `codesign --verify --deep --strict --verbose=4` + `spctl --assess` on `ccsm-daemon`, every `native/*.node`, optional `.app`, optional `.pkg` |
| Linux | `dpkg-sig --verify` (assert `GOODSIG`) on `.deb`; `rpm --checksig -v` (assert both spec literals) on `.rpm`; `gpg --verify` on the bare-binary detached `.sig` |
| Windows | `Get-AuthenticodeSignature` on `ccsm-daemon.exe`, `native\*.node`, optional `.msi`; assert `Status -eq 'Valid'` + non-null `TimeStamperCertificate` + (optional) cert-CN substring match |

### Forever-stable env contract

- `CCSM_VERIFY_SIGNING_STRICT=1` → missing tooling / wrong host / missing inputs are HARD failures (exit 30). CI release jobs set this.
- `CCSM_VERIFY_SIGNING_STRICT` unset → WARN + exit 0 (placeholder-safe — mirrors the T7.3 `sign-*` contract so local dogfood `npm run build` smoke does not break).
- `CCSM_EXPECTED_CERT_CN` → optional substring pin against signer Subject / gpg key id; skipped when unset (dev / no-pin builds).
- A real bad-signature finding always exits 20 regardless of strict mode (strict only governs the should-have-run-but-couldn't class).

### Files

- `tools/verify-signing.sh` — bash, dispatches `Darwin` → mac branch, `Linux` → linux branch, anything else → soft-skip.
- `tools/verify-signing.ps1` — PowerShell, soft-skips on non-Windows or when `Get-AuthenticodeSignature` is unavailable.
- `tools/test/verify-signing.spec.ts` — vitest spec under `tools/vitest.config.ts`. Forever-stable shape gate: file presence, spec-pinned tool invocations per OS, env-var contract, cross-host placeholder-safe exit-0 + WARN, STRICT=1 exit-30 path. Mirrors the proven T7.3 `sign-scripts.spec.ts` pattern.

### Out of scope (per blockedBy graph + §0 boundaries)

- Wiring the verifier into `package-*` CI jobs (T0.9; the ci.yml mutex is locked per the comment in `sign-mac.sh`).
- Real-cert end-to-end verification (lives in CI release jobs that hold Apple / EV / GPG keys).

## Local checks (host: windows-11)

- lint: ✓ (exit 0, turbo cache)
- typecheck: ✓ (exit 0, `tsc --noEmit && tsc --noEmit -p tsconfig.electron.json`)
- build: ✓ (exit 0, turbo all-green)
- new tools spec: ✓ `Test Files 1 passed (1) / Tests 10 passed (10) / Duration 2.94s`
- bash script smoke on host (MINGW64): non-strict → `WARN: unsupported host OS ... exit=0`; STRICT=1 → `FAIL: unsupported host OS ... exit=30`. ✓
- pwsh script smoke on host (Win11 + pwsh 7): strict-unset → `WARN ... exit=0`; STRICT=1 → `FAIL ... exit=30`. ✓
- pwsh script against real signed binary: `pwsh ... -BinaryPath C:/Windows/System32/notepad.exe` → `OK Status=Valid Subject=CN=Microsoft Windows ... -- 1 Windows artifact(s) verified, exit=0`. ✓
- pwsh script with bad CN: `CCSM_EXPECTED_CERT_CN=WrongCN ... notepad.exe` → `FAIL ... does not contain 'WrongCN', exit=20`. ✓ (real bad-signature path)

## Pre-existing test failures (NOT introduced by this PR)

`pnpm --filter @ccsm/daemon test` is red on `origin/working` HEAD (`f0de131`) before any of my changes:

- baseline (origin/working, my files moved aside): `15 failed | 85 passed | 1 skipped (101) / Tests 96 failed | 922 passed`
- with my changes applied: `16 failed | 84 passed | 1 skipped (101) / Tests 97 failed | 921 passed`

The 1-test delta is harness flake noise within the same daemon suite; my PR adds zero `.ts/.tsx` source — only `tools/verify-signing.{sh,ps1}` + a new isolated tools/ vitest spec. None of the failing test files (`crash-raw-recovery.spec.ts`, `pruner.spec.ts`, etc.) reference anything I touched.

`npm run probe:e2e` shows `1 passed, 2 failed` on `working` HEAD (`harness-real-cli` waitForTerminalReady race + `harness-ui` rename focus race) — both unrelated harness flakes that have nothing to do with bash/PowerShell verifier scripts under `tools/`.

## Test plan

- [ ] Reviewer runs `npx vitest run --config tools/vitest.config.ts tools/test/verify-signing.spec.ts` on any host → 10/10 green.
- [ ] On macOS: `bash tools/verify-signing.sh` with no env → `WARN ... exit 0`; with `CCSM_VERIFY_SIGNING_STRICT=1` → `FAIL ... exit 30` (no signed artifacts).
- [ ] On Linux: same expectation as macOS via Linux branch.
- [ ] On Windows: `pwsh tools/verify-signing.ps1 -BinaryPath C:/Windows/System32/notepad.exe` → `Status=Valid` + exit 0 (sanity end-to-end).