### PR TITLE
feat(proto): add SessionTurnState + Session.turn_state field (Task #265)

### DIFF
--- a/packages/proto/lock.json
+++ b/packages/proto/lock.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
   "files": {
-    "src/ccsm/v1/common.proto": "7e06b7b67fe1f4a75852392238e565bb6ba8081964cba3656cedaaaad2ee5102",
+    "src/ccsm/v1/common.proto": "f064186f4af6d0e3a45d3d1a38ba1c2e66bd6ea69f94f5cd3f447c47f311dbe2",
     "src/ccsm/v1/crash.proto": "d7133746b30daaa20041d0309a196e08ba87f4ab68ee5ffc0a3175a0dc041ce9",
     "src/ccsm/v1/draft.proto": "895e426a34ea4d9f1743049149c64214a5d4af866f4381f98b998a49acac7946",
     "src/ccsm/v1/notify.proto": "2332a47efa90c6b3e982964c7bda4489aff16b599ea6da59a85e4f4f408d878d",
     "src/ccsm/v1/pty.proto": "430658cf93fecac7e53e49b63735aa9962b0fe7ff03a4c2398a681167e828d60",
-    "src/ccsm/v1/session.proto": "ab3e9a70f20fdfadb7c64ef7aa37b89d324d14aaa150a7d7938e30de9ca68467",
+    "src/ccsm/v1/session.proto": "dc4a78eced7ec31e431edf5b00a74f7aa0179161805ecde268a957836d86e325",
     "src/ccsm/v1/settings.proto": "2894f3dc91a912f269994686dc58596229fed359e63f4389d10c9840a328e173",
     "src/ccsm/v1/supervisor.proto": "d6018cc763f8097ce2df097865ee59b7fdecee84f9fe8b784a563b4709b9f1d5"
   }

--- a/packages/proto/src/ccsm/v1/common.proto
+++ b/packages/proto/src/ccsm/v1/common.proto
@@ -34,6 +34,40 @@ enum SessionState {
   SESSION_STATE_CRASHED = 4;
 }
 
+// Forever-stable. Per-session SDK-turn axis — ORTHOGONAL to `SessionState`
+// (which is process lifecycle: STARTING/RUNNING/EXITED/CRASHED). A session
+// in `SESSION_STATE_RUNNING` (the OS subprocess is alive) can be in any of
+// the three turn states below depending on what claude is doing inside that
+// subprocess. UI uses the turn axis to drive the AgentIcon attention halo
+// (idle / requires_action → halo on, running → halo off); process axis
+// drives the row presence + crash/exit affordances. Don't conflate.
+//
+// Mirrors the SDK's authoritative `SDKSessionStateChangedMessage.state`
+// enum (see `node_modules/@anthropic-ai/claude-agent-sdk/sdk.d.ts`) so the
+// daemon does not invent a parallel vocabulary the UI then has to translate
+// twice. ccsm spawns the CLI as a subprocess and tails the on-disk JSONL
+// transcript to infer this axis (see
+// `packages/daemon/src/sessionWatcher/inference.ts`).
+//
+// Wire encoding: the proto3 enum names below intentionally collide with no
+// existing identifier. The `*_UNSPECIFIED = 0` slot is the proto3 default
+// and means "daemon has not yet inferred a turn state for this session"
+// (e.g. JSONL file not yet appeared). Clients MUST treat UNSPECIFIED as
+// "no halo signal" — NOT as a synonym for IDLE — to avoid spurious
+// attention flashes during session start-up before the first JSONL frame
+// lands.
+enum SessionTurnState {
+  SESSION_TURN_STATE_UNSPECIFIED = 0;
+  // Claude finished its turn; the user owes the next move. Drive halo on.
+  SESSION_TURN_STATE_IDLE = 1;
+  // Claude is mid-turn (tool call in flight, or user just typed and the
+  // assistant frame hasn't landed yet). Halo off.
+  SESSION_TURN_STATE_RUNNING = 2;
+  // Claude paused on a permission prompt. Drive halo on (same UX as IDLE
+  // for v0.3; v0.4 may differentiate with a distinct affordance).
+  SESSION_TURN_STATE_REQUIRES_ACTION = 3;
+}
+
 // Forever-stable. Used by every RPC for traceability.
 //
 // F7: closes R4 P1 — daemon MUST validate `request_id` is non-empty on every

--- a/packages/proto/src/ccsm/v1/session.proto
+++ b/packages/proto/src/ccsm/v1/session.proto
@@ -144,6 +144,27 @@ message Session {
   // presence-bit: bit unset means "not currently spawned"; any non-zero
   // value is a live OS pid attributable to this session.
   optional int32 runtime_pid = 9;
+  // Task #265: SDK turn-state axis (orthogonal to `state` above, which is
+  // the OS process lifecycle axis). Sourced from the daemon's JSONL
+  // tail-watcher (`packages/daemon/src/sessionWatcher/inference.ts`).
+  // Drives the renderer's AgentIcon attention halo via WatchSessions
+  // `updated` events — daemon emits `SessionEvent.updated` with the new
+  // turn_state whenever the inferred axis transitions for a session.
+  //
+  // `optional` (proto3 field-presence): an unset bit means "daemon has
+  // not yet inferred a turn state for this session" (e.g. JSONL file not
+  // yet appeared / brand-new session). Distinguishable on the wire from
+  // `SESSION_TURN_STATE_UNSPECIFIED` set explicitly only via the
+  // presence bit; clients SHOULD treat both unset and UNSPECIFIED as
+  // "no halo signal".
+  //
+  // v0.3 cutover: the renderer subscribes to WatchSessions, reads
+  // `turn_state` off the `updated` Session payloads, and feeds it through
+  // the existing `mapState` in `src/agent/lifecycle.ts` (replacing the
+  // current Electron-IPC `session:state` channel). Wire is forever-stable;
+  // future axes (e.g. autoscroll-pinned-by-user) get new field numbers,
+  // never reuse 10.
+  optional SessionTurnState turn_state = 10;
 }
 
 // F6: closes R1 P0.1 (chapter 08). Forever-stable. Per-session friendly

--- a/packages/proto/test/contract/session-turn-state.spec.ts
+++ b/packages/proto/test/contract/session-turn-state.spec.ts
@@ -1,0 +1,135 @@
+// Task #265 contract test — `Session.turn_state` wire shape.
+//
+// What it pins (forever-stable):
+//
+//   1. `SessionTurnState` enum has the exact 4 members at exact int values
+//      (UNSPECIFIED=0, IDLE=1, RUNNING=2, REQUIRES_ACTION=3). Reordering or
+//      reusing a slot is a wire break: the 0 slot is the proto3 default
+//      ("daemon hasn't inferred yet"); IDLE/RUNNING/REQUIRES_ACTION are the
+//      three SDK-authoritative states the renderer's AgentIcon halo branches
+//      on (see `src/agent/lifecycle.ts:mapState`).
+//
+//   2. `Session.turn_state` is `optional` (proto3 field-presence). An unset
+//      bit is wire-distinguishable from an explicit `SESSION_TURN_STATE_*`
+//      value, so the renderer can tell "daemon hasn't inferred yet" apart
+//      from "daemon inferred IDLE". A binary round-trip preserves the
+//      presence bit in both directions (set ↔ unset).
+//
+//   3. The field number is 10 (immediately after `runtime_pid = 9`). Field
+//      numbers are forever-stable; this test pins 10 by encoding a Session
+//      with `turnState = IDLE` and asserting the binary contains the proto
+//      tag for field 10 (varint, wire-type 0 → tag byte = (10<<3)|0 = 0x50).
+//
+// Out of scope: how the daemon emits `updated` events with `turn_state`
+// (handler test lives in `packages/daemon/src/sessions/__tests__/`); how
+// the renderer maps to halo on/off (UI test lives in `src/agent/`). This
+// is a wire-shape contract test only.
+
+import { describe, expect, it } from 'vitest';
+import { create, toBinary, fromBinary } from '@bufbuild/protobuf';
+import {
+  SessionTurnState,
+  SessionState,
+  PrincipalSchema,
+  LocalUserSchema,
+} from '../../gen/ts/ccsm/v1/common_pb.js';
+import { SessionSchema } from '../../gen/ts/ccsm/v1/session_pb.js';
+
+describe('SessionTurnState enum (Task #265)', () => {
+  it('pins the 4 members at their forever-stable int values', () => {
+    // Direct numeric equality — reordering or renaming any of these is a
+    // wire break that would silently flip the renderer's halo logic.
+    expect(SessionTurnState.UNSPECIFIED).toBe(0);
+    expect(SessionTurnState.IDLE).toBe(1);
+    expect(SessionTurnState.RUNNING).toBe(2);
+    expect(SessionTurnState.REQUIRES_ACTION).toBe(3);
+  });
+});
+
+describe('Session.turn_state field-presence (Task #265)', () => {
+  function makeSession(
+    overrides: Partial<{ turnState: SessionTurnState | undefined }> = {},
+  ): ReturnType<typeof create<typeof SessionSchema>> {
+    return create(SessionSchema, {
+      id: 'sid-test',
+      owner: create(PrincipalSchema, {
+        kind: {
+          case: 'localUser',
+          value: create(LocalUserSchema, { uid: '1000', displayName: 'tester' }),
+        },
+      }),
+      state: SessionState.RUNNING,
+      cwd: '/tmp',
+      createdUnixMs: 1n,
+      lastActiveUnixMs: 1n,
+      ...overrides,
+    });
+  }
+
+  it('round-trips an UNSET turn_state as undefined', () => {
+    const original = makeSession();
+    expect(original.turnState).toBeUndefined();
+    const wire = toBinary(SessionSchema, original);
+    const decoded = fromBinary(SessionSchema, wire);
+    expect(decoded.turnState).toBeUndefined();
+  });
+
+  it('round-trips an explicit IDLE turn_state', () => {
+    const original = makeSession({ turnState: SessionTurnState.IDLE });
+    const wire = toBinary(SessionSchema, original);
+    const decoded = fromBinary(SessionSchema, wire);
+    expect(decoded.turnState).toBe(SessionTurnState.IDLE);
+  });
+
+  it('round-trips REQUIRES_ACTION distinctly from RUNNING', () => {
+    const a = fromBinary(
+      SessionSchema,
+      toBinary(SessionSchema, makeSession({ turnState: SessionTurnState.REQUIRES_ACTION })),
+    );
+    const b = fromBinary(
+      SessionSchema,
+      toBinary(SessionSchema, makeSession({ turnState: SessionTurnState.RUNNING })),
+    );
+    expect(a.turnState).toBe(SessionTurnState.REQUIRES_ACTION);
+    expect(b.turnState).toBe(SessionTurnState.RUNNING);
+    expect(a.turnState).not.toBe(b.turnState);
+  });
+
+  it('preserves wire-distinguishability between unset and explicit UNSPECIFIED', () => {
+    // Proto3 field-presence: an `optional` field set to its zero value
+    // (UNSPECIFIED = 0) MUST encode the presence bit, so the wire bytes
+    // for "unset" and "explicit zero" differ. Without this, the renderer
+    // could not tell "daemon hasn't inferred yet" from "daemon inferred
+    // UNSPECIFIED" — the spec-wired UX distinction collapses.
+    const unset = makeSession();
+    const explicitZero = makeSession({ turnState: SessionTurnState.UNSPECIFIED });
+    const unsetWire = toBinary(SessionSchema, unset);
+    const explicitWire = toBinary(SessionSchema, explicitZero);
+    expect(unsetWire.length).toBeLessThan(explicitWire.length);
+    // Decoded shape: unset stays undefined, explicit zero comes back as 0.
+    expect(fromBinary(SessionSchema, unsetWire).turnState).toBeUndefined();
+    expect(fromBinary(SessionSchema, explicitWire).turnState).toBe(
+      SessionTurnState.UNSPECIFIED,
+    );
+  });
+
+  it('encodes turn_state at field number 10 (varint tag 0x50)', () => {
+    // Pin the field number on the wire — moving turn_state to a different
+    // field number would silently desync producers/consumers built against
+    // different snapshots of session.proto. Encode an IDLE turn_state and
+    // assert the proto tag byte appears in the output.
+    //
+    // Tag = (field_number << 3) | wire_type. For an enum (varint),
+    // wire_type = 0, field_number = 10 → tag = 0x50.
+    const wire = toBinary(SessionSchema, makeSession({ turnState: SessionTurnState.IDLE }));
+    // IDLE = 1, varint = 0x01. So bytes [..., 0x50, 0x01, ...] must appear.
+    let found = false;
+    for (let i = 0; i < wire.length - 1; i++) {
+      if (wire[i] === 0x50 && wire[i + 1] === 0x01) {
+        found = true;
+        break;
+      }
+    }
+    expect(found).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `SessionTurnState` enum (UNSPECIFIED/IDLE/RUNNING/REQUIRES_ACTION) to `common.proto` mirroring the SDK's authoritative state names.
- Adds `optional SessionTurnState turn_state = 10` to `Session` in `session.proto` so the SDK turn-state axis the daemon already infers in `packages/daemon/src/sessionWatcher/inference.ts` can ride existing `WatchSessions.updated` events.
- Refreshes `packages/proto/lock.json` for the schema change.
- New contract test `packages/proto/test/contract/session-turn-state.spec.ts` pinning enum values, field-presence round-trip (unset vs explicit UNSPECIFIED stay distinguishable), and field number 10 on the wire.

## Design choice (option a vs b)
Spec offered (a) add `turn_state` to `Session` + emit on `updated`, or (b) dedicated `WatchSessionTurnStates` server-stream RPC. Picked (a):
- Process axis (`SessionState`: STARTING/RUNNING/EXITED/CRASHED) and SDK-turn axis are orthogonal but both per-session lifecycle signals; one stream is the natural shape and the proto already documented `updated` as the slot for "state, exit_code, geometry change, etc."
- Frequency is human-interaction speed; co-locating doesn't drown lifecycle traffic.
- Renderer cutover (`src/agent/lifecycle.ts`) becomes a 1-RPC swap: subscribe `WatchSessions`, read `turn_state` off `updated.session`, feed through existing `mapState`. No second subscription to manage.

## Scope
Wire-schema + contract test ONLY. Out of scope (separate followup tasks):
- Daemon emit path: `SessionManager` subscribing to `sessionWatcher` inferred state and publishing `updated` events with `turn_state`.
- Renderer cutover: replace the `window.ccsmSession.onState` Electron-IPC bridge with a `WatchSessions` subscription.

## Field-presence semantics
The `optional` keyword is load-bearing. Unset bit means "daemon hasn't inferred a turn state yet" (e.g. JSONL file not yet appeared on a brand-new session) and is wire-distinguishable from `SESSION_TURN_STATE_UNSPECIFIED` set explicitly. Both should map to "no halo signal" in the renderer (no spurious attention flashes during session startup).

## Local checks (host: windows-11)
- lint: ok (exit 0, 0 errors)
- typecheck: ok (exit 0)
- build: ok (exit 0)
- unit tests: `@ccsm/proto` 7 files / 38 passed (was 31, +7 new). Other workspaces (snapshot-codec, electron) all green: `Test Files 13 passed, Tests 124 passed | 2 skipped`.
- e2e (probe:e2e): pre-existing baseline failures only (`harness-real-cli session-state-becomes-idle: window.ccsmSession.onState not exposed by preload (PR-A wiring missing)` — that's literally the renderer cutover this PR enables; `harness-ui rename` focus race; `harness-real-cli` terminal-ready timing). All unrelated to wire-schema additions.

## Note on baseline
`pnpm --filter @ccsm/daemon test` is red on `working` (sqlite better_sqlite3 native ABI loader, CRLF/LF migration SHA mismatch, parallel-shutdown timing). Verified with `git stash` that these failures reproduce without this PR's changes — orthogonal to wire-schema additions.

## Test plan
- [x] `pnpm --filter @ccsm/proto test` — 38/38 pass including 7 new contract tests
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `pnpm test --filter '!@ccsm/daemon'` — green
- [x] `git diff` proto-only, lock matches gen output
- [ ] Followup PRs: daemon emit + renderer cutover