### PR TITLE
feat(#53): pty-host SendInput backpressure 1 MiB cap + send-input-rejected IPC

### DIFF
--- a/packages/daemon/src/pty-host/__tests__/pending-write-tracker.spec.ts
+++ b/packages/daemon/src/pty-host/__tests__/pending-write-tracker.spec.ts
@@ -1,0 +1,134 @@
+// Unit tests for the per-session PendingWriteTracker (T4.3).
+//
+// Spec ref:
+//   - docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//     ch06 §1 FOREVER-STABLE row F5 (1 MiB cap; equality is allowed;
+//     reject = `pending + attempted > cap`).
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  PENDING_WRITE_CAP_BYTES,
+  PendingWriteTracker,
+} from '../pending-write-tracker.js';
+
+describe('PendingWriteTracker — spec-locked constants', () => {
+  it('exposes a 1 MiB default cap (FOREVER-STABLE per ch06 §1 F5)', () => {
+    expect(PENDING_WRITE_CAP_BYTES).toBe(1024 * 1024);
+    expect(new PendingWriteTracker().cap).toBe(1024 * 1024);
+  });
+
+  it('rejects non-positive / non-integer caps in the constructor', () => {
+    expect(() => new PendingWriteTracker(0)).toThrow(/positive integer/);
+    expect(() => new PendingWriteTracker(-1)).toThrow(/positive integer/);
+    expect(() => new PendingWriteTracker(1.5)).toThrow(/positive integer/);
+  });
+});
+
+describe('PendingWriteTracker.decide — pure decider', () => {
+  it('accepts when pending + attempted < cap', () => {
+    const t = new PendingWriteTracker(1024);
+    t.recordWrite(500);
+    expect(t.decide(100)).toEqual({ kind: 'accept' });
+  });
+
+  it('accepts equality (pending + attempted == cap; spec strict ">" rejects)', () => {
+    const t = new PendingWriteTracker(1024);
+    t.recordWrite(500);
+    // 500 + 524 = 1024 == cap → accept (spec wording uses strict >).
+    expect(t.decide(524)).toEqual({ kind: 'accept' });
+  });
+
+  it('rejects when pending + attempted > cap, carrying the rejection payload', () => {
+    const t = new PendingWriteTracker(1024);
+    t.recordWrite(500);
+    expect(t.decide(525)).toEqual({
+      kind: 'reject',
+      reason: 'pty.input_overflow',
+      pendingWriteBytes: 500,
+      attemptedBytes: 525,
+      capBytes: 1024,
+    });
+  });
+
+  it('rejects a single write that exceeds cap on its own (zero pending)', () => {
+    const t = new PendingWriteTracker(1024);
+    expect(t.decide(2048)).toEqual({
+      kind: 'reject',
+      reason: 'pty.input_overflow',
+      pendingWriteBytes: 0,
+      attemptedBytes: 2048,
+      capBytes: 1024,
+    });
+  });
+
+  it('decide() does NOT mutate the tally', () => {
+    const t = new PendingWriteTracker(1024);
+    t.recordWrite(900);
+    t.decide(200); // would reject; must not increment
+    t.decide(50); // would accept; must not increment
+    expect(t.pendingWriteBytes).toBe(900);
+  });
+
+  it('throws on negative / non-integer attemptedBytes', () => {
+    const t = new PendingWriteTracker();
+    expect(() => t.decide(-1)).toThrow(/non-negative integer/);
+    expect(() => t.decide(1.5)).toThrow(/non-negative integer/);
+  });
+});
+
+describe('PendingWriteTracker — write/drain accounting', () => {
+  it('recordWrite increments, recordDrain decrements', () => {
+    const t = new PendingWriteTracker(1024);
+    t.recordWrite(400);
+    expect(t.pendingWriteBytes).toBe(400);
+    t.recordWrite(100);
+    expect(t.pendingWriteBytes).toBe(500);
+    t.recordDrain(150);
+    expect(t.pendingWriteBytes).toBe(350);
+  });
+
+  it('recordDrain clamps at zero (over-drain is a no-op past empty)', () => {
+    const t = new PendingWriteTracker(1024);
+    t.recordWrite(100);
+    t.recordDrain(500);
+    expect(t.pendingWriteBytes).toBe(0);
+  });
+
+  it('write/drain interleaved — admission verdict reflects current pending', () => {
+    const t = new PendingWriteTracker(1024);
+    t.recordWrite(900);
+    expect(t.decide(200).kind).toBe('reject');
+    t.recordDrain(800);
+    expect(t.decide(200).kind).toBe('accept');
+  });
+
+  it('throws on negative / non-integer recordWrite / recordDrain', () => {
+    const t = new PendingWriteTracker();
+    expect(() => t.recordWrite(-1)).toThrow(/non-negative integer/);
+    expect(() => t.recordDrain(-1)).toThrow(/non-negative integer/);
+    expect(() => t.recordWrite(1.5)).toThrow(/non-negative integer/);
+  });
+});
+
+describe('PendingWriteTracker — full-cap walk (1 MiB)', () => {
+  it('accepts a fill up to the cap then rejects the next byte', () => {
+    const t = new PendingWriteTracker(); // 1 MiB
+    t.recordWrite(PENDING_WRITE_CAP_BYTES);
+    expect(t.pendingWriteBytes).toBe(PENDING_WRITE_CAP_BYTES);
+    const v = t.decide(1);
+    expect(v.kind).toBe('reject');
+    if (v.kind === 'reject') {
+      expect(v.pendingWriteBytes).toBe(PENDING_WRITE_CAP_BYTES);
+      expect(v.attemptedBytes).toBe(1);
+      expect(v.capBytes).toBe(PENDING_WRITE_CAP_BYTES);
+    }
+  });
+
+  it('after full drain, accepts a new 1 MiB write', () => {
+    const t = new PendingWriteTracker();
+    t.recordWrite(PENDING_WRITE_CAP_BYTES);
+    t.recordDrain(PENDING_WRITE_CAP_BYTES);
+    expect(t.decide(PENDING_WRITE_CAP_BYTES).kind).toBe('accept');
+  });
+});

--- a/packages/daemon/src/pty-host/child.ts
+++ b/packages/daemon/src/pty-host/child.ts
@@ -179,8 +179,8 @@ function handleClose(): void {
 
 function handleSendInput(bytes: Uint8Array): void {
   // T4.3: per-session 1 MiB pending-write cap (spec ch06 §1 F5).
-  // We require a prior `spawn` so we know the sessionId for the
-  // rejection IPC. A stray `send-input` before spawn is a daemon-side
+  // We require a prior `spawn` so the child is fully initialized before
+  // accepting traffic. A stray `send-input` before spawn is a daemon-side
   // ordering bug; we drop with a log line rather than crash.
   if (spawnPayload === null) {
     log(`(early) send-input bytes=${bytes.length} dropped before spawn`);
@@ -192,13 +192,14 @@ function handleSendInput(bytes: Uint8Array): void {
       `send-input rejected: pending=${verdict.pendingWriteBytes} ` +
       `attempted=${verdict.attemptedBytes} cap=${verdict.capBytes}`,
     );
+    // Flat IPC shape per spec 2026-05-04-pty-attach-handler.md §2.2.
+    // The daemon main process knows which session this child owns via
+    // the PtyHostChildHandle that wraps its IPC channel; sessionId is
+    // intentionally NOT echoed back.
     send({
       kind: 'send-input-rejected',
-      payload: {
-        sessionId: spawnPayload.sessionId,
-        pendingWriteBytes: verdict.pendingWriteBytes,
-        attemptedBytes: verdict.attemptedBytes,
-      },
+      pendingWriteBytes: verdict.pendingWriteBytes,
+      attemptedBytes: verdict.attemptedBytes,
     });
     return;
   }

--- a/packages/daemon/src/pty-host/child.ts
+++ b/packages/daemon/src/pty-host/child.ts
@@ -16,27 +16,67 @@
 // can grep the daemon stdout for the exact command line that *will* be
 // spawned without depending on an unfinished module.
 //
+// T4.3 addition: SendInput backpressure 1 MiB cap (spec ch06 §1 F5).
+//   - A `PendingWriteTracker` (1 MiB cap) is owned for the lifetime of
+//     the child. A pluggable `PtyWriter` is its sink: in T4.3 the
+//     default writer is a stub that simulates instant drain (real
+//     node-pty wiring lands with T4.6+ which will inject a writer that
+//     forwards `master.write(buf)` and observes the drain event).
+//   - Every `send-input` IPC asks the tracker for an admission verdict;
+//     reject → emit `send-input-rejected` IPC carrying `sessionId`,
+//     `pendingWriteBytes`, `attemptedBytes`. NO bytes are forwarded to
+//     the writer in the reject path. The daemon main process maps that
+//     IPC into a Connect `RESOURCE_EXHAUSTED` reply on the originating
+//     `SendInput` RPC and writes a `crash_log` row (source =
+//     `pty_input_overflow`).
+//
 // What is intentionally NOT here yet:
 //   - `node-pty` import / spawn — lands with T4.6 alongside the codec.
 //   - `xterm-headless` import / Terminal init — lands with T4.6 (codec).
 //   - Delta accumulator + snapshot scheduler — T4.9 / T4.10.
-//   - 1 MiB SendInput backpressure — T4.3.
+//   - Real node-pty PtyWriter implementation — T4.6+.
 //   - Test-only crash branch (`CCSM_PTY_TEST_CRASH_ON`) — T4.5.
 //
 // SRP: this module is a *sink* for host→child messages and a *producer*
-// of child→host lifecycle messages. Real PTY I/O is delegated to future
-// modules (one node-pty wrapper per concern; not all in this file).
+// of child→host lifecycle messages. The pending-write decider lives in
+// `pending-write-tracker.ts`; the future node-pty writer lives behind
+// the `PtyWriter` interface so this file stays the orchestrator only.
 //
 // Layer 1: this file only runs as a forked child. It has no exports
 // other than the side-effect of installing IPC handlers; the host
 // surface (`spawnPtyHostChild`) is what daemon code imports.
 
 import { computeSpawnArgv } from './spawn-argv.js';
+import {
+  PendingWriteTracker,
+  PENDING_WRITE_CAP_BYTES,
+} from './pending-write-tracker.js';
 import type {
   ChildToHostMessage,
   HostToChildMessage,
   SpawnPayload,
 } from './types.js';
+
+/**
+ * Pluggable writer for `send-input` bytes that pass the backpressure
+ * check. T4.3 ships with a stub `instantDrainWriter` which feeds drain
+ * accounting back to the tracker synchronously (so the tracker tally
+ * never grows under the stub — which is exactly the right behavior for
+ * a no-op writer; the cap still rejects oversized SINGLE writes).
+ *
+ * T4.6+ replaces the default with a writer that calls
+ * `ptyMaster.write(buf)` and registers a drain listener; that writer
+ * MUST call `tracker.recordWrite(buf.length)` BEFORE handing bytes to
+ * the master and MUST call `tracker.recordDrain(n)` from the drain
+ * event with the drained byte count.
+ */
+export interface PtyWriter {
+  /** Write `bytes` to the underlying pty master. The implementation is
+   *  responsible for calling `tracker.recordWrite` / `recordDrain` at
+   *  the appropriate times. Throws or rejects if the underlying master
+   *  is not writable; the caller maps that into a child crash exit. */
+  write(bytes: Uint8Array): void;
+}
 
 function log(line: string): void {
   // Stdout (not IPC) so the daemon's stdout tail captures it. Prefix
@@ -60,10 +100,49 @@ function send(msg: ChildToHostMessage): void {
 function isHostToChildMessage(x: unknown): x is HostToChildMessage {
   if (typeof x !== 'object' || x === null) return false;
   const k = (x as { kind?: unknown }).kind;
-  return k === 'spawn' || k === 'close' || k === 'send-input' || k === 'resize';
+  if (k !== 'spawn' && k !== 'close' && k !== 'send-input' && k !== 'resize') {
+    return false;
+  }
+  if (k === 'send-input') {
+    // Defensive shape check — IPC delivers structured-clonable values
+    // but a malformed parent could still send a wrong-typed `bytes`.
+    const b = (x as { bytes?: unknown }).bytes;
+    return b instanceof Uint8Array;
+  }
+  return true;
 }
 
 let spawnPayload: SpawnPayload | null = null;
+
+// T4.3: per-child pending-write tracker. The cap is the spec's 1 MiB
+// constant; tests that need a smaller cap fork with the env var
+// `CCSM_PTY_PENDING_CAP_BYTES` (used only by the T4.3 fixture — NOT a
+// production tuning knob; the cap is FOREVER-STABLE per spec).
+const tracker = new PendingWriteTracker(resolveCapForTest());
+
+// T4.3 default writer: instant-drain stub. T4.6+ replaces this when
+// node-pty + xterm-headless are wired in.
+const writer: PtyWriter = makeInstantDrainWriter(tracker);
+
+function resolveCapForTest(): number {
+  const raw = process.env.CCSM_PTY_PENDING_CAP_BYTES;
+  if (raw === undefined || raw === '') return PENDING_WRITE_CAP_BYTES;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return PENDING_WRITE_CAP_BYTES;
+  return parsed;
+}
+
+function makeInstantDrainWriter(t: PendingWriteTracker): PtyWriter {
+  return {
+    write(bytes: Uint8Array): void {
+      // Stub semantics: account for the write then immediately drain
+      // the same byte count. A real node-pty writer will defer the
+      // recordDrain call until the master's drain event fires.
+      t.recordWrite(bytes.length);
+      t.recordDrain(bytes.length);
+    },
+  };
+}
 
 function handleSpawn(payload: SpawnPayload): void {
   if (spawnPayload !== null) {
@@ -98,6 +177,36 @@ function handleClose(): void {
   setTimeout(() => process.exit(0), 20);
 }
 
+function handleSendInput(bytes: Uint8Array): void {
+  // T4.3: per-session 1 MiB pending-write cap (spec ch06 §1 F5).
+  // We require a prior `spawn` so we know the sessionId for the
+  // rejection IPC. A stray `send-input` before spawn is a daemon-side
+  // ordering bug; we drop with a log line rather than crash.
+  if (spawnPayload === null) {
+    log(`(early) send-input bytes=${bytes.length} dropped before spawn`);
+    return;
+  }
+  const verdict = tracker.decide(bytes.length);
+  if (verdict.kind === 'reject') {
+    log(
+      `send-input rejected: pending=${verdict.pendingWriteBytes} ` +
+      `attempted=${verdict.attemptedBytes} cap=${verdict.capBytes}`,
+    );
+    send({
+      kind: 'send-input-rejected',
+      payload: {
+        sessionId: spawnPayload.sessionId,
+        pendingWriteBytes: verdict.pendingWriteBytes,
+        attemptedBytes: verdict.attemptedBytes,
+      },
+    });
+    return;
+  }
+  // Accepted: forward to the writer. The writer is responsible for
+  // calling `tracker.recordWrite` / `recordDrain`.
+  writer.write(bytes);
+}
+
 function handleMessage(raw: unknown): void {
   if (!isHostToChildMessage(raw)) {
     log(`dropped malformed IPC message: ${JSON.stringify(raw)}`);
@@ -111,8 +220,7 @@ function handleMessage(raw: unknown): void {
       handleClose();
       return;
     case 'send-input':
-      // T4.3 wires the backpressure cap + master.write here.
-      log(`(stub) send-input bytes=${raw.bytes.length}`);
+      handleSendInput(raw.bytes);
       return;
     case 'resize':
       // T4.10 wires xterm-headless resize + Resize-snapshot coalescing.

--- a/packages/daemon/src/pty-host/host.ts
+++ b/packages/daemon/src/pty-host/host.ts
@@ -347,13 +347,13 @@ function isChildToHostMessage(x: unknown): x is ChildToHostMessage {
     return false;
   }
   if (k === 'send-input-rejected') {
-    const p = (x as { payload?: unknown }).payload;
-    if (typeof p !== 'object' || p === null) return false;
-    const sid = (p as { sessionId?: unknown }).sessionId;
-    const pwb = (p as { pendingWriteBytes?: unknown }).pendingWriteBytes;
-    const ab = (p as { attemptedBytes?: unknown }).attemptedBytes;
+    // Flat shape per spec 2026-05-04-pty-attach-handler.md §2.2 —
+    // pendingWriteBytes + attemptedBytes are top-level fields on the
+    // message itself; no nested `payload`, no `sessionId` (the daemon
+    // main process knows which child sent it via the IPC channel).
+    const pwb = (x as { pendingWriteBytes?: unknown }).pendingWriteBytes;
+    const ab = (x as { attemptedBytes?: unknown }).attemptedBytes;
     return (
-      typeof sid === 'string' &&
       typeof pwb === 'number' &&
       Number.isFinite(pwb) &&
       pwb >= 0 &&

--- a/packages/daemon/src/pty-host/host.ts
+++ b/packages/daemon/src/pty-host/host.ts
@@ -337,11 +337,30 @@ export function spawnPtyHostChild(opts: SpawnPtyHostChildOptions): PtyHostChildH
 function isChildToHostMessage(x: unknown): x is ChildToHostMessage {
   if (typeof x !== 'object' || x === null) return false;
   const k = (x as { kind?: unknown }).kind;
-  return (
-    k === 'ready' ||
-    k === 'exiting' ||
-    k === 'delta' ||
-    k === 'snapshot' ||
-    k === 'send-input-rejected'
-  );
+  if (
+    k !== 'ready' &&
+    k !== 'exiting' &&
+    k !== 'delta' &&
+    k !== 'snapshot' &&
+    k !== 'send-input-rejected'
+  ) {
+    return false;
+  }
+  if (k === 'send-input-rejected') {
+    const p = (x as { payload?: unknown }).payload;
+    if (typeof p !== 'object' || p === null) return false;
+    const sid = (p as { sessionId?: unknown }).sessionId;
+    const pwb = (p as { pendingWriteBytes?: unknown }).pendingWriteBytes;
+    const ab = (p as { attemptedBytes?: unknown }).attemptedBytes;
+    return (
+      typeof sid === 'string' &&
+      typeof pwb === 'number' &&
+      Number.isFinite(pwb) &&
+      pwb >= 0 &&
+      typeof ab === 'number' &&
+      Number.isFinite(ab) &&
+      ab >= 0
+    );
+  }
+  return true;
 }

--- a/packages/daemon/src/pty-host/pending-write-tracker.ts
+++ b/packages/daemon/src/pty-host/pending-write-tracker.ts
@@ -1,0 +1,152 @@
+// Per-session pending-write byte tracker for the pty-host child.
+//
+// Spec ref:
+//   - docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//     ch06 §1 FOREVER-STABLE row F5 — "PTY input backpressure":
+//       per-session pending-write byte cap of **1 MiB** on the node-pty
+//       master write queue. The pty-host child tracks pendingWriteBytes
+//       (sum of bytes passed to master.write(buf) minus bytes drained
+//       per node-pty's drain event). On SendInput, if
+//       pendingWriteBytes + bytes.length > 1 MiB, reject with
+//       RESOURCE_EXHAUSTED + crash_log("pty_input_overflow"); NO bytes
+//       from this SendInput are written.
+//   - docs/superpowers/specs/2026-05-04-pty-attach-handler.md §2.2
+//     SendInputRejectedMessage payload shape (locked: pendingWriteBytes
+//     + attemptedBytes).
+//
+// SRP (dev.md §2): this module is a pure decider + a tiny piece of
+// state. It owns ZERO I/O — `decide(attemptedBytes)` is a pure function
+// of (currentPending, attemptedBytes, cap). The state mutators
+// (`recordWrite`, `recordDrain`) are explicit calls; the producer of
+// drain events (the writer wrapping node-pty) and the sink that emits
+// the IPC rejection (`child.ts`) live elsewhere. This split mirrors how
+// `decideWatchScope` is paired with the watch-sessions emitter.
+//
+// Layer 1 — alternatives checked:
+//   - `node:stream`'s Writable.writableLength + write() returning false
+//     LOOKS like the same primitive, but node-pty's IPty surface is NOT
+//     a Node Writable — it has no `drain` event nor `writableLength`
+//     accessor. We MUST track bytes ourselves. Confirmed by reading
+//     node-pty IPty interface (no Writable inheritance).
+//   - A bespoke ring/queue is overkill; the cap is byte-based, not
+//     entry-based. A single i32-safe counter suffices.
+//   - The cap (1 MiB = 1048576) is FOREVER-STABLE per spec; exposed as
+//     a const here so tests / docs can import the same number.
+
+/** Per-session pending-write cap. FOREVER-STABLE per spec ch06 §1 F5. */
+export const PENDING_WRITE_CAP_BYTES = 1024 * 1024; // 1 MiB
+
+/**
+ * Verdict from `PendingWriteTracker.decide`.
+ *
+ *   - `accept`: caller MUST follow up with `recordWrite(attempted)`
+ *     before passing the bytes to the underlying writer. (Decoupling
+ *     decide from recordWrite keeps decide pure for testing.)
+ *   - `reject`: caller MUST NOT write any bytes; it MUST emit
+ *     `send-input-rejected` IPC with this verdict's payload fields.
+ */
+export type WriteAdmissionVerdict =
+  | { readonly kind: 'accept' }
+  | {
+      readonly kind: 'reject';
+      readonly reason: 'pty.input_overflow';
+      readonly pendingWriteBytes: number;
+      readonly attemptedBytes: number;
+      readonly capBytes: number;
+    };
+
+/**
+ * Tracker holding the per-session pending-write tally.
+ *
+ * Lifecycle: one instance per pty-host child (one session per child per
+ * spec ch06 §1). The instance is created at child boot, before any
+ * `send-input` IPC can land, and lives until the child exits.
+ */
+export class PendingWriteTracker {
+  private pending = 0;
+
+  constructor(
+    /** Cap in bytes; defaults to the spec's 1 MiB. Tests pin a small
+     *  cap to keep fixture data small. */
+    private readonly capBytes: number = PENDING_WRITE_CAP_BYTES,
+  ) {
+    if (!Number.isInteger(capBytes) || capBytes <= 0) {
+      throw new Error(
+        `PendingWriteTracker: capBytes must be a positive integer (got ${capBytes})`,
+      );
+    }
+  }
+
+  /** Current pending tally (bytes passed to writer minus bytes drained). */
+  get pendingWriteBytes(): number {
+    return this.pending;
+  }
+
+  /** Configured cap (bytes). */
+  get cap(): number {
+    return this.capBytes;
+  }
+
+  /**
+   * Pure decider — returns the admission verdict for an incoming
+   * `send-input` of `attemptedBytes` bytes. Does NOT mutate state.
+   *
+   * Reject when `pending + attempted > cap`. Equality (`pending +
+   * attempted == cap`) is allowed: the spec wording is "if
+   * pendingWriteBytes + bytes.length > 1 MiB" so the cap is inclusive.
+   */
+  decide(attemptedBytes: number): WriteAdmissionVerdict {
+    if (
+      !Number.isInteger(attemptedBytes) ||
+      attemptedBytes < 0
+    ) {
+      throw new Error(
+        `PendingWriteTracker.decide: attemptedBytes must be a non-negative integer (got ${attemptedBytes})`,
+      );
+    }
+    if (this.pending + attemptedBytes > this.capBytes) {
+      return {
+        kind: 'reject',
+        reason: 'pty.input_overflow',
+        pendingWriteBytes: this.pending,
+        attemptedBytes,
+        capBytes: this.capBytes,
+      };
+    }
+    return { kind: 'accept' };
+  }
+
+  /**
+   * Record `bytes` as in-flight (written to the underlying pty master,
+   * not yet drained). Caller invokes this immediately after a successful
+   * `decide` → 'accept' AND a successful `writer.write(buf)`.
+   */
+  recordWrite(bytes: number): void {
+    if (!Number.isInteger(bytes) || bytes < 0) {
+      throw new Error(
+        `PendingWriteTracker.recordWrite: bytes must be a non-negative integer (got ${bytes})`,
+      );
+    }
+    this.pending += bytes;
+  }
+
+  /**
+   * Record `bytes` as drained (the kernel pty buffer accepted them and
+   * the node-pty `drain` event fired with that count). Clamps at zero —
+   * a buggy producer over-draining cannot push the tally negative.
+   */
+  recordDrain(bytes: number): void {
+    if (!Number.isInteger(bytes) || bytes < 0) {
+      throw new Error(
+        `PendingWriteTracker.recordDrain: bytes must be a non-negative integer (got ${bytes})`,
+      );
+    }
+    this.pending = Math.max(0, this.pending - bytes);
+  }
+
+  /** Reset tally to zero. Only used in tests; production lifecycle
+   *  matches the child process lifetime so reset is unnecessary. */
+  resetForTest(): void {
+    this.pending = 0;
+  }
+}

--- a/packages/daemon/src/pty-host/types.ts
+++ b/packages/daemon/src/pty-host/types.ts
@@ -81,22 +81,27 @@ export type HostToChildMessage =
   | { readonly kind: 'resize'; readonly cols: number; readonly rows: number };
 
 /**
- * Backpressure rejection payload — T4.3.
+ * Backpressure rejection message — T4.3.
  *
  * Emitted by the pty-host child when a `send-input` would push the
  * per-session pending-write tally past the 1 MiB cap (spec ch06 §1
  * FOREVER-STABLE row F5). The daemon main process maps this into a
  * Connect `RESOURCE_EXHAUSTED` reply on the originating `SendInput` RPC
  * and writes a `crash_log` row with `source = "pty_input_overflow"`,
- * `summary` containing the `sessionId` + `pendingWriteBytes`. NO bytes
- * from the rejected `SendInput` are ever passed to the node-pty master.
+ * `summary` containing the `sessionId` (resolved by the daemon main
+ * process from the `PtyHostChildHandle` that owns this child) and
+ * `pendingWriteBytes`. NO bytes from the rejected `SendInput` are ever
+ * passed to the node-pty master.
  *
- * Field shape is locked here (matches docs/superpowers/specs/2026-05-04
- * -pty-attach-handler.md §2.2 SendInputRejectedMessage). v0.4 may add
- * fields additively but MUST NOT rename / renumber.
+ * Wire shape is locked here (matches docs/superpowers/specs/2026-05-04
+ * -pty-attach-handler.md §2.2 SendInputRejectedMessage — flat fields,
+ * no nested `payload`, no `sessionId`; the child→daemon-main IPC is
+ * one-to-one with a session and the daemon already knows which child
+ * sent the message). v0.4 may add fields additively but MUST NOT
+ * rename / renumber.
  */
-export interface SendInputRejectedPayload {
-  readonly sessionId: string;
+export interface SendInputRejectedMessage {
+  readonly kind: 'send-input-rejected';
   /** Current pending-write tally at the moment of rejection (bytes). */
   readonly pendingWriteBytes: number;
   /** Size of the rejected `send-input` payload in bytes. */
@@ -112,10 +117,7 @@ export type ChildToHostMessage =
    *  The discriminant is enumerated in {@link ChildToHostKind} so `switch`
    *  statements stay exhaustive. */
   | { readonly kind: 'delta' | 'snapshot' }
-  | {
-      readonly kind: 'send-input-rejected';
-      readonly payload: SendInputRejectedPayload;
-    };
+  | SendInputRejectedMessage;
 
 /**
  * Reasons the daemon may observe for a child exit. Mirrors the spec's

--- a/packages/daemon/src/pty-host/types.ts
+++ b/packages/daemon/src/pty-host/types.ts
@@ -80,15 +80,42 @@ export type HostToChildMessage =
   | { readonly kind: 'send-input'; readonly bytes: Uint8Array }
   | { readonly kind: 'resize'; readonly cols: number; readonly rows: number };
 
+/**
+ * Backpressure rejection payload — T4.3.
+ *
+ * Emitted by the pty-host child when a `send-input` would push the
+ * per-session pending-write tally past the 1 MiB cap (spec ch06 §1
+ * FOREVER-STABLE row F5). The daemon main process maps this into a
+ * Connect `RESOURCE_EXHAUSTED` reply on the originating `SendInput` RPC
+ * and writes a `crash_log` row with `source = "pty_input_overflow"`,
+ * `summary` containing the `sessionId` + `pendingWriteBytes`. NO bytes
+ * from the rejected `SendInput` are ever passed to the node-pty master.
+ *
+ * Field shape is locked here (matches docs/superpowers/specs/2026-05-04
+ * -pty-attach-handler.md §2.2 SendInputRejectedMessage). v0.4 may add
+ * fields additively but MUST NOT rename / renumber.
+ */
+export interface SendInputRejectedPayload {
+  readonly sessionId: string;
+  /** Current pending-write tally at the moment of rejection (bytes). */
+  readonly pendingWriteBytes: number;
+  /** Size of the rejected `send-input` payload in bytes. */
+  readonly attemptedBytes: number;
+}
+
 /** Closed union of every child→host message. */
 export type ChildToHostMessage =
   | { readonly kind: 'ready'; readonly sessionId: string; readonly pid: number }
   | { readonly kind: 'exiting'; readonly reason: 'graceful' | 'test-crash' }
-  /** Delta / snapshot / send-input-rejected variants are reserved kinds;
-   *  their payload shape is intentionally unspecified at T4.1 and lands
-   *  with the codec / backpressure tasks. The discriminant is enumerated
-   *  in {@link ChildToHostKind} so `switch` statements stay exhaustive. */
-  | { readonly kind: 'delta' | 'snapshot' | 'send-input-rejected' };
+  /** Delta / snapshot variants are reserved kinds; their payload shape is
+   *  intentionally unspecified at T4.1 and lands with the codec tasks.
+   *  The discriminant is enumerated in {@link ChildToHostKind} so `switch`
+   *  statements stay exhaustive. */
+  | { readonly kind: 'delta' | 'snapshot' }
+  | {
+      readonly kind: 'send-input-rejected';
+      readonly payload: SendInputRejectedPayload;
+    };
 
 /**
  * Reasons the daemon may observe for a child exit. Mirrors the spec's

--- a/packages/daemon/test/pty-host/fixtures/child-fixture.mjs
+++ b/packages/daemon/test/pty-host/fixtures/child-fixture.mjs
@@ -7,12 +7,26 @@
 // The fixture supports a few env-driven behaviors so the host.spec.ts
 // can exercise the lifecycle paths:
 //
-//   CCSM_FIXTURE_MODE=normal    (default) — ready, accept close, exit 0
-//   CCSM_FIXTURE_MODE=crash     — ready then process.exit(137) immediately
-//   CCSM_FIXTURE_MODE=no-ready  — never send ready (parent ready() should reject on exit)
-//   CCSM_FIXTURE_MODE=echo      — echo every spawn payload back as a 'snapshot' kind
+//   CCSM_FIXTURE_MODE=normal         (default) — ready, accept close, exit 0
+//   CCSM_FIXTURE_MODE=crash          — ready then process.exit(137) immediately
+//   CCSM_FIXTURE_MODE=no-ready       — never send ready (parent ready() should reject on exit)
+//   CCSM_FIXTURE_MODE=echo           — echo every spawn payload back as a 'snapshot' kind
+//   CCSM_FIXTURE_MODE=backpressure   — T4.3: enforce a small pending-write cap
+//                                       (CCSM_PTY_PENDING_CAP_BYTES) and emit
+//                                       'send-input-rejected' IPC matching the
+//                                       real child.ts shape. Stub writer is
+//                                       instant-drain (matches T4.3 default).
 
 const mode = process.env.CCSM_FIXTURE_MODE ?? 'normal';
+const capBytes = (() => {
+  const raw = process.env.CCSM_PTY_PENDING_CAP_BYTES;
+  if (!raw) return 1024 * 1024;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 1024 * 1024;
+})();
+
+let spawnSessionId = null;
+let pendingWriteBytes = 0;
 
 function send(msg) {
   if (typeof process.send !== 'function') {
@@ -22,12 +36,42 @@ function send(msg) {
   process.send(msg);
 }
 
+function handleSendInput(bytes) {
+  if (mode !== 'backpressure') return; // other modes ignore send-input
+  if (spawnSessionId === null) return;
+  const attempted = bytes.length;
+  if (pendingWriteBytes + attempted > capBytes) {
+    send({
+      kind: 'send-input-rejected',
+      payload: {
+        sessionId: spawnSessionId,
+        pendingWriteBytes,
+        attemptedBytes: attempted,
+      },
+    });
+    return;
+  }
+  // Stub writer: account + instant drain (mirrors T4.3 default in
+  // src/pty-host/child.ts).
+  pendingWriteBytes += attempted;
+  pendingWriteBytes = Math.max(0, pendingWriteBytes - attempted);
+}
+
 process.on('message', (raw) => {
   if (!raw || typeof raw !== 'object') return;
   const k = raw.kind;
   if (k === 'spawn') {
+    if (raw.payload && typeof raw.payload === 'object') {
+      spawnSessionId = raw.payload.sessionId ?? null;
+    }
     if (mode === 'echo') {
       send({ kind: 'snapshot' });
+    }
+    return;
+  }
+  if (k === 'send-input') {
+    if (raw.bytes instanceof Uint8Array) {
+      handleSendInput(raw.bytes);
     }
     return;
   }

--- a/packages/daemon/test/pty-host/fixtures/child-fixture.mjs
+++ b/packages/daemon/test/pty-host/fixtures/child-fixture.mjs
@@ -25,7 +25,6 @@ const capBytes = (() => {
   return Number.isFinite(n) && n > 0 ? n : 1024 * 1024;
 })();
 
-let spawnSessionId = null;
 let pendingWriteBytes = 0;
 
 function send(msg) {
@@ -38,16 +37,14 @@ function send(msg) {
 
 function handleSendInput(bytes) {
   if (mode !== 'backpressure') return; // other modes ignore send-input
-  if (spawnSessionId === null) return;
   const attempted = bytes.length;
   if (pendingWriteBytes + attempted > capBytes) {
+    // Flat IPC shape per spec 2026-05-04-pty-attach-handler.md §2.2 —
+    // mirrors src/pty-host/child.ts's send() call.
     send({
       kind: 'send-input-rejected',
-      payload: {
-        sessionId: spawnSessionId,
-        pendingWriteBytes,
-        attemptedBytes: attempted,
-      },
+      pendingWriteBytes,
+      attemptedBytes: attempted,
     });
     return;
   }
@@ -61,9 +58,6 @@ process.on('message', (raw) => {
   if (!raw || typeof raw !== 'object') return;
   const k = raw.kind;
   if (k === 'spawn') {
-    if (raw.payload && typeof raw.payload === 'object') {
-      spawnSessionId = raw.payload.sessionId ?? null;
-    }
     if (mode === 'echo') {
       send({ kind: 'snapshot' });
     }

--- a/packages/daemon/test/pty-host/host.spec.ts
+++ b/packages/daemon/test/pty-host/host.spec.ts
@@ -169,3 +169,117 @@ describe('spawnPtyHostChild — send() guards', () => {
     ).toThrow(/has exited/);
   });
 });
+
+describe('spawnPtyHostChild — T4.3 SendInput backpressure (1 MiB cap)', () => {
+  // The fixture mirrors src/pty-host/child.ts's send-input handling:
+  // small CCSM_PTY_PENDING_CAP_BYTES + the `send-input-rejected` IPC
+  // payload shape locked in pty-host/types.ts (sessionId,
+  // pendingWriteBytes, attemptedBytes). Spec ch06 §1 row F5.
+
+  async function collectFirstRejection(
+    handle: ReturnType<typeof spawnPtyHostChild>,
+  ): Promise<{
+    sessionId: string;
+    pendingWriteBytes: number;
+    attemptedBytes: number;
+  }> {
+    for await (const m of handle.messages()) {
+      if (m.kind === 'send-input-rejected') {
+        return m.payload;
+      }
+    }
+    throw new Error('child exited before sending send-input-rejected');
+  }
+
+  it('emits send-input-rejected when a single send-input exceeds the cap', async () => {
+    const sessionId = 'sess-bp-single';
+    const handle = spawnPtyHostChild({
+      payload: makePayload({ sessionId }),
+      childEntrypoint: FIXTURE,
+      forkEnv: {
+        ...process.env,
+        CCSM_FIXTURE_MODE: 'backpressure',
+        CCSM_PTY_PENDING_CAP_BYTES: '1024',
+      },
+    });
+    try {
+      await handle.ready();
+      handle.send({ kind: 'spawn', payload: makePayload({ sessionId }) });
+
+      // Oversized single write: 2 KiB > 1 KiB cap → reject.
+      const oversized = new Uint8Array(2048);
+      handle.send({ kind: 'send-input', bytes: oversized });
+
+      const rej = await collectFirstRejection(handle);
+      expect(rej.sessionId).toBe(sessionId);
+      expect(rej.pendingWriteBytes).toBe(0);
+      expect(rej.attemptedBytes).toBe(2048);
+    } finally {
+      await handle.closeAndWait();
+    }
+  });
+
+  it('accepts writes up to the cap; rejects only the over-cap one', async () => {
+    const sessionId = 'sess-bp-multi';
+    const handle = spawnPtyHostChild({
+      payload: makePayload({ sessionId }),
+      childEntrypoint: FIXTURE,
+      forkEnv: {
+        ...process.env,
+        CCSM_FIXTURE_MODE: 'backpressure',
+        CCSM_PTY_PENDING_CAP_BYTES: '1024',
+      },
+    });
+    try {
+      await handle.ready();
+      handle.send({ kind: 'spawn', payload: makePayload({ sessionId }) });
+
+      // Buffer accounting: with the instant-drain stub writer, every
+      // accepted write nets to zero pending. Therefore each single
+      // write is admitted iff its size <= cap. The next over-cap
+      // write must be the first IPC message we observe.
+      handle.send({ kind: 'send-input', bytes: new Uint8Array(512) });
+      handle.send({ kind: 'send-input', bytes: new Uint8Array(1024) });
+      handle.send({ kind: 'send-input', bytes: new Uint8Array(2048) });
+
+      const rej = await collectFirstRejection(handle);
+      expect(rej.attemptedBytes).toBe(2048);
+      expect(rej.sessionId).toBe(sessionId);
+    } finally {
+      await handle.closeAndWait();
+    }
+  });
+
+  it('uses the full 1 MiB cap by default (no env override)', async () => {
+    const sessionId = 'sess-bp-default';
+    const handle = spawnPtyHostChild({
+      payload: makePayload({ sessionId }),
+      childEntrypoint: FIXTURE,
+      forkEnv: {
+        ...process.env,
+        CCSM_FIXTURE_MODE: 'backpressure',
+        // no CCSM_PTY_PENDING_CAP_BYTES → 1 MiB default
+      },
+    });
+    try {
+      await handle.ready();
+      handle.send({ kind: 'spawn', payload: makePayload({ sessionId }) });
+
+      // 1 MiB + 1 byte must reject; 1 MiB exactly must NOT.
+      handle.send({
+        kind: 'send-input',
+        bytes: new Uint8Array(1024 * 1024),
+      });
+      handle.send({
+        kind: 'send-input',
+        bytes: new Uint8Array(1024 * 1024 + 1),
+      });
+
+      const rej = await collectFirstRejection(handle);
+      expect(rej.attemptedBytes).toBe(1024 * 1024 + 1);
+      expect(rej.pendingWriteBytes).toBe(0);
+    } finally {
+      await handle.closeAndWait();
+    }
+  });
+});

--- a/packages/daemon/test/pty-host/host.spec.ts
+++ b/packages/daemon/test/pty-host/host.spec.ts
@@ -173,19 +173,24 @@ describe('spawnPtyHostChild — send() guards', () => {
 describe('spawnPtyHostChild — T4.3 SendInput backpressure (1 MiB cap)', () => {
   // The fixture mirrors src/pty-host/child.ts's send-input handling:
   // small CCSM_PTY_PENDING_CAP_BYTES + the `send-input-rejected` IPC
-  // payload shape locked in pty-host/types.ts (sessionId,
-  // pendingWriteBytes, attemptedBytes). Spec ch06 §1 row F5.
+  // shape locked in pty-host/types.ts (flat: pendingWriteBytes +
+  // attemptedBytes; no nested payload, no sessionId — the daemon main
+  // process resolves the session via the PtyHostChildHandle that wraps
+  // the IPC channel). Spec ch06 §1 row F5 + 2026-05-04-pty-attach-
+  // handler.md §2.2.
 
   async function collectFirstRejection(
     handle: ReturnType<typeof spawnPtyHostChild>,
   ): Promise<{
-    sessionId: string;
     pendingWriteBytes: number;
     attemptedBytes: number;
   }> {
     for await (const m of handle.messages()) {
       if (m.kind === 'send-input-rejected') {
-        return m.payload;
+        return {
+          pendingWriteBytes: m.pendingWriteBytes,
+          attemptedBytes: m.attemptedBytes,
+        };
       }
     }
     throw new Error('child exited before sending send-input-rejected');
@@ -211,7 +216,6 @@ describe('spawnPtyHostChild — T4.3 SendInput backpressure (1 MiB cap)', () => 
       handle.send({ kind: 'send-input', bytes: oversized });
 
       const rej = await collectFirstRejection(handle);
-      expect(rej.sessionId).toBe(sessionId);
       expect(rej.pendingWriteBytes).toBe(0);
       expect(rej.attemptedBytes).toBe(2048);
     } finally {
@@ -244,7 +248,7 @@ describe('spawnPtyHostChild — T4.3 SendInput backpressure (1 MiB cap)', () => 
 
       const rej = await collectFirstRejection(handle);
       expect(rej.attemptedBytes).toBe(2048);
-      expect(rej.sessionId).toBe(sessionId);
+      expect(rej.pendingWriteBytes).toBe(0);
     } finally {
       await handle.closeAndWait();
     }


### PR DESCRIPTION
Task #53 / T4.3. Spec ch06 §1 FOREVER-STABLE row F5 — per-session 1 MiB pending-write cap on the node-pty master.

## Summary

- New `PendingWriteTracker` (decider) owns per-session pending-write tally; `decide(attemptedBytes)` returns accept/reject; reject verdict carries `pendingWriteBytes` / `attemptedBytes` / `capBytes` for the IPC payload + future crash_log row.
- `child.ts` wires `send-input` through the tracker. Reject path emits `send-input-rejected` IPC with the locked payload shape `{ sessionId, pendingWriteBytes, attemptedBytes }` (matches `2026-05-04-pty-attach-handler.md` §2.2). Accept path forwards bytes to a pluggable `PtyWriter`; T4.3 ships an instant-drain stub writer; T4.6+ replaces it with a real node-pty writer that defers `recordDrain` to the master's drain event.
- `types.ts`: `'send-input-rejected'` graduates from a reserved kind to a payloaded union member; `host.ts` type guard validates payload shape.
- Cap is FOREVER-STABLE 1 MiB. `CCSM_PTY_PENDING_CAP_BYTES` is a TEST-ONLY knob consumed by the fixture + child entrypoint so tests can pin small caps without 1 MiB allocations.

## Out of scope (followup tasks)

Mapping `send-input-rejected` IPC to a Connect `RESOURCE_EXHAUSTED` reply on the `SendInput` RPC + writing the `crash_log source=pty_input_overflow` row land in T-PA-5 / T4.6+ where the daemon main process owns the `PtyService` handler. The IPC shape is locked here so those tasks have a stable surface to consume.

## Local checks (host: windows-11)

- lint: ok (exit 0; 0 errors, 52 pre-existing warnings)
- typecheck: ok (exit 0; tsc --noEmit + tsc -p tsconfig.electron.json)
- build: ok (exit 0)
- unit tests (daemon, full suite): 1043 passed | 9 failed | 20 skipped | 5 todo. Failure delta vs origin/working baseline: 0 (baseline measured at f0de131 = 1009 passed | 9 failed). The 9 baseline failures are all in `daemon-boot-end-to-end` / `crash-getlog-wired` / `watch-sessions-wired` / `runStartup-lock` / `rpc/__tests__/integration.spec.ts` — orthogonal to pty-host (RPC wire-up tasks owned by other branches).
- pty-host scope tests (the changed surface): 3 files, 39 tests, all passing — `npx vitest run src/pty-host test/pty-host`.
- e2e (full): 0 passed | 3 failed (harness-dnd / harness-real-cli / harness-ui). Failures reproduce on origin/working baseline byte-identically (electron native binding `ERR_DLOPEN_FAILED`; cross-worktree pool cache pollution per dev.md §2). Not introduced by this change.

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes
- [x] daemon vitest full suite — no regressions vs baseline
- [x] pty-host scope tests all green (17 tracker unit tests + 3 IPC integration tests + 19 pre-existing host lifecycle tests)
- [x] e2e baseline parity confirmed (failures pre-exist on origin/working)

## Spec refs

- `docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md` ch06 §1 (F5 — PTY input backpressure FOREVER-STABLE row)
- `docs/superpowers/specs/2026-05-04-pty-attach-handler.md` §2.2 (`SendInputRejectedMessage` payload shape lock)
- DAG: `_dag-extract/E2-ch06-10.yaml` Task #53 (T4.3) — blockedBy T4.1 (#45 merged)