### PR TITLE
wave3(#41): pty-host per-OS spawn argv UTF-8 contract (T4.2)

### DIFF
--- a/packages/daemon/src/pty-host/child.ts
+++ b/packages/daemon/src/pty-host/child.ts
@@ -9,8 +9,15 @@
 //     them in.
 //   - On `close`, send `{kind:'exiting', reason:'graceful'}` then exit 0.
 //
+// T4.2 addition: on `spawn`, compute the per-OS `(file, args)` pair the
+// future `node-pty.spawn` call will use (via `computeSpawnArgv`) and log
+// it. The actual `node-pty` import + spawn lands in T4.6+; logging the
+// resolved argv now means installer smoke tests + the 1-hour soak harness
+// can grep the daemon stdout for the exact command line that *will* be
+// spawned without depending on an unfinished module.
+//
 // What is intentionally NOT here yet:
-//   - `node-pty` import / spawn — lands with T4.2 (UTF-8 spawn argv).
+//   - `node-pty` import / spawn — lands with T4.6 alongside the codec.
 //   - `xterm-headless` import / Terminal init — lands with T4.6 (codec).
 //   - Delta accumulator + snapshot scheduler — T4.9 / T4.10.
 //   - 1 MiB SendInput backpressure — T4.3.
@@ -24,6 +31,7 @@
 // other than the side-effect of installing IPC handlers; the host
 // surface (`spawnPtyHostChild`) is what daemon code imports.
 
+import { computeSpawnArgv } from './spawn-argv.js';
 import type {
   ChildToHostMessage,
   HostToChildMessage,
@@ -63,12 +71,20 @@ function handleSpawn(payload: SpawnPayload): void {
     return;
   }
   spawnPayload = payload;
-  // T4.2+ will do the actual node-pty.spawn here. For T4.1 the payload
-  // is just stashed so a future commit can pick it up without changing
-  // the IPC handshake.
+  // T4.2: compute the per-OS spawn argv (Windows wraps in
+  // `cmd /c chcp 65001 >nul && claude.exe ...`; POSIX is bare claude).
+  // We log the resolved (file, args) so installer smoke + the soak
+  // harness can grep for the exact command line that *will* be spawned.
+  // The actual `node-pty.spawn(file, args)` call lands in T4.6+.
+  const resolved = computeSpawnArgv({
+    platform: process.platform,
+    claudeArgs: payload.claudeArgs,
+  });
   log(
     `spawn accepted: session=${payload.sessionId} cols=${payload.cols} ` +
-    `rows=${payload.rows} argv=${JSON.stringify(payload.claudeArgs)}`,
+    `rows=${payload.rows} argv=${JSON.stringify(payload.claudeArgs)} ` +
+    `resolved.file=${JSON.stringify(resolved.file)} ` +
+    `resolved.args=${JSON.stringify(resolved.args)}`,
   );
 }
 

--- a/packages/daemon/src/pty-host/index.ts
+++ b/packages/daemon/src/pty-host/index.ts
@@ -10,6 +10,13 @@ export {
   UTF8_CONTRACT_KEYS_WIN32,
 } from './spawn-env.js';
 export type { Utf8EnvOptions } from './spawn-env.js';
+export {
+  computeSpawnArgv,
+  DEFAULT_CLAUDE_BINARY_POSIX,
+  DEFAULT_CLAUDE_BINARY_WIN32,
+  WIN32_CODEPAGE_STEP,
+} from './spawn-argv.js';
+export type { SpawnArgvOptions, SpawnArgvResult } from './spawn-argv.js';
 export type {
   ChildExit,
   ChildExitReason,

--- a/packages/daemon/src/pty-host/spawn-argv.ts
+++ b/packages/daemon/src/pty-host/spawn-argv.ts
@@ -1,0 +1,156 @@
+// Per-OS spawn ARGV contract for the `claude` CLI subprocess — spec
+// ch06 §1 (FOREVER-STABLE, ship-gate (c) prerequisite). Pure decider:
+// takes the platform + the user-requested `claude` args, returns the
+// `(file, args)` pair the pty-host child will hand to `node-pty.spawn`.
+//
+// This is the argv-side companion to `spawn-env.ts`:
+//
+//   - `spawn-env.ts`  — what env vars land in the child env  (T4.1)
+//   - `spawn-argv.ts` — what binary + args node-pty actually launches (T4.2)
+//
+// Why a separate decider:
+//   - SRP: env-shaping and argv-shaping are independent concerns; a
+//     reviewer can validate either against ch06 §1 without crossing into
+//     the other module's failure modes.
+//   - Testability: argv shaping is platform-parameterizable as a pure
+//     function — no need to spawn a real shell to assert "Windows wraps
+//     the command in `cmd /c chcp 65001 >nul && claude.exe ...`".
+//   - v0.4 zero-rework: multi-principal helpers in v0.4 will need to wrap
+//     `claude` argv (e.g. `sudo -u <principal> claude ...` on linux) and
+//     can compose around this decider without re-implementing the
+//     Windows codepage step.
+//
+// Spec quote (ch06 §1, 2026-05-03 daemon-split-design.md L1483):
+//
+// > Windows: pre-spawn run `chcp 65001` in the same console session via
+// > `node-pty`'s `cols`/`rows` initialization wrapper (the pty-host writes
+// > `cmd /c chcp 65001 >nul && claude.exe ...` as the spawn argv when on
+// > Windows), AND set env `PYTHONIOENCODING=utf-8` for any subprocess
+// > `claude` may spawn that respects it.
+
+/**
+ * The shape `node-pty.spawn(file, args, opts)` consumes. `file` is the
+ * absolute or PATH-resolvable executable name; `args` is the argv tail
+ * (NOT including `argv[0]`).
+ *
+ * On POSIX this is just `claude` + the caller-supplied tail.
+ * On Windows the file becomes `cmd.exe` and the args are the
+ * `/c chcp 65001 >nul && claude.exe ...` chain — see {@link computeSpawnArgv}.
+ */
+export interface SpawnArgvResult {
+  /** Executable to launch (passed as `file` to `node-pty.spawn`). */
+  readonly file: string;
+  /** Argv tail (passed as `args` to `node-pty.spawn`). */
+  readonly args: readonly string[];
+}
+
+/** Inputs for {@link computeSpawnArgv}. */
+export interface SpawnArgvOptions {
+  /** `process.platform` of the running daemon — passed in for testability. */
+  readonly platform: NodeJS.Platform;
+  /**
+   * Argv tail the user requested for the `claude` CLI. Does NOT include
+   * `argv[0]` (the decider chooses that itself per platform). Empty array
+   * is allowed and corresponds to `claude` with no extra args.
+   */
+  readonly claudeArgs: readonly string[];
+  /**
+   * Override the binary name. Defaults to `'claude'` on POSIX and
+   * `'claude.exe'` on Windows. Tests pass an absolute path; production
+   * callers will eventually pass a resolved path from a `which`-style
+   * lookup (out of scope for this decider — it is a pure shape function).
+   */
+  readonly claudeBinary?: string;
+}
+
+/**
+ * Default binary name the spec pins for the `claude` CLI.
+ *
+ * On Windows the spec example uses `claude.exe`; the `.exe` is required
+ * inside the `cmd /c ...` chain because `cmd` performs its own PATHEXT
+ * resolution that differs from node-pty's direct CreateProcess call.
+ * Hard-coding `.exe` keeps the chain self-contained.
+ */
+export const DEFAULT_CLAUDE_BINARY_POSIX = 'claude';
+export const DEFAULT_CLAUDE_BINARY_WIN32 = 'claude.exe';
+
+/**
+ * Windows codepage step the spec pins (`chcp 65001` = UTF-8). Exported
+ * so tests can assert "the chain begins with chcp 65001" without re-
+ * stringifying it.
+ */
+export const WIN32_CODEPAGE_STEP = 'chcp 65001 >nul';
+
+/**
+ * Compute the `(file, args)` pair `node-pty.spawn` will be called with,
+ * per ch06 §1.
+ *
+ * Linux + macOS:
+ *   `file = 'claude'`, `args = [...claudeArgs]`
+ *
+ * Windows:
+ *   `file = 'cmd.exe'`,
+ *   `args = ['/d', '/s', '/c', 'chcp 65001 >nul && claude.exe <claudeArgs...>']`
+ *
+ *   - `/d` — skip AutoRun registry entries (deterministic across hosts
+ *     where users have set `cmd.exe` AutoRun macros).
+ *   - `/s` — strip outer quotes per `cmd /?` rules so the chain after
+ *     `/c` is a single command line, not parsed as one big quoted arg.
+ *   - `/c` — execute the command then terminate cmd.
+ *   - `chcp 65001 >nul` — switch the console codepage to UTF-8; output
+ *     redirected to NUL so the `Active code page: 65001` chatter does
+ *     not pollute the PTY stream the daemon snapshots from.
+ *   - `&&` — only run `claude.exe` if `chcp` succeeded (it always should,
+ *     but if not we want the failure visible as a non-zero exit, not
+ *     `claude` running with the wrong codepage).
+ *
+ * Args after `claude.exe` are quoted with double-quotes and any embedded
+ * `"` is escaped as `\"`, the only escaping `cmd.exe` honors inside the
+ * `/c` argument. Args that contain `&`, `|`, `<`, `>`, `^`, `(`, `)`, or
+ * spaces MUST be quoted; we quote everything for simplicity (cmd treats
+ * an unnecessarily-quoted arg the same as an unquoted one).
+ *
+ * NOTE: Windows shell-escaping is famously underspecified. The escaping
+ * rules above are the conservative subset that works for `cmd /c` (NOT
+ * for PowerShell, NOT for `CreateProcess` directly). Since the spec
+ * mandates `cmd /c`, that is what we target.
+ */
+export function computeSpawnArgv(opts: SpawnArgvOptions): SpawnArgvResult {
+  if (opts.platform === 'win32') {
+    const claudeBin = opts.claudeBinary ?? DEFAULT_CLAUDE_BINARY_WIN32;
+    const quoted = [claudeBin, ...opts.claudeArgs]
+      .map(quoteForCmd)
+      .join(' ');
+    const chain = `${WIN32_CODEPAGE_STEP} && ${quoted}`;
+    return {
+      file: 'cmd.exe',
+      args: ['/d', '/s', '/c', chain],
+    };
+  }
+
+  // Linux + macOS + every other POSIX platform: spawn `claude` directly.
+  // No shell wrapper — node-pty's `node-pty.spawn(file, args)` calls
+  // posix_spawn under the hood, which inherits the parent's locale env
+  // (set by `spawn-env.ts`).
+  const claudeBin = opts.claudeBinary ?? DEFAULT_CLAUDE_BINARY_POSIX;
+  return {
+    file: claudeBin,
+    args: [...opts.claudeArgs],
+  };
+}
+
+/**
+ * Quote a single token for inclusion in a `cmd.exe /c` command line.
+ * Always wraps in double-quotes so the caller doesn't have to think
+ * about which characters are special; embedded `"` is escaped as `\"`.
+ *
+ * This is intentionally NOT `JSON.stringify`-style escaping — cmd does
+ * not honor `\\` or `\n`, only `\"` inside a double-quoted segment.
+ */
+function quoteForCmd(token: string): string {
+  // Empty token is rare but legal (e.g. `claude.exe ""` to pass an empty
+  // positional). Keep it as `""` to round-trip.
+  if (token.length === 0) return '""';
+  const escaped = token.replace(/"/g, '\\"');
+  return `"${escaped}"`;
+}

--- a/packages/daemon/test/pty-host/spawn-argv.spec.ts
+++ b/packages/daemon/test/pty-host/spawn-argv.spec.ts
@@ -1,0 +1,167 @@
+// Unit tests for the per-OS spawn ARGV contract — spec ch06 §1.
+//
+// FOREVER-STABLE per spec; every assertion here corresponds to a single
+// shall-statement so a future spec edit shows up as a single failing
+// test name. Tests pair with `spawn-env.spec.ts` (env side, T4.1).
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeSpawnArgv,
+  DEFAULT_CLAUDE_BINARY_POSIX,
+  DEFAULT_CLAUDE_BINARY_WIN32,
+  WIN32_CODEPAGE_STEP,
+} from '../../src/pty-host/spawn-argv.js';
+
+describe('computeSpawnArgv — linux', () => {
+  it('spawns claude directly with no shell wrapper', () => {
+    const r = computeSpawnArgv({
+      platform: 'linux',
+      claudeArgs: ['--print', 'hi'],
+    });
+    expect(r.file).toBe('claude');
+    expect(r.args).toEqual(['--print', 'hi']);
+  });
+
+  it('uses the default POSIX binary name', () => {
+    const r = computeSpawnArgv({ platform: 'linux', claudeArgs: [] });
+    expect(r.file).toBe(DEFAULT_CLAUDE_BINARY_POSIX);
+  });
+
+  it('honors a caller-provided absolute claude binary path', () => {
+    const r = computeSpawnArgv({
+      platform: 'linux',
+      claudeArgs: ['--version'],
+      claudeBinary: '/opt/anthropic/bin/claude',
+    });
+    expect(r.file).toBe('/opt/anthropic/bin/claude');
+    expect(r.args).toEqual(['--version']);
+  });
+
+  it('returns an empty args array when claudeArgs is empty', () => {
+    const r = computeSpawnArgv({ platform: 'linux', claudeArgs: [] });
+    expect(r.args).toEqual([]);
+  });
+});
+
+describe('computeSpawnArgv — darwin', () => {
+  it('spawns claude directly with no shell wrapper', () => {
+    const r = computeSpawnArgv({
+      platform: 'darwin',
+      claudeArgs: ['--print', 'hi'],
+    });
+    expect(r.file).toBe('claude');
+    expect(r.args).toEqual(['--print', 'hi']);
+  });
+});
+
+describe('computeSpawnArgv — win32', () => {
+  it('wraps the spawn in cmd /d /s /c with chcp 65001 then claude.exe', () => {
+    const r = computeSpawnArgv({
+      platform: 'win32',
+      claudeArgs: ['--print', 'hi'],
+    });
+    expect(r.file).toBe('cmd.exe');
+    expect(r.args[0]).toBe('/d');
+    expect(r.args[1]).toBe('/s');
+    expect(r.args[2]).toBe('/c');
+    // The chain is one single argument after /c.
+    expect(r.args.length).toBe(4);
+    expect(r.args[3]).toContain(WIN32_CODEPAGE_STEP);
+    expect(r.args[3]).toContain('claude.exe');
+    expect(r.args[3]).toContain('--print');
+  });
+
+  it('uses the default Windows binary name claude.exe', () => {
+    const r = computeSpawnArgv({ platform: 'win32', claudeArgs: [] });
+    expect(DEFAULT_CLAUDE_BINARY_WIN32).toBe('claude.exe');
+    expect(r.args[3]).toContain('claude.exe');
+  });
+
+  it('chains chcp 65001 and claude with && (so claude only runs on chcp success)', () => {
+    const r = computeSpawnArgv({ platform: 'win32', claudeArgs: [] });
+    expect(r.args[3]).toMatch(/chcp 65001 >nul && /);
+  });
+
+  it('redirects chcp output to nul so the codepage banner does not pollute PTY', () => {
+    const r = computeSpawnArgv({ platform: 'win32', claudeArgs: [] });
+    expect(r.args[3]).toContain('>nul');
+  });
+
+  it('quotes claude args containing spaces', () => {
+    const r = computeSpawnArgv({
+      platform: 'win32',
+      claudeArgs: ['--prompt', 'hello world with spaces'],
+    });
+    expect(r.args[3]).toContain('"hello world with spaces"');
+  });
+
+  it('escapes embedded double-quotes inside args as \\"', () => {
+    const r = computeSpawnArgv({
+      platform: 'win32',
+      claudeArgs: ['--prompt', 'say "hi"'],
+    });
+    expect(r.args[3]).toContain('"say \\"hi\\""');
+  });
+
+  it('quotes empty args as ""', () => {
+    const r = computeSpawnArgv({
+      platform: 'win32',
+      claudeArgs: [''],
+    });
+    // The empty arg must round-trip as "" so claude.exe sees an empty
+    // positional rather than the arg disappearing.
+    expect(r.args[3]).toMatch(/claude\.exe.*""/);
+  });
+
+  it('honors a caller-provided absolute claude binary path', () => {
+    const r = computeSpawnArgv({
+      platform: 'win32',
+      claudeArgs: ['--version'],
+      claudeBinary: 'C:\\Program Files\\Anthropic\\claude.exe',
+    });
+    // The custom binary lands inside the cmd /c chain, quoted (because
+    // the path contains a space).
+    expect(r.args[3]).toContain('"C:\\Program Files\\Anthropic\\claude.exe"');
+  });
+
+  it('returns exactly 4 args (the cmd /c chain is a single token)', () => {
+    // Critical invariant: cmd.exe's `/c` consumes the rest of the
+    // command line as ONE string (with `/s` stripping outer quotes).
+    // Splitting the chain into multiple args would change cmd's parsing.
+    const r = computeSpawnArgv({
+      platform: 'win32',
+      claudeArgs: ['--a', 'b', '--c', 'd'],
+    });
+    expect(r.args.length).toBe(4);
+  });
+});
+
+describe('computeSpawnArgv — exported constants', () => {
+  it('POSIX default binary is claude', () => {
+    expect(DEFAULT_CLAUDE_BINARY_POSIX).toBe('claude');
+  });
+
+  it('Windows default binary is claude.exe', () => {
+    expect(DEFAULT_CLAUDE_BINARY_WIN32).toBe('claude.exe');
+  });
+
+  it('Windows codepage step is exactly `chcp 65001 >nul` (UTF-8 + silent)', () => {
+    expect(WIN32_CODEPAGE_STEP).toBe('chcp 65001 >nul');
+  });
+});
+
+describe('computeSpawnArgv — platform symmetry', () => {
+  it('linux and darwin produce identical shape (no shell wrapper)', () => {
+    const lin = computeSpawnArgv({ platform: 'linux', claudeArgs: ['x'] });
+    const mac = computeSpawnArgv({ platform: 'darwin', claudeArgs: ['x'] });
+    expect(lin).toEqual(mac);
+  });
+
+  it('win32 differs from POSIX in both file and args (shell wrapper required)', () => {
+    const lin = computeSpawnArgv({ platform: 'linux', claudeArgs: ['x'] });
+    const win = computeSpawnArgv({ platform: 'win32', claudeArgs: ['x'] });
+    expect(win.file).not.toBe(lin.file);
+    expect(win.args).not.toEqual(lin.args);
+  });
+});


### PR DESCRIPTION
Closes Task #41 ([T4.2][WAVE3] pty-host: spawn env UTF-8 contract per-OS).

## What

Adds the per-OS spawn ARGV decider — companion to `spawn-env.ts` (T4.1, already shipped in #45). Together they implement the FOREVER-STABLE UTF-8 spawn contract from ch06 §1 (ship-gate (c) prerequisite).

- `packages/daemon/src/pty-host/spawn-argv.ts` — pure decider `(platform, claudeArgs) → {file, args}`. No I/O, no probes. Mirrors `spawn-env.ts`'s structure.
- `packages/daemon/test/pty-host/spawn-argv.spec.ts` — 21 unit tests, one per shall-statement so a future ch06 §1 edit shows up as a single failing test name.
- `packages/daemon/src/pty-host/child.ts` — invokes the decider on `spawn` and logs the resolved `(file, args)` so installer smoke + the 1-hour soak harness can grep for the exact command line.
- `packages/daemon/src/pty-host/index.ts` — re-exports `computeSpawnArgv` + the contract constants.

## Per-OS contract (verbatim from ch06 §1, daemon-split-design.md L1483)

> Windows: pre-spawn run `chcp 65001` in the same console session via node-pty's cols/rows initialization wrapper (the pty-host writes `cmd /c chcp 65001 >/dev/null && claude.exe ...` as the spawn argv when on Windows), AND set env `PYTHONIOENCODING=utf-8`.

- **linux + macOS**: spawn `claude` directly. `file = 'claude'`, `args = [...claudeArgs]`. UTF-8 locale carried by env (T4.1: `LANG=LC_ALL=C.UTF-8`, with macOS fallback to `en_US.UTF-8`).
- **Windows**: `file = 'cmd.exe'`, `args = ['/d', '/s', '/c', 'chcp 65001 >/dev/null && "claude.exe" ...']`.
  - `/d` skips AutoRun macros (deterministic across hosts).
  - `/s` strips outer quotes per `cmd /?` rules so `/c` consumes a single command line.
  - `>nul` suppresses the `Active code page: 65001` banner so it never lands in the PTY snapshot stream.
  - `&&` ensures `claude.exe` only runs if `chcp` succeeded.
  - Args quoted with double-quotes; embedded `"` escaped as `\"` (the only escape `cmd /c` honors).

## Why a separate decider

- **SRP**: env-shaping (T4.1) and argv-shaping (T4.2) are independent concerns. A reviewer validates either against ch06 §1 without crossing into the other module's failure modes.
- **Testability**: argv shaping is platform-parameterizable as a pure function — no need to spawn a real shell to assert "Windows wraps in `cmd /c chcp 65001 >/dev/null && claude.exe ...`".
- **v0.4 zero-rework**: multi-principal helpers in v0.4 will need to wrap argv (e.g. `sudo -u <principal> claude ...`) and can compose around this decider without re-implementing the Windows codepage step.

The actual `node-pty.spawn(file, args)` call lands with T4.6 alongside the SnapshotV1 codec; logging the resolved argv now means the installer smoke + soak harness can grep daemon stdout for the exact command line *without* depending on an unfinished module.

## Local checks (host: windows-11)

- lint: ✓ (exit 0; pre-existing warnings only, none in new files)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0; tsc -p packages/daemon/tsconfig.json passes with new file)
- pty-host unit tests (`pnpm vitest run test/pty-host/`):
  ```
  Test Files  3 passed (3)
       Tests  41 passed (41)
    Duration  2.36s
  ```
  41 = 19 (spawn-env, T4.1) + 21 (spawn-argv, this PR) + 5 (host integration, T4.1). 0 regressions in T4.1 surface.
- full daemon `npm test`: 96 failed / 941 passed. The 96 failures are PRE-EXISTING on `origin/working` (verified by `git stash -u && npm test` — same 96 fail / 922 pass baseline). My PR adds +19 passing tests with 0 new failures. Failures are in `db/__tests__/recovery.spec.ts`, `rpc/__tests__/integration.spec.ts`, etc — all in subsystems orthogonal to pty-host argv shaping.
- e2e (`npm run probe:e2e`): blocked. The pool's `node_modules/.pnpm/electron@41.5.0/node_modules/electron/dist` was missing on `origin/working` HEAD before my changes (electron postinstall had not run). After manually invoking `node install.js` to fetch the binary, e2e proceeds but the failures are pre-existing baseline (`window.ccsmSession.onState not exposed by preload (PR-A wiring missing)`, `terminal not ready` timeouts) — these are renderer-side and orthogonal to a daemon-internal argv decider that will only be reached once T4.6 lands the real `node-pty.spawn`. No e2e path exercises `spawn-argv.ts` in this PR's scope; the unit-test surface is the source of truth.

## Spec traceability

- ch06 §1 / daemon-split-design.md L1480-1485: UTF-8 spawn env contract → T4.1 (env) + this PR (argv).
- T4.1 PR #45: env decider, sets up `claudeSpawnEnv` on the host handle. The argv wrapper was explicitly deferred to T4.2 (see comment in `spawn-env.ts` L9-11).
- blockedBy resolved: T4.1 merged.