### PR TITLE
feat(#42): pty-host child crash semantics — CRASHED state, no respawn

### DIFF
--- a/packages/daemon/src/pty-host/exit-decider.ts
+++ b/packages/daemon/src/pty-host/exit-decider.ts
@@ -1,0 +1,81 @@
+// Pure decider: map a pty-host `ChildExit` observation to the
+// `(SessionEndedReason, exit_code)` pair the SessionManager needs.
+//
+// Spec ch06 §1 — child-exit semantics:
+//   - graceful close: child sent `{kind:'exiting', reason:'graceful'}`
+//     before its `exit` event fired with `code === 0`. Surfaced here as
+//     `reason='graceful'` so the SessionManager records `state=EXITED`.
+//     This matches the user-initiated DestroySession terminal state but
+//     is reached via the child-exit observation rather than the RPC
+//     (the daemon may DestroySession the child first; the child then
+//     exits cleanly; both paths converge on `state=EXITED`).
+//   - everything else: any non-zero exit code, any signal (SIGKILL /
+//     SIGTERM / SIGSEGV), or an IPC disconnect that arrived before a
+//     graceful `exiting` notice. All map to `reason='crashed'` so the
+//     SessionManager records `state=CRASHED`. v0.3 ship rule per spec
+//     ch06 §1: "no respawn" — the daemon does not auto-restart a
+//     crashed pty-host. The user re-launches via a fresh
+//     `CreateSession` RPC.
+//
+// SRP (dev.md §3): this module is a *decider* — pure function over the
+// `ChildExit` input record + the daemon's internal vocabulary. NO I/O,
+// NO logging, NO database access. The sink that calls it (the lifecycle
+// watcher) handles all side effects. Keeping the decision pure means
+// the same logic is unit-testable without forking a real child.
+//
+// Layer 1: this is 5 lines of branching that could live inline at the
+// watcher, but extraction earns three things: (a) the spec invariant
+// "graceful iff `exiting` notice AND code === 0" lives in one place
+// instead of being inlined at every call site that grows over T4.x; (b)
+// unit tests pin the truth-table independently of the watcher's IPC
+// plumbing; (c) a future T9.x crash-source classifier can reuse this
+// to label crash_log rows from the same vocabulary the SessionManager
+// terminal-state uses.
+
+import type { ChildExit } from './types.js';
+
+import type { SessionEndedReason } from '../sessions/types.js';
+
+/**
+ * Result type — exactly the shape `SessionManager.markEnded` expects in
+ * its `MarkEndedParams`. Re-exported as a fresh interface (not aliased
+ * to `MarkEndedParams`) so `pty-host/` does not depend on the
+ * SessionManager's exported parameter types — the watcher does the
+ * import-and-forward.
+ */
+export interface SessionEndDecision {
+  readonly reason: SessionEndedReason;
+  readonly exit_code: number | null;
+}
+
+/**
+ * Decide the terminal `(reason, exit_code)` for a pty-host child exit
+ * record. Pure function; safe to call from anywhere.
+ *
+ * Truth table (spec ch06 §1):
+ *
+ *   exit.reason | exit.code  | exit.signal | decision.reason | decision.exit_code
+ *   ------------+------------+-------------+-----------------+--------------------
+ *   graceful    | 0          | null        | graceful        | 0
+ *   crashed     | <non-zero> | null        | crashed         | <code>
+ *   crashed     | null       | <signal>    | crashed         | null
+ *   crashed     | 0          | null        | crashed         | 0       (a)
+ *   graceful    | <non-zero> | …           | crashed         | <code>  (b)
+ *
+ * Notes:
+ *   (a) The host surface only labels an exit `graceful` when both the
+ *       `exiting` notice arrived AND `code === 0`. So `crashed + code 0`
+ *       at the decider input is already "the child sent no graceful
+ *       notice but happened to exit 0" — still a crash by spec.
+ *   (b) Symmetrically, the host clamps `graceful` to require `code 0`,
+ *       so this row is unreachable in practice — included for
+ *       defense-in-depth: if a future host change relaxes the gate, the
+ *       decider still classifies anything with a non-zero code as a
+ *       crash.
+ */
+export function decideSessionEnd(exit: ChildExit): SessionEndDecision {
+  if (exit.reason === 'graceful' && exit.code === 0 && exit.signal === null) {
+    return { reason: 'graceful', exit_code: 0 };
+  }
+  return { reason: 'crashed', exit_code: exit.code };
+}

--- a/packages/daemon/src/pty-host/index.ts
+++ b/packages/daemon/src/pty-host/index.ts
@@ -19,3 +19,10 @@ export type {
   HostToChildMessage,
   SpawnPayload,
 } from './types.js';
+export { decideSessionEnd } from './exit-decider.js';
+export type { SessionEndDecision } from './exit-decider.js';
+export { watchPtyHostChildLifecycle } from './lifecycle-watcher.js';
+export type {
+  PtyHostChildWatcher,
+  WatchPtyHostChildLifecycleDeps,
+} from './lifecycle-watcher.js';

--- a/packages/daemon/src/pty-host/lifecycle-watcher.ts
+++ b/packages/daemon/src/pty-host/lifecycle-watcher.ts
@@ -1,0 +1,159 @@
+// Lifecycle watcher: bind a per-session pty-host child handle to the
+// SessionManager's terminal-state machinery. Spec ch06 §1.
+//
+// One call per session: `watchPtyHostChildLifecycle(handle, deps)` is
+// invoked right after `spawnPtyHostChild` returns and the daemon has
+// recorded the child's pid against the SessionRow. From that point the
+// watcher owns the child→session bridge until the child exits.
+//
+// On `handle.exited()`:
+//   1. SIGKILL the child's process subtree as a SAFETY NET. Spec ch06
+//      §1: "child.on('exit') SIGKILLs claude/-pgid". The pty-host
+//      child IS the parent of the `claude` CLI, so by the time the
+//      child has exited the OS has already sent SIGCHLD to its
+//      grandparent (this daemon). On linux/mac the `claude` process
+//      sits in the child's process group (we spawn it with
+//      `setsid`-equivalent so SIGTERM/SIGKILL on -pgid reaps the whole
+//      group); on Windows `taskkill /F /T` walks the tree by parent
+//      pid. Either way, calling `killProcessSubtree(handle.pid)` is
+//      safe even after the child itself is gone — the kernel still
+//      knows about orphaned grandchildren until they reap. Best-effort
+//      and idempotent (the killer swallows ESRCH).
+//
+//   2. Map the `ChildExit` record to a `(reason, exit_code)` pair via
+//      the pure `decideSessionEnd` decider.
+//
+//   3. Call `manager.markEnded(sessionId, decision)`. The manager
+//      flips `should_be_running = 0`, writes the new terminal `state`
+//      (CRASHED for crashed children, EXITED for graceful close), and
+//      publishes the `SessionEvent.ended` on the bus so WatchSessions
+//      subscribers see it. **No respawn** — spec ch06 §1 v0.3 ship rule.
+//
+// SRP (dev.md §3): this module is a single SINK. The producer is the
+// `handle.exited()` promise from `spawnPtyHostChild` (T4.1); the
+// decider is `exit-decider.ts`; the bus + DB writes happen inside
+// `SessionManager.markEnded`. This file only chains the three; it has
+// no decision logic of its own beyond defensive try/catch around each
+// side effect so a buggy step cannot block the others.
+//
+// Layer 1 — alternatives checked:
+//   - Inline the kill+markEnded inside `spawnPtyHostChild`'s
+//     `child.on('exit')` handler in `host.ts`: rejected. `host.ts` is
+//     the lifecycle producer and must NOT depend on SessionManager
+//     (the dependency would cycle when SessionManager grows a
+//     pty-host hook). Keeping the host pure means the same handle
+//     can be wired to a test harness that asserts the IPC sequence
+//     without touching SQLite.
+//   - Have `SessionManager.create` return the handle and own the
+//     watcher: rejected — SessionManager's SRP is row CRUD + event
+//     bus. The PTY layer is a separate responsibility per the spec
+//     ch06 §1 boundary; cross-wiring lives in this small adapter.
+//   - Use an EventEmitter to broadcast exits across multiple
+//     listeners: rejected. There is exactly one consumer per child
+//     (the SessionManager), 1:1; an event-bus indirection would
+//     obscure the call graph for no win.
+
+import { killProcessSubtree } from '../ptyHost/processKiller.js';
+import type { ISessionManager } from '../sessions/SessionManager.js';
+
+import { decideSessionEnd } from './exit-decider.js';
+import type { PtyHostChildHandle } from './host.js';
+import type { ChildExit } from './types.js';
+
+/**
+ * Dependencies for `watchPtyHostChildLifecycle`. All fields are
+ * required at runtime; the seams exist so unit tests can swap the
+ * killer for a vi.fn() spy and the manager for an in-memory fake
+ * without standing up a real SQLite + child fork.
+ */
+export interface WatchPtyHostChildLifecycleDeps {
+  /**
+   * SessionManager (or any object satisfying its terminal-state
+   * surface) the watcher will call `markEnded` on. v0.3 daemon wires
+   * the singleton SessionManager here; tests inject a fake.
+   */
+  readonly manager: Pick<ISessionManager, 'markEnded'>;
+  /**
+   * Override the process-subtree killer. Defaults to the production
+   * `killProcessSubtree` from `ptyHost/processKiller.ts` (extracted
+   * earlier, Task #729 Phase A). Tests pass a vi.fn() so they can
+   * assert "the watcher tried to kill pid X" without spawning a real
+   * subtree.
+   */
+  readonly killSubtree?: (pid: number) => void;
+  /**
+   * Override the structured-error reporter. The watcher catches
+   * exceptions from the killer and from `markEnded` so a failure in
+   * one step cannot prevent the other; the caught error is forwarded
+   * here for log triage. Default: a `console.error` line with a
+   * stable prefix the supervisor's log appender (T9.x) can grep.
+   */
+  readonly onError?: (where: 'kill' | 'markEnded', err: unknown) => void;
+}
+
+/**
+ * Handle returned by `watchPtyHostChildLifecycle`. The watcher runs
+ * autonomously once installed; the only operation a caller may need is
+ * to await its completion (e.g. for a graceful daemon shutdown that
+ * wants to flush every child-exit transition before exiting itself).
+ */
+export interface PtyHostChildWatcher {
+  /**
+   * Resolves with the `ChildExit` record once the watcher has finished
+   * processing it (kill + markEnded both attempted). Always resolves;
+   * never rejects — internal errors are routed to `onError`.
+   */
+  done(): Promise<ChildExit>;
+}
+
+const DEFAULT_ON_ERROR = (where: 'kill' | 'markEnded', err: unknown): void => {
+  // Stable log prefix matches the SessionEventBus convention so a
+  // single grep over daemon stdout surfaces both bus and watcher
+  // anomalies.
+  console.error(
+    `[ccsm-daemon] PtyHostChildWatcher ${where} step threw`,
+    err,
+  );
+};
+
+/**
+ * Install the child-exit watcher for a single pty-host child. Returns
+ * synchronously with a handle whose `done()` promise settles after the
+ * exit has been processed.
+ *
+ * Idempotency: the underlying `handle.exited()` promise resolves at
+ * most once per child, and `SessionManager.markEnded` is itself
+ * idempotent against duplicate (state, exit_code) inputs. So a caller
+ * may safely re-install the watcher in a test setup without producing
+ * a duplicate `SessionEvent.ended`.
+ */
+export function watchPtyHostChildLifecycle(
+  handle: PtyHostChildHandle,
+  deps: WatchPtyHostChildLifecycleDeps,
+): PtyHostChildWatcher {
+  const killSubtree = deps.killSubtree ?? killProcessSubtree;
+  const onError = deps.onError ?? DEFAULT_ON_ERROR;
+
+  const done = handle.exited().then((exit) => {
+    // Step 1: SIGKILL the subtree (best-effort safety net for any
+    // claude grandchild the child failed to reap before dying).
+    try {
+      killSubtree(handle.pid);
+    } catch (err) {
+      onError('kill', err);
+    }
+
+    // Step 2 + 3: classify the exit and persist the terminal state.
+    // The decider is pure; the manager call is the side effect.
+    try {
+      const decision = decideSessionEnd(exit);
+      deps.manager.markEnded(handle.sessionId, decision);
+    } catch (err) {
+      onError('markEnded', err);
+    }
+
+    return exit;
+  });
+
+  return { done: () => done };
+}

--- a/packages/daemon/src/sessions/SessionManager.ts
+++ b/packages/daemon/src/sessions/SessionManager.ts
@@ -52,6 +52,7 @@ import { SessionEventBus, type SessionEventListener, type Unsubscribe } from './
 import {
   SessionState,
   type CreateSessionInput,
+  type SessionEndedReason,
   type SessionRow,
   type SessionStateValue,
 } from './types.js';
@@ -203,7 +204,37 @@ export interface ISessionManager {
   get(id: string, caller: Principal): SessionRow;
   list(caller: Principal): readonly SessionRow[];
   destroy(id: string, caller: Principal): SessionRow;
+  markEnded(id: string, params: MarkEndedParams): SessionRow;
   subscribe(caller: Principal, listener: SessionEventListener): Unsubscribe;
+}
+
+/**
+ * Parameters for `SessionManager.markEnded`. Spec ch06 §1: the daemon's
+ * pty-host child-exit handler (see `pty-host/lifecycle-watcher.ts`)
+ * resolves `(reason, exit_code)` from the `ChildExit` record and calls
+ * this method to (a) flip `should_be_running = 0`, (b) write the new
+ * terminal `state` (CRASHED for `reason='crashed'`, EXITED for
+ * `reason='graceful'`), (c) record the `exit_code`, and (d) emit a
+ * `SessionEvent.ended` on the bus so WatchSessions subscribers see it.
+ *
+ * Unlike `destroy`, this method does NOT take a `caller` Principal —
+ * the caller is the daemon itself (a process-level event), not an RPC
+ * principal. Ownership is therefore not asserted; the row simply
+ * transitions through its terminal state regardless of the caller's
+ * identity. (A misrouted `markEnded` cannot leak data: the SessionRow
+ * lookup is by id and the emitted event is bus-filtered by the row's
+ * own `owner_id`.)
+ */
+export interface MarkEndedParams {
+  /** Why the child exited. Maps 1:1 to the new `state` value. */
+  readonly reason: SessionEndedReason;
+  /**
+   * Process exit code observed for the pty-host child. `null` is
+   * persisted as `-1` (the sentinel from `001_initial.sql`) — keeps the
+   * column NOT NULL and lets readers distinguish "exited cleanly with
+   * code 0" from "killed by signal / unknown".
+   */
+  readonly exit_code: number | null;
 }
 
 /**
@@ -233,6 +264,19 @@ const SQL_SELECT_BY_OWNER = `SELECT id, owner_id, state, cwd, env_json, claude_a
 
 const SQL_UPDATE_DESTROY = `UPDATE sessions
   SET state = @state, should_be_running = 0, last_active_ms = @last_active_ms
+  WHERE id = @id`;
+
+/**
+ * Used by `markEnded`. Same `should_be_running = 0` flip as Destroy,
+ * but ALSO writes `exit_code` and accepts an arbitrary terminal state
+ * (EXITED for graceful child close, CRASHED for the pty-host crash
+ * semantics in ch06 §1). Kept separate from `SQL_UPDATE_DESTROY` so
+ * the destroy path stays a 3-column write (its callers never have an
+ * exit code — Destroy is user-initiated before the child exits).
+ */
+const SQL_UPDATE_END = `UPDATE sessions
+  SET state = @state, should_be_running = 0,
+      exit_code = @exit_code, last_active_ms = @last_active_ms
   WHERE id = @id`;
 
 export class SessionManager implements ISessionManager {
@@ -330,6 +374,70 @@ export class SessionManager implements ISessionManager {
    */
   subscribe(caller: Principal, listener: SessionEventListener): Unsubscribe {
     return this.bus.subscribe(principalKey(caller), listener);
+  }
+
+  /**
+   * Transition a session to its terminal state because its pty-host
+   * child exited. Spec ch06 §1.
+   *
+   *   - `reason='crashed'`  → `state := CRASHED` (per spec: any non-`close`-
+   *     initiated child exit, including non-zero exit codes, signals, IPC
+   *     disconnect without a `kind:'exiting'` graceful notice)
+   *   - `reason='graceful'` → `state := EXITED` (matches the user-initiated
+   *     destroy path's terminal state, but reached via the child exit
+   *     observation rather than a `DestroySession` RPC)
+   *
+   * Always flips `should_be_running = 0` so the daemon's restore-on-boot
+   * loop (chapter 05 §7) skips the row regardless of why the child died.
+   * Always writes `exit_code`; a `null` input becomes the `-1` sentinel
+   * from `001_initial.sql` so the NOT NULL column stays satisfied.
+   *
+   * Emits `SessionEvent.ended` on the bus AFTER the UPDATE commits. The
+   * carried `session` row reflects the persisted post-update state.
+   *
+   * Idempotent: if the row is already `should_be_running=0` AND the
+   * incoming `state` matches, the UPDATE is still issued (better-sqlite3
+   * returns `changes=0`) and the event is suppressed. This protects
+   * against duplicate `child.on('exit')` deliveries (the lifecycle
+   * watcher de-dupes via its own `exited()` promise, but defending in
+   * the manager too keeps the event stream clean even if a future
+   * caller forgets the de-dupe).
+   *
+   * Throws `Error` (not a ConnectError — this is not an RPC path) if
+   * the row does not exist; an unknown session id at the daemon-internal
+   * boundary is a programmer error, not an enumeration risk.
+   */
+  markEnded(id: string, params: MarkEndedParams): SessionRow {
+    const row = this.db.prepare(SQL_SELECT_BY_ID).get(id) as SessionRow | undefined;
+    if (row === undefined) {
+      throw new Error(`SessionManager.markEnded: no row for session id ${id}`);
+    }
+    const newState: SessionStateValue =
+      params.reason === 'crashed' ? SessionState.CRASHED : SessionState.EXITED;
+    const exitCode = params.exit_code ?? -1;
+    const now = this.now();
+
+    const alreadyTerminal =
+      row.should_be_running === 0 && row.state === newState && row.exit_code === exitCode;
+    if (alreadyTerminal) {
+      return row;
+    }
+
+    this.db.prepare(SQL_UPDATE_END).run({
+      id: row.id,
+      state: newState,
+      exit_code: exitCode,
+      last_active_ms: now,
+    });
+    const ended: SessionRow = {
+      ...row,
+      state: newState,
+      should_be_running: 0,
+      exit_code: exitCode,
+      last_active_ms: now,
+    };
+    this.bus.publish({ kind: 'ended', session: ended, reason: params.reason });
+    return ended;
   }
 
   /**

--- a/packages/daemon/src/sessions/types.ts
+++ b/packages/daemon/src/sessions/types.ts
@@ -109,4 +109,25 @@ export interface CreateSessionInput {
  */
 export type SessionEvent =
   | { readonly kind: 'created'; readonly session: SessionRow }
-  | { readonly kind: 'destroyed'; readonly session: SessionRow };
+  | { readonly kind: 'destroyed'; readonly session: SessionRow }
+  /**
+   * Lifecycle terminus for a session whose pty-host child exited
+   * (graceful close OR crash). Spec ch06 §1: emitted by the daemon's
+   * pty-host child-exit handler after it has killed any residual claude
+   * subtree and flipped `should_be_running = 0`. The carried `session`
+   * row reflects the post-update state (`state` ∈ {EXITED, CRASHED},
+   * `exit_code` set, `should_be_running = 0`). Distinct from `destroyed`
+   * (which is fired by an explicit DestroySession RPC, not a child exit)
+   * so subscribers can distinguish "user closed" from "child died";
+   * watch-sessions.ts maps both to the proto `updated` oneof case which
+   * carries the full Session row.
+   */
+  | { readonly kind: 'ended'; readonly session: SessionRow; readonly reason: SessionEndedReason };
+
+/**
+ * Reason a session terminated via the pty-host child-exit path. Mirrors
+ * `ChildExitReason` from `pty-host/types.ts` but is duplicated here so
+ * the sessions module does NOT depend on the pty-host module's types
+ * (the dependency direction is pty-host → sessions, never the reverse).
+ */
+export type SessionEndedReason = 'graceful' | 'crashed';

--- a/packages/daemon/src/sessions/watch-sessions.ts
+++ b/packages/daemon/src/sessions/watch-sessions.ts
@@ -217,6 +217,16 @@ export function sessionEventToProto(
       return create(SessionEventSchema, {
         kind: { case: 'destroyed', value: ev.session.id },
       });
+    case 'ended':
+      // Spec ch06 §1: pty-host child exit (graceful or crash). Wire
+      // shape is `updated` carrying the full Session row — clients
+      // read the new `state` (EXITED|CRASHED) and `exit_code` to render
+      // the terminal-state badge. `destroyed` is reserved for the
+      // explicit DestroySession RPC path so a client can distinguish
+      // "user closed it" from "child died" by which oneof case lands.
+      return create(SessionEventSchema, {
+        kind: { case: 'updated', value: sessionRowToProto(ev.session, caller) },
+      });
     default: {
       const _exhaustive: never = ev;
       throw new Error(

--- a/packages/daemon/test/pty-host/exit-decider.spec.ts
+++ b/packages/daemon/test/pty-host/exit-decider.spec.ts
@@ -1,0 +1,66 @@
+// Unit tests for `decideSessionEnd` (T4.4 / Task #42).
+//
+// Pure-function decider — no fixtures, no IO, no fork. Pins the
+// truth-table from `exit-decider.ts` jsdoc against the spec ch06 §1
+// crash-vs-graceful classification.
+
+import { describe, expect, it } from 'vitest';
+
+import { decideSessionEnd } from '../../src/pty-host/exit-decider.js';
+import type { ChildExit } from '../../src/pty-host/types.js';
+
+function exit(partial: Partial<ChildExit>): ChildExit {
+  return {
+    reason: partial.reason ?? 'crashed',
+    code: partial.code ?? null,
+    signal: partial.signal ?? null,
+  };
+}
+
+describe('decideSessionEnd', () => {
+  it('graceful + code 0 + no signal → graceful, exit_code 0', () => {
+    expect(decideSessionEnd(exit({ reason: 'graceful', code: 0 }))).toEqual({
+      reason: 'graceful',
+      exit_code: 0,
+    });
+  });
+
+  it('crashed + non-zero code → crashed with that code', () => {
+    expect(decideSessionEnd(exit({ reason: 'crashed', code: 137 }))).toEqual({
+      reason: 'crashed',
+      exit_code: 137,
+    });
+  });
+
+  it('crashed + signal (no code) → crashed with null exit_code', () => {
+    expect(
+      decideSessionEnd(exit({ reason: 'crashed', code: null, signal: 'SIGKILL' })),
+    ).toEqual({ reason: 'crashed', exit_code: null });
+  });
+
+  it('crashed + code 0 (no graceful notice) is still a crash — defends against silent exit-without-exiting-message', () => {
+    // Spec ch06 §1: graceful requires the `kind:'exiting'` notice AND
+    // code 0. A child that exits 0 without sending the notice is a
+    // crash by definition.
+    expect(decideSessionEnd(exit({ reason: 'crashed', code: 0 }))).toEqual({
+      reason: 'crashed',
+      exit_code: 0,
+    });
+  });
+
+  it('graceful + non-zero code is reclassified as crashed (defense in depth)', () => {
+    // Unreachable today — the host clamps `graceful` to require code 0
+    // — but pinned here so a future host relaxation cannot silently
+    // mark a non-zero-exit child as graceful.
+    expect(decideSessionEnd(exit({ reason: 'graceful', code: 2 }))).toEqual({
+      reason: 'crashed',
+      exit_code: 2,
+    });
+  });
+
+  it('graceful + signal is reclassified as crashed (defense in depth)', () => {
+    expect(
+      decideSessionEnd(exit({ reason: 'graceful', code: 0, signal: 'SIGKILL' })),
+    ).toEqual({ reason: 'crashed', exit_code: 0 });
+  });
+});

--- a/packages/daemon/test/pty-host/lifecycle-watcher.spec.ts
+++ b/packages/daemon/test/pty-host/lifecycle-watcher.spec.ts
@@ -1,0 +1,210 @@
+// Unit tests for `watchPtyHostChildLifecycle` (T4.4 / Task #42).
+//
+// The watcher is a small sink that chains three steps after the
+// child's `exited()` promise resolves:
+//   (1) killSubtree(handle.pid)  — SIGKILL grandchildren safety net
+//   (2) decideSessionEnd(exit)   — pure decider (covered separately)
+//   (3) manager.markEnded(...)   — flip should_be_running, emit event
+//
+// These tests stub the handle and manager so we can exercise every
+// branch (graceful close, crash, kill throw, markEnded throw) without
+// forking a real child or opening a SQLite database. The real
+// integration via `spawnPtyHostChild` + a fork fixture is exercised by
+// the host.spec.ts crash-semantics block (T4.1) — this file pins the
+// watcher's own contract.
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { watchPtyHostChildLifecycle } from '../../src/pty-host/lifecycle-watcher.js';
+import type { PtyHostChildHandle } from '../../src/pty-host/host.js';
+import type { ChildExit } from '../../src/pty-host/types.js';
+import type { ISessionManager } from '../../src/sessions/SessionManager.js';
+import type { SessionRow } from '../../src/sessions/types.js';
+import { SessionState } from '../../src/sessions/types.js';
+
+interface StubHandle extends PtyHostChildHandle {
+  /** Resolve the underlying `exited()` promise from the test body. */
+  resolveExit(exit: ChildExit): void;
+}
+
+function makeHandle(sessionId: string, pid: number): StubHandle {
+  let resolveExit: (x: ChildExit) => void = () => {
+    /* set below */
+  };
+  const exitedPromise = new Promise<ChildExit>((resolve) => {
+    resolveExit = resolve;
+  });
+  // We only fill the surface the watcher consumes; other methods throw
+  // so an accidental call during the test is loud.
+  const notUsed = (): never => {
+    throw new Error('watcher should not call this method');
+  };
+  const handle: StubHandle = {
+    sessionId,
+    pid,
+    claudeSpawnEnv: {},
+    ready: notUsed,
+    send: notUsed,
+    exited: () => exitedPromise,
+    messages: notUsed,
+    closeAndWait: notUsed,
+    resolveExit,
+  };
+  return handle;
+}
+
+function makeManager(): {
+  manager: Pick<ISessionManager, 'markEnded'>;
+  calls: Array<{ id: string; reason: string; exit_code: number | null }>;
+} {
+  const calls: Array<{ id: string; reason: string; exit_code: number | null }> = [];
+  const manager: Pick<ISessionManager, 'markEnded'> = {
+    markEnded(id, params): SessionRow {
+      calls.push({ id, reason: params.reason, exit_code: params.exit_code });
+      // Return a synthetic row — the watcher does not inspect it.
+      return {
+        id,
+        owner_id: 'local-user:1000',
+        state:
+          params.reason === 'crashed' ? SessionState.CRASHED : SessionState.EXITED,
+        cwd: '/',
+        env_json: '{}',
+        claude_args_json: '[]',
+        geometry_cols: 80,
+        geometry_rows: 24,
+        exit_code: params.exit_code ?? -1,
+        created_ms: 1,
+        last_active_ms: 2,
+        should_be_running: 0,
+      };
+    },
+  };
+  return { manager, calls };
+}
+
+describe('watchPtyHostChildLifecycle — happy paths', () => {
+  it('on graceful exit: kills the subtree then calls markEnded with reason=graceful, exit_code=0', async () => {
+    const handle = makeHandle('sess-graceful', 12345);
+    const { manager, calls } = makeManager();
+    const killSpy = vi.fn();
+
+    const watcher = watchPtyHostChildLifecycle(handle, {
+      manager,
+      killSubtree: killSpy,
+    });
+
+    handle.resolveExit({ reason: 'graceful', code: 0, signal: null });
+    const observed = await watcher.done();
+
+    expect(killSpy).toHaveBeenCalledExactlyOnceWith(12345);
+    expect(calls).toEqual([
+      { id: 'sess-graceful', reason: 'graceful', exit_code: 0 },
+    ]);
+    expect(observed).toEqual({ reason: 'graceful', code: 0, signal: null });
+  });
+
+  it('on crash exit (code 137): kills the subtree then calls markEnded with reason=crashed', async () => {
+    const handle = makeHandle('sess-crash', 22222);
+    const { manager, calls } = makeManager();
+    const killSpy = vi.fn();
+
+    const watcher = watchPtyHostChildLifecycle(handle, {
+      manager,
+      killSubtree: killSpy,
+    });
+
+    handle.resolveExit({ reason: 'crashed', code: 137, signal: null });
+    await watcher.done();
+
+    expect(killSpy).toHaveBeenCalledExactlyOnceWith(22222);
+    expect(calls).toEqual([
+      { id: 'sess-crash', reason: 'crashed', exit_code: 137 },
+    ]);
+  });
+
+  it('on signal-killed exit: passes null exit_code through to markEnded', async () => {
+    const handle = makeHandle('sess-signal', 33333);
+    const { manager, calls } = makeManager();
+    const watcher = watchPtyHostChildLifecycle(handle, {
+      manager,
+      killSubtree: vi.fn(),
+    });
+
+    handle.resolveExit({ reason: 'crashed', code: null, signal: 'SIGKILL' });
+    await watcher.done();
+
+    expect(calls).toEqual([
+      { id: 'sess-signal', reason: 'crashed', exit_code: null },
+    ]);
+  });
+});
+
+describe('watchPtyHostChildLifecycle — error containment', () => {
+  it('still calls markEnded if the killer throws (kill error is reported, not propagated)', async () => {
+    const handle = makeHandle('sess-kill-throws', 44444);
+    const { manager, calls } = makeManager();
+    const killSpy = vi.fn(() => {
+      throw new Error('taskkill missing');
+    });
+    const onError = vi.fn();
+
+    const watcher = watchPtyHostChildLifecycle(handle, {
+      manager,
+      killSubtree: killSpy,
+      onError,
+    });
+
+    handle.resolveExit({ reason: 'crashed', code: 1, signal: null });
+    // The watcher must not reject even though the killer threw.
+    await expect(watcher.done()).resolves.toEqual({
+      reason: 'crashed',
+      code: 1,
+      signal: null,
+    });
+
+    expect(calls).toEqual([
+      { id: 'sess-kill-throws', reason: 'crashed', exit_code: 1 },
+    ]);
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]![0]).toBe('kill');
+  });
+
+  it('still resolves done() if markEnded throws (markEnded error is reported, not propagated)', async () => {
+    const handle = makeHandle('sess-mark-throws', 55555);
+    const onError = vi.fn();
+    const manager: Pick<ISessionManager, 'markEnded'> = {
+      markEnded(): never {
+        throw new Error('row missing');
+      },
+    };
+
+    const watcher = watchPtyHostChildLifecycle(handle, {
+      manager,
+      killSubtree: vi.fn(),
+      onError,
+    });
+
+    handle.resolveExit({ reason: 'crashed', code: 2, signal: null });
+    await expect(watcher.done()).resolves.toBeDefined();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]![0]).toBe('markEnded');
+  });
+});
+
+describe('watchPtyHostChildLifecycle — wiring', () => {
+  it('uses the production killProcessSubtree when killSubtree dep is omitted (smoke)', async () => {
+    // We cannot actually kill a real process from a unit test, so we
+    // route the watcher to a child pid that does not exist (1) — the
+    // real `killProcessSubtree` swallows ESRCH so this is safe and
+    // proves the default wiring resolves to a callable function.
+    const handle = makeHandle('sess-default-killer', 1);
+    const { manager, calls } = makeManager();
+
+    const watcher = watchPtyHostChildLifecycle(handle, { manager });
+    handle.resolveExit({ reason: 'graceful', code: 0, signal: null });
+    await watcher.done();
+
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/packages/daemon/test/sessions/SessionManager.spec.ts
+++ b/packages/daemon/test/sessions/SessionManager.spec.ts
@@ -291,3 +291,129 @@ describe('SessionManager.subscribe', () => {
     expect(seen).not.toHaveBeenCalled();
   });
 });
+
+describe('SessionManager.markEnded (T4.4 — pty-host child crash semantics)', () => {
+  it('flips state=CRASHED + should_be_running=0 + writes exit_code, and emits SessionEvent.ended', () => {
+    const db = freshDb();
+    const events: SessionEvent[] = [];
+    const bus = new SessionEventBus();
+    bus.subscribe('local-user:1000', (e) => events.push(e));
+
+    let t = 100;
+    const mgr = new SessionManager(db, {
+      now: () => t,
+      newId: () => 'CRASHED1',
+      eventBus: bus,
+    });
+    const row = mgr.create(createInput(), ALICE);
+    expect(events.at(-1)?.kind).toBe('created');
+
+    t = 700;
+    const ended = mgr.markEnded(row.id, { reason: 'crashed', exit_code: 137 });
+    expect(ended.state).toBe(SessionState.CRASHED);
+    expect(ended.should_be_running).toBe(0);
+    expect(ended.exit_code).toBe(137);
+    expect(ended.last_active_ms).toBe(700);
+
+    const persisted = db
+      .prepare(
+        'SELECT state, should_be_running, exit_code, last_active_ms FROM sessions WHERE id = ?',
+      )
+      .get(row.id) as {
+      state: number;
+      should_be_running: number;
+      exit_code: number;
+      last_active_ms: number;
+    };
+    expect(persisted).toEqual({
+      state: SessionState.CRASHED,
+      should_be_running: 0,
+      exit_code: 137,
+      last_active_ms: 700,
+    });
+
+    const lastEvt = events.at(-1);
+    expect(lastEvt?.kind).toBe('ended');
+    if (lastEvt?.kind === 'ended') {
+      expect(lastEvt.reason).toBe('crashed');
+      expect(lastEvt.session.id).toBe(row.id);
+      expect(lastEvt.session.state).toBe(SessionState.CRASHED);
+      expect(lastEvt.session.exit_code).toBe(137);
+      expect(lastEvt.session.should_be_running).toBe(0);
+    }
+  });
+
+  it('graceful reason transitions to state=EXITED (matches DestroySession terminal state)', () => {
+    const db = freshDb();
+    const mgr = new SessionManager(db, { now: () => 10, newId: () => 'GRACE1' });
+    const row = mgr.create(createInput(), ALICE);
+
+    const ended = mgr.markEnded(row.id, { reason: 'graceful', exit_code: 0 });
+    expect(ended.state).toBe(SessionState.EXITED);
+    expect(ended.should_be_running).toBe(0);
+    expect(ended.exit_code).toBe(0);
+  });
+
+  it('null exit_code is persisted as -1 sentinel (signal-killed children)', () => {
+    const db = freshDb();
+    const mgr = new SessionManager(db, { now: () => 1, newId: () => 'SIGKILL1' });
+    const row = mgr.create(createInput(), ALICE);
+
+    const ended = mgr.markEnded(row.id, { reason: 'crashed', exit_code: null });
+    expect(ended.exit_code).toBe(-1);
+
+    const persisted = db
+      .prepare('SELECT exit_code FROM sessions WHERE id = ?')
+      .get(row.id) as { exit_code: number };
+    expect(persisted.exit_code).toBe(-1);
+  });
+
+  it('is idempotent — a second markEnded with the same (state, exit_code) does not double-publish', () => {
+    const db = freshDb();
+    const events: SessionEvent[] = [];
+    const bus = new SessionEventBus();
+    bus.subscribe('local-user:1000', (e) => events.push(e));
+
+    const mgr = new SessionManager(db, {
+      now: () => 1,
+      newId: () => 'IDEMP1',
+      eventBus: bus,
+    });
+    const row = mgr.create(createInput(), ALICE);
+
+    mgr.markEnded(row.id, { reason: 'crashed', exit_code: 1 });
+    mgr.markEnded(row.id, { reason: 'crashed', exit_code: 1 });
+
+    const endedEvents = events.filter((e) => e.kind === 'ended');
+    expect(endedEvents).toHaveLength(1);
+  });
+
+  it('throws (not a ConnectError) when the row does not exist — daemon-internal contract', () => {
+    const db = freshDb();
+    const mgr = new SessionManager(db);
+    expect(() =>
+      mgr.markEnded('does-not-exist', { reason: 'crashed', exit_code: 1 }),
+    ).toThrow(/no row for session id/);
+  });
+
+  it('does not require a Principal (caller-agnostic; bus still scopes by row owner)', () => {
+    const db = freshDb();
+    const aliceSeen: SessionEvent[] = [];
+    const bobSeen: SessionEvent[] = [];
+    const bus = new SessionEventBus();
+    bus.subscribe('local-user:1000', (e) => aliceSeen.push(e));
+    bus.subscribe('local-user:1001', (e) => bobSeen.push(e));
+
+    const mgr = new SessionManager(db, {
+      now: () => 1,
+      newId: () => 'SCOPE1',
+      eventBus: bus,
+    });
+    const row = mgr.create(createInput(), ALICE);
+
+    mgr.markEnded(row.id, { reason: 'crashed', exit_code: 9 });
+
+    expect(aliceSeen.some((e) => e.kind === 'ended')).toBe(true);
+    expect(bobSeen.some((e) => e.kind === 'ended')).toBe(false);
+  });
+});

--- a/packages/daemon/test/sessions/watch-sessions.spec.ts
+++ b/packages/daemon/test/sessions/watch-sessions.spec.ts
@@ -179,6 +179,20 @@ describe('sessionRowToProto / sessionEventToProto', () => {
     if (ev.kind.case !== 'destroyed') return;
     expect(ev.kind.value).toBe('sess-001');
   });
+
+  it('renders an "ended" SessionEvent as the proto "updated" oneof case carrying the full row (T4.4)', () => {
+    const row = makeRow({
+      state: SessionState.CRASHED,
+      should_be_running: 0,
+      exit_code: 137,
+    });
+    const ev = sessionEventToProto({ kind: 'ended', session: row, reason: 'crashed' }, ALICE);
+    expect(ev.kind.case).toBe('updated');
+    if (ev.kind.case !== 'updated') return;
+    expect(ev.kind.value.id).toBe('sess-001');
+    expect(ev.kind.value.state).toBe(ProtoSessionState.CRASHED);
+    expect(ev.kind.value.exitCode).toBe(137);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Task #42 / T4.4 (ch06 §1). Wires the daemon-side observation of a per-session pty-host child exit into the SessionManager terminal state.

- decider `pty-host/exit-decider.ts`: pure `ChildExit → (reason, exit_code)`. Graceful iff the child sent `kind:'exiting'` AND code 0; everything else (non-zero code, signal, missing notice) is `crashed`. v0.3 ship rule: **no respawn**.
- sink `pty-host/lifecycle-watcher.ts`: chains `handle.exited()` → `killProcessSubtree(handle.pid)` (SIGKILL safety net for any residual `claude` / `-pgid` grandchildren — reuses the existing `ptyHost/processKiller` extracted in Task #729 Phase A) → `SessionManager.markEnded`.
- `SessionManager.markEnded(id, params)`: UPDATE state, flip `should_be_running = 0`, write `exit_code`, emit `SessionEvent.ended`. Maps `crashed → CRASHED`, `graceful → EXITED`. Idempotent against duplicate exit deliveries.
- `SessionEvent` gains an `ended` variant; the watch-sessions proto mapper routes it to the `updated` oneof case so clients see the full Session row with the new state + exit_code (`destroyed` stays reserved for the explicit DestroySession RPC, preserving the user-vs-crash distinction on the wire).

12 new unit specs cover the decider truth-table, watcher kill+markEnded chain (incl. error containment when killer or markEnded throws), and SessionManager.markEnded SQL/event/idempotence.

blockedBy: #45 (T4.1), #55 (T5.2) — both merged.

## Local checks (host: windows-11)

- lint: ✓ (exit 0; 52 pre-existing warnings, none in changed files)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0)
- targeted vitest:
  - `test/pty-host/exit-decider`: 6/6 pass
  - `test/pty-host/lifecycle-watcher`: 6/6 pass
  - `test/sessions/SessionManager`: extended with 6 markEnded cases, all 28 pass
  - `test/sessions/watch-sessions`: extended with 1 mapper case, all 14 pass

## Pre-existing failures (NOT caused by this change)

Full `pnpm --filter @ccsm/daemon test`: 8 failed / 1029 passed. None of the failures touch `pty-host/`, `sessions/`, or `db/migrations/runner` (which I confirmed by re-running my targeted specs in isolation, all green). The 8 failures:

- `runStartup-lock REQUIRED_COMPONENTS exposes the canonical 5-component list` — Task #229 (`crash-rpc`) added a 6th component but didn't update the lock test.
- 7 integration tests under `test/integration/*-wired.spec.ts` and `src/rpc/__tests__/integration.spec.ts` — h2c bind 10s hook timeout (transport setup, not RPC logic).

These exist on `origin/working` HEAD (`f0de131`) before this branch.

Worktree note: pool-4 had a CRLF-corrupted `001_initial.sql` (gitattributes `eol=lf` but on-disk CRLF) that broke 6 migration-runner specs. Re-checked out the file with LF; SHA matches the v0.3 lock.

## Test plan

- [x] decider: graceful + code 0 + no signal → `(graceful, 0)`
- [x] decider: non-zero code → `crashed`
- [x] decider: signal-killed (null code) → `crashed` with null exit_code
- [x] decider: defense-in-depth — code 0 without graceful notice still crashed
- [x] watcher: graceful exit → kill + markEnded(graceful, 0)
- [x] watcher: crash exit → kill + markEnded(crashed, code)
- [x] watcher: kill thrown → markEnded still runs, error reported
- [x] watcher: markEnded thrown → done() still resolves, error reported
- [x] watcher: default killer wires to production killProcessSubtree
- [x] markEnded: state=CRASHED + should_be_running=0 + exit_code, emits `ended`
- [x] markEnded: graceful → EXITED
- [x] markEnded: null exit_code → -1 sentinel persisted
- [x] markEnded: idempotent (no double publish)
- [x] markEnded: throws on missing row
- [x] markEnded: bus scoping by row owner_id (not caller)
- [x] proto mapper: `ended` → `updated` oneof case carrying full Session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Wire-up evidence
- [x] 这个 PR 引入的新 export 被谁 import? — **[LIBRARY-ONLY]** 当前阶段 pty-host 模块仅 library-shape, 仅由 pty-host/index.ts 重导出. v0.3 production wire-up 走 followup task.
- Followup wire-up task: #359 [WAVE3-FOLLOWUP] CreateSession handler: wire spawnPtyHostChild + watchPtyHostChildLifecycle
