### PR TITLE
wave3(#335): wire CrashService.WatchCrashLog handler in production daemon startup

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -46,6 +46,7 @@ import {
   installCaptureSources,
   type Unsubscribe,
 } from './crash/sources.js';
+import { defaultCrashEventBus } from './crash/event-bus.js';
 import { replayCrashRawOnBoot } from './crash/raw-appender.js';
 import { buildDaemonEnv, type DaemonEnv } from './env.js';
 import { Lifecycle, Phase } from './lifecycle.js';
@@ -323,13 +324,25 @@ export async function runStartup(
     // pre-#229 the entire CrashService was a stub on the wire even though
     // `crash_log` is populated end-to-end at boot (`replayCrashRawOnBoot`).
     // We pass the SAME `db` handle the rest of startup uses (single owner
-    // of the SQLite file; the future #335 WatchCrashLog wave reuses this
-    // same instance for its event-bus subscription). The streaming siblings
-    // (#334 GetRawCrashLog, #335 WatchCrashLog) stay `Unimplemented` until
-    // their sub-tasks land — `registerCrashService` ships a partial impl
-    // with only `getCrashLog` and the router's "absent method ->
-    // Unimplemented" rule covers the rest.
-    const crashDeps = { getCrashLogDeps: { db } };
+    // of the SQLite file; the #335 WatchCrashLog overlay reuses this same
+    // boot for its event-bus subscription). The remaining streaming sibling
+    // (#334 GetRawCrashLog) stays `Unimplemented` until its sub-task lands —
+    // `registerCrashService` ships a partial impl with `getCrashLog` +
+    // `watchCrashLog` and the router's "absent method -> Unimplemented" rule
+    // covers the rest.
+    //
+    // Wave-3 #335 — wire CrashService.WatchCrashLog. The handler subscribes
+    // to `defaultCrashEventBus` (Task #340) — the SAME singleton
+    // `crash/raw-appender.ts:appendCrashRaw` emits on after fsync. Routing
+    // both methods through the same `crashDeps` payload keeps the
+    // `registerCrashService` overlay's "single service() call covers every
+    // method" invariant honest (calling `service()` twice for the same
+    // descriptor would silently drop the earlier registration — see
+    // `register.ts` header).
+    const crashDeps = {
+      getCrashLogDeps: { db },
+      watchCrashLogDeps: { bus: defaultCrashEventBus },
+    };
     // Wave-3 §6.9 sub-task 5 (Task #336) — wire the SessionService read
     // pair (ListSessions / GetSession) on top of the WatchSessions
     // overlay. Both handlers reuse the same `sessionManager` (single

--- a/packages/daemon/src/rpc/crash/register.ts
+++ b/packages/daemon/src/rpc/crash/register.ts
@@ -15,10 +15,12 @@
 // the deps interface and the partial impl below; the wiring topology in
 // `router.ts` and `index.ts` does not change.
 //
-// Methods not yet implemented in v0.3 (`watchCrashLog`, `getRawCrashLog`)
-// remain Connect `Unimplemented` per the router's "absent method ->
-// Unimplemented" rule (Connect-ES contract; same way SessionService's
-// not-yet-landed methods stay stubbed).
+// Methods not yet implemented in v0.3 (`getRawCrashLog`) remain Connect
+// `Unimplemented` per the router's "absent method -> Unimplemented" rule
+// (Connect-ES contract; same way SessionService's not-yet-landed methods
+// stay stubbed). With Task #335 landed, both `getCrashLog` and
+// `watchCrashLog` are wired here; only `getRawCrashLog` (Task #334)
+// remains stubbed.
 
 import type { ConnectRouter } from '@connectrpc/connect';
 
@@ -28,15 +30,21 @@ import {
   makeGetCrashLogHandler,
   type GetCrashLogDeps,
 } from './get-crash-log.js';
+import {
+  makeWatchCrashLogHandler,
+  type WatchCrashLogDeps,
+} from './watch-crash-log.js';
 
 /**
  * Aggregate deps for every CrashService handler that ships in v0.3.
- * Today only `GetCrashLog` is wired; future overlays append fields here
- * (`getRawCrashLogDeps`, `watchCrashLogDeps`) without changing the
- * router-level signature in `router.ts:makeDaemonRoutes`.
+ * Today `GetCrashLog` (Task #229) and `WatchCrashLog` (Task #335) are
+ * wired; future overlays append fields here (`getRawCrashLogDeps`)
+ * without changing the router-level signature in
+ * `router.ts:makeDaemonRoutes`.
  */
 export interface CrashServiceDeps {
   readonly getCrashLogDeps: GetCrashLogDeps;
+  readonly watchCrashLogDeps: WatchCrashLogDeps;
 }
 
 /**
@@ -46,9 +54,12 @@ export interface CrashServiceDeps {
  *
  * Per Connect-ES `ConnectRouter.service` semantics, this REPLACES the
  * prior `{}` stub registration for `CrashService` — the partial impl
- * below installs `getCrashLog`, and the router's "absent method ->
- * Unimplemented" fallback keeps `watchCrashLog` / `getRawCrashLog`
- * returning `Code.Unimplemented` until their owning sub-tasks land.
+ * below installs `getCrashLog` + `watchCrashLog` in a SINGLE
+ * `service()` call (calling `service` twice for the same descriptor
+ * silently drops the earlier registration; see `router.ts`
+ * `registerSessionService` for the same caveat). The router's "absent
+ * method -> Unimplemented" fallback keeps `getRawCrashLog` returning
+ * `Code.Unimplemented` until Task #334 lands.
  */
 export function registerCrashService(
   router: ConnectRouter,
@@ -56,6 +67,7 @@ export function registerCrashService(
 ): ConnectRouter {
   router.service(CrashService, {
     getCrashLog: makeGetCrashLogHandler(deps.getCrashLogDeps),
+    watchCrashLog: makeWatchCrashLogHandler(deps.watchCrashLogDeps),
   });
   return router;
 }

--- a/packages/daemon/src/rpc/crash/watch-crash-log.ts
+++ b/packages/daemon/src/rpc/crash/watch-crash-log.ts
@@ -1,0 +1,479 @@
+// packages/daemon/src/rpc/crash/watch-crash-log.ts
+//
+// Wave-3 Task #335 (sub-task 4b of audit #228) — production
+// CrashService.WatchCrashLog server-streaming Connect handler.
+//
+// Audit reference: docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md
+// (sub-task 4b). Pre-#335 the WatchCrashLog method on CrashService was
+// silently `Code.Unimplemented` — the stub baseline plus the partial
+// `registerCrashService` overlay (Task #229 / PR #996) covered only
+// `getCrashLog`; the router's "absent method -> Unimplemented" rule kept
+// the streaming sibling stubbed despite a fully-wired emit hook in
+// `crash/raw-appender.ts:appendCrashRaw -> defaultCrashEventBus.emitCrashAdded`
+// (Task #340).
+//
+// This file ships the streaming handler. It consumes the `CrashEventBus`
+// (Task #340 — packages/daemon/src/crash/event-bus.ts) and yields the
+// proto `CrashEntry` shape for every event whose `owner_id` matches the
+// caller's `OwnerFilter` policy (ch04 §5 OWN/ALL semantics).
+//
+// Spec refs:
+//   - packages/proto/src/ccsm/v1/crash.proto:
+//       service CrashService { rpc WatchCrashLog(WatchCrashLogRequest)
+//         returns (stream CrashEntry); }
+//       message WatchCrashLogRequest { RequestMeta meta = 1;
+//         OwnerFilter owner_filter = 2; }
+//       enum OwnerFilter { UNSPECIFIED = 0 (==OWN); OWN = 1; ALL = 2; }
+//       message CrashEntry { id; ts_unix_ms; source; summary; detail;
+//         labels; owner_id; }
+//   - docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//       ch04 §5 (OwnerFilter contract), ch09 §1 (`'daemon-self'` sentinel
+//       included in OWN by definition), ch12 §3 (crash-stream wire
+//       coverage; OWN passes daemon-self, drops other principals).
+//   - packages/daemon/test/integration/crash-stream.spec.ts already pins
+//       the over-the-wire OWN/ALL/daemon-self semantics this handler
+//       implements end-to-end against an in-test `CrashEventBus`-shaped
+//       bus; this file is the production binding to the real
+//       `defaultCrashEventBus` that `appendCrashRaw` emits on.
+//
+// SRP layering — three roles kept separate (dev.md §2):
+//   * decider:  `decideOwnerScope(filter)` — pure enum verdict over
+//               `OwnerFilter`. UNSPECIFIED/OWN → 'own'; ALL → 'all';
+//               unknown enum → 'reject_permission_denied' (forward-compat
+//               conservative deny, same posture as
+//               `sessions/watch-sessions.ts:decideWatchScope`).
+//   * predicate: `isVisibleToCaller(entry, scope, callerKey)` — pure
+//               function. OWN visibility = `entry.owner_id === callerKey
+//               || entry.owner_id === DAEMON_SELF`. ALL visibility = true.
+//   * producer: `subscribeAsAsyncIterable(bus, options)` — push (bus
+//               callback) → pull (AsyncIterable) adapter with bounded
+//               buffer + abort-signal teardown. Mirrors the
+//               `sessions/watch-sessions.ts:subscribeAsAsyncIterable`
+//               adapter exactly so reviewers see one shape across
+//               subsystems. The visibility filter runs INSIDE the bus
+//               callback so non-matching events never enter the buffer
+//               (a noisy `daemon-self` storm can't pin memory for a
+//               watcher that wouldn't have shown them anyway).
+//   * sink:     `makeWatchCrashLogHandler(deps)` — Connect handler that
+//               reads `PRINCIPAL_KEY` from the HandlerContext (the
+//               `peerCredAuthInterceptor` deposited it before the handler
+//               runs), runs the decider over the request, then either
+//               subscribes to the bus and yields proto events, or throws
+//               `Code.PermissionDenied` with the canonical
+//               `session.not_owned` ErrorDetail (T2.5 single source of
+//               truth — same code GetCrashLog uses for unknown enums).
+//
+// Layer 1 — alternatives checked:
+//   - "Reuse `sessions/watch-sessions.ts:subscribeAsAsyncIterable`": the
+//     two adapters are structurally identical but typed over different
+//     bus shapes. SessionEventBus has principal-keyed `subscribe(key,
+//     listener)` (security-boundary filter inside the bus);
+//     CrashEventBus is a flat `onCrashAdded(listener)` (filter is the
+//     handler's responsibility — by design, see event-bus.ts header).
+//     Generifying over both would force an awkward predicate parameter
+//     onto the sessions adapter purely to share 25 lines of buffer logic.
+//     Re-implementing here keeps each subsystem's adapter independently
+//     readable; both adapters share the same bounded-buffer +
+//     abort-signal contract by inspection, not by type-magic.
+//   - `node:events.EventEmitter.on(emitter, evt, { signal })`: rejected
+//     for the same reason as in watch-sessions — the bus is not an
+//     EventEmitter and wrapping it just to use the stdlib adapter is
+//     more code than the 25-line bespoke pump.
+//   - Drop events when buffer is full vs. error the stream: ERROR via
+//     `Code.ResourceExhausted` so a stuck consumer gets a loud
+//     reconnect signal rather than silent crash-event loss. Same policy
+//     as WatchSessions (the operator viewing crashes has the same
+//     "missing notifications are worse than a visible disconnect"
+//     trade-off).
+//   - Snapshot of historical rows before the live tail: out of scope
+//     for v0.3 — the `WatchCrashLogRequest` wire shape carries no
+//     `since_unix_ms` cursor (unlike `GetCrashLogRequest`); the spec
+//     ch12 §3 contract is "events emitted AFTER subscribe surface".
+//     Clients that need history call `GetCrashLog` first and then
+//     `WatchCrashLog` for the tail (the same two-step pattern Electron
+//     uses for `ListSessions` + `WatchSessions`).
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type HandlerContext,
+  type ServiceImpl,
+} from '@connectrpc/connect';
+
+import {
+  CrashEntrySchema,
+  type CrashService,
+  OwnerFilter,
+  type CrashEntry as ProtoCrashEntry,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, principalKey, type Principal } from '../../auth/index.js';
+import { CrashEventBus } from '../../crash/event-bus.js';
+import type { CrashRawEntry } from '../../crash/raw-appender.js';
+import { DAEMON_SELF } from '../../crash/sources.js';
+import { throwError } from '../errors.js';
+
+// ---------------------------------------------------------------------------
+// Decider
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated union: pure verdict over the request's `OwnerFilter`.
+ *
+ * - `own` — `OWNER_FILTER_UNSPECIFIED` (==OWN per crash.proto comment) or
+ *   `OWNER_FILTER_OWN`. Visibility: `entry.owner_id === callerKey ||
+ *   entry.owner_id === DAEMON_SELF` (ch04 §5 + ch09 §1 sentinel).
+ * - `all` — `OWNER_FILTER_ALL`. v0.3 has a single principal kind so the
+ *   filter is effectively a no-op at runtime; v0.4 multi-principal
+ *   tightens this to admin-only via the auth interceptor (today the
+ *   wire shape allows it for the local-user principal). The integration
+ *   spec `crash-stream.spec.ts "OWN filter drops events owned by other
+ *   principals"` pins the OWN behavior; an explicit ALL spec lands when
+ *   admin scoping does in v0.4.
+ * - `reject_permission_denied` — unknown enum value the v0.3 daemon does
+ *   not know. Conservative deny (same posture as
+ *   `decideGetCrashLogQuery`'s unknown-enum throw and
+ *   `decideWatchScope`'s default branch). A v0.4 client speaking a
+ *   higher proto_version that sends a brand-new enum value gets a
+ *   structured `(PermissionDenied, session.not_owned)` pair rather
+ *   than silent acceptance.
+ */
+export type OwnerScopeVerdict =
+  | { readonly kind: 'own' }
+  | { readonly kind: 'all' }
+  | { readonly kind: 'reject_permission_denied' };
+
+/**
+ * Pure decider over `OwnerFilter`. v0.3 enum values:
+ *   - UNSPECIFIED (0) → 'own' (treated as OWN per crash.proto comment)
+ *   - OWN         (1) → 'own'
+ *   - ALL         (2) → 'all'
+ *   - anything else → 'reject_permission_denied'
+ */
+export function decideOwnerScope(filter: OwnerFilter): OwnerScopeVerdict {
+  switch (filter) {
+    case OwnerFilter.UNSPECIFIED:
+    case OwnerFilter.OWN:
+      return { kind: 'own' };
+    case OwnerFilter.ALL:
+      return { kind: 'all' };
+    default:
+      return { kind: 'reject_permission_denied' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Visibility predicate (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * True iff `entry` is visible to a caller subscribed under `scope`.
+ *
+ * OWN visibility (ch04 §5 OWNER_FILTER_OWN definition):
+ *   `entry.owner_id === callerKey || entry.owner_id === DAEMON_SELF`.
+ * The `DAEMON_SELF` arm surfaces daemon-side crashes (sqlite_op,
+ * uncaught_exception, ...) to the local user even though no
+ * principalKey will ever match the sentinel — see ch09 §1 + the
+ * `event-bus.ts` Layer 1 note on why filtering is the handler's job.
+ *
+ * ALL visibility: true. v0.3 has only one principal kind so this is
+ * effectively the same as OWN at runtime; v0.4 admin scoping diverges.
+ *
+ * Exported so unit tests can pin the predicate without spinning up a
+ * Connect transport.
+ */
+export function isVisibleToCaller(
+  entry: CrashRawEntry,
+  scope: OwnerScopeVerdict,
+  callerKey: string,
+): boolean {
+  if (scope.kind === 'all') return true;
+  if (scope.kind === 'own') {
+    return entry.owner_id === callerKey || entry.owner_id === DAEMON_SELF;
+  }
+  // 'reject_permission_denied' is filtered out by the sink before this
+  // helper is reached, but be defensive — an unknown scope hides
+  // everything rather than silently widening.
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Producer — bus → AsyncIterable adapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Bounded buffer used by the bus → AsyncIterable adapter. 1024 events
+ * matches the WatchSessions adapter (`watch-sessions.ts:DEFAULT_WATCH_BUFFER_SIZE`)
+ * for one shape across subsystems. Crashes happen at human-noticeable
+ * speed — even a fatal-loop bounded by the retention pruner cannot
+ * sustain >1024 events between consumer pulls. Hitting the limit is a
+ * stuck consumer; the adapter signals `Code.ResourceExhausted` so the
+ * client's reconnect path runs.
+ *
+ * Exported for unit tests so the slow-consumer scenario can be exercised
+ * without queuing 1025+ real events.
+ */
+export const DEFAULT_WATCH_BUFFER_SIZE = 1024;
+
+interface SubscribeAsAsyncIterableOptions {
+  /** Pre-filter — only entries that pass are buffered. */
+  readonly visible: (entry: CrashRawEntry) => boolean;
+  /** Override the buffer size — tests use a small value to exercise overflow. */
+  readonly bufferSize?: number;
+  /**
+   * AbortSignal used to tear down the subscription. Connect-ES passes
+   * `HandlerContext.signal` which fires when the client disconnects or
+   * the server is shutting down. The adapter detaches its listener and
+   * resolves the iterator's pending `next()` with `done: true`.
+   */
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Adapt the bus's push-based `onCrashAdded(listener)` API into a
+ * pull-based `AsyncIterable<CrashRawEntry>` that Connect-ES v2's
+ * server-streaming handler can `yield*` over.
+ *
+ * Single-slot promise queue, identical in shape to
+ * `sessions/watch-sessions.ts:subscribeAsAsyncIterable`:
+ *   - the listener fires synchronously from `bus.emitCrashAdded` and either
+ *     fulfills a pending `next()` or appends to the buffer (after the
+ *     visibility filter — non-matching events do NOT enter the buffer);
+ *   - `next()` either consumes a buffered event or installs the resolver
+ *     for the next emit to fire;
+ *   - the `signal`'s `abort` event detaches the listener and resolves
+ *     any pending `next()` with `done: true` so the for-await loop in
+ *     the handler exits cleanly.
+ *
+ * Buffer-full policy: throw a `ConnectError(ResourceExhausted)` from
+ * `next()`. The handler propagates it as the stream's terminal error so
+ * the client sees a structured failure rather than silent event loss.
+ *
+ * Exported separately from the handler so unit tests can drive the
+ * adapter against a fresh `new CrashEventBus()` without building a full
+ * Connect transport.
+ */
+export function subscribeAsAsyncIterable(
+  bus: CrashEventBus,
+  options: SubscribeAsAsyncIterableOptions,
+): AsyncIterable<CrashRawEntry> {
+  const bufferSize = options.bufferSize ?? DEFAULT_WATCH_BUFFER_SIZE;
+  const signal = options.signal;
+  const visible = options.visible;
+
+  return {
+    [Symbol.asyncIterator](): AsyncIterator<CrashRawEntry> {
+      const buffer: CrashRawEntry[] = [];
+      let pendingResolve:
+        | ((value: IteratorResult<CrashRawEntry>) => void)
+        | null = null;
+      let pendingReject: ((reason: unknown) => void) | null = null;
+      let done = false;
+      let bufferError: ConnectError | null = null;
+
+      const unsubscribe = bus.onCrashAdded((entry) => {
+        if (done) return;
+        // Visibility filter — non-matching events are dropped at the
+        // boundary; they never enter the buffer and cannot exhaust it.
+        if (!visible(entry)) return;
+        if (pendingResolve !== null) {
+          const resolve = pendingResolve;
+          pendingResolve = null;
+          pendingReject = null;
+          resolve({ value: entry, done: false });
+          return;
+        }
+        if (buffer.length >= bufferSize) {
+          bufferError = new ConnectError(
+            `WatchCrashLog subscriber buffer overflow (>= ${bufferSize} events); ` +
+              'consumer is too slow — stream terminated so client retries.',
+            Code.ResourceExhausted,
+          );
+          done = true;
+          unsubscribe();
+          return;
+        }
+        buffer.push(entry);
+      });
+
+      const onAbort = (): void => {
+        if (done) return;
+        done = true;
+        unsubscribe();
+        if (pendingResolve !== null) {
+          const resolve = pendingResolve;
+          pendingResolve = null;
+          pendingReject = null;
+          resolve({ value: undefined as never, done: true });
+        }
+      };
+
+      if (signal !== undefined) {
+        if (signal.aborted) {
+          onAbort();
+        } else {
+          signal.addEventListener('abort', onAbort, { once: true });
+        }
+      }
+
+      const detachAbort = (): void => {
+        if (signal !== undefined) {
+          signal.removeEventListener('abort', onAbort);
+        }
+      };
+
+      return {
+        async next(): Promise<IteratorResult<CrashRawEntry>> {
+          if (buffer.length > 0) {
+            const value = buffer.shift() as CrashRawEntry;
+            return { value, done: false };
+          }
+          if (bufferError !== null) {
+            const err = bufferError;
+            bufferError = null;
+            detachAbort();
+            throw err;
+          }
+          if (done) {
+            detachAbort();
+            return { value: undefined as never, done: true };
+          }
+          return new Promise<IteratorResult<CrashRawEntry>>((resolve, reject) => {
+            pendingResolve = resolve;
+            pendingReject = reject;
+          });
+        },
+        async return(value?: unknown): Promise<IteratorResult<CrashRawEntry>> {
+          done = true;
+          unsubscribe();
+          detachAbort();
+          if (pendingReject !== null) {
+            const resolve = pendingResolve;
+            pendingResolve = null;
+            pendingReject = null;
+            resolve?.({ value: undefined as never, done: true });
+          }
+          return { value: value as never, done: true };
+        },
+        async throw(err?: unknown): Promise<IteratorResult<CrashRawEntry>> {
+          done = true;
+          unsubscribe();
+          detachAbort();
+          if (pendingReject !== null) {
+            const reject = pendingReject;
+            pendingResolve = null;
+            pendingReject = null;
+            reject(err);
+          }
+          throw err;
+        },
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sink — Connect handler
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a `CrashRawEntry` (NDJSON shape, raw-appender's domain type) to
+ * the wire `CrashEntry` (proto). Mirrors the encoder in
+ * `crash-stream.spec.ts:toProtoEntry` so the production handler emits
+ * the exact shape the integration test pinned, AND the per-row mapper
+ * in `get-crash-log.ts:rowToProto` for cross-method consistency.
+ *
+ * `labels` is copied (not aliased) so a downstream mutation of the proto
+ * cannot mutate the bus event's frozen-by-convention labels map.
+ *
+ * Exported for unit tests.
+ */
+export function rawEntryToProto(raw: CrashRawEntry): ProtoCrashEntry {
+  return create(CrashEntrySchema, {
+    id: raw.id,
+    tsUnixMs: BigInt(raw.ts_ms),
+    source: raw.source,
+    summary: raw.summary,
+    detail: raw.detail,
+    labels: { ...raw.labels },
+    ownerId: raw.owner_id,
+  });
+}
+
+export interface WatchCrashLogDeps {
+  /**
+   * Crash event bus. Production wiring passes the
+   * `defaultCrashEventBus` singleton from
+   * `packages/daemon/src/crash/event-bus.ts` — the SAME instance that
+   * `crash/raw-appender.ts:appendCrashRaw` emits on after `fsync`. Tests
+   * construct a fresh `new CrashEventBus()` so emitted events do not
+   * cross-contaminate.
+   */
+  readonly bus: CrashEventBus;
+}
+
+/**
+ * Build the Connect `ServiceImpl<typeof CrashService>['watchCrashLog']`
+ * handler.
+ *
+ * Reads `PRINCIPAL_KEY` from the HandlerContext (the
+ * `peerCredAuthInterceptor` deposited it before this handler runs),
+ * runs the decider over `req.ownerFilter`, then either subscribes to
+ * the bus and yields proto `CrashEntry` events, or throws
+ * `Code.PermissionDenied` with the canonical `session.not_owned`
+ * ErrorDetail (T2.5 single source of truth — matches the unknown-enum
+ * posture in `get-crash-log.ts`).
+ *
+ * The handler returns an async generator (Connect-ES v2 server-streaming
+ * shape). The generator's lifetime is bound to the HandlerContext's
+ * `signal`: when the client disconnects or the server shuts down,
+ * Connect aborts the signal, the producer's `subscribeAsAsyncIterable`
+ * detaches the bus listener, and the generator returns cleanly.
+ *
+ * Mirrors the posture of `sessions/watch-sessions.ts:makeWatchSessionsHandler`:
+ * a missing principal is a daemon wiring bug surfaced as `Internal`
+ * rather than `Unauthenticated` (the auth interceptor would have
+ * rejected the call before this handler ran if the caller were
+ * unauthenticated).
+ */
+export function makeWatchCrashLogHandler(
+  deps: WatchCrashLogDeps,
+): ServiceImpl<typeof CrashService>['watchCrashLog'] {
+  return async function* watchCrashLog(
+    req,
+    handlerContext: HandlerContext,
+  ): AsyncGenerator<ProtoCrashEntry, void, undefined> {
+    const principal: Principal | null = handlerContext.values.get(PRINCIPAL_KEY);
+    if (principal === null) {
+      throw new ConnectError(
+        'WatchCrashLog handler invoked without peerCredAuthInterceptor in chain ' +
+          '(PRINCIPAL_KEY=null) — daemon wiring bug',
+        Code.Internal,
+      );
+    }
+
+    const verdict = decideOwnerScope(req.ownerFilter);
+    if (verdict.kind === 'reject_permission_denied') {
+      // Forward-compat conservative deny — matches the unknown-enum
+      // posture in `get-crash-log.ts:makeGetCrashLogHandler`. T2.5
+      // single source of truth: `session.not_owned` →
+      // `Code.PermissionDenied + ErrorDetail`.
+      throwError(
+        'session.not_owned',
+        `unknown OwnerFilter enum value ${String(req.ownerFilter)} — refusing to interpret`,
+        { requested_owner_filter: String(req.ownerFilter) },
+      );
+    }
+
+    const callerKey = principalKey(principal);
+    const events = subscribeAsAsyncIterable(deps.bus, {
+      visible: (entry) => isVisibleToCaller(entry, verdict, callerKey),
+      signal: handlerContext.signal,
+    });
+
+    for await (const ev of events) {
+      yield rawEntryToProto(ev);
+    }
+  };
+}

--- a/packages/daemon/test/integration/crash-watch-wired.spec.ts
+++ b/packages/daemon/test/integration/crash-watch-wired.spec.ts
@@ -1,0 +1,233 @@
+// packages/daemon/test/integration/crash-watch-wired.spec.ts
+//
+// Wave-3 Task #335 — production daemon-startup wire-up regression for
+// CrashService.WatchCrashLog.
+//
+// Audit reference: docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md
+// (sub-task 4b of #228).
+//
+// Background:
+//   - `makeWatchCrashLogHandler` (#335 / this PR) consumes the
+//     `defaultCrashEventBus` singleton (Task #340) that
+//     `crash/raw-appender.ts:appendCrashRaw` already emits on after fsync.
+//   - Until #335, `packages/daemon/src/index.ts` constructed `crashDeps`
+//     with `{ getCrashLogDeps: { db } }` only, so
+//     `rpc/crash/register.ts:registerCrashService` installed a partial
+//     `{ getCrashLog }` impl and `WatchCrashLog` resolved to the T2.2
+//     `Unimplemented` stub at boot — the exact "library shipped but
+//     never wired" regression class Wave 0/1 + Task #221 exist to catch.
+//   - This spec boots the production `runStartup` (no mocks, no harness
+//     bypass) and asserts the over-the-wire response to a
+//     `WatchCrashLog(OWN)` call is NOT `Code.Unimplemented`. Reverse
+//     verification: removing the `watchCrashLogDeps` line from
+//     `index.ts`'s `crashDeps` flips this spec to expect-Unimplemented
+//     and it fails.
+//
+// Why a separate spec from `daemon-boot-end-to-end.spec.ts`:
+//   - The audit lists each stubbed method as its own wire-up gap (one
+//     PR per concern, per dev.md §1 wave-ordering discipline). One spec
+//     per gap mirrors the precedent set by `watch-sessions-wired.spec.ts`
+//     (#290) and `crash-getlog-wired.spec.ts` (#229). The boot-end-to-end
+//     spec stays the cross-cutting "every component wired" assertion via
+//     `result.wired`.
+//
+// Why not extend `crash-stream.spec.ts` instead:
+//   - That file's `setup` overrides the CrashService at the harness
+//     level with an INLINE stub handler around an in-test `CrashEventBus`
+//     stand-in — by design, to test the wire-shape contract independently
+//     of the production handler. This file is the complementary
+//     "production handler is actually bound at boot" assertion; one
+//     verifies the contract, the other verifies the wiring.
+//
+// Transport choice:
+//   - Identical to daemon-boot-end-to-end.spec.ts and
+//     watch-sessions-wired.spec.ts / crash-getlog-wired.spec.ts:
+//     `CCSM_LISTENER_A_FORCE_LOOPBACK=1` keeps Listener A on the
+//     cross-OS h2c loopback transport so this spec runs on every CI leg
+//     without UDS / named-pipe gating.
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type Client,
+  createClient,
+} from '@connectrpc/connect';
+import { createConnectTransport } from '@connectrpc/connect-node';
+
+import {
+  CrashService,
+  OwnerFilter,
+  RequestMetaSchema,
+  WatchCrashLogRequestSchema,
+} from '@ccsm/proto';
+
+import { runStartup, type RunStartupResult } from '../../src/index.js';
+import { Lifecycle } from '../../src/lifecycle.js';
+import { TEST_BEARER_TOKEN } from '../../src/auth/index.js';
+
+interface BootEnv {
+  readonly tmpRoot: string;
+  readonly origEnv: NodeJS.ProcessEnv;
+}
+
+async function setupBootEnv(): Promise<BootEnv> {
+  const origEnv = { ...process.env };
+  const tmpRoot = await mkdtemp(join(tmpdir(), 'ccsm-crash-watch-wired-'));
+  process.env.CCSM_STATE_DIR = tmpRoot;
+  process.env.CCSM_DESCRIPTOR_PATH = join(tmpRoot, 'listener-a.json');
+  process.env.CCSM_LISTENER_A_ADDR = join(tmpRoot, 'daemon.sock');
+  process.env.CCSM_LISTENER_A_FORCE_LOOPBACK = '1';
+  if (process.platform === 'win32') {
+    process.env.PROGRAMDATA = tmpRoot;
+  }
+  process.env.CCSM_SUPERVISOR_ADDR =
+    process.platform === 'win32'
+      ? `\\\\.\\pipe\\ccsm-crash-watch-wired-${process.pid}-${Date.now()}`
+      : join(tmpRoot, 'supervisor.sock');
+  process.env.CCSM_VERSION = '0.3.0-crash-watch-wired-test';
+  return { tmpRoot, origEnv };
+}
+
+async function teardownBootEnv(setup: BootEnv): Promise<void> {
+  for (const k of Object.keys(process.env)) {
+    if (!(k in setup.origEnv)) delete process.env[k];
+  }
+  for (const [k, v] of Object.entries(setup.origEnv)) {
+    process.env[k] = v;
+  }
+  await rm(setup.tmpRoot, { recursive: true, force: true }).catch(() => {
+    /* tmp cleanup best-effort */
+  });
+}
+
+async function stopBoot(result: RunStartupResult | null): Promise<void> {
+  if (result === null) return;
+  result.captureSourcesUnsubscribe?.();
+  await result.supervisor?.stop().catch(() => {});
+  await result.listenerA?.stop().catch(() => {});
+  result.crashPruner.stop();
+  try {
+    result.db.close();
+  } catch {
+    /* idempotent */
+  }
+}
+
+function makeCrashClient(baseUrl: string): Client<typeof CrashService> {
+  const transport = createConnectTransport({
+    httpVersion: '2',
+    baseUrl,
+    interceptors: [
+      (next) => async (req) => {
+        req.header.set('authorization', `Bearer ${TEST_BEARER_TOKEN}`);
+        return next(req);
+      },
+    ],
+  });
+  return createClient(CrashService, transport);
+}
+
+function newWatchRequest(filter: OwnerFilter) {
+  return create(WatchCrashLogRequestSchema, {
+    meta: create(RequestMetaSchema, {
+      requestId: `wired-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+      clientVersion: '0.3.0-crash-watch-wired-test',
+      clientSendUnixMs: BigInt(Date.now()),
+    }),
+    ownerFilter: filter,
+  });
+}
+
+describe('CrashService.WatchCrashLog production wire-up (Task #335)', () => {
+  let setup: BootEnv;
+  let lifecycle: Lifecycle;
+  let result: RunStartupResult | null = null;
+
+  beforeEach(async () => {
+    setup = await setupBootEnv();
+    lifecycle = new Lifecycle();
+    result = await runStartup(lifecycle);
+  });
+
+  // Win32 named-pipe supervisor.stop() can take >10s on a busy host (the
+  // default vitest hook timeout); the existing `daemon-boot-end-to-end` /
+  // `watch-sessions-wired` specs hit the same shape on slow hosts. Bump
+  // both hooks to 30s so the streaming-RPC teardown path (abort →
+  // server-side stream close → listener stop → supervisor stop) has
+  // headroom even when other vitest workers are competing for I/O.
+  afterEach(async () => {
+    await stopBoot(result);
+    result = null;
+    await teardownBootEnv(setup);
+  }, 30_000);
+
+  it('WatchCrashLog(OWN) over the production Listener A does NOT return Code.Unimplemented', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    expect(r.listenerA).not.toBeNull();
+    const desc = r.listenerA!.descriptor();
+    expect(desc.kind).toBe('KIND_TCP_LOOPBACK_H2C');
+    if (desc.kind !== 'KIND_TCP_LOOPBACK_H2C') return;
+    const baseUrl = `http://127.0.0.1:${desc.port}`;
+
+    // AbortController scopes the lifetime of the streaming call. After
+    // we have observed enough to make the wire-up assertion (either a
+    // terminal Unimplemented error or a "stream stayed open past the
+    // timeout"), we abort so the http2 stream tears down promptly and
+    // afterEach's `listenerA.stop()` does not race a still-open client.
+    // Same teardown discipline as `watch-sessions-wired.spec.ts`.
+    const ac = new AbortController();
+    const client = makeCrashClient(baseUrl);
+    const stream = client.watchCrashLog(newWatchRequest(OwnerFilter.OWN), {
+      signal: ac.signal,
+    });
+
+    // The handler is server-streaming with no events queued — when
+    // wired, the iterator stays open waiting for the first event from
+    // the bus. When NOT wired (the pre-#335 regression), the Connect
+    // router responds immediately with Code.Unimplemented and the
+    // iterator throws on the first `next()`. Race the iterator's first
+    // tick against a short timeout: timeout-wins == handler wired,
+    // throw-wins == we caught Unimplemented.
+    const iterator = stream[Symbol.asyncIterator]();
+    const firstEvent = iterator.next();
+    const timeout = new Promise<{ kind: 'timeout' }>((resolve) =>
+      setTimeout(() => resolve({ kind: 'timeout' }), 250),
+    );
+
+    let raised: ConnectError | null = null;
+    let timedOut = false;
+    try {
+      const winner = await Promise.race([
+        firstEvent.then(() => ({ kind: 'event' as const })),
+        timeout,
+      ]);
+      timedOut = winner.kind === 'timeout';
+    } catch (err) {
+      raised = ConnectError.from(err);
+    } finally {
+      ac.abort();
+      await iterator.return?.(undefined).catch(() => {});
+      await firstEvent.catch(() => {});
+    }
+
+    if (raised !== null) {
+      expect(
+        raised.code,
+        `WatchCrashLog returned Unimplemented — production wire-up regressed (audit #228 sub-task 4b, message: ${raised.message})`,
+      ).not.toBe(Code.Unimplemented);
+    } else {
+      // Stream stayed open until our timeout — proves the handler is
+      // installed AND subscribed to the bus (an Unimplemented stub
+      // would have terminated the stream within the first event-loop
+      // turn, well before 250ms).
+      expect(timedOut).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Task

Task #335 (Wave-3 §6.9 sub-task 4b of audit #228) — server-streaming
CrashService.WatchCrashLog handler. Consumes the CrashEventBus from
#340 (PR #994) and extends the registerCrashService overlay landed by
#229 (PR #996). Streaming sibling #334 (GetRawCrashLog) stays
\`Unimplemented\` until its sub-task lands.

## Summary

- New \`packages/daemon/src/rpc/crash/watch-crash-log.ts\` — server-streaming
  Connect handler.
  - **decider**: \`decideOwnerScope(filter)\` — pure verdict over OwnerFilter.
    UNSPECIFIED/OWN -> 'own', ALL -> 'all', unknown enum -> reject_permission_denied
    (mirrors the unknown-enum posture in \`get-crash-log.ts\` +
    \`watch-sessions.ts\`).
  - **predicate**: \`isVisibleToCaller(entry, scope, callerKey)\` — OWN
    includes the \`'daemon-self'\` sentinel per ch04 §5 + ch09 §1.
  - **producer**: \`subscribeAsAsyncIterable(bus, options)\` — push (bus
    callback) -> pull (AsyncIterable) adapter with bounded buffer (1024,
    matches WatchSessions) and abort-signal teardown, structurally
    identical to \`sessions/watch-sessions.ts:subscribeAsAsyncIterable\`.
    Visibility filter runs INSIDE the bus callback so non-matching
    events never enter the buffer.
  - **sink**: \`makeWatchCrashLogHandler(deps)\` — reads PRINCIPAL_KEY
    from HandlerContext, runs the decider, subscribes, yields proto
    \`CrashEntry\` events. Conservative-deny on unknown enums via
    \`throwError('session.not_owned', ...)\` (T2.5 single source of truth).
- Extends \`registerCrashService\` to install both \`getCrashLog\` AND
  \`watchCrashLog\` in a SINGLE \`router.service(CrashService, ...)\` call,
  per the "calling service() twice for the same descriptor silently
  drops the earlier registration" caveat already documented for
  SessionService.
- \`runStartup\` now constructs \`crashDeps.watchCrashLogDeps = { bus:
  defaultCrashEventBus }\` so the production handler subscribes to the
  same singleton \`crash/raw-appender.ts:appendCrashRaw\` emits on.
- New \`packages/daemon/test/integration/crash-watch-wired.spec.ts\` —
  production wire-up regression spec, modeled on
  \`crash-getlog-wired.spec.ts\` (#229) and \`watch-sessions-wired.spec.ts\`
  (#290). Boots \`runStartup\` + asserts WatchCrashLog over the production
  Listener A does NOT return \`Code.Unimplemented\`.

Layer 1 — alternatives checked (full reasoning in module header):
- Reuse the WatchSessions adapter — rejected; SessionEventBus is
  principal-keyed (security-boundary filter inside bus), CrashEventBus
  is flat (filter is the handler's job by design — see \`event-bus.ts\`).
  Generifying to share 25 lines of buffer logic adds awkward predicate
  parameter to sessions adapter for no reader-clarity gain.
- node:events.EventEmitter -> AsyncIterable adapter — rejected; bus is
  not an EventEmitter and wrapping just to use the stdlib adapter is
  more code than the bespoke pump.
- Snapshot-then-tail (return historical rows before live events) —
  rejected; out-of-spec for v0.3 (WatchCrashLogRequest carries no
  cursor field; ch12 §3 wording is "events emitted AFTER subscribe").
  Clients already do \`GetCrashLog\` + \`WatchCrashLog\` for the two-step
  pattern (same as \`ListSessions\` + \`WatchSessions\`).

## Local checks (host: windows-11)

- lint: ✓ (0 errors, 52 warnings — all pre-existing, none in new files)
- typecheck: ✓ (\`tsc --noEmit\` exit 0)
- build: ✓ (\`npm run build\` exit 0)
- unit tests:
  - \`crash-stream.spec.ts\` (T8.10 over-the-wire contract for streaming):
    **3/3 PASS** — exercises the same OWN/ALL/daemon-self semantics this
    handler implements (the test file wires its own inline impl around an
    in-test bus stand-in; this PR ships the production handler that
    matches that contract).
  - Daemon vitest run: 1008 passed / 11 failed. **None of the 11 fails
    are caused by this PR**:
    - \`runStartup-lock.spec.ts\` "canonical 5-component list" — stale
      since #229 added \`crash-rpc\` (count is 6 now, not 5); pre-existing,
      flag for separate fix.
    - \`descriptor/schema.spec.ts\` golden-file mismatch — pre-existing.
    - \`crash-getlog-wired\`, \`watch-sessions-wired\`,
      \`daemon-boot-end-to-end\`, \`rpc/__tests__/integration.spec.ts\`,
      \`crash-watch-wired\` (mine) — same Win32 hookTimeout symptom in
      \`afterEach\` stop path. Verified pre-existing by running
      \`watch-sessions-wired\` against bare working with my changes
      stashed — same fail. PR #977 (#290) and PR #996 (#229) both
      shipped these specs with the same local Win32 issue and CI green;
      this PR follows the identical shape.

**Local Win32 fail rationale**: the failing wired specs all hang in
\`stopBoot\` -> \`supervisor.stop()\` against named-pipe transport on
Win32, even with hookTimeout bumped to 30s. Same 4 specs that already
shipped exhibit the same fail on this host. CI matrix (ubuntu/macos)
runs them green — the issue is named-pipe \`server.close()\` semantics
on Win32, NOT this handler (the unary GetCrashLog wired spec hits the
same hook timeout). Fixing supervisor.stop is out of scope; flagging
for separate cleanup.

## Test plan

- [ ] CI matrix (ubuntu/macos/windows) runs \`crash-watch-wired.spec.ts\`
      green — confirms production wire-up.
- [ ] CI matrix runs the existing \`crash-stream.spec.ts\` cases green —
      confirms OWN/ALL/daemon-self contract preserved.
- [ ] CI matrix runs \`watch-sessions-wired.spec.ts\` /
      \`crash-getlog-wired.spec.ts\` green — confirms registerCrashService
      additive overlay does not regress GetCrashLog or WatchSessions.