### PR TITLE
wave3(#84): uninstaller REMOVEUSERDATA matrix + service unregister (T7.6)

### DIFF
--- a/packages/daemon/build/__tests__/uninstall-matrix.spec.ts
+++ b/packages/daemon/build/__tests__/uninstall-matrix.spec.ts
@@ -1,0 +1,535 @@
+// packages/daemon/build/__tests__/uninstall-matrix.spec.ts
+//
+// Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//       chapter 10 §5 step list ("Common to all uninstallers", steps 1-6)
+//       + chapter 10 §5.1 (Win MSI REMOVEUSERDATA + ServiceControl)
+//       + chapter 10 §5.2 (mac ccsm-uninstall.command path)
+//       + chapter 10 §5.3 (linux postrm CCSM_REMOVE_USER_DATA).
+// Task: T7.6 (#84) — uninstaller: REMOVEUSERDATA matrix + service unregister + cleanup.
+//
+// Forever-stable shape gates that lock the uninstaller behaviour matrix
+// across the 3 OSes:
+//
+//   { OS } × { interactive, silent } × { REMOVEUSERDATA=0, REMOVEUSERDATA=1 }
+//   plus per-OS service-unregister verifications.
+//
+// We assert on the SOURCES (uninstall scripts + WiX manifest) rather than
+// running a real msiexec / launchctl / dpkg, because the toolchain is not
+// uniformly available on dev boxes (same constraint as T7.4 spec). The
+// real round-trip is exercised by tools/installer-roundtrip.{ps1,sh},
+// which is a downstream ship-gate (d) test — these unit tests are the
+// pre-merge contract that lets that ship-gate stay green.
+//
+// Test count discipline (T7.6 spec): ≥ 44 shape gates. The block layout
+// below is sized to 50 it() calls to leave headroom; each gate locks
+// exactly one decision so a future PR cannot quietly drift any single
+// matrix cell.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const BUILD_DIR = path.resolve(__dirname, '..');
+const INSTALL_DIR = path.join(BUILD_DIR, 'install');
+const REPO_ROOT = path.resolve(BUILD_DIR, '..', '..', '..');
+
+// Per-OS layout under build/install/<os>/ (T7.4 lineage).
+const WIN_WXS         = path.join(INSTALL_DIR, 'win', 'Product.wxs.template');
+const MAC_UNINSTALL   = path.join(INSTALL_DIR, 'mac', 'uninstall.sh');
+const MAC_POSTINSTALL = path.join(INSTALL_DIR, 'mac', 'postinstall.sh');
+const MAC_BUILD_PKG   = path.join(INSTALL_DIR, 'mac', 'build-pkg.sh');
+const LINUX_PRERM     = path.join(INSTALL_DIR, 'linux', 'prerm.sh');
+const LINUX_POSTRM    = path.join(INSTALL_DIR, 'linux', 'postrm.sh');
+
+// Top-level wrappers (manager spec: scripts/installer/uninstall.{sh,ps1}).
+const TOP_UNINSTALL_SH  = path.join(REPO_ROOT, 'scripts', 'installer', 'uninstall.sh');
+const TOP_UNINSTALL_PS1 = path.join(REPO_ROOT, 'scripts', 'installer', 'uninstall.ps1');
+
+function read(p: string): string {
+  return readFileSync(p, 'utf8');
+}
+
+describe('uninstall matrix — files exist (T7.6 spec ch10 §5)', () => {
+  it('mac per-OS uninstaller source exists', () => {
+    expect(existsSync(MAC_UNINSTALL)).toBe(true);
+  });
+
+  it('top-level uninstall.sh exists at scripts/installer/', () => {
+    expect(existsSync(TOP_UNINSTALL_SH)).toBe(true);
+  });
+
+  it('top-level uninstall.ps1 exists at scripts/installer/', () => {
+    expect(existsSync(TOP_UNINSTALL_PS1)).toBe(true);
+  });
+
+  it('top-level uninstall.sh is non-empty (>= 1 KB of real content)', () => {
+    expect(statSync(TOP_UNINSTALL_SH).size).toBeGreaterThan(1024);
+  });
+
+  it('top-level uninstall.ps1 is non-empty (>= 1 KB of real content)', () => {
+    expect(statSync(TOP_UNINSTALL_PS1).size).toBeGreaterThan(1024);
+  });
+});
+
+describe('uninstall matrix — Windows MSI ServiceControl + REMOVEUSERDATA (ch10 §5.1)', () => {
+  const wxs = read(WIN_WXS);
+
+  // Spec ch10 §5 common-to-all-uninstallers step 1: stop service (≤10s
+  // clean exit). WiX 4 <ServiceControl Stop="both"> performs blocking
+  // stop with the SCM's 30s default, well within the 10s budget the
+  // /healthz path exercises in §5 step 7.
+  it('declares <ServiceControl Stop="both"> for ccsm-daemon (step 1: stop service)', () => {
+    expect(wxs).toMatch(/<ServiceControl[\s\S]*?Name="ccsm-daemon"[\s\S]*?Stop="both"/);
+  });
+
+  // Spec step 2: unregister service. WiX 4 Remove="uninstall" tells the
+  // SCM to delete the service entry on uninstall (and Remove="install"
+  // would do it on install, which we do NOT want).
+  it('declares <ServiceControl Remove="uninstall"> for ccsm-daemon (step 2: unregister)', () => {
+    expect(wxs).toMatch(/<ServiceControl[\s\S]*?Name="ccsm-daemon"[\s\S]*?Remove="uninstall"/);
+  });
+
+  it('declares <ServiceControl Wait="yes"> so msiexec blocks until service is stopped', () => {
+    // Without Wait="yes" the MSI proceeds before the service has actually
+    // released file handles, races the file-table delete, and leaves
+    // ccsm-daemon.exe on disk under "scheduled for delete on reboot".
+    expect(wxs).toMatch(/<ServiceControl[\s\S]*?Wait="yes"/);
+  });
+
+  // Spec step 4 silent contract: REMOVEUSERDATA public property gates
+  // state-dir removal in /qn mode.
+  it('declares REMOVEUSERDATA as a Public property (uppercase id, MSI public-property convention)', () => {
+    // MSI public properties are uppercase; lowercase would not be
+    // settable from the command line. Spec ch10 §5 step 4 calls it out
+    // by name.
+    expect(wxs).toMatch(/<Property[\s\S]*?Id="REMOVEUSERDATA"/);
+  });
+
+  it('marks REMOVEUSERDATA Secure="yes" (required for /qn elevated installs)', () => {
+    // Without Secure="yes" the value set on the command line is dropped
+    // when running elevated under /qn, defeating the silent path.
+    expect(wxs).toMatch(/Id="REMOVEUSERDATA"[\s\S]*?Secure="yes"/);
+  });
+
+  it('defaults REMOVEUSERDATA to "0" (spec: default keep)', () => {
+    // Spec ch10 §5 step 4 line: 'Default: keep state on uninstall'.
+    expect(wxs).toMatch(/Id="REMOVEUSERDATA"[\s\S]*?Value="0"/);
+  });
+
+  it('has a state-dir component WITHOUT RemoveFolderEx (the keep-data branch)', () => {
+    // The two-component pattern from T7.4: "StateDir" (always created,
+    // no RemoveFolderEx) + "StateDirRemovable" (RemoveFolderEx gated).
+    // We assert the keep-data branch contains no RemoveFolderEx.
+    const stateDirBlock = wxs.match(/<Component\s+Id="StateDir"[\s\S]*?<\/Component>/);
+    expect(stateDirBlock).not.toBeNull();
+    expect(stateDirBlock![0]).not.toMatch(/RemoveFolderEx/);
+  });
+
+  it('has a state-dir component WITH RemoveFolderEx gated to REMOVEUSERDATA="1" (the remove-data branch)', () => {
+    const removableBlock = wxs.match(/<Component\s+Id="StateDirRemovable"[\s\S]*?<\/Component>/);
+    expect(removableBlock).not.toBeNull();
+    expect(removableBlock![0]).toMatch(/util:RemoveFolderEx/);
+    expect(removableBlock![0]).toMatch(/On="uninstall"/);
+    expect(removableBlock![0]).toMatch(/REMOVEUSERDATA="1"/);
+  });
+
+  it('keep-data branch component is conditioned on REMOVEUSERDATA NOT being "1"', () => {
+    const stateDirBlock = wxs.match(/<Component\s+Id="StateDir"[\s\S]*?<\/Component>/);
+    expect(stateDirBlock).not.toBeNull();
+    // The condition is "NOT REMOVEUSERDATA OR REMOVEUSERDATA='0'" —
+    // either form covers the spec's "default keep" branch.
+    expect(stateDirBlock![0]).toMatch(/NOT REMOVEUSERDATA|REMOVEUSERDATA="0"/);
+  });
+
+  it('removes service via WiX <ServiceControl> NOT a sc.exe custom action (spec lock)', () => {
+    // Spec ch10 §5.1 explicitly forbids "sc.exe custom action" because
+    // declarative control is cleaner for uninstall and rollback.
+    expect(wxs).not.toMatch(/<CustomAction[\s\S]*?ExeCommand=".*sc\.exe.*delete/i);
+  });
+});
+
+describe('uninstall matrix — Windows uninstall.ps1 wrapper (interactive + silent)', () => {
+  const ps1 = read(TOP_UNINSTALL_PS1);
+
+  it('exposes a -Silent switch (msiexec /qn path, ship-gate (d))', () => {
+    expect(ps1).toMatch(/\[switch\]\$Silent/);
+  });
+
+  it('exposes a -RemoveUserData switch (force REMOVEUSERDATA=1)', () => {
+    expect(ps1).toMatch(/\[switch\]\$RemoveUserData/);
+  });
+
+  it('exposes a -KeepUserData switch (force REMOVEUSERDATA=0)', () => {
+    expect(ps1).toMatch(/\[switch\]\$KeepUserData/);
+  });
+
+  it('passes REMOVEUSERDATA=$removeUserData on the msiexec command line', () => {
+    // Critical: the value must be passed as a command-line property
+    // assignment, not a switch — msiexec parses "REMOVEUSERDATA=1" as
+    // a property=value pair and matches the WiX <Property> by name.
+    expect(ps1).toMatch(/"REMOVEUSERDATA=\$removeUserData"/);
+  });
+
+  it('uses /qn for silent and /qb for interactive (spec ch10 §5 step 4)', () => {
+    // /qn = no UI, /qb = basic UI with progress bar; interactive must
+    // NOT use full UI /qf since we already gathered the user choice via
+    // PowerShell prompt.
+    expect(ps1).toMatch(/'\/qn'/);
+    expect(ps1).toMatch(/'\/qb'/);
+  });
+
+  it('passes /norestart so MSI never auto-reboots', () => {
+    expect(ps1).toMatch(/'\/norestart'/);
+  });
+
+  it('passes /l*v with a verbose log path so ship-gate (d) can attach on failure', () => {
+    expect(ps1).toMatch(/'\/l\*v'/);
+  });
+
+  it('reads $env:CCSM_REMOVE_USER_DATA in -Silent mode (spec env contract)', () => {
+    expect(ps1).toMatch(/\$env:CCSM_REMOVE_USER_DATA/);
+  });
+
+  it('defaults REMOVEUSERDATA to "0" if no flag and no env (spec: default keep)', () => {
+    // Initial value declaration — explicit "0" so a future refactor
+    // can not accidentally flip the default.
+    expect(ps1).toMatch(/\$removeUserData\s*=\s*'0'/);
+  });
+
+  it('elevation check uses Administrator role (uninstall must run elevated)', () => {
+    expect(ps1).toMatch(/WindowsBuiltInRole\]::Administrator/);
+  });
+
+  it('exits 1 when not elevated', () => {
+    expect(ps1).toMatch(/exit 1/);
+  });
+
+  it('exits 2 when no installed CCSM product is detected', () => {
+    expect(ps1).toMatch(/exit 2/);
+  });
+
+  it('looks up product code from Uninstall registry by DisplayName="CCSM"', () => {
+    // Avoids Win32_Product (slow, side-effect-y); uses both 64-bit
+    // and WOW6432 hives so a 32-bit installer is also discoverable.
+    expect(ps1).toMatch(/DisplayName.*-eq.*'CCSM'/);
+    expect(ps1).toMatch(/WOW6432Node/);
+  });
+
+  it('treats msiexec exit 3010 as success (reboot required)', () => {
+    expect(ps1).toMatch(/3010/);
+  });
+
+  it('rejects both -RemoveUserData and -KeepUserData passed together', () => {
+    expect(ps1).toMatch(/RemoveUserData -and \$KeepUserData/);
+  });
+});
+
+describe('uninstall matrix — macOS uninstall.sh (ccsm-uninstall.command source)', () => {
+  const sh = read(MAC_UNINSTALL);
+
+  it('starts with bash shebang', () => {
+    expect(sh.startsWith('#!/usr/bin/env bash')).toBe(true);
+  });
+
+  it('exposes --silent and --interactive modes (spec ch10 §5 step 4 both variants)', () => {
+    expect(sh).toMatch(/--silent\|-y\)/);
+    expect(sh).toMatch(/--interactive\)/);
+  });
+
+  it('exposes --remove-user-data and --keep-user-data CLI flags', () => {
+    expect(sh).toMatch(/--remove-user-data\)/);
+    expect(sh).toMatch(/--keep-user-data\)/);
+  });
+
+  it('reads CCSM_REMOVE_USER_DATA env in silent mode (default 0 = keep)', () => {
+    expect(sh).toMatch(/\$\{CCSM_REMOVE_USER_DATA:-0\}/);
+  });
+
+  // Step 1: stop service. spec ch10 §5.2: launchctl bootout system/com.ccsm.daemon
+  it('step 1: invokes launchctl bootout system/com.ccsm.daemon', () => {
+    expect(sh).toMatch(/launchctl bootout[\s\S]*?system\/com\.ccsm\.daemon/);
+  });
+
+  it('step 1 escalates to SIGTERM then SIGKILL on bootout-survivor (spec ch10 §8 escalation)', () => {
+    // bootout is best-effort; if a daemon survives we follow the
+    // SIGTERM(5s) → SIGKILL escalation pattern from spec §8.
+    expect(sh).toMatch(/pkill -TERM/);
+    expect(sh).toMatch(/pkill -KILL/);
+  });
+
+  // Step 2: unregister service. Removing the plist is what makes the
+  // unregister persistent across reboots.
+  it('step 2: removes /Library/LaunchDaemons/com.ccsm.daemon.plist', () => {
+    expect(sh).toMatch(/rm -f "\$PLIST"/);
+    expect(sh).toMatch(/\/Library\/LaunchDaemons\/com\.ccsm\.daemon\.plist/);
+  });
+
+  // Step 3: remove binaries. spec ch10 §5.2 install path: /usr/local/ccsm.
+  it('step 3: removes /usr/local/ccsm install dir', () => {
+    expect(sh).toMatch(/rm -rf "\$INSTALL_DIR"/);
+    expect(sh).toMatch(/INSTALL_DIR="\/usr\/local\/ccsm"/);
+  });
+
+  // Step 5: remove state dir, ONLY when remove_user_data=1.
+  it('step 5: removes /Library/Application Support/ccsm only when remove_user_data=1', () => {
+    expect(sh).toMatch(/if \[\[ "\$remove_user_data" == "1" \]\]/);
+    expect(sh).toMatch(/rm -rf "\$STATE_DIR"/);
+    expect(sh).toMatch(/\/Library\/Application Support\/ccsm/);
+  });
+
+  it('step 5: removes /Library/Logs/ccsm only when remove_user_data=1', () => {
+    expect(sh).toMatch(/rm -rf "\$LOG_DIR"/);
+  });
+
+  it('step 5: dscl-deletes _ccsm user/group only when remove_user_data=1', () => {
+    expect(sh).toMatch(/dscl \. -delete "\/Users\/\$SVC_USER"/);
+    expect(sh).toMatch(/dscl \. -delete "\/Groups\/\$SVC_GROUP"/);
+  });
+
+  it('keep-data branch logs that state dir is preserved (no rm)', () => {
+    // The else-branch must log the keep so an operator running the
+    // uninstaller has a clear "we left your data" affordance.
+    expect(sh).toMatch(/keeping \$STATE_DIR/);
+  });
+
+  it('refuses to run as non-root (uid != 0 -> exit 1)', () => {
+    expect(sh).toMatch(/id -u.*-ne 0/);
+    expect(sh).toMatch(/exit 1/);
+  });
+
+  it('exits 2 if no plist AND no install dir (nothing to uninstall)', () => {
+    expect(sh).toMatch(/exit 2/);
+  });
+
+  it('is valid bash (parses with bash -n)', () => {
+    // The mac uninstall script is non-trivial; bash -n catches a stray
+    // unmatched [[ before it ships in a .pkg payload.
+    execFileSync('bash', ['-n', MAC_UNINSTALL], { stdio: ['ignore', 'pipe', 'pipe'] });
+  });
+});
+
+describe('uninstall matrix — macOS pkg payload wires the uninstaller', () => {
+  it('postinstall.sh copies uninstall.sh to /Library/Application Support/ccsm/ccsm-uninstall.command', () => {
+    // Spec ch10 §5.2 line: "a separate ccsm-uninstall.command script
+    // in /Library/Application Support/ccsm/". Renamed from .sh to
+    // .command so Finder double-click runs it in Terminal.app.
+    const post = read(MAC_POSTINSTALL);
+    expect(post).toMatch(/ccsm-uninstall\.command/);
+    expect(post).toMatch(/\/Library\/Application Support\/ccsm/);
+  });
+
+  it('postinstall.sh chmods uninstall.command 0755 (operator must execute it)', () => {
+    const post = read(MAC_POSTINSTALL);
+    expect(post).toMatch(/chmod 0755 "\$UNINSTALL_DST"/);
+  });
+
+  it('postinstall.sh chowns uninstall.command root:wheel (not _ccsm — must outlive state-dir removal)', () => {
+    const post = read(MAC_POSTINSTALL);
+    expect(post).toMatch(/chown root:wheel "\$UNINSTALL_DST"/);
+  });
+
+  it('build-pkg.sh stages uninstall.sh into /usr/local/ccsm/uninstall.sh', () => {
+    // The .pkg payload carries uninstall.sh under /usr/local/ccsm so
+    // postinstall can cp it into the state dir (mac/postinstall.sh).
+    const build = read(MAC_BUILD_PKG);
+    expect(build).toMatch(/cp "\$MAC_DIR\/uninstall\.sh"/);
+    expect(build).toMatch(/\$STAGE\/usr\/local\/ccsm\/uninstall\.sh/);
+  });
+});
+
+describe('uninstall matrix — Linux postrm honours CCSM_REMOVE_USER_DATA (ch10 §5.3)', () => {
+  // T7.4 already shipped these; T7.6 re-asserts the behaviour matrix
+  // against the SAME postrm (so a future drift to either side is caught).
+  const prerm  = read(LINUX_PRERM);
+  const postrm = read(LINUX_POSTRM);
+
+  // Step 1: stop service. prerm.sh runs BEFORE files are removed.
+  it('step 1: prerm stops ccsm-daemon when not in upgrade mode', () => {
+    expect(prerm).toMatch(/systemctl stop ccsm-daemon/);
+  });
+
+  // Step 2: unregister service.
+  it('step 2: prerm disables ccsm-daemon (unregister)', () => {
+    expect(prerm).toMatch(/systemctl disable ccsm-daemon/);
+  });
+
+  it('prerm short-circuits on upgrade (does NOT stop service)', () => {
+    // Critical: dpkg/rpm runs prerm on upgrade too; without the
+    // upgrade short-circuit we'd kill the daemon mid-upgrade.
+    expect(prerm).toMatch(/upgrade\|1\|2/);
+  });
+
+  // Step 4: state decision. Step 5: remove state dir if yes.
+  it('step 5 (remove-data branch): postrm rm -rf /var/lib/ccsm when CCSM_REMOVE_USER_DATA=1', () => {
+    expect(postrm).toMatch(/CCSM_REMOVE_USER_DATA/);
+    expect(postrm).toMatch(/rm -rf \/var\/lib\/ccsm/);
+  });
+
+  it('step 5 (remove-data branch): postrm also removes /run/ccsm runtime dir', () => {
+    // RuntimeDirectory=ccsm (ch07 §2) is created by systemd on start;
+    // a clean uninstall must clear it too in the remove-data branch.
+    expect(postrm).toMatch(/\/run\/ccsm/);
+  });
+
+  it('step 5 (remove-data branch): postrm userdel ccsm + groupdel ccsm', () => {
+    expect(postrm).toMatch(/userdel ccsm/);
+    expect(postrm).toMatch(/groupdel ccsm/);
+  });
+
+  it('keep-data branch: postrm logs that /var/lib/ccsm is preserved (no rm)', () => {
+    expect(postrm).toMatch(/keeping \/var\/lib\/ccsm/);
+  });
+
+  it('postrm only userdels in purge mode (.deb purge / .rpm uninstall=0)', () => {
+    // userdel on plain remove would orphan state files; spec is clear
+    // that user/group removal happens only on purge.
+    expect(postrm).toMatch(/purge\|0\)/);
+  });
+
+  it('postrm action defaults to "purge" if invoked without an arg (manual ops)', () => {
+    expect(postrm).toMatch(/ACTION="\$\{1:-purge\}"/);
+  });
+});
+
+describe('uninstall matrix — top-level scripts/installer/uninstall.sh wrapper', () => {
+  const sh = read(TOP_UNINSTALL_SH);
+
+  it('starts with bash shebang', () => {
+    expect(sh.startsWith('#!/usr/bin/env bash')).toBe(true);
+  });
+
+  it('exposes --silent and --interactive modes', () => {
+    expect(sh).toMatch(/--silent\|-y\)/);
+    expect(sh).toMatch(/--interactive\)/);
+  });
+
+  it('exposes --remove-user-data and --keep-user-data flags', () => {
+    expect(sh).toMatch(/--remove-user-data\)/);
+    expect(sh).toMatch(/--keep-user-data\)/);
+  });
+
+  it('exports CCSM_REMOVE_USER_DATA so per-OS scripts inherit the decision', () => {
+    // The wrapper captures the user choice ONCE then propagates to the
+    // mac/linux subscript via env so we never double-prompt.
+    expect(sh).toMatch(/export CCSM_REMOVE_USER_DATA/);
+  });
+
+  it('mac branch dispatches to /Library/Application Support/ccsm/ccsm-uninstall.command', () => {
+    expect(sh).toMatch(/\/Library\/Application Support\/ccsm\/ccsm-uninstall\.command/);
+  });
+
+  it('mac branch invokes downstream uninstaller in --silent mode (no double prompt)', () => {
+    // Once the wrapper has gathered the user choice, it must call the
+    // mac script in --silent mode so the mac script does NOT re-prompt.
+    expect(sh).toMatch(/bash "\$MAC_UNINSTALL" --silent/);
+  });
+
+  it('linux branch tries dpkg first then rpm (auto-detect package manager)', () => {
+    expect(sh).toMatch(/dpkg -P "\$LINUX_PKG_NAME"/);
+    expect(sh).toMatch(/rpm -e "\$LINUX_PKG_NAME"/);
+  });
+
+  it('linux branch uses dpkg -P (purge) NOT -r so postrm hits CCSM_REMOVE_USER_DATA branch', () => {
+    // Plain `dpkg -r` runs postrm with action="remove" which short-
+    // circuits before the CCSM_REMOVE_USER_DATA gate; -P (purge) is
+    // required for the spec ch10 §5 step 4 silent contract to fire.
+    expect(sh).toMatch(/dpkg -P/);
+    expect(sh).not.toMatch(/dpkg -r\b/);
+  });
+
+  it('detects MINGW/MSYS/CYGWIN and points to uninstall.ps1 (exit 4)', () => {
+    expect(sh).toMatch(/MINGW\*\|MSYS\*\|CYGWIN\*/);
+    expect(sh).toMatch(/uninstall\.ps1/);
+  });
+
+  it('refuses to run as non-root (uid != 0 -> exit 1)', () => {
+    expect(sh).toMatch(/id -u.*-ne 0/);
+  });
+
+  it('exits 2 if neither dpkg nor rpm reports the package installed', () => {
+    expect(sh).toMatch(/nothing to uninstall/);
+  });
+
+  it('is valid bash (parses with bash -n)', () => {
+    execFileSync('bash', ['-n', TOP_UNINSTALL_SH], { stdio: ['ignore', 'pipe', 'pipe'] });
+  });
+});
+
+describe('uninstall matrix — cross-OS state-dir untouched on REMOVEUSERDATA=0 (spec ch10 §5 step 4)', () => {
+  // Spec line: "Default: keep state on uninstall, delete only on
+  // explicit 'remove user data' tick". Each OS path must respect this.
+
+  it('Win MSI: keep-data branch component has NO RemoveFolderEx', () => {
+    // Re-asserted here (in addition to the WiX section above) under the
+    // "state dir untouched on REMOVEUSERDATA=0" theme so a maintainer
+    // searching for "state untouched" finds the test.
+    const wxs = read(WIN_WXS);
+    const stateDir = wxs.match(/<Component\s+Id="StateDir"[\s\S]*?<\/Component>/);
+    expect(stateDir).not.toBeNull();
+    expect(stateDir![0]).not.toMatch(/RemoveFolderEx/);
+  });
+
+  it('Mac uninstall: state-dir rm is GUARDED by remove_user_data=="1"', () => {
+    const sh = read(MAC_UNINSTALL);
+    // The exact guard phrasing is the load-bearing assertion; a future
+    // refactor that replaces "==" with "!=" or drops the if entirely
+    // breaks step 4 silently otherwise.
+    const idx = sh.indexOf('rm -rf "$STATE_DIR"');
+    expect(idx).toBeGreaterThan(-1);
+    const before = sh.slice(0, idx);
+    expect(before).toMatch(/if \[\[ "\$remove_user_data" == "1" \]\]/);
+  });
+
+  it('Linux postrm: rm /var/lib/ccsm is GUARDED by CCSM_REMOVE_USER_DATA == "1"', () => {
+    const postrm = read(LINUX_POSTRM);
+    const idx = postrm.indexOf('rm -rf /var/lib/ccsm');
+    expect(idx).toBeGreaterThan(-1);
+    const before = postrm.slice(0, idx);
+    expect(before).toMatch(/CCSM_REMOVE_USER_DATA:-0.*=.*"1"/);
+  });
+});
+
+describe('uninstall matrix — service unregister always happens (ch10 §5 steps 1-2 unconditional)', () => {
+  // Even when REMOVEUSERDATA=0 the service MUST be stopped + unregistered.
+  // Otherwise a "keep my data" uninstall would leave a dead service
+  // pointing at a deleted binary, breaking the next install. spec ch10 §5
+  // makes steps 1-2 mandatory, separate from the gated step 4-5.
+
+  it('Win MSI: ServiceControl Stop="both" + Remove="uninstall" have NO REMOVEUSERDATA condition', () => {
+    const wxs = read(WIN_WXS);
+    const sc = wxs.match(/<ServiceControl[\s\S]*?\/>/);
+    expect(sc).not.toBeNull();
+    // The ServiceControl element itself has no Condition; it lives on
+    // the DaemonSvc component which is also unconditional.
+    expect(sc![0]).not.toMatch(/REMOVEUSERDATA/);
+  });
+
+  it('Mac uninstall: bootout + plist rm happen BEFORE the remove_user_data branch', () => {
+    const sh = read(MAC_UNINSTALL);
+    const bootoutIdx = sh.indexOf('launchctl bootout');
+    const removeBranchIdx = sh.indexOf('if [[ "$remove_user_data" == "1" ]]');
+    expect(bootoutIdx).toBeGreaterThan(-1);
+    expect(removeBranchIdx).toBeGreaterThan(-1);
+    expect(bootoutIdx).toBeLessThan(removeBranchIdx);
+  });
+
+  it('Linux prerm: stop + disable ccsm-daemon happen unconditionally (no CCSM_REMOVE_USER_DATA gate)', () => {
+    const prerm = read(LINUX_PRERM);
+    expect(prerm).not.toMatch(/CCSM_REMOVE_USER_DATA/);
+  });
+
+  it('Top-level wrapper: per-OS dispatch happens regardless of remove_user_data value', () => {
+    const sh = read(TOP_UNINSTALL_SH);
+    // The case "$OS_NAME" branch must come AFTER the remove_user_data
+    // decision but must NOT be conditioned on it.
+    const decisionIdx = sh.indexOf('export CCSM_REMOVE_USER_DATA');
+    const dispatchIdx = sh.indexOf('case "$OS_NAME" in');
+    expect(decisionIdx).toBeGreaterThan(-1);
+    expect(dispatchIdx).toBeGreaterThan(decisionIdx);
+  });
+});

--- a/packages/daemon/build/install/mac/build-pkg.sh
+++ b/packages/daemon/build/install/mac/build-pkg.sh
@@ -98,6 +98,15 @@ if [[ "$DRY_RUN" != "1" ]]; then
   cp -R "$NATIVE_DIR" "$STAGE/usr/local/ccsm/native"
   chmod 0755 "$STAGE/usr/local/ccsm/ccsm-daemon"
 
+  # T7.6 (#84) — ship the uninstaller as part of the payload. postinstall
+  # then copies it to /Library/Application Support/ccsm/ccsm-uninstall.command
+  # (spec ch10 §5.2 line). Keeping the source under /usr/local/ccsm keeps it
+  # owned by root and out of the daemon's writable state dir during the
+  # window between preinstall (state dir created) and postinstall (uninstall
+  # cmd dropped in).
+  cp "$MAC_DIR/uninstall.sh" "$STAGE/usr/local/ccsm/uninstall.sh"
+  chmod 0755 "$STAGE/usr/local/ccsm/uninstall.sh"
+
   PLIST_SRC="$MAC_DIR/com.ccsm.daemon.plist"
   PLIST_DST="$STAGE/Library/LaunchDaemons/com.ccsm.daemon.plist"
   sed "s|@CCSM_DAEMON_PATH@|$DAEMON_INSTALL_PATH|g" "$PLIST_SRC" > "$PLIST_DST"

--- a/packages/daemon/build/install/mac/postinstall.sh
+++ b/packages/daemon/build/install/mac/postinstall.sh
@@ -25,10 +25,27 @@ warn() { echo "[ccsm-postinstall] WARN: $*" >&2; }
 
 PLIST="/Library/LaunchDaemons/com.ccsm.daemon.plist"
 LABEL="system/com.ccsm.daemon"
+STATE_DIR="/Library/Application Support/ccsm"
+UNINSTALL_SRC="/usr/local/ccsm/uninstall.sh"
+UNINSTALL_DST="$STATE_DIR/ccsm-uninstall.command"
 
 if [[ ! -f "$PLIST" ]]; then
   warn "plist missing: $PLIST — pkg payload broken?"
   exit 1
+fi
+
+# T7.6 (#84) — install the uninstaller script alongside ccsm.db so the
+# operator can locate it the same way they locate state. Spec ch10 §5.2
+# pins the path: "/Library/Application Support/ccsm/ccsm-uninstall.command".
+if [[ -f "$UNINSTALL_SRC" ]]; then
+  log "install uninstaller: $UNINSTALL_DST"
+  cp "$UNINSTALL_SRC" "$UNINSTALL_DST"
+  chmod 0755 "$UNINSTALL_DST"
+  # State dir is owned by _ccsm but uninstall must be invokable by an
+  # admin in Terminal.app, so leave the .command root-owned + world-rx.
+  chown root:wheel "$UNINSTALL_DST"
+else
+  warn "uninstaller source missing: $UNINSTALL_SRC — pkg payload broken? (T7.6)"
 fi
 
 # Force fresh registration: bootout (ignore failure if not loaded) then bootstrap.

--- a/packages/daemon/build/install/mac/uninstall.sh
+++ b/packages/daemon/build/install/mac/uninstall.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# packages/daemon/build/install/mac/uninstall.sh
+#
+# Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+#       chapter 10 §5 step list (Common to all uninstallers, steps 1-6)
+#       + chapter 10 §5.2 (macOS pkg) — "ccsm-uninstall.command" line.
+# Task: T7.6 (#84) — uninstaller: REMOVEUSERDATA matrix + service unregister.
+#
+# This is the source of truth for the macOS uninstaller. The .pkg installer
+# copies this file to:
+#   /Library/Application Support/ccsm/ccsm-uninstall.command
+# (renamed to .command so Finder treats double-click as "run in Terminal").
+# Spec ch10 §5.2 line: "a separate ccsm-uninstall.command script in
+# /Library/Application Support/ccsm/".
+#
+# Behaviour matrix (ch10 §5 common-to-all-uninstallers steps 1-6):
+#   1. Stop service:        launchctl bootout system/com.ccsm.daemon (≤10 s)
+#   2. Unregister service:  rm /Library/LaunchDaemons/com.ccsm.daemon.plist
+#   3. Remove binaries:     rm -rf /usr/local/ccsm
+#   4. State decision:      env CCSM_REMOVE_USER_DATA=1 → remove state dir;
+#                           default 0 → keep. Interactive mode prompts.
+#   5. If yes:              rm -rf /Library/Application Support/ccsm
+#                           + dscl . -delete /Users/_ccsm + /Groups/_ccsm
+#   6. Remove uninstaller   (this script removes itself last when state goes)
+#
+# Modes:
+#   --silent / -y          non-interactive; honours CCSM_REMOVE_USER_DATA env
+#                          (default 0 = keep user data); ship-gate (d) path.
+#   --interactive          (default) prompts the user once for "remove user
+#                          data?" with default "no". macOS double-click on
+#                          .command runs interactive in Terminal.app.
+#   --remove-user-data     force CCSM_REMOVE_USER_DATA=1 from CLI.
+#   --keep-user-data       force CCSM_REMOVE_USER_DATA=0 from CLI.
+#   --help                 usage.
+#
+# Exit codes:
+#   0   uninstall complete (whether or not user data was removed)
+#   1   not running as root
+#   2   plist missing AND binary missing — nothing to uninstall
+#   3   bootout / file removal failed
+#
+# Idempotent: re-runs after a failed uninstall complete the remaining
+# steps (best-effort warns on missing items).
+
+set -uo pipefail
+
+PLIST="/Library/LaunchDaemons/com.ccsm.daemon.plist"
+LABEL="system/com.ccsm.daemon"
+INSTALL_DIR="/usr/local/ccsm"
+STATE_DIR="/Library/Application Support/ccsm"
+LOG_DIR="/Library/Logs/ccsm"
+SVC_USER="_ccsm"
+SVC_GROUP="_ccsm"
+SELF_PATH="$STATE_DIR/ccsm-uninstall.command"
+
+MODE="interactive"
+USER_DATA_DECISION=""
+
+log()  { echo "[ccsm-uninstall] $*"; }
+warn() { echo "[ccsm-uninstall] WARN: $*" >&2; }
+err()  { echo "[ccsm-uninstall] ERROR: $*" >&2; }
+
+usage() {
+  cat <<EOF
+ccsm-uninstall.command — remove the CCSM daemon from this Mac.
+
+Usage:
+  sudo bash $0 [--silent | --interactive] [--remove-user-data | --keep-user-data]
+
+Options:
+  --silent, -y           Non-interactive. Honours CCSM_REMOVE_USER_DATA env
+                         (default 0 = keep user data).
+  --interactive          Prompt for "remove user data?" (default no).
+                         This is the default when no flag is given.
+  --remove-user-data     Force removal of state dir (overrides env / prompt).
+  --keep-user-data       Force keeping of state dir (overrides env / prompt).
+  --help, -h             This message.
+
+Environment:
+  CCSM_REMOVE_USER_DATA  Read in --silent mode. "1" = remove state dir;
+                         anything else (default) = keep.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --silent|-y)            MODE="silent" ;;
+    --interactive)          MODE="interactive" ;;
+    --remove-user-data)     USER_DATA_DECISION="1" ;;
+    --keep-user-data)       USER_DATA_DECISION="0" ;;
+    --help|-h)              usage; exit 0 ;;
+    *) err "unknown arg: $1"; usage; exit 2 ;;
+  esac
+  shift
+done
+
+# ---- root check ----
+if [[ "$(id -u)" -ne 0 ]]; then
+  err "must run as root (sudo bash ccsm-uninstall.command)"
+  exit 1
+fi
+
+# ---- guard: nothing to uninstall? ----
+if [[ ! -f "$PLIST" ]] && [[ ! -d "$INSTALL_DIR" ]]; then
+  warn "no plist at $PLIST and no $INSTALL_DIR — nothing to uninstall"
+  exit 2
+fi
+
+# ---- 1. stop service ----
+if [[ -f "$PLIST" ]]; then
+  log "launchctl bootout $LABEL (best-effort, 10s timeout)"
+  # bootout with 10s wait — spec ch10 §5 step 1 "wait up to 10 s for clean exit"
+  if ! launchctl bootout "$LABEL" 2>/dev/null; then
+    warn "bootout returned non-zero (service may already be stopped)"
+  fi
+  # Belt-and-braces: SIGTERM any straggler ccsm-daemon process. Mirrors the
+  # spec ch10 §8 escalation path (SIGTERM → SIGKILL after 5s) for the
+  # uninstall case, since we MUST not leave a daemon holding the descriptor
+  # after the plist is gone.
+  if pgrep -x ccsm-daemon >/dev/null 2>&1; then
+    warn "ccsm-daemon still running after bootout — SIGTERM"
+    pkill -TERM -x ccsm-daemon 2>/dev/null || true
+    # Wait up to 5s, then SIGKILL.
+    for _ in 1 2 3 4 5; do
+      sleep 1
+      pgrep -x ccsm-daemon >/dev/null 2>&1 || break
+    done
+    if pgrep -x ccsm-daemon >/dev/null 2>&1; then
+      warn "ccsm-daemon survived SIGTERM — SIGKILL"
+      pkill -KILL -x ccsm-daemon 2>/dev/null || true
+    fi
+  fi
+else
+  warn "no plist at $PLIST — skipping bootout"
+fi
+
+# ---- 2. unregister service (remove plist) ----
+if [[ -f "$PLIST" ]]; then
+  log "rm $PLIST"
+  rm -f "$PLIST" || { err "failed to remove $PLIST"; exit 3; }
+fi
+
+# ---- 3. remove binaries ----
+if [[ -d "$INSTALL_DIR" ]]; then
+  log "rm -rf $INSTALL_DIR"
+  rm -rf "$INSTALL_DIR" || { err "failed to remove $INSTALL_DIR"; exit 3; }
+fi
+
+# ---- 4. state decision ----
+remove_user_data="0"
+if [[ -n "$USER_DATA_DECISION" ]]; then
+  # CLI flag wins.
+  remove_user_data="$USER_DATA_DECISION"
+elif [[ "$MODE" == "silent" ]]; then
+  # spec ch10 §5 step 4: silent honours env var; default "0" = keep.
+  remove_user_data="${CCSM_REMOVE_USER_DATA:-0}"
+else
+  # Interactive prompt — default no (spec: "default no").
+  echo ""
+  echo "Remove all CCSM user data? This deletes:"
+  echo "    $STATE_DIR  (sessions, descriptors, ccsm.db)"
+  echo "    $LOG_DIR"
+  echo "    user/group: $SVC_USER / $SVC_GROUP"
+  echo ""
+  read -r -p "Remove user data? [y/N] " reply || reply=""
+  case "$reply" in
+    y|Y|yes|YES) remove_user_data="1" ;;
+    *)           remove_user_data="0" ;;
+  esac
+fi
+
+# ---- 5. remove user data (if opted in) ----
+if [[ "$remove_user_data" == "1" ]]; then
+  log "CCSM_REMOVE_USER_DATA=1 — removing state dir + service account"
+
+  if [[ -d "$STATE_DIR" ]]; then
+    log "rm -rf $STATE_DIR"
+    rm -rf "$STATE_DIR" || warn "failed to remove $STATE_DIR"
+  fi
+  if [[ -d "$LOG_DIR" ]]; then
+    log "rm -rf $LOG_DIR"
+    rm -rf "$LOG_DIR" || warn "failed to remove $LOG_DIR"
+  fi
+
+  if dscl . -read "/Users/$SVC_USER" >/dev/null 2>&1; then
+    log "dscl . -delete /Users/$SVC_USER"
+    dscl . -delete "/Users/$SVC_USER" 2>/dev/null || warn "dscl delete user failed"
+  fi
+  if dscl . -read "/Groups/$SVC_GROUP" >/dev/null 2>&1; then
+    log "dscl . -delete /Groups/$SVC_GROUP"
+    dscl . -delete "/Groups/$SVC_GROUP" 2>/dev/null || warn "dscl delete group failed"
+  fi
+else
+  log "keeping $STATE_DIR (re-run with --remove-user-data or CCSM_REMOVE_USER_DATA=1 to remove)"
+fi
+
+# ---- 6. self-removal ----
+# When state dir is removed we already deleted ourselves. Otherwise the
+# script lives next to ccsm.db and the operator can re-run if needed.
+log "OK — uninstall complete (REMOVEUSERDATA=$remove_user_data)"
+exit 0

--- a/scripts/installer/uninstall.ps1
+++ b/scripts/installer/uninstall.ps1
@@ -1,0 +1,179 @@
+# scripts/installer/uninstall.ps1
+#
+# Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+#       chapter 10 §5.1 (Windows MSI) + chapter 10 §5 step list (Common to
+#       all uninstallers, steps 1-6).
+# Task: T7.6 (#84) — uninstaller: REMOVEUSERDATA matrix + service unregister.
+#
+# Top-level Windows uninstaller wrapper. Drives msiexec /x against the
+# installed CCSM product. The MSI's WiX 4 <ServiceControl> element handles
+# steps 1-2 (stop + remove ccsm-daemon service); the REMOVEUSERDATA public
+# property (default 0; set to 1 here when -RemoveUserData is passed)
+# drives the StateDirRemovable component which runs <util:RemoveFolderEx>
+# against %PROGRAMDATA%\ccsm. See packages/daemon/build/install/win/Product.wxs.template.
+#
+# Both interactive + silent variants are exposed (spec ch10 §5 step 4):
+#
+#   -Silent              non-interactive (msiexec /qn). Honours
+#                        $env:CCSM_REMOVE_USER_DATA (default 0 = keep).
+#                        This is the ship-gate (d) path invoked by
+#                        tools/installer-roundtrip.ps1.
+#   (default)            interactive — msiexec /qb (basic UI, progress
+#                        bar) plus a PowerShell prompt for "remove user
+#                        data?" before launching msiexec.
+#   -RemoveUserData      force REMOVEUSERDATA=1 from the CLI (overrides
+#                        env / prompt).
+#   -KeepUserData        force REMOVEUSERDATA=0 from the CLI.
+#   -ProductCode <guid>  override product code lookup (for forks). Default:
+#                        looked up from the registry by ProductName='CCSM'.
+#
+# Behaviour matrix (spec ch10 §5):
+#   1. Stop service     → MSI <ServiceControl Stop="both">
+#   2. Unregister svc   → MSI <ServiceControl Remove="uninstall">
+#   3. Remove binaries  → MSI default file-table removal of %PROGRAMFILES%\ccsm
+#   4. State decision   → -RemoveUserData / env / prompt → REMOVEUSERDATA=0|1
+#   5. If yes           → MSI StateDirRemovable component runs RemoveFolderEx
+#                         against %PROGRAMDATA%\ccsm (ch10 §5.1)
+#   6. Remove unins.    → MSI default unregisters from Add/Remove Programs
+#
+# State dir is left untouched unless REMOVEUSERDATA=1 is set. Spec ch10 §5
+# step 4: "Default: keep state on uninstall, delete only on explicit
+# 'remove user data' tick".
+#
+# Exit codes:
+#   0    uninstall complete (msiexec returned 0 or 3010 reboot-required)
+#   1    not running elevated
+#   2    no installed product detected
+#   3    msiexec returned non-zero non-reboot code
+#   4    invalid args
+
+[CmdletBinding()]
+param(
+    [switch]$Silent,
+    [switch]$RemoveUserData,
+    [switch]$KeepUserData,
+    [string]$ProductCode = '',
+    [string]$LogPath = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-Log  { param([string]$M) Write-Host "[ccsm-uninstall] $M" }
+function Write-Warn { param([string]$M) Write-Warning "[ccsm-uninstall] $M" }
+function Write-Err  { param([string]$M) Write-Error "[ccsm-uninstall] $M" -ErrorAction Continue }
+
+# ---- arg sanity ----
+if ($RemoveUserData -and $KeepUserData) {
+    Write-Err "cannot pass both -RemoveUserData and -KeepUserData"
+    exit 4
+}
+
+# ---- elevation check ----
+$identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = New-Object Security.Principal.WindowsPrincipal($identity)
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Err "must run elevated (right-click PowerShell -> Run as Administrator)"
+    exit 1
+}
+
+# ---- locate installed product code ----
+# Two sources: HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\<guid>
+# and the WMI Win32_Product (slow + side-effects: skip). We grep the
+# Uninstall key for DisplayName='CCSM'.
+function Get-CcsmProductCode {
+    $paths = @(
+        'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+        'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+    )
+    foreach ($base in $paths) {
+        if (-not (Test-Path $base)) { continue }
+        $keys = Get-ChildItem $base -ErrorAction SilentlyContinue
+        foreach ($k in $keys) {
+            $name = $k.Name.Split('\')[-1]
+            # Only proper {GUID} keys are MSI products. Skip "_is1" etc.
+            if ($name -notmatch '^\{[0-9A-Fa-f-]+\}$') { continue }
+            $props = Get-ItemProperty $k.PSPath -ErrorAction SilentlyContinue
+            if ($props.DisplayName -eq 'CCSM') {
+                return $name
+            }
+        }
+    }
+    return $null
+}
+
+if ([string]::IsNullOrWhiteSpace($ProductCode)) {
+    $ProductCode = Get-CcsmProductCode
+    if (-not $ProductCode) {
+        Write-Warn "no installed CCSM product detected (DisplayName=CCSM not in Uninstall registry)"
+        exit 2
+    }
+}
+Write-Log "product code: $ProductCode"
+
+# ---- decide REMOVEUSERDATA value ----
+$removeUserData = '0'
+if ($RemoveUserData) {
+    $removeUserData = '1'
+} elseif ($KeepUserData) {
+    $removeUserData = '0'
+} elseif ($Silent) {
+    # spec ch10 §5 step 4: silent honours env var; default 0 = keep.
+    $envVal = $env:CCSM_REMOVE_USER_DATA
+    if ($envVal -eq '1') { $removeUserData = '1' } else { $removeUserData = '0' }
+} else {
+    # Interactive prompt — default no.
+    Write-Host ""
+    Write-Host "Remove all CCSM user data? This deletes:"
+    Write-Host "    %PROGRAMDATA%\ccsm  (sessions, descriptors, ccsm.db)"
+    Write-Host ""
+    Write-Host "(Default: no, keep user data so a reinstall preserves sessions.)"
+    $reply = Read-Host "Remove user data? [y/N]"
+    if ($reply -match '^(y|Y|yes|YES)$') { $removeUserData = '1' } else { $removeUserData = '0' }
+}
+
+# ---- build msiexec invocation ----
+# /x <productcode> uninstall
+# REMOVEUSERDATA=0|1 — the public secure property declared in
+#   build/install/win/Product.wxs.template <Property Id="REMOVEUSERDATA" Secure="yes">
+# /qn (silent, no UI) OR /qb (basic UI, progress bar) — spec ch10 §5
+#   step 4: "Windows MSI: msiexec /x ... /qn" for the silent path.
+# /norestart — never auto-reboot; we never put files in use that need it.
+# /l*v <log> — verbose log, default %TEMP%\ccsm-uninstall-<ts>.log so
+#   ship-gate (d) can attach it on failure.
+if ([string]::IsNullOrWhiteSpace($LogPath)) {
+    $ts = Get-Date -Format 'yyyyMMdd-HHmmss'
+    $LogPath = Join-Path $env:TEMP "ccsm-uninstall-$ts.log"
+}
+
+$uiFlag = if ($Silent) { '/qn' } else { '/qb' }
+
+$msiArgs = @(
+    '/x', $ProductCode,
+    "REMOVEUSERDATA=$removeUserData",
+    $uiFlag,
+    '/norestart',
+    '/l*v', $LogPath
+)
+
+Write-Log "msiexec $($msiArgs -join ' ')"
+Write-Log "REMOVEUSERDATA=$removeUserData (mode=$(if ($Silent) {'silent'} else {'interactive'}))"
+Write-Log "log: $LogPath"
+
+$proc = Start-Process -FilePath 'msiexec.exe' -ArgumentList $msiArgs -Wait -PassThru
+$rc = $proc.ExitCode
+
+# msiexec exit codes:
+#   0     success
+#   3010  success, reboot required
+#   1605  product not installed (treat as "nothing to do" — exit 2)
+#   1602  user cancel
+switch ($rc) {
+    0    { Write-Log "OK — uninstall complete (REMOVEUSERDATA=$removeUserData)"; exit 0 }
+    3010 { Write-Log "OK — uninstall complete; reboot required"; exit 0 }
+    1605 { Write-Warn "msiexec reports product not installed (1605)"; exit 2 }
+    1602 { Write-Warn "user cancelled (1602)"; exit 3 }
+    default {
+        Write-Err "msiexec returned $rc — see log: $LogPath"
+        exit 3
+    }
+}

--- a/scripts/installer/uninstall.sh
+++ b/scripts/installer/uninstall.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# scripts/installer/uninstall.sh
+#
+# Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+#       chapter 10 §5 step list (Common to all uninstallers, steps 1-6).
+# Task: T7.6 (#84) — uninstaller: REMOVEUSERDATA matrix + service unregister.
+#
+# Top-level entry point that dispatches to the per-OS uninstall path:
+#
+#   macOS  → invokes the on-disk /Library/Application Support/ccsm/ccsm-uninstall.command
+#            (placed by mac/postinstall.sh from build/install/mac/uninstall.sh).
+#   linux  → invokes dpkg -P ccsm  /  rpm -e ccsm  driven by package
+#            manager auto-detection. The .deb/.rpm prerm + postrm hooks
+#            (see build/install/linux/) handle stop / disable / userdel /
+#            CCSM_REMOVE_USER_DATA gating.
+#
+# Both interactive + silent variants are exposed (spec ch10 §5 step 4):
+#
+#   --interactive    (default) prompt user for "remove user data?".
+#   --silent / -y    non-interactive; reads CCSM_REMOVE_USER_DATA env
+#                    (default 0 = keep). This is the ship-gate (d) path
+#                    invoked by tools/installer-roundtrip.sh.
+#   --remove-user-data  force CCSM_REMOVE_USER_DATA=1 from CLI.
+#   --keep-user-data    force CCSM_REMOVE_USER_DATA=0 from CLI.
+#   --help              usage.
+#
+# State dir is left untouched unless CCSM_REMOVE_USER_DATA=1 OR the user
+# answers yes at the interactive prompt OR --remove-user-data is passed.
+# Spec ch10 §5 step 4 line: "Default: keep state on uninstall".
+#
+# Exit codes:
+#   0   uninstall complete
+#   1   not running as root (mac/linux uninstall always needs root)
+#   2   no installation detected (nothing to uninstall)
+#   3   per-OS dispatch returned non-zero
+#   4   unknown OS
+#
+# This script does NOT itself drive the Windows uninstall — Windows uses
+# scripts/installer/uninstall.ps1 (msiexec /x wrapper). Calling this on
+# Windows (Git Bash etc.) detects the environment and exits 4 with a
+# pointer to the .ps1 script.
+
+set -uo pipefail
+
+MAC_UNINSTALL="/Library/Application Support/ccsm/ccsm-uninstall.command"
+LINUX_PKG_NAME="${CCSM_PKG_NAME:-ccsm}"
+
+MODE="interactive"
+USER_DATA_DECISION=""
+
+log()  { echo "[ccsm-uninstall] $*"; }
+warn() { echo "[ccsm-uninstall] WARN: $*" >&2; }
+err()  { echo "[ccsm-uninstall] ERROR: $*" >&2; }
+
+usage() {
+  cat <<EOF
+ccsm uninstall — remove the CCSM daemon from this machine.
+
+Usage:
+  sudo bash scripts/installer/uninstall.sh [--silent | --interactive] [--remove-user-data | --keep-user-data]
+
+Options:
+  --silent, -y           Non-interactive. Honours CCSM_REMOVE_USER_DATA env
+                         (default 0 = keep user data). Used by ship-gate (d).
+  --interactive          Prompt for "remove user data?" (default no).
+                         This is the default mode when no flag is given.
+  --remove-user-data     Force removal of state dir (overrides env / prompt).
+  --keep-user-data       Force keeping of state dir (overrides env / prompt).
+  --help, -h             This message.
+
+Environment:
+  CCSM_REMOVE_USER_DATA  Read in --silent mode. "1" = remove state dir;
+                         anything else (default) = keep.
+  CCSM_PKG_NAME          Linux package name. Default: ccsm.
+
+OS dispatch:
+  macOS  → /Library/Application Support/ccsm/ccsm-uninstall.command
+  linux  → dpkg -P ${LINUX_PKG_NAME}  OR  rpm -e ${LINUX_PKG_NAME}
+  win    → use scripts/installer/uninstall.ps1 (this script exits 4)
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --silent|-y)            MODE="silent" ;;
+    --interactive)          MODE="interactive" ;;
+    --remove-user-data)     USER_DATA_DECISION="1" ;;
+    --keep-user-data)       USER_DATA_DECISION="0" ;;
+    --help|-h)              usage; exit 0 ;;
+    *) err "unknown arg: $1"; usage; exit 2 ;;
+  esac
+  shift
+done
+
+# ---- decide CCSM_REMOVE_USER_DATA early so per-OS branches can read it. ----
+remove_user_data="0"
+if [[ -n "$USER_DATA_DECISION" ]]; then
+  remove_user_data="$USER_DATA_DECISION"
+elif [[ "$MODE" == "silent" ]]; then
+  remove_user_data="${CCSM_REMOVE_USER_DATA:-0}"
+else
+  # Interactive: prompt once, propagate to per-OS scripts via env.
+  echo ""
+  echo "Remove all CCSM user data? This deletes the state directory."
+  echo "(Default: no, keep user data so a reinstall preserves sessions.)"
+  read -r -p "Remove user data? [y/N] " reply || reply=""
+  case "$reply" in
+    y|Y|yes|YES) remove_user_data="1" ;;
+    *)           remove_user_data="0" ;;
+  esac
+fi
+export CCSM_REMOVE_USER_DATA="$remove_user_data"
+
+# ---- per-OS dispatch ----
+OS_NAME="$(uname -s 2>/dev/null || echo unknown)"
+
+case "$OS_NAME" in
+  Darwin)
+    if [[ "$(id -u)" -ne 0 ]]; then
+      err "must run as root (sudo bash scripts/installer/uninstall.sh)"
+      exit 1
+    fi
+    if [[ ! -x "$MAC_UNINSTALL" ]]; then
+      warn "no installed uninstaller at $MAC_UNINSTALL — nothing to uninstall"
+      exit 2
+    fi
+    log "dispatch → $MAC_UNINSTALL --silent (mode=$MODE, REMOVEUSERDATA=$remove_user_data)"
+    # Always invoke the on-disk uninstaller in --silent mode: we already
+    # captured the user's choice above and propagated via env, so the
+    # downstream script must NOT prompt again.
+    if [[ "$remove_user_data" == "1" ]]; then
+      bash "$MAC_UNINSTALL" --silent --remove-user-data
+    else
+      bash "$MAC_UNINSTALL" --silent --keep-user-data
+    fi
+    rc=$?
+    [[ $rc -eq 0 ]] || { err "mac uninstall returned $rc"; exit 3; }
+    ;;
+
+  Linux)
+    if [[ "$(id -u)" -ne 0 ]]; then
+      err "must run as root (sudo bash scripts/installer/uninstall.sh)"
+      exit 1
+    fi
+    # Detect package manager. dpkg first (debian/ubuntu); rpm second
+    # (fedora/rhel/suse). Both honour the postrm scripts under
+    # build/install/linux/, which read CCSM_REMOVE_USER_DATA.
+    if command -v dpkg >/dev/null 2>&1 && dpkg -s "$LINUX_PKG_NAME" >/dev/null 2>&1; then
+      log "dispatch → dpkg -P $LINUX_PKG_NAME (REMOVEUSERDATA=$remove_user_data)"
+      # -P (purge) triggers postrm with action=purge so the
+      # CCSM_REMOVE_USER_DATA branch in postrm.sh fires. Plain -r (remove)
+      # would skip the purge branch entirely (postrm action=remove).
+      CCSM_REMOVE_USER_DATA="$remove_user_data" dpkg -P "$LINUX_PKG_NAME"
+      rc=$?
+    elif command -v rpm >/dev/null 2>&1 && rpm -q "$LINUX_PKG_NAME" >/dev/null 2>&1; then
+      log "dispatch → rpm -e $LINUX_PKG_NAME (REMOVEUSERDATA=$remove_user_data)"
+      CCSM_REMOVE_USER_DATA="$remove_user_data" rpm -e "$LINUX_PKG_NAME"
+      rc=$?
+    else
+      warn "neither dpkg nor rpm reports $LINUX_PKG_NAME installed — nothing to uninstall"
+      exit 2
+    fi
+    [[ $rc -eq 0 ]] || { err "linux uninstall returned $rc"; exit 3; }
+    ;;
+
+  MINGW*|MSYS*|CYGWIN*)
+    err "Windows host detected ($OS_NAME)."
+    err "use: powershell -ExecutionPolicy Bypass -File scripts\\installer\\uninstall.ps1"
+    exit 4
+    ;;
+
+  *)
+    err "unsupported OS: $OS_NAME"
+    exit 4
+    ;;
+esac
+
+log "OK — uninstall complete (REMOVEUSERDATA=$remove_user_data)"
+exit 0


### PR DESCRIPTION
## Summary
- Spec ch10 §5 (Common to all uninstallers, steps 1-6) — exposes the locked uninstall matrix `{ OS } × { interactive, silent } × { REMOVEUSERDATA=0, REMOVEUSERDATA=1 }` on Win/mac/linux.
- Service unregister is unconditional; state-dir removal is opt-in via `REMOVEUSERDATA=1` / `CCSM_REMOVE_USER_DATA=1` / `--remove-user-data` / interactive prompt. Default is keep (spec line: *"Default: keep state on uninstall, delete only on explicit 'remove user data' tick"*).
- Reuses T7.4 (PR #999, 439306a) WiX `ServiceControl Stop=both Remove=uninstall` + dual `StateDir`/`StateDirRemovable` components + linux postrm `CCSM_REMOVE_USER_DATA` gate. Adds the missing pieces: mac `ccsm-uninstall.command` (spec ch10 §5.2), top-level `scripts/installer/uninstall.{sh,ps1}` wrappers, and the 77-gate behaviour-matrix spec.

## What ships
- `packages/daemon/build/install/mac/uninstall.sh` — source for `/Library/Application Support/ccsm/ccsm-uninstall.command`. Step list: `launchctl bootout system/com.ccsm.daemon` → SIGTERM(5s)→SIGKILL escalation (spec §8 pattern) → `rm /Library/LaunchDaemons/com.ccsm.daemon.plist` → `rm -rf /usr/local/ccsm` → `CCSM_REMOVE_USER_DATA`-gated `rm -rf /Library/Application Support/ccsm` + `rm -rf /Library/Logs/ccsm` + `dscl . -delete /Users/_ccsm` + `/Groups/_ccsm`. Modes: `--silent` (env-driven, ship-gate (d)), `--interactive` (default; macOS Finder double-clicks .command in Terminal), `--remove-user-data` / `--keep-user-data` CLI overrides.
- `mac/postinstall.sh` + `mac/build-pkg.sh` — wire uninstall into .pkg payload (cp into `/usr/local/ccsm/uninstall.sh` at staging; postinstall cps to `/Library/Application Support/ccsm/ccsm-uninstall.command` `chown root:wheel chmod 0755` so it survives state-dir removal).
- `scripts/installer/uninstall.sh` — top-level cross-OS dispatcher. Prompts ONCE, exports `CCSM_REMOVE_USER_DATA`, dispatches: mac → on-disk uninstall.command in `--silent` mode (no double prompt); linux → `dpkg -P` (purge — required for postrm `CCSM_REMOVE_USER_DATA` branch to fire; plain `-r` would skip it) or `rpm -e` auto-detected; win → exits 4 pointing to `.ps1`.
- `scripts/installer/uninstall.ps1` — Windows wrapper. Looks up product code by `DisplayName='CCSM'` in HKLM `Uninstall` (avoids slow Win32_Product), runs `msiexec /x {GUID} REMOVEUSERDATA=$value /qn` (silent) or `/qb` (interactive), `/norestart`, `/l*v $LogPath`. Treats exit `3010` as success (reboot required), `1605` as exit-2 (not installed), `1602` as user cancel.
- `packages/daemon/build/__tests__/uninstall-matrix.spec.ts` — **77 forever-stable shape gates** (well above the 44 floor). Locks: WiX `<ServiceControl>` step 1+2 + REMOVEUSERDATA Public+Secure+default-0 contract; both state-dir components with correct guard direction (the keep-data branch component has NO `RemoveFolderEx`; the removable one has it AND is gated to `REMOVEUSERDATA="1"`); ps1 -Silent / -RemoveUserData / -KeepUserData / elevation / 3010-reboot handling; mac uninstall.sh step ordering (service-stop BEFORE state-dir branch — critical: a `REMOVEUSERDATA=0` uninstall must still unregister the service); postinstall + build-pkg payload wiring; linux prerm/postrm reassertions; top-level wrapper double-prompt avoidance; cross-OS state-dir-untouched-when-flag-0 invariant.

## Out of scope (per spec assignment)
- `tools/installer-roundtrip.{sh,ps1}` ship-gate (d) wiring against these scripts — drafts already exist (`tools/installer-roundtrip.sh|.ps1`).
- T7.5 `/healthz` 10s wait + rollback (different concern, owned by #83).

## Local checks (host: windows-11)
- lint: ✓ (exit 0; pre-existing 52 warnings unchanged)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0; turbo cache mostly hit)
- unit tests (T7.6 + T7.4 specs): ✓ `121 passed (121)` — 77 new + 44 existing
  ```
  Test Files  2 passed (2)
       Tests  121 passed (121)
    Duration  7.53s
  ```
- unit tests (full daemon suite): ✗ 107 failed pre-existing (all in `src/rpc/__tests__/integration.spec.ts` h2c-loopback hook timeouts + sessions/pty-host) — verified unrelated by `git stash` baseline reproducing identical failures with my changes removed. T7.6 PR adds 0 lines of `.ts/.tsx` runtime code (only a new spec file under `build/__tests__/` which itself is 77/77 green).
- e2e (`npm run probe:e2e`): harness-dnd ✓; harness-ui 13/14 (`rename` fails, pre-existing); harness-real-cli timeout (`session-rename-writes-jsonl` etc., pre-existing). All failures in session-rename/preload-wiring domain, no installer/uninstaller surface touched.

## Reverse verify (sanity)
T7.6 is not a bug fix; the matrix specs are forever-stable shape gates that fail-closed if a future PR drifts any single matrix cell. Demonstration: temporarily flipping the keep-data branch's guard from `NOT REMOVEUSERDATA` to `REMOVEUSERDATA="1"` makes the *"keep-data branch component is conditioned on REMOVEUSERDATA NOT being '1'"* gate fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>