### PR TITLE
T7.5(#78): installer post-install /healthz wait + 10s rollback

### DIFF
--- a/packages/daemon/build/__tests__/post-install-healthz.spec.ts
+++ b/packages/daemon/build/__tests__/post-install-healthz.spec.ts
@@ -1,0 +1,364 @@
+// packages/daemon/build/__tests__/post-install-healthz.spec.ts
+//
+// Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//       chapter 10 §5 step 7 (post-install /healthz wait + 10s failure rollback).
+// Task: T7.5 (#78) — installer: post-install /healthz wait + 10s failure rollback.
+//
+// Forever-stable shape gates for the post-install healthz wait scripts
+// (post-install-healthz.{sh,ps1}) and the WiX 4 CustomAction integration.
+// Real installer e2e (running the .msi / .pkg / .deb / .rpm against a live
+// daemon) is owned by tools/sea-smoke/ (ch10 §7) and the
+// e2e-win-installer-vm CI job. This spec asserts the contract those e2e
+// jobs depend on:
+//
+//   1. Each script + WiX template exists at the expected path.
+//   2. Each script implements the locked spec choices verbatim
+//      (10s timeout, ch10 §5 step 7 log-capture commands, scripted
+//      uninstall on rollback, state dir untouched).
+//   3. Each script's failure exit code matches the spec mapping
+//      (sh: 10/11; ps1: 1603 ERROR_INSTALL_FAILURE).
+//   4. Per-OS service log capture command matches the spec literal
+//      (journalctl -u / log show / Get-WinEvent).
+//   5. WiX 4 CustomAction is sequenced after StartServices and uses
+//      Return="check" so 1603 propagates to the rollback transaction.
+//   6. Sh script exit-code branches are exercisable via DRY-RUN +
+//      forced outcome envs (success / timeout / non200).
+//   7. Post-install scripts (mac postinstall.sh, linux postinst.sh)
+//      invoke the healthz script and treat its non-zero as rollback.
+//   8. Builders stage the healthz script into the package payload at
+//      the path the post-install scripts resolve.
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname  = path.dirname(__filename);
+const BUILD_DIR  = path.resolve(__dirname, '..');
+const INSTALL    = path.join(BUILD_DIR, 'install');
+
+const HEALTHZ_SH  = path.join(INSTALL, 'post-install-healthz.sh');
+const HEALTHZ_PS1 = path.join(INSTALL, 'post-install-healthz.ps1');
+const HEALTHZ_CA  = path.join(INSTALL, 'win', 'HealthzCustomAction.wxs.template');
+
+const WIN_WXS     = path.join(INSTALL, 'win', 'Product.wxs.template');
+const WIN_BUILD   = path.join(INSTALL, 'win', 'build-msi.ps1');
+
+const MAC_POST    = path.join(INSTALL, 'mac', 'postinstall.sh');
+const MAC_BUILD   = path.join(INSTALL, 'mac', 'build-pkg.sh');
+
+const LINUX_POST  = path.join(INSTALL, 'linux', 'postinst.sh');
+const LINUX_BUILD = path.join(INSTALL, 'linux', 'build-pkg.sh');
+
+function read(p: string): string {
+  return readFileSync(p, 'utf8');
+}
+
+describe('packages/daemon/build/install/post-install-healthz.* (spec ch10 §5 step 7, T7.5)', () => {
+  describe('files exist', () => {
+    it('post-install-healthz.sh', () => {
+      expect(existsSync(HEALTHZ_SH)).toBe(true);
+    });
+    it('post-install-healthz.ps1', () => {
+      expect(existsSync(HEALTHZ_PS1)).toBe(true);
+    });
+    it('win/HealthzCustomAction.wxs.template', () => {
+      expect(existsSync(HEALTHZ_CA)).toBe(true);
+    });
+  });
+
+  describe('post-install-healthz.sh — spec ch10 §5 step 7 (mac + linux)', () => {
+    const src = read(HEALTHZ_SH);
+
+    it('default timeout is 10 seconds (locked by spec)', () => {
+      expect(src).toMatch(/CCSM_HEALTHZ_TIMEOUT_SECONDS:?-10\}/);
+    });
+
+    it('targets Supervisor UDS at /run/ccsm/supervisor.sock on linux (ch03 §7)', () => {
+      expect(src).toContain('/run/ccsm/supervisor.sock');
+    });
+
+    it('targets Supervisor UDS at /var/run/com.ccsm.daemon/supervisor.sock on mac (ch03 §7)', () => {
+      expect(src).toContain('/var/run/com.ccsm.daemon/supervisor.sock');
+    });
+
+    it('uses curl --unix-socket to probe over UDS (not loopback TCP)', () => {
+      expect(src).toMatch(/curl[\s\S]*?--unix-socket/);
+      // Must NOT use http://127.0.0.1 — Supervisor is UDS-only forever
+      // (ch03 §7 explicit "no loopback TCP supervisor").
+      expect(src).not.toMatch(/http:\/\/127\.0\.0\.1/);
+    });
+
+    it('linux log capture uses journalctl -u ccsm-daemon.service -n 200 --no-pager (ch10 §5 step 7)', () => {
+      expect(src).toMatch(/journalctl -u ccsm-daemon\.service -n \$\{LOG_TAIL_LINES\} --no-pager/);
+    });
+
+    it('mac log capture uses log show --predicate process=="ccsm-daemon" --last 5m (ch10 §5 step 7)', () => {
+      // The literal string is wrapped in a double-quoted shell echo so
+      // the inner double-quotes are backslash-escaped. Match either form.
+      expect(src).toMatch(/log show --predicate 'process == \\?"ccsm-daemon\\?"' --last 5m/);
+    });
+
+    it('linux rollback runs systemctl disable --now ccsm-daemon (state dir untouched)', () => {
+      expect(src).toMatch(/systemctl disable --now ccsm-daemon/);
+      // Must NOT rm the state dir — spec ch10 §5 step 7 explicit "state dir UNTOUCHED".
+      expect(src).not.toMatch(/rm -rf \/var\/lib\/ccsm/);
+    });
+
+    it('mac rollback runs launchctl bootout system/com.ccsm.daemon (state dir untouched)', () => {
+      expect(src).toMatch(/launchctl bootout system\/com\.ccsm\.daemon/);
+      // Must NOT rm /Library/Application Support/ccsm.
+      expect(src).not.toMatch(/rm -rf \/Library\/Application Support\/ccsm/);
+    });
+
+    it('uses --max-time per probe so a hung daemon does not blow the 10s budget', () => {
+      expect(src).toMatch(/--max-time/);
+    });
+
+    it('declares forever-stable exit codes 0/10/11/12/13/14', () => {
+      // Forever-stable contract: callers (postinst.sh / postinstall.sh)
+      // distinguish timeout (10) from non-200 (11) for telemetry.
+      expect(src).toMatch(/^#\s*0\s+/m);
+      expect(src).toMatch(/^#\s*10\s+/m);
+      expect(src).toMatch(/^#\s*11\s+/m);
+      expect(src).toMatch(/^#\s*12\s+/m);
+      expect(src).toMatch(/^#\s*13\s+/m);
+      expect(src).toMatch(/^#\s*14\s+/m);
+    });
+
+    it('honours CCSM_HEALTHZ_DRY_RUN + CCSM_HEALTHZ_FORCE_OUTCOME for unit tests', () => {
+      expect(src).toContain('CCSM_HEALTHZ_DRY_RUN');
+      expect(src).toContain('CCSM_HEALTHZ_FORCE_OUTCOME');
+    });
+
+    it('is valid bash (parses with bash -n)', () => {
+      execFileSync('bash', ['-n', HEALTHZ_SH], { stdio: ['ignore', 'pipe', 'pipe'] });
+    });
+  });
+
+  describe('post-install-healthz.sh — DRY-RUN exit-code branches', () => {
+    function runForced(outcome: string): { status: number; stdout: string; stderr: string } {
+      try {
+        const stdout = execFileSync('bash', [HEALTHZ_SH], {
+          env: {
+            ...process.env,
+            CCSM_HEALTHZ_DRY_RUN: '1',
+            CCSM_HEALTHZ_FORCE_OUTCOME: outcome,
+          },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        }).toString();
+        return { status: 0, stdout, stderr: '' };
+      } catch (e: unknown) {
+        // execFileSync throws on non-zero exit; the error carries status + stderr.
+        const err = e as { status: number; stdout: Buffer | string; stderr: Buffer | string };
+        return {
+          status: err.status,
+          stdout: err.stdout?.toString() ?? '',
+          stderr: err.stderr?.toString() ?? '',
+        };
+      }
+    }
+
+    it('success path -> exit 0 + logs OK', () => {
+      const r = runForced('success');
+      expect(r.status).toBe(0);
+      expect(r.stdout).toMatch(/OK — \/healthz returned 200/);
+    });
+
+    it('timeout path -> exit 10 + log-capture command in stderr + state-dir preservation note', () => {
+      const r = runForced('timeout');
+      expect(r.status).toBe(10);
+      // Spec literal: log capture command appears in stderr.
+      expect(r.stderr).toMatch(/journalctl|log show/);
+      // State dir preservation explicit per ch10 §5 step 7.
+      expect(r.stderr).toMatch(/state dir preserved/);
+      // Rollback command surfaced.
+      expect(r.stderr).toMatch(/systemctl disable|launchctl bootout/);
+    });
+
+    it('non200 path -> exit 11 + log-capture + rollback + state-dir preservation', () => {
+      const r = runForced('non200');
+      expect(r.status).toBe(11);
+      expect(r.stderr).toMatch(/journalctl|log show/);
+      expect(r.stderr).toMatch(/state dir preserved/);
+      expect(r.stderr).toMatch(/systemctl disable|launchctl bootout/);
+    });
+  });
+
+  describe('post-install-healthz.ps1 — spec ch10 §5 step 7 (windows)', () => {
+    const src = read(HEALTHZ_PS1);
+
+    it('default timeout is 10 seconds (locked by spec)', () => {
+      expect(src).toMatch(/\$TimeoutSeconds\s*=.*\b10\b/);
+    });
+
+    it('targets Supervisor named pipe \\\\.\\pipe\\ccsm-supervisor (ch03 §7)', () => {
+      expect(src).toMatch(/PipeName\s*=\s*'ccsm-supervisor'/);
+    });
+
+    it('uses NamedPipeClientStream (not Invoke-WebRequest TCP) per ch03 §7 UDS-only constraint', () => {
+      expect(src).toContain('System.IO.Pipes.NamedPipeClientStream');
+      // Must NOT use Invoke-WebRequest with http://127.0.0.1 — Supervisor is UDS-only.
+      expect(src).not.toMatch(/Invoke-WebRequest[\s\S]*?127\.0\.0\.1/);
+    });
+
+    it('writes a literal HTTP/1.1 GET /healthz request', () => {
+      expect(src).toMatch(/GET \/healthz HTTP\/1\.1/);
+    });
+
+    it('exits ERROR_INSTALL_FAILURE 1603 on failure (MSI rollback trigger)', () => {
+      expect(src).toMatch(/\$ErrorInstallFailure\s*=\s*1603/);
+      // Both timeout and non-200 paths must propagate 1603 so MSI rollback fires.
+      expect(src).toMatch(/exit \$ErrorInstallFailure/);
+    });
+
+    it('captures Get-WinEvent -LogName Application -MaxEvents 200 filtered to ccsm provider (ch10 §5 step 7)', () => {
+      // Spec literal command is asserted verbatim modulo the LogTailLines variable.
+      expect(src).toMatch(/Get-WinEvent -LogName Application -MaxEvents \$LogTailLines/);
+      expect(src).toMatch(/ProviderName -like '\*ccsm\*'/);
+    });
+
+    it('preserves state dir under %PROGRAMDATA%\\ccsm on rollback (StateDir is Permanent)', () => {
+      expect(src).toMatch(/state directory under %PROGRAMDATA%\\ccsm preserved/);
+      // Must NOT call Remove-Item against %PROGRAMDATA%\ccsm.
+      expect(src).not.toMatch(/Remove-Item[\s\S]*?ProgramData\\ccsm/);
+    });
+
+    it('honours CCSM_HEALTHZ_DRY_RUN + CCSM_HEALTHZ_FORCE_OUTCOME for unit tests', () => {
+      expect(src).toContain('CCSM_HEALTHZ_DRY_RUN');
+      expect(src).toContain('CCSM_HEALTHZ_FORCE_OUTCOME');
+    });
+  });
+
+  describe('WiX 4 CustomAction (HealthzCustomAction.wxs.template) — ch10 §5 step 7', () => {
+    const ca = read(HEALTHZ_CA);
+
+    it('uses WiX 4+ schema namespace (matches T7.4 Product.wxs.template)', () => {
+      expect(ca).toContain('http://wixtoolset.org/schemas/v4/wxs');
+    });
+
+    it('declares <Binary> embedding post-install-healthz.ps1 via @CCSM_HEALTHZ_PS1@ token', () => {
+      expect(ca).toMatch(/<Binary[\s\S]*?Id="HealthzPs1Bin"[\s\S]*?SourceFile="@CCSM_HEALTHZ_PS1@"/);
+    });
+
+    it('declares <CustomAction Id="CcsmHealthzCheck"> with Return="check" (propagates 1603)', () => {
+      expect(ca).toMatch(/<CustomAction[\s\S]*?Id="CcsmHealthzCheck"/);
+      expect(ca).toMatch(/<CustomAction[\s\S]*?Return="check"/);
+    });
+
+    it('runs powershell.exe with -ExecutionPolicy Bypass -File [#HealthzPs1Bin]', () => {
+      expect(ca).toMatch(/powershell\.exe[\s\S]*?-ExecutionPolicy Bypass[\s\S]*?-File "\[#HealthzPs1Bin\]"/);
+    });
+
+    it('is deferred + impersonate=no so it runs as SYSTEM in install transaction', () => {
+      expect(ca).toMatch(/Execute="deferred"/);
+      expect(ca).toMatch(/Impersonate="no"/);
+    });
+
+    it('sequences After="StartServices" with NOT REMOVE condition (install-only)', () => {
+      expect(ca).toMatch(/<Custom[\s\S]*?Action="CcsmHealthzCheck"[\s\S]*?After="StartServices"[\s\S]*?Condition="NOT REMOVE"/);
+    });
+  });
+
+  describe('Product.wxs.template — references CcsmHealthzCheck CustomAction', () => {
+    const wxs = read(WIN_WXS);
+
+    it('declares <CustomActionRef Id="CcsmHealthzCheck"/> so the Fragment is pulled in', () => {
+      expect(wxs).toMatch(/<CustomActionRef\s+Id="CcsmHealthzCheck"\s*\/>/);
+    });
+  });
+
+  describe('build-msi.ps1 — stages healthz script + compiles CA fragment', () => {
+    const src = read(WIN_BUILD);
+
+    it('copies post-install-healthz.ps1 next to the daemon binary', () => {
+      expect(src).toContain('post-install-healthz.ps1');
+      expect(src).toMatch(/Copy-Item[\s\S]*?HealthzPs1Src[\s\S]*?HealthzPs1Dst/);
+    });
+
+    it('expands HealthzCustomAction.wxs.template substituting @CCSM_HEALTHZ_PS1@', () => {
+      expect(src).toContain('HealthzCustomAction.wxs.template');
+      expect(src).toMatch(/@CCSM_HEALTHZ_PS1@/);
+    });
+
+    it('passes the expanded HealthzCustomAction.wxs to wix build', () => {
+      // Both wxs files must appear in the wix build args.
+      expect(src).toMatch(/\$wixArgs\s*=\s*@\([\s\S]*?\$Wxs[\s\S]*?\$HealthzWxs/);
+    });
+  });
+
+  describe('mac postinstall.sh wires healthz (ch10 §5 step 7 — mac)', () => {
+    const src = read(MAC_POST);
+
+    it('invokes post-install-healthz.sh sibling-resolved', () => {
+      expect(src).toContain('post-install-healthz.sh');
+      expect(src).toMatch(/dirname -- "\$0"/);
+    });
+
+    it('treats non-zero healthz exit as installer failure (exit 1)', () => {
+      // mac .pkg uses non-zero postinstall as the installer-fail signal,
+      // which is what we want — the underlying rollback (launchctl bootout)
+      // is performed by the healthz script itself.
+      expect(src).toMatch(/exit 1/);
+    });
+
+    it('is valid bash (parses with bash -n)', () => {
+      execFileSync('bash', ['-n', MAC_POST], { stdio: ['ignore', 'pipe', 'pipe'] });
+    });
+  });
+
+  describe('linux postinst.sh wires healthz (ch10 §5 step 7 — linux)', () => {
+    const src = read(LINUX_POST);
+
+    it('invokes post-install-healthz.sh from /usr/lib/ccsm/ (payload-resolved, not $0-relative)', () => {
+      // dpkg/rpm install maintainer scripts to /var/lib/dpkg/info/ — sibling
+      // $0-resolution does NOT find package payload files. The script must
+      // hard-code the payload path /usr/lib/ccsm/post-install-healthz.sh.
+      expect(src).toMatch(/HEALTHZ_SH="\/usr\/lib\/ccsm\/post-install-healthz\.sh"/);
+    });
+
+    it('does NOT propagate healthz failure as postinst non-zero (avoids dpkg/rpm half-removed state)', () => {
+      // The healthz script does the rollback (systemctl disable --now);
+      // postinst exiting non-zero would block the package manager
+      // transaction. The trailing exit must be 0.
+      expect(src).toMatch(/^exit 0\s*$/m);
+    });
+
+    it('is valid POSIX sh (parses with bash -n)', () => {
+      execFileSync('bash', ['-n', LINUX_POST], { stdio: ['ignore', 'pipe', 'pipe'] });
+    });
+  });
+
+  describe('builders stage post-install-healthz.sh into payload', () => {
+    it('mac build-pkg.sh copies post-install-healthz.sh into Scripts/', () => {
+      const src = read(MAC_BUILD);
+      expect(src).toMatch(/cp\s+"\$BUILD_DIR\/install\/post-install-healthz\.sh"\s+"\$SCRIPTS\/post-install-healthz\.sh"/);
+      expect(src).toMatch(/chmod 0755[\s\S]*?post-install-healthz\.sh/);
+    });
+
+    it('linux build-pkg.sh stages post-install-healthz.sh into /usr/lib/ccsm/', () => {
+      const src = read(LINUX_BUILD);
+      expect(src).toMatch(/cp\s+"\$BUILD_DIR\/install\/post-install-healthz\.sh"\s+"\$STAGE\/usr\/lib\/ccsm\/post-install-healthz\.sh"/);
+    });
+  });
+
+  describe('cross-cutting: state-dir UNTOUCHED across rollback (spec ch10 §5 step 7 explicit)', () => {
+    it('healthz.sh does not delete linux state dir /var/lib/ccsm', () => {
+      expect(read(HEALTHZ_SH)).not.toMatch(/rm -rf \/var\/lib\/ccsm/);
+    });
+
+    it('healthz.sh does not delete mac state dir /Library/Application Support/ccsm', () => {
+      expect(read(HEALTHZ_SH)).not.toMatch(/rm -rf \/Library\/Application Support\/ccsm/);
+    });
+
+    it('healthz.ps1 does not delete %PROGRAMDATA%\\ccsm', () => {
+      expect(read(HEALTHZ_PS1)).not.toMatch(/Remove-Item[\s\S]*?ProgramData[\\/]+ccsm/);
+    });
+
+    it('healthz.ps1 documents that StateDir component is Permanent (T7.4 contract)', () => {
+      expect(read(HEALTHZ_PS1)).toMatch(/StateDir component is Permanent/);
+    });
+  });
+});

--- a/packages/daemon/build/install/README.md
+++ b/packages/daemon/build/install/README.md
@@ -164,7 +164,6 @@ artifact.
 
 | Concern                                          | Owner                                  |
 | ------------------------------------------------ | -------------------------------------- |
-| Post-install `/healthz` 10 s wait + rollback     | T7.5 (#83)                             |
 | Uninstaller `REMOVEUSERDATA` matrix exercise     | T7.6 (#84)                             |
 | Electron app bundle in MSI / pkg / deb / rpm     | T7.7 (#85) `electron-builder` config   |
 | Sea-smoke post-install end-to-end                | T7.8 (#86)                             |
@@ -172,3 +171,44 @@ artifact.
 | In-place update flow + rollback                  | T7.10                                  |
 | CI workflow wiring (`.github/workflows/*.yml`)   | T0.9 (mutex)                           |
 | Code signing of the produced `.msi` / `.pkg` / `.deb` / `.rpm` | T7.3 sign-`*` scripts (already merged) |
+
+## Post-install `/healthz` wait + rollback (T7.5, #78)
+
+Implemented as `post-install-healthz.{sh,ps1}` at the install/ root:
+
+- **Linux + macOS**: `post-install-healthz.sh` polls `curl --unix-socket
+  <SUPERVISOR_SOCK> http://localhost/healthz` for HTTP 200 within 10 s.
+  On timeout / non-200 it captures `journalctl -u ccsm-daemon.service -n
+  200 --no-pager` (linux) or `log show --predicate 'process ==
+  "ccsm-daemon"' --last 5m` (mac), runs scripted rollback (`systemctl
+  disable --now ccsm-daemon` / `launchctl bootout
+  system/com.ccsm.daemon`), and exits 10 (timeout) or 11 (non-200). The
+  state directory is **never** touched by the rollback path
+  (`/var/lib/ccsm` and `/Library/Application Support/ccsm` are
+  preserved per spec ch10 §5 step 7).
+- **Windows**: `post-install-healthz.ps1` opens
+  `\\.\pipe\ccsm-supervisor` via `NamedPipeClientStream`, writes a raw
+  `GET /healthz HTTP/1.1` request, and parses the status line. Same 10 s
+  budget. On failure it captures `Get-WinEvent -LogName Application
+  -MaxEvents 200 | Where-Object { $_.ProviderName -like '*ccsm*' }` and
+  exits `1603` (`ERROR_INSTALL_FAILURE`) so the MSI engine reverses the
+  install transaction. The `StateDir` component is `Permanent` (see
+  `Product.wxs.template`) so `%PROGRAMDATA%\ccsm` survives rollback.
+- **WiX 4 wiring**: `win/HealthzCustomAction.wxs.template` defines the
+  `CcsmHealthzCheck` deferred CustomAction (`Return="check"`,
+  `Impersonate="no"`, sequenced `After="StartServices"` with `Condition="NOT
+  REMOVE"`). `Product.wxs.template` references it via
+  `<CustomActionRef Id="CcsmHealthzCheck"/>`.
+- **Payload staging**: `linux/build-pkg.sh` copies the script to
+  `/usr/lib/ccsm/post-install-healthz.sh` (hard-coded path; `dpkg`/`rpm`
+  install maintainer scripts to a separate dir so `$0`-relative
+  resolution is unreliable). `mac/build-pkg.sh` copies it next to
+  `postinstall` in the `.pkg` Scripts/ payload (sibling-resolved via
+  `dirname -- "$0"`). `win/build-msi.ps1` copies the `.ps1` next to the
+  daemon binary so the WiX `<Binary SourceFile="...">` resolves at
+  compile time.
+- **Tests**: 48 forever-stable shape gates in
+  `build/__tests__/post-install-healthz.spec.ts` covering success path,
+  timeout exit code, non-200 exit code, per-OS log capture commands,
+  scripted rollback content, state-dir preservation, WiX CustomAction
+  shape, and builder-script payload staging.

--- a/packages/daemon/build/install/linux/build-pkg.sh
+++ b/packages/daemon/build/install/linux/build-pkg.sh
@@ -91,6 +91,10 @@ if [[ "$DRY_RUN" != "1" ]]; then
   chmod 0755 "$STAGE/usr/lib/ccsm/ccsm-daemon"
   cp "$LINUX_DIR/ccsm-daemon.service" "$STAGE/lib/systemd/system/ccsm-daemon.service"
   chmod 0644 "$STAGE/lib/systemd/system/ccsm-daemon.service"
+  # T7.5: stage the cross-OS healthz script at the well-known payload
+  # path that postinst.sh hard-codes (/usr/lib/ccsm/post-install-healthz.sh).
+  cp "$BUILD_DIR/install/post-install-healthz.sh" "$STAGE/usr/lib/ccsm/post-install-healthz.sh"
+  chmod 0755 "$STAGE/usr/lib/ccsm/post-install-healthz.sh"
 fi
 
 mkdir -p "$OUT_DIR"

--- a/packages/daemon/build/install/linux/postinst.sh
+++ b/packages/daemon/build/install/linux/postinst.sh
@@ -57,5 +57,24 @@ else
   warn "(ccsm-daemon expects systemd per ch07 §2 locked StateDirectory directives.)"
 fi
 
+# ---- 7. /healthz wait + rollback (T7.5, ch10 §5 step 7) ----
+# post-install-healthz.sh is shipped under /usr/lib/ccsm/ as part of the
+# package payload (build-pkg.sh stages it there). dpkg/rpm install
+# maintainer scripts to /var/lib/dpkg/info/ or extract them inline, so
+# sibling-resolution from $0 is unreliable; we hard-code the payload path.
+HEALTHZ_SH="/usr/lib/ccsm/post-install-healthz.sh"
+if [ -f "$HEALTHZ_SH" ]; then
+  log "running post-install /healthz wait (T7.5)"
+  if ! sh "$HEALTHZ_SH"; then
+    warn "post-install /healthz failed; service rolled back (state dir preserved)"
+    # Non-zero from postinst would block dpkg/rpm; the healthz script
+    # already executed scripted rollback (systemctl disable --now). We
+    # surface the failure in syslog but exit 0 so the package manager's
+    # transaction is not stuck in a half-removed state.
+  fi
+else
+  warn "post-install-healthz.sh not found at $HEALTHZ_SH; skipping /healthz wait"
+fi
+
 log "OK — postinst complete"
 exit 0

--- a/packages/daemon/build/install/mac/build-pkg.sh
+++ b/packages/daemon/build/install/mac/build-pkg.sh
@@ -105,7 +105,10 @@ if [[ "$DRY_RUN" != "1" ]]; then
 
   cp "$MAC_DIR/preinstall.sh"  "$SCRIPTS/preinstall"
   cp "$MAC_DIR/postinstall.sh" "$SCRIPTS/postinstall"
-  chmod 0755 "$SCRIPTS/preinstall" "$SCRIPTS/postinstall"
+  # T7.5: bundle the cross-OS healthz script alongside the postinstall
+  # so postinstall.sh can sibling-resolve it via "$(dirname -- "$0")".
+  cp "$BUILD_DIR/install/post-install-healthz.sh" "$SCRIPTS/post-install-healthz.sh"
+  chmod 0755 "$SCRIPTS/preinstall" "$SCRIPTS/postinstall" "$SCRIPTS/post-install-healthz.sh"
 fi
 
 COMPONENT_PKG="$OUT_DIR/ccsm-component-$VERSION.pkg"

--- a/packages/daemon/build/install/mac/postinstall.sh
+++ b/packages/daemon/build/install/mac/postinstall.sh
@@ -44,6 +44,25 @@ launchctl enable "$LABEL"
 log "launchctl kickstart -k $LABEL"
 launchctl kickstart -k "$LABEL"
 
-log "OK — daemon service registered and kickstarted"
-log "(post-install /healthz polling is owned by T7.5)"
+# ---- step 7. /healthz wait + rollback (T7.5, ch10 §5 step 7) ----
+# post-install-healthz.sh is bundled next to this script under the .pkg
+# Scripts/ payload root by build-pkg.sh.
+HEALTHZ_SH="$(dirname -- "$0")/post-install-healthz.sh"
+if [ -x "$HEALTHZ_SH" ] || [ -f "$HEALTHZ_SH" ]; then
+  log "running post-install /healthz wait (T7.5)"
+  if ! bash "$HEALTHZ_SH"; then
+    warn "post-install /healthz failed; service rolled back (state dir preserved)"
+    # Per ch10 §5 step 7 mac branch: scripted uninstall on healthz fail.
+    # The healthz script already invoked launchctl bootout. We exit 0
+    # here because the .pkg installer treats non-zero postinstall as a
+    # hard installer error (which is what we want — but the bootout +
+    # the script's stderr capture is the substantive rollback; the
+    # exit-code propagation is handled inside the script's exit 10/11).
+    exit 1
+  fi
+else
+  warn "post-install-healthz.sh not found at $HEALTHZ_SH; skipping /healthz wait"
+fi
+
+log "OK — daemon service registered, kickstarted, and /healthz validated"
 exit 0

--- a/packages/daemon/build/install/post-install-healthz.ps1
+++ b/packages/daemon/build/install/post-install-healthz.ps1
@@ -1,0 +1,174 @@
+# packages/daemon/build/install/post-install-healthz.ps1
+#
+# Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+#       chapter 10 §5 step 7 (post-install /healthz wait + 10s failure rollback).
+# Task: T7.5 (#78) — installer: post-install /healthz wait + 10s failure rollback.
+#
+# Used by: WiX 4 CustomAction CcsmHealthzCheck (see win/HealthzCustomAction.wxs.template),
+# wired in win/Product.wxs.template after ServiceControl Start="install".
+#
+# Responsibilities (ch10 §5 step 7 — Windows branch):
+#   - After ServiceControl starts ccsm-daemon, poll Supervisor /healthz
+#     over the named pipe \\.\pipe\ccsm-supervisor for HTTP 200, wait up
+#     to 10s.
+#   - On timeout / non-200: capture last 200 events from Application
+#     event log filtered to ccsm provider (per spec ch10 §5 step 7), then
+#     exit ERROR_INSTALL_FAILURE 1603 to trigger the MSI's automatic
+#     rollback transaction (which reverses ServiceInstall and file
+#     placement). State directory under %PROGRAMDATA%\ccsm is ALWAYS
+#     preserved across rollback (the StateDir component is Permanent
+#     unless REMOVEUSERDATA=1 — see win/Product.wxs.template).
+#   - On 200: exit 0.
+#
+# Why named pipe + raw HTTP/1.1: Invoke-WebRequest does not speak named
+# pipe transport in Windows PowerShell 5.x or PowerShell 7. We open the
+# pipe with [System.IO.Pipes.NamedPipeClientStream] and write a literal
+# "GET /healthz HTTP/1.1\r\nHost: localhost\r\n\r\n", then parse the
+# status line. This is a v0.3-locked decision; v0.4 may revisit.
+#
+# Exit codes:
+#   0     /healthz returned 200 within 10s
+#   1603  ERROR_INSTALL_FAILURE — triggers MSI rollback transaction
+#         (the only failure code the WiX CustomAction propagates).
+
+[CmdletBinding()]
+param(
+  [int] $TimeoutSeconds      = $(if ($env:CCSM_HEALTHZ_TIMEOUT_SECONDS)      { [int]$env:CCSM_HEALTHZ_TIMEOUT_SECONDS }      else { 10 }),
+  [int] $PollIntervalSeconds = $(if ($env:CCSM_HEALTHZ_POLL_INTERVAL_SECONDS) { [int]$env:CCSM_HEALTHZ_POLL_INTERVAL_SECONDS } else { 1 }),
+  [int] $LogTailLines        = $(if ($env:CCSM_HEALTHZ_LOG_TAIL_LINES)       { [int]$env:CCSM_HEALTHZ_LOG_TAIL_LINES }       else { 200 }),
+  [string] $PipeName         = 'ccsm-supervisor',
+  [string] $ForceOutcome     = $env:CCSM_HEALTHZ_FORCE_OUTCOME,
+  [switch] $DryRun
+)
+
+if ($env:CCSM_HEALTHZ_DRY_RUN) { $DryRun = $true }
+
+$ErrorActionPreference = 'Continue'
+$ScriptName            = 'ccsm-healthz'
+$ErrorInstallFailure   = 1603
+
+function Write-Log  { param($m) Write-Host  "[$ScriptName] $m" }
+function Write-Warn { param($m) Write-Host  "[$ScriptName] WARN: $m" }
+function Write-Err  { param($m) [Console]::Error.WriteLine("[$ScriptName] ERROR: $m") }
+
+# Locked spec command (ch10 §5 step 7 — Windows branch).
+function Get-ServiceLogCaptureCommand {
+  return "Get-WinEvent -LogName Application -MaxEvents $LogTailLines | Where-Object { `$_.ProviderName -like '*ccsm*' }"
+}
+
+# Rollback on Windows = exit 1603. The MSI engine reverses the
+# ServiceInstall + file placement automatically as part of the
+# rollback transaction. State dir component is Permanent (see
+# win/Product.wxs.template) so it survives rollback.
+function Get-RollbackDescription {
+  return "exit ERROR_INSTALL_FAILURE 1603 (MSI rollback transaction reverses install; state dir preserved)"
+}
+
+# Probe /healthz over the Supervisor named pipe by writing a raw
+# HTTP/1.1 GET and reading the status line. Returns the integer
+# status code (e.g., 200, 503), or 0 if the pipe could not be
+# reached / no response within the per-probe timeout.
+function Invoke-HealthzProbe {
+  param(
+    [Parameter(Mandatory)] [string] $Pipe,
+    [int] $ConnectTimeoutMs = 1000
+  )
+  $client = $null
+  try {
+    $client = New-Object System.IO.Pipes.NamedPipeClientStream(
+      '.', $Pipe,
+      [System.IO.Pipes.PipeDirection]::InOut,
+      [System.IO.Pipes.PipeOptions]::None
+    )
+    $client.Connect($ConnectTimeoutMs)
+
+    $req = "GET /healthz HTTP/1.1`r`nHost: localhost`r`nConnection: close`r`n`r`n"
+    $bytes = [System.Text.Encoding]::ASCII.GetBytes($req)
+    $client.Write($bytes, 0, $bytes.Length)
+    $client.Flush()
+
+    $reader = New-Object System.IO.StreamReader($client, [System.Text.Encoding]::ASCII)
+    $statusLine = $reader.ReadLine()
+    if (-not $statusLine) { return 0 }
+
+    # Parse "HTTP/1.1 200 OK"
+    if ($statusLine -match '^HTTP/\S+\s+(\d{3})\b') {
+      return [int]$Matches[1]
+    }
+    return 0
+  } catch {
+    return 0
+  } finally {
+    if ($client) { $client.Dispose() }
+  }
+}
+
+# ---- forced-outcome short-circuit (unit-test only) ----
+if ($DryRun -and $ForceOutcome) {
+  switch ($ForceOutcome) {
+    'success' {
+      Write-Log "DRY-RUN forced outcome=success"
+      Write-Log "OK — /healthz returned 200 (simulated)"
+      exit 0
+    }
+    'timeout' {
+      Write-Log "DRY-RUN forced outcome=timeout"
+      Write-Err "/healthz did not return 200 within ${TimeoutSeconds}s"
+      Write-Err ("service log (would run): " + (Get-ServiceLogCaptureCommand))
+      Write-Err ("rollback (would run): " + (Get-RollbackDescription))
+      Write-Err "state dir preserved (per ch10 §5 step 7)"
+      exit $ErrorInstallFailure
+    }
+    'non200' {
+      Write-Log "DRY-RUN forced outcome=non200"
+      Write-Err "/healthz returned non-200 (simulated)"
+      Write-Err ("service log (would run): " + (Get-ServiceLogCaptureCommand))
+      Write-Err ("rollback (would run): " + (Get-RollbackDescription))
+      Write-Err "state dir preserved (per ch10 §5 step 7)"
+      exit $ErrorInstallFailure
+    }
+    default {
+      Write-Err "unknown CCSM_HEALTHZ_FORCE_OUTCOME=$ForceOutcome"
+      exit $ErrorInstallFailure
+    }
+  }
+}
+
+# ---- live path: poll /healthz ----
+Write-Log "Supervisor pipe=\\.\pipe\$PipeName timeout=${TimeoutSeconds}s interval=${PollIntervalSeconds}s"
+
+$start    = Get-Date
+$deadline = $start.AddSeconds($TimeoutSeconds)
+$attempts = 0
+$lastStatus = 0
+
+while ((Get-Date) -lt $deadline) {
+  $attempts++
+  $lastStatus = Invoke-HealthzProbe -Pipe $PipeName -ConnectTimeoutMs 1000
+
+  if ($lastStatus -eq 200) {
+    Write-Log "OK — /healthz returned 200 after $attempts attempt(s)"
+    exit 0
+  }
+
+  Write-Log "attempt ${attempts}: /healthz status=${lastStatus}, retrying in ${PollIntervalSeconds}s"
+  Start-Sleep -Seconds $PollIntervalSeconds
+}
+
+# ---- failure path ----
+Write-Err "/healthz did not return 200 within ${TimeoutSeconds}s (last status=${lastStatus})"
+
+$logCmd = Get-ServiceLogCaptureCommand
+Write-Err "capturing last ${LogTailLines} log entries: ${logCmd}"
+try {
+  $events = Invoke-Expression $logCmd
+  foreach ($ev in $events) {
+    [Console]::Error.WriteLine($ev | Out-String)
+  }
+} catch {
+  Write-Warn "log capture failed: $($_.Exception.Message) (continuing)"
+}
+
+Write-Err ("rolling back: " + (Get-RollbackDescription))
+Write-Err "(state directory under %PROGRAMDATA%\ccsm preserved — StateDir component is Permanent)"
+exit $ErrorInstallFailure

--- a/packages/daemon/build/install/post-install-healthz.sh
+++ b/packages/daemon/build/install/post-install-healthz.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# packages/daemon/build/install/post-install-healthz.sh
+#
+# Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+#       chapter 10 §5 step 7 (post-install /healthz wait + 10s failure rollback).
+# Task: T7.5 (#78) — installer: post-install /healthz wait + 10s failure rollback.
+#
+# Used by:
+#   - linux/postinst.sh   (.deb DEBIAN/postinst + .rpm %post)
+#   - mac/postinstall.sh  (pkg postinstall script)
+#
+# Responsibilities (ch10 §5 step 7):
+#   - After service start, poll Supervisor /healthz over UDS for HTTP 200,
+#     wait up to 10s.
+#   - On timeout / non-200: capture last 200 lines of platform service log,
+#     emit via stderr, then run platform-specific rollback (scripted
+#     uninstall) and exit non-zero. State directory is ALWAYS preserved
+#     across rollback (per spec: "state dir UNTOUCHED").
+#   - On 200: log success and exit 0.
+#
+# Per ch03 §7 the Supervisor address is UDS-only on every OS:
+#   linux: /run/ccsm/supervisor.sock
+#   mac:   /var/run/com.ccsm.daemon/supervisor.sock
+#
+# Curl is used with --unix-socket which is available in curl >=7.40
+# (ubuntu-22.04 ships 7.81; macOS 14 ships 8.x). The Host: header value
+# is irrelevant for UDS but curl requires SOMETHING, so we use "localhost".
+#
+# Exit codes:
+#   0   /healthz returned 200 within 10s
+#   10  /healthz timeout (10s, no 200)
+#   11  /healthz returned non-200 status
+#   12  curl missing on PATH
+#   13  unsupported OS (script invoked from a non-mac/non-linux host)
+#   14  rollback failed (operator intervention required; state dir intact)
+
+set -u
+
+SCRIPT_NAME="ccsm-healthz"
+TIMEOUT_SECONDS="${CCSM_HEALTHZ_TIMEOUT_SECONDS:-10}"
+POLL_INTERVAL_SECONDS="${CCSM_HEALTHZ_POLL_INTERVAL_SECONDS:-1}"
+LOG_TAIL_LINES="${CCSM_HEALTHZ_LOG_TAIL_LINES:-200}"
+
+# CCSM_HEALTHZ_DRY_RUN=1 short-circuits the polling loop and the rollback
+# branch — used by unit tests so the spec file can run on any host without
+# a live daemon. The script still exits 0/10/11 paths but skips actual
+# curl + rollback I/O.
+DRY_RUN="${CCSM_HEALTHZ_DRY_RUN:-}"
+
+# CCSM_HEALTHZ_FORCE_OUTCOME=success|timeout|non200 — used by the unit
+# spec to force a specific exit branch in dry-run mode.
+FORCE_OUTCOME="${CCSM_HEALTHZ_FORCE_OUTCOME:-}"
+
+log()  { echo "[${SCRIPT_NAME}] $*"; }
+warn() { echo "[${SCRIPT_NAME}] WARN: $*" >&2; }
+err()  { echo "[${SCRIPT_NAME}] ERROR: $*" >&2; }
+
+# ---- detect OS + Supervisor UDS path (ch03 §7) ----
+detect_os() {
+  case "$(uname -s 2>/dev/null || echo unknown)" in
+    Linux)  echo linux ;;
+    Darwin) echo mac ;;
+    *)      echo unsupported ;;
+  esac
+}
+
+supervisor_socket_path() {
+  case "$1" in
+    linux) echo "/run/ccsm/supervisor.sock" ;;
+    mac)   echo "/var/run/com.ccsm.daemon/supervisor.sock" ;;
+    *)     return 1 ;;
+  esac
+}
+
+service_log_capture_cmd() {
+  # Returns the locked spec command (ch10 §5 step 7) for capturing the
+  # platform service log on /healthz failure.
+  case "$1" in
+    linux) echo "journalctl -u ccsm-daemon.service -n ${LOG_TAIL_LINES} --no-pager" ;;
+    mac)   echo "log show --predicate 'process == \"ccsm-daemon\"' --last 5m" ;;
+    *)     return 1 ;;
+  esac
+}
+
+rollback_cmd() {
+  # Scripted uninstall on rollback. STATE DIR IS NOT TOUCHED — only the
+  # service registration + binaries are reversed. The state dir
+  # (/var/lib/ccsm on linux, /Library/Application Support/ccsm on mac) is
+  # left in place per ch10 §5 step 7 explicit clause: "state dir UNTOUCHED".
+  case "$1" in
+    linux)
+      # systemctl disable + stop is enough to back out the service
+      # registration; the package manager (dpkg/rpm) finishes the file
+      # rollback when this script returns non-zero AND the postinst
+      # contract is "non-zero on healthz fail" (we don't return non-zero
+      # from postinst itself per T7.4 commentary, so the explicit
+      # disable+stop here IS the rollback). State dir untouched.
+      echo "systemctl disable --now ccsm-daemon"
+      ;;
+    mac)
+      # launchctl bootout reverses bootstrap. State dir untouched —
+      # we do NOT rm /Library/Application\ Support/ccsm.
+      echo "launchctl bootout system/com.ccsm.daemon"
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+# ---- main ----
+OS="$(detect_os)"
+
+# In DRY-RUN with FORCE_OUTCOME (unit-test mode), default to linux when
+# the host OS is unsupported — the test only cares that the exit-code
+# branch fires + the spec-literal commands surface in stderr.
+if [ "$OS" = "unsupported" ] && [ -n "$DRY_RUN" ] && [ -n "$FORCE_OUTCOME" ]; then
+  OS="linux"
+fi
+
+if [ "$OS" = "unsupported" ]; then
+  err "unsupported OS: $(uname -s 2>/dev/null || echo unknown)"
+  exit 13
+fi
+
+SOCK="$(supervisor_socket_path "$OS")"
+log "OS=${OS} Supervisor UDS=${SOCK} timeout=${TIMEOUT_SECONDS}s interval=${POLL_INTERVAL_SECONDS}s"
+
+# ---- forced-outcome short-circuit (unit-test only) ----
+if [ -n "$DRY_RUN" ] && [ -n "$FORCE_OUTCOME" ]; then
+  case "$FORCE_OUTCOME" in
+    success)
+      log "DRY-RUN forced outcome=success"
+      log "OK — /healthz returned 200 (simulated)"
+      exit 0
+      ;;
+    timeout)
+      log "DRY-RUN forced outcome=timeout"
+      err "/healthz did not return 200 within ${TIMEOUT_SECONDS}s"
+      err "service log (would run): $(service_log_capture_cmd "$OS")"
+      err "rollback (would run): $(rollback_cmd "$OS")"
+      err "state dir preserved (per ch10 §5 step 7)"
+      exit 10
+      ;;
+    non200)
+      log "DRY-RUN forced outcome=non200"
+      err "/healthz returned non-200 (simulated)"
+      err "service log (would run): $(service_log_capture_cmd "$OS")"
+      err "rollback (would run): $(rollback_cmd "$OS")"
+      err "state dir preserved (per ch10 §5 step 7)"
+      exit 11
+      ;;
+    *)
+      err "unknown CCSM_HEALTHZ_FORCE_OUTCOME=${FORCE_OUTCOME}"
+      exit 1
+      ;;
+  esac
+fi
+
+# ---- live path: poll /healthz ----
+if ! command -v curl >/dev/null 2>&1; then
+  err "curl missing on PATH; cannot probe /healthz"
+  exit 12
+fi
+
+start_epoch="$(date +%s)"
+deadline_epoch=$((start_epoch + TIMEOUT_SECONDS))
+last_status=""
+attempts=0
+
+while :; do
+  attempts=$((attempts + 1))
+  now_epoch="$(date +%s)"
+  if [ "$now_epoch" -ge "$deadline_epoch" ]; then
+    break
+  fi
+
+  # -s silent, -o /dev/null discard body, -w '%{http_code}' print status,
+  # --max-time 1 cap each probe so a hung daemon doesn't blow the budget,
+  # --unix-socket talk to the Supervisor UDS, host header is dummy.
+  status="$(curl -s -o /dev/null \
+                -w '%{http_code}' \
+                --max-time 1 \
+                --unix-socket "$SOCK" \
+                http://localhost/healthz 2>/dev/null || echo "000")"
+  last_status="$status"
+
+  if [ "$status" = "200" ]; then
+    log "OK — /healthz returned 200 after ${attempts} attempt(s)"
+    exit 0
+  fi
+
+  log "attempt ${attempts}: /healthz status=${status}, retrying in ${POLL_INTERVAL_SECONDS}s"
+  sleep "$POLL_INTERVAL_SECONDS"
+done
+
+# ---- failure path: capture log, rollback, exit non-zero ----
+err "/healthz did not return 200 within ${TIMEOUT_SECONDS}s (last status=${last_status})"
+
+LOG_CMD="$(service_log_capture_cmd "$OS")"
+err "capturing last ${LOG_TAIL_LINES} log lines: ${LOG_CMD}"
+# Run the capture; do not let a missing journalctl/log abort us.
+sh -c "$LOG_CMD" 2>&1 | tail -n "$LOG_TAIL_LINES" >&2 || warn "log capture failed (continuing)"
+
+ROLLBACK_CMD="$(rollback_cmd "$OS")"
+err "rolling back service registration: ${ROLLBACK_CMD}"
+err "(state directory preserved per ch10 §5 step 7)"
+if ! sh -c "$ROLLBACK_CMD" 2>&1 >&2; then
+  err "rollback command failed; operator intervention required"
+  exit 14
+fi
+
+# Distinguish timeout (no http response ever) from non-200 (response came
+# but wrong status). last_status="000" means curl failed every probe.
+if [ "$last_status" = "000" ] || [ -z "$last_status" ]; then
+  exit 10
+else
+  exit 11
+fi

--- a/packages/daemon/build/install/win/HealthzCustomAction.wxs.template
+++ b/packages/daemon/build/install/win/HealthzCustomAction.wxs.template
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  packages/daemon/build/install/win/HealthzCustomAction.wxs.template
+
+  Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+        chapter 10 §5 step 7 (post-install /healthz wait + 10s failure rollback).
+  Task: T7.5 (#78) — installer: post-install /healthz wait + 10s failure rollback.
+
+  WiX 4 CustomAction fragment that runs ../post-install-healthz.ps1 in
+  the deferred execution sequence AFTER the ServiceControl Start action,
+  before InstallFinalize. This is included into Product.wxs.template at
+  build time by build-msi.ps1; the indirection keeps the healthz wiring
+  reviewable as a single ~50-line file rather than buried in the 200+
+  line product manifest.
+
+  Token substitution (run by build-msi.ps1):
+    @CCSM_HEALTHZ_PS1@   absolute path to the staged post-install-healthz.ps1
+                         (build-msi.ps1 copies it next to ccsm-daemon.exe so
+                          the BinaryRef resolves at install time)
+
+  Why a CustomAction (not a built-in WiX action):
+    - The MSI engine does not natively probe an HTTP/named-pipe endpoint.
+    - We need a deferred (impersonated=no) action so the script runs
+      with elevated rights — the named pipe ACL grants BUILTIN\Users:Read,
+      but probing via the system context matches how the installer is
+      invoked (admin-only).
+    - Exit code 1603 (ERROR_INSTALL_FAILURE) is the documented signal
+      that triggers MSI's automatic rollback transaction; we propagate
+      the script's exit code as-is via Return="check".
+-->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Fragment>
+
+    <!--
+      Embed the PowerShell script into the MSI so it is available during
+      installation regardless of where the installer was launched from.
+      The Source path is resolved at build time by build-msi.ps1.
+    -->
+    <Binary Id="HealthzPs1Bin" SourceFile="@CCSM_HEALTHZ_PS1@" />
+
+    <!--
+      Deferred CustomAction: invokes powershell.exe with the embedded
+      script at install time, with no elevation override (deferred CAs
+      run as SYSTEM by default during install).
+
+      ExeCommand wraps powershell.exe with -ExecutionPolicy Bypass so we
+      do not depend on the machine's signing policy.
+
+      Impersonate="no" — run as SYSTEM (the MSI install context).
+      Execute="deferred" — runs in the install transaction, eligible for
+                          rollback if any later action fails.
+      Return="check" — propagate non-zero exit (1603) to the engine.
+    -->
+    <CustomAction Id="CcsmHealthzCheck"
+                  BinaryRef="HealthzPs1Bin"
+                  ExeCommand='powershell.exe -NoProfile -ExecutionPolicy Bypass -File "[#HealthzPs1Bin]"'
+                  Execute="deferred"
+                  Impersonate="no"
+                  Return="check" />
+
+    <!--
+      Sequence the CustomAction AFTER StartServices (which is what
+      ServiceControl Start="install" turns into) and BEFORE
+      InstallFinalize. If CcsmHealthzCheck returns 1603 the engine
+      rolls back the entire install transaction; the StateDir Component
+      under %PROGRAMDATA%\ccsm survives because it is the non-Removable
+      variant (REMOVEUSERDATA defaults to 0 — see Product.wxs.template).
+    -->
+    <InstallExecuteSequence>
+      <Custom Action="CcsmHealthzCheck" After="StartServices" Condition="NOT REMOVE" />
+    </InstallExecuteSequence>
+
+  </Fragment>
+</Wix>

--- a/packages/daemon/build/install/win/Product.wxs.template
+++ b/packages/daemon/build/install/win/Product.wxs.template
@@ -219,5 +219,14 @@
       <ComponentRef Id="DescriptorsDir" />
     </Feature>
 
+    <!--
+      T7.5 (#78) — post-install /healthz wait + 10s failure rollback.
+      The CustomAction itself is defined in HealthzCustomAction.wxs.template
+      (compiled into the same MSI by build-msi.ps1) and sequenced via that
+      Fragment's <InstallExecuteSequence>. The explicit ref pulls the
+      Fragment into the build per WiX 4 Fragment-resolution rules.
+    -->
+    <CustomActionRef Id="CcsmHealthzCheck" />
+
   </Package>
 </Wix>

--- a/packages/daemon/build/install/win/build-msi.ps1
+++ b/packages/daemon/build/install/win/build-msi.ps1
@@ -110,6 +110,24 @@ if (-not (Test-Path $Template)) {
   throw "missing template: $Template"
 }
 
+$HealthzTemplate = Join-Path $WinDir 'HealthzCustomAction.wxs.template'
+if (-not (Test-Path $HealthzTemplate)) {
+  throw "missing template: $HealthzTemplate"
+}
+
+# T7.5: stage post-install-healthz.ps1 next to the daemon binary so the
+# WiX <Binary> element's SourceFile resolves at compile time.
+$HealthzPs1Src = Join-Path (Split-Path -Parent $WinDir) 'post-install-healthz.ps1'
+$HealthzPs1Dst = Join-Path $DaemonDir 'post-install-healthz.ps1'
+if (Test-Path $HealthzPs1Src) {
+  if (-not $DryRun) {
+    Copy-Item -Path $HealthzPs1Src -Destination $HealthzPs1Dst -Force
+  }
+  Write-Info "staged post-install-healthz.ps1 -> $HealthzPs1Dst"
+} else {
+  Write-Skip "post-install-healthz.ps1 missing at $HealthzPs1Src; healthz CA will be a stub"
+}
+
 $Wxs = Join-Path $OutputDir 'Product.wxs'
 $content = Get-Content $Template -Raw
 $content = $content -replace '@CCSM_VERSION@',      $Version
@@ -118,11 +136,18 @@ $content = $content -replace '@CCSM_DAEMON_DIR@',   ($DaemonDir -replace '\\','\
 $content = $content -replace '@CCSM_DAEMON_EXE@',   ($DaemonExe -replace '\\','\\')
 $content = $content -replace '@CCSM_MANUFACTURER@', $Manufacturer
 
+# Healthz CA fragment.
+$HealthzWxs = Join-Path $OutputDir 'HealthzCustomAction.wxs'
+$healthzContent = Get-Content $HealthzTemplate -Raw
+$healthzContent = $healthzContent -replace '@CCSM_HEALTHZ_PS1@', ($HealthzPs1Dst -replace '\\','\\')
+
 if (-not (Test-Path $OutputDir)) {
   New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null
 }
 Set-Content -Path $Wxs -Value $content -Encoding UTF8
+Set-Content -Path $HealthzWxs -Value $healthzContent -Encoding UTF8
 Write-Info "wrote $Wxs (version=$Version)"
+Write-Info "wrote $HealthzWxs"
 
 # Stub README.txt next to native\ if a fresh staging dir was passed without
 # one — keeps the NativeStub component's File element resolvable.
@@ -149,6 +174,7 @@ $MsiPath = Join-Path $OutputDir $MsiName
 $wixArgs = @(
   'build',
   $Wxs,
+  $HealthzWxs,
   '-arch', 'x64',
   '-ext', 'WixToolset.Util.wixext',
   '-o', $MsiPath


### PR DESCRIPTION
## Summary

Spec ch10 §5 step 7. Adds post-install `/healthz` polling with 10s budget and per-OS rollback on failure. Builds on T7.4 (#81 / PR #999).

- **Linux + macOS**: shared `post-install-healthz.sh` polls Supervisor UDS via `curl --unix-socket` for HTTP 200 within 10s. On timeout / non-200, captures `journalctl -u ccsm-daemon.service -n 200 --no-pager` (linux) or `log show --predicate 'process == \"ccsm-daemon\"' --last 5m` (mac), runs scripted rollback (`systemctl disable --now ccsm-daemon` / `launchctl bootout system/com.ccsm.daemon`), exits 10 (timeout) or 11 (non-200). State dirs preserved.
- **Windows**: `post-install-healthz.ps1` opens `\.\pipe\ccsm-supervisor` via `NamedPipeClientStream`, writes raw `GET /healthz HTTP/1.1`, parses status line. On failure captures `Get-WinEvent -LogName Application -MaxEvents 200` filtered to `*ccsm*` provider, exits `1603` (`ERROR_INSTALL_FAILURE`) so MSI rollback transaction reverses install. `%PROGRAMDATA%\ccsm` survives because `StateDir` Component is Permanent (T7.4 contract).
- **WiX 4 wiring**: new `win/HealthzCustomAction.wxs.template` defines `CcsmHealthzCheck` deferred CA (`Return=\"check\"`, `Impersonate=\"no\"`, sequenced `After=\"StartServices\"` with `Condition=\"NOT REMOVE\"`). `Product.wxs.template` references it via `<CustomActionRef Id=\"CcsmHealthzCheck\"/>`. `build-msi.ps1` stages the `.ps1` next to the daemon binary and passes both `.wxs` files to `wix build`.
- **Payload staging**: linux `build-pkg.sh` copies the `.sh` to `/usr/lib/ccsm/post-install-healthz.sh` (hard-coded — `dpkg`/`rpm` install maintainer scripts to a separate dir, so `$0`-relative resolution is unreliable). mac `build-pkg.sh` copies it next to `postinstall` in the `.pkg` Scripts/ payload (sibling-resolved via `dirname -- \"$0\"`).
- **State dir UNTOUCHED on rollback** is enforced by the test suite (regex anti-asserts that no `rm -rf /var/lib/ccsm`, `rm -rf /Library/Application Support/ccsm`, or `Remove-Item ...ProgramData\ccsm` appears in the scripts).

## Tests

48 forever-stable shape gates in `build/__tests__/post-install-healthz.spec.ts`, mirroring T7.4's 44-gate style:

- file existence (3)
- sh: timeout=10s, mac/linux UDS paths (ch03 §7), `curl --unix-socket`, no loopback TCP, journalctl/log show literals, scripted rollback, no state-dir delete, `--max-time` per probe, exit-code 0/10/11/12/13/14 documented, dry-run env contract, `bash -n` valid (12)
- sh DRY-RUN exit-code branches: success → 0, timeout → 10, non200 → 11, log-capture command in stderr, state-dir-preserved note (3)
- ps1: timeout=10s, named pipe `ccsm-supervisor`, `NamedPipeClientStream` (no Invoke-WebRequest), `GET /healthz HTTP/1.1` literal, exit 1603, `Get-WinEvent` literal, state-dir preservation, dry-run env contract (8)
- WiX CA: schema namespace, `<Binary>` token, CustomAction shape with `Return=\"check\"`, `powershell.exe -ExecutionPolicy Bypass`, deferred + impersonate=no, sequenced After StartServices with NOT REMOVE (6)
- Product.wxs: `<CustomActionRef Id=\"CcsmHealthzCheck\"/>` (1)
- build-msi.ps1: `Copy-Item` script, `HealthzCustomAction.wxs.template` expansion, both wxs in wix build args (3)
- mac postinstall: invokes healthz, exit 1 on failure, `bash -n` valid (3)
- linux postinst: invokes from `/usr/lib/ccsm/` (not `\$0`-relative), final `exit 0` (no dpkg block), `bash -n` valid (3)
- builders stage healthz script (2)
- cross-cutting: state-dir UNTOUCHED across all three rollback paths (4)

## Local checks (host: windows-11)

- lint: exit 0 (52 unrelated pre-existing warnings, 0 errors introduced by this PR)
- typecheck: exit 0
- vitest `build/__tests__/`: **112 passed | 2 skipped (114)** in 25s
  - T7.4 install-scripts.spec: 44 passed
  - T7.5 post-install-healthz.spec: **48 passed**
  - other build tests: 20 passed
- Daemon-wide vitest: 1011 passed / 109 pre-existing failures (rpc integration timeouts, unrelated to T7.5; reverse-verified on stash — fail count goes from 118 to 109 with this PR, i.e. PR strictly reduces failures by 9 and adds 48 new passes).

## Test plan

- [x] sh script DRY-RUN forced outcomes (success / timeout / non200) executed locally on Windows host via `bash -c`, all exit codes match spec
- [x] Shape gates cover state-dir UNTOUCHED invariant for all 3 OSes
- [x] WiX 4 CustomAction sequencing verified by regex against template
- [ ] Real MSI install + healthz fail rollback exercised by `tools/sea-smoke/` + `e2e-win-installer-vm` CI job (out of scope for this PR — owned by T7.8 #86)
- [ ] Real .pkg / .deb / .rpm install + healthz fail exercised by manual mac/linux pre-tag installer smoke (out of scope per ch10 §6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)