### PR TITLE
wave3(#66): cwd_state OSC 7 parser for pty-host (T5.8)

### DIFF
--- a/packages/daemon/src/pty-host/__tests__/oscCwdSniffer.spec.ts
+++ b/packages/daemon/src/pty-host/__tests__/oscCwdSniffer.spec.ts
@@ -1,0 +1,277 @@
+// UTs for the OSC 7 cwd sniffer (T5.8 / Task #66). Pins the OSC 7 escape
+// scanner contract: BEL/ST terminators, multi-OSC chunks, split-across-chunk
+// escapes, per-sid isolation, clear() semantics, percent-decoding,
+// Windows path normalization, and bounded-buffer behaviour for hostile
+// streams.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  OscCwdSniffer,
+  parseOsc7Body,
+  type OscCwdEvent,
+} from '../oscCwdSniffer.js';
+
+function collect(sniffer: OscCwdSniffer): OscCwdEvent[] {
+  const events: OscCwdEvent[] = [];
+  sniffer.on('osc-cwd', (e: OscCwdEvent) => events.push(e));
+  return events;
+}
+
+describe('parseOsc7Body', () => {
+  it('parses a POSIX file:// URI with empty host', () => {
+    expect(parseOsc7Body('file:///tmp/foo')).toBe('/tmp/foo');
+  });
+
+  it('parses a POSIX file:// URI with literal hostname', () => {
+    expect(parseOsc7Body('file://my-host/tmp/foo')).toBe('/tmp/foo');
+  });
+
+  it('percent-decodes the path', () => {
+    expect(parseOsc7Body('file:///tmp/with%20space')).toBe('/tmp/with space');
+    expect(parseOsc7Body('file:///%E4%B8%AD%E6%96%87')).toBe('/中文');
+  });
+
+  it('strips the leading slash on Windows-style drive paths', () => {
+    expect(parseOsc7Body('file:///C:/Users/foo')).toBe('C:/Users/foo');
+    expect(parseOsc7Body('file://host/D:/work')).toBe('D:/work');
+  });
+
+  it('keeps POSIX leading slash', () => {
+    expect(parseOsc7Body('file:///')).toBe('/');
+    expect(parseOsc7Body('file:///a')).toBe('/a');
+  });
+
+  it('returns null for non-file:// schemes', () => {
+    expect(parseOsc7Body('http://example.com/foo')).toBeNull();
+    expect(parseOsc7Body('/tmp/raw')).toBeNull();
+    expect(parseOsc7Body('')).toBeNull();
+  });
+
+  it('returns null for malformed file:// URIs (no path slash after host)', () => {
+    expect(parseOsc7Body('file://host')).toBeNull();
+    expect(parseOsc7Body('file://')).toBeNull();
+  });
+
+  it('returns null for malformed percent-encoding', () => {
+    expect(parseOsc7Body('file:///bad/%ZZ')).toBeNull();
+  });
+});
+
+describe('OscCwdSniffer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-04T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('emits on a single OSC 7 BEL-terminated escape', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+    s.feed('sid-1', '\x1b]7;file:///tmp/foo\x07');
+    expect(events).toEqual([
+      { sid: 'sid-1', cwd: '/tmp/foo', ts: Date.now() },
+    ]);
+  });
+
+  it('emits on a single OSC 7 ST-terminated escape', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+    s.feed('sid-1', '\x1b]7;file:///tmp/bar\x1b\\');
+    expect(events).toEqual([
+      { sid: 'sid-1', cwd: '/tmp/bar', ts: Date.now() },
+    ]);
+  });
+
+  it('emits with a literal host segment in the URI', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+    s.feed('sid-1', '\x1b]7;file://localhost/var/tmp\x07');
+    expect(events).toEqual([
+      { sid: 'sid-1', cwd: '/var/tmp', ts: Date.now() },
+    ]);
+  });
+
+  it('emits multiple OSC 7 sequences from a single chunk in order', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+    s.feed(
+      'sid-1',
+      '\x1b]7;file:///a\x07prompt$\x1b]7;file:///b\x07',
+    );
+    expect(events.map((e) => e.cwd)).toEqual(['/a', '/b']);
+    expect(events.every((e) => e.sid === 'sid-1')).toBe(true);
+  });
+
+  it('handles an OSC escape split across two chunks (one emit only)', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+    s.feed('sid-1', 'noise \x1b]7;file:///tm');
+    expect(events).toHaveLength(0);
+    s.feed('sid-1', 'p/foo\x07');
+    expect(events).toEqual([
+      { sid: 'sid-1', cwd: '/tmp/foo', ts: Date.now() },
+    ]);
+  });
+
+  it('handles a partial OSC 7 prefix split across chunks (\\x1b]7 then ;...)', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+    s.feed('sid-1', 'pre\x1b]7');
+    expect(events).toHaveLength(0);
+    s.feed('sid-1', ';file:///x\x07');
+    expect(events).toEqual([
+      { sid: 'sid-1', cwd: '/x', ts: Date.now() },
+    ]);
+  });
+
+  it('keeps per-sid buffers isolated', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+
+    s.feed('sid-A', 'x\x1b]7;file:///pa'); // partial on A
+    s.feed('sid-B', '\x1b]7;file:///done\x07'); // complete on B
+
+    expect(events).toEqual([
+      { sid: 'sid-B', cwd: '/done', ts: Date.now() },
+    ]);
+
+    s.feed('sid-A', 'rtial\x07');
+    expect(events).toEqual([
+      { sid: 'sid-B', cwd: '/done', ts: Date.now() },
+      { sid: 'sid-A', cwd: '/partial', ts: Date.now() },
+    ]);
+  });
+
+  it('does not emit on plain text chunks with no OSC', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+    s.feed('sid-1', 'hello world\nno escapes here at all\n');
+    expect(events).toHaveLength(0);
+  });
+
+  it('does not emit (silently drops) on a non-file:// OSC 7 body', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+    s.feed('sid-1', '\x1b]7;http://nope/path\x07');
+    expect(events).toHaveLength(0);
+    // A subsequent valid OSC 7 still parses.
+    s.feed('sid-1', '\x1b]7;file:///ok\x07');
+    expect(events).toEqual([
+      { sid: 'sid-1', cwd: '/ok', ts: Date.now() },
+    ]);
+  });
+
+  it('does not emit on malformed percent-encoded body', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+    s.feed('sid-1', '\x1b]7;file:///bad/%ZZ\x07');
+    expect(events).toHaveLength(0);
+  });
+
+  it('clear(sid) drops any pending partial buffer', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+
+    s.feed('sid-1', '\x1b]7;file:///will-be-drop'); // partial
+    s.clear('sid-1');
+
+    // Feeding the would-be terminator alone should not produce an emit
+    // because the prefix is gone.
+    s.feed('sid-1', 'ped\x07');
+    expect(events).toHaveLength(0);
+
+    // And the sniffer should still work for a fresh OSC 7.
+    s.feed('sid-1', '\x1b]7;file:///fresh\x07');
+    expect(events).toEqual([
+      { sid: 'sid-1', cwd: '/fresh', ts: Date.now() },
+    ]);
+  });
+
+  it('caps buffer growth on long OSC-free streams', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+
+    const noise = 'x'.repeat(100 * 1024); // 100 KiB, no OSC
+    s.feed('sid-1', noise);
+
+    expect(events).toHaveLength(0);
+    const internal = (s as unknown as { buffers: Map<string, string> }).buffers;
+    const tail = internal.get('sid-1') ?? '';
+    expect(tail.length).toBeLessThanOrEqual(64 * 1024);
+    expect(tail.length).toBeLessThan(noise.length);
+
+    // And a follow-up OSC 7 still parses.
+    s.feed('sid-1', '\x1b]7;file:///ok\x07');
+    expect(events).toEqual([{ sid: 'sid-1', cwd: '/ok', ts: Date.now() }]);
+  });
+
+  it('caps buffer growth on a never-terminated OSC 7', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+
+    s.feed('sid-1', '\x1b]7;file:///' + 'A'.repeat(100 * 1024));
+    expect(events).toHaveLength(0);
+
+    const internal = (s as unknown as { buffers: Map<string, string> }).buffers;
+    const tail = internal.get('sid-1') ?? '';
+    expect(tail.length).toBeLessThanOrEqual(64 * 1024);
+  });
+
+  it('stamps ts from Date.now() on each emit', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+
+    vi.setSystemTime(new Date('2026-05-04T12:00:00Z'));
+    const t1 = Date.now();
+    s.feed('sid-1', '\x1b]7;file:///first\x07');
+
+    vi.setSystemTime(new Date('2026-05-04T12:00:05Z'));
+    const t2 = Date.now();
+    s.feed('sid-1', '\x1b]7;file:///second\x07');
+
+    expect(events).toEqual([
+      { sid: 'sid-1', cwd: '/first', ts: t1 },
+      { sid: 'sid-1', cwd: '/second', ts: t2 },
+    ]);
+    expect(t2).toBeGreaterThan(t1);
+  });
+
+  it('ignores empty/null chunks safely', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+    s.feed('sid-1', '');
+    s.feed('sid-1', Buffer.alloc(0));
+    expect(events).toHaveLength(0);
+  });
+
+  it('accepts Buffer input', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+    s.feed('sid-1', Buffer.from('\x1b]7;file:///buf\x07', 'utf8'));
+    expect(events).toEqual([{ sid: 'sid-1', cwd: '/buf', ts: Date.now() }]);
+  });
+
+  it('decodes Windows-style drive path with leading-slash stripped', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+    s.feed('sid-1', '\x1b]7;file:///C:/Users/foo\x07');
+    expect(events).toEqual([
+      { sid: 'sid-1', cwd: 'C:/Users/foo', ts: Date.now() },
+    ]);
+  });
+
+  it('decodes percent-encoded spaces and unicode in cwd', () => {
+    const s = new OscCwdSniffer();
+    const events = collect(s);
+    s.feed(
+      'sid-1',
+      '\x1b]7;file:///tmp/with%20space/%E4%B8%AD%E6%96%87\x07',
+    );
+    expect(events).toEqual([
+      { sid: 'sid-1', cwd: '/tmp/with space/中文', ts: Date.now() },
+    ]);
+  });
+});

--- a/packages/daemon/src/pty-host/oscCwdSniffer.ts
+++ b/packages/daemon/src/pty-host/oscCwdSniffer.ts
@@ -1,0 +1,184 @@
+// OSC 7 ("current working directory") sniffer for the pty-host child.
+// Spec: ch07 §3 cwd_state (T5.8 / Task #66).
+//
+// Wire format (xterm / iTerm2 / VTE convention):
+//   ESC ] 7 ; file://<host>/<path> BEL        (\x1b]7;file://<host>/<path>\x07)
+//   ESC ] 7 ; file://<host>/<path> ST         (\x1b]7;file://<host>/<path>\x1b\\)
+//
+// The shell (claude's spawned shell, via PROMPT_COMMAND / precmd hooks) is
+// responsible for emitting OSC 7 on every cd. The pty-host child is the SOLE
+// observer for cwd updates — the daemon does NOT shell out to lsof / proc.
+// On parse, this module emits {sid, cwd, ts}; the pty-host child posts a
+// {kind:'cwd_update'} IPC message to the daemon main process which UPSERTs
+// the cwd_state row through the write coalescer (ch07 §5). That wiring lands
+// once T4.9 (delta accumulator) is merged and is intentionally out of scope
+// here — this file is a pure producer (SRP) so each layer can be tested in
+// isolation, mirroring the OSC 0/2 title sniffer in `ptyHost/oscTitleSniffer.ts`.
+//
+// Layer 1 / 5-tier note: in-repo `ptyHost/oscTitleSniffer.ts` already
+// implements the same scan/buffer/per-sid/terminator pattern for OSC 0/2.
+// Cloning that pattern (rather than introducing a different OSC parser
+// flavor) keeps the codebase consistent — OSC framing across the two
+// sniffers diverges only in the OSC code (`0`/`2` vs `7`) and the body
+// interpretation (raw title vs file://-URI → cwd path).
+
+import { EventEmitter } from 'events';
+
+export interface OscCwdEvent {
+  sid: string;
+  /** Decoded absolute path (percent-decoding applied; file:// + host stripped). */
+  cwd: string;
+  ts: number;
+}
+
+// Cap per-sid buffer growth to defend against pathological streams that
+// emit `\x1b]7;` and never terminate it (or just enormous non-OSC text).
+// 64 KiB is enough to span any realistic split escape across chunks and
+// matches the OSC 0/2 sniffer cap.
+const MAX_BUFFER_BYTES = 64 * 1024;
+
+const OSC7_PREFIX = '\x1b]7;';
+const OSC7_PREFIX_LEN = OSC7_PREFIX.length; // 4 bytes
+
+const FILE_SCHEME = 'file://';
+
+/**
+ * Decode the body of an OSC 7 sequence (the bytes between `\x1b]7;` and the
+ * BEL/ST terminator) into an absolute filesystem path. Returns `null` if
+ * the body does not parse as a `file://` URI we recognize.
+ *
+ * Spec contract:
+ *   body = `file://<host>/<percent-encoded-path>`
+ *   - <host> may be empty (e.g. `file:///tmp/foo`) or a hostname (often
+ *     the literal machine hostname). We do NOT validate it — different
+ *     shells emit different things and we only care about the path.
+ *   - The path is percent-encoded per RFC 3986. We use `decodeURIComponent`
+ *     to undo it; malformed sequences (e.g. `%ZZ`) yield `null` so the
+ *     caller can drop the event rather than store garbage in cwd_state.
+ *   - On Windows, paths arrive as `/C:/Users/foo` — we strip the leading
+ *     slash so the result is a real Windows path (`C:/Users/foo`).
+ *
+ * Anything that doesn't start with `file://` is rejected (some shells
+ * emit raw paths in OSC 7 — non-standard, ignored to avoid accepting
+ * garbage as cwd).
+ */
+export function parseOsc7Body(body: string): string | null {
+  if (!body.startsWith(FILE_SCHEME)) return null;
+  // Strip `file://`, then strip everything up to the next `/` (the host).
+  // If there is no `/` after the scheme we have a malformed URI.
+  const afterScheme = body.slice(FILE_SCHEME.length);
+  const slashIdx = afterScheme.indexOf('/');
+  if (slashIdx === -1) return null;
+  let path = afterScheme.slice(slashIdx); // keeps the leading `/`
+  // Percent-decode. Malformed sequences throw — treat as parse failure.
+  try {
+    path = decodeURIComponent(path);
+  } catch {
+    return null;
+  }
+  // Windows: strip the leading `/` from `/X:/...` so we hand back a real
+  // Windows path. POSIX paths (`/tmp/foo`) keep their leading slash.
+  if (
+    path.length >= 4 &&
+    path.charCodeAt(0) === 0x2f /* '/' */ &&
+    isAsciiLetter(path.charCodeAt(1)) &&
+    path.charCodeAt(2) === 0x3a /* ':' */ &&
+    path.charCodeAt(3) === 0x2f /* '/' */
+  ) {
+    path = path.slice(1);
+  }
+  if (path.length === 0) return null;
+  return path;
+}
+
+function isAsciiLetter(code: number): boolean {
+  return (code >= 0x41 && code <= 0x5a) || (code >= 0x61 && code <= 0x7a);
+}
+
+export class OscCwdSniffer extends EventEmitter {
+  private readonly buffers = new Map<string, string>();
+
+  feed(sid: string, chunk: string | Buffer): void {
+    if (chunk == null) return;
+    const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    if (text.length === 0) return;
+
+    let buf = (this.buffers.get(sid) ?? '') + text;
+
+    // Scan for complete OSC 7 sequences. Loop because one chunk can hold
+    // multiple sequences (rare in practice for OSC 7, but cheap to handle).
+    let scanFrom = 0;
+    let lastEmitEnd = 0;
+    while (scanFrom < buf.length) {
+      const oscStart = buf.indexOf(OSC7_PREFIX, scanFrom);
+      if (oscStart === -1) break;
+
+      const bodyStart = oscStart + OSC7_PREFIX_LEN;
+
+      // Find terminator: BEL (\x07) or ST (\x1b\\). Pick the earlier one.
+      const belIdx = buf.indexOf('\x07', bodyStart);
+      const stIdx = buf.indexOf('\x1b\\', bodyStart);
+
+      let termIdx = -1;
+      let termLen = 0;
+      if (belIdx !== -1 && (stIdx === -1 || belIdx < stIdx)) {
+        termIdx = belIdx;
+        termLen = 1;
+      } else if (stIdx !== -1) {
+        termIdx = stIdx;
+        termLen = 2;
+      }
+
+      if (termIdx === -1) {
+        // Incomplete escape — leave it (and everything before it that we
+        // haven't yet consumed) for the next feed.
+        break;
+      }
+
+      const body = buf.slice(bodyStart, termIdx);
+      const cwd = parseOsc7Body(body);
+      if (cwd !== null) {
+        this.emit('osc-cwd', {
+          sid,
+          cwd,
+          ts: Date.now(),
+        } satisfies OscCwdEvent);
+      }
+      // Malformed body: silently drop. Spec ch07 §3 is "OSC 7 is the SOLE
+      // source of truth"; a junk body is just a no-op (cwd_state stays at
+      // its last known good value or sessions.cwd fallback).
+
+      scanFrom = termIdx + termLen;
+      lastEmitEnd = scanFrom;
+    }
+
+    // Keep only the tail starting at the first byte we haven't consumed.
+    // If we found an incomplete OSC 7 start, keep from there so the next
+    // feed can complete it. Otherwise discard plain text but retain a
+    // small (3-byte) tail so a split `\x1b]7` prefix straddling the chunk
+    // boundary still completes next round. Mirrors the OSC 0/2 sniffer.
+    let tail: string;
+    const incompleteOscStart = buf.indexOf(OSC7_PREFIX, lastEmitEnd);
+    if (incompleteOscStart !== -1) {
+      tail = buf.slice(incompleteOscStart);
+    } else {
+      tail = buf.slice(Math.max(buf.length - 3, lastEmitEnd));
+    }
+
+    if (tail.length > MAX_BUFFER_BYTES) {
+      // Truncate from the LEFT — keep the most recent bytes since an OSC
+      // terminator (if it ever arrives) will appear later in the stream.
+      tail = tail.slice(tail.length - MAX_BUFFER_BYTES);
+    }
+
+    if (tail.length === 0) {
+      this.buffers.delete(sid);
+    } else {
+      this.buffers.set(sid, tail);
+    }
+  }
+
+  clear(sid: string): void {
+    this.buffers.delete(sid);
+  }
+}


### PR DESCRIPTION
## Summary

Task #66 / T5.8 — `OscCwdSniffer`: a standalone OSC 7 (`ESC ] 7 ; file://<host>/<path> BEL`) parser for the pty-host child, per spec ch07 §3 cwd_state.

- Pure producer, SRP. Mirrors `ptyHost/oscTitleSniffer.ts` framing/buffering/cap pattern (5-tier Layer 1: pattern-clone in-repo, no new deps).
- Body decoding: strips `file://` + host, `decodeURIComponent`, strips Windows leading-slash on `/X:/...` paths, silently drops malformed bodies.
- 26 UTs cover BEL/ST terminators, multi-OSC chunks, split-prefix recovery, per-sid isolation, percent-decoding (incl. UTF-8 + spaces), Windows drives, buffer caps (64 KiB) on hostile streams, and `clear(sid)`.

Out of scope (per task note "OSC 7 parser 模块独立, 可并行写"): wiring this sniffer into the pty-host child + posting `{kind:'cwd_update'}` IPC to daemon main + UPSERT-through-coalescer + restored-session boot read. Those need T4.9 (delta accumulator, blockedBy) merged first and will land in a follow-up. The migration's `cwd_state` table already exists (T5.2 `001_initial.sql`).

## Local checks (host: windows-11)
- lint: ok (exit 0; only pre-existing unused-disable warnings on unrelated files)
- typecheck: ok (exit 0)
- build: ok (exit 0; tsc -p tsconfig.json + electron tsc both clean)
- unit tests (new module — `npx vitest run src/pty-host/__tests__/oscCwdSniffer.spec.ts`):
  ```
  Test Files  1 passed (1)
       Tests  26 passed (26)
    Duration  3.19s
  ```
- unit tests (full `npm test`): 945 passed, 99 failed, 23 skipped, 5 todo. **The 99 failures are pre-existing on `working` HEAD** — verified by hiding my two new files and re-running: 919 passed, 99 failed (same 99). My change adds 26 new passing tests, breaks zero. Failing files (`recovery.spec.ts`, `integration.spec.ts`, `crash-raw-recovery.spec.ts`, `pruner.spec.ts`, `crash-getlog-wired.spec.ts`, `daemon-boot-end-to-end.spec.ts`, `native-loader.spec.ts`, `shutdown.spec.ts`, ...) are all in domains my isolated parser module doesn't touch.
- e2e (`npm run probe:e2e`): `harness-dnd` passed (38754ms), `harness-ui` passed 14/14 (47948ms), `harness-real-cli` timed out at 300000ms with two pre-existing failures (`waitForTerminalReady` for a sid + `window.ccsmSession.onState not exposed by preload (PR-A wiring missing)`). The OSC 7 parser is not wired into anything yet (the wiring task is gated on T4.9), so no e2e harness exercises it — these are pre-existing harness wiring tasks unrelated to this PR.