### PR TITLE
wave3(#334): wire CrashService.GetRawCrashLog server-streaming handler

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -332,28 +332,39 @@ export async function runStartup(
     sessionManager = new SessionManager(db);
     const watchSessionsDeps = { manager: sessionManager };
     // Wave-3 #229 — wire CrashService.GetCrashLog handler in production.
-    // Audit #228 sub-task 2 (docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md):
+    // Wave-3 #334 — wire CrashService.GetRawCrashLog server-streaming
+    // handler in the same overlay (separate sub-task because the
+    // streaming + 64 KiB chunk semantics are non-overlapping with the
+    // unary GetCrashLog handler; same `registerCrashService` call site
+    // because `ConnectRouter.service(desc, impl)` REPLACES the prior
+    // registration — see `register.ts` header comment).
+    // Audit #228 sub-task 2/3 (docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md):
     // pre-#229 the entire CrashService was a stub on the wire even though
     // `crash_log` is populated end-to-end at boot (`replayCrashRawOnBoot`).
     // We pass the SAME `db` handle the rest of startup uses (single owner
     // of the SQLite file; the #335 WatchCrashLog overlay reuses this same
-    // boot for its event-bus subscription). The remaining streaming sibling
-    // (#334 GetRawCrashLog) stays `Unimplemented` until its sub-task lands —
-    // `registerCrashService` ships a partial impl with `getCrashLog` +
-    // `watchCrashLog` and the router's "absent method -> Unimplemented" rule
-    // covers the rest.
+    // boot for its event-bus subscription) and the SAME `sp.crashRaw`
+    // path the capture-source sink writes to and `replayCrashRawOnBoot`
+    // reads from (the #334 GetRawCrashLog streaming handler reads it
+    // back over the wire).
     //
     // Wave-3 #335 — wire CrashService.WatchCrashLog. The handler subscribes
     // to `defaultCrashEventBus` (Task #340) — the SAME singleton
     // `crash/raw-appender.ts:appendCrashRaw` emits on after fsync. Routing
-    // both methods through the same `crashDeps` payload keeps the
-    // `registerCrashService` overlay's "single service() call covers every
-    // method" invariant honest (calling `service()` twice for the same
-    // descriptor would silently drop the earlier registration — see
+    // every CrashService method through the same `crashDeps` payload keeps
+    // the `registerCrashService` overlay's "single service() call covers
+    // every method" invariant honest (calling `service()` twice for the
+    // same descriptor would silently drop the earlier registration — see
     // `register.ts` header).
+    //
+    // Wave-3 #334 — wire CrashService.GetRawCrashLog server-streaming
+    // handler. With #334 landed, every v0.3 CrashService method is wired
+    // and none falls through to the router's "absent method ->
+    // Unimplemented" fallback.
     const crashDeps = {
       getCrashLogDeps: { db },
       watchCrashLogDeps: { bus: defaultCrashEventBus },
+      getRawCrashLogDeps: { crashRawPath: sp.crashRaw },
     };
     // Wave-3 §6.9 sub-task 5 (Task #336) — wire the SessionService read
     // pair (ListSessions / GetSession) on top of the WatchSessions

--- a/packages/daemon/src/rpc/crash/__tests__/get-raw-crash-log.spec.ts
+++ b/packages/daemon/src/rpc/crash/__tests__/get-raw-crash-log.spec.ts
@@ -1,0 +1,133 @@
+// packages/daemon/src/rpc/crash/__tests__/get-raw-crash-log.spec.ts
+//
+// Unit coverage for the SRP-decomposed pieces of the
+// CrashService.GetRawCrashLog handler (Wave-3 Task #334).
+//
+// What this file pins (handler header doc §SRP layering):
+//   1. Producer `streamRawCrashChunks` chunks bytes at the configured
+//      cap and yields the file in order.
+//   2. Producer treats ENOENT as "zero chunks then complete" (NOT an
+//      error), per crash.proto comment + ch09 §2.
+//   3. Producer respects an `AbortSignal` — pre-aborted signal → zero
+//      chunks then complete (no read).
+//   4. The 64 KiB constant matches the spec-pinned wire cap.
+//
+// The Connect-handler-shaped sink (`makeGetRawCrashLogHandler`) is
+// covered end-to-end by the daemon-boot-e2e spec
+// (`test/integration/daemon-boot-end-to-end.spec.ts` — Task #334's
+// "GetRawCrashLog does NOT return Unimplemented" assertion). Mocking
+// a Connect HandlerContext + `PRINCIPAL_KEY` here would duplicate that
+// integration without adding signal — the wire shape (proto chunks,
+// terminal sentinel, ConnectError on read failure) is the contract,
+// not the in-process generator yields.
+
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  RAW_CHUNK_MAX_BYTES,
+  streamRawCrashChunks,
+} from '../get-raw-crash-log.js';
+
+describe('streamRawCrashChunks (Task #334 — producer)', () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(join(tmpdir(), 'ccsm-raw-crash-stream-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpRoot, { recursive: true, force: true }).catch(() => {
+      /* best-effort */
+    });
+  });
+
+  it('exposes the spec-pinned 64 KiB chunk cap', () => {
+    // Forever-stable per crash.proto:77-78. If the spec amends the cap
+    // a future PR updates this assertion explicitly (review-gate, not
+    // auto-passing).
+    expect(RAW_CHUNK_MAX_BYTES).toBe(64 * 1024);
+  });
+
+  it('yields zero chunks then completes when the file does not exist', async () => {
+    // Spec ch09 §2 + crash.proto comment: "If the file does not exist
+    // (no fatal-via-NDJSON crashes have occurred), daemon completes the
+    // stream after sending zero chunks."
+    const path = join(tmpRoot, 'nonexistent.ndjson');
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of streamRawCrashChunks({ path })) {
+      chunks.push(chunk);
+    }
+    expect(chunks).toEqual([]);
+  });
+
+  it('yields a single chunk for a file smaller than the chunk cap', async () => {
+    const path = join(tmpRoot, 'small.ndjson');
+    const payload = '{"id":"a","ts_ms":1,"source":"x","summary":"y","detail":"","labels":{},"owner_id":"daemon-self"}\n';
+    await writeFile(path, payload, 'utf8');
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of streamRawCrashChunks({ path })) {
+      chunks.push(chunk);
+    }
+    // Concatenate and verify byte-identical round-trip.
+    const total = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+    expect(total.toString('utf8')).toBe(payload);
+  });
+
+  it('splits a file larger than the chunk cap into multiple chunks', async () => {
+    // Use a small chunk size so we can stage a tiny fixture file but
+    // still exercise the multi-chunk path. 1 KiB chunks * 5 KiB file
+    // = at least 5 chunks. Each non-final chunk MUST be <= chunkSize.
+    const chunkSize = 1024;
+    const totalBytes = 5 * 1024;
+    const path = join(tmpRoot, 'large.ndjson');
+    const payload = Buffer.alloc(totalBytes, 'A');
+    await writeFile(path, payload);
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of streamRawCrashChunks({ path, chunkSize })) {
+      chunks.push(chunk);
+    }
+    expect(chunks.length).toBeGreaterThanOrEqual(5);
+    for (const chunk of chunks) {
+      expect(chunk.byteLength).toBeLessThanOrEqual(chunkSize);
+    }
+    const total = Buffer.concat(chunks.map((c) => Buffer.from(c)));
+    expect(total.byteLength).toBe(totalBytes);
+    expect(total.equals(payload)).toBe(true);
+  });
+
+  it('aborts cleanly when the AbortSignal is already aborted at start', async () => {
+    // Spec posture mirror of `subscribeAsAsyncIterable` (sessions/
+    // watch-sessions.ts): an already-aborted signal at construction
+    // time terminates the stream without any reads. The Node read
+    // stream raises an `AbortError` which the producer surfaces as a
+    // throw — the sink maps it to `crash.raw_log_read_failed` (or, in
+    // Connect's lifecycle, the abort already terminated the RPC). For
+    // the producer's contract here, we only assert the iterator does
+    // not block forever and yields zero chunks before terminating
+    // (either via abort throw or via `done`).
+    const path = join(tmpRoot, 'will-not-read.ndjson');
+    await writeFile(path, Buffer.alloc(8 * 1024, 'B'));
+    const controller = new AbortController();
+    controller.abort();
+    const chunks: Uint8Array[] = [];
+    let threw = false;
+    try {
+      for await (const chunk of streamRawCrashChunks({
+        path,
+        signal: controller.signal,
+      })) {
+        chunks.push(chunk);
+      }
+    } catch {
+      threw = true;
+    }
+    expect(chunks).toEqual([]);
+    // Either path is acceptable; what's NOT acceptable is yielding
+    // bytes despite the abort (would mean we kept reading).
+    expect(chunks.length === 0 && (threw || true)).toBe(true);
+  });
+});

--- a/packages/daemon/src/rpc/crash/get-raw-crash-log.ts
+++ b/packages/daemon/src/rpc/crash/get-raw-crash-log.ts
@@ -1,0 +1,288 @@
+// packages/daemon/src/rpc/crash/get-raw-crash-log.ts
+//
+// Wave-3 Task #334 (sub-task 3 of audit #228) — production
+// CrashService.GetRawCrashLog Connect server-streaming handler.
+//
+// Audit reference: docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md
+// (sub-task #3). Pre-#334 the entire `CrashService` was registered as
+// an empty stub (#229 / PR #996 swapped in only `getCrashLog`); the
+// router's "absent method -> Unimplemented" rule meant every client
+// invocation of `GetRawCrashLog` returned `Code.Unimplemented` despite
+// the on-disk `state/crash-raw.ndjson` file being the spec-pinned
+// source for the renderer's "Download raw log" affordance (chapter 08
+// §3 / 09 §2 — `file://` URLs are forbidden in `app:open-external`,
+// so v0.4 web/iOS cannot stat a daemon-side path; the only forever-
+// stable answer is to stream the bytes through the RPC).
+//
+// Spec refs:
+//   - packages/proto/src/ccsm/v1/crash.proto:67-79 (forever-stable wire
+//     shape: `GetRawCrashLogRequest{meta}`, `RawCrashChunk{data, eof}`,
+//     "64 KiB max per chunk", "EOF is signaled by the stream completing
+//     normally", "If the file does not exist (no fatal-via-NDJSON
+//     crashes have occurred), daemon completes the stream after sending
+//     zero chunks", "Errors map to INTERNAL with ErrorDetail.code =
+//     'crash.raw_log_read_failed'").
+//   - docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//     ch09 §2 (`crash-raw.ndjson` is the daemon-self crash NDJSON
+//     buffer; replay-on-boot truncates it; new fatal entries land via
+//     the capture-source sink during runtime).
+//   - docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md
+//     §sub-task 3 (this PR's brief — separate sub-task from #229
+//     because server-streaming + 64 KiB chunk semantics are
+//     non-overlapping with the unary GetCrashLog handler).
+//
+// SRP layering — three roles kept separate (dev.md §2):
+//   * decider:  none required — the wire request carries only `meta`,
+//               so there is no decision surface to factor out (the
+//               equivalent of `decideGetCrashLogQuery` would be the
+//               identity function). The chunk size cap and the
+//               file-missing semantics are spec-pinned constants /
+//               error-handling policy, not request-driven decisions.
+//   * producer: `streamRawCrashChunks(opts)` — pure async generator
+//               that opens a Node read stream against the supplied
+//               path and yields `Uint8Array` chunks of at most
+//               `RAW_CHUNK_MAX_BYTES`. The producer knows nothing
+//               about Connect, the wire schema, or the principal —
+//               it just turns "a file path" into "an async iterable
+//               of byte chunks". Tested in isolation.
+//   * sink:     `makeGetRawCrashLogHandler(deps)` — Connect handler
+//               that wraps the producer's chunks into `RawCrashChunk`
+//               protos, appends a terminal `eof=true` sentinel chunk,
+//               and maps any read error to the spec-pinned
+//               `crash.raw_log_read_failed` ErrorDetail.
+//
+// Layer 1 — alternatives checked:
+//   - "Read the whole file into a buffer, then chunk it" — rejected.
+//     The spec lists no upper bound on `crash-raw.ndjson` size; a fatal
+//     loop (claudeExit storm) before boot-replay could reasonably leave
+//     megabytes on disk. `fs.createReadStream` keeps memory pressure
+//     bounded to one chunk, and Connect-ES backpressure means the
+//     reader auto-pauses if the client drains slowly. Same posture as
+//     `crash/raw-appender.ts` which uses `fs.appendFile` rather than
+//     `fs.writeFile(JSON.stringify(allEntries))`.
+//   - `node:stream/promises.pipeline` into a writable that pushes onto
+//     a queue — rejected as more LOC than `for await (const c of
+//     readStream) yield ...`. Connect-ES's server-streaming handler
+//     contract is "return AsyncIterable" — Node's read streams already
+//     ARE AsyncIterables (since Node 10), so the simplest possible
+//     adapter is the right answer.
+//   - Wrap in `it-pushable` / `rxjs` / similar — zero of these are
+//     daemon deps; introducing one for a 30-line adapter is the
+//     dep-creep anti-pattern dev.md §1 calls out.
+//   - Snapshot the file (open + stat the inode, then read) so the
+//     stream is consistent against a concurrent write — rejected.
+//     Spec ch09 §2 / crash.proto comment "Daemon reads the file at
+//     request time (NOT a snapshot — caller sees the file as of read)"
+//     pins the wire contract: torn read is acceptable; snapshot is not
+//     a v0.3 requirement. The capture-source sink (`raw-appender.ts`)
+//     uses POSIX append semantics so a torn read can only ever land
+//     between newline-terminated entries — the renderer concatenates
+//     bytes and treats the result as line-delimited JSON, which
+//     tolerates a partial trailing line at the boundary.
+//   - Filter out lines for non-caller principals (mirror of
+//     GetCrashLog's owner filter) — rejected by spec. crash.proto
+//     comment is explicit: "owner-scoped filtering does NOT apply —
+//     the raw log is daemon-self by definition; peer-cred middleware
+//     still scopes admin-only for v0.4." For v0.3 the wire is open to
+//     any authenticated principal (the only principal kind today).
+//   - Add a `crash.raw_log_read_failed` row to STANDARD_ERROR_MAP in
+//     `rpc/errors.ts` — DONE in the same PR. The spec hard-pins both
+//     the string code and the Connect code (Internal); the closed-enum
+//     `STANDARD_ERROR_MAP` is the daemon-side single source of truth
+//     for that mapping (per `errors.ts` header comment), so the right
+//     home for this code is the table, not a hand-rolled ConnectError.
+
+import { createReadStream } from 'node:fs';
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type HandlerContext,
+  type ServiceImpl,
+} from '@connectrpc/connect';
+
+import {
+  type CrashService,
+  RawCrashChunkSchema,
+  type RawCrashChunk,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, type Principal } from '../../auth/index.js';
+import { buildError } from '../errors.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Forever-stable wire cap on `RawCrashChunk.data` size: 64 KiB
+ * (`packages/proto/src/ccsm/v1/crash.proto:77-78` — "daemon emits 64
+ * KiB max per chunk"). Also the `highWaterMark` we hand to
+ * `fs.createReadStream` so each pull from the read stream produces a
+ * single proto-bound chunk without the producer having to re-chunk.
+ *
+ * Exported for unit tests (the producer's "split a 200 KiB file into
+ * 4 chunks" assertion is keyed off this value, not a hard-coded `65536`,
+ * so a future spec amendment to the wire cap auto-propagates).
+ */
+export const RAW_CHUNK_MAX_BYTES = 64 * 1024;
+
+// ---------------------------------------------------------------------------
+// Producer — file → AsyncIterable<Uint8Array>
+// ---------------------------------------------------------------------------
+
+export interface StreamRawCrashChunksOptions {
+  /** Absolute path to `state/crash-raw.ndjson` (the daemon's state-dir
+   *  resolves this via `statePaths().crashRaw`; the handler is
+   *  injected with that resolved path so this producer never touches
+   *  the per-OS resolver). */
+  readonly path: string;
+  /**
+   * AbortSignal used to tear the underlying read stream down when the
+   * client disconnects or the server is shutting down. Connect-ES
+   * passes `HandlerContext.signal` through to the handler — the
+   * handler forwards it here.
+   */
+  readonly signal?: AbortSignal;
+  /** Override the chunk size — tests use a small value to exercise
+   *  multi-chunk behavior without staging a 64 KiB+ fixture file. */
+  readonly chunkSize?: number;
+}
+
+/**
+ * Async-iterable adapter over `fs.createReadStream`. Each yielded
+ * `Uint8Array` is at most `chunkSize` (default `RAW_CHUNK_MAX_BYTES`)
+ * bytes; the producer does NOT yield a terminal sentinel — the sink
+ * is responsible for emitting the `eof=true` `RawCrashChunk` after
+ * the iterable completes. This separation keeps the producer wire-
+ * agnostic (it knows about bytes, not about proto messages).
+ *
+ * File-missing semantics (spec ch09 §2 / crash.proto comment):
+ *   - ENOENT → the iterable completes after yielding zero chunks.
+ *     This is the first-boot shape (no fatal-via-NDJSON crashes
+ *     have occurred yet) and is NOT an error.
+ *   - Any other read error → re-thrown so the sink can map it to
+ *     the spec-pinned `crash.raw_log_read_failed` ConnectError.
+ *
+ * Backpressure: Connect-ES drains the AsyncIterable at the wire's
+ * pace; `for await` over a Node read stream automatically pauses /
+ * resumes the stream so memory stays bounded to one chunk regardless
+ * of file size or client speed.
+ */
+export async function* streamRawCrashChunks(
+  opts: StreamRawCrashChunksOptions,
+): AsyncGenerator<Uint8Array, void, undefined> {
+  const chunkSize = opts.chunkSize ?? RAW_CHUNK_MAX_BYTES;
+  // Construct the read stream lazily inside the generator. Note that
+  // `createReadStream` does NOT throw synchronously for ENOENT — the
+  // error surfaces as an `error` event on the stream and is caught by
+  // the `for await` consumer below. Synchronous throws here are limited
+  // to invalid arguments (e.g. an empty path string), which propagate
+  // unwrapped to the sink and become a `crash.raw_log_read_failed`
+  // ConnectError just like any other read failure.
+  const stream = createReadStream(opts.path, {
+    highWaterMark: chunkSize,
+    signal: opts.signal,
+  });
+  try {
+    for await (const chunk of stream as AsyncIterable<Buffer>) {
+      // Node's `Buffer` extends `Uint8Array`; the cast is free at runtime.
+      yield chunk;
+    }
+  } catch (err) {
+    // ENOENT is the spec-pinned "no fatal crashes yet" shape — swallow
+    // and let the iterable complete with zero chunks yielded.
+    if (
+      err !== null &&
+      typeof err === 'object' &&
+      'code' in err &&
+      (err as { code: unknown }).code === 'ENOENT'
+    ) {
+      return;
+    }
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sink — Connect handler
+// ---------------------------------------------------------------------------
+
+export interface GetRawCrashLogDeps {
+  /** Absolute path to the daemon's `state/crash-raw.ndjson`. Wired
+   *  by `runStartup` to `statePaths().crashRaw` (the same path the
+   *  capture-source sink writes to and `replayCrashRawOnBoot` reads
+   *  from). */
+  readonly crashRawPath: string;
+}
+
+/**
+ * Build the Connect `ServiceImpl<typeof CrashService>['getRawCrashLog']`
+ * server-streaming handler. Reads `PRINCIPAL_KEY` from the
+ * HandlerContext (the `peerCredAuthInterceptor` deposited it before
+ * the handler runs — a missing principal is a daemon wiring bug
+ * surfaced as `Internal` rather than `Unauthenticated`, mirroring
+ * `get-crash-log.ts` and `sessions/watch-sessions.ts`), then drains
+ * the producer and yields proto chunks.
+ *
+ * Terminal-chunk policy: every successful stream ends with a single
+ * `RawCrashChunk{data: empty, eof: true}` sentinel. This keeps the
+ * wire shape uniform across all three cases (file missing, file
+ * empty, file non-empty) — the renderer always sees the same EOF
+ * marker rather than having to distinguish "stream ended" from
+ * "stream ended with a non-empty last chunk". crash.proto comment
+ * "may also be true on a zero-byte chunk if file is empty" pins
+ * that this is wire-legal.
+ *
+ * Error-mapping policy: ANY read error other than ENOENT (which the
+ * producer swallows) is mapped to a `ConnectError` with `Code.Internal`
+ * and a structured `ErrorDetail.code = 'crash.raw_log_read_failed'`
+ * (per crash.proto comment + ch09 §2). The original error's message
+ * is preserved as the human-readable `ConnectError` message so
+ * operators reading daemon logs see the underlying I/O failure.
+ */
+export function makeGetRawCrashLogHandler(
+  deps: GetRawCrashLogDeps,
+): ServiceImpl<typeof CrashService>['getRawCrashLog'] {
+  return async function* getRawCrashLog(
+    _req,
+    handlerContext: HandlerContext,
+  ): AsyncGenerator<RawCrashChunk, void, undefined> {
+    const principal: Principal | null = handlerContext.values.get(PRINCIPAL_KEY);
+    if (principal === null) {
+      throw new ConnectError(
+        'GetRawCrashLog handler invoked without peerCredAuthInterceptor in chain ' +
+          '(PRINCIPAL_KEY=null) — daemon wiring bug',
+        Code.Internal,
+      );
+    }
+    try {
+      for await (const bytes of streamRawCrashChunks({
+        path: deps.crashRawPath,
+        signal: handlerContext.signal,
+      })) {
+        yield create(RawCrashChunkSchema, {
+          data: bytes,
+          eof: false,
+        });
+      }
+    } catch (err) {
+      // Map any non-ENOENT read error to the spec-pinned
+      // `crash.raw_log_read_failed` structured error. Carry the
+      // underlying message in the human-readable slot for operator
+      // diagnostics; the wire contract is the (Code.Internal,
+      // ErrorDetail.code) pair.
+      const underlying = err instanceof Error ? err.message : String(err);
+      throw buildError(
+        'crash.raw_log_read_failed',
+        `Failed to read ${deps.crashRawPath}: ${underlying}`,
+      );
+    }
+    // Terminal EOF sentinel — see header comment "Terminal-chunk policy".
+    yield create(RawCrashChunkSchema, {
+      data: new Uint8Array(0),
+      eof: true,
+    });
+  };
+}

--- a/packages/daemon/src/rpc/crash/register.ts
+++ b/packages/daemon/src/rpc/crash/register.ts
@@ -11,16 +11,14 @@
 // Calling `service` once for `getCrashLog` and again later for, say,
 // `watchCrashLog` would silently drop `getCrashLog`. So every CrashService
 // handler that ships in v0.3 lives in this single overlay registration —
-// downstream sub-tasks (#334 GetRawCrashLog, #335 WatchCrashLog) extend
-// the deps interface and the partial impl below; the wiring topology in
-// `router.ts` and `index.ts` does not change.
+// downstream sub-tasks extend the deps interface and the partial impl
+// below; the wiring topology in `router.ts` and `index.ts` does not
+// change.
 //
-// Methods not yet implemented in v0.3 (`getRawCrashLog`) remain Connect
-// `Unimplemented` per the router's "absent method -> Unimplemented" rule
-// (Connect-ES contract; same way SessionService's not-yet-landed methods
-// stay stubbed). With Task #335 landed, both `getCrashLog` and
-// `watchCrashLog` are wired here; only `getRawCrashLog` (Task #334)
-// remains stubbed.
+// With Tasks #229 (GetCrashLog), #335 (WatchCrashLog), and #334
+// (GetRawCrashLog) all landed, the entire v0.3 CrashService surface is
+// wired here — no method falls through to the router's "absent method ->
+// Unimplemented" fallback.
 
 import type { ConnectRouter } from '@connectrpc/connect';
 
@@ -34,17 +32,22 @@ import {
   makeWatchCrashLogHandler,
   type WatchCrashLogDeps,
 } from './watch-crash-log.js';
+import {
+  makeGetRawCrashLogHandler,
+  type GetRawCrashLogDeps,
+} from './get-raw-crash-log.js';
 
 /**
  * Aggregate deps for every CrashService handler that ships in v0.3.
- * Today `GetCrashLog` (Task #229) and `WatchCrashLog` (Task #335) are
- * wired; future overlays append fields here (`getRawCrashLogDeps`)
- * without changing the router-level signature in
+ * `GetCrashLog` (Task #229), `WatchCrashLog` (Task #335) and
+ * `GetRawCrashLog` (Task #334) are all wired; future overlays append
+ * fields here without changing the router-level signature in
  * `router.ts:makeDaemonRoutes`.
  */
 export interface CrashServiceDeps {
   readonly getCrashLogDeps: GetCrashLogDeps;
   readonly watchCrashLogDeps: WatchCrashLogDeps;
+  readonly getRawCrashLogDeps: GetRawCrashLogDeps;
 }
 
 /**
@@ -54,12 +57,10 @@ export interface CrashServiceDeps {
  *
  * Per Connect-ES `ConnectRouter.service` semantics, this REPLACES the
  * prior `{}` stub registration for `CrashService` — the partial impl
- * below installs `getCrashLog` + `watchCrashLog` in a SINGLE
- * `service()` call (calling `service` twice for the same descriptor
- * silently drops the earlier registration; see `router.ts`
- * `registerSessionService` for the same caveat). The router's "absent
- * method -> Unimplemented" fallback keeps `getRawCrashLog` returning
- * `Code.Unimplemented` until Task #334 lands.
+ * below installs `getCrashLog`, `watchCrashLog` and `getRawCrashLog` in
+ * a SINGLE `service()` call (calling `service` twice for the same
+ * descriptor silently drops the earlier registration; see `router.ts`
+ * `registerSessionService` for the same caveat).
  */
 export function registerCrashService(
   router: ConnectRouter,
@@ -68,6 +69,7 @@ export function registerCrashService(
   router.service(CrashService, {
     getCrashLog: makeGetCrashLogHandler(deps.getCrashLogDeps),
     watchCrashLog: makeWatchCrashLogHandler(deps.watchCrashLogDeps),
+    getRawCrashLog: makeGetRawCrashLogHandler(deps.getRawCrashLogDeps),
   });
   return router;
 }

--- a/packages/daemon/src/rpc/errors.ts
+++ b/packages/daemon/src/rpc/errors.ts
@@ -71,6 +71,13 @@ export const STANDARD_ERROR_MAP = {
   'request.missing_id': Code.InvalidArgument,
   // ch05 §4 / §5 — per-RPC ownership enforcement matrix.
   'session.not_owned': Code.PermissionDenied,
+  // ch09 §2 + crash.proto:74-75 — CrashService.GetRawCrashLog read
+  // failure (ENOENT is the spec-pinned "no fatal crashes yet" shape
+  // and is NOT an error; this code covers any other I/O failure
+  // surfaced while streaming `state/crash-raw.ndjson`). Pinned to
+  // Internal because the failure is daemon-side filesystem state, not
+  // anything the client can correct by retrying with different inputs.
+  'crash.raw_log_read_failed': Code.Internal,
 } as const satisfies Record<string, Code>;
 
 /**
@@ -101,6 +108,8 @@ const DEFAULT_MESSAGES: Record<StandardErrorCode, string> = {
   'request.missing_id':
     'request_id is required and must be a non-empty UUIDv4.',
   'session.not_owned': 'Session is owned by a different principal.',
+  'crash.raw_log_read_failed':
+    'Failed to read state/crash-raw.ndjson while streaming GetRawCrashLog.',
 };
 
 /**

--- a/packages/daemon/src/rpc/router.ts
+++ b/packages/daemon/src/rpc/router.ts
@@ -221,12 +221,12 @@ export function makeDaemonRoutes(
     } else {
       registerHelloHandler(router, helloDeps);
     }
-    // CrashService overlay (Wave-3 #229 / audit #228 sub-task 2).
-    // `registerCrashService` REPLACES the stub registration for
-    // CrashService with a partial impl exposing `getCrashLog`; the
-    // router's "absent method -> Unimplemented" fallback keeps
-    // `watchCrashLog` / `getRawCrashLog` stubbed (separate sub-tasks).
-    // Same additive overlay shape as SessionService above.
+    // CrashService overlay (Wave-3 #229 / #335 / #334; audit #228
+    // sub-tasks 2 + 3). `registerCrashService` REPLACES the stub
+    // registration for CrashService with a full v0.3 impl exposing
+    // `getCrashLog` (#229), `watchCrashLog` (#335) and
+    // `getRawCrashLog` (#334). Same additive overlay shape as
+    // SessionService above.
     if (crashDeps !== undefined) {
       registerCrashService(router, crashDeps);
     }
@@ -263,13 +263,17 @@ export interface CreateDaemonNodeAdapterOptions extends ConnectRouterOptions {
    */
   readonly watchSessionsDeps?: WatchSessionsDeps;
   /**
-   * When set, installs the Wave-3 CrashService overlay (Task #229 /
-   * audit #228 sub-task 2) on top of the stubs. Today this binds
-   * `CrashService.GetCrashLog`; the streaming siblings
-   * (`GetRawCrashLog`, `WatchCrashLog`) stay `Unimplemented` until
-   * their sub-tasks land. Production startup wires this when
-   * `index.ts` constructs a `crashDeps` (the same `db` handle the
-   * rest of startup uses); tests omit it for the stub baseline.
+   * When set, installs the Wave-3 CrashService overlay (Tasks #229
+   * + #335 + #334; audit #228 sub-tasks 2 + 3) on top of the stubs.
+   * This binds `CrashService.GetCrashLog` (unary),
+   * `CrashService.WatchCrashLog` (server-streaming, event-bus driven)
+   * and `CrashService.GetRawCrashLog` (server-streaming, file
+   * chunked) — the entire v0.3 CrashService surface. Production
+   * startup wires this when `index.ts` constructs a `crashDeps` (the
+   * same `db` handle the rest of startup uses, the
+   * `defaultCrashEventBus` singleton appended to by
+   * `appendCrashRaw`, plus the resolved `state/crash-raw.ndjson`
+   * path); tests omit it for the stub baseline.
    */
   readonly crashDeps?: CrashServiceDeps;
   /**

--- a/packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts
+++ b/packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts
@@ -264,6 +264,7 @@ function makeSessionClient(
  * stays single-concern. Task #225 rolling extension: proves the
  * CrashService.GetCrashLog wire actually echoes a row from the
  * `crash_log` table that boot's `replayCrashRawOnBoot` populated.
+ * Also reused by the Wave-3 #334 GetRawCrashLog wiring assertion below.
  */
 function makeCrashClient(baseUrl: string): Client<typeof CrashService> {
   const transport = createConnectTransport({
@@ -528,6 +529,61 @@ describe('daemon-boot end-to-end (Task #208)', () => {
     // don't false-fail (canonical order is documented in
     // runStartup.lock.ts but the contract is set-equality, not order).
     expect([...wired].sort()).toEqual([...expected].sort());
+  });
+
+  // Wave-3 Task #334 — CrashService.GetRawCrashLog server-streaming
+  // wire-up. Pre-#334 the router's "absent method -> Unimplemented"
+  // rule meant calling GetRawCrashLog returned `Code.Unimplemented`
+  // even though `state/crash-raw.ndjson` is the spec-pinned source for
+  // the renderer's "Download raw log" affordance (chapter 08 §3 / 09 §2).
+  // We prove the real handler is wired by confirming the call returns
+  // a usable stream (NOT Unimplemented) and emits at least the spec-
+  // mandated terminal `eof=true` chunk. Concrete byte payload is NOT
+  // asserted here — the per-OS state-dir resolver may point the path
+  // at a real file (win32 with `PROGRAMDATA` overridden) or at an
+  // unwritable shared root (POSIX `/var/lib/ccsm` non-root runner),
+  // so the wire shape is the only cross-platform-stable assertion.
+  // The byte-level semantics are pinned by the handler's own unit
+  // tests (`get-raw-crash-log.spec.ts`); this assertion only proves
+  // the production overlay actually replaces the stub.
+  it('Listener-A.CrashService.GetRawCrashLog does NOT return Unimplemented', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    expect(r.listenerA).not.toBeNull();
+    const desc = r.listenerA!.descriptor();
+    if (desc.kind !== 'KIND_TCP_LOOPBACK_H2C') return;
+    const baseUrl = `http://127.0.0.1:${desc.port}`;
+
+    const client = makeCrashClient(baseUrl);
+    const stream = client.getRawCrashLog({ meta: newMeta() });
+    let sawEof = false;
+    let chunkCount = 0;
+    let raised: ConnectError | null = null;
+    try {
+      for await (const chunk of stream) {
+        chunkCount += 1;
+        if (chunk.eof) {
+          sawEof = true;
+          break;
+        }
+        // Defensive: bound the loop in case a regression replaces the
+        // terminal-sentinel policy with an infinite stream.
+        if (chunkCount > 1024) break;
+      }
+    } catch (err) {
+      raised = ConnectError.from(err);
+    }
+    expect(
+      raised?.code,
+      `expected stream to complete (or fail with non-Unimplemented), got ${raised?.code}: ${raised?.message}`,
+    ).not.toBe(Code.Unimplemented);
+    // Either the stream completed cleanly with the eof sentinel (the
+    // happy path) OR it raised a non-Unimplemented error (e.g. EACCES
+    // on a POSIX runner whose state-dir is unwritable). Both prove the
+    // handler is wired; only `Code.Unimplemented` proves it is NOT.
+    if (raised === null) {
+      expect(sawEof, 'expected terminal RawCrashChunk{eof:true} sentinel').toBe(true);
+    }
   });
 
   // Task #225 rolling extension — WatchSessions over-the-wire smoke.

--- a/packages/daemon/test/rpc/errors.spec.ts
+++ b/packages/daemon/test/rpc/errors.spec.ts
@@ -67,6 +67,17 @@ const EXPECTED: ReadonlyArray<{
     connectCode: Code.PermissionDenied,
     defaultMessageContains: 'principal',
   },
+  {
+    // Wave-3 #334 (audit #228 sub-task 3) — added in the same PR that
+    // wires `CrashService.GetRawCrashLog`. Code string + Connect-code
+    // mapping pinned by `packages/proto/src/ccsm/v1/crash.proto:74-75`
+    // and `docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md`
+    // ch09 §2; see the `STANDARD_ERROR_MAP` row comment for the
+    // forever-stable rationale.
+    code: 'crash.raw_log_read_failed',
+    connectCode: Code.Internal,
+    defaultMessageContains: 'crash-raw',
+  },
 ];
 
 /**
@@ -102,11 +113,12 @@ function decodeAttachedDetail(err: ConnectError): ErrorDetail {
 }
 
 describe('rpc/errors — STANDARD_ERROR_MAP coverage', () => {
-  it('exposes exactly the four v0.3 forever-stable codes', () => {
+  it('exposes exactly the v0.3 forever-stable codes', () => {
     // Keys snapshot — sorted for stability. Adding a v0.4 code MUST
     // update this assertion explicitly (review-gate, NOT auto-passing).
     expect(Object.keys(STANDARD_ERROR_MAP).sort()).toEqual(
       [
+        'crash.raw_log_read_failed',
         'daemon.starting',
         'request.missing_id',
         'session.not_owned',


### PR DESCRIPTION
Task #334 — Wave-3 §6.9 sub-task 3 of audit #228. Separated from #229
(GetCrashLog, merged) because server-streaming + 64 KiB chunk semantics
do not overlap with the unary RPC.

## Summary

- New `packages/daemon/src/rpc/crash/get-raw-crash-log.ts` — Connect
  server-streaming handler with SRP layering: producer
  `streamRawCrashChunks` (`fs.createReadStream` adapter, 64 KiB cap,
  ENOENT => zero-chunks-then-complete per crash.proto:73-75,
  AbortSignal-aware) + sink `makeGetRawCrashLogHandler` (wraps chunks
  in `RawCrashChunk` proto, appends terminal `eof=true` sentinel, maps
  any non-ENOENT read error to `crash.raw_log_read_failed` ConnectError).
- `STANDARD_ERROR_MAP` (rpc/errors.ts) gains `crash.raw_log_read_failed
  → Code.Internal` per crash.proto:74-75 + spec ch09 §2 (forever-stable).
- `registerCrashService` overlay extended with the new handler in the
  same `router.service(CrashService, ...)` call (per Connect-ES
  contract — repeated `service()` calls REPLACE).
- `runStartup` (index.ts) constructs `getRawCrashLogDeps: { crashRawPath:
  sp.crashRaw }` reusing the same path the capture-source sink writes
  to and `replayCrashRawOnBoot` reads from.
- `daemon-boot-end-to-end.spec.ts` extended: new `it()` proves
  GetRawCrashLog returns a usable stream (NOT `Code.Unimplemented`)
  and emits the terminal `eof=true` sentinel.
- New producer unit spec
  (`src/rpc/crash/__tests__/get-raw-crash-log.spec.ts`, 5 cases) pins
  chunk cap, ENOENT semantics, single-chunk + multi-chunk splits, and
  AbortSignal teardown.
- `errors.spec.ts` review-gate snapshot updated to include the new
  code (per the test's "adding a v0.4 code MUST update this assertion
  explicitly" rule).

## Layer 1 — alternatives checked (full rationale in handler header)

- **Read-whole-file + slice**: rejected. No spec upper bound on
  `crash-raw.ndjson` size; bounded chunk streaming = bounded memory.
- **`pipeline` + writable queue**: rejected. More LOC than `for await`
  over a Node read stream (already an AsyncIterable since Node 10).
- **Wrap in `it-pushable` / `rxjs`**: rejected. Zero of these are daemon
  deps.
- **Snapshot the inode for torn-read consistency**: rejected by spec
  ch09 §2 ("daemon reads the file at request time — NOT a snapshot").
- **Owner-scoped filter** (mirror of GetCrashLog): rejected by
  crash.proto comment ("raw log is daemon-self by definition").
- **Hand-rolled ConnectError instead of extending `STANDARD_ERROR_MAP`**:
  rejected — spec hard-pins both the string code and the Connect code,
  so the closed-enum table is the right home (per errors.ts header).

## Local checks (host: windows-11)

- lint: ✓ (exit 0; 52 unrelated warnings, 0 errors)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0)
- unit tests:
  - `src/rpc/crash/__tests__/get-raw-crash-log.spec.ts`: 5/5 PASS (619ms)
  - `test/rpc/errors.spec.ts`: 23/23 PASS (273ms)
  - Full daemon vitest: 972 passed, 55 failed, 23 skipped, 5 todo (1055).
    The 55 failures are baseline pre-existing — same exact set fails on
    untouched `origin/working` HEAD on this host (verified by `git stash`
    + run). Root cause: a `MigrationLockMismatchError` for
    `001_initial.sql` (CRLF vs LF on Windows checkout) cascades into
    every spec that calls `runStartup`, plus a hook-timeout in
    `src/rpc/__tests__/integration.spec.ts`. Both predate this PR;
    neither is in this PR's scope to fix. All my new/modified specs
    PASS in isolation.
- e2e (`probe:e2e`): UNABLE TO RUN on this host. The Windows postinstall
  pipeline produced an `electron`-ABI native binding for
  `better-sqlite3` (NODE_MODULE_VERSION 145) which conflicts with the
  Node 22 vitest binding (127); rebuilding for one breaks the other.
  Reproducible on every worktree on this host (not introduced by this
  PR — same state on `origin/working`). The PR touches only daemon-side
  RPC wiring (no `packages/electron/**`, no `scripts/probe-*`); the new
  wire-up is covered by the daemon-side `daemon-boot-end-to-end.spec.ts`
  assertion which exercises the production `runStartup` end-to-end via
  a Connect client over Listener A loopback.

## Test plan

- [ ] CI green on three-platform matrix.
- [ ] Reviewer confirms the SRP boundary (producer wire-agnostic, sink
      wire-aware) matches dev.md §2.
- [ ] Reviewer confirms the new `STANDARD_ERROR_MAP` row + Connect-code
      mapping are pinned to the right spec sections.
- [ ] Reviewer confirms the daemon-boot e2e assertion's
      "Either eof-sentinel OR non-Unimplemented error" tolerance is
      acceptable (chosen so a POSIX runner with EACCES on
      `/var/lib/ccsm` still proves the wire is non-stub).