### PR TITLE
T4.9(#50): pty-host delta accumulator (raw VT, 16ms / 16 KiB)

### DIFF
--- a/packages/daemon/src/pty/__tests__/segmentation.spec.ts
+++ b/packages/daemon/src/pty/__tests__/segmentation.spec.ts
@@ -1,0 +1,392 @@
+// Unit tests for the per-session pty delta accumulator (T4.9, ch06 §3).
+//
+// Drives the accumulator with an injected fake clock + fake timer so the
+// 16 ms / 16 KiB segmentation invariants can be asserted deterministically
+// without sleeping or spawning a real pty.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DeltaAccumulator,
+  PTY_CADENCE,
+  SEGMENTATION_BYTE_CAP,
+  SEGMENTATION_TIMEOUT_MS,
+  K_TIME_MS,
+  M_DELTAS,
+  B_BYTES,
+  type Clock,
+  type PtyDeltaPayload,
+  type TimerOps,
+} from '../segmentation.js';
+
+interface PendingTimer {
+  cb: () => void;
+  fireAtMs: number;
+  cleared: boolean;
+}
+
+function makeFakeEnv(startMs = 1_000_000): {
+  clock: Clock;
+  timer: TimerOps;
+  advance: (ms: number) => void;
+  pending: () => PendingTimer | null;
+} {
+  let nowMs = startMs;
+  let pending: PendingTimer | null = null;
+
+  const clock: Clock = () => nowMs;
+  const timer: TimerOps = {
+    setTimer(cb, delayMs) {
+      // Spec invariant: at most one pending timer per accumulator. The
+      // accumulator clears the previous handle before arming a new one,
+      // so observing two simultaneous timers in this fake would be a bug
+      // we WANT to catch.
+      if (pending !== null && !pending.cleared) {
+        throw new Error(
+          `fake timer: setTimer called while a previous timer (fireAt=${pending.fireAtMs}) is still pending`,
+        );
+      }
+      const t: PendingTimer = { cb, fireAtMs: nowMs + delayMs, cleared: false };
+      pending = t;
+      return t;
+    },
+    clearTimer(h) {
+      const t = h as PendingTimer;
+      t.cleared = true;
+      if (pending === t) pending = null;
+    },
+  };
+
+  function advance(ms: number): void {
+    nowMs += ms;
+    // Fire the pending timer if its deadline has passed.
+    while (pending !== null && pending.fireAtMs <= nowMs && !pending.cleared) {
+      const t = pending;
+      pending = null;
+      t.cb();
+    }
+  }
+
+  return {
+    clock,
+    timer,
+    advance,
+    pending: () => pending,
+  };
+}
+
+function bytes(...values: number[]): Uint8Array {
+  return Uint8Array.from(values);
+}
+
+describe('cadence constants', () => {
+  it('exports the spec ch06 values', () => {
+    expect(SEGMENTATION_TIMEOUT_MS).toBe(16);
+    expect(SEGMENTATION_BYTE_CAP).toBe(16384);
+    expect(K_TIME_MS).toBe(30_000);
+    expect(M_DELTAS).toBe(256);
+    expect(B_BYTES).toBe(1024 * 1024);
+    expect(PTY_CADENCE.SEGMENTATION_TIMEOUT_MS).toBe(SEGMENTATION_TIMEOUT_MS);
+    expect(PTY_CADENCE.SEGMENTATION_BYTE_CAP).toBe(SEGMENTATION_BYTE_CAP);
+    expect(PTY_CADENCE.K_TIME_MS).toBe(K_TIME_MS);
+    expect(PTY_CADENCE.M_DELTAS).toBe(M_DELTAS);
+    expect(PTY_CADENCE.B_BYTES).toBe(B_BYTES);
+  });
+
+  it('PTY_CADENCE is frozen', () => {
+    expect(Object.isFrozen(PTY_CADENCE)).toBe(true);
+  });
+});
+
+describe('DeltaAccumulator — empty / no-op behavior', () => {
+  it('zero-byte push emits nothing and arms no timer', () => {
+    const env = makeFakeEnv();
+    const out: PtyDeltaPayload[] = [];
+    const acc = new DeltaAccumulator({
+      onDelta: (d) => out.push(d),
+      now: env.clock,
+      timer: env.timer,
+    });
+
+    acc.push(new Uint8Array(0));
+
+    expect(out).toEqual([]);
+    expect(env.pending()).toBeNull();
+    expect(acc.bufferedBytes()).toBe(0);
+  });
+
+  it('flushNow on empty buffer is a no-op', () => {
+    const env = makeFakeEnv();
+    const out: PtyDeltaPayload[] = [];
+    const acc = new DeltaAccumulator({
+      onDelta: (d) => out.push(d),
+      now: env.clock,
+      timer: env.timer,
+    });
+    acc.flushNow();
+    expect(out).toEqual([]);
+  });
+});
+
+describe('DeltaAccumulator — 16 ms timeout boundary', () => {
+  it('arms a 16 ms timer on the first byte and flushes when it fires', () => {
+    const env = makeFakeEnv(1_000_000);
+    const out: PtyDeltaPayload[] = [];
+    const acc = new DeltaAccumulator({
+      onDelta: (d) => out.push(d),
+      now: env.clock,
+      timer: env.timer,
+    });
+
+    acc.push(bytes(0x68, 0x69)); // 'hi'
+
+    // Timer must be armed at exactly +16ms and no delta yet.
+    expect(env.pending()).not.toBeNull();
+    expect(env.pending()!.fireAtMs).toBe(1_000_000 + SEGMENTATION_TIMEOUT_MS);
+    expect(out).toEqual([]);
+
+    // Advance just-under and ensure no flush.
+    env.advance(SEGMENTATION_TIMEOUT_MS - 1);
+    expect(out).toEqual([]);
+
+    // Cross the deadline; flush must happen.
+    env.advance(1);
+    expect(out.length).toBe(1);
+    expect(out[0].seq).toBe(1);
+    expect(out[0].payload).toEqual(bytes(0x68, 0x69));
+    // tsMs is the wall-clock at the FIRST byte (not the flush time) so
+    // T4.10's correlation with K_TIME aligns to byte arrival, not flush.
+    expect(out[0].tsMs).toBe(1_000_000);
+  });
+
+  it('multiple pushes inside the same window coalesce into one delta', () => {
+    const env = makeFakeEnv();
+    const out: PtyDeltaPayload[] = [];
+    const acc = new DeltaAccumulator({
+      onDelta: (d) => out.push(d),
+      now: env.clock,
+      timer: env.timer,
+    });
+
+    acc.push(bytes(0x41));
+    env.advance(5);
+    acc.push(bytes(0x42, 0x43));
+    env.advance(5);
+    acc.push(bytes(0x44));
+
+    expect(out).toEqual([]);
+    expect(acc.bufferedBytes()).toBe(4);
+
+    env.advance(SEGMENTATION_TIMEOUT_MS); // crosses 16 ms from FIRST byte
+    expect(out.length).toBe(1);
+    expect(out[0].seq).toBe(1);
+    expect(out[0].payload).toEqual(bytes(0x41, 0x42, 0x43, 0x44));
+  });
+
+  it('starts a new timer for each fresh segment', () => {
+    const env = makeFakeEnv(2_000_000);
+    const out: PtyDeltaPayload[] = [];
+    const acc = new DeltaAccumulator({
+      onDelta: (d) => out.push(d),
+      now: env.clock,
+      timer: env.timer,
+    });
+
+    acc.push(bytes(1));
+    env.advance(SEGMENTATION_TIMEOUT_MS);
+    expect(out.length).toBe(1);
+    expect(env.pending()).toBeNull();
+
+    // Second segment, second timer arming.
+    acc.push(bytes(2, 3));
+    expect(env.pending()).not.toBeNull();
+    env.advance(SEGMENTATION_TIMEOUT_MS);
+    expect(out.length).toBe(2);
+    expect(out[1].seq).toBe(2);
+    expect(out[1].payload).toEqual(bytes(2, 3));
+  });
+});
+
+describe('DeltaAccumulator — 16 KiB byte cap', () => {
+  it('flushes synchronously when a single push exactly fills the cap', () => {
+    const env = makeFakeEnv();
+    const out: PtyDeltaPayload[] = [];
+    const acc = new DeltaAccumulator({
+      onDelta: (d) => out.push(d),
+      now: env.clock,
+      timer: env.timer,
+    });
+
+    const buf = new Uint8Array(SEGMENTATION_BYTE_CAP).fill(0x58); // 'X'
+    acc.push(buf);
+
+    expect(out.length).toBe(1);
+    expect(out[0].payload.length).toBe(SEGMENTATION_BYTE_CAP);
+    expect(out[0].seq).toBe(1);
+    // No timer pending — the buffer is empty after the synchronous flush.
+    expect(env.pending()).toBeNull();
+    expect(acc.bufferedBytes()).toBe(0);
+  });
+
+  it('splits an oversized push into back-to-back full-cap deltas + tail', () => {
+    const env = makeFakeEnv(5_000_000);
+    const out: PtyDeltaPayload[] = [];
+    const acc = new DeltaAccumulator({
+      onDelta: (d) => out.push(d),
+      now: env.clock,
+      timer: env.timer,
+    });
+
+    // 50_000 bytes ≈ 3 full caps + 768-byte tail.
+    const big = new Uint8Array(50_000);
+    for (let i = 0; i < big.length; i++) big[i] = i & 0xff;
+    acc.push(big);
+
+    // Three full-cap deltas should have flushed synchronously.
+    expect(out.length).toBe(3);
+    expect(out[0].payload.length).toBe(SEGMENTATION_BYTE_CAP);
+    expect(out[1].payload.length).toBe(SEGMENTATION_BYTE_CAP);
+    expect(out[2].payload.length).toBe(SEGMENTATION_BYTE_CAP);
+
+    // Seq is monotonic and contiguous.
+    expect(out.map((d) => d.seq)).toEqual([1, 2, 3]);
+
+    // Tail remains buffered, timer armed.
+    expect(acc.bufferedBytes()).toBe(50_000 - 3 * SEGMENTATION_BYTE_CAP);
+    expect(env.pending()).not.toBeNull();
+
+    // Drain the tail via the deadline.
+    env.advance(SEGMENTATION_TIMEOUT_MS);
+    expect(out.length).toBe(4);
+    expect(out[3].seq).toBe(4);
+    expect(out[3].payload.length).toBe(50_000 - 3 * SEGMENTATION_BYTE_CAP);
+
+    // Re-assemble: every input byte should appear in the same order in
+    // the concatenated output payloads (raw VT preservation).
+    const cat = new Uint8Array(50_000);
+    let off = 0;
+    for (const d of out) {
+      cat.set(d.payload, off);
+      off += d.payload.length;
+    }
+    expect(cat).toEqual(big);
+  });
+
+  it('mid-segment cap fill flushes the prefix that fills the cap, then continues', () => {
+    const env = makeFakeEnv();
+    const out: PtyDeltaPayload[] = [];
+    const acc = new DeltaAccumulator({
+      onDelta: (d) => out.push(d),
+      now: env.clock,
+      timer: env.timer,
+    });
+
+    const half = new Uint8Array(SEGMENTATION_BYTE_CAP - 100).fill(0x41);
+    acc.push(half);
+    expect(out.length).toBe(0);
+    expect(acc.bufferedBytes()).toBe(SEGMENTATION_BYTE_CAP - 100);
+
+    // Push 200 bytes — 100 fill the cap, 100 carry over to the next seg.
+    const more = new Uint8Array(200).fill(0x42);
+    acc.push(more);
+
+    expect(out.length).toBe(1);
+    expect(out[0].payload.length).toBe(SEGMENTATION_BYTE_CAP);
+    expect(acc.bufferedBytes()).toBe(100);
+    expect(env.pending()).not.toBeNull();
+  });
+});
+
+describe('DeltaAccumulator — flushNow / dispose / firstSeq', () => {
+  it('flushNow drains the buffer immediately and clears the timer', () => {
+    const env = makeFakeEnv();
+    const out: PtyDeltaPayload[] = [];
+    const acc = new DeltaAccumulator({
+      onDelta: (d) => out.push(d),
+      now: env.clock,
+      timer: env.timer,
+    });
+    acc.push(bytes(9, 9, 9));
+    expect(env.pending()).not.toBeNull();
+    acc.flushNow();
+    expect(out.length).toBe(1);
+    expect(env.pending()).toBeNull();
+
+    // Advance past the original deadline — must NOT produce a phantom
+    // delta (a flushNow that didn't disarm the timer would).
+    env.advance(SEGMENTATION_TIMEOUT_MS * 4);
+    expect(out.length).toBe(1);
+  });
+
+  it('dispose clears the pending timer and silences further pushes', () => {
+    const env = makeFakeEnv();
+    const out: PtyDeltaPayload[] = [];
+    const acc = new DeltaAccumulator({
+      onDelta: (d) => out.push(d),
+      now: env.clock,
+      timer: env.timer,
+    });
+    acc.push(bytes(1, 2));
+    acc.dispose();
+    expect(env.pending()).toBeNull();
+
+    acc.push(bytes(3, 4));
+    acc.flushNow();
+    env.advance(SEGMENTATION_TIMEOUT_MS * 4);
+    expect(out).toEqual([]);
+  });
+
+  it('firstSeq lets the daemon resume seq numbering across restart', () => {
+    const env = makeFakeEnv();
+    const out: PtyDeltaPayload[] = [];
+    const acc = new DeltaAccumulator({
+      onDelta: (d) => out.push(d),
+      now: env.clock,
+      timer: env.timer,
+      firstSeq: 4097,
+    });
+    expect(acc.nextSeqWillEmit()).toBe(4097);
+
+    acc.push(bytes(0));
+    acc.flushNow();
+    expect(out[0].seq).toBe(4097);
+    expect(acc.nextSeqWillEmit()).toBe(4098);
+
+    acc.push(bytes(1));
+    acc.flushNow();
+    expect(out[1].seq).toBe(4098);
+  });
+});
+
+describe('DeltaAccumulator — monotonic seq invariant', () => {
+  it('emits strictly increasing seq across many mixed-cadence segments', () => {
+    const env = makeFakeEnv();
+    const out: PtyDeltaPayload[] = [];
+    const acc = new DeltaAccumulator({
+      onDelta: (d) => out.push(d),
+      now: env.clock,
+      timer: env.timer,
+    });
+
+    // Pattern: a small write → timer flush, a big oversized write →
+    // synchronous multi-flush, a manual flushNow, repeat.
+    for (let i = 0; i < 5; i++) {
+      acc.push(bytes(i + 1));
+      env.advance(SEGMENTATION_TIMEOUT_MS);
+      const big = new Uint8Array(SEGMENTATION_BYTE_CAP * 2 + 300);
+      acc.push(big);
+      acc.flushNow();
+    }
+
+    // Every seq must be unique, contiguous, and starting at 1.
+    const seqs = out.map((d) => d.seq);
+    for (let i = 0; i < seqs.length; i++) {
+      expect(seqs[i]).toBe(i + 1);
+    }
+    // And the running sum of payload bytes equals the running sum of
+    // input bytes — no bytes lost or duplicated.
+    const totalOut = out.reduce((s, d) => s + d.payload.length, 0);
+    const totalIn = 5 * (1 + SEGMENTATION_BYTE_CAP * 2 + 300);
+    expect(totalOut).toBe(totalIn);
+  });
+});

--- a/packages/daemon/src/pty/segmentation.ts
+++ b/packages/daemon/src/pty/segmentation.ts
@@ -1,0 +1,360 @@
+// PTY delta segmentation cadence — spec ch06 §3 (FOREVER-STABLE).
+//
+// This file is the SINGLE source of truth for the per-session pty cadence
+// constants used throughout the daemon. The `test/lock/segmentation-cadence`
+// lock spec asserts that the numeric literals (16, 16384, 30000, 256,
+// 1048576) and the named exports below MUST NOT appear in any other file
+// under `packages/daemon/src/`. Consumers import from here.
+//
+// Why one file:
+//   - The cadence is per-session (NOT per-subscriber): the pty-host child
+//     accumulates raw VT bytes once per session and broadcasts each
+//     resulting `PtyDelta` to every Attach subscriber as the SAME byte
+//     range. A second source of truth would invite skew between the
+//     accumulator (T4.9) and the snapshot scheduler (T4.10) and would
+//     break ship-gate (b)/(c) byte-equality on reattach.
+//   - v0.4 web/iOS clients reuse identical cadence; client-side coalescing
+//     for high-latency transports happens in the renderer, NEVER on the
+//     daemon emitter (see ch06 §3 narrative lock + ch15 §3 #26).
+//
+// SRP:
+//   - This module is a *decider*: a `DeltaAccumulator` is a pure-ish
+//     state machine that, given (a) a stream of raw VT byte chunks from
+//     `node-pty.master.onData` and (b) a clock + flush callback, emits
+//     monotonic-seq `PtyDeltaPayload`s at the 16 ms / 16 KiB boundary.
+//     It owns NO I/O: no timers fire on the JS event loop unless the
+//     caller wires `setTimeout` to `arm`/`disarm`; the test harness drives
+//     time deterministically via an injected clock.
+//   - The constants are exported individually AND grouped under
+//     `PTY_CADENCE` so call sites can pick whichever ergonomics fit.
+//   - T4.10 (snapshot scheduler) imports K_TIME_MS / M_DELTAS / B_BYTES
+//     from here; T4.9 (this PR) only USES the segmentation constants but
+//     EXPORTS all five so the lock spec passes once the file exists.
+
+/**
+ * Maximum time the delta accumulator buffers raw VT bytes before flushing
+ * a `PtyDelta`. **16 milliseconds** matches the snapshot/write coalescer
+ * tick (ch07 §5) so all daemon-wide async fan-out happens on the same
+ * cadence — no jitter between delta-emit and SQLite-write.
+ *
+ * FOREVER-STABLE per spec ch06 §3.
+ */
+export const SEGMENTATION_TIMEOUT_MS = 16;
+
+/**
+ * Maximum bytes the delta accumulator buffers before forcing a flush —
+ * **16 KiB = 16384 bytes**. Picked so a single `PtyDelta.payload` fits in
+ * a typical TLS record / HTTP/2 frame without needing on-wire splitting.
+ *
+ * FOREVER-STABLE per spec ch06 §3.
+ */
+export const SEGMENTATION_BYTE_CAP = 16384;
+
+/**
+ * Snapshot cadence — time trigger. The pty-host snapshot scheduler
+ * (T4.10) takes a snapshot after **30 seconds** since the last snapshot
+ * if at least one delta has been emitted in that window.
+ *
+ * FOREVER-STABLE per spec ch06 §4. Exported here (not in the snapshot
+ * scheduler module) so the cadence-source-of-truth lock holds.
+ */
+export const K_TIME_MS = 30000;
+
+/**
+ * Snapshot cadence — delta-count trigger. **256 deltas** since the last
+ * snapshot forces a new snapshot.
+ *
+ * FOREVER-STABLE per spec ch06 §4.
+ */
+export const M_DELTAS = 256;
+
+/**
+ * Snapshot cadence — byte-volume trigger. **1 MiB = 1048576 bytes** of
+ * cumulative delta payload since the last snapshot forces a new snapshot.
+ *
+ * FOREVER-STABLE per spec ch06 §4.
+ */
+export const B_BYTES = 1048576;
+
+/**
+ * Convenience grouped object for call sites that prefer a single import.
+ * Mirrors the named exports above; both shapes are FOREVER-STABLE.
+ */
+export const PTY_CADENCE = Object.freeze({
+  SEGMENTATION_TIMEOUT_MS,
+  SEGMENTATION_BYTE_CAP,
+  K_TIME_MS,
+  M_DELTAS,
+  B_BYTES,
+} as const);
+
+/**
+ * One emitted segment. The payload is a contiguous slice of raw VT bytes
+ * (ch06 §3: "no re-encoding, no escape-sequence parsing on the daemon
+ * side"). `seq` is per-session, monotonically increasing by 1, never
+ * reused, and starts at `firstSeq` (defaulting to 1) for the lifetime of
+ * one accumulator instance.
+ *
+ * `tsMs` is the wall-clock time at the FIRST byte of the segment,
+ * captured via the injected clock. It is NOT used as part of the wire
+ * format (raw VT only) but is included so the snapshot scheduler (T4.10)
+ * can correlate with the K_TIME trigger and so log lines can attribute
+ * latency.
+ */
+export interface PtyDeltaPayload {
+  readonly seq: number;
+  readonly payload: Uint8Array;
+  readonly tsMs: number;
+}
+
+/**
+ * Caller-injected clock. Deterministic tests pass a fake clock; production
+ * passes `Date.now`. The accumulator never reads the wall clock directly.
+ */
+export type Clock = () => number;
+
+/**
+ * Caller-injected timer ops. Production code wires these to `setTimeout`
+ * / `clearTimeout`; tests pass deterministic stubs that surface the
+ * scheduled deadline so the harness can advance time exactly.
+ *
+ * The accumulator only ever holds AT MOST ONE pending timer (the 16 ms
+ * deadline starting from the first byte of the current segment). It is
+ * the caller's responsibility to make sure `setTimer` is idempotent in
+ * the face of synchronous re-arming, which the implementation does
+ * internally by always clearing before re-arming.
+ */
+export interface TimerOps {
+  setTimer(cb: () => void, delayMs: number): TimerHandle;
+  clearTimer(h: TimerHandle): void;
+}
+
+/** Opaque timer handle — `unknown` because production uses Node's
+ *  `Timeout` and tests use whatever stub they like. */
+export type TimerHandle = unknown;
+
+export interface DeltaAccumulatorOptions {
+  /** Sink invoked synchronously when a segment is ready to emit.
+   *  Caller fans the payload out to the IPC channel + the in-memory ring
+   *  + the SQLite write coalescer. The accumulator does NOT care what
+   *  the sink does — it only cares that `seq` is consumed. */
+  readonly onDelta: (delta: PtyDeltaPayload) => void;
+  /** Wall-clock source. Production: `Date.now`. */
+  readonly now: Clock;
+  /** Timer ops. Production: `{ setTimer: setTimeout, clearTimer: clearTimeout }`. */
+  readonly timer: TimerOps;
+  /** First `seq` value to emit. Defaults to `1`. After daemon restart
+   *  the caller passes `lastSnapshotBaseSeq + 1` so the seq sequence
+   *  continues monotonically across the restart boundary (ch06 §7). */
+  readonly firstSeq?: number;
+}
+
+/**
+ * Per-session raw-VT delta accumulator. Spec ch06 §3.
+ *
+ * Contract:
+ *   - `push(bytes)` MAY be called any number of times with any byte
+ *     count >= 0 (zero-byte calls are allowed and are a no-op).
+ *   - On the first byte of a segment, the accumulator arms a 16 ms
+ *     deadline via `timer.setTimer`. If the buffer reaches 16 KiB before
+ *     the deadline fires, the accumulator flushes synchronously and
+ *     disarms the timer. If the deadline fires first, the accumulator
+ *     flushes whatever is buffered.
+ *   - When the byte cap is hit MID-CHUNK (a single `push` carries enough
+ *     bytes to overflow), the accumulator flushes the prefix that fills
+ *     the cap, then loops on the suffix. A single `push` of 50_000 bytes
+ *     produces three back-to-back full-cap `onDelta` calls and a tail
+ *     segment that arms the timer.
+ *   - Empty intervals (no `push` between two timer fires) emit no delta —
+ *     the timer never arms while the buffer is empty, so this is by
+ *     construction (not a special case).
+ *   - `flushNow()` is the manual-flush entry the snapshot scheduler
+ *     (T4.10) calls before taking a snapshot, so the snapshot's
+ *     `base_seq` matches the most-recent emitted delta. No-op when the
+ *     buffer is empty.
+ *   - `dispose()` clears any pending timer and prevents further
+ *     `onDelta` calls. The accumulator is NOT reusable after dispose.
+ *
+ * Concurrency: this is a synchronous state machine running on the JS
+ * event loop. There is no locking; the only async edge is the timer
+ * callback the caller schedules.
+ */
+export class DeltaAccumulator {
+  private readonly opts: Required<Omit<DeltaAccumulatorOptions, 'firstSeq'>> & {
+    firstSeq: number;
+  };
+  private buf: Uint8Array[] = [];
+  private bufBytes = 0;
+  private nextSeq: number;
+  private pendingTimer: TimerHandle | null = null;
+  private firstByteTsMs: number | null = null;
+  private disposed = false;
+
+  constructor(opts: DeltaAccumulatorOptions) {
+    this.opts = {
+      onDelta: opts.onDelta,
+      now: opts.now,
+      timer: opts.timer,
+      firstSeq: opts.firstSeq ?? 1,
+    };
+    this.nextSeq = this.opts.firstSeq;
+  }
+
+  /**
+   * Feed raw VT bytes (`node-pty` master `data` event) into the
+   * accumulator. Splits the input across as many `onDelta` calls as the
+   * 16 KiB cap requires, then arms the 16 ms deadline if any tail bytes
+   * remain buffered.
+   *
+   * Zero-byte input is a legal no-op (some terminal emitters can flush a
+   * `Buffer.alloc(0)` between real writes; treating it as a delta would
+   * burn a `seq` for no observable bytes).
+   */
+  push(bytes: Uint8Array): void {
+    if (this.disposed) return;
+    if (bytes.length === 0) return;
+
+    let view = bytes;
+    while (view.length > 0) {
+      const room = SEGMENTATION_BYTE_CAP - this.bufBytes;
+      if (view.length >= room) {
+        // This chunk fills the segment. Take `room` bytes, flush, loop
+        // on the remainder (which may itself be >= 16 KiB — the loop
+        // handles that the same way).
+        const head = view.subarray(0, room);
+        this.appendNoArm(head);
+        this.flushBuffered();
+        view = view.subarray(room);
+      } else {
+        // Fits in the current segment. Append; the timer-arm happens at
+        // the bottom of the function so a synchronous flush above does
+        // not leave a stale timer pending.
+        this.appendNoArm(view);
+        view = view.subarray(view.length);
+      }
+    }
+
+    if (this.bufBytes > 0 && this.pendingTimer === null) {
+      this.armTimer();
+    }
+  }
+
+  /**
+   * Flush any buffered bytes immediately. Called by the snapshot
+   * scheduler (T4.10) so the snapshot's `base_seq` reflects the
+   * most-recent emitted delta, and by callers that want to drain on
+   * shutdown before disposing.
+   *
+   * No-op when the buffer is empty.
+   */
+  flushNow(): void {
+    if (this.disposed) return;
+    if (this.bufBytes === 0) return;
+    this.flushBuffered();
+  }
+
+  /**
+   * Stop the accumulator. Clears the pending timer if any. Does NOT
+   * flush buffered bytes — buffered bytes that have not yet been emitted
+   * are dropped, because `dispose` is called on session teardown (the
+   * pty-host child is exiting) and the daemon already serialized the
+   * latest snapshot via T4.10's pre-shutdown flush. Callers that need a
+   * pre-dispose drain should call `flushNow()` first.
+   *
+   * After dispose, `push` / `flushNow` are silent no-ops.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.pendingTimer !== null) {
+      this.opts.timer.clearTimer(this.pendingTimer);
+      this.pendingTimer = null;
+    }
+    this.buf = [];
+    this.bufBytes = 0;
+    this.firstByteTsMs = null;
+  }
+
+  /**
+   * Returns the seq value that the NEXT emitted delta will carry. Used
+   * by the snapshot scheduler to compute `base_seq` after a flush
+   * (`base_seq = nextSeqWillEmit() - 1`) and by tests for assertions.
+   */
+  nextSeqWillEmit(): number {
+    return this.nextSeq;
+  }
+
+  /**
+   * Returns the number of bytes currently buffered (not yet emitted).
+   * Useful for diagnostics and for tests that want to assert on
+   * mid-segment state without forcing a flush.
+   */
+  bufferedBytes(): number {
+    return this.bufBytes;
+  }
+
+  // --- internal -----------------------------------------------------------
+
+  private appendNoArm(bytes: Uint8Array): void {
+    if (bytes.length === 0) return;
+    if (this.bufBytes === 0) {
+      this.firstByteTsMs = this.opts.now();
+    }
+    this.buf.push(bytes);
+    this.bufBytes += bytes.length;
+  }
+
+  private armTimer(): void {
+    // Always disarm before arming so the invariant "at most one pending
+    // timer" holds. The caller's `setTimer` may be a stub that returns a
+    // sentinel; clearing a fresh handle is harmless.
+    if (this.pendingTimer !== null) {
+      this.opts.timer.clearTimer(this.pendingTimer);
+    }
+    this.pendingTimer = this.opts.timer.setTimer(() => {
+      this.pendingTimer = null;
+      if (this.bufBytes > 0) {
+        this.flushBuffered();
+      }
+    }, SEGMENTATION_TIMEOUT_MS);
+  }
+
+  private flushBuffered(): void {
+    if (this.bufBytes === 0) return;
+    if (this.pendingTimer !== null) {
+      this.opts.timer.clearTimer(this.pendingTimer);
+      this.pendingTimer = null;
+    }
+    const merged = concatChunks(this.buf, this.bufBytes);
+    const tsMs = this.firstByteTsMs ?? this.opts.now();
+    this.buf = [];
+    this.bufBytes = 0;
+    this.firstByteTsMs = null;
+
+    const seq = this.nextSeq;
+    this.nextSeq += 1;
+    this.opts.onDelta({ seq, payload: merged, tsMs });
+  }
+}
+
+/**
+ * Concatenate a list of `Uint8Array` chunks into a single `Uint8Array`
+ * of length `total`. Pulled out so the hot-path `flushBuffered` reads
+ * top-to-bottom without an inline reduce.
+ *
+ * Uses `Uint8Array` (not `Buffer`) for portability — the accumulator
+ * lives in `packages/daemon/src/` and is consumed by code that ships
+ * over IPC where the daemon may convert to `Buffer` later, but the
+ * accumulator itself stays Node-API-agnostic so it is unit-testable in
+ * any JS runtime (vitest, browser-mode, etc.).
+ */
+function concatChunks(chunks: readonly Uint8Array[], total: number): Uint8Array {
+  if (chunks.length === 1) return chunks[0];
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.length;
+  }
+  return out;
+}


### PR DESCRIPTION
Implements Task #50 = T4.9 = pty-host delta accumulator per spec ch06 §3 (FOREVER-STABLE), wave 3.

## Summary

- **New `packages/daemon/src/pty/segmentation.ts`** — single source of truth for the pty cadence constants (`SEGMENTATION_TIMEOUT_MS=16`, `SEGMENTATION_BYTE_CAP=16384`, `K_TIME_MS=30000`, `M_DELTAS=256`, `B_BYTES=1048576`) and the `DeltaAccumulator` decider class. The lock spec at `test/lock/segmentation-cadence.spec.ts` (chapter 15 §3 #26) asserts no other src file may define these values; this PR makes that lock active (it was skipping previously because the file did not exist).
- **`DeltaAccumulator`** is a per-session pure-decider state machine: feed raw VT bytes via `push(Uint8Array)`, get monotonic-seq `PtyDeltaPayload` callbacks at the 16 ms / 16 KiB boundary. Per spec, segmentation is per-session BEFORE multi-subscriber broadcast — no per-subscriber knobs anywhere in the API.
- Mid-chunk byte-cap overflow splits into back-to-back full-cap deltas + tail. `flushNow()` gives T4.10 a hook for snapshot-aligned `base_seq`. `firstSeq` lets the daemon resume seq across restart (ch06 §7).
- 14 unit tests cover the empty case, 16 ms timeout boundary, 16 KiB cap (single push exactly fills, oversized push 50 KB → 3 full + tail with byte-perfect reassembly, mid-segment overflow), `flushNow` / `dispose` lifecycle, `firstSeq` restart behaviour, and the monotonic-seq invariant across mixed-cadence segments. All tests use an injected fake clock + fake timer for deterministic assertions; no real timers, no spawned pty.
- The accumulator is intentionally NOT yet wired into `pty-host/child.ts` — that wire-up depends on T4.2 (real `node-pty.spawn`) which is not yet merged. T4.10 lands the snapshot scheduler and the wire-up at the same call site, in the same module, so the cadence-lock invariant remains trivial to verify.

## Layer 1 trace

1. Required by spec ch06 §3 + downstream tasks (#46/#42/#43/#44/#52 all blockedBy T4.9).
2. Simpler approach? No — the 16 ms / 16 KiB / monotonic-seq cadence is a ccsm-specific business rule; nothing in node stdlib or existing deps does this with the right semantics.
3. Direction-aligned: per-session, no per-subscriber knobs, raw VT only — exactly the spec lock.
4. Scope: T4.9 = delta accumulator. T4.10 (snapshot scheduler) and the actual `node-pty` master.onData wire-up are explicitly out of scope.
5. Pattern matches `pty-host/spawn-env.ts` (pure decider with injected dependencies + JSDoc + SRP comment).
6. Not reinventing — node has no segmentation primitive at this granularity; ch06 §3 is the wheel.

5-tier: tier 5 (self-write); justified — tiers 1-4 do not cover a per-session 16 ms / 16 KiB accumulator with monotonic seq + flushNow hook for snapshot alignment.

## Local checks (host: windows-11)

- lint: ok (exit 0; pre-existing warnings only — 0 errors)
- typecheck: ok (exit 0)
- build: ok (tsc daemon emits `dist/pty/segmentation.{js,d.ts}`)
- unit tests: all 14 new tests pass. In-scope quick run (`src/pty + test/lock/segmentation-cadence`):
  ```
  Test Files  14 passed (14)
       Tests  167 passed (167)
  ```
  The `segmentation-cadence` lock spec transitions from `skipIf` (file missing) to **3 passing assertions** (single source file, spec-mandated literals, no stray references in other src files).

## Pre-existing baseline (NOT introduced here)

The daemon test suite on a clean `origin/working` checkout has **98 failures** at HEAD `f0de131`, dominated by:
- better-sqlite3 / node-pty native-binding ABI mismatch in the worktree-pool's shared pnpm store (NODE_MODULE_VERSION 145 vs 127). Affects `db/__tests__/sqlite.spec.ts`, `db/migrations/__tests__/runner.spec.ts`, `db/__tests__/recovery.spec.ts`, `__tests__/native-loader.spec.ts`, and a chain of integration specs that need a working DB.
- `test/lock/runStartup-lock.spec.ts` is stale vs PR #996 (added `crash-rpc` to `REQUIRED_COMPONENTS` but the lock list was not updated).

With this PR applied: **97 failures** (the segmentation-cadence lock moves from `skipIf` → 3 passing tests), 938 passes (+18 = 14 new tests + 4 newly-active lock assertions / setup deltas), 1060 total (+14). **No new regressions.**

## Test plan

- [ ] CI runs all of `npm run lint`, `typecheck`, `build`, `test` on the GitHub matrix (Windows native bindings should be clean there — the failures above are local-pool cache).
- [ ] CI runs the cadence lock spec — must report 3 passing tests in `test/lock/segmentation-cadence.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)