### PR TITLE
wave3(#352): per-subscriber ack-state + bounded channel (T-PA-3)

### DIFF
--- a/packages/daemon/src/pty-host/__tests__/ack-state.spec.ts
+++ b/packages/daemon/src/pty-host/__tests__/ack-state.spec.ts
@@ -1,0 +1,414 @@
+// Unit tests for ack-state.ts (Task #352, T-PA-3 / T-PA-4 ack-state slice).
+//
+// Spec ref: docs/superpowers/specs/2026-05-04-pty-attach-handler.md
+// §4.2 (per-subscriber state shape) / §4.3 (overflow trigger) / §4.5
+// (capacity == DELTA_RETENTION_SEQS == 4096) / §6.1 (ack validation).
+//
+// Coverage matrix (one assertion per spec invariant):
+//   BoundedChannel
+//     - construction validates capacity (positive integer)
+//     - default capacity matches ACK_CHANNEL_CAPACITY (4096) per §4.5
+//     - enqueue under cap returns 'ok', size accounting correct
+//     - enqueue at cap returns 'overflow' WITHOUT mutating channel
+//       (§4.3 producer-side: must distinguish from silent drop)
+//     - dequeue returns FIFO order
+//     - dequeue from empty returns undefined
+//     - peek returns head without removing
+//     - clear empties the channel
+//     - enqueueDroppingOldest drops head when full, returns dropped item
+//       (separate primitive used by emitter ring per code comment;
+//        validates the "drop old entry" path the task spec named)
+//   AckSubscriberState
+//     - initial state: lastDelivered == lastAcked == initialSeq;
+//                      unackedBacklog == 0
+//     - onDelivered advances lastDeliveredSeq; backlog math correct
+//     - onDelivered rejects non-monotonic seq (throws — handler bug)
+//     - onAck advances lastAckedSeq for in-window ack
+//     - onAck idempotent for repeated equal ack (§6.1: benign retry)
+//     - onAck returns 'pty.ack_overrun' when applied_seq > lastDelivered
+//     - onAck returns 'pty.ack_regress' when applied_seq < lastAcked
+//     - rejected acks DO NOT mutate state
+//     - channel attached at construction with requested capacity
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  ACK_CHANNEL_CAPACITY,
+  AckSubscriberState,
+  BoundedChannel,
+  type DeltaEnvelope,
+} from '../ack-state.js';
+
+function makeDelta(seq: bigint, byte = 0): DeltaEnvelope {
+  return {
+    seq,
+    tsUnixMs: 1_700_000_000_000n + seq,
+    payload: new Uint8Array([byte]),
+  };
+}
+
+describe('ACK_CHANNEL_CAPACITY', () => {
+  it('equals DELTA_RETENTION_SEQS = 4096 per spec §4.5', () => {
+    // This is a forever-stable invariant: changing it without also
+    // changing DELTA_RETENTION_SEQS breaks the kick+reconnect recovery
+    // contract. The `as const` literal type catches accidental drift.
+    expect(ACK_CHANNEL_CAPACITY).toBe(4096);
+  });
+});
+
+describe('BoundedChannel — construction', () => {
+  it('rejects zero capacity', () => {
+    expect(() => new BoundedChannel(0)).toThrow(RangeError);
+  });
+
+  it('rejects negative capacity', () => {
+    expect(() => new BoundedChannel(-1)).toThrow(RangeError);
+  });
+
+  it('rejects non-integer capacity', () => {
+    expect(() => new BoundedChannel(1.5)).toThrow(RangeError);
+  });
+
+  it('defaults to ACK_CHANNEL_CAPACITY when no arg given', () => {
+    const ch = new BoundedChannel<number>();
+    expect(ch.capacity).toBe(ACK_CHANNEL_CAPACITY);
+    expect(ch.size).toBe(0);
+    expect(ch.isEmpty).toBe(true);
+    expect(ch.isFull).toBe(false);
+  });
+
+  it('honors custom capacity', () => {
+    const ch = new BoundedChannel<number>(8);
+    expect(ch.capacity).toBe(8);
+  });
+});
+
+describe('BoundedChannel — enqueue / dequeue FIFO behavior', () => {
+  it('enqueue under cap returns ok and tracks size', () => {
+    const ch = new BoundedChannel<number>(3);
+    expect(ch.enqueue(1)).toBe('ok');
+    expect(ch.size).toBe(1);
+    expect(ch.enqueue(2)).toBe('ok');
+    expect(ch.size).toBe(2);
+    expect(ch.isFull).toBe(false);
+    expect(ch.enqueue(3)).toBe('ok');
+    expect(ch.size).toBe(3);
+    expect(ch.isFull).toBe(true);
+  });
+
+  it('enqueue at cap returns overflow and does NOT mutate', () => {
+    const ch = new BoundedChannel<number>(2);
+    ch.enqueue(1);
+    ch.enqueue(2);
+    expect(ch.size).toBe(2);
+    // §4.3 producer-side check: overflow signal must be observable.
+    expect(ch.enqueue(3)).toBe('overflow');
+    expect(ch.size).toBe(2);
+    // Original head still there — no silent drop, no shift.
+    expect(ch.peek()).toBe(1);
+  });
+
+  it('dequeue returns FIFO order', () => {
+    const ch = new BoundedChannel<number>(3);
+    ch.enqueue(10);
+    ch.enqueue(20);
+    ch.enqueue(30);
+    expect(ch.dequeue()).toBe(10);
+    expect(ch.dequeue()).toBe(20);
+    expect(ch.dequeue()).toBe(30);
+    expect(ch.size).toBe(0);
+    expect(ch.isEmpty).toBe(true);
+  });
+
+  it('dequeue from empty returns undefined', () => {
+    const ch = new BoundedChannel<number>(2);
+    expect(ch.dequeue()).toBeUndefined();
+  });
+
+  it('survives wrap-around (head/tail cycle past capacity)', () => {
+    // Validates the ring math, not just append-then-drain.
+    const ch = new BoundedChannel<number>(3);
+    ch.enqueue(1);
+    ch.enqueue(2);
+    expect(ch.dequeue()).toBe(1);
+    ch.enqueue(3);
+    ch.enqueue(4); // tail wraps to slot 0
+    expect(ch.size).toBe(3);
+    expect(ch.dequeue()).toBe(2);
+    expect(ch.dequeue()).toBe(3);
+    expect(ch.dequeue()).toBe(4);
+    expect(ch.isEmpty).toBe(true);
+  });
+
+  it('peek returns head without removing', () => {
+    const ch = new BoundedChannel<number>(2);
+    ch.enqueue(7);
+    ch.enqueue(8);
+    expect(ch.peek()).toBe(7);
+    expect(ch.peek()).toBe(7);
+    expect(ch.size).toBe(2);
+  });
+
+  it('peek on empty returns undefined', () => {
+    const ch = new BoundedChannel<number>(2);
+    expect(ch.peek()).toBeUndefined();
+  });
+});
+
+describe('BoundedChannel — clear', () => {
+  it('empties a partially-full channel', () => {
+    const ch = new BoundedChannel<number>(4);
+    ch.enqueue(1);
+    ch.enqueue(2);
+    ch.clear();
+    expect(ch.size).toBe(0);
+    expect(ch.isEmpty).toBe(true);
+    expect(ch.dequeue()).toBeUndefined();
+  });
+
+  it('is a no-op on an empty channel', () => {
+    const ch = new BoundedChannel<number>(2);
+    ch.clear();
+    expect(ch.size).toBe(0);
+  });
+
+  it('clears wrap-around state', () => {
+    const ch = new BoundedChannel<number>(3);
+    ch.enqueue(1);
+    ch.enqueue(2);
+    ch.dequeue();
+    ch.enqueue(3);
+    ch.enqueue(4);
+    ch.clear();
+    expect(ch.size).toBe(0);
+    // Reuse after clear behaves like fresh.
+    ch.enqueue(99);
+    expect(ch.dequeue()).toBe(99);
+  });
+});
+
+describe('BoundedChannel — enqueueDroppingOldest (drop-old primitive)', () => {
+  it('appends without dropping when not full', () => {
+    const ch = new BoundedChannel<number>(3);
+    expect(ch.enqueueDroppingOldest(1)).toBeUndefined();
+    expect(ch.enqueueDroppingOldest(2)).toBeUndefined();
+    expect(ch.size).toBe(2);
+  });
+
+  it('drops the oldest entry when full and returns it', () => {
+    // The "drop old entry" path the task spec named — used by the
+    // emitter's per-session in-memory ring (T-PA-5) which prunes by
+    // snapshot cadence and tolerates losing oldest deltas. The Attach
+    // subscriber channel does NOT use this method (spec §4.3 closes
+    // the stream instead), but the primitive lives here.
+    const ch = new BoundedChannel<number>(3);
+    ch.enqueueDroppingOldest(1);
+    ch.enqueueDroppingOldest(2);
+    ch.enqueueDroppingOldest(3);
+    expect(ch.size).toBe(3);
+    expect(ch.enqueueDroppingOldest(4)).toBe(1);
+    expect(ch.size).toBe(3);
+    expect(ch.dequeue()).toBe(2);
+    expect(ch.dequeue()).toBe(3);
+    expect(ch.dequeue()).toBe(4);
+  });
+
+  it('preserves FIFO across many drops (ring wrap correctness)', () => {
+    const ch = new BoundedChannel<number>(2);
+    ch.enqueueDroppingOldest(1);
+    ch.enqueueDroppingOldest(2);
+    expect(ch.enqueueDroppingOldest(3)).toBe(1);
+    expect(ch.enqueueDroppingOldest(4)).toBe(2);
+    expect(ch.enqueueDroppingOldest(5)).toBe(3);
+    expect(ch.dequeue()).toBe(4);
+    expect(ch.dequeue()).toBe(5);
+  });
+});
+
+describe('AckSubscriberState — construction', () => {
+  it('initializes lastDelivered/lastAcked from initialSeq with zero backlog', () => {
+    const s = new AckSubscriberState({
+      subscriberId: 'sub-1',
+      sessionId: 'sess-1',
+      initialSeq: 42n,
+    });
+    expect(s.subscriberId).toBe('sub-1');
+    expect(s.sessionId).toBe('sess-1');
+    expect(s.lastDeliveredSeq).toBe(42n);
+    expect(s.lastAckedSeq).toBe(42n);
+    expect(s.unackedBacklog).toBe(0n);
+  });
+
+  it('attaches a channel with default capacity when none specified', () => {
+    const s = new AckSubscriberState({
+      subscriberId: 'sub',
+      sessionId: 'sess',
+      initialSeq: 0n,
+    });
+    expect(s.channel.capacity).toBe(ACK_CHANNEL_CAPACITY);
+  });
+
+  it('honors custom channel capacity (used by tests / future v0.4 tuning)', () => {
+    const s = new AckSubscriberState({
+      subscriberId: 'sub',
+      sessionId: 'sess',
+      initialSeq: 0n,
+      channelCapacity: 16,
+    });
+    expect(s.channel.capacity).toBe(16);
+  });
+});
+
+describe('AckSubscriberState — onDelivered (ack-pointer advance)', () => {
+  it('advances lastDeliveredSeq monotonically; backlog tracks delta', () => {
+    const s = new AckSubscriberState({
+      subscriberId: 'sub',
+      sessionId: 'sess',
+      initialSeq: 0n,
+    });
+    s.onDelivered(1n);
+    expect(s.lastDeliveredSeq).toBe(1n);
+    expect(s.unackedBacklog).toBe(1n);
+    s.onDelivered(2n);
+    s.onDelivered(3n);
+    expect(s.lastDeliveredSeq).toBe(3n);
+    expect(s.unackedBacklog).toBe(3n);
+  });
+
+  it('throws on equal seq (non-strictly-monotonic = handler bug)', () => {
+    const s = new AckSubscriberState({
+      subscriberId: 'sub',
+      sessionId: 'sess',
+      initialSeq: 5n,
+    });
+    expect(() => s.onDelivered(5n)).toThrow(/non-monotonic/);
+  });
+
+  it('throws on regressing seq', () => {
+    const s = new AckSubscriberState({
+      subscriberId: 'sub',
+      sessionId: 'sess',
+      initialSeq: 0n,
+    });
+    s.onDelivered(10n);
+    expect(() => s.onDelivered(9n)).toThrow(/non-monotonic/);
+    expect(s.lastDeliveredSeq).toBe(10n); // unchanged after throw
+  });
+});
+
+describe('AckSubscriberState — onAck validation per spec §6.1', () => {
+  function freshState(initialSeq: bigint = 0n): AckSubscriberState {
+    return new AckSubscriberState({
+      subscriberId: 'sub',
+      sessionId: 'sess',
+      initialSeq,
+    });
+  }
+
+  it('advances lastAckedSeq for in-window ack', () => {
+    const s = freshState();
+    s.onDelivered(1n);
+    s.onDelivered(2n);
+    s.onDelivered(3n);
+    const r = s.onAck(2n);
+    expect(r.kind).toBe('ok');
+    if (r.kind === 'ok') {
+      expect(r.newLastAckedSeq).toBe(2n);
+    }
+    expect(s.lastAckedSeq).toBe(2n);
+    expect(s.unackedBacklog).toBe(1n); // delivered 3 - acked 2
+  });
+
+  it('idempotent for repeated equal ack (benign retry under packet loss)', () => {
+    const s = freshState();
+    s.onDelivered(1n);
+    s.onDelivered(2n);
+    expect(s.onAck(2n).kind).toBe('ok');
+    const r = s.onAck(2n);
+    expect(r.kind).toBe('ok');
+    expect(s.lastAckedSeq).toBe(2n);
+  });
+
+  it('rejects pty.ack_overrun when applied_seq > lastDeliveredSeq', () => {
+    const s = freshState();
+    s.onDelivered(1n);
+    s.onDelivered(2n);
+    const r = s.onAck(5n);
+    expect(r).toEqual({
+      kind: 'rejected',
+      reason: 'pty.ack_overrun',
+      appliedSeq: 5n,
+      lastDeliveredSeq: 2n,
+      lastAckedSeq: 0n,
+    });
+    // State must NOT mutate on rejection.
+    expect(s.lastAckedSeq).toBe(0n);
+  });
+
+  it('rejects pty.ack_regress when applied_seq < lastAckedSeq', () => {
+    const s = freshState();
+    s.onDelivered(1n);
+    s.onDelivered(2n);
+    s.onDelivered(3n);
+    s.onAck(2n);
+    const r = s.onAck(1n);
+    expect(r).toEqual({
+      kind: 'rejected',
+      reason: 'pty.ack_regress',
+      appliedSeq: 1n,
+      lastDeliveredSeq: 3n,
+      lastAckedSeq: 2n,
+    });
+    // State must NOT mutate on rejection.
+    expect(s.lastAckedSeq).toBe(2n);
+  });
+
+  it('respects non-zero initialSeq (subscriber resumed mid-stream)', () => {
+    // Attach with since_seq=100 sets initialSeq=100; first delivered
+    // is seq=101; an ack of 100 is the in-window idempotent baseline,
+    // an ack of 99 must regress.
+    const s = freshState(100n);
+    expect(s.onAck(100n).kind).toBe('ok');
+    s.onDelivered(101n);
+    expect(s.onAck(101n).kind).toBe('ok');
+    const regress = s.onAck(99n);
+    expect(regress.kind).toBe('rejected');
+    if (regress.kind === 'rejected') {
+      expect(regress.reason).toBe('pty.ack_regress');
+    }
+  });
+});
+
+describe('AckSubscriberState — channel composition', () => {
+  it('routes deltas through the bounded channel', () => {
+    const s = new AckSubscriberState({
+      subscriberId: 'sub',
+      sessionId: 'sess',
+      initialSeq: 0n,
+      channelCapacity: 4,
+    });
+    expect(s.channel.enqueue(makeDelta(1n))).toBe('ok');
+    expect(s.channel.enqueue(makeDelta(2n))).toBe('ok');
+    expect(s.channel.size).toBe(2);
+    const head = s.channel.dequeue();
+    expect(head?.seq).toBe(1n);
+  });
+
+  it('signals overflow per spec §4.3 when consumer falls behind capacity', () => {
+    const s = new AckSubscriberState({
+      subscriberId: 'sub',
+      sessionId: 'sess',
+      initialSeq: 0n,
+      channelCapacity: 2,
+    });
+    s.channel.enqueue(makeDelta(1n));
+    s.channel.enqueue(makeDelta(2n));
+    // Producer hits cap; signal must be 'overflow', not silent.
+    expect(s.channel.enqueue(makeDelta(3n))).toBe('overflow');
+    // The Attach handler reacts to this by closing the stream with
+    // Code.ResourceExhausted / pty.subscriber_channel_full per §4.3.
+    // Channel state must still be intact for any in-flight dequeue.
+    expect(s.channel.size).toBe(2);
+    expect(s.channel.peek()?.seq).toBe(1n);
+  });
+});

--- a/packages/daemon/src/pty-host/ack-state.ts
+++ b/packages/daemon/src/pty-host/ack-state.ts
@@ -1,0 +1,363 @@
+// Per-subscriber ack-state + bounded channel primitive for PtyService.Attach.
+//
+// Spec ref: docs/superpowers/specs/2026-05-04-pty-attach-handler.md §4.2
+// (per-subscriber AckSubscriberState shape) and §4.5 (channel capacity ==
+// DELTA_RETENTION_SEQS == 4096; pinning the two equal makes the
+// "kick + reconnect on overflow" recovery reliable).
+//
+// Task #352 — Wave 3 §6.9 sub-task 10 / T-PA-3 (forward-safe).
+//
+// Scope (one PR = one concern):
+//   - The bounded channel primitive (FIFO ring with `enqueue` / `dequeue` /
+//     `size` accessors and an explicit overflow signal), and
+//   - The `AckSubscriberState` data structure plus pure transitions
+//     (`onDelivered`, `onAck`, `unackedBacklog`).
+//
+// NOT in this PR (T-PA-5 / T-PA-6 / T-PA-8):
+//   - The Attach handler itself (subscribes to the emitter, drains the
+//     channel into the wire, observes HandlerContext.signal).
+//   - The PtySessionEmitter that produces deltas/snapshots into the channel.
+//   - The AckPty RPC handler that mutates `lastAckedSeq` from the wire.
+//
+// SRP (dev.md §2): this module is a (b) decider + the data shape. Pure
+// functions over plain records; no I/O, no proto, no Connect imports.
+// The Attach handler (sink) and emitter (producer) compose this.
+//
+// 5-tier "no wheel reinvention" judgement (dev.md §1 step 2):
+//   1. Repo has no existing BoundedChannel / RingBuffer export (verified
+//      via grep across packages/**).
+//   2. `node:stream` Readable.from has bounded backpressure but no peek
+//      / size accessor — the §4.3 producer-side check needs `size`
+//      synchronously to decide enqueue-vs-close, so Stream is unsuitable.
+//      (Spec §9.1 T-PA-3 already locked this judgement.)
+//   3. No current daemon dep provides a peekable bounded channel.
+//   4. Open-source ring buffers exist but a textbook FIFO ring sized at
+//      construction is ~30 lines; copying an OSS impl would add a
+//      license-attribution surface for less code than the attribution
+//      banner. The `lastDeliveredSeq` / `lastAckedSeq` validation logic
+//      around it has no OSS analogue.
+//   5. Self-written, justified above. Test coverage in
+//      `__tests__/ack-state.spec.ts` exercises every branch (enqueue
+//      under cap / overflow signal / dequeue order / size accounting /
+//      ack monotonicity / out-of-bounds ack rejection / backlog math).
+
+/**
+ * Channel capacity — pinned equal to `DELTA_RETENTION_SEQS` per spec
+ * §4.5. Changing one without the other breaks the steady-state
+ * "kick + reconnect" recovery invariant: a subscriber that overflows
+ * its channel must always be able to reconnect with
+ * `since_seq = lastAckedSeq` and resume via deltas-only, which is only
+ * true when the in-memory ring has retained everything the channel
+ * could have held.
+ *
+ * Exported as a constant (not configurable per-instance) precisely so
+ * a cross-module mismatch is a compile-time / link-time concern.
+ */
+export const ACK_CHANNEL_CAPACITY = 4096 as const;
+
+/**
+ * Result of attempting to enqueue into a {@link BoundedChannel}. The
+ * channel never silently drops: callers MUST distinguish `'ok'` from
+ * `'overflow'` and react per spec §4.3 (close stream with
+ * `Code.ResourceExhausted`, `pty.subscriber_channel_full`).
+ */
+export type EnqueueResult = 'ok' | 'overflow';
+
+/**
+ * FIFO bounded channel with synchronous size accounting. Used by the
+ * Attach handler (sink side) to buffer deltas between the emitter
+ * listener (producer; runs synchronously inside the IPC `'message'`
+ * handler) and the `for-await` loop that yields `PtyFrame`s onto the
+ * Connect stream.
+ *
+ * Implementation: fixed-capacity circular buffer over a plain array,
+ * O(1) enqueue / dequeue / size. No allocation per operation after
+ * construction (the underlying array is sized once at capacity and
+ * holes are filled with `undefined` after dequeue so V8 hidden classes
+ * stay stable).
+ *
+ * Not exported as an event-emitter: callers compose this with their own
+ * "wake the consumer" primitive (a `Promise` resolver pair in T-PA-6).
+ * Keeping the channel pure data lets the unit tests stay synchronous.
+ */
+export class BoundedChannel<T> {
+  readonly capacity: number;
+  // Circular buffer storage. `undefined` slots are vacant (we do not
+  // store undefined values; the type parameter is non-nullable in
+  // practice — `DeltaInMem` is always defined).
+  readonly #buf: Array<T | undefined>;
+  #head = 0; // index of the next dequeue
+  #tail = 0; // index of the next enqueue
+  #size = 0;
+
+  constructor(capacity: number = ACK_CHANNEL_CAPACITY) {
+    if (!Number.isInteger(capacity) || capacity <= 0) {
+      throw new RangeError(
+        `BoundedChannel capacity must be a positive integer, got ${String(capacity)}`,
+      );
+    }
+    this.capacity = capacity;
+    this.#buf = new Array<T | undefined>(capacity).fill(undefined);
+  }
+
+  /** Number of items currently buffered. O(1). */
+  get size(): number {
+    return this.#size;
+  }
+
+  /** True iff `size === 0`. */
+  get isEmpty(): boolean {
+    return this.#size === 0;
+  }
+
+  /** True iff `size === capacity`. */
+  get isFull(): boolean {
+    return this.#size === this.capacity;
+  }
+
+  /**
+   * Push an item to the tail of the FIFO. Returns `'overflow'` (and
+   * does NOT mutate the channel) when `size === capacity`. Returns
+   * `'ok'` after a successful append.
+   *
+   * Per spec §4.3 the producer-side overflow check happens BEFORE
+   * enqueue: callers should treat `'overflow'` as a signal to close
+   * the subscriber stream with `Code.ResourceExhausted`, not as a
+   * silent retry condition.
+   */
+  enqueue(item: T): EnqueueResult {
+    if (this.#size === this.capacity) {
+      return 'overflow';
+    }
+    this.#buf[this.#tail] = item;
+    this.#tail = (this.#tail + 1) % this.capacity;
+    this.#size += 1;
+    return 'ok';
+  }
+
+  /**
+   * Remove and return the item at the head of the FIFO, or `undefined`
+   * if the channel is empty. The vacated slot is reset to `undefined`
+   * so we don't pin GC of the dequeued reference.
+   */
+  dequeue(): T | undefined {
+    if (this.#size === 0) {
+      return undefined;
+    }
+    const item = this.#buf[this.#head];
+    this.#buf[this.#head] = undefined;
+    this.#head = (this.#head + 1) % this.capacity;
+    this.#size -= 1;
+    return item;
+  }
+
+  /**
+   * Peek at the head without removing it. Returns `undefined` if empty.
+   * Used by the Attach handler to inspect what would yield next without
+   * committing to dequeue (e.g. for seq-gap diagnostics).
+   */
+  peek(): T | undefined {
+    return this.#size === 0 ? undefined : this.#buf[this.#head];
+  }
+
+  /**
+   * Drop the oldest item if the channel is full, then enqueue. Returns
+   * the dropped item (or `undefined` if the channel had room).
+   *
+   * NOT used by the Attach handler in spec §4 — the spec explicitly
+   * chooses "close stream on overflow" over "drop old". This method
+   * exists for the per-session in-memory ring of the EMITTER (T-PA-5),
+   * which prunes by snapshot cadence but uses the same primitive shape
+   * for "old data is fine to lose because the subscriber will rehydrate
+   * via snapshot". Keeping it on the same class avoids a parallel
+   * implementation drift.
+   */
+  enqueueDroppingOldest(item: T): T | undefined {
+    let dropped: T | undefined;
+    if (this.#size === this.capacity) {
+      dropped = this.#buf[this.#head];
+      this.#buf[this.#head] = undefined;
+      this.#head = (this.#head + 1) % this.capacity;
+      this.#size -= 1;
+    }
+    this.#buf[this.#tail] = item;
+    this.#tail = (this.#tail + 1) % this.capacity;
+    this.#size += 1;
+    return dropped;
+  }
+
+  /**
+   * Empty the channel. Called by the Attach handler on stream teardown
+   * so the subscriber's references are released promptly without
+   * waiting for the GC to find the channel object.
+   */
+  clear(): void {
+    if (this.#size === 0) {
+      this.#head = 0;
+      this.#tail = 0;
+      return;
+    }
+    // Walk only the live slots so we don't pin garbage in any vacant
+    // ones (which are already `undefined`).
+    let i = this.#head;
+    for (let n = 0; n < this.#size; n += 1) {
+      this.#buf[i] = undefined;
+      i = (i + 1) % this.capacity;
+    }
+    this.#head = 0;
+    this.#tail = 0;
+    this.#size = 0;
+  }
+}
+
+/**
+ * Result of an `AckSubscriberState.onAck` call. Mirrors the §6.1 ack
+ * validation table: out-of-bound (acks a frame the daemon hasn't
+ * delivered) and regress (acks a seq lower than the last) are both
+ * `Code.InvalidArgument` at the RPC boundary, with distinct
+ * `ErrorDetail.code` strings the renderer can instrument.
+ */
+export type AckResult =
+  | { readonly kind: 'ok'; readonly newLastAckedSeq: bigint }
+  | {
+      readonly kind: 'rejected';
+      readonly reason: 'pty.ack_overrun' | 'pty.ack_regress';
+      readonly appliedSeq: bigint;
+      readonly lastDeliveredSeq: bigint;
+      readonly lastAckedSeq: bigint;
+    };
+
+/**
+ * Per-subscriber ack-state. One instance per Attach RPC stream that
+ * was opened with `requires_ack=true`. The Attach handler owns
+ * lifecycle (creates on stream open, drops on stream close); the
+ * AckPty RPC handler mutates `lastAckedSeq` via {@link onAck}; the
+ * Attach handler's emitter listener mutates `lastDeliveredSeq` via
+ * {@link onDelivered}.
+ *
+ * `requires_ack=false` subscribers DO NOT use this struct — they go
+ * through the simpler 1024-deep fallback path described in spec §4.4.
+ */
+export interface AckSubscriberStateInit {
+  /** ULID minted by the Attach handler at stream-open time. */
+  readonly subscriberId: string;
+  /** The session this subscriber attached to. */
+  readonly sessionId: string;
+  /**
+   * The seq the client claims to have already applied (== Attach's
+   * `since_seq` after the resume decision succeeds). Initialized to
+   * this so `unackedBacklog` reads zero before any frame ships.
+   */
+  readonly initialSeq: bigint;
+  /** Channel capacity override; defaults to {@link ACK_CHANNEL_CAPACITY}. */
+  readonly channelCapacity?: number;
+}
+
+export class AckSubscriberState {
+  readonly subscriberId: string;
+  readonly sessionId: string;
+  readonly channel: BoundedChannel<DeltaEnvelope>;
+  #lastDeliveredSeq: bigint;
+  #lastAckedSeq: bigint;
+
+  constructor(init: AckSubscriberStateInit) {
+    this.subscriberId = init.subscriberId;
+    this.sessionId = init.sessionId;
+    this.#lastDeliveredSeq = init.initialSeq;
+    this.#lastAckedSeq = init.initialSeq;
+    this.channel = new BoundedChannel<DeltaEnvelope>(
+      init.channelCapacity ?? ACK_CHANNEL_CAPACITY,
+    );
+  }
+
+  get lastDeliveredSeq(): bigint {
+    return this.#lastDeliveredSeq;
+  }
+
+  get lastAckedSeq(): bigint {
+    return this.#lastAckedSeq;
+  }
+
+  /**
+   * `unackedBacklog = lastDeliveredSeq - lastAckedSeq`. The §4.3
+   * watchdog uses this; the producer-side overflow check uses
+   * `channel.size` directly because acks are decoupled from channel
+   * draining (the consumer can dequeue ahead of the client's ack).
+   */
+  get unackedBacklog(): bigint {
+    return this.#lastDeliveredSeq - this.#lastAckedSeq;
+  }
+
+  /**
+   * Record that a delta has been yielded onto the wire. Called by the
+   * Attach handler's `for-await` loop after the channel hands an item
+   * to the Connect stream.
+   *
+   * Validates strict monotonicity against `lastDeliveredSeq` so a
+   * programming error in the handler (e.g. delivering an out-of-order
+   * delta) trips this layer rather than silently corrupting the ack
+   * watermark. Throws on violation — the Attach handler must convert
+   * to a Connect error at its boundary.
+   */
+  onDelivered(seq: bigint): void {
+    if (seq <= this.#lastDeliveredSeq) {
+      throw new Error(
+        `AckSubscriberState.onDelivered: non-monotonic seq ${seq} <= lastDeliveredSeq ${this.#lastDeliveredSeq} (subscriberId=${this.subscriberId})`,
+      );
+    }
+    this.#lastDeliveredSeq = seq;
+  }
+
+  /**
+   * Record an `AckPty(applied_seq)` from the wire. Returns a
+   * structured `AckResult` rather than throwing, because the AckPty
+   * RPC handler converts both `'rejected'` cases into
+   * `Code.InvalidArgument` Connect responses — exceptions would
+   * conflate them with internal errors.
+   *
+   * Spec §6.1:
+   *   - `applied_seq > lastDeliveredSeq` ⇒ overrun (client claims to
+   *     have applied a frame the daemon never sent).
+   *   - `applied_seq < lastAckedSeq` ⇒ regress.
+   *   - `applied_seq == lastAckedSeq` is benign (idempotent ack;
+   *     happens when the client retries an AckPty under packet loss).
+   */
+  onAck(appliedSeq: bigint): AckResult {
+    if (appliedSeq > this.#lastDeliveredSeq) {
+      return {
+        kind: 'rejected',
+        reason: 'pty.ack_overrun',
+        appliedSeq,
+        lastDeliveredSeq: this.#lastDeliveredSeq,
+        lastAckedSeq: this.#lastAckedSeq,
+      };
+    }
+    if (appliedSeq < this.#lastAckedSeq) {
+      return {
+        kind: 'rejected',
+        reason: 'pty.ack_regress',
+        appliedSeq,
+        lastDeliveredSeq: this.#lastDeliveredSeq,
+        lastAckedSeq: this.#lastAckedSeq,
+      };
+    }
+    this.#lastAckedSeq = appliedSeq;
+    return { kind: 'ok', newLastAckedSeq: appliedSeq };
+  }
+}
+
+/**
+ * Minimal in-memory delta shape that the Attach handler buffers in the
+ * subscriber channel. Mirrors `DeltaMessage` (T-PA-1) without the IPC
+ * `kind` discriminant (channel members are all deltas; the snapshot
+ * frame is sent once at attach-time, outside the channel).
+ *
+ * Defined here (instead of imported from `types.ts`) because T-PA-1
+ * has not landed yet and this PR is forward-safe; once T-PA-1 lands
+ * the shapes are byte-identical and this alias becomes a re-export.
+ */
+export interface DeltaEnvelope {
+  readonly seq: bigint;
+  readonly tsUnixMs: bigint;
+  readonly payload: Uint8Array;
+}


### PR DESCRIPTION
Task #352 — Wave 3 §6.9 sub-task 10 / T-PA-3 (forward-safe).

Implements the per-subscriber ack-state data structure plus the bounded
channel primitive locked in #341 design spec (PR #992) §4.2 / §4.3 /
§4.5 / §6.1. New file under `packages/daemon/src/pty-host/`; does NOT
modify the existing Attach handler (T-PA-6) or pty-host child (T-PA-8)
per task scope ("不动现有 attach handler" + "一 PR 一 concern").

## Module surface

`packages/daemon/src/pty-host/ack-state.ts`:

- `BoundedChannel<T>`: fixed-capacity FIFO ring with O(1) enqueue /
  dequeue / size / peek / clear. `enqueue` returns `'ok' | 'overflow'`
  — explicit signal, never silent drop, per spec §4.3 producer-side
  check. Includes an `enqueueDroppingOldest` variant the emitter ring
  (T-PA-5) will use for snapshot-cadence pruning; the Attach
  subscriber channel does NOT use this path (spec §4.3 closes the
  stream on overflow instead).
- `ACK_CHANNEL_CAPACITY = 4096 as const`, pinned equal to
  `DELTA_RETENTION_SEQS` per spec §4.5 forever-stable invariant.
  Changing one without the other breaks the steady-state
  "kick + reconnect" recovery.
- `AckSubscriberState`: per-subscriber `lastDeliveredSeq` /
  `lastAckedSeq` / `unackedBacklog`, with §6.1-validated transitions
  — `onDelivered` enforces strict monotonicity (throws on handler
  bug); `onAck` returns structured `AckResult` mapping rejections
  to `pty.ack_overrun` / `pty.ack_regress` so the AckPty RPC handler
  can convert them to `Code.InvalidArgument` without conflating with
  internal errors.
- `DeltaEnvelope` interface placeholder for the channel item shape
  (will collapse to a re-export once T-PA-1 lands the IPC payload
  shape in `types.ts`).

## Test coverage (32 cases)

`packages/daemon/src/pty-host/__tests__/ack-state.spec.ts`:

- channel construction validation (zero / negative / non-integer
  capacity rejected); default vs custom capacity
- enqueue under cap returns `'ok'`; at cap returns `'overflow'`
  WITHOUT mutating channel state
- dequeue FIFO order; empty returns undefined; wrap-around
  correctness past capacity
- peek returns head without removing; empty peek undefined
- clear empties partial / wrap-around / no-op on empty
- `enqueueDroppingOldest` appends without dropping when not full;
  drops + returns oldest when full; preserves FIFO across many drops
- ack-state init: `lastDelivered == lastAcked == initialSeq`,
  backlog 0; default + custom channel capacity
- `onDelivered` advances + tracks backlog; throws on equal seq;
  throws on regress; state unchanged after throw
- `onAck` advances on in-window; idempotent for repeated equal ack
  (benign retry under packet loss); returns structured
  `pty.ack_overrun` / `pty.ack_regress` rejections; state unchanged
  on rejection; respects non-zero `initialSeq` for mid-stream resume
- channel composition: `AckSubscriberState.channel` accepts delta
  envelopes; overflow signal observable per §4.3

## 5-tier judgement (dev.md §1 step 2)

1. No existing repo `BoundedChannel` / `RingBuffer` (grep across
   `packages/**`).
2. `node:stream` Readable.from has bounded backpressure but no `size`
   accessor — §4.3 producer-side check needs it synchronously to
   choose enqueue vs close-stream. Spec §9.1 already locked this.
3. No current daemon dep provides a peekable bounded channel.
4. OSS ring buffers exist but a textbook FIFO ring sized at
   construction is ~30 LOC; copying an OSS impl would add a
   license-attribution surface for less code than the attribution
   banner. Ack validation logic has no OSS analogue.
5. Self-written, justified above.

## Forward-safe scope (one PR = one concern)

In scope: data structures + pure transitions + unit tests.

Out of scope (separate PRs per spec §9):
- T-PA-1: extend `types.ts` IPC payload (DeltaMessage etc.)
- T-PA-2: `attach-decider.ts` (pure since_seq decider)
- T-PA-5: `PtySessionEmitter` (consumes the channel primitive)
- T-PA-6: `pty-attach.ts` Attach handler (composes everything)
- T-PA-7 / T-PA-8: SessionManager / child wave-locked tightenings

This PR is forward-safe (new file under `pty-host/`; does not modify
`host.ts` / `child.ts` / `types.ts` / `index.ts`), so it can land
ahead of T-PA-5 without blocking parallel wave work.

## Local checks (host: windows-11)

- lint: exit 0 (0 errors; 52 pre-existing warnings, none in my files)
- typecheck: exit 0
- build: turbo cached pass (`@ccsm/daemon#build` = `tsc -p tsconfig.json`)
- ack-state unit tests: `32 passed (8.65s)` — all 32 cases green
- daemon vitest full: `994 passed / 110 failed` — the 110 failures
  match the origin/working baseline (recovery.spec.ts /
  rpc/integration.spec.ts / etc.); none touch `pty-host` or
  `ack-state`. This PR adds 32 to the pass count and 0 to the
  fail count.
- e2e: `harness-dnd` OK, `harness-ui` OK; `harness-real-cli` timed
  out on a pre-existing `window.ccsmSession.onState not exposed by
  preload (PR-A wiring missing)` gap unrelated to a daemon-internal
  data structure.

## References

- Design spec: `docs/superpowers/specs/2026-05-04-pty-attach-handler.md`
  §4.2, §4.3, §4.5, §6.1, §9.1 T-PA-3 (PR #992 merged)
- Audit: #228 RPC stub gap audit
- Sibling tasks: T-PA-1 (#TBD), T-PA-2 (#TBD), T-PA-5/6/7/8 (wave-locked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)