### PR TITLE
wave3-6.9.10-impl.2(#351): PtyService.Attach ResumeDecision decider

### DIFF
--- a/packages/daemon/src/pty-host/attach-decider.spec.ts
+++ b/packages/daemon/src/pty-host/attach-decider.spec.ts
@@ -1,0 +1,366 @@
+// Unit tests for the PtyService.Attach since_seq resume decider
+// (spec docs/superpowers/specs/2026-05-04-pty-attach-handler.md §3).
+//
+// The decider is a pure function — these tests exercise every branch of
+// §3.4's pseudo-code plus the edge cases that emerge from spec §3.3
+// (synthetic initial snapshot at baseSeq=0n) and §4.5 (oldestRetained ==
+// currentMax - N + 1n). No I/O, no async — fast (sub-ms) tests; the spec
+// §9.1 T-PA-2 split exists precisely so this layer is unit-testable in
+// isolation.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  decideAttachResume,
+  type DeltaInMem,
+  type PtySnapshotInMem,
+  type ResumeDeciderInput,
+} from './attach-decider.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function snapshotAt(baseSeq: bigint): PtySnapshotInMem {
+  return {
+    baseSeq,
+    geometry: { cols: 80, rows: 24 },
+    // Distinct payload per baseSeq makes assertion failures readable.
+    screenState: new Uint8Array([Number(baseSeq & 0xffn)]),
+    schemaVersion: 1,
+  };
+}
+
+function delta(seq: bigint): DeltaInMem {
+  return {
+    seq,
+    tsUnixMs: 1_700_000_000_000n + seq,
+    payload: new Uint8Array([Number(seq & 0xffn)]),
+  };
+}
+
+/**
+ * Build a `deltasSince` mock backed by an in-memory array. Returns the
+ * slice with `seq > sinceSeq` AND `seq <= currentMaxSeq` (the same
+ * contract the real `PtySessionEmitter.deltasSince` will honor per spec
+ * §2.3). The mock asserts it is only invoked on the `deltas_only`
+ * branch (i.e. with arguments inside the retained window) so a decider
+ * regression that calls it from the wrong branch fails the test loudly.
+ */
+function mockDeltasSince(
+  ring: readonly DeltaInMem[],
+): { fn: (sinceSeq: bigint) => readonly DeltaInMem[]; calls: bigint[] } {
+  const calls: bigint[] = [];
+  return {
+    fn: (sinceSeq: bigint) => {
+      calls.push(sinceSeq);
+      return ring.filter((d) => d.seq > sinceSeq);
+    },
+    calls,
+  };
+}
+
+function baseInput(overrides: Partial<ResumeDeciderInput> = {}): ResumeDeciderInput {
+  return {
+    sinceSeq: 0n,
+    currentMaxSeq: 0n,
+    oldestRetainedSeq: 0n,
+    currentSnapshot: snapshotAt(0n),
+    deltasSince: () => [],
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Branch 1: snapshot_then_live (sinceSeq == 0n)
+// ---------------------------------------------------------------------------
+
+describe('decideAttachResume — branch 1: snapshot_then_live (sinceSeq == 0n)', () => {
+  it('returns snapshot + resumeSeq = baseSeq + 1n on synthetic initial snapshot', () => {
+    // Spec §3.3: fresh session right after `ready`, no deltas yet,
+    // synthetic snapshot at baseSeq=0n.
+    const snap = snapshotAt(0n);
+    const verdict = decideAttachResume(
+      baseInput({ sinceSeq: 0n, currentMaxSeq: 0n, currentSnapshot: snap }),
+    );
+
+    expect(verdict.kind).toBe('snapshot_then_live');
+    if (verdict.kind !== 'snapshot_then_live') return; // type narrow
+    expect(verdict.snapshot).toBe(snap);
+    expect(verdict.resumeSeq).toBe(1n);
+  });
+
+  it('returns snapshot + resumeSeq = baseSeq + 1n on cadence-driven snapshot', () => {
+    // Mid-session snapshot: cadence fired after some deltas; baseSeq = 257n
+    // (spec ch06 §4 M_DELTAS=256 trigger fires at seq 257 conceptually).
+    const snap = snapshotAt(257n);
+    const verdict = decideAttachResume(
+      baseInput({
+        sinceSeq: 0n,
+        currentMaxSeq: 257n,
+        oldestRetainedSeq: 1n,
+        currentSnapshot: snap,
+      }),
+    );
+
+    expect(verdict.kind).toBe('snapshot_then_live');
+    if (verdict.kind !== 'snapshot_then_live') return;
+    expect(verdict.snapshot).toBe(snap);
+    expect(verdict.resumeSeq).toBe(258n);
+  });
+
+  it('does NOT call deltasSince on the snapshot branch', () => {
+    // Pure-function discipline: the snapshot path must not pull deltas.
+    const ds = mockDeltasSince([delta(1n), delta(2n)]);
+    decideAttachResume(
+      baseInput({
+        sinceSeq: 0n,
+        currentMaxSeq: 2n,
+        oldestRetainedSeq: 1n,
+        currentSnapshot: snapshotAt(2n),
+        deltasSince: ds.fn,
+      }),
+    );
+    expect(ds.calls).toEqual([]);
+  });
+
+  it('throws if currentSnapshot is null on sinceSeq=0n (programming error)', () => {
+    // Spec §3.3 + ResumeDeciderInput.currentSnapshot doc: the sink must
+    // await awaitSnapshot() before calling the decider on the first-
+    // snapshot race. Calling with null is a contract violation.
+    expect(() =>
+      decideAttachResume(baseInput({ sinceSeq: 0n, currentSnapshot: null })),
+    ).toThrow(/currentSnapshot is null/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Branch 4: deltas_only (the happy "mid-window" path)
+// ---------------------------------------------------------------------------
+
+describe('decideAttachResume — branch 4: deltas_only (mid-window resume)', () => {
+  it('replays the (sinceSeq, currentMaxSeq] slice and computes resumeSeq', () => {
+    const ring: DeltaInMem[] = [delta(1n), delta(2n), delta(3n), delta(4n), delta(5n)];
+    const ds = mockDeltasSince(ring);
+
+    // Client has applied through seq=2; reattaching wants 3,4,5.
+    const verdict = decideAttachResume(
+      baseInput({
+        sinceSeq: 2n,
+        currentMaxSeq: 5n,
+        oldestRetainedSeq: 1n,
+        currentSnapshot: snapshotAt(0n),
+        deltasSince: ds.fn,
+      }),
+    );
+
+    expect(verdict.kind).toBe('deltas_only');
+    if (verdict.kind !== 'deltas_only') return;
+    expect(verdict.deltas.map((d) => d.seq)).toEqual([3n, 4n, 5n]);
+    // resumeSeq = sinceSeq + 1 + len(deltas) = 2 + 1 + 3 = 6.
+    expect(verdict.resumeSeq).toBe(6n);
+    expect(ds.calls).toEqual([2n]);
+  });
+
+  it('handles caught-up client (sinceSeq == currentMaxSeq) with empty slice', () => {
+    // Renderer is fully caught up; deltas slice is empty; live subscription
+    // picks up at currentMaxSeq + 1n. This is the steady-state reattach
+    // shape after a brief blip.
+    const ds = mockDeltasSince([delta(1n), delta(2n), delta(3n)]);
+    const verdict = decideAttachResume(
+      baseInput({
+        sinceSeq: 3n,
+        currentMaxSeq: 3n,
+        oldestRetainedSeq: 1n,
+        currentSnapshot: snapshotAt(0n),
+        deltasSince: ds.fn,
+      }),
+    );
+
+    expect(verdict.kind).toBe('deltas_only');
+    if (verdict.kind !== 'deltas_only') return;
+    expect(verdict.deltas).toEqual([]);
+    expect(verdict.resumeSeq).toBe(4n);
+  });
+
+  it('handles sinceSeq exactly at oldestRetainedSeq (window boundary inclusive)', () => {
+    // Spec §3.1.2: the lower bound is INCLUSIVE — sinceSeq ==
+    // oldestRetainedSeq is in-window. (deltasSince still returns the
+    // strictly-greater slice, so a client that has applied EXACTLY
+    // through oldestRetainedSeq receives oldestRetainedSeq+1 onwards.)
+    const ring: DeltaInMem[] = [delta(10n), delta(11n), delta(12n)];
+    const ds = mockDeltasSince(ring);
+    const verdict = decideAttachResume(
+      baseInput({
+        sinceSeq: 10n,
+        currentMaxSeq: 12n,
+        oldestRetainedSeq: 10n,
+        currentSnapshot: snapshotAt(9n),
+        deltasSince: ds.fn,
+      }),
+    );
+
+    expect(verdict.kind).toBe('deltas_only');
+    if (verdict.kind !== 'deltas_only') return;
+    expect(verdict.deltas.map((d) => d.seq)).toEqual([11n, 12n]);
+    expect(verdict.resumeSeq).toBe(13n);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Branch 3: refused_too_far_behind (sinceSeq < oldestRetainedSeq)
+// ---------------------------------------------------------------------------
+
+describe('decideAttachResume — branch 3: refused_too_far_behind', () => {
+  it('refuses when sinceSeq is one below oldestRetainedSeq', () => {
+    // Tightest off-window case — oldestRetainedSeq=10, client at 9.
+    // Spec §3.2: refuse loudly with structured ConnectError so the
+    // renderer instruments the lag (silently re-snapshotting would
+    // mask the bug).
+    const verdict = decideAttachResume(
+      baseInput({
+        sinceSeq: 9n,
+        currentMaxSeq: 12n,
+        oldestRetainedSeq: 10n,
+        currentSnapshot: snapshotAt(9n),
+      }),
+    );
+
+    expect(verdict).toEqual({
+      kind: 'refused_too_far_behind',
+      reason: 'out-of-window',
+      sinceSeq: 9n,
+      oldestRetainedSeq: 10n,
+    });
+  });
+
+  it('refuses when sinceSeq is far below oldestRetainedSeq (ring rolled over)', () => {
+    // Spec §8.4 acceptance: client disconnects, daemon emits >4096
+    // deltas, oldestRetainedSeq advances; reattach with stale seq.
+    const verdict = decideAttachResume(
+      baseInput({
+        sinceSeq: 1n,
+        currentMaxSeq: 5000n,
+        oldestRetainedSeq: 905n, // 5000 - 4096 + 1
+        currentSnapshot: snapshotAt(4900n),
+      }),
+    );
+
+    expect(verdict.kind).toBe('refused_too_far_behind');
+    if (verdict.kind !== 'refused_too_far_behind') return;
+    expect(verdict.sinceSeq).toBe(1n);
+    expect(verdict.oldestRetainedSeq).toBe(905n);
+  });
+
+  it('does NOT call deltasSince on the refused branch', () => {
+    const ds = mockDeltasSince([delta(10n), delta(11n)]);
+    decideAttachResume(
+      baseInput({
+        sinceSeq: 5n,
+        currentMaxSeq: 11n,
+        oldestRetainedSeq: 10n,
+        currentSnapshot: snapshotAt(9n),
+        deltasSince: ds.fn,
+      }),
+    );
+    expect(ds.calls).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Branch 2: refused_protocol_violation (sinceSeq > currentMaxSeq)
+// ---------------------------------------------------------------------------
+
+describe('decideAttachResume — branch 2: refused_protocol_violation (future-seq)', () => {
+  it('refuses when sinceSeq exceeds currentMaxSeq by 1', () => {
+    // Tightest off-by-one — client claims to have applied seq=11 when
+    // daemon has only emitted through seq=10. Spec §3.4: surfaces the
+    // renderer's `lastAppliedSeq` accounting bug loudly.
+    const verdict = decideAttachResume(
+      baseInput({
+        sinceSeq: 11n,
+        currentMaxSeq: 10n,
+        oldestRetainedSeq: 1n,
+        currentSnapshot: snapshotAt(10n),
+      }),
+    );
+
+    expect(verdict).toEqual({
+      kind: 'refused_protocol_violation',
+      reason: 'future-seq',
+      sinceSeq: 11n,
+      currentMaxSeq: 10n,
+    });
+  });
+
+  it('refuses sinceSeq>0n on a freshly created session (currentMaxSeq == 0n)', () => {
+    // Edge: synthetic snapshot only, no deltas yet (currentMaxSeq=0n,
+    // oldestRetainedSeq=0n). A client sending sinceSeq>0n is buggy —
+    // there is nothing to resume from. This must hit branch 2
+    // (future-seq), NOT branch 3, because the seq it claims is impossible.
+    // Branch ordering in the decider (branch 2 before branch 3) ensures
+    // this verdict.
+    const verdict = decideAttachResume(
+      baseInput({
+        sinceSeq: 1n,
+        currentMaxSeq: 0n,
+        oldestRetainedSeq: 0n,
+        currentSnapshot: snapshotAt(0n),
+      }),
+    );
+
+    expect(verdict.kind).toBe('refused_protocol_violation');
+    if (verdict.kind !== 'refused_protocol_violation') return;
+    expect(verdict.sinceSeq).toBe(1n);
+    expect(verdict.currentMaxSeq).toBe(0n);
+  });
+
+  it('does NOT call deltasSince on the refused branch', () => {
+    const ds = mockDeltasSince([]);
+    decideAttachResume(
+      baseInput({
+        sinceSeq: 99n,
+        currentMaxSeq: 10n,
+        oldestRetainedSeq: 1n,
+        currentSnapshot: snapshotAt(10n),
+        deltasSince: ds.fn,
+      }),
+    );
+    expect(ds.calls).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+describe('decideAttachResume — input validation', () => {
+  it('throws on negative sinceSeq (proto u64 cannot be negative)', () => {
+    expect(() => decideAttachResume(baseInput({ sinceSeq: -1n }))).toThrow(
+      /sinceSeq must be >= 0n/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Determinism: pure function — same input → same output
+// ---------------------------------------------------------------------------
+
+describe('decideAttachResume — determinism', () => {
+  it('returns structurally equal verdicts on repeated calls with same input', () => {
+    const ring: DeltaInMem[] = [delta(1n), delta(2n), delta(3n)];
+    const input: ResumeDeciderInput = {
+      sinceSeq: 1n,
+      currentMaxSeq: 3n,
+      oldestRetainedSeq: 1n,
+      currentSnapshot: snapshotAt(0n),
+      deltasSince: (s) => ring.filter((d) => d.seq > s),
+    };
+
+    const a = decideAttachResume(input);
+    const b = decideAttachResume(input);
+
+    expect(a).toEqual(b);
+    expect(a.kind).toBe('deltas_only');
+  });
+});

--- a/packages/daemon/src/pty-host/attach-decider.ts
+++ b/packages/daemon/src/pty-host/attach-decider.ts
@@ -1,0 +1,286 @@
+// PtyService.Attach `since_seq` resume decider — pure function (no I/O).
+//
+// Spec ref: docs/superpowers/specs/2026-05-04-pty-attach-handler.md §3
+// (since_seq resume decision tree) and §9.1 T-PA-2 (this task).
+//
+// SRP layering — this module is a `decider` per dev.md §2: pure function
+// `(sinceSeq, currentMaxSeq, oldestRetainedSeq, currentSnapshot,
+// deltasSince) -> ResumeDecision`. No reading, no writing, no awaiting.
+// The Attach handler (T-PA-6, future PR) is the `sink` that consumes the
+// verdict and either streams a snapshot+live or replays deltas or throws
+// the structured ConnectError. The `PtySessionEmitter` (T-PA-5, future
+// PR) is the `producer` that owns the in-memory snapshot/ring this decider
+// reads through the injected `deltasSince` callback.
+//
+// Mirrors `decideWatchScope` in sessions/watch-sessions.ts (same shape:
+// pure function returning a discriminated union; sink translates `refused_*`
+// verdicts into ConnectError). Two copies of the pattern are clearer than
+// a shared abstraction (each decider's verdict shape is concern-specific).
+//
+// Layer 1 — alternatives checked:
+//   - Embed the decision logic inline in the Attach handler (T-PA-6).
+//     Rejected: §3 has four branches with non-trivial seq math; pulling
+//     them out as a pure function makes the branches independently
+//     unit-testable without spinning up a Connect handler / pty-host
+//     child / SQLite. The spec §9.1 explicitly calls out T-PA-2 as a
+//     forward-safe split for this reason.
+//   - Make this a class with state (cache the last verdict). Rejected:
+//     decider per dev.md §2 SRP MUST be stateless; caching belongs to
+//     the emitter (which already owns the in-memory ring).
+//
+// Forever-stable invariants this decider locks (spec §10):
+//   - synthetic snapshot at base_seq=0n is treated as a normal snapshot
+//     by the `since_seq=0` branch (no special case);
+//   - too-far-behind ⇒ refused_too_far_behind verdict (sink maps to
+//     Code.OutOfRange + "pty.attach_too_far_behind");
+//   - future seq ⇒ refused_protocol_violation verdict (sink maps to
+//     Code.InvalidArgument + "pty.attach_future_seq").
+
+// ---------------------------------------------------------------------------
+// In-memory shapes the decider reads (forward-declared here; the
+// PtySessionEmitter in T-PA-5 will export the same shapes from a shared
+// neighbor module and this file will re-export from there. Defining them
+// inline today keeps this PR forward-safe — T-PA-5 lands without churning
+// the decider's import surface).
+// ---------------------------------------------------------------------------
+
+/**
+ * In-memory snapshot record held by the daemon-main per-session emitter.
+ *
+ * `baseSeq` is the seq of the last delta at capture time. The synthetic
+ * initial snapshot (spec §3.3, emitted by the pty-host child on `'ready'`
+ * before any deltas) carries `baseSeq = 0n`. After cadence-driven
+ * snapshots fire (spec ch06 §4: 30s / 256 deltas / 1 MiB / Resize), this
+ * value advances monotonically per session.
+ *
+ * `screenState` is the SnapshotV1 wire bytes (already zstd-wrapped by the
+ * codec package per spec ch06 §2). The decider treats it as opaque — only
+ * the sink hands it to the proto mapper.
+ */
+export interface PtySnapshotInMem {
+  readonly baseSeq: bigint;
+  readonly geometry: { readonly cols: number; readonly rows: number };
+  readonly screenState: Uint8Array;
+  readonly schemaVersion: number;
+}
+
+/**
+ * In-memory delta record held in the per-session ring (last
+ * `DELTA_RETENTION_SEQS = 4096` entries; spec §2.3, §4.5). `seq` is
+ * monotonically-increasing per session; the synthetic initial snapshot
+ * occupies the `baseSeq=0` slot but no `DeltaInMem` carries `seq=0n`
+ * (deltas start at `1n`).
+ */
+export interface DeltaInMem {
+  readonly seq: bigint;
+  readonly tsUnixMs: bigint;
+  readonly payload: Uint8Array;
+}
+
+// ---------------------------------------------------------------------------
+// Decider verdict shape (discriminated union; mirrors WatchScopeVerdict).
+// ---------------------------------------------------------------------------
+
+/**
+ * Verdict the decider returns. Pure data; the Attach handler (sink)
+ * translates `refused_*` variants into `ConnectError` and streams the
+ * `snapshot_then_live` / `deltas_only` variants onto the wire.
+ *
+ * The four variants enumerate the four branches of spec §3.1 + §3.4:
+ *
+ *   - `snapshot_then_live`     — `sinceSeq == 0n`. Sink emits one
+ *                                `PtyFrame.snapshot` then subscribes for
+ *                                live deltas at `resumeSeq`
+ *                                (== snapshot.baseSeq + 1n).
+ *
+ *   - `deltas_only`            — `0n < sinceSeq <= currentMaxSeq` AND
+ *                                `sinceSeq >= oldestRetainedSeq`. Sink
+ *                                replays the `(sinceSeq, currentMaxSeq]`
+ *                                slice from `deltas`, then subscribes for
+ *                                live deltas at `resumeSeq`.
+ *
+ *   - `refused_too_far_behind` — `sinceSeq < oldestRetainedSeq`. Sink
+ *                                throws `Code.OutOfRange` with
+ *                                `ErrorDetail.code = "pty.attach_too_far_behind"`,
+ *                                detail carrying `sinceSeq` +
+ *                                `oldestRetainedSeq` (per spec §3.2).
+ *
+ *   - `refused_protocol_violation` — `sinceSeq > currentMaxSeq`. Sink
+ *                                throws `Code.InvalidArgument` with
+ *                                `ErrorDetail.code = "pty.attach_future_seq"`
+ *                                (per spec §3.4). This branch should never
+ *                                fire for a correct client; surfacing it
+ *                                loudly catches `lastAppliedSeq` accounting
+ *                                bugs in the renderer.
+ */
+export type ResumeDecision =
+  | {
+      readonly kind: 'snapshot_then_live';
+      readonly snapshot: PtySnapshotInMem;
+      readonly resumeSeq: bigint;
+    }
+  | {
+      readonly kind: 'deltas_only';
+      readonly deltas: readonly DeltaInMem[];
+      readonly resumeSeq: bigint;
+    }
+  | {
+      readonly kind: 'refused_too_far_behind';
+      readonly reason: 'out-of-window';
+      readonly sinceSeq: bigint;
+      readonly oldestRetainedSeq: bigint;
+    }
+  | {
+      readonly kind: 'refused_protocol_violation';
+      readonly reason: 'future-seq';
+      readonly sinceSeq: bigint;
+      readonly currentMaxSeq: bigint;
+    };
+
+// ---------------------------------------------------------------------------
+// Decider input
+// ---------------------------------------------------------------------------
+
+/**
+ * Inputs the decider needs. Modelled as an injected struct so the unit
+ * tests can drive every branch without constructing a full
+ * `PtySessionEmitter`. The handler (T-PA-6) will populate this from the
+ * emitter's accessors:
+ *
+ *   ```ts
+ *   decideAttachResume({
+ *     sinceSeq: req.sinceSeq,
+ *     currentMaxSeq: emitter.currentMaxSeq,
+ *     oldestRetainedSeq: emitter.oldestRetainedSeq,
+ *     currentSnapshot: emitter.currentSnapshot(),
+ *     deltasSince: (s) => emitter.deltasSince(s),
+ *   });
+ *   ```
+ *
+ * `currentSnapshot` MAY be `null` ONLY in the first-snapshot race window
+ * (spec §3.3); when it is, the `snapshot_then_live` branch returns a
+ * verdict whose `snapshot` field is sourced via `emitter.awaitSnapshot()`
+ * by the sink — but that's an I/O concern, NOT a decider concern. To keep
+ * the decider pure, the `snapshot_then_live` branch requires a
+ * non-null `currentSnapshot`; if the sink encounters the race it must
+ * await the snapshot first and then call the decider with the resolved
+ * value. The decider throws a clear error if invoked with a null
+ * snapshot on the `sinceSeq=0n` branch (programming error, not a runtime
+ * condition) so the contract is checkable at the call site.
+ */
+export interface ResumeDeciderInput {
+  /** `AttachRequest.since_seq` from the wire. `0n` means "fresh attach". */
+  readonly sinceSeq: bigint;
+  /** Highest seq ever emitted to subscribers; `0n` if no deltas yet. */
+  readonly currentMaxSeq: bigint;
+  /**
+   * Lowest seq still in the in-memory ring (== `max(1n, currentMaxSeq -
+   * N + 1n)` once N deltas exist; `0n` before any deltas). When
+   * `currentMaxSeq == 0n`, this is `0n` and the deltas-only branch is
+   * unreachable (any positive `sinceSeq` > `currentMaxSeq` ⇒
+   * future-seq).
+   */
+  readonly oldestRetainedSeq: bigint;
+  /**
+   * Most recent snapshot in memory, or `null` if the synthetic initial
+   * snapshot has not yet been captured (race window per spec §3.3). The
+   * sink resolves the null case via `awaitSnapshot()` BEFORE calling the
+   * decider — see `ResumeDeciderInput` doc above.
+   */
+  readonly currentSnapshot: PtySnapshotInMem | null;
+  /**
+   * Source of the `(sinceSeq, currentMaxSeq]` slice for the deltas-only
+   * branch. Must return the deltas with `seq` strictly greater than the
+   * argument and less-than-or-equal to `currentMaxSeq`, in seq-order. The
+   * decider only invokes this on the `deltas_only` branch.
+   */
+  readonly deltasSince: (sinceSeq: bigint) => readonly DeltaInMem[];
+}
+
+// ---------------------------------------------------------------------------
+// Decider
+// ---------------------------------------------------------------------------
+
+/**
+ * Decide which `ResumeDecision` to apply for an Attach request. Pure;
+ * deterministic in its inputs. No I/O, no awaits, no time.
+ *
+ * Branch order (matches spec §3.4 pseudo-code):
+ *   1. `sinceSeq == 0n`  → snapshot_then_live
+ *   2. `sinceSeq > currentMaxSeq` → refused_protocol_violation
+ *   3. `sinceSeq < oldestRetainedSeq` → refused_too_far_behind
+ *   4. otherwise → deltas_only
+ *
+ * Branch 2 and 3 ordering matters when `currentMaxSeq < oldestRetainedSeq`
+ * is impossible (the emitter invariant is `oldestRetainedSeq <=
+ * currentMaxSeq` whenever `currentMaxSeq > 0n`). When `currentMaxSeq ==
+ * 0n` (no deltas yet, synthetic snapshot only), `oldestRetainedSeq ==
+ * 0n` too: any `sinceSeq > 0n` falls into branch 2 (future-seq), which
+ * is the right verdict — the client claims to have applied a delta the
+ * daemon never produced.
+ *
+ * @throws Error if `sinceSeq == 0n` AND `currentSnapshot == null` —
+ *   programming error: the sink must await the snapshot before invoking
+ *   the decider on the first-snapshot race window (spec §3.3, see
+ *   `ResumeDeciderInput.currentSnapshot` doc).
+ *
+ * @throws Error if `sinceSeq < 0n` — wire-impossible (proto u64) but
+ *   guards against caller bugs in tests / future host-side caller code.
+ */
+export function decideAttachResume(input: ResumeDeciderInput): ResumeDecision {
+  const { sinceSeq, currentMaxSeq, oldestRetainedSeq, currentSnapshot, deltasSince } = input;
+
+  if (sinceSeq < 0n) {
+    throw new Error(
+      `decideAttachResume: sinceSeq must be >= 0n (got ${sinceSeq}); proto u64 cannot be negative`,
+    );
+  }
+
+  // Branch 1: fresh attach. Send snapshot, then live deltas at baseSeq+1.
+  if (sinceSeq === 0n) {
+    if (currentSnapshot === null) {
+      throw new Error(
+        'decideAttachResume: currentSnapshot is null on sinceSeq=0n branch; ' +
+          'the sink must await emitter.awaitSnapshot() before invoking the decider ' +
+          '(see spec §3.3 first-snapshot race; ResumeDeciderInput.currentSnapshot doc)',
+      );
+    }
+    return {
+      kind: 'snapshot_then_live',
+      snapshot: currentSnapshot,
+      resumeSeq: currentSnapshot.baseSeq + 1n,
+    };
+  }
+
+  // Branch 2: client claims a future seq. Protocol violation.
+  if (sinceSeq > currentMaxSeq) {
+    return {
+      kind: 'refused_protocol_violation',
+      reason: 'future-seq',
+      sinceSeq,
+      currentMaxSeq,
+    };
+  }
+
+  // Branch 3: client too far behind retained window. Refuse loudly so
+  // the renderer's stale-state bug surfaces (spec §3.2).
+  if (sinceSeq < oldestRetainedSeq) {
+    return {
+      kind: 'refused_too_far_behind',
+      reason: 'out-of-window',
+      sinceSeq,
+      oldestRetainedSeq,
+    };
+  }
+
+  // Branch 4: happy path — deltas-only resume.
+  // Note: `sinceSeq == currentMaxSeq` is valid here and yields an empty
+  // `deltas` slice; the live subscription picks up at `currentMaxSeq + 1n`.
+  // `deltasSince` returns the slice STRICTLY greater than `sinceSeq`.
+  const deltas = deltasSince(sinceSeq);
+  return {
+    kind: 'deltas_only',
+    deltas,
+    resumeSeq: sinceSeq + 1n + BigInt(deltas.length),
+  };
+}


### PR DESCRIPTION
Task #351 — spec `docs/superpowers/specs/2026-05-04-pty-attach-handler.md` §9.1 T-PA-2.

## Summary
- New file `packages/daemon/src/pty-host/attach-decider.ts`: pure-function `decideAttachResume` that returns the `ResumeDecision` verdict for the four §3 branches (`snapshot_then_live`, `deltas_only`, `refused_too_far_behind`, `refused_protocol_violation`).
- Mirrors the SRP shape of `decideWatchScope` in `sessions/watch-sessions.ts` (pure function, no I/O; sink in T-PA-6 maps `refused_*` to `ConnectError`).
- Forward-safe: new file, no callers yet — T-PA-5 (PtySessionEmitter) and T-PA-6 (Attach handler) will import it. `PtySnapshotInMem` / `DeltaInMem` shapes are forward-declared here so the decider is unit-testable without waiting for T-PA-1; T-PA-5 will switch this file to a re-export when those shapes land in the emitter module.
- 15-case unit test (`attach-decider.spec.ts`) covers every §3 branch + edge cases: synthetic vs. cadence-driven snapshot, caught-up client (empty slice), window-boundary inclusivity, off-by-one too-far-behind / future-seq, freshly-created session, input validation, determinism.

Locked invariants (spec §10):
- synthetic snapshot at `base_seq=0n` is a normal snapshot from the decider's POV;
- branch ordering: `sinceSeq > currentMaxSeq` resolves before `sinceSeq < oldestRetainedSeq`, so `sinceSeq=1n` on a `currentMaxSeq=0n` session is `refused_protocol_violation` (future-seq), not `refused_too_far_behind`;
- `deltasSince` is invoked only on the `deltas_only` branch (asserted by the spec mock).

## Local checks (host: windows-11 / Node v22.18.0)
- lint: PASS (no new warnings; pre-existing warnings unchanged)
- typecheck: PASS (`tsc --noEmit && tsc --noEmit -p tsconfig.electron.json`)
- build: PASS (turbo cache hit)
- unit tests, this file: 15 passed (15) in 21ms.
- unit tests, full daemon suite: 1033 passed / 10 failed / 23 skipped / 5 todo. The 10 failures are 100% pre-existing baseline failures in `src/rpc/__tests__/integration.spec.ts`, `test/integration/{daemon-boot-end-to-end,crash-getlog-wired,watch-sessions-wired}.spec.ts`, `test/lock/runStartup-lock.spec.ts` — confirmed by re-running against `git stash -u` / origin/working (same failures reproduce on the baseline). None of the failures touch `pty-host/`; this PR adds no imports outside the new file.
- e2e (`probe:e2e`): pool-12 worktree environment failure — `harness-real-cli` cannot start Electron and `harness-ui` hits `ERR_DLOPEN_FAILED` on a node-pty native binding. Root cause is pnpm's `Ignored build scripts` policy: `pnpm install --frozen-lockfile` skipped the postinstall scripts for `better-sqlite3`, `electron@41.5.0`, and `node-pty`. I manually ran `prebuild-install` for `better-sqlite3` (which fixed the unit-test native loader) and `node install.js` for `electron@41.5.0` (which produced the `electron.exe`), but `node-pty` still has no working native binding in this pool. Flagging per dev.md §3 rather than silently skipping; this is an environment recovery issue orthogonal to the PR (the new file has no runtime callers, no electron/renderer touch).

## Test plan
- [ ] Reviewer confirms unit-test coverage matches §3.1 + §3.4 branch table.
- [ ] Reviewer confirms `PtySnapshotInMem` / `DeltaInMem` placement (forward-declared in `attach-decider.ts`) is acceptable until T-PA-5 lands.
- [ ] CI (Linux / macOS / Windows matrix) — RPC integration + e2e expected to follow baseline (this PR does not change the failure surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)