### PR TITLE
wave3-6.9.9-impl(#349): daemon SettingsService + DraftService wire-up + boot derived fields

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -26,6 +26,7 @@
 //   - Graceful shutdown                        → T1.8 (`Shutdown.run` + signal handlers)
 
 import { mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
 import { dirname } from 'node:path';
 
 import type { Interceptor } from '@connectrpc/connect';
@@ -55,6 +56,7 @@ import { writeDescriptor, type DescriptorV1 } from './listeners/descriptor.js';
 import type { Listener } from './listeners/types.js';
 import { LISTENER_A_HELLO_ID } from './rpc/hello.js';
 import { makeRouterBindHook } from './rpc/bind.js';
+import { upsertSettingsBoot } from './rpc/settings/store.js';
 import { SessionManager, type ISessionManager } from './sessions/SessionManager.js';
 import { statePaths } from './state-dir/paths.js';
 import {
@@ -216,6 +218,29 @@ export async function runStartup(
         .map((m) => m.version)
         .join(',')}`,
     );
+    // Wave-3 #349 — UPSERT daemon-derived Settings rows (spec #337 §5).
+    // Runs AFTER migrations (settings table exists) and BEFORE
+    // assertWired so SettingsService.GetSettings sees both rows on the
+    // first post-boot call. Idempotent — every boot writes the same
+    // two rows; consecutive boots with no env change are a no-op at
+    // the row-content level. The task brief simplifies the spec's
+    // `~/.claude/settings.json` parse to an env-var fallback
+    // (`CCSM_DETECTED_CLAUDE_DEFAULT_MODEL`) so the boot path stays
+    // hermetic for the daemon-boot e2e — full settings.json parsing
+    // is forward-safe (a sibling task can extend this UPSERT to read
+    // the file without touching the wire shape).
+    const detectedModel =
+      process.env.CCSM_DETECTED_CLAUDE_DEFAULT_MODEL ?? '';
+    upsertSettingsBoot(db, {
+      userHomePath: homedir(),
+      detectedClaudeDefaultModel: detectedModel,
+    });
+    log(
+      `settings boot UPSERT: user_home_path=set ` +
+        `detected_claude_default_model=${
+          detectedModel === '' ? 'empty' : 'set'
+        }`,
+    );
   } catch (err) {
     // Close the handle so we don't leak it on a startup-abort path.
     try {
@@ -363,12 +388,32 @@ export async function runStartup(
     // descriptor twice replaces" caveat that forces all SessionService
     // handlers into one registration.
     const readHandlersDeps = { manager: sessionManager };
+    // Wave-3 #349 — wire SettingsService + DraftService production
+    // overlays (spec #337 §6.1 step 1). Both services share the same
+    // `db` handle (drafts ride on the `settings` table under key
+    // `draft:<session_id>` per spec §2.2). Pre-#349 both services
+    // were stubs returning `Code.Unimplemented` despite `001_initial.sql`
+    // having created the `settings` table from day one — closing the
+    // wire gap that the audit #228 sub-task 9 flagged. The boot UPSERT
+    // for `user_home_path` / `detected_claude_default_model` ran above
+    // (after `runMigrations`) so the first post-boot `GetSettings`
+    // call sees the daemon-derived rows.
+    const settingsDeps = {
+      getSettingsDeps: { db, onUnknownKey: (k: string) => log(`settings: unknown key '${k}' (forward-tolerant; ignored)`) },
+      updateSettingsDeps: { db, onUnknownKey: (k: string) => log(`settings: unknown key '${k}' (forward-tolerant; ignored)`) },
+    };
+    const draftDeps = {
+      getDraftDeps: { db },
+      updateDraftDeps: { db },
+    };
     listenerA = makeListenerA(env, {
       bindHook: makeRouterBindHook({
         helloDeps,
         watchSessionsDeps,
         crashDeps,
         readHandlersDeps,
+        settingsDeps,
+        draftDeps,
         // Order matters: bearer→PeerInfo deposit MUST run before
         // peerCredAuthInterceptor (which reads PEER_INFO_KEY and
         // derives Principal). `requestMetaInterceptor` is prepended by
@@ -472,6 +517,15 @@ export async function runStartup(
   // this name correctly stays absent from `wired` (assertWired then
   // throws on the missing `listener-a` first).
   if (listenerA !== null) wired.push('crash-rpc');
+  // `settings-service` / `draft-service`: bound to the Listener A
+  // Connect router via `makeRouterBindHook({ settingsDeps, draftDeps })`
+  // above (Wave-3 #349 / spec #337 §6.1 step 1). Both names are tied
+  // to the listener bind: `CCSM_DAEMON_SKIP_LISTENER=1` short-circuits
+  // the bind and the overlays never reach the router, in which case
+  // these names correctly stay absent from `wired` (assertWired then
+  // throws on the missing `listener-a` first).
+  if (listenerA !== null) wired.push('settings-service');
+  if (listenerA !== null) wired.push('draft-service');
   // `write-coalescer`: NOT pushed yet — module exists at
   // `src/sqlite/coalescer.ts` but the per-session pty-host bridge
   // wires in T6.x. `assertWired` treats this name as WARN_ONLY for now

--- a/packages/daemon/src/rpc/draft/get.ts
+++ b/packages/daemon/src/rpc/draft/get.ts
@@ -1,0 +1,169 @@
+// packages/daemon/src/rpc/draft/get.ts
+//
+// Wave-3 Task #349 (spec #337 §4.3) — production
+// `DraftService.GetDraft` Connect handler.
+//
+// Storage shape: drafts ride on the same `settings` table under key
+// `draft:<session_id>` (spec #337 §2.2 + draft.proto line 8). Row
+// `value` is JSON `{ "text": "...", "updated_unix_ms": N }`.
+//
+// SRP layering (dev.md §2):
+//   * decider:  `decideDraftAccess(req, ctx, sessionLookup)` — pure
+//     function over the wire request + the session ownership row;
+//     either OK or PermissionDenied / InvalidArgument.
+//   * producer: `readOneSettingsRow(db, draftKey(sid))` (in
+//     `../settings/store.ts`).
+//   * sink:     `makeGetDraftHandler(deps)` — Connect handler wiring
+//     the decider to the producer + JSON decoding the row.
+//
+// Peer-cred check (spec §4.3, draft.proto line 14-16): the handler
+// MUST verify the calling principal owns the session. v0.3 has only
+// one principal so the check is "trivially true" today, but landing it
+// now closes the TOCTOU window before v0.4 introduces multiple
+// principals (acceptance §7 #8 pins the check is wired).
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type HandlerContext,
+  type ServiceImpl,
+} from '@connectrpc/connect';
+
+import {
+  type DraftService,
+  type GetDraftRequest,
+  GetDraftResponseSchema,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, principalKey, type Principal } from '../../auth/index.js';
+import type { SqliteDatabase } from '../../db/sqlite.js';
+import { throwError } from '../errors.js';
+import {
+  draftKey,
+  ULID_RE,
+} from '../settings/keys.js';
+import { readOneSettingsRow } from '../settings/store.js';
+
+export interface DraftDeps {
+  readonly db: SqliteDatabase;
+}
+
+interface DraftValue {
+  readonly text: string;
+  readonly updated_unix_ms: number;
+}
+
+/**
+ * Resolve `sessions.owner_id` for the supplied session_id. Returns
+ * `null` if the row does not exist (the handler treats absent-session
+ * as `PermissionDenied` rather than `NotFound` — spec §4.3 mandates
+ * peer-cred ownership and we deliberately do not leak existence).
+ */
+function lookupSessionOwner(
+  db: SqliteDatabase,
+  sessionId: string,
+): string | null {
+  const row = db
+    .prepare<[string], { owner_id: string }>(
+      'SELECT owner_id FROM sessions WHERE id = ?',
+    )
+    .get(sessionId);
+  return row?.owner_id ?? null;
+}
+
+/**
+ * Common ownership/format gate used by both Get and Update. Throws on
+ * malformed session_id or non-owning caller. Centralised so the two
+ * handlers cannot drift on the rejection shape.
+ */
+export function assertOwnsSession(
+  db: SqliteDatabase,
+  ctx: HandlerContext,
+  sessionId: string,
+): void {
+  if (!ULID_RE.test(sessionId)) {
+    throw new ConnectError(
+      'session_id must be a 26-char Crockford ULID.',
+      Code.InvalidArgument,
+    );
+  }
+  const principal: Principal | null = ctx.values.get(PRINCIPAL_KEY);
+  if (principal === null) {
+    // Auth interceptor should have rejected before we got here; if it
+    // didn't, that's a daemon wiring bug — surface as Internal so the
+    // boot-time wiring assertion (§7 #6 implicitly via "not Unimplemented")
+    // catches it the next time the boot e2e runs.
+    throw new ConnectError(
+      'GetDraft/UpdateDraft handler invoked without peerCredAuthInterceptor in chain ' +
+        '(PRINCIPAL_KEY=null) — daemon wiring bug',
+      Code.Internal,
+    );
+  }
+  const owner = lookupSessionOwner(db, sessionId);
+  if (owner === null) {
+    // Do not leak session existence to non-owners — return the same
+    // PermissionDenied a real owner-mismatch would yield.
+    throwError(
+      'session.not_owned',
+      'session does not exist or is owned by a different principal',
+      { session_id: sessionId },
+    );
+  }
+  const callerKey = principalKey(principal);
+  if (owner !== callerKey) {
+    throwError('session.not_owned', undefined, {
+      session_id: sessionId,
+      principal: callerKey,
+    });
+  }
+}
+
+/**
+ * Decode the JSON `value` blob stored under `draft:<sid>`. Defensive
+ * — a corrupt row surfaces as the empty-draft response rather than
+ * crashing the handler (forward-tolerant per spec §2.4).
+ */
+function decodeDraftValue(raw: string): DraftValue {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      'text' in parsed &&
+      'updated_unix_ms' in parsed
+    ) {
+      const obj = parsed as Record<string, unknown>;
+      const text = typeof obj.text === 'string' ? obj.text : '';
+      const ts =
+        typeof obj.updated_unix_ms === 'number' ? obj.updated_unix_ms : 0;
+      return { text, updated_unix_ms: ts };
+    }
+  } catch {
+    // fall through
+  }
+  return { text: '', updated_unix_ms: 0 };
+}
+
+export function makeGetDraftHandler(
+  deps: DraftDeps,
+): ServiceImpl<typeof DraftService>['getDraft'] {
+  return async function getDraft(req: GetDraftRequest, ctx) {
+    assertOwnsSession(deps.db, ctx, req.sessionId);
+    const row = readOneSettingsRow(deps.db, draftKey(req.sessionId));
+    if (row === null) {
+      // Empty-draft response (draft.proto comments line 18-19).
+      return create(GetDraftResponseSchema, {
+        meta: req.meta,
+        text: '',
+        updatedUnixMs: BigInt(0),
+      });
+    }
+    const decoded = decodeDraftValue(row.value);
+    return create(GetDraftResponseSchema, {
+      meta: req.meta,
+      text: decoded.text,
+      updatedUnixMs: BigInt(decoded.updated_unix_ms),
+    });
+  };
+}

--- a/packages/daemon/src/rpc/draft/register.ts
+++ b/packages/daemon/src/rpc/draft/register.ts
@@ -1,0 +1,36 @@
+// packages/daemon/src/rpc/draft/register.ts
+//
+// Wave-3 Task #349 (spec #337 §6.1 step 1) — register the production
+// DraftService overlay on top of the T2.2 stub baseline. Mirrors the
+// CrashService / SettingsService overlay shape.
+//
+// Per Connect-ES `ConnectRouter.service` semantics, calling `service`
+// once for a descriptor REPLACES any prior registration. Both v0.3
+// methods (`GetDraft` + `UpdateDraft`) ship in the single registration
+// below.
+
+import type { ConnectRouter } from '@connectrpc/connect';
+
+import { DraftService } from '@ccsm/proto';
+
+import { makeGetDraftHandler, type DraftDeps } from './get.js';
+import {
+  makeUpdateDraftHandler,
+  type UpdateDraftDeps,
+} from './update.js';
+
+export interface DraftServiceDeps {
+  readonly getDraftDeps: DraftDeps;
+  readonly updateDraftDeps: UpdateDraftDeps;
+}
+
+export function registerDraftService(
+  router: ConnectRouter,
+  deps: DraftServiceDeps,
+): ConnectRouter {
+  router.service(DraftService, {
+    getDraft: makeGetDraftHandler(deps.getDraftDeps),
+    updateDraft: makeUpdateDraftHandler(deps.updateDraftDeps),
+  });
+  return router;
+}

--- a/packages/daemon/src/rpc/draft/update.ts
+++ b/packages/daemon/src/rpc/draft/update.ts
@@ -1,0 +1,63 @@
+// packages/daemon/src/rpc/draft/update.ts
+//
+// Wave-3 Task #349 (spec #337 §4.4) — production
+// `DraftService.UpdateDraft` Connect handler.
+//
+// Behaviour (spec §4.4 + draft.proto line 31):
+//   - empty `text` ⇒ DELETE the row.
+//   - non-empty `text` ⇒ UPSERT with `updated_unix_ms = Date.now()`.
+//   - Same peer-cred ownership gate as GetDraft (spec §4.3).
+//   - One IMMEDIATE transaction (`applySettingsWrites`).
+// Response carries the post-write `updated_unix_ms` so the renderer can
+// detect "newer write won" without an extra GetDraft.
+
+import { create } from '@bufbuild/protobuf';
+import type { ServiceImpl } from '@connectrpc/connect';
+
+import {
+  type DraftService,
+  type UpdateDraftRequest,
+  UpdateDraftResponseSchema,
+} from '@ccsm/proto';
+
+import { draftKey } from '../settings/keys.js';
+import { applySettingsWrites } from '../settings/store.js';
+import { assertOwnsSession, type DraftDeps } from './get.js';
+
+/** Injectable clock so unit tests can pin `updated_unix_ms`. */
+export type ClockFn = () => number;
+
+export interface UpdateDraftDeps extends DraftDeps {
+  /** Defaults to `Date.now`. */
+  readonly now?: ClockFn;
+}
+
+export function makeUpdateDraftHandler(
+  deps: UpdateDraftDeps,
+): ServiceImpl<typeof DraftService>['updateDraft'] {
+  const now = deps.now ?? (() => Date.now());
+  return async function updateDraft(req: UpdateDraftRequest, ctx) {
+    assertOwnsSession(deps.db, ctx, req.sessionId);
+    const key = draftKey(req.sessionId);
+    if (req.text === '') {
+      // DELETE branch — empty text wipes the draft (draft.proto line 31).
+      applySettingsWrites(deps.db, [{ kind: 'delete', key }]);
+      return create(UpdateDraftResponseSchema, {
+        meta: req.meta,
+        updatedUnixMs: BigInt(0),
+      });
+    }
+    const ts = now();
+    applySettingsWrites(deps.db, [
+      {
+        kind: 'upsert',
+        key,
+        value: JSON.stringify({ text: req.text, updated_unix_ms: ts }),
+      },
+    ]);
+    return create(UpdateDraftResponseSchema, {
+      meta: req.meta,
+      updatedUnixMs: BigInt(ts),
+    });
+  };
+}

--- a/packages/daemon/src/rpc/router.ts
+++ b/packages/daemon/src/rpc/router.ts
@@ -70,8 +70,13 @@ import {
 } from '../sessions/watch-sessions.js';
 
 import { registerCrashService, type CrashServiceDeps } from './crash/register.js';
+import { registerDraftService, type DraftServiceDeps } from './draft/register.js';
 import { makeHelloHandler, type HelloDeps } from './hello.js';
 import { requestMetaInterceptor } from './middleware/request-meta.js';
+import {
+  registerSettingsService,
+  type SettingsServiceDeps,
+} from './settings/register.js';
 
 /**
  * Stable enumeration of every v0.3 Connect service from `@ccsm/proto`.
@@ -213,6 +218,8 @@ export function makeDaemonRoutes(
   watchSessionsDeps?: WatchSessionsDeps,
   crashDeps?: CrashServiceDeps,
   readHandlersDeps?: ReadHandlersDeps,
+  settingsDeps?: SettingsServiceDeps,
+  draftDeps?: DraftServiceDeps,
 ): (router: ConnectRouter) => void {
   return (router: ConnectRouter): void => {
     registerStubServices(router);
@@ -229,6 +236,20 @@ export function makeDaemonRoutes(
     // Same additive overlay shape as SessionService above.
     if (crashDeps !== undefined) {
       registerCrashService(router, crashDeps);
+    }
+    // SettingsService overlay (Wave-3 #349 / audit #228 sub-task 9 /
+    // spec #337 §6.1 step 1). Replaces the stub `{}` registration with
+    // a full impl exposing `GetSettings` + `UpdateSettings` against the
+    // existing `settings` table (no new migration — spec §1).
+    if (settingsDeps !== undefined) {
+      registerSettingsService(router, settingsDeps);
+    }
+    // DraftService overlay (Wave-3 #349 / spec #337 §6.1 step 1).
+    // Drafts ride on the same `settings` table under key
+    // `draft:<session_id>` (spec §2.2 + draft.proto line 8); the
+    // overlay exposes `GetDraft` + `UpdateDraft`.
+    if (draftDeps !== undefined) {
+      registerDraftService(router, draftDeps);
     }
   };
 }
@@ -282,6 +303,23 @@ export interface CreateDaemonNodeAdapterOptions extends ConnectRouterOptions {
    * `Unimplemented`.
    */
   readonly readHandlersDeps?: ReadHandlersDeps;
+  /**
+   * When set, installs the Wave-3 SettingsService overlay (Task #349 /
+   * audit #228 sub-task 9 / spec #337 §6.1 step 1) on top of the
+   * stubs. Both `GetSettings` and `UpdateSettings` ship in this
+   * registration (no streaming methods on the service). Production
+   * startup wires this when `index.ts` constructs a `settingsDeps`
+   * against the same `db` handle; tests omit it for the stub baseline.
+   */
+  readonly settingsDeps?: SettingsServiceDeps;
+  /**
+   * When set, installs the Wave-3 DraftService overlay (Task #349 /
+   * spec #337 §6.1 step 1) on top of the stubs. Both `GetDraft` and
+   * `UpdateDraft` ship in this registration. Drafts ride on the
+   * `settings` table under key `draft:<session_id>` so this overlay
+   * shares the SettingsService `db` handle.
+   */
+  readonly draftDeps?: DraftServiceDeps;
 }
 
 /**
@@ -320,9 +358,27 @@ export type DaemonNodeHandler = ReturnType<typeof connectNodeAdapter>;
 export function createDaemonNodeAdapter(
   options: CreateDaemonNodeAdapterOptions = {},
 ): DaemonNodeHandler {
-  const { helloDeps, watchSessionsDeps, crashDeps, readHandlersDeps, interceptors: callerInterceptors, ...rest } = options;
+  const {
+    helloDeps,
+    watchSessionsDeps,
+    crashDeps,
+    readHandlersDeps,
+    settingsDeps,
+    draftDeps,
+    interceptors: callerInterceptors,
+    ...rest
+  } = options;
   const routes =
-    helloDeps !== undefined ? makeDaemonRoutes(helloDeps, watchSessionsDeps, crashDeps, readHandlersDeps) : stubRoutes;
+    helloDeps !== undefined
+      ? makeDaemonRoutes(
+          helloDeps,
+          watchSessionsDeps,
+          crashDeps,
+          readHandlersDeps,
+          settingsDeps,
+          draftDeps,
+        )
+      : stubRoutes;
   const interceptors = [
     requestMetaInterceptor,
     ...(callerInterceptors ?? []),

--- a/packages/daemon/src/rpc/settings/get.ts
+++ b/packages/daemon/src/rpc/settings/get.ts
@@ -1,0 +1,88 @@
+// packages/daemon/src/rpc/settings/get.ts
+//
+// Wave-3 Task #349 (spec #337 §4.1) — production
+// `SettingsService.GetSettings` Connect handler.
+//
+// SRP layering (dev.md §2):
+//   * decider:  `decideGetSettings(req)` — validate scope; on
+//     PRINCIPAL → reject with InvalidArgument (settings.proto line 36 +
+//     spec §4.1 last paragraph).
+//   * producer: `readSettingsRows` (in `./store.ts`).
+//   * sink:     `makeGetSettingsHandler(deps)` — Connect handler that
+//     glues decider + producer + decoder, then echoes
+//     `effective_scope = SETTINGS_SCOPE_GLOBAL` per spec §9 q5.
+//
+// Pre-#349 the service was a stub on the wire — every method returned
+// `Code.Unimplemented` despite the `settings` table existing in
+// `001_initial.sql`. This handler closes that gap.
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type ServiceImpl,
+} from '@connectrpc/connect';
+
+import {
+  GetSettingsResponseSchema,
+  type GetSettingsRequest,
+  type SettingsService,
+  SettingsScope,
+} from '@ccsm/proto';
+
+import type { SqliteDatabase } from '../../db/sqlite.js';
+import { readSettingsRows, rowsToSettings } from './store.js';
+
+export interface GetSettingsDeps {
+  /** Same `SqliteDatabase` handle the rest of the daemon uses (single
+   *  owner of the DB; see `index.ts` `runStartup`). */
+  readonly db: SqliteDatabase;
+  /** Optional debug-level logger for unknown row keys (spec §2.4 forward
+   *  tolerance). Defaults to a no-op so unit tests need not inject one. */
+  readonly onUnknownKey?: (key: string) => void;
+}
+
+/**
+ * Validate the request scope. Spec §4.1: UNSPECIFIED + GLOBAL proceed;
+ * PRINCIPAL rejects with `Code.InvalidArgument` (matches
+ * settings.proto line 36 + acceptance §7 #4).
+ *
+ * Pure decider — no DB access. Returning a discriminated union rather
+ * than throwing keeps the function unit-testable without a Connect
+ * harness.
+ */
+export type GetSettingsDecision =
+  | { readonly kind: 'ok' }
+  | { readonly kind: 'reject_scope'; readonly scope: SettingsScope };
+
+export function decideGetSettings(req: GetSettingsRequest): GetSettingsDecision {
+  if (
+    req.scope !== SettingsScope.UNSPECIFIED &&
+    req.scope !== SettingsScope.GLOBAL
+  ) {
+    return { kind: 'reject_scope', scope: req.scope };
+  }
+  return { kind: 'ok' };
+}
+
+export function makeGetSettingsHandler(
+  deps: GetSettingsDeps,
+): ServiceImpl<typeof SettingsService>['getSettings'] {
+  return async function getSettings(req) {
+    const decision = decideGetSettings(req);
+    if (decision.kind === 'reject_scope') {
+      throw new ConnectError(
+        `SettingsScope ${SettingsScope[decision.scope] ?? String(decision.scope)} ` +
+          'is not supported in v0.3 (only GLOBAL / UNSPECIFIED).',
+        Code.InvalidArgument,
+      );
+    }
+    const rows = readSettingsRows(deps.db);
+    const settings = rowsToSettings(rows, { onUnknown: deps.onUnknownKey });
+    return create(GetSettingsResponseSchema, {
+      meta: req.meta,
+      settings,
+      effectiveScope: SettingsScope.GLOBAL,
+    });
+  };
+}

--- a/packages/daemon/src/rpc/settings/keys.ts
+++ b/packages/daemon/src/rpc/settings/keys.ts
@@ -1,0 +1,94 @@
+// packages/daemon/src/rpc/settings/keys.ts
+//
+// Wave-3 Task #349 (spec #337 §2 / §4) — canonical (scope, key) row
+// vocabulary for the v0.3 SettingsService + DraftService production
+// handlers.
+//
+// FOREVER-STABLE per spec #337 §2.4 ("Reserved key namespace prefixes").
+// These strings are written into the on-disk `settings` table on every
+// boot; renaming any of them in a v0.3.x patch silently orphans the rows
+// from prior installs. v0.4 is allowed to ADD new keys / new prefixes
+// here additively but MUST NOT rename or remove any existing entry.
+//
+// Every `value` column entry is JSON-encoded (spec #337 §2.3) — readers
+// `JSON.parse(value)`, writers `JSON.stringify(value)`. The single
+// uniform parse path avoids the "did someone JSON.stringify a string
+// twice" class of bugs and matches the proto-to-storage codec discipline
+// used elsewhere (`env_json` / `claude_args_json` in the `sessions`
+// table).
+//
+// SRP: pure constants — no I/O, no logic. Imported by every handler
+// + the boot UPSERT path so the row vocabulary lives in exactly one
+// file.
+
+/** Forever-stable v0.3 scope literal (spec #337 §2.2). */
+export const SCOPE_GLOBAL = 'global';
+
+/**
+ * Canonical typed-scalar / message-typed key strings. One row per entry
+ * in the `settings` table when present (UPSERT semantics).
+ */
+export const SETTINGS_KEYS = {
+  defaultGeometry: 'default_geometry',
+  crashRetention: 'crash_retention',
+  detectedClaudeDefaultModel: 'detected_claude_default_model',
+  userHomePath: 'user_home_path',
+  locale: 'locale',
+  sentryEnabled: 'sentry_enabled',
+} as const;
+
+/**
+ * Daemon-derived keys — set by the boot path (spec #337 §5) and rejected
+ * with `Code.InvalidArgument` if a client tries to write them via
+ * UpdateSettings (spec #337 §4.2 + acceptance §7 #5).
+ *
+ * `Set` not `ReadonlyArray` so the handler can do `.has(key)` without
+ * scanning.
+ */
+export const DAEMON_DERIVED_KEYS: ReadonlySet<string> = new Set([
+  SETTINGS_KEYS.detectedClaudeDefaultModel,
+  SETTINGS_KEYS.userHomePath,
+]);
+
+/**
+ * Prefix that identifies a `Settings.ui_prefs` map entry row in the
+ * settings table. Spec #337 §2.2: the GetSettings handler reconstructs
+ * the proto map by filtering rows whose `key` starts with this prefix
+ * and slicing the prefix off.
+ *
+ * The trailing dot is the boundary — `ui_prefs.appearance.theme` →
+ * map key `appearance.theme`. A row whose key starts with
+ * `ui_prefs.draft:` is unambiguous (it's a ui_prefs entry literally
+ * named `draft:foo`) because draft rows live under the bare `draft:`
+ * prefix without `ui_prefs.` in front (spec #337 §9 q6).
+ */
+export const UI_PREFS_PREFIX = 'ui_prefs.';
+
+/**
+ * Prefix that identifies a per-session draft row in the settings table.
+ * Spec #337 §2.2 + draft.proto line 8. Key shape is `draft:<session_id>`.
+ *
+ * GetSettings SKIPS these rows (drafts are owned by DraftService, not
+ * exposed via Settings). DraftService.GetDraft / UpdateDraft target
+ * exactly one row each by full key.
+ */
+export const DRAFT_PREFIX = 'draft:';
+
+/**
+ * Build the full `draft:<session_id>` storage key. Centralised so a
+ * future change (e.g. adding a `v2:` segment for v0.4 backward-incompat
+ * draft format) lands in exactly one place — the spec §2.4 reservation
+ * is on the `draft:` prefix, not on the rest of the key.
+ */
+export function draftKey(sessionId: string): string {
+  return `${DRAFT_PREFIX}${sessionId}`;
+}
+
+/**
+ * ULID format guard for `session_id`. Spec #337 §8.3: defence-in-depth
+ * — better-sqlite3 parameter binding already prevents SQL injection,
+ * but rejecting malformed ids early keeps the storage table free of
+ * garbage rows (and surfaces the bug at the wire boundary instead of
+ * later).
+ */
+export const ULID_RE = /^[0-9A-HJKMNP-TV-Z]{26}$/;

--- a/packages/daemon/src/rpc/settings/register.ts
+++ b/packages/daemon/src/rpc/settings/register.ts
@@ -1,0 +1,45 @@
+// packages/daemon/src/rpc/settings/register.ts
+//
+// Wave-3 Task #349 (spec #337 §6.1 step 1) — register the production
+// SettingsService overlay on top of the T2.2 stub baseline. Mirrors the
+// CrashService overlay shape (PR #996, #229).
+//
+// Per Connect-ES `ConnectRouter.service` semantics, calling `service`
+// once for a descriptor REPLACES any prior registration (the router is
+// a path-keyed map). All v0.3 SettingsService methods (`GetSettings` +
+// `UpdateSettings`) ship in this single overlay registration; if a
+// future v0.4 method joins, extend the impl object below — DO NOT add
+// a second `router.service(SettingsService, ...)` call (that would
+// silently drop the prior).
+
+import type { ConnectRouter } from '@connectrpc/connect';
+
+import { SettingsService } from '@ccsm/proto';
+
+import { makeGetSettingsHandler, type GetSettingsDeps } from './get.js';
+import {
+  makeUpdateSettingsHandler,
+  type UpdateSettingsDeps,
+} from './update.js';
+
+/**
+ * Aggregate deps for every SettingsService handler that ships in v0.3.
+ * Get + Update share the same `db` handle today, so the deps interface
+ * is collapsed; future overlays (v0.4 admin-gated keys, etc.) extend
+ * here without changing the router-level signature in `router.ts`.
+ */
+export interface SettingsServiceDeps {
+  readonly getSettingsDeps: GetSettingsDeps;
+  readonly updateSettingsDeps: UpdateSettingsDeps;
+}
+
+export function registerSettingsService(
+  router: ConnectRouter,
+  deps: SettingsServiceDeps,
+): ConnectRouter {
+  router.service(SettingsService, {
+    getSettings: makeGetSettingsHandler(deps.getSettingsDeps),
+    updateSettings: makeUpdateSettingsHandler(deps.updateSettingsDeps),
+  });
+  return router;
+}

--- a/packages/daemon/src/rpc/settings/store.ts
+++ b/packages/daemon/src/rpc/settings/store.ts
@@ -1,0 +1,421 @@
+// packages/daemon/src/rpc/settings/store.ts
+//
+// Wave-3 Task #349 (spec #337 §4) — read/write primitives that back
+// every SettingsService + DraftService production handler. Pure data
+// in, pure data out: no Connect knowledge, no logging, no clocks
+// beyond `Date.now()` for the boot UPSERT timestamp (which the caller
+// supplies).
+//
+// SRP layering (dev.md §2):
+//   - producer: `readSettingsRows(db)` — single SQL SELECT against
+//     the `(scope='global')` index-prefix.
+//   - decider:  `rowsToSettings(rows)` — pure function row[] → proto
+//     `Settings`. Forward-tolerant per spec #337 §2.4 (unknown keys
+//     are logged and skipped, not thrown on).
+//   - sink:     `upsertSettings`, `deleteSettingsRow`,
+//     `upsertSettingsBoot` — UPSERT/DELETE inside a single
+//     `db.transaction(...)` (BEGIN IMMEDIATE) per spec §4.2 / §4.5.
+//
+// Cap-and-clamp policy (spec §4.2 + settings.proto line 121-123):
+//   `crash_retention.max_entries` is clamped at 10000 BEFORE write; same
+//   for `max_age_days` at 90. Applied at write-time, not read-time, so
+//   the DB state never holds an out-of-range value (the GetCrashLog +
+//   pruner code can trust the column without re-clamping).
+
+import { create } from '@bufbuild/protobuf';
+
+import {
+  CrashRetentionSchema,
+  PtyGeometrySchema,
+  SettingsSchema,
+  type Settings,
+} from '@ccsm/proto';
+
+import type { SqliteDatabase } from '../../db/sqlite.js';
+import {
+  DAEMON_DERIVED_KEYS,
+  DRAFT_PREFIX,
+  SCOPE_GLOBAL,
+  SETTINGS_KEYS,
+  UI_PREFS_PREFIX,
+} from './keys.js';
+
+// ---------------------------------------------------------------------------
+// Caps (spec §4.2 / settings.proto line 121-123).
+// ---------------------------------------------------------------------------
+
+/** Forever-stable spec-mandated caps. */
+export const CAPS = Object.freeze({
+  crashRetentionMaxEntries: 10000,
+  crashRetentionMaxAgeDays: 90,
+});
+
+function clampInt(v: number, max: number): number {
+  if (!Number.isFinite(v) || v < 0) return 0;
+  return v > max ? max : Math.floor(v);
+}
+
+// ---------------------------------------------------------------------------
+// Producer — read all 'global'-scope rows.
+// ---------------------------------------------------------------------------
+
+interface SettingsRow {
+  readonly key: string;
+  readonly value: string;
+}
+
+/**
+ * Read every `(scope='global')` row from the settings table.
+ *
+ * Cost (spec #337 §8.4): O(rows in 'global' scope). With the
+ * `(scope, key)` PRIMARY KEY this is an index-prefix scan — sub-ms for
+ * a typical install. Switching to a key-prefix-targeted query if
+ * `ui_prefs` ever balloons to thousands of entries is a one-line
+ * change with no schema impact.
+ */
+export function readSettingsRows(
+  db: SqliteDatabase,
+): readonly SettingsRow[] {
+  return db
+    .prepare<[string], SettingsRow>(
+      'SELECT key, value FROM settings WHERE scope = ?',
+    )
+    .all(SCOPE_GLOBAL);
+}
+
+/**
+ * Read exactly one settings row by key. Returns `null` when absent
+ * (used by DraftService.GetDraft to return the empty-draft response
+ * without a separate "exists?" round-trip).
+ */
+export function readOneSettingsRow(
+  db: SqliteDatabase,
+  key: string,
+): SettingsRow | null {
+  const row = db
+    .prepare<[string, string], SettingsRow>(
+      'SELECT key, value FROM settings WHERE scope = ? AND key = ?',
+    )
+    .get(SCOPE_GLOBAL, key);
+  return row ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Decider — rows -> proto Settings.
+// ---------------------------------------------------------------------------
+
+/**
+ * Project the row stream returned by `readSettingsRows` into a proto
+ * `Settings` message. Spec #337 §2.4 forward-tolerance: unknown keys
+ * are reported via the optional `onUnknown` callback (the caller logs
+ * at debug level) but never throw — proto3 unknown-field semantics
+ * applied to the storage layer.
+ *
+ * `draft:*` rows are SKIPPED (drafts are owned by DraftService, not
+ * surfaced through SettingsService — spec §4.1 step 2).
+ */
+export function rowsToSettings(
+  rows: readonly SettingsRow[],
+  options: { readonly onUnknown?: (key: string) => void } = {},
+): Settings {
+  const settings = create(SettingsSchema, {});
+  const uiPrefs: Record<string, string> = {};
+  for (const row of rows) {
+    if (row.key.startsWith(DRAFT_PREFIX)) {
+      continue; // owned by DraftService
+    }
+    if (row.key.startsWith(UI_PREFS_PREFIX)) {
+      const mapKey = row.key.slice(UI_PREFS_PREFIX.length);
+      // Spec §2.2: ui_prefs row `value` is the already-JSON-encoded
+      // string verbatim (the proto field type is already `string`;
+      // daemon does NOT re-encode). However writers in this module
+      // pass the proto-string through `JSON.stringify` to keep the
+      // table 100% JSON-encoded (spec §2.3) — read parses to recover
+      // the original string.
+      try {
+        const parsed = JSON.parse(row.value);
+        if (typeof parsed === 'string') uiPrefs[mapKey] = parsed;
+      } catch {
+        // Corrupt row — surface as if absent. Forward-tolerant.
+      }
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(row.value);
+    } catch {
+      // Corrupt row — skip. Forward-tolerant.
+      continue;
+    }
+    switch (row.key) {
+      case SETTINGS_KEYS.defaultGeometry: {
+        if (
+          parsed !== null &&
+          typeof parsed === 'object' &&
+          'cols' in parsed &&
+          'rows' in parsed
+        ) {
+          const obj = parsed as { cols: unknown; rows: unknown };
+          settings.defaultGeometry = create(PtyGeometrySchema, {
+            cols: typeof obj.cols === 'number' ? obj.cols : 0,
+            rows: typeof obj.rows === 'number' ? obj.rows : 0,
+          });
+        }
+        break;
+      }
+      case SETTINGS_KEYS.crashRetention: {
+        if (
+          parsed !== null &&
+          typeof parsed === 'object' &&
+          'max_entries' in parsed &&
+          'max_age_days' in parsed
+        ) {
+          const obj = parsed as { max_entries: unknown; max_age_days: unknown };
+          settings.crashRetention = create(CrashRetentionSchema, {
+            maxEntries:
+              typeof obj.max_entries === 'number' ? obj.max_entries : 0,
+            maxAgeDays:
+              typeof obj.max_age_days === 'number' ? obj.max_age_days : 0,
+          });
+        }
+        break;
+      }
+      case SETTINGS_KEYS.detectedClaudeDefaultModel:
+        if (typeof parsed === 'string') settings.detectedClaudeDefaultModel = parsed;
+        break;
+      case SETTINGS_KEYS.userHomePath:
+        if (typeof parsed === 'string') settings.userHomePath = parsed;
+        break;
+      case SETTINGS_KEYS.locale:
+        if (typeof parsed === 'string') settings.locale = parsed;
+        break;
+      case SETTINGS_KEYS.sentryEnabled:
+        if (typeof parsed === 'boolean') settings.sentryEnabled = parsed;
+        break;
+      default:
+        options.onUnknown?.(row.key);
+    }
+  }
+  settings.uiPrefs = uiPrefs;
+  return settings;
+}
+
+// ---------------------------------------------------------------------------
+// Sink — UPSERT / DELETE primitives.
+// ---------------------------------------------------------------------------
+
+/**
+ * Encoded write op produced by the UpdateSettings decider before the
+ * transaction runs. Either an UPSERT (key with new JSON value) or a
+ * DELETE (clearing a `ui_prefs` entry — spec §4.2: empty string ==
+ * "client asked to forget this key").
+ */
+export type SettingsWriteOp =
+  | { readonly kind: 'upsert'; readonly key: string; readonly value: string }
+  | { readonly kind: 'delete'; readonly key: string };
+
+/**
+ * Apply a batch of write ops in a single IMMEDIATE transaction (spec
+ * §4.2 + §4.5). Better-sqlite3's `db.transaction(...).immediate(...)`
+ * is the canonical primitive (already used by `WriteCoalescer.flushBatch`).
+ *
+ * IMMEDIATE acquires the writer lock at BEGIN time, so a partial
+ * failure mid-batch rolls back cleanly; SQLite's writer-lock semantics
+ * (one writer, many readers) serialize against any concurrent
+ * coalescer write on the same connection.
+ */
+export function applySettingsWrites(
+  db: SqliteDatabase,
+  ops: readonly SettingsWriteOp[],
+): void {
+  if (ops.length === 0) return;
+  const upsert = db.prepare<[string, string, string]>(
+    'INSERT INTO settings (scope, key, value) VALUES (?, ?, ?) ' +
+      'ON CONFLICT(scope, key) DO UPDATE SET value = excluded.value',
+  );
+  const del = db.prepare<[string, string]>(
+    'DELETE FROM settings WHERE scope = ? AND key = ?',
+  );
+  const txn = db.transaction((batch: readonly SettingsWriteOp[]) => {
+    for (const op of batch) {
+      if (op.kind === 'upsert') {
+        upsert.run(SCOPE_GLOBAL, op.key, op.value);
+      } else {
+        del.run(SCOPE_GLOBAL, op.key);
+      }
+    }
+  });
+  txn.immediate(ops);
+}
+
+// ---------------------------------------------------------------------------
+// Boot UPSERT — daemon-derived fields.
+// ---------------------------------------------------------------------------
+
+export interface BootDerivedFields {
+  readonly userHomePath: string;
+  readonly detectedClaudeDefaultModel: string;
+}
+
+/**
+ * UPSERT the daemon-derived rows (spec §5). Called once per boot from
+ * `runStartup` AFTER migrations have run and BEFORE `assertWired`. Both
+ * writes go through the same `INSERT … ON CONFLICT … DO UPDATE` path
+ * the handler uses (spec §4.2), in a single boot transaction so a
+ * crash mid-write leaves the table in a consistent state.
+ *
+ * Idempotent — every boot writes the same two rows; consecutive boots
+ * with no env change are a no-op at the row-content level (the UPSERT
+ * still runs but `excluded.value` equals the existing value).
+ */
+export function upsertSettingsBoot(
+  db: SqliteDatabase,
+  fields: BootDerivedFields,
+): void {
+  applySettingsWrites(db, [
+    {
+      kind: 'upsert',
+      key: SETTINGS_KEYS.userHomePath,
+      value: JSON.stringify(fields.userHomePath),
+    },
+    {
+      kind: 'upsert',
+      key: SETTINGS_KEYS.detectedClaudeDefaultModel,
+      value: JSON.stringify(fields.detectedClaudeDefaultModel),
+    },
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Encode patch — proto Settings -> SettingsWriteOp[]
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of running the partial-update decider on a proto `Settings`:
+ * either a list of write ops to apply, or a daemon-derived field
+ * rejection that the handler turns into `Code.InvalidArgument` (spec
+ * §4.2 + acceptance §7 #5).
+ *
+ * The decider does NOT return a `Promise` and does NOT touch the
+ * database — the handler runs the ops via `applySettingsWrites` after
+ * inspecting this result. This separation keeps the cap-and-clamp
+ * logic unit-testable without a sqlite handle.
+ */
+export type EncodePatchResult =
+  | { readonly kind: 'ok'; readonly ops: readonly SettingsWriteOp[] }
+  | { readonly kind: 'reject_daemon_derived'; readonly key: string };
+
+/**
+ * Translate a client's `Settings` message into a write-op list per
+ * spec §4.2.
+ *
+ * Field-presence handling:
+ *   - `default_geometry` / `crash_retention` are proto3 `optional` —
+ *     the generated TS type uses `T | undefined`, so `!== undefined`
+ *     IS the presence bit (spec §4.2 step 1).
+ *   - All other scalars (`locale`, `sentry_enabled`,
+ *     `detected_claude_default_model`, `user_home_path`) lack proto3
+ *     presence — the wire always carries a value. We adopt the
+ *     "non-default value = client touched" heuristic (matches the F7
+ *     spec footnote scope: "presence semantics for `optional` fields";
+ *     scalars without `optional` are documented as "always-present").
+ *     For `sentry_enabled` specifically, the absence of presence on a
+ *     bool is genuinely ambiguous (false could mean "default" or
+ *     "client asked false"); since the proto comment documents the
+ *     default as `true`, we treat `false` as "client touched" and
+ *     `true` as "no change unless row is currently absent". Spec #337
+ *     §9 q1 leaves this open; this matches the ship behaviour
+ *     reviewers should expect.
+ *   - `ui_prefs` map: every entry the client sent gets one upsert,
+ *     except empty-string values which DELETE the row (spec §4.2 last
+ *     bullet — "client asked to forget this key").
+ *
+ * Daemon-derived rejection: if the client sent a NON-EMPTY value for
+ * `user_home_path` or `detected_claude_default_model`, return the
+ * reject result; the handler raises `Code.InvalidArgument`. An empty
+ * value is silently ignored (proto3 default — "client didn't touch").
+ */
+export function encodeUpdatePatch(s: Settings): EncodePatchResult {
+  const ops: SettingsWriteOp[] = [];
+
+  // Daemon-derived rejection FIRST so we never partially apply a batch
+  // that includes a forbidden field.
+  if (s.userHomePath !== '') {
+    return { kind: 'reject_daemon_derived', key: SETTINGS_KEYS.userHomePath };
+  }
+  if (s.detectedClaudeDefaultModel !== '') {
+    return {
+      kind: 'reject_daemon_derived',
+      key: SETTINGS_KEYS.detectedClaudeDefaultModel,
+    };
+  }
+
+  if (s.defaultGeometry !== undefined) {
+    ops.push({
+      kind: 'upsert',
+      key: SETTINGS_KEYS.defaultGeometry,
+      value: JSON.stringify({
+        cols: s.defaultGeometry.cols,
+        rows: s.defaultGeometry.rows,
+      }),
+    });
+  }
+  if (s.crashRetention !== undefined) {
+    const clamped = {
+      max_entries: clampInt(
+        s.crashRetention.maxEntries,
+        CAPS.crashRetentionMaxEntries,
+      ),
+      max_age_days: clampInt(
+        s.crashRetention.maxAgeDays,
+        CAPS.crashRetentionMaxAgeDays,
+      ),
+    };
+    ops.push({
+      kind: 'upsert',
+      key: SETTINGS_KEYS.crashRetention,
+      value: JSON.stringify(clamped),
+    });
+  }
+
+  if (s.locale !== '') {
+    ops.push({
+      kind: 'upsert',
+      key: SETTINGS_KEYS.locale,
+      value: JSON.stringify(s.locale),
+    });
+  }
+  // Treat `sentry_enabled === false` as the client's signal to opt out
+  // (proto comment documents the default as `true`). `true` is taken
+  // as "no opinion / leave alone" in the absence of a presence bit;
+  // the row stays at whatever the boot / prior write left it.
+  if (s.sentryEnabled === false) {
+    ops.push({
+      kind: 'upsert',
+      key: SETTINGS_KEYS.sentryEnabled,
+      value: JSON.stringify(false),
+    });
+  }
+
+  for (const [k, v] of Object.entries(s.uiPrefs)) {
+    const fullKey = `${UI_PREFS_PREFIX}${k}`;
+    if (v === '') {
+      ops.push({ kind: 'delete', key: fullKey });
+    } else {
+      ops.push({
+        kind: 'upsert',
+        key: fullKey,
+        // Spec §2.2 ui_prefs row note: store the JSON-encoded form so
+        // the table is 100% JSON. Reader symmetrically `JSON.parse`s.
+        value: JSON.stringify(v),
+      });
+    }
+  }
+
+  // Keep the linter happy about `DAEMON_DERIVED_KEYS` being live —
+  // referenced here as the canonical source of which keys are
+  // daemon-derived. The conditional above is the actual gate.
+  void DAEMON_DERIVED_KEYS;
+
+  return { kind: 'ok', ops };
+}

--- a/packages/daemon/src/rpc/settings/update.ts
+++ b/packages/daemon/src/rpc/settings/update.ts
@@ -1,0 +1,93 @@
+// packages/daemon/src/rpc/settings/update.ts
+//
+// Wave-3 Task #349 (spec #337 §4.2) — production
+// `SettingsService.UpdateSettings` Connect handler.
+//
+// Behaviour summary (spec §4.2):
+//   - Reject PRINCIPAL scope with InvalidArgument (same as Get).
+//   - Reject any non-empty `user_home_path` / `detected_claude_default_model`
+//     write with InvalidArgument (those fields are daemon-derived; spec
+//     §5 + acceptance §7 #5).
+//   - Cap-and-clamp `crash_retention.{max_entries,max_age_days}` BEFORE
+//     write (spec §4.2 + settings.proto line 121-123).
+//   - Apply every UPSERT/DELETE in ONE IMMEDIATE transaction so a
+//     partial failure rolls back (spec §4.2 + §4.5).
+//   - Round-trip the post-merge `Settings` in the response so the
+//     client sees the authoritative resolved view (settings.proto F7
+//     mandate).
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type ServiceImpl,
+} from '@connectrpc/connect';
+
+import {
+  SettingsScope,
+  type SettingsService,
+  UpdateSettingsResponseSchema,
+} from '@ccsm/proto';
+
+import type { SqliteDatabase } from '../../db/sqlite.js';
+import { decideGetSettings } from './get.js';
+import {
+  applySettingsWrites,
+  encodeUpdatePatch,
+  readSettingsRows,
+  rowsToSettings,
+} from './store.js';
+
+export interface UpdateSettingsDeps {
+  readonly db: SqliteDatabase;
+  readonly onUnknownKey?: (key: string) => void;
+}
+
+export function makeUpdateSettingsHandler(
+  deps: UpdateSettingsDeps,
+): ServiceImpl<typeof SettingsService>['updateSettings'] {
+  return async function updateSettings(req) {
+    // Scope validation reuses the GetSettings decider — same rule, same
+    // error shape (acceptance §7 #4 covers Get; the Update path keeps
+    // it symmetric).
+    const decision = decideGetSettings(
+      // The decider only reads `scope` from the request; the field
+      // sits on UpdateSettingsRequest under the same name.
+      { scope: req.scope } as Parameters<typeof decideGetSettings>[0],
+    );
+    if (decision.kind === 'reject_scope') {
+      throw new ConnectError(
+        `SettingsScope ${SettingsScope[decision.scope] ?? String(decision.scope)} ` +
+          'is not supported in v0.3 (only GLOBAL / UNSPECIFIED).',
+        Code.InvalidArgument,
+      );
+    }
+
+    const incoming = req.settings;
+    if (!incoming) {
+      throw new ConnectError(
+        'UpdateSettingsRequest.settings is required.',
+        Code.InvalidArgument,
+      );
+    }
+
+    const encoded = encodeUpdatePatch(incoming);
+    if (encoded.kind === 'reject_daemon_derived') {
+      throw new ConnectError(
+        `${encoded.key} is daemon-derived and cannot be set via UpdateSettings.`,
+        Code.InvalidArgument,
+      );
+    }
+
+    applySettingsWrites(deps.db, encoded.ops);
+
+    // Round-trip the post-merge view (spec §4.2 + settings.proto F7).
+    const rows = readSettingsRows(deps.db);
+    const merged = rowsToSettings(rows, { onUnknown: deps.onUnknownKey });
+    return create(UpdateSettingsResponseSchema, {
+      meta: req.meta,
+      settings: merged,
+      effectiveScope: SettingsScope.GLOBAL,
+    });
+  };
+}

--- a/packages/daemon/src/runStartup.lock.ts
+++ b/packages/daemon/src/runStartup.lock.ts
@@ -34,6 +34,18 @@
  *   the `crash_log` table being populated; this name asserts the wire
  *   handler is in the production overlay so a regression that drops
  *   the `crashDeps` pass-through fails boot.
+ * - `settings-service` — `SettingsService.{GetSettings,UpdateSettings}`
+ *   Connect handlers installed on Listener A (Wave-3 #349 / audit #228
+ *   sub-task 9 / spec #337 §6.1 step 1). Pre-#349 the entire
+ *   SettingsService returned `Unimplemented` despite the `settings`
+ *   table being created by `001_initial.sql` from day one. This name
+ *   asserts the wire handler is in the production overlay AND that
+ *   the boot path UPSERT-ed the daemon-derived `user_home_path` /
+ *   `detected_claude_default_model` rows (spec §5).
+ * - `draft-service`  — `DraftService.{GetDraft,UpdateDraft}` Connect
+ *   handlers installed on Listener A (Wave-3 #349 / spec #337 §6.1
+ *   step 1). Drafts ride on the same `settings` table under key
+ *   `draft:<session_id>` (spec §2.2 + draft.proto line 8).
  * - `write-coalescer`— SQLite write coalescer is wired (ch07 §5).
  *   v0.3 status: the coalescer module exists at
  *   `src/sqlite/coalescer.ts` but the per-session bridge that hands it
@@ -50,6 +62,8 @@ export const REQUIRED_COMPONENTS: ReadonlyArray<string> = [
   'capture-sources',
   'crash-replayer',
   'crash-rpc',
+  'settings-service',
+  'draft-service',
   'write-coalescer',
 ] as const;
 

--- a/packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts
+++ b/packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts
@@ -97,11 +97,16 @@ import { createConnectTransport } from '@connectrpc/connect-node';
 
 import {
   PROTO_VERSION,
+  CrashRetentionSchema,
   CrashService,
+  DraftService,
   GetCrashLogRequestSchema,
   OwnerFilter,
   RequestMetaSchema,
   SessionService,
+  SettingsSchema,
+  SettingsScope,
+  SettingsService,
   WatchScope,
   WatchSessionsRequestSchema,
 } from '@ccsm/proto';
@@ -277,6 +282,41 @@ function makeCrashClient(baseUrl: string): Client<typeof CrashService> {
     ],
   });
   return createClient(CrashService, transport);
+}
+
+/**
+ * Generic Connect-client factory parameterised on a service descriptor.
+ * Used by the Wave-3 #349 SettingsService + DraftService assertions
+ * which would otherwise repeat the transport-construction boilerplate.
+ */
+function makeServiceClient<S extends Parameters<typeof createClient>[0]>(
+  service: S,
+  baseUrl: string,
+  authzHeader: string | null = `Bearer ${TEST_BEARER_TOKEN}`,
+): Client<S> {
+  const transport = createConnectTransport({
+    httpVersion: '2',
+    baseUrl,
+    interceptors: [
+      (next) => async (req) => {
+        if (authzHeader !== null) {
+          req.header.set('authorization', authzHeader);
+        }
+        return next(req);
+      },
+    ],
+  });
+  return createClient(service, transport);
+}
+
+/** Pull the loopback baseUrl out of a bound listener descriptor. Throws
+ *  if the descriptor is not loopback (the boot-e2e always forces it). */
+function loopbackBaseUrl(result: RunStartupResult): string {
+  const desc = result.listenerA!.descriptor();
+  if (desc.kind !== 'KIND_TCP_LOOPBACK_H2C') {
+    throw new Error(`expected loopback descriptor, got ${desc.kind}`);
+  }
+  return `http://127.0.0.1:${desc.port}`;
 }
 
 function newMeta() {
@@ -706,5 +746,295 @@ describe('daemon-boot end-to-end (Task #208)', () => {
       // where PROGRAMDATA override always succeeds.
       expect(resp.entries.length).toBeGreaterThanOrEqual(0);
     }
+  });
+
+  // ===========================================================================
+  // Wave-3 #349 — SettingsService + DraftService production wire-up
+  // (spec docs/superpowers/specs/2026-05-04-settings-storage.md §7).
+  //
+  // Nine acceptance assertions extending the rolling-extension contract
+  // (#225, plan §6.6 — every new wire-up PR adds an assertion). Pre-#349
+  // both services were stubs returning `Code.Unimplemented`; these checks
+  // pin the boot UPSERT (§5), the round-trip semantics (§4.2 / §4.4), the
+  // partial-update presence semantics (§4.2), the scope/daemon-derived
+  // rejections (§4.1 / §4.2), the empty-draft + DELETE branch (§4.4), the
+  // peer-cred ownership gate (§4.3), and the migration-lock self-check.
+  // ===========================================================================
+
+  it('§7 #1 — SettingsService.GetSettings is wired and returns boot UPSERT user_home_path', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    const baseUrl = loopbackBaseUrl(r);
+    const client = makeServiceClient(SettingsService, baseUrl);
+    const resp = await client.getSettings({
+      meta: newMeta(),
+      scope: SettingsScope.GLOBAL,
+    });
+    // Pre-#349 contract was Code.Unimplemented; getting a populated
+    // GetSettingsResponse proves the overlay landed.
+    expect(resp.effectiveScope).toBe(SettingsScope.GLOBAL);
+    expect(resp.settings).toBeDefined();
+    // Boot UPSERT (spec §5) writes os.homedir() into `user_home_path`;
+    // it MUST be a non-empty string on every boot regardless of OS.
+    expect(typeof resp.settings?.userHomePath).toBe('string');
+    expect(resp.settings!.userHomePath.length).toBeGreaterThan(0);
+  });
+
+  it('§7 #2 — Settings round-trip: UpdateSettings ui_prefs entry then GetSettings returns it', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    const baseUrl = loopbackBaseUrl(r);
+    const client = makeServiceClient(SettingsService, baseUrl);
+    const upd = await client.updateSettings({
+      meta: newMeta(),
+      settings: create(SettingsSchema, {
+        uiPrefs: { 'appearance.theme': 'dark' },
+      }),
+      scope: SettingsScope.GLOBAL,
+    });
+    // F7 round-trip: the post-merge Settings comes back in the response.
+    expect(upd.settings?.uiPrefs?.['appearance.theme']).toBe('dark');
+    // Subsequent GetSettings reads from the same row.
+    const get = await client.getSettings({
+      meta: newMeta(),
+      scope: SettingsScope.GLOBAL,
+    });
+    expect(get.settings?.uiPrefs?.['appearance.theme']).toBe('dark');
+    // Boot UPSERT row is still present — UpdateSettings did not
+    // clobber daemon-derived state.
+    expect(get.settings!.userHomePath.length).toBeGreaterThan(0);
+  });
+
+  it('§7 #3 — partial-update presence: crash_retention.max_entries=0 with presence bit writes 0', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    const baseUrl = loopbackBaseUrl(r);
+    const client = makeServiceClient(SettingsService, baseUrl);
+    const upd = await client.updateSettings({
+      meta: newMeta(),
+      settings: create(SettingsSchema, {
+        crashRetention: create(CrashRetentionSchema, {
+          maxEntries: 0,
+          maxAgeDays: 0,
+        }),
+      }),
+      scope: SettingsScope.GLOBAL,
+    });
+    expect(upd.settings?.crashRetention).toBeDefined();
+    expect(upd.settings?.crashRetention?.maxEntries).toBe(0);
+    expect(upd.settings?.crashRetention?.maxAgeDays).toBe(0);
+    const get = await client.getSettings({
+      meta: newMeta(),
+      scope: SettingsScope.GLOBAL,
+    });
+    expect(get.settings?.crashRetention).toBeDefined();
+    expect(get.settings?.crashRetention?.maxEntries).toBe(0);
+    expect(get.settings?.crashRetention?.maxAgeDays).toBe(0);
+  });
+
+  it('§7 #4 — Settings rejects PRINCIPAL scope with Code.InvalidArgument', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    const baseUrl = loopbackBaseUrl(r);
+    const client = makeServiceClient(SettingsService, baseUrl);
+    let raised: ConnectError | null = null;
+    try {
+      await client.getSettings({
+        meta: newMeta(),
+        scope: SettingsScope.PRINCIPAL,
+      });
+    } catch (err) {
+      raised = ConnectError.from(err);
+    }
+    expect(raised, 'expected ConnectError on PRINCIPAL scope').not.toBeNull();
+    expect(raised!.code).toBe(Code.InvalidArgument);
+  });
+
+  it('§7 #5 — Settings rejects daemon-derived field write with Code.InvalidArgument', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    const baseUrl = loopbackBaseUrl(r);
+    const client = makeServiceClient(SettingsService, baseUrl);
+    let raised: ConnectError | null = null;
+    try {
+      await client.updateSettings({
+        meta: newMeta(),
+        settings: create(SettingsSchema, {
+          userHomePath: '/tmp/spoofed',
+        }),
+        scope: SettingsScope.GLOBAL,
+      });
+    } catch (err) {
+      raised = ConnectError.from(err);
+    }
+    expect(raised, 'expected ConnectError on user_home_path write').not.toBeNull();
+    expect(raised!.code).toBe(Code.InvalidArgument);
+  });
+
+  it('§7 #6 — DraftService.GetDraft is wired and returns empty for unknown session', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    const baseUrl = loopbackBaseUrl(r);
+    // Seed a session row owned by the test principal so the peer-cred
+    // gate passes. principalKey for TEST_BEARER_TOKEN is `local-user:test`
+    // (auth/interceptor.ts).
+    const sid = '01HXXXXXXXXXXXXXXXXXXXXXXX'; // valid 26-char Crockford ULID
+    r.db
+      .prepare(
+        'INSERT INTO principals (id, kind, first_seen_ms, last_seen_ms) VALUES (?, ?, ?, ?)',
+      )
+      .run('local-user:test', 'local-user', Date.now(), Date.now());
+    r.db
+      .prepare(
+        'INSERT INTO sessions (id, owner_id, state, cwd, env_json, claude_args_json, geometry_cols, geometry_rows, created_ms, last_active_ms) ' +
+          'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      )
+      .run(
+        sid,
+        'local-user:test',
+        0,
+        '/tmp',
+        '{}',
+        '[]',
+        80,
+        24,
+        Date.now(),
+        Date.now(),
+      );
+    const client = makeServiceClient(DraftService, baseUrl);
+    const resp = await client.getDraft({
+      meta: newMeta(),
+      sessionId: sid,
+    });
+    // Pre-#349 contract was Code.Unimplemented; populated response with
+    // text='' + updated_unix_ms=0 proves the overlay + the empty-draft
+    // branch (draft.proto comment line 18-19).
+    expect(resp.text).toBe('');
+    expect(Number(resp.updatedUnixMs)).toBe(0);
+  });
+
+  it('§7 #7 — Draft round-trip + DELETE: Update→Get returns text; UpdateDraft("") clears the row', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    const baseUrl = loopbackBaseUrl(r);
+    const sid = '01HYYYYYYYYYYYYYYYYYYYYYYY';
+    // Reuse the principal row from §7 #6 (still present in this beforeEach
+    // — single boot per test); just add a second session row.
+    r.db
+      .prepare(
+        'INSERT OR IGNORE INTO principals (id, kind, first_seen_ms, last_seen_ms) VALUES (?, ?, ?, ?)',
+      )
+      .run('local-user:test', 'local-user', Date.now(), Date.now());
+    r.db
+      .prepare(
+        'INSERT INTO sessions (id, owner_id, state, cwd, env_json, claude_args_json, geometry_cols, geometry_rows, created_ms, last_active_ms) ' +
+          'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      )
+      .run(
+        sid,
+        'local-user:test',
+        0,
+        '/tmp',
+        '{}',
+        '[]',
+        80,
+        24,
+        Date.now(),
+        Date.now(),
+      );
+    const client = makeServiceClient(DraftService, baseUrl);
+    const updResp = await client.updateDraft({
+      meta: newMeta(),
+      sessionId: sid,
+      text: 'hello',
+    });
+    expect(Number(updResp.updatedUnixMs)).toBeGreaterThan(0);
+    const getResp = await client.getDraft({
+      meta: newMeta(),
+      sessionId: sid,
+    });
+    expect(getResp.text).toBe('hello');
+    // DELETE branch: UpdateDraft("") removes the row.
+    await client.updateDraft({
+      meta: newMeta(),
+      sessionId: sid,
+      text: '',
+    });
+    const getAfterDelete = await client.getDraft({
+      meta: newMeta(),
+      sessionId: sid,
+    });
+    expect(getAfterDelete.text).toBe('');
+    expect(Number(getAfterDelete.updatedUnixMs)).toBe(0);
+    // Direct SQL probe — row actually GONE, not just empty-string value.
+    const row = r.db
+      .prepare<[string, string], { value: string }>(
+        'SELECT value FROM settings WHERE scope = ? AND key = ?',
+      )
+      .get('global', `draft:${sid}`);
+    expect(row).toBeUndefined();
+  });
+
+  it('§7 #8 — Draft peer-cred enforcement: GetDraft for foreign-owned session returns PermissionDenied', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    const baseUrl = loopbackBaseUrl(r);
+    const sid = '01HZZZZZZZZZZZZZZZZZZZZZZZ';
+    // Insert a "foreign" principal row + a session owned by them.
+    r.db
+      .prepare(
+        'INSERT INTO principals (id, kind, first_seen_ms, last_seen_ms) VALUES (?, ?, ?, ?)',
+      )
+      .run('local-user:other', 'local-user', Date.now(), Date.now());
+    r.db
+      .prepare(
+        'INSERT INTO sessions (id, owner_id, state, cwd, env_json, claude_args_json, geometry_cols, geometry_rows, created_ms, last_active_ms) ' +
+          'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      )
+      .run(
+        sid,
+        'local-user:other',
+        0,
+        '/tmp',
+        '{}',
+        '[]',
+        80,
+        24,
+        Date.now(),
+        Date.now(),
+      );
+    const client = makeServiceClient(DraftService, baseUrl);
+    let raised: ConnectError | null = null;
+    try {
+      await client.getDraft({
+        meta: newMeta(),
+        sessionId: sid,
+      });
+    } catch (err) {
+      raised = ConnectError.from(err);
+    }
+    expect(
+      raised,
+      'expected ConnectError on foreign-owned session GetDraft',
+    ).not.toBeNull();
+    expect(raised!.code).toBe(Code.PermissionDenied);
+  });
+
+  it('§7 #9 — migration-lock self-check still passes (no surprise 002_*.sql)', async () => {
+    // Pull the lock + runner exports lazily so the boot above is the
+    // only path that opens the production DB.
+    const { MIGRATION_LOCKS } = await import(
+      '../../src/db/locked.js'
+    );
+    const { runMigrations } = await import('../../src/db/migrations/runner.js');
+    // Spec §7 #9: exactly one entry (001) and a re-run returns
+    // applied: [] because the table-already-there state is the
+    // expected post-boot shape.
+    expect(MIGRATION_LOCKS.length).toBe(1);
+    expect(MIGRATION_LOCKS[0]?.version).toBe(1);
+    expect(result).not.toBeNull();
+    const r = result!;
+    const rerun = runMigrations(r.db);
+    expect(rerun.applied).toEqual([]);
   });
 });

--- a/packages/daemon/test/lock/runStartup-lock.spec.ts
+++ b/packages/daemon/test/lock/runStartup-lock.spec.ts
@@ -80,13 +80,19 @@ describe('assertWired (Task #221)', () => {
     expect(() => assertWired(HARD_REQUIRED)).not.toThrow();
   });
 
-  it('REQUIRED_COMPONENTS exposes the canonical 6-component list in stable order', () => {
+  it('REQUIRED_COMPONENTS exposes the canonical component list in stable order', () => {
+    // Order is load-bearing — daemon-boot-end-to-end.spec.ts relies on
+    // it for deep-equal assertions. New entries (crash-rpc Wave-3 #229,
+    // settings-service / draft-service Wave-3 #349) appended in the
+    // order their wire-up landed.
     expect(REQUIRED_COMPONENTS).toEqual([
       'listener-a',
       'supervisor',
       'capture-sources',
       'crash-replayer',
       'crash-rpc',
+      'settings-service',
+      'draft-service',
       'write-coalescer',
     ]);
   });


### PR DESCRIPTION
Task #349 — spec [`docs/superpowers/specs/2026-05-04-settings-storage.md`](../blob/working/docs/superpowers/specs/2026-05-04-settings-storage.md) §6.1 step 1 + §7. Closes audit #228 sub-task 9.

## What lands

Daemon-only impl. Renderer / main untouched (that is #303).

### New production overlay (mirrors CrashService overlay PR #996, #229)

- `packages/daemon/src/rpc/settings/{keys,store,get,update,register}.ts`
  - `SettingsService.GetSettings` + `UpdateSettings` against the existing `settings` table from `001_initial.sql`. NO new migration (spec §1).
  - JSON-encoded values for every key (spec §2.3 — uniform parse path).
  - Partial-update presence semantics for `optional` fields (`default_geometry`, `crash_retention`); cap-and-clamp `crash_retention.{max_entries,max_age_days}` BEFORE write (spec §4.2 + settings.proto F7).
  - `PRINCIPAL` scope rejected with `Code.InvalidArgument` (settings.proto line 36).
  - Daemon-derived field write rejected (`user_home_path` / `detected_claude_default_model` — spec §4.2 + acceptance §7 #5).
  - Single IMMEDIATE transaction for batched UPSERT/DELETE (spec §4.5).

- `packages/daemon/src/rpc/draft/{get,update,register}.ts`
  - `DraftService.GetDraft` + `UpdateDraft` riding on the same `settings` table under key `draft:<session_id>` (spec §2.2 + draft.proto line 8).
  - Empty-text `UpdateDraft` ⇒ DELETE branch (draft.proto line 31).
  - Peer-cred ownership gate via `sessions.owner_id` lookup (spec §4.3 + acceptance §7 #8). v0.3 has only one principal but the check lands now to close the TOCTOU window before v0.4 multi-principal.
  - ULID format guard on `session_id` (spec §8.3 defence-in-depth).

### Boot wiring (`packages/daemon/src/index.ts`)

- Boot UPSERT of daemon-derived rows (spec §5):
  - `user_home_path` ← `os.homedir()`.
  - `detected_claude_default_model` ← `CCSM_DETECTED_CLAUDE_DEFAULT_MODEL` env (forward-safe — sibling task can extend to `~/.claude/settings.json` parse without wire change).
  - Runs AFTER `runMigrations` and BEFORE `assertWired`.
- Wire `settingsDeps` + `draftDeps` through `makeRouterBindHook`.
- Push `'settings-service'` / `'draft-service'` to `wired`.

### `assertWired` lock (`runStartup.lock.ts`)

- Append `'settings-service'` + `'draft-service'` to `REQUIRED_COMPONENTS` so a regression dropping the deps pass-through fails boot.

### Tests

- `test/integration/daemon-boot-end-to-end.spec.ts`: +9 acceptance assertions (spec §7 #1–#9):
  1. Get wired + boot UPSERT `user_home_path` surfaced
  2. Update→Get round-trip (`ui_prefs` entry)
  3. Partial-update presence with `crash_retention.max_entries=0`
  4. `PRINCIPAL` scope rejection
  5. Daemon-derived field write rejection
  6. Draft wired + empty response for fresh session
  7. Draft round-trip + DELETE row gone (verified via direct SQL probe)
  8. Peer-cred `PermissionDenied` for foreign-owned session
  9. Migration-lock self-check (no surprise `002_*.sql`)
- `test/lock/runStartup-lock.spec.ts`: extend canonical-list assertion to include the new entries (this UT was already failing on `origin/working` because of `crash-rpc`; my edit brings it back to green AND extends for #349).
- Existing `settings-roundtrip.spec.ts` NOT deleted — runs as a superset against an in-process module-local store with its own key vocabulary, complementary to the production handler tests.

`forward-safe`: additive new files + wire-row additions only; no edits to locked migration files or shipped descriptors.

## Local checks (host: windows-11)

- lint: ✓ (exit 0; pre-existing warnings only)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0)
- unit tests: ✓
  - `test/lock/runStartup-lock.spec.ts`: 12 passed
  - `test/integration/settings-roundtrip.spec.ts`: 6 passed
  - `test/integration/settings-error.spec.ts`: 7 passed
  - `src/db/__tests__/`: 41 passed
- integration tests: 9 acceptance test BODIES pass — boot logs show `[ccsm-daemon] settings boot UPSERT: user_home_path=set` on every boot; assertions inside `it(...)` complete without an `AssertionError`. Vitest reports them failed only because `afterEach` `listenerA.stop()` hangs at 10s. **Same pattern as pre-existing baseline failures** (`Hello`, `unauthenticated`, `crash-getlog-wired`, `watch-sessions-wired`) on `origin/working` before this PR — confirmed by `git stash; vitest run; git stash pop`. Root cause is `server.close()` in `transport/h2c-loopback.ts` waiting for `connect-node` http2 client drain; out of scope for #349 (separate listener-shutdown hardening task should add `server.closeAllConnections()`).

## Spec coverage matrix

| Spec section | Implementation |
|---|---|
| §2.2 row layout | `keys.ts` constants + `store.ts` `rowsToSettings` / `encodeUpdatePatch` |
| §2.3 JSON-wrap everything | `applySettingsWrites` always JSON-stringifies |
| §2.4 forward-tolerance | `rowsToSettings({ onUnknown })` skips unknown keys |
| §4.1 GetSettings | `settings/get.ts` |
| §4.2 UpdateSettings + cap-and-clamp | `settings/update.ts` + `store.encodeUpdatePatch` |
| §4.3 GetDraft + peer-cred | `draft/get.ts` `assertOwnsSession` |
| §4.4 UpdateDraft + DELETE branch | `draft/update.ts` |
| §4.5 single IMMEDIATE transaction | `applySettingsWrites` uses `db.transaction(...).immediate(...)` |
| §5 boot UPSERT | `index.ts` `upsertSettingsBoot` after `runMigrations` |
| §7 acceptance #1–#9 | new tests in `daemon-boot-end-to-end.spec.ts` |