### PR TITLE
test(daemon): sync runStartup-lock REQUIRED_COMPONENTS expectation 5 -> 6 (crash-rpc)

### DIFF
--- a/packages/daemon/test/lock/runStartup-lock.spec.ts
+++ b/packages/daemon/test/lock/runStartup-lock.spec.ts
@@ -37,7 +37,7 @@ describe('assertWired (Task #221)', () => {
     expect(warnLines[0]).toContain('write-coalescer');
   });
 
-  it('throws listing all 5 components when present is empty', () => {
+  it('throws listing all hard-required components when present is empty', () => {
     let raised: Error | null = null;
     try {
       assertWired([]);
@@ -80,12 +80,13 @@ describe('assertWired (Task #221)', () => {
     expect(() => assertWired(HARD_REQUIRED)).not.toThrow();
   });
 
-  it('REQUIRED_COMPONENTS exposes the canonical 5-component list in stable order', () => {
+  it('REQUIRED_COMPONENTS exposes the canonical 6-component list in stable order', () => {
     expect(REQUIRED_COMPONENTS).toEqual([
       'listener-a',
       'supervisor',
       'capture-sources',
       'crash-replayer',
+      'crash-rpc',
       'write-coalescer',
     ]);
   });


### PR DESCRIPTION
## Summary
- Sync \`packages/daemon/test/lock/runStartup-lock.spec.ts\` deep-equality assertion from the stale 5-component list to the current canonical 6-component list (adds \`'crash-rpc'\`).
- PR #229 / PR #996 wired the \`CrashService.GetCrashLog\` Connect handler in production daemon startup and added \`'crash-rpc'\` to \`REQUIRED_COMPONENTS\` in \`packages/daemon/src/runStartup.lock.ts\`, but the lock spec assertion was not updated, leaving \`runStartup-lock.spec.ts > REQUIRED_COMPONENTS exposes the canonical 5-component list in stable order\` failing on \`origin/working\`.
- Also generalize the description of the \"\`present is empty\` -> throws all 5\" test to \"throws all hard-required components\" so the next addition (e.g. when \`write-coalescer\` graduates from \`WARN_ONLY\`) does not re-stale the message.

No source change. \`REQUIRED_COMPONENTS\` source already lists 6 entries (\`runStartup.lock.ts:47-54\`); this commit only brings the spec back in line with reality.

Refs: Task #360, #229, #228 (sub-task 2)

## Local checks (host: windows-11)
- lint (\`packages/daemon\`): exit 0, 52 warnings (all pre-existing, 0 errors)
- typecheck (\`packages/daemon\`): exit 0
- targeted unit (\`vitest run test/lock/runStartup-lock.spec.ts\`): \`Test Files 1 passed (1) | Tests 10 passed (10) | Duration ~1.3s\`

### Reverse-verify
- stash fix -> \`vitest run test/lock/runStartup-lock.spec.ts\`: \`Test Files 1 failed (1) | Tests 1 failed | 9 passed (10)\` — \`AssertionError: expected [..., 'crash-rpc', ...] to deeply equal [...]\` (the diff shows the missing \`'crash-rpc'\` line)
- stash pop -> same vitest invocation: \`Test Files 1 passed (1) | Tests 10 passed (10)\`

### Worktree disclosure (full repo lint/typecheck/build/test/probe e2e)
The pool-11 worktree on this host was being concurrently churned by other agents (branch-switched + \`reset --hard origin/working\`'d 3+ times during this task; reflog confirms a \`reset: moving to origin/working\` overwrote the local commit on the working tree mid-test-run, recovered via reflog before push). I could not run the full repo-wide \`pnpm lint && pnpm typecheck && pnpm build && pnpm test && pnpm probe:e2e\` matrix end-to-end against my own commit on this worktree without my local state being trampled again.

What WAS verified (commit isolated from churn):
- Daemon-package lint (0 errors) and typecheck (0 errors) ran clean against the working tree containing this commit.
- The targeted lock spec runs green and reverse-verifies as above.
- \`daemon-boot-end-to-end.spec.ts\` does not import the literal \`'crash-rpc'\` string — it imports \`REQUIRED_COMPONENTS\` and asserts \`result.wired\` covers every hard-required entry. So this commit (which only changes the spec literal, not the source array) cannot affect e2e behavior.

CI (ubuntu+macos+windows matrix) is the authoritative cross-check for the full e2e + build matrix here.

## Test plan
- [ ] CI green (ubuntu, macos, windows matrices)
- [ ] \`runStartup-lock.spec.ts > REQUIRED_COMPONENTS exposes the canonical 6-component list in stable order\` passes on all three OS

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>