### PR TITLE
wave3(#43): pty-host snapshot scheduler (T4.10)

### DIFF
--- a/packages/daemon/src/pty-host/__tests__/snapshot-scheduler.spec.ts
+++ b/packages/daemon/src/pty-host/__tests__/snapshot-scheduler.spec.ts
@@ -1,0 +1,366 @@
+// Unit tests for the per-session pty-host snapshot scheduler (T4.10, ch06 §4).
+//
+// Drives the decider with an injected fake clock + fake timer so the four
+// trigger rules (K_TIME / M_DELTAS / B_BYTES / Resize with 500ms coalescing)
+// can be asserted deterministically without sleeping or spawning a real pty.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  K_TIME_MS,
+  M_DELTAS,
+  B_BYTES,
+  type Clock,
+  type TimerOps,
+} from '../../pty/segmentation.js';
+import {
+  SnapshotScheduler,
+  RESIZE_COALESCE_WINDOW_MS,
+  type SnapshotReason,
+} from '../snapshot-scheduler.js';
+
+interface PendingTimer {
+  cb: () => void;
+  fireAtMs: number;
+  cleared: boolean;
+}
+
+function makeFakeEnv(startMs = 1_000_000): {
+  clock: Clock;
+  timer: TimerOps;
+  advance: (ms: number) => void;
+  pendingCount: () => number;
+} {
+  let nowMs = startMs;
+  const pending: PendingTimer[] = [];
+
+  const clock: Clock = () => nowMs;
+  const timer: TimerOps = {
+    setTimer(cb, delayMs) {
+      const t: PendingTimer = { cb, fireAtMs: nowMs + delayMs, cleared: false };
+      pending.push(t);
+      return t;
+    },
+    clearTimer(h) {
+      const t = h as PendingTimer;
+      t.cleared = true;
+      const idx = pending.indexOf(t);
+      if (idx >= 0) pending.splice(idx, 1);
+    },
+  };
+
+  function advance(ms: number): void {
+    nowMs += ms;
+    // Fire any pending timers whose deadline has passed, in deadline order.
+    // Loop because timer callbacks may schedule new timers at the same now.
+    for (;;) {
+      const due = pending
+        .filter((t) => !t.cleared && t.fireAtMs <= nowMs)
+        .sort((a, b) => a.fireAtMs - b.fireAtMs);
+      if (due.length === 0) return;
+      const t = due[0];
+      const idx = pending.indexOf(t);
+      if (idx >= 0) pending.splice(idx, 1);
+      t.cb();
+    }
+  }
+
+  return {
+    clock,
+    timer,
+    advance,
+    pendingCount: () => pending.filter((t) => !t.cleared).length,
+  };
+}
+
+function makeRecorder(): {
+  fired: SnapshotReason[];
+  onSnapshot: (r: SnapshotReason) => void;
+} {
+  const fired: SnapshotReason[] = [];
+  return {
+    fired,
+    onSnapshot: (r) => {
+      fired.push(r);
+    },
+  };
+}
+
+describe('SnapshotScheduler — M_DELTAS trigger', () => {
+  it('does not fire before M_DELTAS deltas', () => {
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    for (let i = 0; i < M_DELTAS - 1; i++) sched.noteDelta(1);
+    expect(rec.fired).toEqual([]);
+    expect(sched.deltasSinceLastSnapshot()).toBe(M_DELTAS - 1);
+  });
+
+  it('fires exactly once when the M_DELTAS-th delta arrives and resets counters', () => {
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    for (let i = 0; i < M_DELTAS; i++) sched.noteDelta(1);
+    expect(rec.fired).toEqual(['deltas']);
+    expect(sched.deltasSinceLastSnapshot()).toBe(0);
+    expect(sched.bytesSinceLastSnapshot()).toBe(0);
+  });
+
+  it('fires twice across two full M_DELTAS cycles', () => {
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    for (let i = 0; i < M_DELTAS * 2; i++) sched.noteDelta(1);
+    expect(rec.fired).toEqual(['deltas', 'deltas']);
+  });
+});
+
+describe('SnapshotScheduler — B_BYTES trigger', () => {
+  it('fires on the delta that crosses B_BYTES', () => {
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    // Two slightly-under-half deltas stay below B_BYTES; a small third
+    // delta crosses. Stays well clear of M_DELTAS (3 << 256).
+    const underHalf = Math.floor(B_BYTES / 2) - 1;
+    sched.noteDelta(underHalf);
+    sched.noteDelta(underHalf);
+    expect(rec.fired).toEqual([]);
+    sched.noteDelta(2); // crosses by 0 → 1 over B_BYTES
+    expect(rec.fired).toEqual(['bytes']);
+    expect(sched.bytesSinceLastSnapshot()).toBe(0);
+    expect(sched.deltasSinceLastSnapshot()).toBe(0);
+  });
+
+  it('treats negative byteCount as zero (no contribution to B_BYTES)', () => {
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    sched.noteDelta(-100);
+    expect(sched.bytesSinceLastSnapshot()).toBe(0);
+    expect(sched.deltasSinceLastSnapshot()).toBe(1);
+  });
+
+  it('M_DELTAS wins ordering when both thresholds cross in the same noteDelta', () => {
+    // A pathological large-payload stream where each delta is large enough
+    // that M_DELTAS deltas cumulatively exceed B_BYTES — both thresholds
+    // cross on the M_DELTAS-th call. Spec says either reason is valid; we
+    // pin the ordering to `deltas` so the report is deterministic.
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    const perDelta = Math.ceil(B_BYTES / M_DELTAS) + 1; // ensures byte cross at delta #M_DELTAS
+    for (let i = 0; i < M_DELTAS; i++) sched.noteDelta(perDelta);
+    expect(rec.fired).toEqual(['deltas']);
+  });
+});
+
+describe('SnapshotScheduler — K_TIME trigger', () => {
+  it('does NOT fire after K_TIME_MS if no delta arrived in the window', () => {
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    env.advance(K_TIME_MS * 2);
+    expect(rec.fired).toEqual([]);
+  });
+
+  it('fires after K_TIME_MS once at least one delta has arrived', () => {
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    env.advance(1000);
+    sched.noteDelta(64); // arms K_TIME timer; remaining = K_TIME_MS - 1000
+    env.advance(K_TIME_MS - 1001); // 1 ms before deadline
+    expect(rec.fired).toEqual([]);
+    env.advance(2); // crosses deadline
+    expect(rec.fired).toEqual(['time']);
+    expect(sched.deltasSinceLastSnapshot()).toBe(0);
+  });
+
+  it('fires immediately if a delta arrives after K_TIME_MS has already elapsed (idle session)', () => {
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    // No deltas during the entire 30s window.
+    env.advance(K_TIME_MS + 100);
+    expect(rec.fired).toEqual([]);
+    sched.noteDelta(1); // both clauses now true → fire synchronously
+    expect(rec.fired).toEqual(['time']);
+  });
+
+  it('K_TIME timer is rearmed against the new baseline after a snapshot', () => {
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    // Burst to fire M_DELTAS, baseline reset.
+    for (let i = 0; i < M_DELTAS; i++) sched.noteDelta(1);
+    expect(rec.fired).toEqual(['deltas']);
+    // Now wait nearly K_TIME but produce one delta then wait the rest.
+    env.advance(5_000);
+    sched.noteDelta(1);
+    env.advance(K_TIME_MS - 5_000 - 1);
+    expect(rec.fired).toEqual(['deltas']);
+    env.advance(2);
+    expect(rec.fired).toEqual(['deltas', 'time']);
+  });
+});
+
+describe('SnapshotScheduler — Resize trigger + 500ms coalescing', () => {
+  it('a single Resize fires a snapshot after RESIZE_COALESCE_WINDOW_MS', () => {
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    sched.noteResize();
+    expect(rec.fired).toEqual([]);
+    env.advance(RESIZE_COALESCE_WINDOW_MS - 1);
+    expect(rec.fired).toEqual([]);
+    env.advance(1);
+    expect(rec.fired).toEqual(['resize']);
+  });
+
+  it('coalesces a burst of Resizes into a single snapshot at the end of the 500ms window', () => {
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    // 30 resizes over 480ms (drag-resize @ ~60Hz).
+    for (let i = 0; i < 30; i++) {
+      sched.noteResize();
+      env.advance(16);
+    }
+    expect(rec.fired).toEqual([]); // still inside the first 500ms window
+    env.advance(RESIZE_COALESCE_WINDOW_MS); // well past the deadline
+    expect(rec.fired).toEqual(['resize']);
+  });
+
+  it('a Resize after the previous coalescing window starts a fresh window', () => {
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    sched.noteResize();
+    env.advance(RESIZE_COALESCE_WINDOW_MS);
+    expect(rec.fired).toEqual(['resize']);
+    sched.noteResize();
+    env.advance(RESIZE_COALESCE_WINDOW_MS);
+    expect(rec.fired).toEqual(['resize', 'resize']);
+  });
+});
+
+describe('SnapshotScheduler — interaction between triggers', () => {
+  it('a Resize during a delta burst still produces a separate resize snapshot', () => {
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    // Burst that fires deltas trigger.
+    for (let i = 0; i < M_DELTAS; i++) sched.noteDelta(1);
+    expect(rec.fired).toEqual(['deltas']);
+    // Resize 200ms later.
+    env.advance(200);
+    sched.noteResize();
+    env.advance(RESIZE_COALESCE_WINDOW_MS);
+    expect(rec.fired).toEqual(['deltas', 'resize']);
+  });
+
+  it('dispose() prevents any further snapshots and cancels pending timers', () => {
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    sched.noteDelta(1); // arms K_TIME
+    sched.noteResize(); // arms resize coalescing
+    expect(env.pendingCount()).toBe(2);
+    sched.dispose();
+    expect(env.pendingCount()).toBe(0);
+    env.advance(K_TIME_MS * 10);
+    expect(rec.fired).toEqual([]);
+    // post-dispose calls are no-ops
+    sched.noteDelta(B_BYTES);
+    sched.noteResize();
+    env.advance(K_TIME_MS);
+    expect(rec.fired).toEqual([]);
+  });
+
+  it('dispose() is idempotent', () => {
+    const env = makeFakeEnv();
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    sched.dispose();
+    expect(() => sched.dispose()).not.toThrow();
+  });
+
+  it('lastSnapshotAtMs() advances on each fire', () => {
+    const env = makeFakeEnv(1_000_000);
+    const rec = makeRecorder();
+    const sched = new SnapshotScheduler({
+      onSnapshot: rec.onSnapshot,
+      now: env.clock,
+      timer: env.timer,
+    });
+    expect(sched.lastSnapshotAtMs()).toBe(1_000_000);
+    env.advance(123);
+    for (let i = 0; i < M_DELTAS; i++) sched.noteDelta(1);
+    expect(sched.lastSnapshotAtMs()).toBe(1_000_123);
+  });
+});

--- a/packages/daemon/src/pty-host/snapshot-scheduler.ts
+++ b/packages/daemon/src/pty-host/snapshot-scheduler.ts
@@ -1,0 +1,309 @@
+// Per-session pty-host snapshot scheduler — spec ch06 §4 (T4.10).
+//
+// [LIBRARY-ONLY] Pure decider: given (a) per-delta byte/count notifications,
+// (b) Resize events, and (c) a clock + timer abstraction, this module decides
+// WHEN a SnapshotV1 must be taken. It does NOT take the snapshot itself —
+// the caller (the pty-host child, wired in T4.12 #48 Attach handler) supplies
+// an `onSnapshot(reason)` sink. Storage of the snapshot bytes lives in the
+// in-memory delta ring (T4.11 #47) + SQLite write coalescer (T5.5).
+//
+// SRP:
+//   - This is a *decider*. No I/O, no real timers (the caller injects
+//     `TimerOps` so tests can advance time deterministically), no knowledge
+//     of the snapshot wire format.
+//   - The four cadence numbers (time / deltas / bytes thresholds) live in
+//     `packages/daemon/src/pty/segmentation.ts` per the
+//     `test/lock/segmentation-cadence` lock — this module imports the named
+//     constants under aliases (so the canonical identifier names appear in
+//     exactly one source file, satisfying the single-source lock) and never
+//     redefines them.
+//
+// Trigger matrix (ch06 §4):
+//   1. Wall-clock window — 30s of wall clock has elapsed since the last
+//      snapshot AND at least one delta has been emitted in that window.
+//      (No deltas → no snapshot — empty sessions stay quiet.)
+//   2. Delta-count window — 256 deltas have been observed since the last
+//      snapshot.
+//   3. Byte-volume window — 1 MiB of cumulative delta payload bytes since
+//      the last snapshot.
+//   4. Resize — any geometry change forces a snapshot, BUT consecutive
+//      Resizes are coalesced into a single snapshot using a 500ms cap
+//      (drag-resize emits SIGWINCH many times per second; without
+//      coalescing the daemon would queue a snapshot per Resize, which
+//      thrashes the snapshot writer and wastes IO). See ch06 §4 narrative
+//      lock — "Resize-triggered snapshot coalescing (drag-resize emits
+//      Resize many times per second; without coalescing the daemon would
+//      queue a snapshot per Resize)".
+//
+// Wire-up follows T4.11 (in-memory ring) + T4.12 (Attach handler). Until
+// then, this module is wired by unit tests only.
+//
+// Aliases below: the named constant exports are re-imported under
+// scheduler-local names so the canonical names (and the magic numbers they
+// carry) only appear in `pty/segmentation.ts`. The single-source lock spec
+// allows the import line itself to mention the canonical names; everything
+// else in this file uses the aliases.
+
+// prettier-ignore
+import { K_TIME_MS as TIME_TRIGGER_MS, M_DELTAS as DELTA_COUNT_TRIGGER, B_BYTES as BYTE_VOLUME_TRIGGER, type Clock, type TimerOps, type TimerHandle } from '../pty/segmentation.js';
+
+/**
+ * Why a snapshot was triggered. Surfaced to the `onSnapshot` sink so the
+ * caller can attribute snapshot writes in logs / metrics. The variants are
+ * 1:1 with the four trigger rules in ch06 §4.
+ */
+export type SnapshotReason = 'time' | 'deltas' | 'bytes' | 'resize';
+
+/**
+ * Maximum time the scheduler waits after the FIRST Resize event in a burst
+ * before forcing a snapshot. Subsequent Resizes inside this window are
+ * coalesced into the same snapshot.
+ *
+ * Spec ch06 §4 narrative lock fixes this at 500ms. Forever-stable; the
+ * cadence-source-of-truth lock only forbids the wall-clock / delta-count /
+ * byte-volume / segmentation literals from leaving `pty/segmentation.ts`,
+ * so the resize coalescing window (which is a property of the resize
+ * trigger, not of the delta segmenter) lives next to the code that uses it.
+ */
+export const RESIZE_COALESCE_WINDOW_MS = 500;
+
+export interface SnapshotSchedulerOptions {
+  /**
+   * Sink invoked synchronously when a snapshot must be taken. The caller
+   * is responsible for actually capturing xterm-headless screen state and
+   * writing the SnapshotV1 bytes; this scheduler only decides WHEN.
+   *
+   * After `onSnapshot` returns, all four counters are reset to zero and
+   * the wall-clock baseline is reset to `now()`. The caller MUST NOT
+   * throw from `onSnapshot` — failures are tracked by T4.11
+   * (consecutiveSnapshotWriteFailures + DEGRADED) at a layer above this
+   * decider.
+   */
+  readonly onSnapshot: (reason: SnapshotReason) => void;
+  /** Wall-clock source. Production: `Date.now`. */
+  readonly now: Clock;
+  /** Timer ops. Production: `{ setTimer: setTimeout, clearTimer: clearTimeout }`. */
+  readonly timer: TimerOps;
+}
+
+/**
+ * Per-session snapshot scheduler. Spec ch06 §4.
+ *
+ * Lifecycle:
+ *   - Construct one per pty-host session. The wall-clock baseline starts
+ *     at `now()` at construction (treat construction as "time of session
+ *     start" — there is no snapshot at seq=0).
+ *   - The pty-host calls `noteDelta(byteCount)` once per emitted PtyDelta
+ *     (after the delta accumulator from T4.9 has decided to flush), and
+ *     `noteResize()` once per processed Resize RPC.
+ *   - When any trigger fires, the scheduler synchronously invokes
+ *     `onSnapshot(reason)` and resets counters. The caller's snapshot
+ *     write is part of that synchronous call so no second delta can slip
+ *     in between the trigger and the counter reset.
+ *   - `dispose()` clears all pending timers and prevents further
+ *     `onSnapshot` calls. Idempotent.
+ *
+ * Concurrency: synchronous state machine. The only async edges are the
+ * two timers (the wall-clock window and the Resize coalescing window),
+ * both of which are driven through the injected `TimerOps`.
+ */
+export class SnapshotScheduler {
+  private readonly opts: SnapshotSchedulerOptions;
+
+  // Counters since the last snapshot (or since construction, before the
+  // first snapshot). Both reset to zero in `resetCounters`.
+  private deltasSince = 0;
+  private bytesSince = 0;
+
+  // Wall-clock time of the last snapshot. Used to compute time elapsed.
+  // Initialized to `now()` at construction so the first window starts at
+  // session start, not at the first delta.
+  private lastSnapshotMs: number;
+
+  // Wall-clock window timer — armed when there is at least one delta and
+  // we are waiting for the window to elapse. Disarmed after each snapshot
+  // (counters reset → no in-window deltas → re-arm on next delta).
+  private windowTimer: TimerHandle | null = null;
+
+  // Resize coalescing timer — armed by the FIRST Resize in a burst and
+  // disarmed when it fires (which takes the snapshot). Subsequent Resizes
+  // while this is armed are no-ops (coalesced).
+  private resizeTimer: TimerHandle | null = null;
+
+  private disposed = false;
+
+  constructor(opts: SnapshotSchedulerOptions) {
+    this.opts = opts;
+    this.lastSnapshotMs = opts.now();
+  }
+
+  /**
+   * The pty-host child calls this once per emitted `PtyDelta` (after the
+   * delta accumulator from T4.9 flushes). `byteCount` is the size of the
+   * `payload` field on the delta (raw VT bytes only — header / wire
+   * framing not counted).
+   *
+   * Increments the delta counter and the byte counter. If either crosses
+   * its trigger threshold, fires `onSnapshot` synchronously with the
+   * matching reason. Otherwise, arms the wall-clock-window timer if it
+   * isn't already armed (the timer fires when the window has elapsed
+   * since the last snapshot, AND we just observed a delta in that window
+   * — exactly the AND clause in ch06 §4 trigger #1).
+   *
+   * `byteCount` of zero is treated as a real delta (it still counts
+   * toward the delta-count trigger) but does not advance the byte
+   * counter. Negative byte counts are programmer errors and are clamped
+   * to zero — this matches the accumulator's invariant that empty pushes
+   * never produce a delta.
+   */
+  noteDelta(byteCount: number): void {
+    if (this.disposed) return;
+    const safeBytes = byteCount > 0 ? byteCount : 0;
+    this.deltasSince += 1;
+    this.bytesSince += safeBytes;
+
+    // Trigger checks: delta-count first, then byte-volume. Ordering only
+    // affects the `reason` reported in the rare race where both triggers
+    // cross in the same noteDelta — it does NOT affect snapshot
+    // frequency. The spec ch06 §4 enumerates the triggers as a set, so
+    // either reason is valid attribution. We pick delta-count first
+    // because it is the higher-frequency trigger in practice (256 deltas
+    // of avg ~512 bytes = 128 KiB << 1 MiB).
+    if (this.deltasSince >= DELTA_COUNT_TRIGGER) {
+      this.fire('deltas');
+      return;
+    }
+    if (this.bytesSince >= BYTE_VOLUME_TRIGGER) {
+      this.fire('bytes');
+      return;
+    }
+
+    // No threshold crossing → arm the wall-clock-window timer if it isn't
+    // already armed. The timer fires `TIME_TRIGGER_MS` after the LAST
+    // snapshot (lastSnapshotMs), not relative to this delta — otherwise
+    // a steady trickle of deltas would push the trigger out forever.
+    this.armWindowTimer();
+  }
+
+  /**
+   * The pty-host child calls this once per processed Resize RPC (geometry
+   * change applied to xterm-headless via `terminal.resize(cols, rows)`).
+   *
+   * Schedules a snapshot to fire `RESIZE_COALESCE_WINDOW_MS` (500ms) from
+   * now if no resize timer is already armed. Subsequent Resizes inside
+   * the window are no-ops, so a continuous drag-resize produces exactly
+   * one snapshot at the end of each 500ms epoch.
+   *
+   * Why coalesce instead of snapshotting per-Resize: drag-resize on a
+   * desktop terminal emits SIGWINCH at the screen refresh rate
+   * (~60Hz = once per ~16ms). Snapshotting per-Resize would queue ~30
+   * snapshot writes during a 500ms drag, each ~tens of KiB, which thrashes
+   * the snapshot writer and burns IO for no reattach benefit (the user is
+   * mid-drag; only the final geometry matters).
+   */
+  noteResize(): void {
+    if (this.disposed) return;
+    if (this.resizeTimer !== null) return; // already coalescing
+    this.resizeTimer = this.opts.timer.setTimer(() => {
+      this.resizeTimer = null;
+      // Disposed-after-arm guard: if dispose() ran between arm and fire,
+      // bail rather than calling the sink.
+      if (this.disposed) return;
+      this.fire('resize');
+    }, RESIZE_COALESCE_WINDOW_MS);
+  }
+
+  /**
+   * Stop the scheduler. Clears any pending timer and prevents further
+   * `onSnapshot` calls. Idempotent.
+   *
+   * Does NOT fire a final snapshot — callers that want a pre-shutdown
+   * drain should snapshot explicitly before disposing.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.windowTimer !== null) {
+      this.opts.timer.clearTimer(this.windowTimer);
+      this.windowTimer = null;
+    }
+    if (this.resizeTimer !== null) {
+      this.opts.timer.clearTimer(this.resizeTimer);
+      this.resizeTimer = null;
+    }
+  }
+
+  /**
+   * Diagnostics: number of deltas observed since the last snapshot.
+   */
+  deltasSinceLastSnapshot(): number {
+    return this.deltasSince;
+  }
+
+  /**
+   * Diagnostics: cumulative delta payload bytes since the last snapshot.
+   */
+  bytesSinceLastSnapshot(): number {
+    return this.bytesSince;
+  }
+
+  /**
+   * Diagnostics: wall-clock time the last snapshot fired (or construction
+   * time, if no snapshot has fired yet).
+   */
+  lastSnapshotAtMs(): number {
+    return this.lastSnapshotMs;
+  }
+
+  // --- internal -----------------------------------------------------------
+
+  private fire(reason: SnapshotReason): void {
+    // Reset state BEFORE invoking the sink so a re-entrant `noteDelta`
+    // from the sink (in theory; in practice sinks are pure writes) sees a
+    // fresh window. Then invoke the sink.
+    this.resetCounters();
+    this.opts.onSnapshot(reason);
+  }
+
+  private resetCounters(): void {
+    this.deltasSince = 0;
+    this.bytesSince = 0;
+    this.lastSnapshotMs = this.opts.now();
+    if (this.windowTimer !== null) {
+      this.opts.timer.clearTimer(this.windowTimer);
+      this.windowTimer = null;
+    }
+    // Note: we DO NOT clear `resizeTimer` here. A Resize-triggered fire
+    // already cleared it in its callback; a deltas/bytes/time fire that
+    // races with a pending resize timer should let the resize timer keep
+    // running — it will fire shortly with `reason=resize` on what is by
+    // then a fresh window, which is the correct user-visible behavior
+    // (the user resized, they should get a post-resize snapshot).
+  }
+
+  private armWindowTimer(): void {
+    if (this.windowTimer !== null) return;
+    const elapsed = this.opts.now() - this.lastSnapshotMs;
+    const remaining = TIME_TRIGGER_MS - elapsed;
+    // If the window has already elapsed (e.g. the session was idle for
+    // longer than the window and only now produced a delta), fire
+    // immediately rather than scheduling a 0ms or negative timer. This
+    // keeps the trigger semantics crisp: "window elapsed AND at least
+    // one delta" — both conditions are true the moment we observe this
+    // delta.
+    if (remaining <= 0) {
+      this.fire('time');
+      return;
+    }
+    this.windowTimer = this.opts.timer.setTimer(() => {
+      this.windowTimer = null;
+      if (this.disposed) return;
+      // Re-check the AND clause: at least one delta in the window. If
+      // the most recent fire (e.g. a resize) reset counters to zero and
+      // no further delta arrived, do nothing — the next noteDelta will
+      // re-arm the timer with a fresh baseline.
+      if (this.deltasSince === 0) return;
+      this.fire('time');
+    }, remaining);
+  }
+}


### PR DESCRIPTION
## Summary

Task #43 — `[T4.10][WAVE3] pty-host: snapshot scheduler` per spec ch06 §4.

[LIBRARY-ONLY] Pure decider for the four snapshot triggers:

1. **wall-clock window** — 30s elapsed since last snapshot AND >=1 delta in the window
2. **delta-count window** — 256 deltas since last snapshot
3. **byte-volume window** — 1 MiB cumulative delta payload bytes since last snapshot
4. **Resize** — coalesced into one snapshot with a 500ms cap so drag-resize bursts (~60Hz SIGWINCH) do not queue per-Resize writes

The three numeric thresholds live in `packages/daemon/src/pty/segmentation.ts` (T4.9 / #50, single-source lock per ch15 §3 #26). This module imports them under scheduler-local aliases (`TIME_TRIGGER_MS` / `DELTA_COUNT_TRIGGER` / `BYTE_VOLUME_TRIGGER`) so the canonical identifier names appear in exactly one source file. The 500ms resize coalescing window is exported here (it belongs to the resize trigger, not the segmenter).

SRP: decider only — caller injects clock + `TimerOps` + `onSnapshot` sink. No real timers, no I/O, no knowledge of SnapshotV1 wire format. Wire-up follows T4.11 (#47 in-mem ring) and T4.12 (#48 Attach handler).

## Files

- `packages/daemon/src/pty-host/snapshot-scheduler.ts` — `SnapshotScheduler` class + `RESIZE_COALESCE_WINDOW_MS` constant + `SnapshotReason` type
- `packages/daemon/src/pty-host/__tests__/snapshot-scheduler.spec.ts` — 17 deterministic UTs with fake clock + fake timer (no sleep, no real pty)

## Local checks (host: windows-11)

- lint: ✓ (0 errors; baseline 52 warnings unchanged)
- typecheck: ✓ (`tsc --noEmit && tsc --noEmit -p tsconfig.electron.json`)
- build: ✓ (`turbo build` — daemon + snapshot-codec + proto)
- new unit tests: 17 passed (`snapshot-scheduler.spec.ts`)
- segmentation-cadence lock: 5 passed (single-source lock holds with the new file)

### Pre-existing baseline failures (NOT introduced by this PR)

Verified by stash + re-run on `origin/working` HEAD (`d0fa395`):

- `src/rpc/__tests__/integration.spec.ts` — 3 cases timeout in `afterEach` cleanup (Hook timed out 10000ms). Pre-existing on baseline; landed with PR #1013 (T-PA-3 ack-state). Unrelated to pty-host.
- `npm run probe:e2e` — `harness-real-cli` and `harness-ui` fail on `window.ccsmSession.onState not exposed by preload (PR-A wiring missing)` and Radix focus-restoration race. Pre-existing UI/preload gaps; this PR adds no UI/IPC/preload code.

This PR adds two new library files only; it imports nothing app-level, so it cannot affect those failures.

## Test plan

- [x] 17 new UTs cover all four triggers, threshold-crossing edges, dispose() idempotence, timer cancellation, and trigger interaction (resize during delta burst).
- [x] Single-source cadence lock (`test/lock/segmentation-cadence`) still passes — verified the imported constants are aliased on a single import line so the canonical names (`K_TIME_MS` / `M_DELTAS` / `B_BYTES`) appear only in `pty/segmentation.ts`.

base=working, blockedBy=#50 (merged), forward-safe (new files only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)