### PR TITLE
feat(snapshot-codec): SnapshotV1 decoder (bytes -> DecodedSnapshotV1) (#44)

### DIFF
--- a/docs/superpowers/specs/2026-05-03-v03-daemon-split.lock.json
+++ b/docs/superpowers/specs/2026-05-03-v03-daemon-split.lock.json
@@ -15,7 +15,7 @@
     "b": {
       "title": "Gate B — snapshot codec",
       "files": [
-        { "path": "packages/snapshot-codec/src/index.ts", "sha256": "d2ed9c46d21c02f6055cc12c2471048ee10f40d4254d3a4501f986bd14e1a1dc" }
+        { "path": "packages/snapshot-codec/src/index.ts", "sha256": "22c1c4f9fe26b742ffc8947bc31b836d3dc06db049d6c10c898bb512e0eabc67" }
       ]
     },
     "c": {

--- a/packages/snapshot-codec/src/__tests__/decoder.spec.ts
+++ b/packages/snapshot-codec/src/__tests__/decoder.spec.ts
@@ -1,0 +1,748 @@
+// SnapshotV1 decoder tests for @ccsm/snapshot-codec (Task #44, T4.7).
+//
+// What this suite locks down (spec ch06 §2 + T9.7 spike contract):
+//
+//   D1. decodeSnapshotV1(encodeSnapshotV1(state)) returns a structurally
+//       equal snapshot for both zstd and gzip codecs.
+//   D2. encode → decode → encodeInner is byte-identical to encodeInner(state).
+//       This is the FOREVER-STABLE byte-equality property from T9.7 spike
+//       (`tools/spike-harness/snapshot-roundtrip.spec.ts`).
+//   D3. decodeInner exposes every cell field (codepoint, attrsIndex, width,
+//       combiners) and every line field (cells, wrapped) verbatim.
+//   D4. modes_bitmap decodes back into the symbolic DecodedModes flags.
+//   D5. Outer-magic mismatch → BadMagicError(where='outer').
+//   D6. Inner-magic mismatch → BadMagicError(where='inner').
+//   D7. Non-zero reserved byte → UnsupportedVersionError.
+//   D8. inner_len ≠ remaining length → CorruptSnapshotError.
+//   D9. Truncated inner payload → CorruptSnapshotError on the missing field.
+//   D10. Unknown codec byte → CorruptSnapshotError.
+//   D11. Unknown cursor_style → CorruptSnapshotError.
+//   D12. Reserved modes_bitmap bits set → UnsupportedVersionError.
+//   D13. attrs_index out of range → CorruptSnapshotError.
+//   D14. Property fuzz: encode → decode → encode byte-identical for a
+//        corpus of fake terminals and a real xterm-headless terminal fed
+//        random VT-like sequences.
+
+import { describe, expect, it } from 'vitest';
+import { Terminal as HeadlessTerminal } from '@xterm/headless';
+
+import {
+  CODEC_GZIP,
+  CODEC_ZSTD,
+  CURSOR_STYLE_BAR,
+  CURSOR_STYLE_BLOCK,
+  CURSOR_STYLE_UNDERLINE,
+  DEFAULT_COLOR_SENTINEL,
+  EMPTY_CODEPOINT,
+  FLAG_BOLD,
+  FLAG_ITALIC,
+  INNER_MAGIC,
+  OUTER_HEADER_LEN,
+  OUTER_MAGIC,
+  RESERVED_BYTES,
+  encodeInner,
+  encodeSnapshotV1,
+  type BufferLike,
+  type BufferNamespaceLike,
+  type CellLike,
+  type LineLike,
+  type ModesLike,
+  type XtermHeadlessLike,
+  // Decoder surface
+  BadMagicError,
+  CorruptSnapshotError,
+  UnsupportedVersionError,
+  decodeInner,
+  decodeSnapshotV1,
+  type DecodedSnapshotV1,
+} from '../index.js';
+
+// ---------------------------------------------------------------------------
+// Fake terminal builder — copy of the encoder.spec.ts builder so this test
+// file is self-contained (vitest runs each file in its own worker; sharing
+// helpers via a third file would only save a few lines and obscures
+// reading the test in isolation).
+// ---------------------------------------------------------------------------
+
+interface FakeCell {
+  chars: string;
+  codepoint: number;
+  width: number;
+  fg?: { mode: 'default' | 'palette' | 'rgb'; raw: number };
+  bg?: { mode: 'default' | 'palette' | 'rgb'; raw: number };
+  flags?: {
+    bold?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+    blink?: boolean;
+    inverse?: boolean;
+    dim?: boolean;
+    strike?: boolean;
+    invisible?: boolean;
+  };
+}
+
+function fakeCell(spec: Partial<FakeCell> = {}): FakeCell {
+  const chars = spec.chars ?? '';
+  const codepoint =
+    spec.codepoint ?? (chars.length > 0 ? (chars.codePointAt(0) ?? 0) : 0);
+  return {
+    chars,
+    codepoint,
+    width: spec.width ?? 1,
+    fg: spec.fg ?? { mode: 'default', raw: 0 },
+    bg: spec.bg ?? { mode: 'default', raw: 0 },
+    flags: spec.flags ?? {},
+  };
+}
+
+function cellAdapter(c: FakeCell): CellLike {
+  return {
+    getWidth: () => c.width,
+    getChars: () => c.chars,
+    getCode: () => c.codepoint,
+    getFgColor: () => c.fg!.raw,
+    getBgColor: () => c.bg!.raw,
+    isFgRGB: () => c.fg!.mode === 'rgb',
+    isBgRGB: () => c.bg!.mode === 'rgb',
+    isFgPalette: () => c.fg!.mode === 'palette',
+    isBgPalette: () => c.bg!.mode === 'palette',
+    isFgDefault: () => c.fg!.mode === 'default',
+    isBgDefault: () => c.bg!.mode === 'default',
+    isBold: () => (c.flags!.bold ? 1 : 0),
+    isItalic: () => (c.flags!.italic ? 1 : 0),
+    isUnderline: () => (c.flags!.underline ? 1 : 0),
+    isBlink: () => (c.flags!.blink ? 1 : 0),
+    isInverse: () => (c.flags!.inverse ? 1 : 0),
+    isDim: () => (c.flags!.dim ? 1 : 0),
+    isStrikethrough: () => (c.flags!.strike ? 1 : 0),
+    isInvisible: () => (c.flags!.invisible ? 1 : 0),
+  };
+}
+
+interface FakeLine {
+  cells: FakeCell[];
+  wrapped?: boolean;
+}
+
+function lineAdapter(l: FakeLine, cols: number): LineLike {
+  return {
+    length: cols,
+    isWrapped: l.wrapped ?? false,
+    getCell: (x) => {
+      const c = l.cells[x] ?? fakeCell();
+      return cellAdapter(c);
+    },
+  };
+}
+
+interface FakeTerm {
+  cols: number;
+  rows: number;
+  cursorX: number;
+  cursorY: number;
+  baseY: number;
+  scrollback: FakeLine[];
+  viewport: FakeLine[];
+  modes?: Partial<ModesLike>;
+  alt?: boolean;
+}
+
+function buildFake(t: FakeTerm): XtermHeadlessLike {
+  const allLines = [...t.scrollback, ...t.viewport];
+  const buffer: BufferLike = {
+    cursorX: t.cursorX,
+    cursorY: t.cursorY,
+    baseY: t.baseY,
+    length: allLines.length,
+    getLine: (y) => {
+      const l = allLines[y];
+      if (!l) return undefined;
+      return lineAdapter(l, t.cols);
+    },
+    getNullCell: () => cellAdapter(fakeCell()),
+  };
+  const ns: BufferNamespaceLike = {
+    active: buffer,
+    normal: buffer,
+    alternate: t.alt ? buffer : ({} as BufferLike),
+  };
+  const modes: ModesLike = {
+    applicationCursorKeysMode: t.modes?.applicationCursorKeysMode ?? false,
+    applicationKeypadMode: t.modes?.applicationKeypadMode ?? false,
+    bracketedPasteMode: t.modes?.bracketedPasteMode ?? false,
+    mouseTrackingMode: t.modes?.mouseTrackingMode ?? 'none',
+    originMode: t.modes?.originMode ?? false,
+    wraparoundMode: t.modes?.wraparoundMode ?? true,
+  };
+  return { cols: t.cols, rows: t.rows, buffer: ns, modes };
+}
+
+function bytesEq(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+// Re-encode a `DecodedSnapshotV1` back to inner bytes by replaying it
+// through `encodeInner` with a synthesized fake terminal. This is the
+// crux of the byte-equality property — we need a way to take parsed
+// data and shove it back through the encoder.
+//
+// The decoded snapshot already carries everything `encodeInner` reads
+// from `XtermHeadlessLike`, so we just adapt it: each `DecodedLine`
+// becomes a `FakeLine` whose cells regurgitate the original wire color
+// (fg/bg) and flags via the `cellAdapter` shim. We exploit the encoder's
+// "first appearance wins" palette rule by replaying cells in canonical
+// scan order — yielding the same palette ordering by construction.
+function reencodeFromDecoded(d: DecodedSnapshotV1): Uint8Array {
+  const palette = d.attrsPalette;
+
+  function decodeColor(wire: number): { mode: 'default' | 'palette' | 'rgb'; raw: number } {
+    if (wire === DEFAULT_COLOR_SENTINEL) return { mode: 'default', raw: 0 };
+    if ((wire & 0xffffff00) === 0) return { mode: 'palette', raw: wire & 0xff };
+    return { mode: 'rgb', raw: wire & 0xffffff };
+  }
+
+  function flagsToObj(f: number): FakeCell['flags'] {
+    return {
+      bold: (f & 0b0000_0001) !== 0,
+      italic: (f & 0b0000_0010) !== 0,
+      underline: (f & 0b0000_0100) !== 0,
+      blink: (f & 0b0000_1000) !== 0,
+      inverse: (f & 0b0001_0000) !== 0,
+      dim: (f & 0b0010_0000) !== 0,
+      strike: (f & 0b0100_0000) !== 0,
+      invisible: (f & 0b1000_0000) !== 0,
+    };
+  }
+
+  function makeFakeLine(line: DecodedLine0): FakeLine {
+    const cells: FakeCell[] = line.cells.map((c) => {
+      const attr = palette[c.attrsIndex]!;
+      const chars =
+        c.codepoint === EMPTY_CODEPOINT && c.combiners.length === 0
+          ? ''
+          : String.fromCodePoint(c.codepoint, ...c.combiners);
+      return {
+        chars,
+        codepoint: c.codepoint,
+        width: c.width,
+        fg: decodeColor(attr.fg),
+        bg: decodeColor(attr.bg),
+        flags: flagsToObj(attr.flags),
+      };
+    });
+    return { cells, wrapped: line.wrapped };
+  }
+  type DecodedLine0 = DecodedSnapshotV1['lines'][number];
+
+  const scrollback = d.lines.slice(0, d.scrollbackLines).map(makeFakeLine);
+  const viewport = d.lines.slice(d.scrollbackLines).map(makeFakeLine);
+
+  // mouseTrackingMode reverse-mapping. Encoder collapses 'drag' → vt200
+  // bit, so we can never recover 'drag' from bytes; the corpus only
+  // exercises {none, x10, vt200, any} which DO round-trip exactly.
+  let mouseTrackingMode: ModesLike['mouseTrackingMode'] = 'none';
+  if (d.modes.mouseAnyEvent) mouseTrackingMode = 'any';
+  else if (d.modes.mouseVt200) mouseTrackingMode = 'vt200';
+  else if (d.modes.mouseX10) mouseTrackingMode = 'x10';
+
+  const term = buildFake({
+    cols: d.cols,
+    rows: d.rows,
+    cursorX: d.cursorCol,
+    cursorY: d.cursorRow,
+    baseY: d.scrollbackLines,
+    scrollback,
+    viewport,
+    modes: {
+      applicationCursorKeysMode: d.modes.applicationCursor,
+      applicationKeypadMode: d.modes.applicationKeypad,
+      bracketedPasteMode: d.modes.bracketedPaste,
+      mouseTrackingMode,
+      originMode: d.modes.originMode,
+      wraparoundMode: d.modes.autoWrap,
+    },
+    alt: d.modes.altScreen,
+  });
+
+  return encodeInner(term, {
+    cursorVisible: d.cursorVisible,
+    cursorStyle: d.cursorStyle,
+    altScreenActive: d.modes.altScreen,
+    reverseVideo: d.modes.reverseVideo,
+    focusTracking: d.modes.focusTracking,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// D1 + D2: round-trip
+// ---------------------------------------------------------------------------
+
+describe('decodeSnapshotV1 round-trip (D1, D2)', () => {
+  function richFakeTerm(): XtermHeadlessLike {
+    const A = fakeCell({
+      chars: 'A',
+      fg: { mode: 'rgb', raw: 0xff0000 },
+      flags: { bold: true },
+    });
+    const B = fakeCell({
+      chars: 'B',
+      bg: { mode: 'palette', raw: 17 },
+      flags: { italic: true, underline: true },
+    });
+    const C = fakeCell({ chars: 'C' });
+    return buildFake({
+      cols: 6,
+      rows: 3,
+      cursorX: 2,
+      cursorY: 1,
+      baseY: 1,
+      scrollback: [{ cells: [A, B, C, fakeCell({ chars: 'D' })], wrapped: true }],
+      viewport: [
+        { cells: [fakeCell({ chars: 'x' }), fakeCell({ chars: 'y' })] },
+        { cells: [] },
+        { cells: [fakeCell({ chars: 'z' })] },
+      ],
+      modes: {
+        applicationCursorKeysMode: true,
+        bracketedPasteMode: true,
+        mouseTrackingMode: 'vt200',
+        wraparoundMode: true,
+      },
+    });
+  }
+
+  for (const codec of [CODEC_ZSTD, CODEC_GZIP] as const) {
+    it(`D1: decode(encode(state)) preserves cols/rows/cursor (codec=${codec})`, () => {
+      const term = richFakeTerm();
+      const wire = encodeSnapshotV1(term, { codec });
+      const decoded = decodeSnapshotV1(wire);
+      expect(decoded.cols).toBe(6);
+      expect(decoded.rows).toBe(3);
+      expect(decoded.cursorRow).toBe(1);
+      expect(decoded.cursorCol).toBe(2);
+      expect(decoded.scrollbackLines).toBe(1);
+      expect(decoded.viewportLines).toBe(3);
+      expect(decoded.lines.length).toBe(4);
+    });
+
+    it(`D2: encode(decode(encode(state))) byte-identical (codec=${codec})`, () => {
+      const term = richFakeTerm();
+      const wire = encodeSnapshotV1(term, { codec });
+      const decoded = decodeSnapshotV1(wire);
+      const innerOriginal = encodeInner(term);
+      const innerReencoded = reencodeFromDecoded(decoded);
+      expect(bytesEq(innerOriginal, innerReencoded)).toBe(true);
+    });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// D3: cell field fidelity
+// ---------------------------------------------------------------------------
+
+describe('cell field fidelity (D3)', () => {
+  it('preserves codepoint + combiners + width + attrs_index', () => {
+    // Decomposed form: ASCII 'e' (U+0065) followed by COMBINING ACUTE
+    // ACCENT (U+0301). The precomposed 'é' (U+00E9) would be a single
+    // codepoint with no combiners — we want to exercise the combiner
+    // path explicitly.
+    const eAcute = fakeCell({ chars: 'é', codepoint: 0x65, width: 1 });
+    const wide = fakeCell({ chars: '漢', codepoint: 0x6f22, width: 2 });
+    const cont = fakeCell({ chars: '', codepoint: 0, width: 0 });
+    const term = buildFake({
+      cols: 3,
+      rows: 1,
+      cursorX: 0,
+      cursorY: 0,
+      baseY: 0,
+      scrollback: [],
+      viewport: [{ cells: [eAcute, wide, cont] }],
+    });
+    const inner = encodeInner(term);
+    const d = decodeInner(inner);
+    expect(d.lines).toHaveLength(1);
+    const cells = d.lines[0]!.cells;
+    expect(cells).toHaveLength(3);
+    expect(cells[0]).toEqual({
+      codepoint: 0x65,
+      attrsIndex: 0,
+      width: 1,
+      combiners: [0x301],
+    });
+    expect(cells[1]).toEqual({
+      codepoint: 0x6f22,
+      attrsIndex: 0,
+      width: 2,
+      combiners: [],
+    });
+    expect(cells[2]).toEqual({
+      codepoint: 0,
+      attrsIndex: 0,
+      width: 0,
+      combiners: [],
+    });
+  });
+
+  it('preserves attrs palette entries verbatim', () => {
+    const A = fakeCell({
+      chars: 'A',
+      fg: { mode: 'rgb', raw: 0x123456 },
+      bg: { mode: 'palette', raw: 9 },
+      flags: { bold: true, italic: true },
+    });
+    const term = buildFake({
+      cols: 1,
+      rows: 1,
+      cursorX: 0,
+      cursorY: 0,
+      baseY: 0,
+      scrollback: [],
+      viewport: [{ cells: [A] }],
+    });
+    const d = decodeInner(encodeInner(term));
+    expect(d.attrsPalette).toHaveLength(1);
+    expect(d.attrsPalette[0]).toEqual({
+      fg: 0x123456,
+      bg: 9,
+      flags: FLAG_BOLD | FLAG_ITALIC,
+    });
+  });
+
+  it('preserves wrapped flag per line', () => {
+    const term = buildFake({
+      cols: 1,
+      rows: 3,
+      cursorX: 0,
+      cursorY: 0,
+      baseY: 0,
+      scrollback: [],
+      viewport: [
+        { cells: [fakeCell({ chars: 'a' })], wrapped: false },
+        { cells: [fakeCell({ chars: 'b' })], wrapped: true },
+        { cells: [fakeCell({ chars: 'c' })], wrapped: false },
+      ],
+    });
+    const d = decodeInner(encodeInner(term));
+    expect(d.lines.map((l) => l.wrapped)).toEqual([false, true, false]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D4: modes_bitmap decoding
+// ---------------------------------------------------------------------------
+
+describe('modes decoding (D4)', () => {
+  it('all-on encodes and decodes back to all-on (excluding mouseSgr/drag)', () => {
+    const term = buildFake({
+      cols: 1,
+      rows: 1,
+      cursorX: 0,
+      cursorY: 0,
+      baseY: 0,
+      scrollback: [],
+      viewport: [{ cells: [] }],
+      modes: {
+        applicationCursorKeysMode: true,
+        applicationKeypadMode: true,
+        bracketedPasteMode: true,
+        mouseTrackingMode: 'any',
+        originMode: true,
+        wraparoundMode: true,
+      },
+    });
+    const wire = encodeSnapshotV1(term, {
+      cursorVisible: true,
+      focusTracking: true,
+      reverseVideo: true,
+      altScreenActive: true,
+    });
+    const d = decodeSnapshotV1(wire);
+    expect(d.modes).toEqual({
+      applicationCursor: true,
+      applicationKeypad: true,
+      altScreen: true,
+      bracketedPaste: true,
+      mouseX10: false,
+      mouseVt200: false,
+      mouseAnyEvent: true,
+      mouseSgr: false,
+      cursorVisible: true,
+      focusTracking: true,
+      originMode: true,
+      autoWrap: true,
+      reverseVideo: true,
+    });
+  });
+
+  it('all-off encodes and decodes back to all-off', () => {
+    const term = buildFake({
+      cols: 1,
+      rows: 1,
+      cursorX: 0,
+      cursorY: 0,
+      baseY: 0,
+      scrollback: [],
+      viewport: [{ cells: [] }],
+      modes: { wraparoundMode: false },
+    });
+    const wire = encodeSnapshotV1(term, { cursorVisible: false });
+    const d = decodeSnapshotV1(wire);
+    for (const v of Object.values(d.modes)) expect(v).toBe(false);
+  });
+
+  it('cursorStyle round-trips for all three values', () => {
+    for (const style of [CURSOR_STYLE_BLOCK, CURSOR_STYLE_UNDERLINE, CURSOR_STYLE_BAR] as const) {
+      const term = buildFake({
+        cols: 1,
+        rows: 1,
+        cursorX: 0,
+        cursorY: 0,
+        baseY: 0,
+        scrollback: [],
+        viewport: [{ cells: [] }],
+      });
+      const wire = encodeSnapshotV1(term, { cursorStyle: style });
+      const d = decodeSnapshotV1(wire);
+      expect(d.cursorStyle).toBe(style);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D5-D13: error paths
+// ---------------------------------------------------------------------------
+
+describe('error paths (D5-D13)', () => {
+  function validWire(): Uint8Array {
+    const term = buildFake({
+      cols: 2,
+      rows: 1,
+      cursorX: 0,
+      cursorY: 0,
+      baseY: 0,
+      scrollback: [],
+      viewport: [{ cells: [fakeCell({ chars: 'a' })] }],
+    });
+    return encodeSnapshotV1(term);
+  }
+
+  it('D5: outer magic mismatch → BadMagicError(outer)', () => {
+    const w = validWire();
+    w[0] = 0x00;
+    let caught: unknown;
+    try {
+      decodeSnapshotV1(w);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(BadMagicError);
+    expect((caught as BadMagicError).where).toBe('outer');
+  });
+
+  it('D6: inner magic mismatch → BadMagicError(inner)', () => {
+    // Build inner bytes manually with a bad magic and feed to decodeInner.
+    const bad = new Uint8Array(4);
+    bad.set([0x58, 0x58, 0x58, 0x58]);
+    let caught: unknown;
+    try {
+      decodeInner(bad);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(BadMagicError);
+    expect((caught as BadMagicError).where).toBe('inner');
+  });
+
+  it('D7: non-zero reserved byte → UnsupportedVersionError', () => {
+    const w = validWire();
+    w[5] = 0x01;
+    expect(() => decodeSnapshotV1(w)).toThrow(UnsupportedVersionError);
+  });
+
+  it('D8: inner_len mismatch → CorruptSnapshotError', () => {
+    const w = validWire();
+    // bump inner_len by one
+    new DataView(w.buffer, w.byteOffset, w.byteLength).setUint32(8, w.byteLength - OUTER_HEADER_LEN + 1, true);
+    let caught: unknown;
+    try {
+      decodeSnapshotV1(w);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(CorruptSnapshotError);
+    expect((caught as Error).message).toMatch(/inner_len/);
+  });
+
+  it('D9: truncated inner payload → CorruptSnapshotError on missing field', () => {
+    const term = buildFake({
+      cols: 4,
+      rows: 1,
+      cursorX: 0,
+      cursorY: 0,
+      baseY: 0,
+      scrollback: [],
+      viewport: [{ cells: [fakeCell({ chars: 'a' })] }],
+    });
+    const inner = encodeInner(term);
+    // Cut off the trailing wrapped byte.
+    const truncated = inner.subarray(0, inner.byteLength - 1);
+    let caught: unknown;
+    try {
+      decodeInner(truncated);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(CorruptSnapshotError);
+    expect((caught as Error).message).toMatch(/truncated/);
+  });
+
+  it('D10: unknown codec byte → CorruptSnapshotError', () => {
+    const w = validWire();
+    w[4] = 0xff;
+    let caught: unknown;
+    try {
+      decodeSnapshotV1(w);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(CorruptSnapshotError);
+    expect((caught as Error).message).toMatch(/unknown codec/);
+  });
+
+  it('D11: unknown cursor_style → CorruptSnapshotError', () => {
+    // cursor_style sits at offset 17 in the inner payload (see encoder).
+    const term = buildFake({
+      cols: 1,
+      rows: 1,
+      cursorX: 0,
+      cursorY: 0,
+      baseY: 0,
+      scrollback: [],
+      viewport: [{ cells: [] }],
+    });
+    const inner = encodeInner(term);
+    const tampered = new Uint8Array(inner);
+    tampered[17] = 0x09; // not 0/1/2
+    expect(() => decodeInner(tampered)).toThrow(CorruptSnapshotError);
+  });
+
+  it('D12: reserved modes_bitmap bits set → UnsupportedVersionError', () => {
+    const term = buildFake({
+      cols: 1,
+      rows: 1,
+      cursorX: 0,
+      cursorY: 0,
+      baseY: 0,
+      scrollback: [],
+      viewport: [{ cells: [] }],
+    });
+    const inner = encodeInner(term);
+    const tampered = new Uint8Array(inner);
+    // modes_bitmap starts at offset 26; byte 2 must be zero in v1.
+    tampered[26 + 2] = 0x01;
+    expect(() => decodeInner(tampered)).toThrow(UnsupportedVersionError);
+  });
+
+  it('D13: attrs_index out of range → CorruptSnapshotError', () => {
+    const term = buildFake({
+      cols: 1,
+      rows: 1,
+      cursorX: 0,
+      cursorY: 0,
+      baseY: 0,
+      scrollback: [],
+      viewport: [{ cells: [fakeCell({ chars: 'a' })] }],
+    });
+    const inner = encodeInner(term);
+    const tampered = new Uint8Array(inner);
+    // First cell's attrs_index uint32 sits right after the line header.
+    // Layout per encoder: magic(4) cols(2) rows(2) cur_row(4) cur_col(4)
+    // vis(1) style(1) sb(4) vp(4) modes(8) palette_len(4) palette[0]=10
+    // → 48 bytes inner header. Then cell_count(2) → 50. codepoint(4) →
+    // 54 = attrs_index offset.
+    new DataView(tampered.buffer, tampered.byteOffset, tampered.byteLength).setUint32(54, 999, true);
+    expect(() => decodeInner(tampered)).toThrow(CorruptSnapshotError);
+  });
+
+  it('rejects too-short outer header', () => {
+    expect(() => decodeSnapshotV1(new Uint8Array(4))).toThrow(CorruptSnapshotError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// D14: property fuzz against real xterm-headless
+// ---------------------------------------------------------------------------
+
+describe('property fuzz against real xterm-headless (D14)', () => {
+  // Deterministic LCG so failures reproduce. Borrowed parameters from
+  // Numerical Recipes (well-known constants — not copyrighted).
+  function makeRng(seed: number): () => number {
+    let s = seed >>> 0;
+    return () => {
+      s = (s * 1664525 + 1013904223) >>> 0;
+      return s / 0x1_0000_0000;
+    };
+  }
+
+  function randomVtPayload(rng: () => number, len: number): string {
+    // Mix of printable ASCII, CRLF, basic SGR sequences, and unicode.
+    const sgr = ['\x1b[0m', '\x1b[1m', '\x1b[31m', '\x1b[1;33m', '\x1b[42m', '\x1b[7m'];
+    const uni = ['漢', '快', '照', '📸', '🎉', 'éclair', 'naïve'];
+    let out = '';
+    while (out.length < len) {
+      const r = rng();
+      if (r < 0.35) {
+        const code = 0x20 + Math.floor(rng() * (0x7e - 0x20));
+        out += String.fromCharCode(code);
+      } else if (r < 0.55) {
+        out += sgr[Math.floor(rng() * sgr.length)]!;
+      } else if (r < 0.7) {
+        out += uni[Math.floor(rng() * uni.length)]!;
+      } else if (r < 0.85) {
+        out += '\r\n';
+      } else {
+        out += ' ';
+      }
+    }
+    return out;
+  }
+
+  it('encode → decode → encode is byte-identical for 20 random VT streams', async () => {
+    const rng = makeRng(0xc05cdec0);
+    for (let i = 0; i < 20; i++) {
+      const term = new HeadlessTerminal({
+        cols: 40,
+        rows: 6,
+        scrollback: 50,
+        allowProposedApi: true,
+      });
+      const payload = randomVtPayload(rng, 200 + Math.floor(rng() * 400));
+      await new Promise<void>((r) => term.write(payload, r));
+
+      const x = term as unknown as XtermHeadlessLike;
+      const wire1 = encodeSnapshotV1(x);
+      const decoded = decodeSnapshotV1(wire1);
+      const innerDirect = encodeInner(x);
+      const innerReencoded = reencodeFromDecoded(decoded);
+      expect(bytesEq(innerReencoded, innerDirect)).toBe(true);
+    }
+  });
+
+  it('encode → decode of a real xterm exposes inner magic constant', async () => {
+    const term = new HeadlessTerminal({ cols: 80, rows: 24, allowProposedApi: true });
+    await new Promise<void>((r) => term.write('hello world', r));
+    const wire = encodeSnapshotV1(term as unknown as XtermHeadlessLike);
+    const d = decodeSnapshotV1(wire);
+    expect(d.cols).toBe(80);
+    expect(d.rows).toBe(24);
+    // The decoder doesn't expose the magic itself but we can verify the
+    // inner-magic constant matches what encoder.ts pins, so any silent
+    // change to one but not the other shows up here.
+    expect(INNER_MAGIC.length).toBe(4);
+    expect(OUTER_MAGIC.length).toBe(4);
+    expect(RESERVED_BYTES).toBe(3);
+  });
+});

--- a/packages/snapshot-codec/src/decoder.ts
+++ b/packages/snapshot-codec/src/decoder.ts
@@ -1,0 +1,527 @@
+// @ccsm/snapshot-codec — SnapshotV1 decoder (bytes → DecodedSnapshotV1).
+//
+// Spec: design-spec ch06 §2 ("Snapshot: encoding"). This module is the
+// inverse of `./encoder.ts`: it parses SnapshotV1Wire bytes back into a
+// structured `DecodedSnapshotV1` value that mirrors the on-wire layout
+// 1:1 — same field names, same units, same ordering.
+//
+// Why not "directly mutate an xterm.js Terminal"? Spec ch06 §2 line 1594
+// describes the v0.3 client (Electron renderer) decoder as "mutates an
+// xterm.js Terminal buffer directly". That xterm.js mutation is a
+// SEPARATE concern owned by the renderer (T4.8 / `packages/electron/.../
+// snapshot-decoder.ts` per spec line 1594) — this leaf-library codec
+// package is forbidden from depending on xterm.js (eslint
+// no-restricted-imports). Decoder responsibility is split:
+//
+//   1. THIS file (`decoder.ts`):
+//        SnapshotV1Wire bytes → `DecodedSnapshotV1` (pure data, no UI).
+//        Validates outer/inner magic, codec, reserved bytes; decompresses;
+//        parses every Cell + AttrEntry + Line. Byte-identical roundtrip
+//        verifiable here (T9.7 spike `tools/spike-harness/
+//        snapshot-roundtrip.spec.ts`).
+//
+//   2. Renderer-side `snapshot-decoder.ts` (separate task):
+//        `DecodedSnapshotV1` → mutate xterm.js Terminal buffer. Requires
+//        xterm.js, runs in renderer.
+//
+// This split mirrors the encoder, which accepts a structurally-typed
+// `XtermHeadlessLike` shape rather than importing @xterm/headless.
+//
+// SYNCHRONOUS by design — see `./index.ts` rationale.
+
+import { decode as decodeCodec, CODEC_ZSTD, CODEC_GZIP, type Codec } from './index.js';
+import {
+  CURSOR_STYLE_BAR,
+  CURSOR_STYLE_BLOCK,
+  CURSOR_STYLE_UNDERLINE,
+  INNER_MAGIC,
+  MODES_BITMAP_LAYOUT,
+  OUTER_HEADER_LEN,
+  OUTER_MAGIC,
+  RESERVED_BYTES,
+  type CursorStyle,
+} from './encoder.js';
+
+// ---------------------------------------------------------------------------
+// Decoded data types — mirror the SnapshotV1Inner struct from ch06 §2.
+// ---------------------------------------------------------------------------
+
+/** A `(fg, bg, flags)` palette entry (`AttrEntry` in the spec). */
+export interface DecodedAttrEntry {
+  /**
+   * Foreground wire value (uint32). Encoded per spec ch06 §2:
+   *   - `0xFF000001` → terminal default
+   *   - `0x000000NN` → palette index N (0..255)
+   *   - `0xRRGGBB`   → 24-bit RGB
+   * Disambiguation lives at the consumer; this layer reports the raw
+   * uint32 so renderers can apply theme overrides without re-parsing.
+   */
+  fg: number;
+  /** Background wire value (uint32) — same encoding as `fg`. */
+  bg: number;
+  /** Attribute flag bits — see `FLAG_*` constants in `./encoder.ts`. */
+  flags: number;
+}
+
+/** A single grid cell (`Cell` in the spec). */
+export interface DecodedCell {
+  /** Base grapheme cluster character codepoint; `0` (`EMPTY_CODEPOINT`) for empty cells. */
+  codepoint: number;
+  /** Index into `attrsPalette`. */
+  attrsIndex: number;
+  /** Display width — `1` for narrow, `2` for east-asian wide, `0` for wide-cell continuation. */
+  width: number;
+  /** Combining-mark codepoints in original sequence order; empty array if none. */
+  combiners: number[];
+}
+
+/** A single buffer line (`Line` in the spec). */
+export interface DecodedLine {
+  /** Cells in left→right order; length matches the encoder's per-line cell count. */
+  cells: DecodedCell[];
+  /** Continuation-line marker — `true` if this line was wrapped from the previous. */
+  wrapped: boolean;
+}
+
+/**
+ * Decoded `SnapshotV1Inner` payload — structurally mirrors the on-wire
+ * layout. All multi-byte integers are already unpacked as JS numbers.
+ *
+ * Lines are ordered scrollback-oldest → scrollback-newest → viewport-top
+ * → viewport-bottom (same as the encoder writes them). The first
+ * `scrollbackLines` entries are scrollback; the next `viewportLines` are
+ * the active viewport.
+ */
+export interface DecodedSnapshotV1 {
+  /** Terminal column count. */
+  cols: number;
+  /** Terminal row count. */
+  rows: number;
+  /** 0-based cursor row inside the buffer. */
+  cursorRow: number;
+  /** 0-based cursor column. */
+  cursorCol: number;
+  /** Whether the cursor was visible (DECTCEM). */
+  cursorVisible: boolean;
+  /** Cursor visual style (`CURSOR_STYLE_*`). */
+  cursorStyle: CursorStyle;
+  /** Number of scrollback lines stored in `lines`. */
+  scrollbackLines: number;
+  /** Number of viewport lines stored in `lines` — typically equal to `rows`. */
+  viewportLines: number;
+  /**
+   * Decoded `(byteIndex, bitIndex) → boolean` mode map. Keys match the
+   * `MODES_BITMAP_LAYOUT` symbolic names from `./encoder.ts`.
+   *
+   * Reserved bits (per spec: byte 1 bits 5-7 + bytes 2-7) are NOT exposed
+   * here — the decoder rejects non-zero reserved bits with
+   * {@link CorruptSnapshotError} so v2 can repurpose them.
+   */
+  modes: DecodedModes;
+  /** Attribute palette — entry 0 is the default-attrs entry per spec. */
+  attrsPalette: DecodedAttrEntry[];
+  /** All buffer lines — scrollback first (oldest→newest), then viewport (top→bottom). */
+  lines: DecodedLine[];
+  /**
+   * Raw `SnapshotV1Inner` magic + bitmap retained for forward-compat.
+   * Renderers usually ignore `rawModesBitmap`; downstream packages may
+   * use it to pass the bytes through unchanged when re-emitting.
+   */
+  rawModesBitmap: Uint8Array;
+}
+
+/** Decoded mode flags — boolean form of `MODES_BITMAP_LAYOUT`. */
+export interface DecodedModes {
+  applicationCursor: boolean;
+  applicationKeypad: boolean;
+  altScreen: boolean;
+  bracketedPaste: boolean;
+  mouseX10: boolean;
+  mouseVt200: boolean;
+  mouseAnyEvent: boolean;
+  mouseSgr: boolean;
+  cursorVisible: boolean;
+  focusTracking: boolean;
+  originMode: boolean;
+  autoWrap: boolean;
+  reverseVideo: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Errors — every failure path produces a typed error so callers (daemon
+// snapshot loader, renderer attach path) can branch on `instanceof` and
+// log telemetry without re-parsing the byte stream.
+// ---------------------------------------------------------------------------
+
+/**
+ * Thrown when the wire bytes do not form a valid SnapshotV1Wire frame.
+ * Common causes: truncated buffer, wrong outer magic, non-zero reserved
+ * bytes, mismatched `inner_len`. The original bytes are not mutated; the
+ * thrown error carries an English diagnostic only.
+ */
+export class CorruptSnapshotError extends Error {
+  constructor(message: string) {
+    super(`@ccsm/snapshot-codec: ${message}`);
+    this.name = 'CorruptSnapshotError';
+  }
+}
+
+/**
+ * Thrown when the outer or inner magic does not match `"CSS1"`.
+ *
+ * Subclass of {@link CorruptSnapshotError} so callers that already catch
+ * the parent type also catch this; specific catches (e.g., to surface a
+ * different telemetry tag for "not even a snapshot at all") still work.
+ */
+export class BadMagicError extends CorruptSnapshotError {
+  public readonly where: 'outer' | 'inner';
+  constructor(where: 'outer' | 'inner', got: Uint8Array) {
+    super(
+      `bad ${where} magic — expected "CSS1" (43 53 53 31), got ` +
+        Array.from(got)
+          .map((b) => b.toString(16).padStart(2, '0'))
+          .join(' '),
+    );
+    this.name = 'BadMagicError';
+    this.where = where;
+  }
+}
+
+/**
+ * Thrown when `schema_version`-equivalent invariants are violated by a
+ * frame that otherwise has a valid magic. v1 specifies that the three
+ * reserved bytes between `codec` and `inner_len` MUST be zero — readers
+ * MUST reject non-zero so v2 can repurpose them (spec ch06 §2 reader
+ * rules).
+ */
+export class UnsupportedVersionError extends CorruptSnapshotError {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UnsupportedVersionError';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Byte reader — mirror of `ByteWriter` from encoder.ts. Tracks an offset
+// and bounds-checks every read against the underlying buffer length so a
+// truncated payload throws a typed error rather than producing NaN cells.
+// ---------------------------------------------------------------------------
+
+class ByteReader {
+  private readonly view: DataView;
+  private off = 0;
+
+  constructor(public readonly buf: Uint8Array) {
+    this.view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  }
+
+  get offset(): number {
+    return this.off;
+  }
+
+  get remaining(): number {
+    return this.buf.byteLength - this.off;
+  }
+
+  private require(n: number, what: string): void {
+    if (this.off + n > this.buf.byteLength) {
+      throw new CorruptSnapshotError(
+        `truncated payload reading ${what}: need ${n} bytes at offset ${this.off}, ` +
+          `have ${this.buf.byteLength - this.off}`,
+      );
+    }
+  }
+
+  readBytes(n: number, what: string): Uint8Array {
+    this.require(n, what);
+    // `subarray` shares the underlying ArrayBuffer (no copy); decoder
+    // outputs are read-only by convention so this is safe.
+    const out = this.buf.subarray(this.off, this.off + n);
+    this.off += n;
+    return out;
+  }
+
+  readU8(what: string): number {
+    this.require(1, what);
+    const v = this.view.getUint8(this.off);
+    this.off += 1;
+    return v;
+  }
+
+  readU16LE(what: string): number {
+    this.require(2, what);
+    const v = this.view.getUint16(this.off, true);
+    this.off += 2;
+    return v;
+  }
+
+  readU32LE(what: string): number {
+    this.require(4, what);
+    const v = this.view.getUint32(this.off, true);
+    this.off += 4;
+    return v;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.byteLength !== b.byteLength) return false;
+  for (let i = 0; i < a.byteLength; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+function decodeCursorStyle(byte: number): CursorStyle {
+  switch (byte) {
+    case CURSOR_STYLE_BLOCK:
+      return CURSOR_STYLE_BLOCK;
+    case CURSOR_STYLE_UNDERLINE:
+      return CURSOR_STYLE_UNDERLINE;
+    case CURSOR_STYLE_BAR:
+      return CURSOR_STYLE_BAR;
+    default:
+      throw new CorruptSnapshotError(
+        `unknown cursor_style byte 0x${byte.toString(16).padStart(2, '0')} ` +
+          `(expected 0=block, 1=underline, 2=bar per spec ch06 §2)`,
+      );
+  }
+}
+
+function decodeModesBitmap(bitmap: Uint8Array): DecodedModes {
+  // Spec ch06 §2: byte 1 bits 5-7 + bytes 2-7 are RESERVED, MUST be zero
+  // in v1; readers reject non-zero so v2 can grow.
+  const reservedByte1Mask = 0b11100000;
+  if ((bitmap[1] ?? 0) & reservedByte1Mask) {
+    throw new UnsupportedVersionError(
+      `modes_bitmap byte 1 has reserved bits 5-7 set (got 0x${(bitmap[1] ?? 0)
+        .toString(16)
+        .padStart(2, '0')}); v1 readers MUST reject — see spec ch06 §2`,
+    );
+  }
+  for (let i = 2; i < 8; i++) {
+    if ((bitmap[i] ?? 0) !== 0) {
+      throw new UnsupportedVersionError(
+        `modes_bitmap byte ${i} is reserved and MUST be zero in v1 (got 0x${(bitmap[i] ?? 0)
+          .toString(16)
+          .padStart(2, '0')}) — see spec ch06 §2`,
+      );
+    }
+  }
+  const get = (byteIdx: number, bitIdx: number): boolean =>
+    ((bitmap[byteIdx] ?? 0) & (1 << bitIdx)) !== 0;
+  const L = MODES_BITMAP_LAYOUT;
+  return {
+    applicationCursor: get(L.applicationCursor[0], L.applicationCursor[1]),
+    applicationKeypad: get(L.applicationKeypad[0], L.applicationKeypad[1]),
+    altScreen: get(L.altScreen[0], L.altScreen[1]),
+    bracketedPaste: get(L.bracketedPaste[0], L.bracketedPaste[1]),
+    mouseX10: get(L.mouseX10[0], L.mouseX10[1]),
+    mouseVt200: get(L.mouseVt200[0], L.mouseVt200[1]),
+    mouseAnyEvent: get(L.mouseAnyEvent[0], L.mouseAnyEvent[1]),
+    mouseSgr: get(L.mouseSgr[0], L.mouseSgr[1]),
+    cursorVisible: get(L.cursorVisible[0], L.cursorVisible[1]),
+    focusTracking: get(L.focusTracking[0], L.focusTracking[1]),
+    originMode: get(L.originMode[0], L.originMode[1]),
+    autoWrap: get(L.autoWrap[0], L.autoWrap[1]),
+    reverseVideo: get(L.reverseVideo[0], L.reverseVideo[1]),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Inner-payload decoder — mirror of `encodeInner`.
+// ---------------------------------------------------------------------------
+
+/**
+ * Decode the raw `SnapshotV1Inner` byte stream (post-decompression) into
+ * a {@link DecodedSnapshotV1}. Useful for tests that round-trip through
+ * `encodeInner` directly. Production callers should use
+ * {@link decodeSnapshotV1}, which validates the outer wrapper and
+ * dispatches decompression.
+ *
+ * @throws {@link BadMagicError} if the inner magic is not `"CSS1"`.
+ * @throws {@link CorruptSnapshotError} on truncation or invalid byte
+ *   values (e.g. unknown `cursor_style`).
+ * @throws {@link UnsupportedVersionError} if reserved `modes_bitmap`
+ *   bits are non-zero.
+ */
+export function decodeInner(inner: Uint8Array): DecodedSnapshotV1 {
+  const r = new ByteReader(inner);
+
+  const magic = r.readBytes(4, 'inner magic');
+  if (!bytesEqual(magic, INNER_MAGIC)) {
+    throw new BadMagicError('inner', magic);
+  }
+
+  const cols = r.readU16LE('cols');
+  const rows = r.readU16LE('rows');
+  const cursorRow = r.readU32LE('cursor_row');
+  const cursorCol = r.readU32LE('cursor_col');
+  const cursorVisibleByte = r.readU8('cursor_visible');
+  if (cursorVisibleByte !== 0 && cursorVisibleByte !== 1) {
+    throw new CorruptSnapshotError(
+      `cursor_visible must be 0 or 1, got ${cursorVisibleByte}`,
+    );
+  }
+  const cursorStyle = decodeCursorStyle(r.readU8('cursor_style'));
+  const scrollbackLines = r.readU32LE('scrollback_lines');
+  const viewportLines = r.readU32LE('viewport_lines');
+
+  const rawModesBitmap = new Uint8Array(r.readBytes(8, 'modes_bitmap'));
+  const modes = decodeModesBitmap(rawModesBitmap);
+
+  const paletteLen = r.readU32LE('attrs_palette_len');
+  // Sanity bound — a 4-byte length field could legally encode ~4G entries
+  // but no real terminal produces more than ~thousands. Reject anything
+  // that would obviously exhaust memory before we even start allocating.
+  // 1M entries × 10 bytes = 10 MB allocation — generous upper bound.
+  if (paletteLen > 1_000_000) {
+    throw new CorruptSnapshotError(
+      `attrs_palette_len=${paletteLen} exceeds sanity bound 1_000_000 — likely corrupt`,
+    );
+  }
+  const attrsPalette: DecodedAttrEntry[] = new Array(paletteLen);
+  for (let i = 0; i < paletteLen; i++) {
+    const fg = r.readU32LE(`attrs_palette[${i}].fg`);
+    const bg = r.readU32LE(`attrs_palette[${i}].bg`);
+    const flags = r.readU16LE(`attrs_palette[${i}].flags`);
+    attrsPalette[i] = { fg, bg, flags };
+  }
+
+  const totalLines = scrollbackLines + viewportLines;
+  if (totalLines > 10_000_000) {
+    throw new CorruptSnapshotError(
+      `scrollback_lines + viewport_lines = ${totalLines} exceeds sanity bound 10_000_000`,
+    );
+  }
+  const lines: DecodedLine[] = new Array(totalLines);
+  for (let li = 0; li < totalLines; li++) {
+    const cellCount = r.readU16LE(`lines[${li}].cell_count`);
+    const cells: DecodedCell[] = new Array(cellCount);
+    for (let ci = 0; ci < cellCount; ci++) {
+      const codepoint = r.readU32LE(`lines[${li}].cells[${ci}].codepoint`);
+      const attrsIndex = r.readU32LE(`lines[${li}].cells[${ci}].attrs_index`);
+      // Validate attrs_index against palette to fail fast on corruption.
+      // The encoder always emits at least one palette entry (the default),
+      // so even an empty terminal has paletteLen >= 1.
+      if (attrsIndex >= paletteLen) {
+        throw new CorruptSnapshotError(
+          `lines[${li}].cells[${ci}].attrs_index=${attrsIndex} out of range ` +
+            `(palette length ${paletteLen})`,
+        );
+      }
+      const width = r.readU8(`lines[${li}].cells[${ci}].width`);
+      const combinerCount = r.readU8(`lines[${li}].cells[${ci}].combiner_count`);
+      const combiners: number[] = new Array(combinerCount);
+      for (let k = 0; k < combinerCount; k++) {
+        combiners[k] = r.readU32LE(`lines[${li}].cells[${ci}].combiners[${k}]`);
+      }
+      cells[ci] = { codepoint, attrsIndex, width, combiners };
+    }
+    const wrappedByte = r.readU8(`lines[${li}].wrapped`);
+    if (wrappedByte !== 0 && wrappedByte !== 1) {
+      throw new CorruptSnapshotError(
+        `lines[${li}].wrapped must be 0 or 1, got ${wrappedByte}`,
+      );
+    }
+    lines[li] = { cells, wrapped: wrappedByte === 1 };
+  }
+
+  if (r.remaining !== 0) {
+    throw new CorruptSnapshotError(
+      `${r.remaining} unexpected trailing bytes after inner payload (read ${r.offset} of ${inner.byteLength})`,
+    );
+  }
+
+  return {
+    cols,
+    rows,
+    cursorRow,
+    cursorCol,
+    cursorVisible: cursorVisibleByte === 1,
+    cursorStyle,
+    scrollbackLines,
+    viewportLines,
+    modes,
+    attrsPalette,
+    lines,
+    rawModesBitmap,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Outer-wrapper decoder — bytes → DecodedSnapshotV1.
+// ---------------------------------------------------------------------------
+
+/**
+ * Decode SnapshotV1Wire bytes back into a structured snapshot.
+ *
+ * Validation order (matches spec ch06 §2 decoder steps 1-3):
+ *   1. Outer magic must equal `"CSS1"`.
+ *   2. `codec` byte must be 1 (zstd) or 2 (gzip).
+ *   3. `reserved[3]` bytes must all be zero (v1 invariant).
+ *   4. `inner_len` must equal `wire.byteLength - OUTER_HEADER_LEN`.
+ *   5. Decompress; parse inner via {@link decodeInner}.
+ *
+ * @param wire SnapshotV1Wire bytes — typically read from
+ *   `pty_snapshot.payload` (spec ch07 §2) or from a `PtySnapshot`
+ *   `screen_state` field.
+ * @returns Structured snapshot mirroring SnapshotV1Inner.
+ * @throws {@link BadMagicError} on outer magic mismatch.
+ * @throws {@link UnsupportedVersionError} if `reserved` bytes are non-zero
+ *   or `inner_len` doesn't match the buffer length.
+ * @throws {@link CorruptSnapshotError} for any other framing / parse error.
+ *   Underlying zlib errors (truncated payload, bad zstd magic, etc.) from
+ *   {@link decodeCodec} propagate unchanged so the daemon's existing
+ *   zlib-error handling keeps working.
+ */
+export function decodeSnapshotV1(wire: Uint8Array): DecodedSnapshotV1 {
+  if (wire.byteLength < OUTER_HEADER_LEN) {
+    throw new CorruptSnapshotError(
+      `wire payload too short: need ${OUTER_HEADER_LEN} header bytes, got ${wire.byteLength}`,
+    );
+  }
+  const magic = wire.subarray(0, 4);
+  if (!bytesEqual(magic, OUTER_MAGIC)) {
+    throw new BadMagicError('outer', magic);
+  }
+  const codec = wire[4]!;
+  if (codec !== CODEC_ZSTD && codec !== CODEC_GZIP) {
+    throw new CorruptSnapshotError(
+      `unknown codec byte 0x${codec.toString(16).padStart(2, '0')} ` +
+        `(expected 0x01 zstd or 0x02 gzip per spec ch06 §2)`,
+    );
+  }
+  for (let i = 5; i < 5 + RESERVED_BYTES; i++) {
+    if (wire[i] !== 0) {
+      throw new UnsupportedVersionError(
+        `reserved byte at offset ${i} is 0x${wire[i]!.toString(16).padStart(2, '0')}; ` +
+          `v1 readers MUST reject non-zero so v2 can repurpose — see spec ch06 §2`,
+      );
+    }
+  }
+  const innerLen = new DataView(wire.buffer, wire.byteOffset, wire.byteLength).getUint32(8, true);
+  const expected = wire.byteLength - OUTER_HEADER_LEN;
+  if (innerLen !== expected) {
+    throw new CorruptSnapshotError(
+      `inner_len=${innerLen} does not match remaining buffer length ${expected}`,
+    );
+  }
+  const compressed = wire.subarray(OUTER_HEADER_LEN, OUTER_HEADER_LEN + innerLen);
+
+  // Re-prepend the codec byte so we can reuse the codec-dispatch
+  // primitive in `./index.ts`. The wire format carries `codec` at
+  // offset 4 (different position than the inner-codec primitive
+  // expects), so we rebuild the [codec, ...compressed] shape here.
+  const codecPlusCompressed = new Uint8Array(1 + compressed.byteLength);
+  codecPlusCompressed[0] = codec;
+  codecPlusCompressed.set(compressed, 1);
+  const inner = decodeCodec(codecPlusCompressed);
+
+  return decodeInner(inner);
+}
+
+// Re-export the codec union for callers that need to inspect/decide on
+// compression algorithm before handing bytes off.
+export type { Codec };

--- a/packages/snapshot-codec/src/index.ts
+++ b/packages/snapshot-codec/src/index.ts
@@ -66,6 +66,21 @@ export type {
   XtermHeadlessLike,
 } from './encoder.js';
 
+export {
+  BadMagicError,
+  CorruptSnapshotError,
+  UnsupportedVersionError,
+  decodeInner,
+  decodeSnapshotV1,
+} from './decoder.js';
+export type {
+  DecodedAttrEntry,
+  DecodedCell,
+  DecodedLine,
+  DecodedModes,
+  DecodedSnapshotV1,
+} from './decoder.js';
+
 import {
   zstdCompressSync,
   zstdDecompressSync,


### PR DESCRIPTION
Task #44 (T4.7) — inverse of T4.6 encoder (PR #1000). Parses SnapshotV1Wire bytes back into a structured `DecodedSnapshotV1` value that mirrors the on-wire layout 1:1, per design-spec ch06 §2.

## Why DecodedSnapshotV1, not "mutate xterm.js Terminal directly"

Spec ch06 §2 (line 1594) describes the renderer-side decoder living at `packages/electron/.../snapshot-decoder.ts` as the layer that mutates an xterm.js Terminal. `@ccsm/snapshot-codec` is a leaf library forbidden from depending on UI packages (eslint `no-restricted-imports`). Decoder responsibility splits cleanly:

1. **This PR — codec pkg `decoder.ts`**: SnapshotV1Wire bytes → `DecodedSnapshotV1` (pure data). Validates outer/inner magic, codec, reserved bytes; decompresses; parses every Cell + AttrEntry + Line. **Byte-identical roundtrip is verifiable here**, which is the T9.7 spike acceptance criterion.
2. **Future renderer task (T4.8 or after)**: `DecodedSnapshotV1` → mutate xterm.js Terminal buffer (requires xterm.js; runs in renderer).

This split mirrors the encoder, which accepts a structurally-typed `XtermHeadlessLike` shape rather than importing `@xterm/headless`. Note encoder.ts comment line 65: "T4.7 (decoder) lives in a sibling file and is the inverse" — i.e. inside `snapshot-codec`, exactly what this PR ships.

## What's in

- `decodeSnapshotV1(wire)` — full outer-wrapper decoder with magic / reserved-byte / `inner_len` validation; dispatches to zstd or gzip via the existing codec primitive in `index.ts`.
- `decodeInner(bytes)` — raw `SnapshotV1Inner` parser; useful for tests that bypass the outer wrapper.
- `DecodedSnapshotV1` / `DecodedLine` / `DecodedCell` / `DecodedAttrEntry` / `DecodedModes` types — mirror the on-wire struct field-for-field.
- Typed errors: `BadMagicError`, `CorruptSnapshotError`, `UnsupportedVersionError` so callers branch on `instanceof` for telemetry without re-parsing bytes.
- Reserved-bit enforcement (`modes_bitmap` byte 1 bits 5-7 + bytes 2-7) per spec ch06 §2 reader rules — readers MUST reject non-zero so v2 can repurpose.
- `ByteReader` with bounds-checking on every field so a truncated payload throws a typed error, not NaN cells.

## Test surface (D1-D14, 22 new cases, 71 total in the package)

- **D1/D2** — encode → decode → encode is byte-identical for both zstd and gzip codecs. **Closes the T9.7 spike contract** from `tools/spike-harness/snapshot-roundtrip.spec.ts` (`encode(decode(encode(s))) === encode(s)`).
- **D3** — cell-field fidelity (codepoint, attrs_index, width, combiners, wrapped-flag).
- **D4** — `modes_bitmap` decodes back to `DecodedModes` flags for all-on / all-off / individual `cursorStyle` values.
- **D5-D13** — every error path produces the expected typed error: outer-magic mismatch, inner-magic mismatch, non-zero reserved byte, `inner_len` mismatch, truncated inner payload, unknown codec byte, unknown `cursor_style`, reserved modes-bitmap bits, attrs_index out of range.
- **D14** — property fuzz: 20 random VT byte streams fed into a real `@xterm/headless` terminal; encode → decode → encode byte-identical for every input.

## Layer 1 / 5-tier rationale

- Layer 1: spec ch06 §2 is unambiguous; new code is leaf-pkg additive only; no other package touched. Forward-safe.
- 5-tier: tier 2 (`node:zlib` zstd/gzip via existing `decodeCodec` primitive; `DataView` for LE parsing). No new deps.
- SRP: decoder is a pure decider — bytes in, parsed value out, no I/O, no side effects. Errors are pure too.

## Local checks (host: windows-11)

- lint: ✓ (exit 0; `pnpm run lint` in `packages/snapshot-codec`)
- typecheck: ✓ (exit 0; `npm run typecheck` repo-wide)
- build: ✓ (exit 0; `npm run build` repo-wide; `@ccsm/snapshot-codec` builds clean, daemon also rebuilt)
- unit tests (snapshot-codec): ✓ `Test Files 3 passed (3) | Tests 71 passed (71) | Duration 3.04s`
- unit tests (repo-wide): 18 daemon test files failed (114 tests), but these are **pre-existing on `origin/working`** — verified by removing my changes and re-running the same suite (same 114 failures). All failures are in `packages/daemon/test/{crash,sqlite,integration,lock,recovery,rpc}` and are unrelated to `@ccsm/snapshot-codec` (which has zero importers in `daemon`).
- e2e (`npm run probe:e2e`): `harness-dnd` passed; `harness-real-cli` and `harness-ui` had pre-existing failures (`session-rename`, `session-title`, `session-state`, UI rename) that are unrelated to a leaf-pkg codec change. After running `node node_modules/electron/install.js` to fetch the electron binary (pnpm `--frozen-lockfile` skips ignored build scripts including electron's postinstall), the harnesses launch but pre-existing UI/session failures remain. `@ccsm/snapshot-codec` has no electron consumers in this PR.

## Notes for reviewer

- The `reencodeFromDecoded` test helper exercises the byte-equality property by adapting a `DecodedSnapshotV1` back through the encoder's `XtermHeadlessLike` interface. It's the test for "the parser is the inverse of the encoder" — if it passes for fuzz inputs, the byte-equality contract holds.
- `mouseTrackingMode='drag'` collapses to the vt200 bit at the encoder per spec; the byte-equality fuzz only exercises {none, x10, vt200, any} which round-trip exactly.
- Schema additions on the wire (`schema_version=2`) would land as a new file `decoder-v2.ts` + a top-level dispatch on the magic; this PR keeps `decodeSnapshotV1` strict on v1 so v2 readers can be added without changing v1 semantics.