### PR TITLE
feat(daemon)(#338): SessionService.DestroySession Connect handler

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -388,6 +388,17 @@ export async function runStartup(
     // descriptor twice replaces" caveat that forces all SessionService
     // handlers into one registration.
     const readHandlersDeps = { manager: sessionManager };
+    // Wave-3 §6.9 sub-task 7 (Task #338) — wire SessionService.DestroySession
+    // on top of the SessionService overlay. Audit #228 sub-task 7
+    // (docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md): pre-#338
+    // DestroySession was a stub on the wire even though
+    // `SessionManager.destroy()` (T3.2 / #38) is fully implemented. Reuse
+    // the SAME `sessionManager` so a DestroySession publishes to the
+    // same in-memory event bus the WatchSessions stream subscribes to
+    // (round-trip: destroy one -> watcher sees `destroyed` event) and so
+    // the post-destroy row state is visible to ListSessions / GetSession
+    // on the same boot.
+    const destroyHandlerDeps = { manager: sessionManager };
     // Wave-3 #349 — wire SettingsService + DraftService production
     // overlays (spec #337 §6.1 step 1). Both services share the same
     // `db` handle (drafts ride on the `settings` table under key
@@ -412,6 +423,7 @@ export async function runStartup(
         watchSessionsDeps,
         crashDeps,
         readHandlersDeps,
+        destroyHandlerDeps,
         settingsDeps,
         draftDeps,
         // Order matters: bearer→PeerInfo deposit MUST run before

--- a/packages/daemon/src/rpc/router.ts
+++ b/packages/daemon/src/rpc/router.ts
@@ -60,6 +60,10 @@ import {
 } from '@ccsm/proto';
 
 import {
+  makeDestroySessionHandler,
+  type DestroySessionDeps,
+} from '../sessions/destroy-handler.js';
+import {
   makeGetSessionHandler,
   makeListSessionsHandler,
   type ReadHandlersDeps,
@@ -160,31 +164,32 @@ export function registerHelloHandler(
 
 /**
  * Register the v0.3 SessionService handlers that have landed so far —
- * Hello (T2.3), WatchSessions (T3.3) and the read pair ListSessions /
- * GetSession (Wave 3 §6.9 sub-task 5 / Task #336) — under a SINGLE
+ * Hello (T2.3), WatchSessions (T3.3), the read pair ListSessions /
+ * GetSession (Wave 3 §6.9 sub-task 5 / Task #336) and DestroySession
+ * (Wave 3 §6.9 sub-task 7 / Task #338) — under a SINGLE
  * `router.service(SessionService, ...)` call.
  *
  * Why a combined registration (not multiple `service()` calls): per
  * Connect-ES `ConnectRouter.service` semantics, calling
  * `service(desc, impl)` more than once for the same descriptor REPLACES
  * the prior registration (the router is a path-keyed map). Registering
- * Hello, then WatchSessions, then ListSessions/GetSession in three
- * separate calls would silently drop the first two. The Hello-only
- * path (`registerHelloHandler` above) is preserved for callers that
- * have not yet wired a SessionManager (existing test fixtures);
+ * Hello, then WatchSessions, then ListSessions/GetSession/DestroySession
+ * in separate calls would silently drop the earlier ones. The
+ * Hello-only path (`registerHelloHandler` above) is preserved for callers
+ * that have not yet wired a SessionManager (existing test fixtures);
  * production startup wiring (T1.7) uses this combined form.
  *
- * `readHandlersDeps` is optional so existing callers (test fixtures
- * that built `{ helloDeps, watchSessionsDeps }` before #336 landed)
- * keep compiling without churn. In production startup wiring (T1.7)
- * it is always supplied — see `index.ts` where the same
- * `SessionManager` instance is reused across watchSessionsDeps and
- * readHandlersDeps (single owner of the sessions table).
+ * `readHandlersDeps` and `destroyHandlerDeps` are optional so existing
+ * callers (test fixtures that built `{ helloDeps, watchSessionsDeps }`
+ * before #336 / #338 landed) keep compiling without churn. In production
+ * startup wiring (T1.7) all four are always supplied off the same
+ * `SessionManager` instance — single owner of the sessions table; a
+ * DestroySession publishes to the same in-memory event bus the
+ * WatchSessions stream subscribes to.
  *
- * Methods not yet implemented (CreateSession, DestroySession,
- * RenameSession, ...) remain `Unimplemented` per the Connect router's
- * "absent method → Unimplemented" rule, exactly as in the stub-only
- * path.
+ * Methods not yet implemented (CreateSession, RenameSession, ...) remain
+ * `Unimplemented` per the Connect router's "absent method →
+ * Unimplemented" rule, exactly as in the stub-only path.
  */
 export function registerSessionService(
   router: ConnectRouter,
@@ -192,6 +197,7 @@ export function registerSessionService(
     readonly helloDeps: HelloDeps;
     readonly watchSessionsDeps: WatchSessionsDeps;
     readonly readHandlersDeps?: ReadHandlersDeps;
+    readonly destroyHandlerDeps?: DestroySessionDeps;
   },
 ): ConnectRouter {
   const impl: Parameters<typeof router.service<typeof SessionService>>[1] = {
@@ -201,6 +207,9 @@ export function registerSessionService(
   if (deps.readHandlersDeps !== undefined) {
     impl.listSessions = makeListSessionsHandler(deps.readHandlersDeps);
     impl.getSession = makeGetSessionHandler(deps.readHandlersDeps);
+  }
+  if (deps.destroyHandlerDeps !== undefined) {
+    impl.destroySession = makeDestroySessionHandler(deps.destroyHandlerDeps);
   }
   router.service(SessionService, impl);
   return router;
@@ -218,13 +227,19 @@ export function makeDaemonRoutes(
   watchSessionsDeps?: WatchSessionsDeps,
   crashDeps?: CrashServiceDeps,
   readHandlersDeps?: ReadHandlersDeps,
+  destroyHandlerDeps?: DestroySessionDeps,
   settingsDeps?: SettingsServiceDeps,
   draftDeps?: DraftServiceDeps,
 ): (router: ConnectRouter) => void {
   return (router: ConnectRouter): void => {
     registerStubServices(router);
     if (watchSessionsDeps !== undefined) {
-      registerSessionService(router, { helloDeps, watchSessionsDeps, readHandlersDeps });
+      registerSessionService(router, {
+        helloDeps,
+        watchSessionsDeps,
+        readHandlersDeps,
+        destroyHandlerDeps,
+      });
     } else {
       registerHelloHandler(router, helloDeps);
     }
@@ -304,6 +319,17 @@ export interface CreateDaemonNodeAdapterOptions extends ConnectRouterOptions {
    */
   readonly readHandlersDeps?: ReadHandlersDeps;
   /**
+   * When set (and `helloDeps` + `watchSessionsDeps` are also set),
+   * installs the Wave 3 §6.9 sub-task 7 (Task #338) DestroySession
+   * handler in the same SessionService registration. Reuses the same
+   * `SessionManager` instance the WatchSessions / read overlays use so
+   * a DestroySession publishes to the same in-memory event bus the
+   * WatchSessions stream subscribes to (round-trip: destroy one ->
+   * watcher sees `destroyed` event). Tests that don't need the destroy
+   * wire-up simply omit it and the method stays `Unimplemented`.
+   */
+  readonly destroyHandlerDeps?: DestroySessionDeps;
+  /**
    * When set, installs the Wave-3 SettingsService overlay (Task #349 /
    * audit #228 sub-task 9 / spec #337 §6.1 step 1) on top of the
    * stubs. Both `GetSettings` and `UpdateSettings` ship in this
@@ -363,6 +389,7 @@ export function createDaemonNodeAdapter(
     watchSessionsDeps,
     crashDeps,
     readHandlersDeps,
+    destroyHandlerDeps,
     settingsDeps,
     draftDeps,
     interceptors: callerInterceptors,
@@ -375,6 +402,7 @@ export function createDaemonNodeAdapter(
           watchSessionsDeps,
           crashDeps,
           readHandlersDeps,
+          destroyHandlerDeps,
           settingsDeps,
           draftDeps,
         )

--- a/packages/daemon/src/sessions/destroy-handler.ts
+++ b/packages/daemon/src/sessions/destroy-handler.ts
@@ -1,0 +1,162 @@
+// packages/daemon/src/sessions/destroy-handler.ts
+//
+// Wave-3 Task #338 — production SessionService.DestroySession Connect handler
+// (audit #228 sub-task 7).
+//
+// Audit reference: docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md
+// (sub-task #7). Pre-#338 SessionService.DestroySession was the T2.2 empty
+// stub on the wire (`router.ts:STUB_SERVICES`), returning Connect
+// `Code.Unimplemented` despite `SessionManager.destroy()` (T3.2 / #38)
+// being fully implemented and unit-tested. This file is the thin adapter
+// from the proto request shape onto `SessionManager.destroy()` and back to
+// the proto `DestroySessionResponse` (which carries only `meta` per the
+// session.proto contract — Destroy returns acknowledgement, not the
+// destroyed Session). Mirrors the read-side pattern in
+// `sessions/read-handlers.ts:makeGetSessionHandler` (Wave 3 §6.9 sub-task
+// 5 / Task #336), the WatchSessions stream handler in
+// `sessions/watch-sessions.ts` (T3.3 / PR #939) and the symmetric
+// CreateSession handler in `sessions/create-handler.ts` (Wave 3 §6.9
+// sub-task 6 / Task #339).
+//
+// Spec refs:
+//   - packages/proto/src/ccsm/v1/session.proto (DestroySessionRequest =
+//     `{ meta, session_id }`; DestroySessionResponse = `{ meta }` only —
+//     the destroyed Session is delivered via the WatchSessions stream's
+//     `destroyed` event, not in the unary response).
+//   - docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//     ch04 §3 (DestroySession unary RPC: principal-scoped, returns
+//     acknowledgement immediately so the caller can dismiss the row from
+//     its UI before the bus event arrives).
+//     ch05 §5 (load by id; `assertOwnership`; flip `should_be_running=0`,
+//     transition state to EXITED). The "no such id" and "not yours" cases
+//     both collapse to `Code.PermissionDenied + ErrorDetail{code:
+//     "session.not_owned"}` inside `SessionManager.loadRow` to prevent
+//     cross-principal id enumeration — same security boundary the
+//     GetSession handler relies on.
+//
+// SRP layering — three roles kept separate (dev.md §2):
+//   * decider:  there is none worth naming. The wire request carries only
+//               `session_id`; no normalization is needed before the
+//               manager call (mirrors GetSession in `read-handlers.ts`,
+//               which also does no decoding beyond pulling the id off the
+//               request).
+//   * producer: `SessionManager.destroy(id, caller)` — already implemented
+//               in T3.2 / #38; this handler does NOT ship a new producer.
+//               The manager is the single source of truth for the row
+//               state transition + event-bus publish, shared with the
+//               pty-host's `markEnded` lifecycle path.
+//   * sink:     `makeDestroySessionHandler(deps)` — Connect handler that
+//               reads the principal from `HandlerContext`, calls
+//               `manager.destroy()`, and renders the meta-only
+//               acknowledgement. The destroyed row's proto shape is
+//               available at `sessionRowToProto(row, principal)` if a
+//               future v0.4 wire change wants to echo it; v0.3 deliberately
+//               does not (the WatchSessions stream is the source of truth
+//               for the post-destroy row, per ch04 §3 — keeping Destroy
+//               unary lean lets the client's optimistic-removal path
+//               render before the round-trip completes).
+//
+// Layer 1 — alternatives checked:
+//   - Re-implement the row -> proto translation locally and echo the
+//     destroyed Session in the response: rejected — the proto contract
+//     (`DestroySessionResponse { meta }`) only carries `meta`. Adding a
+//     `session` field would be a breaking proto change outside this PR's
+//     scope, and the post-destroy row is already deliverable via the
+//     WatchSessions stream's `destroyed` event payload (a single source
+//     of truth across unary + streaming).
+//   - Add a `manager.destroyWithProto(req, principal)` convenience:
+//     rejected for the same reason as `create-handler.ts` — the manager
+//     is intentionally proto-agnostic (see `sessions/types.ts` header
+//     comment) so unit tests do not need a proto fixture and the v0.3 /
+//     v0.4 wire shapes can evolve independently of the in-process row
+//     shape. The adapter (this file) is the right seam.
+//   - Inline the SQL UPDATE in the handler: rejected — duplicates
+//     `SessionManager.destroy()` and bypasses `assertRowOwned` (the
+//     security boundary). Sharing the manager keeps the
+//     "not_owned == not_found" enumeration-prevention rule in one place.
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type HandlerContext,
+  type ServiceImpl,
+} from '@connectrpc/connect';
+
+import {
+  DestroySessionResponseSchema,
+  type DestroySessionRequest,
+  type SessionService,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, type Principal as AuthPrincipal } from '../auth/index.js';
+
+import type { ISessionManager } from './SessionManager.js';
+
+// ---------------------------------------------------------------------------
+// Sink — Connect handler
+// ---------------------------------------------------------------------------
+
+export interface DestroySessionDeps {
+  readonly manager: ISessionManager;
+}
+
+/**
+ * Build the Connect `ServiceImpl<typeof SessionService>['destroySession']`
+ * handler. Reads `PRINCIPAL_KEY` from the HandlerContext (the
+ * `peerCredAuthInterceptor` deposited it before the handler runs), calls
+ * `manager.destroy()`, and returns a meta-only acknowledgement.
+ *
+ * Mirrors the posture of `read-handlers.ts:makeGetSessionHandler`,
+ * `watch-sessions.ts:makeWatchSessionsHandler`, and
+ * `create-handler.ts:makeCreateSessionHandler`: a missing principal is a
+ * daemon wiring bug surfaced as `Internal` rather than `Unauthenticated`
+ * (the auth interceptor would have rejected the call before this handler
+ * ran if the caller were unauthenticated).
+ *
+ * Errors raised by `manager.destroy()` propagate unchanged. Spec ch05 §5:
+ *   - "no such id"          -> Code.PermissionDenied + session.not_owned
+ *   - "id owned by a peer"  -> Code.PermissionDenied + session.not_owned
+ *   (collapsed inside `SessionManager.loadRow` -> `assertRowOwned` to
+ *    prevent cross-principal id enumeration; same security boundary the
+ *    GetSession handler relies on).
+ *
+ * The destroyed row IS delivered to the caller via the WatchSessions
+ * stream's `destroyed` event (the SessionManager publishes on the same
+ * in-memory bus the WatchSessions handler subscribes to — single
+ * SessionManager instance shared across all SessionService overlays per
+ * `index.ts` startup wiring). v0.3 does NOT echo it in the unary response
+ * (the proto `DestroySessionResponse` only carries `meta`).
+ */
+export function makeDestroySessionHandler(
+  deps: DestroySessionDeps,
+): ServiceImpl<typeof SessionService>['destroySession'] {
+  return async function destroySession(
+    req: DestroySessionRequest,
+    handlerContext: HandlerContext,
+  ) {
+    const principal: AuthPrincipal | null = handlerContext.values.get(PRINCIPAL_KEY);
+    if (principal === null) {
+      throw new ConnectError(
+        'DestroySession handler invoked without peerCredAuthInterceptor in chain ' +
+          '(PRINCIPAL_KEY=null) — daemon wiring bug',
+        Code.Internal,
+      );
+    }
+
+    // The manager performs load + assertOwnership + UPDATE + bus publish.
+    // We deliberately discard the returned `SessionRow` — the proto
+    // response carries only `meta` (see file header comment + spec
+    // ch04 §3). Subscribers to the WatchSessions stream observe the
+    // post-destroy row via the bus event.
+    deps.manager.destroy(req.sessionId, principal);
+
+    return create(DestroySessionResponseSchema, {
+      // Echo request meta unchanged — same convention as the other unary
+      // handlers (Hello, GetCrashLog, ListSessions, GetSession,
+      // CreateSession). Clients correlate on request_id round-trip per
+      // spec ch04 §2.
+      meta: req.meta,
+    });
+  };
+}

--- a/packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts
+++ b/packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts
@@ -482,6 +482,33 @@ describe('daemon-boot end-to-end (Task #208)', () => {
     expect(raised!.code).toBe(Code.PermissionDenied);
   });
 
+  // Wave 3 §6.9 sub-task 7 (Task #338) — SessionService.DestroySession.
+  // Same regression catch as the read-pair / Hello assertions above:
+  // prove the production wire path actually swaps the stub for the real
+  // handler. We exercise the unknown-id branch (no created session at
+  // boot — CreateSession handler hasn't landed yet) which surfaces
+  // `Code.PermissionDenied` via `SessionManager.loadRow`'s
+  // not_owned-collapses-not_found rule. NOT Unimplemented proves the
+  // overlay is live.
+  it('Listener-A.SessionService.DestroySession does NOT return Unimplemented', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    const desc = r.listenerA!.descriptor();
+    if (desc.kind !== 'KIND_TCP_LOOPBACK_H2C') return;
+    const baseUrl = `http://127.0.0.1:${desc.port}`;
+
+    const client = makeSessionClient(baseUrl);
+    let raised: ConnectError | null = null;
+    try {
+      await client.destroySession({ meta: newMeta(), sessionId: 'no-such-id' });
+    } catch (err) {
+      raised = ConnectError.from(err);
+    }
+    expect(raised, 'expected ConnectError on unknown session id').not.toBeNull();
+    expect(raised!.code).not.toBe(Code.Unimplemented);
+    expect(raised!.code).toBe(Code.PermissionDenied);
+  });
+
   it('rejects unauthenticated calls (no bearer token) with Code.Unauthenticated', async () => {
     expect(result).not.toBeNull();
     const r = result!;

--- a/packages/daemon/test/sessions/destroy-handler.spec.ts
+++ b/packages/daemon/test/sessions/destroy-handler.spec.ts
@@ -1,0 +1,243 @@
+// Unit tests for SessionService.DestroySession Connect handler
+// (Wave 3 §6.9 sub-task 7 / Task #338).
+//
+// Covers (mirrors `read-handlers.spec.ts` layout):
+//   - Sink (handler) over the in-process Connect router transport:
+//       * DestroySession: returns meta-only ack and echoes
+//         RequestMeta.request_id; the destroyed row is NOT in the
+//         response (proto contract: `DestroySessionResponse { meta }`),
+//         it is delivered via the WatchSessions stream's `destroyed`
+//         event (asserted here through the SessionManager event bus).
+//       * DestroySession: actually flips the row's `should_be_running`
+//         to 0 and transitions state to EXITED — proves the handler
+//         calls into the production `SessionManager.destroy()` (not a
+//         no-op stub).
+//       * DestroySession: peer's id collapses to
+//         `Code.PermissionDenied + ErrorDetail.code = "session.not_owned"`
+//         (single source of truth in `SessionManager.loadRow`; no
+//         cross-principal id enumeration leak).
+//       * DestroySession: unknown id ALSO collapses to PermissionDenied
+//         (same security boundary the GetSession handler relies on).
+//       * DestroySession: missing PRINCIPAL_KEY → ConnectError(Internal)
+//         (defensive — proves the handler refuses to run if the auth
+//         interceptor was not wired).
+//
+// Spec refs: ch04 §3, ch05 §5; T2.5 / PR #926; T3.2 / PR #933.
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  createClient,
+  createRouterTransport,
+} from '@connectrpc/connect';
+import { describe, expect, it } from 'vitest';
+
+import {
+  DestroySessionRequestSchema,
+  ErrorDetailSchema,
+  RequestMetaSchema,
+  SessionService,
+  type ErrorDetail,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, type Principal as AuthPrincipal } from '../../src/auth/index.js';
+import { runMigrations } from '../../src/db/migrations/runner.js';
+import { openDatabase, type SqliteDatabase } from '../../src/db/sqlite.js';
+import { makeDestroySessionHandler } from '../../src/sessions/destroy-handler.js';
+import { SessionManager } from '../../src/sessions/SessionManager.js';
+import { SessionState } from '../../src/sessions/types.js';
+
+const ALICE: AuthPrincipal = { kind: 'local-user', uid: '1000', displayName: 'alice' };
+const BOB: AuthPrincipal = { kind: 'local-user', uid: '1001', displayName: 'bob' };
+
+function freshDb(): SqliteDatabase {
+  const db = openDatabase(':memory:');
+  runMigrations(db);
+  // sessions.owner_id has an FK to principals(id) — see SessionManager.spec.ts.
+  const insertPrincipal = db.prepare(
+    `INSERT INTO principals (id, kind, display_name, first_seen_ms, last_seen_ms)
+     VALUES (?, ?, ?, ?, ?)`,
+  );
+  insertPrincipal.run('local-user:1000', 'local-user', 'alice', 1, 1);
+  insertPrincipal.run('local-user:1001', 'local-user', 'bob', 1, 1);
+  return db;
+}
+
+function createInput(cwd = '/home/alice') {
+  return {
+    cwd,
+    env_json: '{}',
+    claude_args_json: '[]',
+    geometry_cols: 80,
+    geometry_rows: 24,
+  };
+}
+
+function makeBoundTransport(
+  manager: SessionManager,
+  principal: AuthPrincipal | null = ALICE,
+) {
+  return createRouterTransport(
+    (router) => {
+      router.service(SessionService, {
+        destroySession: makeDestroySessionHandler({ manager }),
+      });
+    },
+    {
+      router: {
+        interceptors: [
+          (next) => async (req) => {
+            req.contextValues.set(PRINCIPAL_KEY, principal);
+            return next(req);
+          },
+        ],
+      },
+    },
+  );
+}
+
+function newMeta(requestId = '11111111-2222-3333-4444-555555555555') {
+  return create(RequestMetaSchema, {
+    requestId,
+    clientVersion: '0.3.0-test',
+    clientSendUnixMs: 0n,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// DestroySession
+// ---------------------------------------------------------------------------
+
+describe('SessionService.DestroySession — handler', () => {
+  it('returns meta-only ack and echoes RequestMeta.request_id', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const created = manager.create(createInput(), ALICE);
+    const client = createClient(SessionService, makeBoundTransport(manager, ALICE));
+
+    const reqId = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+    const resp = await client.destroySession(
+      create(DestroySessionRequestSchema, {
+        meta: newMeta(reqId),
+        sessionId: created.id,
+      }),
+    );
+    expect(resp.meta?.requestId).toBe(reqId);
+    // Proto contract: DestroySessionResponse { meta } — no `session`
+    // field. The destroyed row is delivered via the WatchSessions
+    // stream's `destroyed` event (asserted in the next case).
+    expect(Object.keys(resp).sort()).toEqual(['$typeName', 'meta']);
+  });
+
+  it('flips should_be_running=0, transitions state to EXITED, and emits destroyed bus event', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const created = manager.create(createInput(), ALICE);
+    expect(created.should_be_running).toBe(1);
+    expect(created.state).toBe(SessionState.STARTING);
+
+    // Subscribe BEFORE the destroy so the bus event is observable here
+    // (the handler calls `manager.destroy()` which publishes
+    // `SessionEvent.destroyed` synchronously).
+    const events: Array<{ kind: string; sessionId: string }> = [];
+    const unsubscribe = manager.subscribe(ALICE, (ev) => {
+      events.push({ kind: ev.kind, sessionId: ev.session.id });
+    });
+
+    const client = createClient(SessionService, makeBoundTransport(manager, ALICE));
+    await client.destroySession(
+      create(DestroySessionRequestSchema, {
+        meta: newMeta(),
+        sessionId: created.id,
+      }),
+    );
+    unsubscribe();
+
+    // Row state actually transitioned (proves the handler is wired to the
+    // real manager, not a stub).
+    const after = manager.get(created.id, ALICE);
+    expect(after.should_be_running).toBe(0);
+    expect(after.state).toBe(SessionState.EXITED);
+
+    // The WatchSessions stream's `destroyed` event payload is the source
+    // of truth for the post-destroy row (the unary response intentionally
+    // omits it per the proto contract).
+    const destroyed = events.find((e) => e.kind === 'destroyed');
+    expect(destroyed).toBeDefined();
+    expect(destroyed!.sessionId).toBe(created.id);
+  });
+
+  it('rejects a peer-owned id with PermissionDenied + session.not_owned', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const bobRow = manager.create(createInput('/home/bob'), BOB);
+
+    const client = createClient(SessionService, makeBoundTransport(manager, ALICE));
+    let raised: ConnectError | null = null;
+    try {
+      await client.destroySession(
+        create(DestroySessionRequestSchema, {
+          meta: newMeta(),
+          sessionId: bobRow.id,
+        }),
+      );
+    } catch (err) {
+      raised = ConnectError.from(err);
+    }
+    expect(raised).not.toBeNull();
+    expect(raised!.code).toBe(Code.PermissionDenied);
+    const detail = raised!.findDetails(ErrorDetailSchema)[0] as ErrorDetail | undefined;
+    expect(detail?.code).toBe('session.not_owned');
+
+    // Bob's row MUST be untouched — Alice's failed destroy attempt
+    // cannot mutate it.
+    const stillThere = manager.get(bobRow.id, BOB);
+    expect(stillThere.should_be_running).toBe(1);
+    expect(stillThere.state).toBe(SessionState.STARTING);
+  });
+
+  it('collapses unknown session id into PermissionDenied (no enumeration leak)', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const client = createClient(SessionService, makeBoundTransport(manager, ALICE));
+
+    let raised: ConnectError | null = null;
+    try {
+      await client.destroySession(
+        create(DestroySessionRequestSchema, {
+          meta: newMeta(),
+          sessionId: 'no-such-id',
+        }),
+      );
+    } catch (err) {
+      raised = ConnectError.from(err);
+    }
+    expect(raised).not.toBeNull();
+    // Critical: NOT NotFound — the SessionManager's loadRow maps the
+    // missing-row case to `session.not_owned` so a malicious caller
+    // cannot probe other principals' ids by branching on the code.
+    expect(raised!.code).toBe(Code.PermissionDenied);
+    expect(raised!.code).not.toBe(Code.NotFound);
+  });
+
+  it('throws Code.Internal when PRINCIPAL_KEY was never deposited (wiring bug)', async () => {
+    const db = freshDb();
+    const manager = new SessionManager(db);
+    const client = createClient(SessionService, makeBoundTransport(manager, null));
+
+    let raised: ConnectError | null = null;
+    try {
+      await client.destroySession(
+        create(DestroySessionRequestSchema, {
+          meta: newMeta(),
+          sessionId: 'whatever',
+        }),
+      );
+    } catch (err) {
+      raised = ConnectError.from(err);
+    }
+    expect(raised).not.toBeNull();
+    expect(raised!.code).toBe(Code.Internal);
+  });
+});


### PR DESCRIPTION
## Summary

Wave-3 §6.9 sub-task 7 — wire `SessionService.DestroySession` (audit
#228 sub-task 7). Pre-#338 `DestroySession` was the T2.2 empty stub on
the wire, returning Connect `Code.Unimplemented` despite
`SessionManager.destroy()` (T3.2 / #38) being fully implemented +
unit-tested. This PR is the thin adapter from the proto request shape
onto `SessionManager.destroy()` and back to the meta-only
`DestroySessionResponse`.

Symmetric to #336 (read pair, merged) and #339 (`CreateSession`,
in-progress). Reuses the same `SessionManager` instance the
WatchSessions / read-pair overlays use so a `DestroySession` publishes
to the same in-memory event bus the `WatchSessions` stream subscribes
to (round-trip: destroy one -> watcher sees `destroyed` event).

## Layering (SRP, dev.md §2)

- producer: `SessionManager.destroy()` (T3.2 / #38, unchanged)
- decider:  none — request carries only `session_id`; mirrors
            `GetSession` which also has no decoding
- sink:     `makeDestroySessionHandler(deps)` — Connect handler (this PR)

## Layer 1 — alternatives checked

(see `destroy-handler.ts` header for full reasoning)

- Re-impl row→proto translation locally and echo the destroyed
  `Session` in the response: rejected. Proto contract is meta-only
  (`DestroySessionResponse { meta }`); the post-destroy row is
  delivered via the WatchSessions stream's `destroyed` event payload
  (single source of truth across unary + streaming).
- `manager.destroyWithProto(req, principal)` convenience: rejected.
  Manager stays proto-agnostic per `sessions/types.ts` — adapter
  (this file) is the right seam.
- Inline the SQL UPDATE in the handler: rejected. Duplicates the
  manager and bypasses `assertRowOwned` (security boundary that
  collapses NotFound→not_owned to prevent cross-principal id
  enumeration).

## Files

| Path | Change |
|---|---|
| `packages/daemon/src/sessions/destroy-handler.ts` | new (162 LOC w/ comments) |
| `packages/daemon/src/rpc/router.ts` | add `destroyHandlerDeps` to `registerSessionService` + `CreateDaemonNodeAdapterOptions` |
| `packages/daemon/src/index.ts` | pass `destroyHandlerDeps` from the same `sessionManager` |
| `packages/daemon/test/sessions/destroy-handler.spec.ts` | new — 5 cases (meta echo, row mutation + bus event, peer rejection, unknown-id collapse, missing principal) |
| `packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts` | add `DestroySession`-NOT-`Unimplemented` wire-up assertion |

## Local checks (host: windows-11)

- lint: ✓ (52 pre-existing warnings, 0 errors — same as `working`)
- typecheck: ✓ (exit 0)
- unit tests (`test/sessions/destroy-handler.spec.ts`): ✓ 5/5 PASS

```
 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  19:47:36
   Duration  2.57s (transform 458ms, setup 0ms, import 1.34s, tests 106ms, environment 0ms)
```

## Pre-existing flake noted (not introduced)

The `daemon-boot-end-to-end.spec.ts` file's listener-A loopback e2e
cases (`Hello`, `ListSessions`, `GetSession`, the new `DestroySession`,
`Unauthenticated rejection`, `WatchSessions(OWN)`, `GetCrashLog`,
`WatchCrashLog`) all hit a 10–30s client.* call timeout on this dev
host — verified by running the same `Hello` test against `origin/working`
**before** applying this PR (also timed out). The bind itself succeeds
(`listener-a bound: kind=KIND_TCP_LOOPBACK_H2C` + `descriptor written`
+ `phase -> READY` are all printed); the connect-node h2c client just
never completes the round-trip locally. Out of scope for this PR.

The new DestroySession e2e assertion follows the SAME structure as the
sibling GetSession/Hello assertions, so it will pass / fail in lockstep
with them on CI.

## Test plan

- [x] `npm run typecheck` (daemon) — exit 0
- [x] `npm run lint` (daemon) — 0 errors
- [x] `npm test -- test/sessions/destroy-handler.spec.ts` — 5/5 pass
- [ ] CI: full daemon test suite + listener-A e2e (DestroySession
      assertion expected green when the listener-A loopback cases pass
      generally on CI)


## Followups (NOT in this PR)

This PR is intentionally a **thin adapter**. Per design spec
`docs/superpowers/specs/2026-05-04-pty-attach-handler.md` §7.2,
`DestroySession` MUST eventually wait for all Attach subscribers to
receive a terminal `Code.Canceled` + `ErrorDetail.code='pty.session_destroyed'`
frame before returning. That semantic tightening is wave-locked in
**Task #356** (T-PA-7), which modifies `SessionManager.destroy()` to
await subscriber teardown. #356 is blocked by #354 (T-PA-5 emitter
wire-up), so it is sequenced after this PR per spec §9.3 graph.
