### PR TITLE
wave0d.5(#270): electron->@ccsm/daemon import-path migration + drop electron/ptyHost shim

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -59,7 +59,7 @@ process.on('uncaughtException', (err) => {
 // init is idempotent and a no-op when no DSN is set.
 initSentry();
 
-import { killAllPtySessions } from './ptyHost';
+import { killAllPtySessions } from '../packages/daemon/src/ptyHost';
 import { configureSessionWatcher } from './sessionWatcher';
 import { BadgeManager } from './notify/badge';
 import {

--- a/electron/notify/bootstrap/__tests__/installPipeline.test.ts
+++ b/electron/notify/bootstrap/__tests__/installPipeline.test.ts
@@ -5,7 +5,7 @@
 // We mock the four boundary modules so the test runs in plain Node:
 //   * electron (app + BrowserWindow)
 //   * ../sinks/pipeline (recording installNotifyPipeline)
-//   * ../../ptyHost (onPtyData subscriber capture)
+//   * ../../../packages/daemon/src/ptyHost (onPtyData subscriber capture)
 //   * ../../sessionWatcher (sessionWatcher EventEmitter capture)
 //
 // Each test then triggers a producer and asserts the corresponding
@@ -88,7 +88,7 @@ vi.mock('../../sinks/pipeline', () => ({
   },
 }));
 
-vi.mock('../../../ptyHost', () => ({
+vi.mock('../../../../packages/daemon/src/ptyHost', () => ({
   onPtyData: (cb: (sid: string, chunk: string | Buffer) => void) => {
     h.ptyDataCb.current = cb;
   },

--- a/electron/notify/bootstrap/installPipeline.ts
+++ b/electron/notify/bootstrap/installPipeline.ts
@@ -14,7 +14,7 @@
 
 import { app, BrowserWindow } from 'electron';
 import { installNotifyPipeline } from '../sinks/pipeline';
-import { onPtyData } from '../../ptyHost';
+import { onPtyData } from '../../../packages/daemon/src/ptyHost';
 import { sessionWatcher } from '../../sessionWatcher';
 import { forgetSid as forgetSessionTitleSid } from '../../sessionTitles';
 

--- a/electron/notify/sinks/pipeline.ts
+++ b/electron/notify/sinks/pipeline.ts
@@ -17,7 +17,7 @@
 // forgetSid) are forwarded straight to the tracker.
 
 import type { BrowserWindow } from 'electron';
-import { OscTitleSniffer, type OscTitleEvent } from '../../ptyHost/oscTitleSniffer';
+import { OscTitleSniffer, type OscTitleEvent } from '../../../packages/daemon/src/ptyHost/oscTitleSniffer';
 import { decide, type Ctx } from '../notifyDecider';
 import { createRunStateTracker, type RunStateTracker } from '../runStateTracker';
 import { classifyTitleState } from '../titleStateClassifier';

--- a/electron/ptyHost/index.ts
+++ b/electron/ptyHost/index.ts
@@ -1,8 +1,0 @@
-// TODO(v0.4): remove when out-of-zone consumers (electron/main.ts,
-// electron/notify/bootstrap/installPipeline.ts, electron/notify/sinks/
-// pipeline.ts, electron/testHooks.ts) migrate to @ccsm/daemon imports
-// directly.
-//
-// Re-export shim — real implementation lives in
-// packages/daemon/src/ptyHost/index.ts (moved Wave 0d.4 / #251).
-export * from '../../packages/daemon/src/ptyHost/index';

--- a/electron/ptyHost/oscTitleSniffer.ts
+++ b/electron/ptyHost/oscTitleSniffer.ts
@@ -1,4 +1,0 @@
-// TODO(v0.4): re-export shim — real implementation lives in
-// packages/daemon/src/ptyHost/oscTitleSniffer.ts (moved Wave 0d.4 / #251).
-// Imported by electron/notify/sinks/pipeline.ts.
-export * from '../../packages/daemon/src/ptyHost/oscTitleSniffer';


### PR DESCRIPTION
## Summary

Task #270 Option A — manager picked the import-path migration after the previous dev round correctly pushed back on the larger "move installPipeline into the daemon" interpretation. The shim TODO at `electron/ptyHost/index.ts:1-8` already named the four out-of-zone callers; this PR completes that migration:

- `electron/main.ts`: `killAllPtySessions` import now points at `../packages/daemon/src/ptyHost`
- `electron/notify/bootstrap/installPipeline.ts`: `onPtyData` import now points at `../../../packages/daemon/src/ptyHost`
- `electron/notify/sinks/pipeline.ts`: `OscTitleSniffer` + `OscTitleEvent` imports now point at `../../../packages/daemon/src/ptyHost/oscTitleSniffer`
- `electron/notify/bootstrap/__tests__/installPipeline.test.ts`: `vi.mock(...)` path string updated 1:1 so the 15 installPipeline cases keep mocking the same surface (zero behavior change)
- `electron/ptyHost/{index,oscTitleSniffer}.ts` re-export shims are now unreferenced and **deleted**

`electron/testHooks.ts` was listed in the shim's TODO comment but never actually imported `ptyHost` (verified via `grep -n "ptyHost" electron/testHooks.ts` → no import lines), so no edit was required there. The 4th caller is the test file (`installPipeline.test.ts` mock path).

## Why this shape (and not "move installPipeline into the daemon")

The previous dev round flagged that moving `installPipeline` / `OscTitleSniffer` consumption into `packages/daemon/` would violate the v0.3 zero-rework rule because `docs/superpowers/specs/2026-05-02-final-architecture.md` keeps OS Notification rendering (and therefore the in-process `OscTitleSniffer` driving it) in the Electron shell, not in the daemon. Manager picked Option A — pure import-path swap — for that reason.

## Why deep-relative-path and not literal `@ccsm/daemon`

The shim TODO writes "@ccsm/daemon" as shorthand for "the real implementation in `packages/daemon/`". Concretely:
- The repo has **no** `@ccsm/daemon` package mapping in `tsconfig.json` `paths`, no `exports` field in `packages/daemon/package.json`, and zero existing electron-side files import the bare specifier `@ccsm/daemon` (verified by `grep -rn "@ccsm/daemon" electron/`).
- Every other shell-side shim under `electron/` (`agent/`, `notify/badgeStore.ts`, `notify/notifyDecider.ts`, `notify/runStateTracker.ts`, `sessionTitles/`, `sessionWatcher/`, `shared/claudePaths.ts`, `shared/stateSavedBus.ts`, …) re-exports its real implementation via the same `'../../packages/daemon/src/...'` deep relative path. The four edits here follow that convention 1:1.
- The import surface (`onPtyData`, `OscTitleSniffer`, `OscTitleEvent`, `killAllPtySessions`) is **the same one the daemon already exports today** at `packages/daemon/src/ptyHost/index.ts:43-88`. No daemon package shape changes.

When v0.4 puts those callers behind the Connect-RPC boundary, the import surface they target stays exactly the same — this is forward-safe.

## Local checks (host: windows-11)

- lint: ok (exit 0)
- typecheck: ok (exit 0)
- lint:no-ipc: PASS (zero IPC residue under `electron/`, `src/`, `packages/electron/src/`)
- check-v02-shrinking: PASS (16 checked, 1 step, no v0.2-only file grew; `electron/main.ts` unchanged at 288 lines)
- build:app: ok (`tsc -p tsconfig.electron.json` + webpack)
- `npm run test:app` (vitest unit, electron side): **830 passed / 1 fail**. The 1 fail is `tests/electron-load-smoke.test.ts > loads sentry/init` test-timeout at 15s — a pre-existing host flake, **not** introduced here. Stash-verified: with this commit stashed and base electron/ checked out, the same `loads sentry/init` test fails in the same way (plus 12 more `db.ts` better-sqlite3 ABI fails that vanish once `npm run rebuild:native` is run on a clean install — none of which I touched).
- `npm run probe:e2e` (full): **harness-dnd OK, harness-ui OK (14/14), harness-real-cli timeout**. The harness-real-cli timeout is `waitForTerminalReady: terminal not ready for sid=… within 60000ms` + `window.ccsmSession.onState not exposed by preload (PR-A wiring missing)` — both are pre-existing host environment failures **identical to base**. Verified by checking out `origin/working`'s `electron/` and re-running `npm run probe:e2e -- --only=harness-real-cli` from this worktree: same `waitForTerminalReady`/`onState not exposed` failures. The four import paths I changed are not in the harness-real-cli execution graph (terminal mount + preload wiring sit elsewhere).

No `ERR_REQUIRE_ESM` from a manual `node -e "require('./dist/electron/<changed>.js')"` smoke on the three changed runtime files (the only smoke-load failure mode dev.md cares about); the loader hits an unrelated Electron-runtime guard ("Electron failed to install correctly") because Electron's own postinstall is gated behind `pnpm approve-builds` on this host, which is the same posture base ships with.

## References

- Previous dev round push back (Task #270 manager thread)
- `electron/ptyHost/index.ts:1-8` shim TODO naming the four target callers
- v0.3 zero-rework rule (memory: `feedback_v03_zero_rework.md`)
- v0.4 final architecture (`docs/superpowers/specs/2026-05-02-final-architecture.md`) — keeps OS Notification rendering in Electron shell

## Test plan

- [x] lint, typecheck, lint:no-ipc, check-v02-shrinking all green locally
- [x] build:app succeeds; dist/electron/* updated
- [x] vitest unit suite: 830/831 passing (lone fail is pre-existing host flake `loads sentry/init`)
- [x] e2e harness-dnd + harness-ui PASS; harness-real-cli timeout reproduces on base electron/
- [x] grep confirms no `from '../../ptyHost'` / `from './ptyHost'` residue
- [x] `electron/ptyHost/` directory deleted