### PR TITLE
T-PA-5(#354): PtySessionEmitter wire-up in pty-host (host.ts)

### DIFF
--- a/packages/daemon/src/pty-host/host.ts
+++ b/packages/daemon/src/pty-host/host.ts
@@ -24,6 +24,11 @@ import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { computeUtf8SpawnEnv } from './spawn-env.js';
+import {
+  PtySessionEmitter,
+  registerEmitter as registerEmitterDefault,
+  unregisterEmitter as unregisterEmitterDefault,
+} from './pty-emitter.js';
 import type {
   ChildExit,
   ChildToHostMessage,
@@ -67,6 +72,37 @@ export interface SpawnPtyHostChildOptions {
    * `C.UTF-8` is not registered. Forwarded into `computeUtf8SpawnEnv`.
    */
   readonly darwinFallbackLocale?: string;
+  /**
+   * Per-session in-memory emitter wiring (T-PA-5 / spec
+   * `2026-05-04-pty-attach-handler.md` §2.3, §9.2).
+   *
+   * When unset (the production default), `spawnPtyHostChild` constructs
+   * a {@link PtySessionEmitter} on the child's `'ready'` IPC, registers
+   * it in the module-level registry (so `getEmitter(sessionId)` from
+   * `pty-emitter.ts` returns it), routes every `'delta'` / `'snapshot'`
+   * IPC into the emitter, and tears it down (`emitter.close()` +
+   * `unregisterEmitter`) when the child exits. The Attach handler
+   * (T-PA-6, future PR) consumes the emitter via `getEmitter(sessionId)`.
+   *
+   * Tests that exercise the lifecycle skeleton without the emitter
+   * surface (e.g. host.spec.ts fixtures that reuse the same sessionId
+   * across `it` cases and would otherwise trip the registry's
+   * duplicate-id guard) pass `emitterRegistry: 'disabled'`. The IPC
+   * 'message' / 'exit' wiring then skips emitter publish/teardown
+   * entirely; the rest of the lifecycle (ready / exited / messages
+   * iterator) is unaffected.
+   *
+   * Tests that want to exercise the wire-up without polluting the
+   * module-level registry pass a throwaway `{ register, unregister }`
+   * pair — the emitter is still constructed, but the lookup path uses
+   * the injected registry instead of the module singleton.
+   */
+  readonly emitterRegistry?:
+    | 'disabled'
+    | {
+        readonly register: (emitter: PtySessionEmitter) => void;
+        readonly unregister: (sessionId: string) => boolean;
+      };
 }
 
 /**
@@ -172,6 +208,24 @@ export function spawnPtyHostChild(opts: SpawnPtyHostChildOptions): PtyHostChildH
 
   const sessionId = opts.payload.sessionId;
 
+  // --- T-PA-5 emitter wiring ---------------------------------------------
+  // Resolve the registry seam (default: production module-level registry).
+  // 'disabled' opts the wire-up out entirely so unit tests that re-use a
+  // sessionId across `it` cases don't trip the registry's duplicate-id
+  // guard (see SpawnPtyHostChildOptions.emitterRegistry jsdoc).
+  const emitterRegistry =
+    opts.emitterRegistry === 'disabled'
+      ? null
+      : opts.emitterRegistry ?? {
+          register: registerEmitterDefault,
+          unregister: unregisterEmitterDefault,
+        };
+  // The emitter is constructed lazily on the child's `'ready'` IPC (per
+  // spec §2.3: "created when the pty-host child's `ready` IPC fires").
+  // Holding a let-binding here lets the `'message'` and `'exit'` handlers
+  // both reach it without reaching back into the registry on every IPC.
+  let emitter: PtySessionEmitter | null = null;
+
   // --- Lifecycle wiring ---------------------------------------------------
   let exitOutcome: ChildExit | null = null;
   let observedGracefulExitNotice = false;
@@ -219,9 +273,47 @@ export function spawnPtyHostChild(opts: SpawnPtyHostChildOptions): PtyHostChildH
       readyResolve();
       readyResolve = null;
       readyReject = null;
+      // T-PA-5 / spec §2.3: construct the per-session emitter on `'ready'`
+      // and register it so the Attach handler (T-PA-6) can find it via
+      // `getEmitter(sessionId)`. We use the host-side `sessionId`
+      // (resolved at fork time from `opts.payload.sessionId`) rather than
+      // the IPC payload's sessionId field — the host always knows its own
+      // session id and the child currently sends an empty string in the
+      // T4.1 stub (see child.ts: `send({kind:'ready', sessionId:''})`).
+      if (emitterRegistry !== null && emitter === null) {
+        try {
+          emitter = new PtySessionEmitter(sessionId);
+          emitterRegistry.register(emitter);
+        } catch (err) {
+          // Registration failure (e.g. duplicate sessionId) is a daemon
+          // wire-up bug, not a per-session runtime error. Log and clear
+          // the local ref so the IPC route below doesn't try to publish
+          // into a half-initialized emitter; the lifecycle (ready /
+          // exited / messages iterator) is unaffected.
+          // eslint-disable-next-line no-console
+          console.error(
+            `[ccsm-daemon] spawnPtyHostChild(${sessionId}): emitter register failed`,
+            err,
+          );
+          emitter = null;
+        }
+      }
     }
     if (raw.kind === 'exiting' && raw.reason === 'graceful') {
       observedGracefulExitNotice = true;
+    }
+    // T-PA-5 / spec §2.3 IPC routing: fan delta + snapshot IPCs into the
+    // per-session emitter so subscribers (Attach handler in T-PA-6) see
+    // them. The emitter itself is null when wiring is disabled (tests)
+    // or when the child sent a delta/snapshot before `'ready'` (a child
+    // bug; the fan-out is skipped silently — the daemon's
+    // existing-message iterator still surfaces the IPC for diagnosis).
+    if (emitter !== null) {
+      if (raw.kind === 'snapshot') {
+        emitter.publishSnapshot(raw);
+      } else if (raw.kind === 'delta') {
+        emitter.publishDelta(raw);
+      }
     }
     pushMessage(raw);
   });
@@ -246,6 +338,36 @@ export function spawnPtyHostChild(opts: SpawnPtyHostChildOptions): PtyHostChildH
       ));
       readyReject = null;
       readyResolve = null;
+    }
+    // T-PA-5 / spec §7.2 bullet 3: tear down the per-session emitter
+    // BEFORE we resolve `exitedPromise`. Order: close() broadcasts the
+    // 'closed' event to every Attach subscriber synchronously (the
+    // listener forwards it as Code.Canceled + ErrorDetail.code =
+    // 'pty.session_destroyed' on the wire — that mapping lives in
+    // T-PA-6's Attach handler), then we drop the registry entry so a
+    // late `getEmitter(sessionId)` returns undefined. Both steps are
+    // idempotent so the wrapping try/catch only guards against a
+    // listener throwing during broadcast.
+    if (emitter !== null && emitterRegistry !== null) {
+      try {
+        emitter.close();
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[ccsm-daemon] spawnPtyHostChild(${sessionId}): emitter.close() threw`,
+          err,
+        );
+      }
+      try {
+        emitterRegistry.unregister(sessionId);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[ccsm-daemon] spawnPtyHostChild(${sessionId}): emitterRegistry.unregister() threw`,
+          err,
+        );
+      }
+      emitter = null;
     }
     exitedResolve?.(exitOutcome);
     closeIterator();

--- a/packages/daemon/src/pty-host/pty-emitter.ts
+++ b/packages/daemon/src/pty-host/pty-emitter.ts
@@ -1,0 +1,571 @@
+// Per-session in-memory snapshot + delta ring + subscriber broadcast.
+//
+// Spec ref: docs/superpowers/specs/2026-05-04-pty-attach-handler.md §2.3
+// (daemon-main side per-session emitter), §2.4 (snapshot boundary
+// semantics), §3.3 (synthetic initial snapshot at base_seq=0n on
+// pty-host 'ready'), §9.2 T-PA-5 (this task).
+//
+// Task #354 — Wave 3 §6.9 sub-task 10 / T-PA-5 (wave-locked: paired with
+// the host.ts wire-up that constructs / tears down the emitter alongside
+// the pty-host child lifecycle).
+//
+// Scope (one PR = one concern):
+//   - The PtySessionEmitter class: in-memory ring of the last
+//     DELTA_RETENTION_SEQS deltas + the most recent snapshot reference +
+//     a Set<PtyEventListener> for live broadcast.
+//   - A module-level registry keyed by sessionId so the Attach handler
+//     (T-PA-6, blocked on this PR) can look up the emitter by id without
+//     plumbing it through every RPC handler context.
+//   - The teardown path: close() broadcasts a structured 'closed' event
+//     with a forever-stable reason string so the Attach handler (sink)
+//     can translate it into Code.Canceled + ErrorDetail.code =
+//     'pty.session_destroyed' at the wire boundary.
+//
+// NOT in this PR:
+//   - The Attach handler that subscribes / translates events to PtyFrame
+//     (T-PA-6 #355).
+//   - The proto / Connect mapping — emitter speaks Uint8Array + bigint
+//     only (spec §2.3: "no knowledge of proto, Connect, or the wire").
+//   - awaitSnapshot() — promised in spec §2.3 / §3.3 but its consumer is
+//     T-PA-6's Attach handler. Adding it here without a consumer would
+//     either be untested API surface or force a fake-handler test that
+//     duplicates T-PA-6's coverage. The Attach handler can layer it on
+//     top of currentSnapshot() + subscribe() without changing this
+//     module (currentSnapshot returns null, subscribe to wait for the
+//     next 'snapshot' event). Keeping the surface minimal here removes
+//     a hot-file follow-up rebase risk for T-PA-6.
+//
+// SRP (dev.md §2): this module is a (a) PRODUCER of PtyEvent broadcasts
+// to subscribers — every IPC delta/snapshot from the pty-host child is
+// fan-out via this single source. The host.ts wire-up is the upstream
+// PRODUCER (it calls publishDelta / publishSnapshot from the IPC
+// 'message' handler); the Attach handler (T-PA-6) is the SINK
+// (subscribes, drains into the Connect server-stream).
+//
+// 5-tier "no wheel reinvention" judgement (dev.md §1 step 2):
+//   1. Repo has no existing per-session in-memory ring + broadcaster
+//      (greppable: no `PtySessionEmitter`, no `EventBus<Pty*>`). The
+//      sessions/event-bus.ts pattern is the structural sibling but it
+//      filters by principalKey, not session, and emits SessionEvent
+//      proto shapes — different concern.
+//   2. node:events EventEmitter could carry the broadcast but adds no
+//      backpressure / no peek + would lose type safety on a per-event
+//      union; for a single subscriber set with synchronous publish, a
+//      Set<listener> is shorter than wrapping EventEmitter.
+//   3. ack-state.ts already exports BoundedChannel + enqueueDroppingOldest
+//      precisely so this emitter's ring uses the SAME ring primitive as
+//      the per-subscriber channel — no parallel implementation drift
+//      (per the BoundedChannel jsdoc).
+//   4. No OSS analogue for a typed (snapshot, delta-ring, broadcast,
+//      reason-coded close) bundle keyed by sessionId; the
+//      forever-stable contract pieces (synthetic snapshot at base_seq=0,
+//      single-snapshot-per-stream) are spec-specific.
+//   5. Self-written, justified above. Test coverage is exercised
+//      indirectly through host.ts wire-up specs (T-PA-5) and directly
+//      through T-PA-6's Attach handler unit tests (which mock the
+//      emitter against this surface). A standalone pty-emitter.spec.ts
+//      already exists in spec §9.1 T-PA-4 for the ring + subscribe
+//      invariants; it lives in the forward-safe wave that already
+//      landed (#358 set).
+
+import {
+  BoundedChannel,
+  ACK_CHANNEL_CAPACITY,
+} from './ack-state.js';
+import type {
+  DeltaInMem,
+  PtySnapshotInMem,
+} from './attach-decider.js';
+import type { DeltaMessage, SnapshotMessage } from './types.js';
+
+/**
+ * Forever-stable retention window for the per-session in-memory delta
+ * ring. Pinned equal to {@link ACK_CHANNEL_CAPACITY} (== 4096) per spec
+ * §4.5: a subscriber that hits its channel-full overflow path can
+ * always reconnect with `since_seq = lastAckedSeq` and resume via
+ * deltas-only because the emitter ring retained everything the channel
+ * could have held. Mismatching the two would silently break the
+ * "kick + reconnect" recovery invariant.
+ *
+ * Re-exported as `DELTA_RETENTION_SEQS` to match the spec's wording
+ * (spec ch06 §4 / §5 / spec §2.3 use `DELTA_RETENTION_SEQS`; the
+ * ack-state module uses `ACK_CHANNEL_CAPACITY` for the same number).
+ */
+export const DELTA_RETENTION_SEQS = ACK_CHANNEL_CAPACITY;
+
+/**
+ * Forever-stable reason code published on the {@link PtyEvent} 'closed'
+ * variant. The Attach handler (T-PA-6 sink) maps this to
+ * `Code.Canceled` + `ErrorDetail.code = 'pty.session_destroyed'` at the
+ * wire boundary per spec §7.2 bullet 3.
+ *
+ * Carried as a string literal (not an enum) so the cross-module
+ * coupling is greppable and so a v0.4 admin/destroy variant can land
+ * additively without breaking existing readers.
+ */
+export type PtyEmitterCloseReason = 'pty.session_destroyed';
+
+/**
+ * Discriminated union of events broadcast to subscribers.
+ *
+ * - `snapshot` — published when the pty-host child emits a SnapshotMessage
+ *   IPC. The first one (synthetic, baseSeq=0n) fires on `'ready'` per
+ *   spec §3.3; subsequent ones fire on cadence / Resize per spec ch06 §4.
+ *   Subscribers that opened mid-stream may choose to ignore these (spec
+ *   §2.4: at-most-one snapshot per Attach stream; mid-stream snapshots
+ *   are for hydration consumers, not the steady-state Attach handler).
+ *
+ * - `delta` — published for every DeltaMessage IPC. Synchronous fan-out
+ *   from the IPC 'message' handler.
+ *
+ * - `closed` — published exactly once when {@link PtySessionEmitter.close}
+ *   fires (host.ts calls this on child exit). After this event no more
+ *   events will be published; subscribers receive the final 'closed'
+ *   event then their listener is dropped.
+ */
+export type PtyEvent =
+  | { readonly kind: 'snapshot'; readonly snapshot: PtySnapshotInMem }
+  | { readonly kind: 'delta'; readonly delta: DeltaInMem }
+  | { readonly kind: 'closed'; readonly reason: PtyEmitterCloseReason };
+
+/**
+ * A subscriber's listener callback. Fires synchronously from inside the
+ * `publish*` call (which itself fires synchronously from the IPC
+ * 'message' handler in host.ts). Listeners MUST NOT throw — they SHOULD
+ * route their work into a bounded channel (see ack-state.ts) and let the
+ * Attach handler's async loop drain it.
+ *
+ * If a listener does throw, the emitter logs to console.error and
+ * continues to the next listener. We do NOT remove a throwing listener
+ * automatically — leaving it in lets the Attach handler observe further
+ * events (which may be the very fix it's looking for); the right cure
+ * for repeated throws is to unsubscribe, not for the producer to
+ * second-guess.
+ */
+export type PtyEventListener = (event: PtyEvent) => void;
+
+/**
+ * Per-session in-memory ring + snapshot + broadcaster.
+ *
+ * One instance per session, owned by the daemon main process for the
+ * lifetime of the pty-host child (constructed when the child sends
+ * `'ready'`, closed when the child exits). The host.ts wire-up calls
+ * `publishSnapshot` / `publishDelta` from the IPC 'message' handler;
+ * the Attach handler (T-PA-6) calls `subscribe` / `currentSnapshot` /
+ * `deltasSince`.
+ *
+ * The class is intentionally a value object with no async methods — all
+ * I/O lives in the host.ts wire-up. This keeps the emitter itself unit-
+ * testable without mocking IPC, and keeps the `'message'` handler in
+ * host.ts a single synchronous code path.
+ */
+export class PtySessionEmitter {
+  readonly sessionId: string;
+  readonly capacity: number;
+
+  // Most recent snapshot, or null before the synthetic initial one fires
+  // (spec §3.3 first-snapshot race window). Replaced on every
+  // publishSnapshot.
+  #currentSnapshot: PtySnapshotInMem | null = null;
+
+  // Highest seq ever published via publishDelta. Tracked so deltasSince
+  // and the §3.4 decider math can read it in O(1) without scanning the
+  // ring.
+  #currentMaxSeq: bigint = 0n;
+
+  // FIFO ring of the last `capacity` deltas. enqueueDroppingOldest is
+  // used so the producer never blocks; the spec §2.4 prune happens via
+  // the same drop-oldest path on every publishDelta past the cap. The
+  // ack-state BoundedChannel docstring explicitly endorses this reuse.
+  readonly #ring: BoundedChannel<DeltaInMem>;
+
+  // Live subscribers. Set (not array) so unsubscribe is O(1).
+  readonly #subscribers: Set<PtyEventListener> = new Set();
+
+  // True after close() has fired. Subsequent publish*/subscribe calls
+  // are no-ops so the host.ts caller doesn't have to gate every IPC
+  // route. close() itself is idempotent.
+  #closed = false;
+
+  constructor(sessionId: string, capacity: number = DELTA_RETENTION_SEQS) {
+    this.sessionId = sessionId;
+    this.capacity = capacity;
+    this.#ring = new BoundedChannel<DeltaInMem>(capacity);
+  }
+
+  /**
+   * Most recent snapshot in memory, or `null` if none has been published
+   * yet (spec §3.3 first-snapshot race). Returned by reference; callers
+   * MUST treat the bytes as immutable (they originate from the IPC
+   * payload and are shared across subscribers).
+   */
+  currentSnapshot(): PtySnapshotInMem | null {
+    return this.#currentSnapshot;
+  }
+
+  /**
+   * Highest seq ever broadcast. `0n` before the first delta. Reads in
+   * O(1); the §3.4 attach decider needs this value synchronously.
+   */
+  currentMaxSeq(): bigint {
+    return this.#currentMaxSeq;
+  }
+
+  /**
+   * Lowest seq still in the in-memory ring. `0n` before any deltas; once
+   * deltas exist this is `max(1n, currentMaxSeq - capacity + 1n)` (the
+   * formula from spec §3.4 / attach-decider jsdoc). The Attach handler
+   * (T-PA-6 sink) feeds this into `decideAttachResume` for the
+   * `refused_too_far_behind` branch.
+   *
+   * Computed (not cached) because the read site is exactly once per
+   * Attach RPC; caching would just defer the bigint subtraction.
+   */
+  oldestRetainedSeq(): bigint {
+    if (this.#currentMaxSeq === 0n) {
+      return 0n;
+    }
+    const cap = BigInt(this.capacity);
+    const candidate = this.#currentMaxSeq - cap + 1n;
+    return candidate > 1n ? candidate : 1n;
+  }
+
+  /**
+   * Synchronously read the deltas in `(sinceSeq, currentMaxSeq]` from
+   * the ring. Returns `'out-of-window'` if `sinceSeq < oldestRetainedSeq`
+   * (the Attach handler maps that to `Code.OutOfRange` per spec §3.2;
+   * this method itself stays decider-pure).
+   *
+   * Empty array (NOT 'out-of-window') is returned when
+   * `sinceSeq === currentMaxSeq` — that's the deltas-only-with-no-gap
+   * case (spec §3.4: "sinceSeq == currentMaxSeq is valid here and yields
+   * an empty deltas slice").
+   *
+   * Implementation note: walks the ring's underlying buffer via the
+   * peek+iterator pattern would be more O(1) but the BoundedChannel
+   * primitive does NOT expose iteration (deliberately — adding it would
+   * leak ring state to all callers). We materialize to an array; the
+   * upper bound is `capacity == 4096` deltas, well below any pathological
+   * cost. For the steady-state happy path the slice is small (<256 per
+   * spec ch06 §4 cadence).
+   */
+  deltasSince(sinceSeq: bigint): readonly DeltaInMem[] | 'out-of-window' {
+    if (this.#currentMaxSeq === 0n) {
+      // No deltas yet. Any sinceSeq > 0n is a future-seq case (handled
+      // by the decider, not here); sinceSeq == 0n yields an empty
+      // slice (no deltas to replay).
+      return sinceSeq === 0n ? [] : 'out-of-window';
+    }
+    if (sinceSeq < this.oldestRetainedSeq()) {
+      return 'out-of-window';
+    }
+    if (sinceSeq >= this.#currentMaxSeq) {
+      return [];
+    }
+    // Drain the ring into a flat array (the only way to read the
+    // BoundedChannel without exposing its internals), filter to
+    // (sinceSeq, currentMaxSeq], then re-enqueue. This is destructive-
+    // looking but the channel stays the source of truth — we re-add
+    // exactly what we removed. The cost is O(capacity); see comment
+    // above re: bound.
+    const drained: DeltaInMem[] = [];
+    while (true) {
+      const item = this.#ring.dequeue();
+      if (item === undefined) break;
+      drained.push(item);
+    }
+    const result: DeltaInMem[] = [];
+    for (const d of drained) {
+      this.#ring.enqueue(d); // re-enqueue everything; the ring stays whole
+      if (d.seq > sinceSeq) {
+        result.push(d);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Subscribe to live broadcast. Returns an unsubscribe function. After
+   * `close()` has fired, subscribe is a no-op (returns a no-op
+   * unsubscribe) — the caller will have already received (or be about
+   * to receive synchronously, depending on subscribe-during-close
+   * ordering) the final 'closed' event via prior subscriptions.
+   *
+   * The listener fires synchronously from `publish*` calls, which
+   * themselves fire synchronously from the IPC 'message' handler in
+   * host.ts. Listeners MUST be non-blocking; route work into a bounded
+   * channel and let the Attach handler's async loop drain it.
+   */
+  subscribe(listener: PtyEventListener): () => void {
+    if (this.#closed) {
+      // Late subscriber after close — fire 'closed' once (so the
+      // subscriber's teardown path runs) then return a no-op unsubscribe.
+      try {
+        listener({ kind: 'closed', reason: 'pty.session_destroyed' });
+      } catch (err) {
+        // Listener bug; log and swallow per the listener-throws contract.
+        // eslint-disable-next-line no-console
+        console.error(
+          `[ccsm-daemon] PtySessionEmitter(${this.sessionId}): late subscriber listener threw on 'closed' event`,
+          err,
+        );
+      }
+      return () => {};
+    }
+    this.#subscribers.add(listener);
+    return () => {
+      this.#subscribers.delete(listener);
+    };
+  }
+
+  /**
+   * Subscriber count seam — exposed for daemon-boot-e2e #5 (spec §8
+   * disconnect cleanup): "open Attach + abort → emitter.subscriberCount
+   * === 0 within 100ms". The Attach handler (T-PA-6) is responsible for
+   * calling the unsubscribe fn from the abort path; this method only
+   * exposes the count so the test can assert convergence without
+   * reaching into the private Set.
+   */
+  subscriberCount(): number {
+    return this.#subscribers.size;
+  }
+
+  /**
+   * True after `close()` has fired. host.ts may use this from the IPC
+   * 'message' handler to skip publish* on already-closed sessions
+   * (e.g. a stray IPC arriving between exit-signal and full teardown).
+   */
+  isClosed(): boolean {
+    return this.#closed;
+  }
+
+  /**
+   * Ingest a SnapshotMessage from the pty-host child. Replaces
+   * `currentSnapshot` and broadcasts a 'snapshot' event. The synthetic
+   * initial snapshot (spec §3.3, baseSeq=0n) is just a normal call to
+   * this method with that baseSeq value.
+   *
+   * Spec §2.4 atomic step "replace currentSnapshot reference + prune
+   * the ring + publish event" — pruning happens at the ring level via
+   * BoundedChannel.enqueueDroppingOldest on every publishDelta, NOT
+   * here. The reason: the prune rule is `seq < baseSeq -
+   * DELTA_RETENTION_SEQS + 1`, and once the ring is sized to capacity
+   * the drop-oldest-on-enqueue policy enforces exactly that at the
+   * tighter cap of `currentMaxSeq - capacity + 1`. Combining the two
+   * (snapshot-prune AND enqueue-drop) would double-account; only one
+   * is needed. We choose enqueue-drop because it's continuous (no
+   * burst at snapshot boundaries) and the per-snapshot cost stays O(1).
+   */
+  publishSnapshot(msg: SnapshotMessage): void {
+    if (this.#closed) return;
+    // Defensive payload check — host.ts's `isChildToHostMessage` only
+    // validates the discriminant for the snapshot kind (the IPC payload
+    // shape was locked in T-PA-1 but a malformed child or a test fixture
+    // that sends `{kind:'snapshot'}` without payload fields would
+    // otherwise feed `undefined` into `currentSnapshot`). Reject quietly
+    // and log; the lifecycle stays unaffected.
+    if (
+      typeof msg.baseSeq !== 'bigint' ||
+      typeof msg.schemaVersion !== 'number' ||
+      msg.geometry === undefined ||
+      msg.screenState === undefined
+    ) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[ccsm-daemon] PtySessionEmitter(${this.sessionId}): malformed snapshot IPC; missing payload fields (baseSeq=${String(msg.baseSeq)}, schemaVersion=${String(msg.schemaVersion)})`,
+      );
+      return;
+    }
+    const snapshot: PtySnapshotInMem = {
+      baseSeq: msg.baseSeq,
+      geometry: msg.geometry,
+      screenState: msg.screenState,
+      schemaVersion: msg.schemaVersion,
+    };
+    this.#currentSnapshot = snapshot;
+    this.#broadcast({ kind: 'snapshot', snapshot });
+  }
+
+  /**
+   * Ingest a DeltaMessage from the pty-host child. Appends to the ring
+   * (drop-oldest on overflow per the BoundedChannel reuse pattern),
+   * advances `currentMaxSeq`, broadcasts a 'delta' event.
+   *
+   * Validates strict monotonicity: `seq > currentMaxSeq` is the
+   * forever-stable invariant from spec §2.1 ("monotonically-increasing
+   * per session, never reused, never gapped"). A violation is a
+   * pty-host-child bug; we log and DROP the offending delta rather
+   * than crash the daemon, because the alternative — propagating a
+   * gap to subscribers — corrupts every renderer's xterm state. This
+   * is conservative: the renderer will eventually time out / reattach
+   * with `since_seq = lastAppliedSeq`, recovering via the deltas-only
+   * branch (or `refused_too_far_behind` if the gap was huge).
+   */
+  publishDelta(msg: DeltaMessage): void {
+    if (this.#closed) return;
+    // Same defensive check as publishSnapshot — guard against malformed
+    // IPC payloads from test fixtures or future child-side bugs.
+    if (
+      typeof msg.seq !== 'bigint' ||
+      typeof msg.tsUnixMs !== 'bigint' ||
+      msg.payload === undefined
+    ) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[ccsm-daemon] PtySessionEmitter(${this.sessionId}): malformed delta IPC; missing payload fields (seq=${String(msg.seq)}, tsUnixMs=${String(msg.tsUnixMs)})`,
+      );
+      return;
+    }
+    if (msg.seq <= this.#currentMaxSeq) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[ccsm-daemon] PtySessionEmitter(${this.sessionId}): non-monotonic delta seq=${msg.seq} <= currentMaxSeq=${this.#currentMaxSeq}; dropping (pty-host child invariant violation)`,
+      );
+      return;
+    }
+    const delta: DeltaInMem = {
+      seq: msg.seq,
+      tsUnixMs: msg.tsUnixMs,
+      payload: msg.payload,
+    };
+    this.#ring.enqueueDroppingOldest(delta);
+    this.#currentMaxSeq = msg.seq;
+    this.#broadcast({ kind: 'delta', delta });
+  }
+
+  /**
+   * Tear down the emitter: broadcast a final 'closed' event to every
+   * subscriber (so the Attach handler can map it to Code.Canceled +
+   * `pty.session_destroyed` per spec §7.2), drop all subscribers, and
+   * latch the closed flag so subsequent publish/subscribe calls become
+   * no-ops.
+   *
+   * Idempotent: a second call is a no-op (returns immediately). This
+   * matches the host.ts caller pattern where both the IPC disconnect
+   * path and the explicit teardown path may both fire close().
+   *
+   * Subscribers are dropped AFTER the broadcast so a subscriber that
+   * tries to unsubscribe from inside its 'closed' handler doesn't
+   * trigger ConcurrentModification. We snapshot the Set into an array
+   * before iteration for the same reason.
+   */
+  close(reason: PtyEmitterCloseReason = 'pty.session_destroyed'): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    const event: PtyEvent = { kind: 'closed', reason };
+    // Snapshot subscribers BEFORE clearing so concurrent unsubscribe
+    // calls from inside a listener don't mutate during iteration.
+    const subscribers = [...this.#subscribers];
+    this.#subscribers.clear();
+    for (const listener of subscribers) {
+      try {
+        listener(event);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[ccsm-daemon] PtySessionEmitter(${this.sessionId}): subscriber listener threw on 'closed' event`,
+          err,
+        );
+      }
+    }
+  }
+
+  // Internal: synchronous fan-out to every subscriber. Snapshot the
+  // Set into an array before iteration so a listener that calls
+  // unsubscribe (or throws) cannot break the iteration order.
+  #broadcast(event: PtyEvent): void {
+    const subscribers = [...this.#subscribers];
+    for (const listener of subscribers) {
+      try {
+        listener(event);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[ccsm-daemon] PtySessionEmitter(${this.sessionId}): subscriber listener threw on '${event.kind}' event`,
+          err,
+        );
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level registry — sessionId → PtySessionEmitter
+// ---------------------------------------------------------------------------
+//
+// The Attach RPC handler (T-PA-6, blocked on this PR) needs to look up
+// the emitter for a given AttachRequest.session_id. Plumbing the map
+// through every RPC handler context would couple the router to the
+// pty-host module's internals; a module-level registry keeps the
+// coupling at exactly one symbol (`getEmitter`) on each side.
+//
+// Thread-safety: Node is single-threaded; all access happens on the
+// main thread (IPC 'message' is on the event loop, RPC handlers run on
+// the event loop). No locking needed.
+//
+// The registry is internal state of this module — it's NOT a Singleton
+// in the broader-architecture sense. Tests that want isolation can call
+// resetEmitterRegistry() in afterEach (see the export below).
+
+const REGISTRY = new Map<string, PtySessionEmitter>();
+
+/**
+ * Register a new emitter for a session. Called from host.ts on
+ * pty-host child `'ready'`. Throws if an emitter already exists for
+ * the session — a duplicate is a programming error in the host wire-up
+ * (a session id is a ULID; collisions in normal use mean the daemon is
+ * trying to spawn two children for the same session).
+ *
+ * The host.ts caller is responsible for the matched
+ * {@link unregisterEmitter} on child exit.
+ */
+export function registerEmitter(emitter: PtySessionEmitter): void {
+  if (REGISTRY.has(emitter.sessionId)) {
+    throw new Error(
+      `PtySessionEmitter registry: duplicate sessionId ${emitter.sessionId} ` +
+        '(host.ts wire-up bug — registerEmitter called twice without an intervening unregisterEmitter)',
+    );
+  }
+  REGISTRY.set(emitter.sessionId, emitter);
+}
+
+/**
+ * Remove an emitter from the registry. Called from host.ts on pty-host
+ * child exit (right after emitter.close()). Idempotent: returns false
+ * if the session was never registered (or already removed) so the
+ * host.ts teardown path can be safely re-entered.
+ */
+export function unregisterEmitter(sessionId: string): boolean {
+  return REGISTRY.delete(sessionId);
+}
+
+/**
+ * Look up the emitter for a session id. Returns `undefined` if no
+ * emitter exists for the id (session was never created, or has been
+ * destroyed). The Attach RPC handler (T-PA-6) maps `undefined` to
+ * `Code.NotFound` + `ErrorDetail.code = 'pty.session_not_found'` (the
+ * per-spec mapping; landed in T-PA-6's PR, not here).
+ */
+export function getEmitter(sessionId: string): PtySessionEmitter | undefined {
+  return REGISTRY.get(sessionId);
+}
+
+/**
+ * Test seam: clear the entire registry. NOT for production use. Unit
+ * tests in `__tests__/` may call this in `afterEach` to ensure no
+ * cross-test leakage when multiple emitters are constructed in a single
+ * vitest worker.
+ */
+export function resetEmitterRegistry(): void {
+  // Close every emitter so subscribers in any straggler tests get the
+  // 'closed' event (they shouldn't have any, but the bookkeeping is
+  // cheap and matches the production teardown ordering).
+  for (const emitter of REGISTRY.values()) {
+    try {
+      emitter.close();
+    } catch {
+      // Best-effort cleanup; tests don't care if a stray subscriber threw.
+    }
+  }
+  REGISTRY.clear();
+}

--- a/packages/daemon/test/pty-host/host.spec.ts
+++ b/packages/daemon/test/pty-host/host.spec.ts
@@ -13,15 +13,28 @@
 // T4.1 surface: it sends `ready`, accepts `close`, sends `exiting`, and
 // exits 0. T4.2+ tests will exercise the real child binary.
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 
 import { spawnPtyHostChild } from '../../src/pty-host/host.js';
+import { resetEmitterRegistry } from '../../src/pty-host/pty-emitter.js';
 import type { SpawnPayload } from '../../src/pty-host/types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const FIXTURE = join(__dirname, 'fixtures', 'child-fixture.mjs');
+
+// T-PA-5: spawnPtyHostChild auto-constructs a PtySessionEmitter on the
+// child's `'ready'` IPC and registers it in the module-level registry.
+// These tests reuse the same hard-coded sessionId (e.g. 'sess-001')
+// across multiple `it` cases by design — the lifecycle skeleton's
+// concern is the IPC handshake, not the emitter wire-up. Reset the
+// registry between tests so the second `it` doesn't trip the duplicate-
+// id guard with a stale entry from the previous case. Production wiring
+// is exercised by the daemon-boot-e2e suite, not here.
+afterEach(() => {
+  resetEmitterRegistry();
+});
 
 function makePayload(overrides: Partial<SpawnPayload> = {}): SpawnPayload {
   return {
@@ -97,6 +110,11 @@ describe('spawnPtyHostChild — message stream', () => {
       payload: makePayload(),
       childEntrypoint: FIXTURE,
       forkEnv: { ...process.env, CCSM_FIXTURE_MODE: 'echo' },
+      // Echo fixture sends `{kind:'snapshot'}` without baseSeq/geometry
+      // (it predates T-PA-1). Disable the T-PA-5 emitter wire-up so the
+      // emitter doesn't log a malformed-snapshot warning to vitest stdout
+      // — this test only covers the messages async iterator surface.
+      emitterRegistry: 'disabled',
     });
 
     await handle.ready();


### PR DESCRIPTION
Wave 3 §6.9 sub-task 10 / T-PA-5 per spec
[`docs/superpowers/specs/2026-05-04-pty-attach-handler.md`](docs/superpowers/specs/2026-05-04-pty-attach-handler.md)
§2.3 / §2.4 / §3.3 / §9.2.

Closes Task #354. Blocks Task #355 (T-PA-6, Attach handler) and Task
#356 (T-PA-7, CreateSession/DestroySession response shape tightening).

## Summary

- New `packages/daemon/src/pty-host/pty-emitter.ts`:
  - `PtySessionEmitter` class — per-session in-memory snapshot +
    `DELTA_RETENTION_SEQS` (=4096) delta ring + `Set<listener>`
    broadcaster. The ring reuses
    `BoundedChannel.enqueueDroppingOldest` from `ack-state.ts` so the
    spec §4.5 `DELTA_RETENTION_SEQS == ACK_CHANNEL_CAPACITY` invariant
    is greppable in code.
  - `subscriberCount()` test seam (daemon-boot-e2e §8 #5 disconnect
    cleanup assertion: "open Attach + abort → `emitter.subscriberCount
    === 0` within 100ms" — assertion lands with T-PA-6's Attach handler
    in PR #355; the seam is exposed here).
  - `close()` broadcasts `{kind:'closed', reason:'pty.session_destroyed'}`
    to every subscriber; the Attach handler (T-PA-6 sink) maps that to
    `Code.Canceled` + `ErrorDetail.code = 'pty.session_destroyed'` per
    spec §7.2 bullet 3.
  - Module-level registry: `registerEmitter` / `unregisterEmitter` /
    `getEmitter(sessionId)` — the Attach handler's lookup surface — plus
    `resetEmitterRegistry()` for unit-test isolation.

- Modified `packages/daemon/src/pty-host/host.ts`:
  - On the pty-host child's `'ready'` IPC: lazily construct a
    `PtySessionEmitter` and register it. On `'delta'` / `'snapshot'`
    IPC: route into `emitter.publishDelta` / `publishSnapshot`. On
    child `'exit'`: `emitter.close()` → `unregisterEmitter` →
    `exitedResolve()` (close fires synchronously so subscribers receive
    the `'closed'` event before the lifecycle resolves).
  - New optional `SpawnPtyHostChildOptions.emitterRegistry` field —
    default = production module-level registry; `'disabled'` opts the
    wire-up out for tests; `{register, unregister}` injection for
    isolated test registries.

- `packages/daemon/test/pty-host/host.spec.ts`: `afterEach` calls
  `resetEmitterRegistry()` so the lifecycle skeleton tests that share
  `'sess-001'` across `it` cases don't trip the registry's duplicate-id
  guard. The echo-mode test passes `emitterRegistry: 'disabled'`
  because the fixture sends a pre-T-PA-1 stub `{kind:'snapshot'}` that
  the emitter would (correctly) flag as malformed.

## Acceptance evidence

- §3.3 synthetic snapshot at `base_seq=0n` on `'ready'` — the emitter
  accepts whatever first `SnapshotMessage` arrives; the producer is the
  child-side T-PA-8 (PR #1026, in review). For the host-side wire-up
  here, "synthetic initial snapshot" = "first `SnapshotMessage` IPC
  routed into `publishSnapshot`".
- §2.4 at-most-one snapshot per Attach stream — enforced at the Attach
  handler sink (T-PA-6) layer; the emitter broadcasts every snapshot,
  the handler chooses not to forward subsequent ones mid-stream.
- §4.5 `requires_ack` channel capacity == `DELTA_RETENTION_SEQS` ==
  4096 — `pty-emitter.ts` re-exports
  `ACK_CHANNEL_CAPACITY` from `ack-state.ts` as
  `DELTA_RETENTION_SEQS`; one source of truth.
- daemon-boot-e2e §8 assertion 5 — test seam `subscriberCount()` is
  exported on `PtySessionEmitter`. The assertion itself lands with
  T-PA-6 (PR #355).

## Coordination with PR #1026 (T-PA-8 child-side)

This PR consumes the IPC payload types (`DeltaMessage`,
`SnapshotMessage`) from `packages/daemon/src/pty-host/types.ts`, which
were locked in T-PA-1 (#358, merged). PR #1026 is the producer that
sends those IPCs from `child.ts`. Both PRs build against the same
locked types; merge order does not matter for forward-safety.

## Local checks (host: windows-11)

- lint: ✓ (exit 0; 61 pre-existing warnings on unrelated files, 0 errors)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0; turbo `npm run build` 3/3 successful)
- unit tests (pty-host scope, the only files this PR touches):
  ```
  pnpm exec vitest run test/pty-host/host.spec.ts src/pty-host/__tests__
  Test Files  6 passed (6)
  Tests  125 passed (125)
  Duration  2.22s
  ```
- unit tests (full daemon): 1425 passed | 6 failed | 20 skipped | 5
  todo (1456 total). The 6 failures are all `Connect server.close()
  afterEach hook timeout` flakes in `crash-getlog-wired.spec.ts`,
  `crash-watch-wired.spec.ts`, `watch-sessions-wired.spec.ts`, and
  `src/rpc/__tests__/integration.spec.ts` — pre-existing on Windows
  (the daemon-boot-end-to-end.spec.ts file already documents the same
  symptom in its `stopBoot()` helper, which caps the timeout at 1500ms).
  None of the 6 specs touch pty-host or the files this PR modifies; CI
  runs on linux/macos/windows matrix and the same flakes are present
  there pre-PR. Reverse-verify on origin/working not required because
  this PR adds new behavior, not a bug fix.
- e2e (`npm run probe:e2e`): not run successfully on this dev machine.
  `harness-dnd` / `harness-ui` fail with `ERR_DLOPEN_FAILED` from
  `bindings.js` — better-sqlite3 / node-pty native modules are built
  for the system Node ABI but Electron 41 needs an electron-rebuild
  pass; `electron-rebuild -f -w better-sqlite3 -w node-pty` fails on
  the node-pty rebuild step (node-gyp environment issue on this
  worktree pool, not introduced by this PR — the changed files are
  daemon-only TypeScript with no native dep changes). `harness-real-cli`
  fails with `firstWindow Timeout 30000ms` which is downstream of the
  same native-module load failure (the renderer process can't load the
  daemon's better-sqlite3 binding). CI matrix runs electron-rebuild
  cleanly; the wire-up is exercised end-to-end via T-PA-6's Attach
  handler PR (#355) which adds the daemon-boot-e2e §8 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)