### PR TITLE
T-PA-6(#355): PtyService.Attach Connect server-stream handler

### DIFF
--- a/packages/daemon/src/rpc/pty-attach.spec.ts
+++ b/packages/daemon/src/rpc/pty-attach.spec.ts
@@ -1,0 +1,617 @@
+// PtyService.Attach handler — unit tests (Task #355 / T-PA-6).
+//
+// Drives `makeAttachHandler` through `createRouterTransport` (in-process
+// Connect router; same shape as `__tests__/router.spec.ts` and
+// `test/sessions/watch-sessions.spec.ts`). Covers spec
+// `2026-05-04-pty-attach-handler.md` §3 decider branches at the wire,
+// §4 backpressure, §5 abort cleanup, §3.3 first-snapshot await.
+//
+// Fakes (no real pty-host child, no real http2):
+//   - FakeEmitter implements PtySessionEmitterLike. Sync publish methods
+//     fan-out to subscribers; close() emits 'closed' once. Mirrors PR
+//     #1027's PtySessionEmitter exact contract on the methods this
+//     handler reads.
+//   - peerCredAuthInterceptor is faked via a minimal interceptor that
+//     deposits a Principal under PRINCIPAL_KEY, matching production
+//     wiring (see daemon/src/index.ts `bearerToPeerInfoInterceptor` +
+//     `peerCredAuthInterceptor`).
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  createClient,
+  createRouterTransport,
+  type Interceptor,
+} from '@connectrpc/connect';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  AttachRequestSchema,
+  ErrorDetailSchema,
+  PtyService,
+  RequestMetaSchema,
+  type ErrorDetail,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, type Principal as AuthPrincipal } from '../auth/index.js';
+import type {
+  DeltaInMem,
+  PtySnapshotInMem,
+} from '../pty-host/attach-decider.js';
+import { ACK_CHANNEL_CAPACITY } from '../pty-host/ack-state.js';
+
+import {
+  ATTACH_FAST_PATH_BUFFER_SIZE,
+  awaitSnapshot,
+  deltaToFrame,
+  makeAttachHandler,
+  snapshotToFrame,
+  type PtyAttachDeps,
+  type PtyEmitterEvent,
+  type PtyEmitterListener,
+  type PtySessionEmitterLike,
+} from './pty-attach.js';
+
+// ---------------------------------------------------------------------------
+// Fake emitter — mirrors PR #1027 PtySessionEmitter contract for the
+// surface this handler reads. Synchronous publish; subscribers receive in
+// insertion order.
+// ---------------------------------------------------------------------------
+
+class FakeEmitter implements PtySessionEmitterLike {
+  readonly sessionId: string;
+  readonly capacity: number;
+  #snapshot: PtySnapshotInMem | null = null;
+  #maxSeq: bigint = 0n;
+  readonly #ring: DeltaInMem[] = [];
+  readonly #subs: Set<PtyEmitterListener> = new Set();
+  #closed = false;
+
+  constructor(sessionId: string, capacity = 4096) {
+    this.sessionId = sessionId;
+    this.capacity = capacity;
+  }
+
+  currentSnapshot(): PtySnapshotInMem | null {
+    return this.#snapshot;
+  }
+  currentMaxSeq(): bigint {
+    return this.#maxSeq;
+  }
+  oldestRetainedSeq(): bigint {
+    if (this.#maxSeq === 0n) return 0n;
+    const cap = BigInt(this.capacity);
+    const candidate = this.#maxSeq - cap + 1n;
+    return candidate > 1n ? candidate : 1n;
+  }
+  deltasSince(sinceSeq: bigint): readonly DeltaInMem[] | 'out-of-window' {
+    if (this.#maxSeq === 0n) {
+      return sinceSeq === 0n ? [] : 'out-of-window';
+    }
+    if (sinceSeq < this.oldestRetainedSeq()) return 'out-of-window';
+    if (sinceSeq >= this.#maxSeq) return [];
+    return this.#ring.filter((d) => d.seq > sinceSeq);
+  }
+  subscribe(listener: PtyEmitterListener): () => void {
+    if (this.#closed) {
+      try {
+        listener({ kind: 'closed', reason: 'pty.session_destroyed' });
+      } catch {
+        /* swallow */
+      }
+      return () => {};
+    }
+    this.#subs.add(listener);
+    return () => {
+      this.#subs.delete(listener);
+    };
+  }
+  isClosed(): boolean {
+    return this.#closed;
+  }
+
+  // ---- Test surface (match PR #1027 publishSnapshot / publishDelta /
+  //      close shape but skip the malformed-ipc defensive checks) ----
+
+  publishSnapshot(snap: PtySnapshotInMem): void {
+    if (this.#closed) return;
+    this.#snapshot = snap;
+    this.#broadcast({ kind: 'snapshot', snapshot: snap });
+  }
+  publishDelta(delta: DeltaInMem): void {
+    if (this.#closed) return;
+    if (delta.seq <= this.#maxSeq) {
+      throw new Error(`non-monotonic seq ${delta.seq} <= ${this.#maxSeq}`);
+    }
+    this.#ring.push(delta);
+    if (this.#ring.length > this.capacity) {
+      this.#ring.shift();
+    }
+    this.#maxSeq = delta.seq;
+    this.#broadcast({ kind: 'delta', delta });
+  }
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    const event: PtyEmitterEvent = {
+      kind: 'closed',
+      reason: 'pty.session_destroyed',
+    };
+    const subs = [...this.#subs];
+    this.#subs.clear();
+    for (const l of subs) {
+      try {
+        l(event);
+      } catch {
+        /* swallow */
+      }
+    }
+  }
+  subscriberCount(): number {
+    return this.#subs.size;
+  }
+
+  #broadcast(event: PtyEmitterEvent): void {
+    const subs = [...this.#subs];
+    for (const l of subs) {
+      try {
+        l(event);
+      } catch {
+        /* swallow */
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+const TEST_PRINCIPAL: AuthPrincipal = {
+  kind: 'local-user',
+  uid: '1000',
+  displayName: 'tester',
+};
+
+const depositPrincipal: Interceptor = (next) => async (req) => {
+  req.contextValues.set(PRINCIPAL_KEY, TEST_PRINCIPAL);
+  return next(req);
+};
+
+function makeSnapshot(baseSeq: bigint, screen = new Uint8Array([1, 2])): PtySnapshotInMem {
+  return {
+    baseSeq,
+    geometry: { cols: 80, rows: 24 },
+    screenState: screen,
+    schemaVersion: 1,
+  };
+}
+
+function makeDelta(seq: bigint, payload = new Uint8Array([0xaa])): DeltaInMem {
+  return { seq, tsUnixMs: 1700000000000n + seq, payload };
+}
+
+function makeReq(overrides: {
+  readonly sessionId?: string;
+  readonly sinceSeq?: bigint;
+  readonly requiresAck?: boolean;
+}): ReturnType<typeof create<typeof AttachRequestSchema>> {
+  return create(AttachRequestSchema, {
+    meta: create(RequestMetaSchema, {
+      requestId: '11111111-2222-3333-4444-555555555555',
+    }),
+    sessionId: overrides.sessionId ?? 'sess-1',
+    sinceSeq: overrides.sinceSeq ?? 0n,
+    requiresAck: overrides.requiresAck ?? false,
+  });
+}
+
+function makeTransport(
+  registry: Map<string, FakeEmitter>,
+): ReturnType<typeof createRouterTransport> {
+  const deps: PtyAttachDeps = {
+    getEmitter: (id) => registry.get(id),
+  };
+  return createRouterTransport(
+    (router) => {
+      router.service(PtyService, { attach: makeAttachHandler(deps) });
+    },
+    {
+      router: { interceptors: [depositPrincipal] },
+    },
+  );
+}
+
+function readErrorDetail(err: unknown): ErrorDetail | null {
+  if (!(err instanceof ConnectError)) return null;
+  const details = err.findDetails(ErrorDetailSchema);
+  return details[0] ?? null;
+}
+
+// ---------------------------------------------------------------------------
+// Pure-function tests (mappers + awaitSnapshot)
+// ---------------------------------------------------------------------------
+
+describe('snapshotToFrame / deltaToFrame', () => {
+  it('snapshotToFrame copies all fields onto the proto oneof', () => {
+    const snap = makeSnapshot(42n, new Uint8Array([9, 8, 7]));
+    const frame = snapshotToFrame(snap);
+    expect(frame.kind.case).toBe('snapshot');
+    if (frame.kind.case !== 'snapshot') throw new Error('case mismatch');
+    expect(frame.kind.value.baseSeq).toBe(42n);
+    expect(frame.kind.value.schemaVersion).toBe(1);
+    expect(frame.kind.value.geometry?.cols).toBe(80);
+    expect(frame.kind.value.geometry?.rows).toBe(24);
+    expect(Array.from(frame.kind.value.screenState)).toEqual([9, 8, 7]);
+  });
+
+  it('deltaToFrame copies seq + payload + ts', () => {
+    const delta = makeDelta(7n, new Uint8Array([0xff, 0x00]));
+    const frame = deltaToFrame(delta);
+    expect(frame.kind.case).toBe('delta');
+    if (frame.kind.case !== 'delta') throw new Error('case mismatch');
+    expect(frame.kind.value.seq).toBe(7n);
+    expect(frame.kind.value.tsUnixMs).toBe(1700000000007n);
+    expect(Array.from(frame.kind.value.payload)).toEqual([0xff, 0x00]);
+  });
+});
+
+describe('awaitSnapshot (spec §3.3 first-snapshot race)', () => {
+  it('resolves synchronously when a snapshot is already in memory', async () => {
+    const emitter = new FakeEmitter('sess-1');
+    emitter.publishSnapshot(makeSnapshot(0n));
+    const snap = await awaitSnapshot(emitter, undefined);
+    expect(snap.baseSeq).toBe(0n);
+  });
+
+  it('waits and resolves when a snapshot arrives after subscribe', async () => {
+    const emitter = new FakeEmitter('sess-1');
+    const promise = awaitSnapshot(emitter, undefined);
+    expect(emitter.subscriberCount()).toBe(1);
+    emitter.publishSnapshot(makeSnapshot(0n));
+    const snap = await promise;
+    expect(snap.baseSeq).toBe(0n);
+    // Subscriber MUST be detached after resolution (spec §5).
+    expect(emitter.subscriberCount()).toBe(0);
+  });
+
+  it('rejects with pty.session_destroyed if the session ends first', async () => {
+    const emitter = new FakeEmitter('sess-1');
+    const promise = awaitSnapshot(emitter, undefined);
+    emitter.close();
+    await expect(promise).rejects.toMatchObject({
+      code: Code.Canceled,
+    });
+    const err = await promise.catch((e) => e);
+    const detail = readErrorDetail(err);
+    expect(detail?.code).toBe('pty.session_destroyed');
+    expect(emitter.subscriberCount()).toBe(0);
+  });
+
+  it('rejects when the AbortSignal fires before a snapshot arrives', async () => {
+    const emitter = new FakeEmitter('sess-1');
+    const ac = new AbortController();
+    const promise = awaitSnapshot(emitter, ac.signal);
+    expect(emitter.subscriberCount()).toBe(1);
+    ac.abort(new Error('client disconnected'));
+    await expect(promise).rejects.toThrow('client disconnected');
+    expect(emitter.subscriberCount()).toBe(0);
+  });
+
+  it('rejects immediately for an already-closed emitter', async () => {
+    const emitter = new FakeEmitter('sess-1');
+    emitter.close();
+    await expect(awaitSnapshot(emitter, undefined)).rejects.toMatchObject({
+      code: Code.Canceled,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wire-level tests through createRouterTransport
+// ---------------------------------------------------------------------------
+
+describe('PtyService.Attach — over the wire', () => {
+  let registry: Map<string, FakeEmitter>;
+  let client: ReturnType<typeof createClient<typeof PtyService>>;
+
+  beforeEach(() => {
+    registry = new Map();
+    client = createClient(PtyService, makeTransport(registry));
+  });
+
+  afterEach(() => {
+    for (const e of registry.values()) e.close();
+    registry.clear();
+  });
+
+  it('rejects empty session_id with pty.session_not_found', async () => {
+    const iter = client.attach(makeReq({ sessionId: '' }));
+    const err = await drainExpectError(iter);
+    expect(err.code).toBe(Code.NotFound);
+    expect(readErrorDetail(err)?.code).toBe('pty.session_not_found');
+  });
+
+  it('rejects unknown session id with pty.session_not_found', async () => {
+    const iter = client.attach(makeReq({ sessionId: 'no-such' }));
+    const err = await drainExpectError(iter);
+    expect(err.code).toBe(Code.NotFound);
+    expect(readErrorDetail(err)?.code).toBe('pty.session_not_found');
+    expect(readErrorDetail(err)?.extra.session_id).toBe('no-such');
+  });
+
+  it('since_seq=0 yields snapshot then live deltas (spec §3.1.1)', async () => {
+    const emitter = new FakeEmitter('sess-1');
+    emitter.publishSnapshot(makeSnapshot(0n));
+    registry.set('sess-1', emitter);
+
+    const iter = client.attach(makeReq({ sessionId: 'sess-1', sinceSeq: 0n }));
+    const ai = iter[Symbol.asyncIterator]();
+
+    const f1 = await ai.next();
+    expect(f1.done).toBe(false);
+    expect(f1.value?.kind.case).toBe('snapshot');
+
+    // Now publish a live delta — handler should yield it.
+    void Promise.resolve().then(() => emitter.publishDelta(makeDelta(1n)));
+    const f2 = await ai.next();
+    expect(f2.done).toBe(false);
+    expect(f2.value?.kind.case).toBe('delta');
+    if (f2.value?.kind.case === 'delta') {
+      expect(f2.value.kind.value.seq).toBe(1n);
+    }
+
+    // Close session — handler should throw pty.session_destroyed.
+    void Promise.resolve().then(() => emitter.close());
+    const err = await ai.next().then(
+      () => null,
+      (e) => e as unknown,
+    );
+    expect(err).toBeInstanceOf(ConnectError);
+    expect((err as ConnectError).code).toBe(Code.Canceled);
+    expect(readErrorDetail(err)?.code).toBe('pty.session_destroyed');
+  });
+
+  it('since_seq>0 with retained deltas replays the slice then streams live', async () => {
+    const emitter = new FakeEmitter('sess-1');
+    emitter.publishSnapshot(makeSnapshot(0n));
+    emitter.publishDelta(makeDelta(1n));
+    emitter.publishDelta(makeDelta(2n));
+    emitter.publishDelta(makeDelta(3n));
+    registry.set('sess-1', emitter);
+
+    const iter = client.attach(makeReq({ sessionId: 'sess-1', sinceSeq: 1n }));
+    const ai = iter[Symbol.asyncIterator]();
+
+    // Replays (sinceSeq, currentMaxSeq] = (1, 3] = [2, 3].
+    const r1 = await ai.next();
+    expect(r1.value?.kind.case).toBe('delta');
+    if (r1.value?.kind.case === 'delta') expect(r1.value.kind.value.seq).toBe(2n);
+    const r2 = await ai.next();
+    if (r2.value?.kind.case === 'delta') expect(r2.value.kind.value.seq).toBe(3n);
+
+    // Live delta at seq=4.
+    void Promise.resolve().then(() => emitter.publishDelta(makeDelta(4n)));
+    const r3 = await ai.next();
+    if (r3.value?.kind.case === 'delta') expect(r3.value.kind.value.seq).toBe(4n);
+
+    // Cleanup — abort by returning the iterator. (We don't assert the
+    // subscriber count converges here; that's covered in the dedicated
+    // AbortSignal test below — abort propagation across the
+    // in-process router transport is async and would require a poll
+    // loop to observe deterministically.)
+    await ai.return?.(undefined);
+  });
+
+  it('since_seq < oldestRetainedSeq throws OutOfRange + pty.attach_too_far_behind (spec §3.2)', async () => {
+    const emitter = new FakeEmitter('sess-1', /* capacity */ 4);
+    emitter.publishSnapshot(makeSnapshot(0n));
+    // Push 6 deltas → ring keeps last 4 → oldestRetainedSeq = 3.
+    for (let i = 1n; i <= 6n; i += 1n) emitter.publishDelta(makeDelta(i));
+    registry.set('sess-1', emitter);
+
+    // sinceSeq = 1 is too far behind (oldest is 3).
+    const iter = client.attach(makeReq({ sessionId: 'sess-1', sinceSeq: 1n }));
+    const err = await drainExpectError(iter);
+    expect(err.code).toBe(Code.OutOfRange);
+    const detail = readErrorDetail(err);
+    expect(detail?.code).toBe('pty.attach_too_far_behind');
+    expect(detail?.extra.since_seq).toBe('1');
+    expect(detail?.extra.oldest_retained_seq).toBe('3');
+  });
+
+  it('since_seq > currentMaxSeq throws InvalidArgument + pty.attach_future_seq (spec §3.4)', async () => {
+    const emitter = new FakeEmitter('sess-1');
+    emitter.publishSnapshot(makeSnapshot(0n));
+    emitter.publishDelta(makeDelta(1n));
+    registry.set('sess-1', emitter);
+
+    const iter = client.attach(makeReq({ sessionId: 'sess-1', sinceSeq: 99n }));
+    const err = await drainExpectError(iter);
+    expect(err.code).toBe(Code.InvalidArgument);
+    const detail = readErrorDetail(err);
+    expect(detail?.code).toBe('pty.attach_future_seq');
+    expect(detail?.extra.since_seq).toBe('99');
+    expect(detail?.extra.current_max_seq).toBe('1');
+  });
+
+  it('since_seq=0 awaits the synthetic snapshot when emitter has none yet (§3.3)', async () => {
+    const emitter = new FakeEmitter('sess-1');
+    registry.set('sess-1', emitter); // No snapshot yet.
+
+    const iter = client.attach(makeReq({ sessionId: 'sess-1', sinceSeq: 0n }));
+    const ai = iter[Symbol.asyncIterator]();
+
+    // Schedule the snapshot to arrive after the handler subscribes.
+    void Promise.resolve().then(() => emitter.publishSnapshot(makeSnapshot(0n)));
+    const f = await ai.next();
+    expect(f.done).toBe(false);
+    expect(f.value?.kind.case).toBe('snapshot');
+
+    await ai.return?.(undefined);
+  });
+
+  it('mid-stream snapshots are NOT yielded onto the wire (spec §2.4 at-most-one)', async () => {
+    const emitter = new FakeEmitter('sess-1');
+    emitter.publishSnapshot(makeSnapshot(0n));
+    registry.set('sess-1', emitter);
+
+    const iter = client.attach(makeReq({ sessionId: 'sess-1', sinceSeq: 0n }));
+    const ai = iter[Symbol.asyncIterator]();
+
+    const initial = await ai.next();
+    expect(initial.value?.kind.case).toBe('snapshot');
+
+    // Mid-stream: deltas, then a NEW snapshot, then more deltas. Wire
+    // MUST see only the deltas (the second snapshot is dropped).
+    void Promise.resolve().then(() => emitter.publishDelta(makeDelta(1n)));
+    const d1 = await ai.next();
+    expect(d1.value?.kind.case).toBe('delta');
+
+    void Promise.resolve().then(() => {
+      emitter.publishDelta(makeDelta(2n));
+      emitter.publishSnapshot(makeSnapshot(2n));
+      emitter.publishDelta(makeDelta(3n));
+    });
+    const d2 = await ai.next();
+    if (d2.value?.kind.case === 'delta') expect(d2.value.kind.value.seq).toBe(2n);
+    const d3 = await ai.next();
+    if (d3.value?.kind.case === 'delta') expect(d3.value.kind.value.seq).toBe(3n);
+
+    await ai.return?.(undefined);
+  });
+
+  it('AbortSignal teardown unsubscribes from the emitter (spec §5)', async () => {
+    const emitter = new FakeEmitter('sess-1');
+    emitter.publishSnapshot(makeSnapshot(0n));
+    registry.set('sess-1', emitter);
+
+    const ac = new AbortController();
+    const iter = client.attach(makeReq({ sessionId: 'sess-1', sinceSeq: 0n }), {
+      signal: ac.signal,
+    });
+    const ai = iter[Symbol.asyncIterator]();
+    await ai.next(); // consume the snapshot frame so the handler is parked
+    expect(emitter.subscriberCount()).toBe(1);
+
+    ac.abort();
+    // Drain — the handler returns cleanly on abort.
+    try {
+      while (true) {
+        const r = await ai.next();
+        if (r.done) break;
+      }
+    } catch {
+      // Connect may surface the abort as a Canceled error; either is fine.
+    }
+    // Convergence: subscriber count drops to 0.
+    expect(emitter.subscriberCount()).toBe(0);
+  });
+
+  it('fast-path overflow throws ResourceExhausted + pty.subscriber_channel_full', async () => {
+    // Drive a SLOW consumer: never call .next() past the snapshot, so
+    // every published delta queues into the bounded fallback buffer.
+    // After ATTACH_FAST_PATH_BUFFER_SIZE deltas, the next publish
+    // overflows and the next .next() observes the terminal error.
+    const emitter = new FakeEmitter('sess-1');
+    emitter.publishSnapshot(makeSnapshot(0n));
+    registry.set('sess-1', emitter);
+
+    const iter = client.attach(
+      makeReq({ sessionId: 'sess-1', sinceSeq: 0n, requiresAck: false }),
+    );
+    const ai = iter[Symbol.asyncIterator]();
+    // Consume the snapshot — handler is now parked on the channel.
+    await ai.next();
+
+    // Fill the fallback buffer + 1 to trigger overflow.
+    for (let i = 1n; i <= BigInt(ATTACH_FAST_PATH_BUFFER_SIZE) + 1n; i += 1n) {
+      emitter.publishDelta(makeDelta(i));
+    }
+
+    // Drain — at some point we should hit the overflow ConnectError.
+    const err = await (async (): Promise<unknown> => {
+      try {
+        while (true) {
+          const r = await ai.next();
+          if (r.done) return new Error('expected overflow error');
+        }
+      } catch (e) {
+        return e;
+      }
+    })();
+    expect(err).toBeInstanceOf(ConnectError);
+    expect((err as ConnectError).code).toBe(Code.ResourceExhausted);
+    expect(readErrorDetail(err)?.code).toBe('pty.subscriber_channel_full');
+  });
+
+  it('requires_ack=true uses ACK_CHANNEL_CAPACITY (4096) per spec §4.5', async () => {
+    // Smoke test: open Attach with requires_ack=true, push capacity-1
+    // deltas, ensure no overflow. (Pushing 4097 here would be slow;
+    // we trust the BoundedChannel unit tests for the exact capacity
+    // boundary and just verify the ACK path uses a larger cap than
+    // the fast path.)
+    const emitter = new FakeEmitter('sess-1', /* ring */ ACK_CHANNEL_CAPACITY + 64);
+    emitter.publishSnapshot(makeSnapshot(0n));
+    registry.set('sess-1', emitter);
+
+    const iter = client.attach(
+      makeReq({ sessionId: 'sess-1', sinceSeq: 0n, requiresAck: true }),
+    );
+    const ai = iter[Symbol.asyncIterator]();
+    await ai.next(); // consume snapshot
+
+    // Push fast-path-cap + 50 deltas (would overflow the false path)
+    // and verify we can still drain them — the requires_ack channel
+    // is larger.
+    const N = ATTACH_FAST_PATH_BUFFER_SIZE + 50;
+    for (let i = 1n; i <= BigInt(N); i += 1n) {
+      emitter.publishDelta(makeDelta(i));
+    }
+    let drained = 0;
+    while (drained < N) {
+      const r = await ai.next();
+      if (r.done) break;
+      drained += 1;
+    }
+    expect(drained).toBe(N);
+
+    await ai.return?.(undefined);
+  });
+
+  it('emitter close mid-stream surfaces pty.session_destroyed (§7.2)', async () => {
+    const emitter = new FakeEmitter('sess-1');
+    emitter.publishSnapshot(makeSnapshot(0n));
+    registry.set('sess-1', emitter);
+
+    const iter = client.attach(makeReq({ sessionId: 'sess-1', sinceSeq: 0n }));
+    const ai = iter[Symbol.asyncIterator]();
+    await ai.next(); // snapshot
+
+    void Promise.resolve().then(() => emitter.close());
+    const err = await ai.next().then(
+      () => null,
+      (e) => e as unknown,
+    );
+    expect(err).toBeInstanceOf(ConnectError);
+    expect((err as ConnectError).code).toBe(Code.Canceled);
+    expect(readErrorDetail(err)?.code).toBe('pty.session_destroyed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function drainExpectError(iter: AsyncIterable<unknown>): Promise<ConnectError> {
+  try {
+    for await (const _f of iter) {
+      void _f;
+    }
+  } catch (err) {
+    if (err instanceof ConnectError) return err;
+    throw err;
+  }
+  throw new Error('expected the stream to error, but it ended cleanly');
+}

--- a/packages/daemon/src/rpc/pty-attach.ts
+++ b/packages/daemon/src/rpc/pty-attach.ts
@@ -1,0 +1,761 @@
+// PtyService.Attach handler — Connect server-streaming sink that maps an
+// in-memory PtySessionEmitter (from `pty-host/pty-emitter.ts`, landing in
+// PR #1027 / T-PA-5) onto the wire `PtyFrame` proto. Spec ref:
+// docs/superpowers/specs/2026-05-04-pty-attach-handler.md §2-§5, §9.2 T-PA-6.
+//
+// Task #355 — Wave 3 §6.9 sub-task 10 / T-PA-6 (wave-locked: modifies
+// rpc/router.ts to register the overlay).
+//
+// SRP layering — three roles, kept separate (dev.md §2):
+//   - decider:  `decideAttachResume` (already lives in
+//               `pty-host/attach-decider.ts`, T-PA-2 / PR shipped). This
+//               module imports the pure verdict and translates each
+//               variant into a wire action.
+//   - producer: `PtySessionEmitterLike.subscribe(listener)` — the per-
+//               session in-memory ring + snapshot + broadcaster owned by
+//               the daemon main process (T-PA-5 / pty-host wire-up).
+//               This handler subscribes; the emitter pushes; the handler's
+//               consumer drains a bounded buffer onto the Connect stream.
+//   - sink:     `makeAttachHandler(deps)` — the only place that constructs
+//               `ConnectError`, `create(PtyFrameSchema, ...)`, and yields
+//               onto the AsyncGenerator Connect-ES v2 server-streaming
+//               handlers must return. Reads PRINCIPAL_KEY from
+//               HandlerContext, runs the decider, owns AbortSignal
+//               teardown.
+//
+// Why deps-injected `getEmitter` (NOT a direct module import of
+// `pty-host/pty-emitter.ts`'s `getEmitter` symbol):
+//   - PR #1027 (T-PA-5 PtySessionEmitter wire-up) is OPEN at the time
+//     this PR opens; importing the symbol directly would force this PR
+//     to wait on #1027. Spec §9.3 packs T-PA-5 → T-PA-6 in adjacent
+//     waves but the manager's "forward-safe over wave-locked" rule lets
+//     this PR land independently as long as the seam is one symbol on
+//     each side.
+//   - The `PtySessionEmitterLike` shape below mirrors PR #1027's
+//     `PtySessionEmitter` exact public surface (the methods this handler
+//     needs); when #1027 lands, daemon startup wiring (`index.ts`)
+//     supplies `getEmitter: (id) => ptyEmitterRegistry.getEmitter(id)`
+//     and TypeScript structural typing matches one-shot. No follow-up
+//     refactor of this file. The dual import path (deps for prod,
+//     fakes for tests) also matches `makeWatchSessionsHandler(deps)`
+//     and `makeHelloHandler(deps)` precedent — no new pattern.
+//
+// Why we re-implement `awaitSnapshot` here (not on the emitter):
+//   - PR #1027 deliberately omitted `awaitSnapshot()` from the emitter
+//     surface (see its file header §9.1 commentary): "The Attach handler
+//     can layer it on top of currentSnapshot() + subscribe() without
+//     changing this module." Layering it here keeps the emitter minimal
+//     and the await semantics (signal aborts, session-ends-before-first-
+//     snapshot) co-located with the handler that owns the AbortSignal.
+//
+// 5-tier "no wheel reinvention" judgement (dev.md §1 step 2):
+//   1. Repo `subscribeAsAsyncIterable` in sessions/watch-sessions.ts is
+//      the structural sibling — bus → AsyncIterable adapter with
+//      bounded buffer, abort-signal teardown, ConnectError on overflow.
+//      We do NOT extract a shared helper because:
+//      (a) the per-event mapping differs (SessionEvent vs PtyFrame oneof);
+//      (b) the snapshot-then-deltas warm-up has no analogue in
+//          watch-sessions; and
+//      (c) the spec §5 cleanup contract calls for explicit
+//          subscribe/unsubscribe pairing here too — duplicating the
+//          25-line adapter is clearer than a generic that has to handle
+//          both shapes (dev.md §1: "two copies are clearer than a
+//          shared abstraction").
+//   2. node:events `on(emitter, evt, { signal })` would adapt an
+//      EventEmitter to AsyncIterable but the PtySessionEmitter is
+//      bespoke (Set<listener> + ring) — wrapping it in EventEmitter just
+//      to use the stdlib adapter is more code than the local adapter.
+//   3. ack-state.ts (PR shipped) already supplies the BoundedChannel
+//      primitive AND the `AckSubscriberState` decider. The
+//      `requires_ack=true` path uses both verbatim.
+//   4. No OSS lib provides "snapshot-then-deltas server stream with
+//      per-frame ack and signal teardown" — every concern listed above
+//      is spec-specific.
+//   5. Self-written; the surface is small (~250 LoC including the
+//      adapter) and every block has a §-numbered spec ref.
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type HandlerContext,
+  type ServiceImpl,
+} from '@connectrpc/connect';
+
+import {
+  ErrorDetailSchema,
+  PtyDeltaSchema,
+  PtyFrameSchema,
+  PtyGeometrySchema,
+  PtySnapshotSchema,
+  type AttachRequest,
+  type PtyFrame,
+  type PtyService,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY } from '../auth/index.js';
+import {
+  decideAttachResume,
+  type DeltaInMem,
+  type PtySnapshotInMem,
+  type ResumeDecision,
+} from '../pty-host/attach-decider.js';
+import {
+  ACK_CHANNEL_CAPACITY,
+  BoundedChannel,
+} from '../pty-host/ack-state.js';
+
+// ---------------------------------------------------------------------------
+// Emitter port — structural shape this handler needs from the per-session
+// in-memory broadcaster. Mirrors the `PtySessionEmitter` class landing in
+// PR #1027 (T-PA-5) so production wiring can pass that class directly via
+// `getEmitter` without an adapter, and tests can pass an inline fake
+// without depending on PR #1027.
+// ---------------------------------------------------------------------------
+
+/**
+ * Discriminated event union the emitter broadcasts to subscribers.
+ *
+ * Mirrors PR #1027's `PtyEvent` exactly — the structural type lets a
+ * production `PtySessionEmitter` (T-PA-5) be passed in via
+ * {@link PtyAttachDeps.getEmitter} with no adapter.
+ *
+ * Spec §2.3-§2.4 — `'snapshot'` events fire on every snapshot
+ * publication (steady-state Attach IGNORES these per §2.4 "at-most-one
+ * snapshot per Attach"; only the warm-up snapshot is yielded onto the
+ * wire). `'delta'` events fire for every IPC delta. `'closed'` fires
+ * exactly once on emitter teardown.
+ */
+export type PtyEmitterEvent =
+  | { readonly kind: 'snapshot'; readonly snapshot: PtySnapshotInMem }
+  | { readonly kind: 'delta'; readonly delta: DeltaInMem }
+  | { readonly kind: 'closed'; readonly reason: 'pty.session_destroyed' };
+
+export type PtyEmitterListener = (event: PtyEmitterEvent) => void;
+
+/**
+ * Subset of `PtySessionEmitter`'s public surface this handler uses.
+ * Structural-typed so the production class (PR #1027) plugs in via
+ * {@link PtyAttachDeps.getEmitter} with no glue layer.
+ *
+ * Method docs cross-reference the canonical implementation in
+ * `pty-host/pty-emitter.ts` (PR #1027) — when that PR lands, the
+ * comments there are the source of truth; this interface is just the
+ * type shadow.
+ */
+export interface PtySessionEmitterLike {
+  /** Session ULID. Used for log lines and structural keying. */
+  readonly sessionId: string;
+  /**
+   * Most recent snapshot in memory, or `null` if the synthetic initial
+   * snapshot has not yet been captured (§3.3 first-snapshot race).
+   * Returned by reference; the bytes MUST be treated as immutable.
+   */
+  currentSnapshot(): PtySnapshotInMem | null;
+  /** Highest seq ever broadcast. `0n` before the first delta. */
+  currentMaxSeq(): bigint;
+  /**
+   * Lowest seq still in the in-memory ring (== `max(1n, currentMaxSeq -
+   * N + 1n)` once N deltas exist; `0n` before any deltas).
+   */
+  oldestRetainedSeq(): bigint;
+  /**
+   * Synchronously read deltas in `(sinceSeq, currentMaxSeq]`. Returns
+   * `'out-of-window'` if `sinceSeq < oldestRetainedSeq` (handler maps
+   * to `Code.OutOfRange`).
+   */
+  deltasSince(sinceSeq: bigint): readonly DeltaInMem[] | 'out-of-window';
+  /**
+   * Subscribe to live broadcast. Returns an unsubscribe function. The
+   * listener fires SYNCHRONOUSLY from inside the emitter's `publish*`
+   * call (which is called from the IPC `'message'` handler).
+   *
+   * Late subscribers (after `close()` has fired) MUST receive a single
+   * 'closed' event then a no-op unsubscribe — matches PR #1027 contract.
+   */
+  subscribe(listener: PtyEmitterListener): () => void;
+  /** True iff `close()` has fired. */
+  isClosed(): boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Handler deps
+// ---------------------------------------------------------------------------
+
+/**
+ * Dependencies the Attach handler factory needs.
+ *
+ * `getEmitter` is the seam to PR #1027's module-level
+ * `PtySessionEmitter` registry. Production startup wires it as
+ * `(sid) => ptyEmitterRegistry.getEmitter(sid)`; tests pass an inline
+ * map-backed fake. Returning `undefined` means "no session by that id"
+ * — the handler maps to `Code.NotFound` + `pty.session_not_found`.
+ */
+export interface PtyAttachDeps {
+  readonly getEmitter: (
+    sessionId: string,
+  ) => PtySessionEmitterLike | undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Forever-stable error code strings — local to this handler.
+//
+// `errors.ts` (`STANDARD_ERROR_MAP`) is the cross-handler registry but
+// its closed-enum is intentionally minimal (4 strings as of T2.5) and
+// this handler ships THREE pty-specific codes that the spec pins to
+// this single call site (none used by other RPCs). Inlining the
+// ConnectError construction keeps the registry from accreting per-
+// handler one-offs while still letting the spec-pinned strings be a
+// closed union the test suite can assert on.
+// ---------------------------------------------------------------------------
+
+/**
+ * The forever-stable `ErrorDetail.code` strings this handler may emit.
+ * Spec §3.2, §3.4, §7.2, §1 (CreateSession not_found path is in T-PA-7;
+ * the not_found here surfaces "session id never existed OR was already
+ * destroyed"). `pty.subscriber_channel_full` lands when
+ * `requires_ack=true` and the per-subscriber bounded channel overflows
+ * (spec §4.3).
+ */
+export type PtyAttachErrorCode =
+  | 'pty.session_not_found'
+  | 'pty.attach_too_far_behind'
+  | 'pty.attach_future_seq'
+  | 'pty.session_destroyed'
+  | 'pty.subscriber_channel_full';
+
+const PTY_ERROR_CODE_TO_CONNECT: Record<PtyAttachErrorCode, Code> = {
+  // §1 (this handler) — session id resolves to no live emitter. Map to
+  // NotFound so a client can distinguish "you typo'd" from
+  // OutOfRange / InvalidArgument.
+  'pty.session_not_found': Code.NotFound,
+  // §3.2 — refused_too_far_behind verdict.
+  'pty.attach_too_far_behind': Code.OutOfRange,
+  // §3.4 — refused_protocol_violation verdict.
+  'pty.attach_future_seq': Code.InvalidArgument,
+  // §7.2 — emitter close() fires under the open Attach (DestroySession
+  // wins the race).
+  'pty.session_destroyed': Code.Canceled,
+  // §4.3 — `requires_ack=true` per-subscriber channel overflow.
+  'pty.subscriber_channel_full': Code.ResourceExhausted,
+};
+
+function ptyError(
+  code: PtyAttachErrorCode,
+  message: string,
+  extra: Readonly<Record<string, string>> = {},
+): ConnectError {
+  const connectCode = PTY_ERROR_CODE_TO_CONNECT[code];
+  return new ConnectError(message, connectCode, undefined, [
+    {
+      desc: ErrorDetailSchema,
+      value: {
+        code,
+        message,
+        extra: { ...extra },
+      },
+    },
+  ]);
+}
+
+// ---------------------------------------------------------------------------
+// Frame mappers (in-memory shape → proto)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a `PtyFrame.snapshot` proto from an in-memory snapshot record.
+ * Pure, exported for unit tests.
+ */
+export function snapshotToFrame(snapshot: PtySnapshotInMem): PtyFrame {
+  return create(PtyFrameSchema, {
+    kind: {
+      case: 'snapshot',
+      value: create(PtySnapshotSchema, {
+        baseSeq: snapshot.baseSeq,
+        geometry: create(PtyGeometrySchema, {
+          cols: snapshot.geometry.cols,
+          rows: snapshot.geometry.rows,
+        }),
+        screenState: snapshot.screenState,
+        schemaVersion: snapshot.schemaVersion,
+      }),
+    },
+  });
+}
+
+/**
+ * Build a `PtyFrame.delta` proto from an in-memory delta record. Pure,
+ * exported for unit tests.
+ */
+export function deltaToFrame(delta: DeltaInMem): PtyFrame {
+  return create(PtyFrameSchema, {
+    kind: {
+      case: 'delta',
+      value: create(PtyDeltaSchema, {
+        seq: delta.seq,
+        payload: delta.payload,
+        tsUnixMs: delta.tsUnixMs,
+      }),
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// awaitSnapshot — local (spec §3.3 first-snapshot race window)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve with the emitter's current snapshot. If `currentSnapshot()`
+ * is non-null, resolves SYNCHRONOUSLY (microtask) with it. Otherwise
+ * subscribes and resolves with the first `'snapshot'` event.
+ *
+ * Spec §3.3 — the pty-host child is REQUIRED to emit a synthetic
+ * snapshot at `'ready'` BEFORE any deltas. With T-PA-8 in place every
+ * Attach for a live session sees a non-null `currentSnapshot()` on the
+ * first call — but the daemon-boot race window (CreateSession returns
+ * after `'ready'`; the IPC fan-out into the emitter is also synchronous
+ * but happens on the next tick) makes the null case observable. The
+ * await path closes the race deterministically.
+ *
+ * Rejects if:
+ *   - the emitter is closed before the first snapshot ever arrives
+ *     (`'closed'` event observed) — `Code.Canceled` +
+ *     `pty.session_destroyed`, matching the steady-state DestroySession
+ *     mapping (§7.2);
+ *   - the abort signal fires before the first snapshot — propagates
+ *     `signal.reason ?? AbortError`; the handler catches and re-throws
+ *     as Connect's standard cancellation (caller hands the abort to
+ *     Connect by returning the rejected promise into its for-await loop).
+ *
+ * Exported for unit tests.
+ */
+export function awaitSnapshot(
+  emitter: PtySessionEmitterLike,
+  signal: AbortSignal | undefined,
+): Promise<PtySnapshotInMem> {
+  // Fast path: non-null already.
+  const current = emitter.currentSnapshot();
+  if (current !== null) {
+    return Promise.resolve(current);
+  }
+  // Already-closed emitter — late subscriber path. The spec calls this
+  // a "session ended before first snapshot" failure (e.g. claude
+  // crashed during init). Map to canceled per §7.2.
+  if (emitter.isClosed()) {
+    return Promise.reject(
+      ptyError(
+        'pty.session_destroyed',
+        `session ${emitter.sessionId} ended before its first snapshot`,
+      ),
+    );
+  }
+  // Already-aborted signal — short-circuit before subscribing.
+  if (signal !== undefined && signal.aborted) {
+    return Promise.reject(
+      signal.reason instanceof Error
+        ? signal.reason
+        : new Error('Attach aborted before first snapshot'),
+    );
+  }
+
+  return new Promise<PtySnapshotInMem>((resolve, reject) => {
+    let unsubscribe: (() => void) | null = null;
+    let detachAbort: (() => void) | null = null;
+    let settled = false;
+
+    const cleanup = (): void => {
+      if (unsubscribe !== null) {
+        const u = unsubscribe;
+        unsubscribe = null;
+        u();
+      }
+      if (detachAbort !== null) {
+        const d = detachAbort;
+        detachAbort = null;
+        d();
+      }
+    };
+
+    const onAbort = (): void => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(
+        signal?.reason instanceof Error
+          ? signal.reason
+          : new Error('Attach aborted before first snapshot'),
+      );
+    };
+
+    if (signal !== undefined) {
+      signal.addEventListener('abort', onAbort, { once: true });
+      detachAbort = (): void => signal.removeEventListener('abort', onAbort);
+    }
+
+    unsubscribe = emitter.subscribe((event) => {
+      if (settled) return;
+      switch (event.kind) {
+        case 'snapshot':
+          settled = true;
+          cleanup();
+          resolve(event.snapshot);
+          return;
+        case 'closed':
+          settled = true;
+          cleanup();
+          reject(
+            ptyError(
+              'pty.session_destroyed',
+              `session ${emitter.sessionId} ended before its first snapshot`,
+            ),
+          );
+          return;
+        case 'delta':
+          // Spec §3.3 forbids deltas before the first snapshot — the
+          // pty-host child contract is "synthetic snapshot at ready,
+          // THEN deltas". A delta-before-snapshot is a child-side
+          // protocol violation; we ignore it here (the steady-state
+          // for-await loop will see it) and keep waiting for the
+          // snapshot. Logging would belong on the emitter side.
+          return;
+      }
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Bounded buffer for live-event drain (spec §4.4 fast path)
+// ---------------------------------------------------------------------------
+
+/**
+ * Default capacity of the per-subscriber fallback buffer used on the
+ * `requires_ack=false` fast path (spec §4.4). 1024 mirrors the
+ * watch-sessions.ts choice — generous for any sane consumer; overflow
+ * indicates a stuck reader and terminates the stream with
+ * `Code.ResourceExhausted` so the client reconnects.
+ *
+ * The `requires_ack=true` path uses {@link ACK_CHANNEL_CAPACITY} (4096)
+ * via {@link BoundedChannel} from `ack-state.ts` per spec §4.5.
+ */
+export const ATTACH_FAST_PATH_BUFFER_SIZE = 1024;
+
+// ---------------------------------------------------------------------------
+// Main handler factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the `PtyService.Attach` server-streaming handler.
+ *
+ * Flow per spec §3-§5:
+ *   1. Validate principal is on the context (defensive — same shape as
+ *      `makeWatchSessionsHandler` / `makeHelloHandler`).
+ *   2. Look up the emitter for `req.sessionId`. NotFound → throw.
+ *   3. Resolve the snapshot (if `sinceSeq=0n` and snapshot is null,
+ *      `awaitSnapshot` blocks — see §3.3).
+ *   4. Run the pure decider over the resume math. Translate refused_*
+ *      verdicts to ConnectError.
+ *   5. Yield the warm-up frames (snapshot OR replayed deltas).
+ *   6. Subscribe for live deltas. Drain into a bounded buffer; yield
+ *      each as a `PtyFrame.delta` proto.
+ *   7. On AbortSignal fire OR `'closed'` event, terminate cleanly
+ *      (cancel) or re-throw `pty.session_destroyed` (closed).
+ *
+ * `requires_ack=true` (spec §4) uses the {@link BoundedChannel} from
+ * ack-state.ts at capacity 4096; overflow throws
+ * `pty.subscriber_channel_full`. The full AckPty companion handler
+ * (spec §6) is wired in a separate task — this handler only needs to
+ * APPLY the per-subscriber backpressure cap, not the per-frame ack
+ * watermark.
+ */
+export function makeAttachHandler(
+  deps: PtyAttachDeps,
+): ServiceImpl<typeof PtyService>['attach'] {
+  return async function* attach(
+    req: AttachRequest,
+    handlerContext: HandlerContext,
+  ): AsyncGenerator<PtyFrame, void, undefined> {
+    // Defensive: peerCredAuthInterceptor MUST have deposited the
+    // principal before this handler runs. Mirrors hello.ts /
+    // watch-sessions.ts posture — surface as Internal so operators see
+    // a daemon-side wiring bug rather than the client being told they
+    // are unauthenticated.
+    const principal = handlerContext.values.get(PRINCIPAL_KEY);
+    if (principal === null) {
+      throw new ConnectError(
+        'PtyService.Attach handler invoked without peerCredAuthInterceptor in chain ' +
+          '(PRINCIPAL_KEY=null) — daemon wiring bug',
+        Code.Internal,
+      );
+    }
+
+    const sessionId = req.sessionId;
+    if (sessionId.length === 0) {
+      throw ptyError(
+        'pty.session_not_found',
+        'AttachRequest.session_id MUST be non-empty',
+      );
+    }
+
+    const emitter = deps.getEmitter(sessionId);
+    if (emitter === undefined) {
+      throw ptyError(
+        'pty.session_not_found',
+        `no live pty session with id=${sessionId}`,
+        { session_id: sessionId },
+      );
+    }
+
+    const sinceSeq = req.sinceSeq;
+    const signal = handlerContext.signal;
+
+    // §3.3 first-snapshot race window. For `sinceSeq=0n` we MAY need
+    // to await the synthetic snapshot before the decider can run (the
+    // decider throws on null currentSnapshot in that branch). For any
+    // positive sinceSeq the decider doesn't read currentSnapshot, so
+    // we skip the await on the deltas-only path.
+    let resolvedSnapshot: PtySnapshotInMem | null = emitter.currentSnapshot();
+    if (sinceSeq === 0n && resolvedSnapshot === null) {
+      resolvedSnapshot = await awaitSnapshot(emitter, signal);
+    }
+
+    // §3.4 — pure decider. Snapshot of state is taken right BEFORE we
+    // subscribe so the subscribe-then-decide ordering doesn't double-
+    // emit a delta that landed between the two reads.
+    const verdict: ResumeDecision = decideAttachResume({
+      sinceSeq,
+      currentMaxSeq: emitter.currentMaxSeq(),
+      oldestRetainedSeq: emitter.oldestRetainedSeq(),
+      currentSnapshot: resolvedSnapshot,
+      deltasSince: (s) => {
+        const result = emitter.deltasSince(s);
+        if (result === 'out-of-window') {
+          // The decider's branch ordering already ruled this out (it
+          // checks `sinceSeq < oldestRetainedSeq` first); reaching here
+          // means a race between snapshot capture and our read. Fall
+          // back to an empty slice — the live subscription picks up
+          // the missing window via the next snapshot+delta cadence.
+          return [];
+        }
+        return result;
+      },
+    });
+
+    switch (verdict.kind) {
+      case 'refused_too_far_behind':
+        throw ptyError(
+          'pty.attach_too_far_behind',
+          `since_seq=${verdict.sinceSeq} is older than oldest retained seq=${verdict.oldestRetainedSeq}; ` +
+            'reattach with since_seq=0',
+          {
+            session_id: sessionId,
+            since_seq: String(verdict.sinceSeq),
+            oldest_retained_seq: String(verdict.oldestRetainedSeq),
+          },
+        );
+      case 'refused_protocol_violation':
+        throw ptyError(
+          'pty.attach_future_seq',
+          `since_seq=${verdict.sinceSeq} exceeds daemon current_max_seq=${verdict.currentMaxSeq}; ` +
+            'client lastAppliedSeq accounting bug',
+          {
+            session_id: sessionId,
+            since_seq: String(verdict.sinceSeq),
+            current_max_seq: String(verdict.currentMaxSeq),
+          },
+        );
+      case 'snapshot_then_live':
+      case 'deltas_only':
+        // Fall through to the streaming body below.
+        break;
+    }
+
+    // §4.2 / §4.4 — pick the buffer primitive based on requires_ack.
+    // Both shapes are FIFO; differ only in capacity + the exhaustion
+    // error code (§4.3).
+    const requiresAck = req.requiresAck === true;
+    const channelCapacity = requiresAck
+      ? ACK_CHANNEL_CAPACITY
+      : ATTACH_FAST_PATH_BUFFER_SIZE;
+    const channel = new BoundedChannel<DeltaInMem>(channelCapacity);
+    const overflowErrorCode: PtyAttachErrorCode = requiresAck
+      ? 'pty.subscriber_channel_full'
+      : 'pty.subscriber_channel_full';
+
+    // Producer→consumer rendezvous primitive. The emitter listener
+    // resolves a pending `next()`; if no consumer is waiting it appends
+    // to the channel. Mirrors the watch-sessions.ts adapter shape
+    // (single-slot promise queue) but threaded through the
+    // BoundedChannel so the consumer can drain in FIFO order.
+    let pendingResolve: ((event: PtyEmitterEvent | null) => void) | null = null;
+    const eventQueue: PtyEmitterEvent[] = [];
+    type ClosedReason =
+      | { readonly kind: 'aborted' }
+      | { readonly kind: 'session-destroyed' }
+      | { readonly kind: 'overflow' };
+    let closedReason: ClosedReason | null = null;
+
+    const wakeConsumer = (event: PtyEmitterEvent | null): void => {
+      if (pendingResolve !== null) {
+        const resolve = pendingResolve;
+        pendingResolve = null;
+        resolve(event);
+        return;
+      }
+      if (event !== null) {
+        eventQueue.push(event);
+      }
+    };
+
+    const listener: PtyEmitterListener = (event) => {
+      if (closedReason !== null) {
+        // Already terminating — drop further events. The unsubscribe
+        // either ran already or will run shortly.
+        return;
+      }
+      if (event.kind === 'delta') {
+        const result = channel.enqueue(event.delta);
+        if (result === 'overflow') {
+          closedReason = { kind: 'overflow' } satisfies ClosedReason;
+          wakeConsumer(null);
+          return;
+        }
+      }
+      // Always wake the consumer — the consumer drains via channel for
+      // deltas and via the event itself for snapshot/closed.
+      wakeConsumer(event);
+    };
+
+    const unsubscribe = emitter.subscribe(listener);
+
+    // §5 — abort signal forwarding. Connect-ES fires the signal on
+    // client disconnect, server shutdown, or listener rotation. We
+    // detach the listener AND wake any pending consumer so the
+    // for-await loop exits cleanly.
+    const onAbort = (): void => {
+      if (closedReason !== null) return;
+      closedReason = { kind: 'aborted' } satisfies ClosedReason;
+      wakeConsumer(null);
+    };
+    if (signal.aborted) {
+      onAbort();
+    } else {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+    const detachAbort = (): void => {
+      signal.removeEventListener('abort', onAbort);
+    };
+
+    try {
+      // ---- Warm-up frames ----------------------------------------
+      if (verdict.kind === 'snapshot_then_live') {
+        yield snapshotToFrame(verdict.snapshot);
+      } else {
+        // deltas_only — replay the (sinceSeq, currentMaxSeq] slice.
+        for (const delta of verdict.deltas) {
+          yield deltaToFrame(delta);
+        }
+      }
+
+      // ---- Steady-state drain -----------------------------------
+      // Loop invariant: after each pass either we yield a frame, we
+      // throw a terminal error, or we return cleanly (signal aborted).
+      // The bounded channel may already contain entries that the
+      // listener queued between subscribe() and the first await — drain
+      // those FIRST before parking on a new resolver.
+      while (true) {
+        // 1) Drain any deltas the listener buffered.
+        while (true) {
+          const delta = channel.dequeue();
+          if (delta === undefined) break;
+          yield deltaToFrame(delta);
+        }
+
+        // 2) If a terminal condition fired during the drain, react now.
+        // (Cast through ClosedReason — TS narrows `closedReason` to the
+        // 'session-destroyed' variant when looking at this generator
+        // body in isolation because the 'aborted' / 'overflow'
+        // assignments live inside the listener / onAbort closures.
+        // The runtime variable is the full union; the cast restores
+        // the type the variable was declared with.)
+        if (closedReason !== null) {
+          const reason = closedReason as ClosedReason;
+          switch (reason.kind) {
+            case 'aborted':
+              return; // clean cancel — Connect surfaces as canceled
+            case 'session-destroyed':
+              throw ptyError(
+                'pty.session_destroyed',
+                `session ${sessionId} was destroyed`,
+                { session_id: sessionId },
+              );
+            case 'overflow':
+              throw ptyError(
+                overflowErrorCode,
+                requiresAck
+                  ? `subscriber channel full (>= ${ACK_CHANNEL_CAPACITY} unacked deltas); ` +
+                      `reconnect with since_seq = lastAckedSeq`
+                  : `subscriber channel full (>= ${ATTACH_FAST_PATH_BUFFER_SIZE} buffered deltas); ` +
+                      `consumer too slow — reconnect`,
+                { session_id: sessionId },
+              );
+            default: {
+              const _exhaustive: never = reason;
+              throw new Error(
+                `unhandled closedReason: ${String((_exhaustive as { kind: string }).kind)}`,
+              );
+            }
+          }
+        }
+
+        // 3) Process any non-delta events the listener queued (snapshot
+        //    is ignored per §2.4 "at-most-one snapshot per Attach";
+        //    closed sets closedReason and short-circuits next pass).
+        while (eventQueue.length > 0) {
+          const ev = eventQueue.shift() as PtyEmitterEvent;
+          if (ev.kind === 'closed') {
+            closedReason = { kind: 'session-destroyed' } satisfies ClosedReason;
+          }
+          // 'snapshot' and 'delta' (already enqueued above) — drop.
+        }
+        if (closedReason !== null) {
+          continue; // re-evaluate the terminal-conditions block
+        }
+
+        // 4) Park on the next event. The listener resolves with `null`
+        //    on overflow / abort (terminal) or with the event for
+        //    snapshot/closed/delta (non-null).
+        const nextEvent = await new Promise<PtyEmitterEvent | null>(
+          (resolve) => {
+            pendingResolve = resolve;
+          },
+        );
+        if (nextEvent === null) {
+          // Wake by overflow or abort — re-evaluate at top of loop.
+          continue;
+        }
+        if (nextEvent.kind === 'closed') {
+          closedReason = { kind: 'session-destroyed' } satisfies ClosedReason;
+          continue;
+        }
+        if (nextEvent.kind === 'snapshot') {
+          // Steady-state Attach IGNORES mid-stream snapshots per §2.4.
+          continue;
+        }
+        // nextEvent.kind === 'delta': it was already enqueued by the
+        // listener; the next loop iteration's drain step yields it.
+      }
+    } finally {
+      detachAbort();
+      unsubscribe();
+      channel.clear();
+      // Wake any straggler resolver so a Promise we're not awaiting
+      // does not pin GC. (Defensive — by construction we never `await`
+      // after entering `finally`.)
+      if (pendingResolve !== null) {
+        const resolve = pendingResolve;
+        pendingResolve = null;
+        resolve(null);
+      }
+    }
+  };
+}

--- a/packages/daemon/src/rpc/router.ts
+++ b/packages/daemon/src/rpc/router.ts
@@ -77,6 +77,7 @@ import { registerCrashService, type CrashServiceDeps } from './crash/register.js
 import { registerDraftService, type DraftServiceDeps } from './draft/register.js';
 import { makeHelloHandler, type HelloDeps } from './hello.js';
 import { requestMetaInterceptor } from './middleware/request-meta.js';
+import { makeAttachHandler, type PtyAttachDeps } from './pty-attach.js';
 import {
   registerSettingsService,
   type SettingsServiceDeps,
@@ -216,6 +217,30 @@ export function registerSessionService(
 }
 
 /**
+ * Register the v0.3 PtyService.Attach handler (Wave 3 §6.9 sub-task 10 /
+ * Task #355 / spec `2026-05-04-pty-attach-handler.md` §9.2 T-PA-6).
+ *
+ * REPLACES the stub `{}` registration for PtyService with `{ attach }`.
+ * Other PtyService methods (SendInput / Resize / AckPty /
+ * CheckClaudeAvailable) stay `Code.Unimplemented` per the
+ * "absent-method → unimplemented" Connect router rule until their
+ * owning tasks land. The combined-registration caveat that applies to
+ * SessionService also applies here (`router.service` REPLACES on the
+ * same descriptor) — so when the next PtyService method handler ships,
+ * it MUST be added to this same call site rather than registered via a
+ * second `service()` call.
+ */
+export function registerPtyService(
+  router: ConnectRouter,
+  deps: PtyAttachDeps,
+): ConnectRouter {
+  router.service(PtyService, {
+    attach: makeAttachHandler(deps),
+  });
+  return router;
+}
+
+/**
  * Bundled routes callback that installs stubs for every service AND the
  * real T2.3 Hello handler on SessionService. Use this from the daemon's
  * production startup wiring (T1.7) — pass through to
@@ -230,6 +255,7 @@ export function makeDaemonRoutes(
   destroyHandlerDeps?: DestroySessionDeps,
   settingsDeps?: SettingsServiceDeps,
   draftDeps?: DraftServiceDeps,
+  ptyAttachDeps?: PtyAttachDeps,
 ): (router: ConnectRouter) => void {
   return (router: ConnectRouter): void => {
     registerStubServices(router);
@@ -265,6 +291,15 @@ export function makeDaemonRoutes(
     // overlay exposes `GetDraft` + `UpdateDraft`.
     if (draftDeps !== undefined) {
       registerDraftService(router, draftDeps);
+    }
+    // PtyService.Attach overlay (Wave-3 §6.9 sub-task 10 / Task #355 /
+    // spec `2026-05-04-pty-attach-handler.md` §9.2 T-PA-6). Wires the
+    // server-streaming Attach handler against the per-session in-memory
+    // emitter registry (PR #1027 / T-PA-5 supplies the production
+    // `getEmitter`; tests pass an inline fake). Other PtyService
+    // methods stay `Code.Unimplemented` until their tasks land.
+    if (ptyAttachDeps !== undefined) {
+      registerPtyService(router, ptyAttachDeps);
     }
   };
 }
@@ -350,6 +385,18 @@ export interface CreateDaemonNodeAdapterOptions extends ConnectRouterOptions {
    * shares the SettingsService `db` handle.
    */
   readonly draftDeps?: DraftServiceDeps;
+  /**
+   * When set, installs the Wave-3 §6.9 sub-task 10 (Task #355 / spec
+   * `2026-05-04-pty-attach-handler.md` §9.2 T-PA-6) PtyService.Attach
+   * server-streaming overlay. `getEmitter` is the seam to the per-
+   * session `PtySessionEmitter` registry that PR #1027 (T-PA-5)
+   * exports. Production startup wires it as `(sid) =>
+   * ptyEmitterRegistry.getEmitter(sid)`; tests pass an inline fake.
+   * Other PtyService methods (SendInput / Resize / AckPty /
+   * CheckClaudeAvailable) stay `Code.Unimplemented` until their
+   * owning tasks land.
+   */
+  readonly ptyAttachDeps?: PtyAttachDeps;
 }
 
 /**
@@ -396,6 +443,7 @@ export function createDaemonNodeAdapter(
     destroyHandlerDeps,
     settingsDeps,
     draftDeps,
+    ptyAttachDeps,
     interceptors: callerInterceptors,
     ...rest
   } = options;
@@ -409,6 +457,7 @@ export function createDaemonNodeAdapter(
           destroyHandlerDeps,
           settingsDeps,
           draftDeps,
+          ptyAttachDeps,
         )
       : stubRoutes;
   const interceptors = [


### PR DESCRIPTION
## Summary

Add `makeAttachHandler` — the Connect-ES v2 server-streaming sink that maps an in-memory `PtySessionEmitter` (per-session ring + broadcaster from PR #1027 / T-PA-5) onto the wire `PtyFrame` proto. Composes the pure `decideAttachResume` decider (T-PA-2 / shipped) and the `BoundedChannel` primitive (T-PA-3 / shipped). Registers via the same overlay pattern as Hello / WatchSessions / CrashService.

Spec: `docs/superpowers/specs/2026-05-04-pty-attach-handler.md` §2-§5, §9.2 T-PA-6.

## Forever-stable wire surface this PR locks in

- `since_seq=0` → `PtyFrame.snapshot` then live deltas (§3.1.1)
- `since_seq` in window → replay `(since_seq, currentMaxSeq]` then live (§3.1.2)
- `since_seq` too far back → `Code.OutOfRange` + `pty.attach_too_far_behind` (§3.2)
- `since_seq` future → `Code.InvalidArgument` + `pty.attach_future_seq` (§3.4)
- session not registered → `Code.NotFound` + `pty.session_not_found`
- emitter close mid-stream → `Code.Canceled` + `pty.session_destroyed` (§7.2)
- subscriber overflow → `Code.ResourceExhausted` + `pty.subscriber_channel_full` (§4.3)
- mid-stream snapshots → IGNORED on the wire (§2.4 at-most-one per Attach)
- `HandlerContext.signal` → propagated into subscribe + awaitSnapshot (§5)

## Coordination with PR #1027 (T-PA-5 PtySessionEmitter wire-up)

PR #1027 is OPEN at this PR's open time. To keep this PR mergeable independently:

- This PR uses a deps-injected `getEmitter` seam (`PtyAttachDeps`). The local `PtySessionEmitterLike` interface mirrors PR #1027's `PtySessionEmitter` exact public surface (the methods this handler reads).
- Production wire-up in `index.ts` is intentionally NOT in this PR — it requires `getEmitter` from `pty-host/pty-emitter.ts` which only exists on PR #1027's branch. Once #1027 lands, a follow-up one-liner in `index.ts`:
  ```ts
  ptyAttachDeps: { getEmitter: (id) => ptyEmitterRegistry.getEmitter(id) }
  ```
  flips PtyService.Attach from `Code.Unimplemented` to the real handler. No changes to `pty-attach.ts` needed — TypeScript structural typing matches one-shot.
- The router overlay is already wired (`makeRouterBindHook({ ptyAttachDeps })` field added) so the follow-up is purely additive at the daemon-startup wiring layer.

## Out of scope (separate tasks per spec §9)

- `index.ts` production wire-up (waits on #1027 merge — see above)
- `AckPty` companion handler (§6 — separate task)
- `SendInput` / `Resize` / `CheckClaudeAvailable` handlers (separate tasks)

## Local checks (host: windows-11)

- lint: ✓ (exit 0; 52 preexisting warnings, 0 errors)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0; tsc + webpack via `npm run build`)
- unit tests (rpc + pty-host scope): **189 passed | 0 failed** (8 files)
- pty-attach.spec.ts specifically: **19 passed | 0 failed**
- broader daemon suite: pre-existing native-binding failures (better-sqlite3 / node-pty rebuild on Node 22.18 + winpty `GetCommitHash.bat` per repo postinstall warning) are NOT introduced by this PR — verified by stashing the router.ts mod and re-running `rpc/__tests__/integration.spec.ts`: same 3 fails on baseline. CI runs Node 20 per `ci.yml`, where native rebuilds succeed.

## Test plan

- [x] All 19 `pty-attach.spec.ts` cases green (decider branches, awaitSnapshot first-snapshot race, signal teardown, fast-path overflow, requires_ack channel cap, session-destroyed mid-stream)
- [x] `router.spec.ts` baseline (every PtyService method still `Unimplemented` when `ptyAttachDeps` not supplied)
- [ ] Once #1027 lands: follow-up wires `index.ts` and the daemon-boot end-to-end test asserts `PtyService.Attach` does NOT return `Unimplemented`

🤖 Generated with [Claude Code](https://claude.com/claude-code)