### PR TITLE
feat(daemon)(#386): T4.11a snapshot->WriteCoalescer wire-up in host.ts

### DIFF
--- a/packages/daemon/src/pty-host/host.ts
+++ b/packages/daemon/src/pty-host/host.ts
@@ -33,8 +33,10 @@ import type {
   ChildExit,
   ChildToHostMessage,
   HostToChildMessage,
+  SnapshotMessage,
   SpawnPayload,
 } from './types.js';
+import type { SnapshotWrite } from '../sqlite/coalescer.js';
 
 /**
  * Configuration for `spawnPtyHostChild`. All fields beyond `payload`
@@ -103,6 +105,39 @@ export interface SpawnPtyHostChildOptions {
         readonly register: (emitter: PtySessionEmitter) => void;
         readonly unregister: (sessionId: string) => boolean;
       };
+  /**
+   * Optional sink that receives every well-formed `'snapshot'` IPC the
+   * child sends, mapped from the IPC {@link SnapshotMessage} shape into a
+   * {@link SnapshotWrite} (the coalescer's narrow payload).
+   *
+   * T4.11a (Task #386) wire-up: spec ch07 §5 assumes a SQLite write path
+   * exists for snapshots so the 3-strike DEGRADED counter has something to
+   * count against. Before this wire-up, the snapshot IPC was only fanned
+   * out to the in-memory {@link PtySessionEmitter}; there was no caller of
+   * {@link import('../sqlite/coalescer.js').WriteCoalescer.enqueueSnapshot}
+   * anywhere in the daemon. Routing snapshots into both the emitter (live
+   * fan-out) and the coalescer (durable persistence) is non-mutually-
+   * exclusive: the emitter feeds Attach subscribers from RAM, the
+   * coalescer persists to `pty_snapshot` for cold-attach replay.
+   *
+   * Production: daemon main constructs the {@link import('../sqlite/coalescer.js').WriteCoalescer}
+   * once at boot (with the shared SQLite handle) and passes the same
+   * instance into every `spawnPtyHostChild` call. Tests may pass a stub
+   * implementing only `enqueueSnapshot` (duck-typed) to assert call
+   * shape without standing up a real DB.
+   *
+   * Unset (or explicitly `undefined`) opts the snapshot→SQLite path out
+   * entirely — useful for tests covering only the emitter / lifecycle
+   * surfaces and for the daemon-boot path before T5.x stitches the
+   * coalescer in. The emitter fan-out is unaffected by this option.
+   *
+   * The 60s DEGRADED cooldown + `session_state_changed` PtyFrame proto
+   * change are explicitly out of scope here — they ship in Task #385,
+   * which is blocked-by this wire-up.
+   */
+  readonly coalescer?: {
+    readonly enqueueSnapshot: (write: SnapshotWrite) => void;
+  };
 }
 
 /**
@@ -313,6 +348,51 @@ export function spawnPtyHostChild(opts: SpawnPtyHostChildOptions): PtyHostChildH
         emitter.publishSnapshot(raw);
       } else if (raw.kind === 'delta') {
         emitter.publishDelta(raw);
+      }
+    }
+    // T4.11a (Task #386) — snapshot→WriteCoalescer wire-up. Runs in
+    // parallel with the emitter fan-out above (in-memory live stream)
+    // and writes a `pty_snapshot` row for cold-attach replay
+    // (spec ch07 §5). Skipped silently when no coalescer was injected
+    // (tests covering only emitter/lifecycle surfaces, or daemon-boot
+    // paths before T5.x stitches the coalescer in).
+    //
+    // Mapping IPC SnapshotMessage → SnapshotWrite: the IPC shape
+    // (pty-host/types.ts SnapshotMessage) is what the child posts; the
+    // coalescer's payload (sqlite/coalescer.ts SnapshotWrite) is the
+    // narrow column subset for `pty_snapshot`. We hold sessionId on the
+    // host (resolved at fork time from `opts.payload.sessionId`) — the
+    // child's IPC envelope intentionally does NOT carry sessionId
+    // because the daemon-side IPC channel is one-to-one with a session.
+    // `createdMs` uses Date.now() at receive time; the IPC payload does
+    // not carry a capture timestamp (spec §2.4 SnapshotMessage), and
+    // jitter at this layer is bounded by the IPC RTT (sub-ms locally).
+    if (opts.coalescer !== undefined && raw.kind === 'snapshot') {
+      const snap = raw satisfies SnapshotMessage;
+      try {
+        opts.coalescer.enqueueSnapshot({
+          kind: 'snapshot',
+          sessionId,
+          baseSeq: Number(snap.baseSeq),
+          schemaVersion: snap.schemaVersion,
+          geometryCols: snap.geometry.cols,
+          geometryRows: snap.geometry.rows,
+          payload: snap.screenState,
+          createdMs: Date.now(),
+        });
+      } catch (err) {
+        // The coalescer's documented throw paths are RESOURCE_EXHAUSTED
+        // (queue cap) and programmer-error rethrows. Both are session-
+        // scoped and must NOT crash the daemon main process — the
+        // session keeps running off the in-memory ring (emitter
+        // fan-out above). The DEGRADED state machine + `crash_log`
+        // wiring lives elsewhere (Task #385 / ch07 §5); here we only
+        // need to keep the IPC pump alive.
+        // eslint-disable-next-line no-console
+        console.error(
+          `[ccsm-daemon] spawnPtyHostChild(${sessionId}): coalescer.enqueueSnapshot threw`,
+          err,
+        );
       }
     }
     pushMessage(raw);

--- a/packages/daemon/test/pty-host/fixtures/child-fixture.mjs
+++ b/packages/daemon/test/pty-host/fixtures/child-fixture.mjs
@@ -11,6 +11,11 @@
 //   CCSM_FIXTURE_MODE=crash          — ready then process.exit(137) immediately
 //   CCSM_FIXTURE_MODE=no-ready       — never send ready (parent ready() should reject on exit)
 //   CCSM_FIXTURE_MODE=echo           — echo every spawn payload back as a 'snapshot' kind
+//   CCSM_FIXTURE_MODE=snapshot-coalescer — emit one well-formed SnapshotMessage on spawn
+//                                       (T4.11a / Task #386: coalescer wire-up coverage).
+//                                       Payload bytes are deterministic so the spec can
+//                                       byte-compare the SnapshotWrite the coalescer
+//                                       receives.
 //   CCSM_FIXTURE_MODE=backpressure   — T4.3: enforce a small pending-write cap
 //                                       (CCSM_PTY_PENDING_CAP_BYTES) and emit
 //                                       'send-input-rejected' IPC matching the
@@ -60,6 +65,18 @@ process.on('message', (raw) => {
   if (k === 'spawn') {
     if (mode === 'echo') {
       send({ kind: 'snapshot' });
+    } else if (mode === 'snapshot-coalescer') {
+      // Well-formed SnapshotMessage per pty-host/types.ts §2.4. bigint
+      // fields survive the IPC because spawnPtyHostChild uses
+      // serialization: 'advanced' (structured clone). Deterministic
+      // payload so host.spec.ts can assert byte equality.
+      send({
+        kind: 'snapshot',
+        baseSeq: 7n,
+        geometry: { cols: 120, rows: 40 },
+        screenState: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+        schemaVersion: 1,
+      });
     }
     return;
   }

--- a/packages/daemon/test/pty-host/host.spec.ts
+++ b/packages/daemon/test/pty-host/host.spec.ts
@@ -188,6 +188,121 @@ describe('spawnPtyHostChild — send() guards', () => {
   });
 });
 
+describe('spawnPtyHostChild — T4.11a snapshot→WriteCoalescer wire-up (Task #386)', () => {
+  // Spec ch07 §5: every snapshot the child posts must be enqueued into
+  // the coalescer (parallel to the in-memory emitter fan-out, not
+  // mutually exclusive). Stub the coalescer with a duck-typed object
+  // that records every call — no DB needed at this layer.
+
+  it('routes a well-formed SnapshotMessage IPC into coalescer.enqueueSnapshot exactly once with the correct payload', async () => {
+    const calls: Array<{
+      kind: 'snapshot';
+      sessionId: string;
+      baseSeq: number;
+      schemaVersion: number;
+      geometryCols: number;
+      geometryRows: number;
+      payload: Uint8Array;
+      createdMs: number;
+    }> = [];
+    const coalescer = {
+      enqueueSnapshot(write: typeof calls[number]) {
+        calls.push(write);
+      },
+    };
+
+    const handle = spawnPtyHostChild({
+      payload: makePayload({ sessionId: 'sess-coalescer' }),
+      childEntrypoint: FIXTURE,
+      forkEnv: { ...process.env, CCSM_FIXTURE_MODE: 'snapshot-coalescer' },
+      coalescer,
+    });
+
+    try {
+      await handle.ready();
+      handle.send({ kind: 'spawn', payload: makePayload({ sessionId: 'sess-coalescer' }) });
+
+      // Drive the iterator until the snapshot lands so we don't race the
+      // closeAndWait teardown.
+      for await (const m of handle.messages()) {
+        if (m.kind === 'snapshot') break;
+      }
+    } finally {
+      await handle.closeAndWait();
+    }
+
+    expect(calls).toHaveLength(1);
+    const got = calls[0]!;
+    expect(got.kind).toBe('snapshot');
+    expect(got.sessionId).toBe('sess-coalescer');
+    expect(got.baseSeq).toBe(7);
+    expect(got.schemaVersion).toBe(1);
+    expect(got.geometryCols).toBe(120);
+    expect(got.geometryRows).toBe(40);
+    expect(Array.from(got.payload)).toEqual([0xde, 0xad, 0xbe, 0xef]);
+    expect(typeof got.createdMs).toBe('number');
+    expect(got.createdMs).toBeGreaterThan(0);
+  });
+
+  it('does not call coalescer.enqueueSnapshot when no coalescer is provided (opt-out default)', async () => {
+    // Same fixture mode emits a snapshot; with no coalescer wired, the
+    // host must silently skip the SQLite path (lifecycle + emitter
+    // fan-out unaffected).
+    const handle = spawnPtyHostChild({
+      payload: makePayload({ sessionId: 'sess-no-coalescer' }),
+      childEntrypoint: FIXTURE,
+      forkEnv: { ...process.env, CCSM_FIXTURE_MODE: 'snapshot-coalescer' },
+    });
+
+    try {
+      await handle.ready();
+      handle.send({ kind: 'spawn', payload: makePayload({ sessionId: 'sess-no-coalescer' }) });
+      for await (const m of handle.messages()) {
+        if (m.kind === 'snapshot') break;
+      }
+    } finally {
+      await handle.closeAndWait();
+    }
+    // No assertion needed beyond reaching here without throwing — the
+    // absence of a coalescer must not crash the IPC pump.
+  });
+
+  it('keeps the IPC pump alive when coalescer.enqueueSnapshot throws', async () => {
+    // The coalescer documents two throw paths: ConnectError(RESOURCE_
+    // EXHAUSTED) on queue cap, and programmer-error rethrows. Neither
+    // may take down the daemon main process — the session keeps
+    // running off the in-memory ring.
+    const coalescer = {
+      enqueueSnapshot(): void {
+        throw new Error('simulated coalescer failure');
+      },
+    };
+    const handle = spawnPtyHostChild({
+      payload: makePayload({ sessionId: 'sess-coalescer-throws' }),
+      childEntrypoint: FIXTURE,
+      forkEnv: { ...process.env, CCSM_FIXTURE_MODE: 'snapshot-coalescer' },
+      coalescer,
+    });
+
+    try {
+      await handle.ready();
+      handle.send({ kind: 'spawn', payload: makePayload({ sessionId: 'sess-coalescer-throws' }) });
+      // Iterator must still see the snapshot — the throw is swallowed.
+      let sawSnapshot = false;
+      for await (const m of handle.messages()) {
+        if (m.kind === 'snapshot') {
+          sawSnapshot = true;
+          break;
+        }
+      }
+      expect(sawSnapshot).toBe(true);
+    } finally {
+      const exit = await handle.closeAndWait();
+      expect(exit.reason).toBe('graceful');
+    }
+  });
+});
+
 describe('spawnPtyHostChild — T4.3 SendInput backpressure (1 MiB cap)', () => {
   // The fixture mirrors src/pty-host/child.ts's send-input handling:
   // small CCSM_PTY_PENDING_CAP_BYTES + the `send-input-rejected` IPC


### PR DESCRIPTION
## Summary

Task #386 (T4.11a) — sub-task #1 of T4.11. Adds the missing snapshot→SQLite wire-up so spec ch07 §5's 3-strike DEGRADED counter has something to count against. Before this PR the `'snapshot'` IPC was only fanned out to the in-memory `PtySessionEmitter` (T-PA-5, PR #1027); no production code anywhere in the daemon called `WriteCoalescer.enqueueSnapshot`.

- New optional `coalescer` seam on `spawnPtyHostChild` mirrors the existing `emitterRegistry` pattern (duck-typed `{ enqueueSnapshot }` sink). Production daemon main will pass the shared `WriteCoalescer` instance once it stitches the SQLite handle in; tests pass a stub recorder.
- IPC `'snapshot'` handler now does `coalescer.enqueueSnapshot(...)` in parallel with `emitter.publishSnapshot(...)` — non-mutually-exclusive so the live stream (RAM) and the cold-attach replay log (`pty_snapshot`) both see every snapshot.
- Mapping: `SnapshotMessage` (IPC, types.ts) → `SnapshotWrite` (coalescer column subset). `sessionId` is resolved host-side (the IPC envelope intentionally does not carry it). `createdMs = Date.now()` at receive (the IPC payload has no capture timestamp; jitter is bounded by sub-ms IPC RTT).
- Coalescer throws (RESOURCE_EXHAUSTED, programmer rethrows) are caught + logged. A session-scoped failure must not take down the daemon main process; the in-memory emitter keeps streaming.

Out of scope (Task #385, blocked-by this PR): 60s DEGRADED cooldown, `PtyFrame.session_state_changed` proto change.

## Local checks (host: windows-11)

- lint: ✓ (exit 0, turbo cached + 3 successful)
- typecheck: ✓ (exit 0, both `tsconfig.json` and `tsconfig.electron.json`)
- build: ✓ (exit 0, 3 packages successful)
- unit tests (full daemon suite): see baseline note below
  - With this PR: `131 failed | 1303 passed | 20 skipped | 5 todo (1459 total)`
  - Without this PR (origin/working clean): `131 failed | 1300 passed | 20 skipped | 5 todo (1456 total)`
  - **Delta: +3 passed (the 3 new wire-up tests in `host.spec.ts`); 0 new failures.**
- targeted suite (`packages/daemon` only, `host.spec.ts`): **13 passed (13)** in 2.23s
- e2e (`npm run probe:e2e`): `harness-dnd` ✓, `harness-ui` ✓ (14/14 cases), `harness-real-cli` timeout (pre-existing — UI preload `window.ccsmSession.onState not exposed` and `terminal not ready` fails are unrelated to daemon `host.ts` IPC routing; this PR touches no electron/UI code)

### Baseline note

The 131 pre-existing unit-test failures concentrate in `src/rpc/__tests__/integration.spec.ts` (loopback router / h2c bind) and other RPC layers — confirmed by stashing this branch's diff and re-running on origin/working unchanged. They are independent of the pty-host IPC seam this PR adds. Likely related to in-flight T-PA-6 (Task #355, pool-4 working on `rpc/pty-attach.ts`) and other un-merged WAVE work. Flagging for manager visibility; if you want me to also try to land repairs for the rpc baseline as a separate PR, ping back.

## Test plan

- [x] `host.spec.ts` covers happy path (snapshot IPC → `enqueueSnapshot` called once with correct `SnapshotWrite` fields, byte-equal payload)
- [x] No-coalescer default = no-op (lifecycle + emitter unaffected)
- [x] Coalescer throwing does not break the IPC pump or the graceful close path
- [x] Existing `emitterRegistry: 'disabled'` tests still pass (no behavioral coupling between the two seams)

🤖 Generated with [Claude Code](https://claude.com/claude-code)