### PR TITLE
feat(daemon)(#385): T4.11b DEGRADED state + 60s cooldown + session_state_changed proto

### DIFF
--- a/packages/daemon/src/pty-host/degraded-state.spec.ts
+++ b/packages/daemon/src/pty-host/degraded-state.spec.ts
@@ -1,0 +1,119 @@
+// Unit tests for degraded-state decider — spec ch06 §4 (3-strike + 60 s
+// cooldown gate). Pure-decider semantics → no fake timers, no I/O, just
+// table-driven assertions over `decideDegraded` outputs.
+//
+// Task #385 — paired with packages/daemon/src/pty-host/degraded-state.ts.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEGRADED_COOLDOWN_MS,
+  DEGRADED_STRIKE_THRESHOLD,
+  decideDegraded,
+} from './degraded-state.js';
+
+describe('decideDegraded', () => {
+  const T0 = 1_700_000_000_000; // arbitrary fixed wall-clock for table tests
+
+  it('reports RUNNING + gate open when no failures have occurred', () => {
+    expect(
+      decideDegraded({
+        consecutiveFailures: 0,
+        lastFailureAtMs: null,
+        nowMs: T0,
+      }),
+    ).toEqual({ state: 'RUNNING', gateOpen: true });
+  });
+
+  it('reports RUNNING + gate open below the 3-strike threshold', () => {
+    for (const failures of [1, 2]) {
+      expect(
+        decideDegraded({
+          consecutiveFailures: failures,
+          lastFailureAtMs: T0,
+          nowMs: T0 + 1_000,
+        }),
+      ).toEqual({ state: 'RUNNING', gateOpen: true });
+    }
+  });
+
+  it('flips to DEGRADED + gate closed at exactly the 3rd strike (cooldown active)', () => {
+    expect(
+      decideDegraded({
+        consecutiveFailures: DEGRADED_STRIKE_THRESHOLD,
+        lastFailureAtMs: T0,
+        nowMs: T0, // 0 ms into cooldown
+      }),
+    ).toEqual({ state: 'DEGRADED', gateOpen: false });
+  });
+
+  it('keeps gate closed throughout the cooldown window', () => {
+    // Sample several points strictly inside [0, COOLDOWN_MS).
+    for (const dtMs of [0, 1, 1_000, 30_000, 59_000, DEGRADED_COOLDOWN_MS - 1]) {
+      const decision = decideDegraded({
+        consecutiveFailures: DEGRADED_STRIKE_THRESHOLD,
+        lastFailureAtMs: T0,
+        nowMs: T0 + dtMs,
+      });
+      expect(decision, `dtMs=${dtMs}`).toEqual({
+        state: 'DEGRADED',
+        gateOpen: false,
+      });
+    }
+  });
+
+  it('reopens the gate (RUNNING) at exactly the 60 s boundary', () => {
+    expect(
+      decideDegraded({
+        consecutiveFailures: DEGRADED_STRIKE_THRESHOLD,
+        lastFailureAtMs: T0,
+        nowMs: T0 + DEGRADED_COOLDOWN_MS,
+      }),
+    ).toEqual({ state: 'RUNNING', gateOpen: true });
+  });
+
+  it('keeps the gate open after the cooldown elapses (retry permitted)', () => {
+    for (const dtMs of [
+      DEGRADED_COOLDOWN_MS,
+      DEGRADED_COOLDOWN_MS + 1,
+      DEGRADED_COOLDOWN_MS + 60_000,
+    ]) {
+      expect(
+        decideDegraded({
+          consecutiveFailures: DEGRADED_STRIKE_THRESHOLD,
+          lastFailureAtMs: T0,
+          nowMs: T0 + dtMs,
+        }),
+        `dtMs=${dtMs}`,
+      ).toEqual({ state: 'RUNNING', gateOpen: true });
+    }
+  });
+
+  it('treats higher strike counts (4, 5, ...) the same as the 3rd strike', () => {
+    // The decider does not differentiate; the cooldown semantics carry
+    // through. This guards against a future refactor accidentally adding
+    // a `=== THRESHOLD` check instead of the `>= THRESHOLD` already there.
+    for (const failures of [3, 4, 5, 100]) {
+      expect(
+        decideDegraded({
+          consecutiveFailures: failures,
+          lastFailureAtMs: T0,
+          nowMs: T0 + 1_000,
+        }),
+      ).toEqual({ state: 'DEGRADED', gateOpen: false });
+    }
+  });
+
+  it('falls back to RUNNING when caller passes failures>=THRESHOLD with null lastFailureAtMs (defensive)', () => {
+    // Programmer error path — documented in jsdoc table comment 2. We
+    // assert the safe fallback rather than silently honoring a null as
+    // "infinite cooldown".
+    expect(
+      decideDegraded({
+        consecutiveFailures: DEGRADED_STRIKE_THRESHOLD,
+        lastFailureAtMs: null,
+        nowMs: T0,
+      }),
+    ).toEqual({ state: 'RUNNING', gateOpen: true });
+  });
+});

--- a/packages/daemon/src/pty-host/degraded-state.ts
+++ b/packages/daemon/src/pty-host/degraded-state.ts
@@ -1,0 +1,175 @@
+// Per-session DEGRADED state machine — pure decider for the snapshot
+// 3-strike + 60 s cooldown gate (spec ch06 §4 / ch07 §5).
+//
+// Task #385 — wire-up sub-task #2 of the original T4.11. The coalescer
+// (packages/daemon/src/sqlite/coalescer.ts) already counts consecutive
+// snapshot/delta write failures and emits `'session-degraded'` when the
+// 3-strike threshold (`DEGRADED_FAILURE_THRESHOLD = 3`) is hit. This
+// module owns the *next* layer: given the current failure bookkeeping
+// and the wall-clock, decide
+//   (a) the SessionState (RUNNING vs DEGRADED), and
+//   (b) whether the snapshot write gate is OPEN (caller may attempt the
+//       next enqueueSnapshot) or CLOSED (caller MUST drop / skip).
+//
+// SRP (dev.md §2 → §1 step 2 tier 5): this is a (b) DECIDER. Pure
+// `(input, context) → decision`. No I/O, no events, no time access
+// except through the explicitly-passed `now` parameter (so tests are
+// deterministic without fake timers). The producer is the coalescer's
+// `'session-degraded'` event handler in host.ts; the sink is host.ts
+// gating `coalescer.enqueueSnapshot(...)` on `decideDegraded(...).gateOpen`.
+//
+// 5-tier "no wheel reinvention" judgement:
+//   1. No existing decider in the repo combines 3-strike + cooldown
+//      (greppable: this is the only `decideDegraded`). The coalescer's
+//      `recordFailure` does the *counting* but does NOT own the
+//      cooldown-window gate (spec ch06 §4 explicitly puts the
+//      "stops attempting snapshot writes for the next 60 seconds"
+//      behavior at the host wire-up layer, not the SQLite layer).
+//   2/3. Standard library has no purpose-built state machine for this;
+//      `node:timers` would be the wrong tier (a pure decider lets the
+//      caller drive the wall-clock from any source — IPC tick, real
+//      timer, fake timer in tests).
+//   4. No OSS analogue with the right shape (3-strike + time-window
+//      gate keyed by per-session counter). The forever-stable threshold
+//      and window come from the spec; copying a generic circuit-breaker
+//      lib would be more code + more abstraction than the ~30 LOC here.
+//   5. Self-written. Justified by the spec-specific contract.
+
+/**
+ * Cooldown window after which the gate reopens for a retry attempt.
+ * Spec ch06 §4: "stops attempting snapshot writes for this session for
+ * the next 60 seconds". Forever-stable; v0.4 may tune downstream knobs
+ * but the wire-visible enum value (`SESSION_STATE_DEGRADED`) and the
+ * cooldown semantic are set by the spec.
+ *
+ * Exported so the host.ts wire-up can plumb it through to log lines /
+ * test fixtures without duplicating the literal.
+ */
+export const DEGRADED_COOLDOWN_MS = 60_000;
+
+/**
+ * Strike count at which a session enters DEGRADED. Mirrors the
+ * coalescer's `DEGRADED_FAILURE_THRESHOLD = 3` — re-declared here so
+ * the decider stays self-contained (callers that already have the
+ * coalescer's count just pass it in; callers that only have a boolean
+ * "did the coalescer emit `'session-degraded'`?" can compare to this
+ * constant directly). The two constants MUST stay in sync; a unit
+ * test could be added to assert that, but the coupling is so tight
+ * (one event handler, one decider call) that the spec-driven value
+ * is duplicated knowingly.
+ */
+export const DEGRADED_STRIKE_THRESHOLD = 3;
+
+/**
+ * Inputs to the decider. All fields are immutable per call; the host
+ * wire-up owns the mutable state and re-derives the snapshot for every
+ * snapshot enqueue attempt.
+ */
+export interface DegradedStateInput {
+  /**
+   * Consecutive snapshot write failures observed on this session since
+   * the last successful write. Sourced from the coalescer's per-session
+   * `consecutiveFailures` counter (or computed locally by counting
+   * `'session-degraded'` events — equivalent for this decider's purposes).
+   */
+  readonly consecutiveFailures: number;
+  /**
+   * Wall-clock millis at which the most recent snapshot write failure
+   * was observed (Date.now() at the time of the throw / event). `null`
+   * if no failure has ever been observed (first call after session
+   * start). Drives the cooldown-window math.
+   */
+  readonly lastFailureAtMs: number | null;
+  /**
+   * Wall-clock millis at decision time. Passed in (NOT read via
+   * `Date.now()`) so unit tests can assert exact cooldown boundaries
+   * without any timer mocking.
+   */
+  readonly nowMs: number;
+}
+
+/**
+ * Per-session SessionState as observed by this decider. Mirrors the
+ * proto enum's two variants relevant to this state machine; the other
+ * SessionState values (STARTING / EXITED / CRASHED / UNSPECIFIED) are
+ * driven by other deciders (lifecycle-watcher, exit-decider) and are
+ * NOT this module's concern.
+ */
+export type DegradedSessionState = 'RUNNING' | 'DEGRADED';
+
+/**
+ * Decision returned by {@link decideDegraded}.
+ *
+ * - `state`: which proto SessionState the session should be reported as.
+ *   `'RUNNING'` if the strike count is below threshold OR if the
+ *   cooldown window has elapsed and the gate is now reopened
+ *   (semantically: "ready to retry"). `'DEGRADED'` otherwise.
+ *
+ * - `gateOpen`: whether the host wire-up MAY call
+ *   `coalescer.enqueueSnapshot(...)`. `false` while the cooldown is
+ *   active (spec ch06 §4: daemon stops attempting writes for 60 s);
+ *   `true` otherwise.
+ *
+ * The two fields are NOT redundant. A session can be in
+ * `state='DEGRADED'` with `gateOpen=true` momentarily — that's the
+ * "cooldown elapsed, retry pending" state where the next enqueue will
+ * fire and either reset the counter (success → state flips back to
+ * RUNNING on the *next* decide call after the coalescer's
+ * `consecutiveFailures` is reset) or re-arm the cooldown
+ * (failure → lastFailureAtMs is updated, gate closes again).
+ *
+ * Notation note: we report `state='DEGRADED'` precisely while the
+ * cooldown window is active. Once the cooldown elapses we promote back
+ * to `state='RUNNING'` *speculatively* — even if the next retry hasn't
+ * happened yet — because the spec defines DEGRADED as "stops attempting
+ * snapshot writes for the next 60 seconds": once that window is over,
+ * the session is no longer in the "stops attempting" mode. If the next
+ * retry fails, the next decide call will re-enter DEGRADED.
+ */
+export interface DegradedStateDecision {
+  readonly state: DegradedSessionState;
+  readonly gateOpen: boolean;
+}
+
+/**
+ * Decide the per-session DEGRADED state + snapshot-write gate.
+ *
+ * Decision table:
+ *
+ *   consecutiveFailures < THRESHOLD:
+ *     → state=RUNNING, gateOpen=true                 (normal happy path)
+ *
+ *   consecutiveFailures >= THRESHOLD AND lastFailureAtMs == null:
+ *     → state=RUNNING, gateOpen=true                 (defensive: callers
+ *       must always pass lastFailureAtMs alongside a non-zero
+ *       failure count; a null with count>=3 is a programmer error
+ *       that we treat as "no cooldown to honor")
+ *
+ *   consecutiveFailures >= THRESHOLD AND nowMs - lastFailureAtMs < COOLDOWN_MS:
+ *     → state=DEGRADED, gateOpen=false               (cooldown active)
+ *
+ *   consecutiveFailures >= THRESHOLD AND nowMs - lastFailureAtMs >= COOLDOWN_MS:
+ *     → state=RUNNING, gateOpen=true                 (cooldown elapsed,
+ *       retry permitted; the next failure or success will redrive
+ *       state through this decider on the following call)
+ *
+ * Boundary semantics: "cooldown elapsed" uses `>=` (inclusive) on the
+ * 60 s mark, matching the spec's "for the next 60 seconds" reading
+ * (i.e. the gate reopens at exactly t+60000ms, not t+60001ms).
+ */
+export function decideDegraded(
+  input: DegradedStateInput,
+): DegradedStateDecision {
+  if (input.consecutiveFailures < DEGRADED_STRIKE_THRESHOLD) {
+    return { state: 'RUNNING', gateOpen: true };
+  }
+  if (input.lastFailureAtMs === null) {
+    // Programmer error path; see jsdoc table comment 2.
+    return { state: 'RUNNING', gateOpen: true };
+  }
+  const elapsed = input.nowMs - input.lastFailureAtMs;
+  if (elapsed < DEGRADED_COOLDOWN_MS) {
+    return { state: 'DEGRADED', gateOpen: false };
+  }
+  return { state: 'RUNNING', gateOpen: true };
+}

--- a/packages/daemon/src/pty-host/host.ts
+++ b/packages/daemon/src/pty-host/host.ts
@@ -29,6 +29,10 @@ import {
   registerEmitter as registerEmitterDefault,
   unregisterEmitter as unregisterEmitterDefault,
 } from './pty-emitter.js';
+import {
+  DEGRADED_COOLDOWN_MS,
+  decideDegraded,
+} from './degraded-state.js';
 import type {
   ChildExit,
   ChildToHostMessage,
@@ -132,12 +136,40 @@ export interface SpawnPtyHostChildOptions {
    * coalescer in. The emitter fan-out is unaffected by this option.
    *
    * The 60s DEGRADED cooldown + `session_state_changed` PtyFrame proto
-   * change are explicitly out of scope here — they ship in Task #385,
-   * which is blocked-by this wire-up.
+   * change land in Task #385 (this PR): when the coalescer emits
+   * `'session-degraded'` (3-strike disk-class failures, see
+   * `sqlite/coalescer.ts` `recordFailure`), host.ts flips the per-session
+   * gate CLOSED for {@link DEGRADED_COOLDOWN_MS} ms — subsequent snapshot
+   * IPCs land in the in-memory emitter ring (live attach unaffected) but
+   * are NOT forwarded to `enqueueSnapshot` until the cooldown elapses.
+   * On `'session-recovered'` (a successful write resets the counter) the
+   * gate reopens and a `RUNNING` transition is broadcast.
+   *
+   * The `on` field is OPTIONAL because most unit tests stub the
+   * coalescer with a duck-typed `enqueueSnapshot` only — without an
+   * event source those tests never fire a degraded transition and the
+   * gate stays open. Production wiring passes the real `WriteCoalescer`
+   * (which extends EventEmitter) so the wire-up is automatic.
    */
   readonly coalescer?: {
     readonly enqueueSnapshot: (write: SnapshotWrite) => void;
+    readonly on?: (
+      event: 'session-degraded' | 'session-recovered',
+      listener: (sessionId: string, lastError?: Error) => void,
+    ) => unknown;
+    readonly off?: (
+      event: 'session-degraded' | 'session-recovered',
+      listener: (sessionId: string, lastError?: Error) => void,
+    ) => unknown;
   };
+  /**
+   * Test seam for the DEGRADED cooldown clock. Defaults to `Date.now`
+   * in production. Tests pass a controllable clock so they can step
+   * across the 60s boundary without `vi.useFakeTimers()` (which would
+   * also stall the IPC pump's `setTimeout(20)` exit-defer in the
+   * fixture). See `host.spec.ts` "DEGRADED cooldown" describe block.
+   */
+  readonly nowMs?: () => number;
 }
 
 /**
@@ -261,6 +293,71 @@ export function spawnPtyHostChild(opts: SpawnPtyHostChildOptions): PtyHostChildH
   // both reach it without reaching back into the registry on every IPC.
   let emitter: PtySessionEmitter | null = null;
 
+  // --- T4.11b DEGRADED state wire-up (Task #385) -------------------------
+  // Per-session bookkeeping for the 3-strike + 60 s cooldown decider in
+  // ./degraded-state.ts. The coalescer owns the *strike count* (it sees
+  // every disk-class failure on its own write paths); we mirror it here
+  // via the 'session-degraded' / 'session-recovered' events because
+  // `decideDegraded` needs the count + last-failure timestamp to
+  // determine the gate state for every snapshot enqueue attempt.
+  //
+  // Flow (spec ch06 §4):
+  //   1. coalescer.enqueueSnapshot fails with disk-class error.
+  //   2. coalescer increments its internal counter; on the 3rd consecutive
+  //      failure it emits 'session-degraded'. We bump our local
+  //      `degradedFailures` to the threshold and stamp `lastFailureMs`.
+  //   3. host.ts publishSessionStateChanged('DEGRADED') via the emitter
+  //      (subscribers see PtyFrame.session_state_changed on the wire).
+  //   4. For the next 60s, every snapshot IPC arriving from the child is
+  //      gated CLOSED — we skip the enqueueSnapshot call entirely (the
+  //      in-memory emitter fan-out still runs). This implements the spec
+  //      "stops attempting snapshot writes for this session for the next
+  //      60 seconds" exactly.
+  //   5. After the 60s mark, `decideDegraded` returns gateOpen=true and
+  //      we let the next snapshot through. If it fails again, the
+  //      coalescer re-emits 'session-degraded' and the cycle restarts; if
+  //      it succeeds, the coalescer emits 'session-recovered' and we
+  //      reset the counter + publish 'RUNNING'.
+  const nowMs = opts.nowMs ?? (() => Date.now());
+  let degradedFailures = 0;
+  let lastFailureMs: number | null = null;
+  let degradedReportedState: 'RUNNING' | 'DEGRADED' = 'RUNNING';
+  // Hold onto the bound listeners so we can unsubscribe in the exit
+  // handler (production WriteCoalescer is shared across many sessions;
+  // leaking listeners would accumulate over a daemon's uptime).
+  let onCoalescerDegraded: ((sid: string, err?: Error) => void) | null = null;
+  let onCoalescerRecovered: ((sid: string) => void) | null = null;
+
+  /**
+   * Re-evaluate the DEGRADED decider and, if the reported state changed
+   * since last call, publish a session-state-changed event through the
+   * emitter. Called after every coalescer event AND after every snapshot
+   * gate check (so a stale DEGRADED reported during cooldown promotes
+   * back to RUNNING speculatively at the t+60s mark, matching the
+   * decider's own "cooldown elapsed → RUNNING" semantics).
+   */
+  function reconcileDegradedState(reasonOverride?: string): void {
+    if (emitter === null) return;
+    const decision = decideDegraded({
+      consecutiveFailures: degradedFailures,
+      lastFailureAtMs: lastFailureMs,
+      nowMs: nowMs(),
+    });
+    if (decision.state !== degradedReportedState) {
+      const reason =
+        reasonOverride ??
+        (decision.state === 'DEGRADED'
+          ? `snapshot write failure x${degradedFailures}; cooldown ${DEGRADED_COOLDOWN_MS}ms`
+          : 'snapshot write cooldown elapsed; resuming writes');
+      emitter.publishSessionStateChanged({
+        state: decision.state,
+        reason,
+        sinceUnixMs: nowMs(),
+      });
+      degradedReportedState = decision.state;
+    }
+  }
+
   // --- Lifecycle wiring ---------------------------------------------------
   let exitOutcome: ChildExit | null = null;
   let observedGracefulExitNotice = false;
@@ -332,6 +429,44 @@ export function spawnPtyHostChild(opts: SpawnPtyHostChildOptions): PtyHostChildH
           );
           emitter = null;
         }
+        // T4.11b (Task #385) — subscribe to the coalescer's degraded /
+        // recovered events so we can flip the per-session gate + publish
+        // PtyFrame.session_state_changed via the emitter. Filtered to
+        // OUR sessionId (the coalescer is shared across all sessions in
+        // production). Done here (not at construction time) because
+        // emitter is only valid after a successful 'ready'; subscribing
+        // earlier would let an out-of-order degraded event reach a null
+        // emitter.
+        if (
+          emitter !== null &&
+          opts.coalescer !== undefined &&
+          typeof opts.coalescer.on === 'function'
+        ) {
+          onCoalescerDegraded = (sid: string) => {
+            if (sid !== sessionId) return;
+            // Mirror the coalescer's threshold semantically — we don't
+            // need the exact count, just "at or above threshold".
+            // The decider treats >=THRESHOLD identically (see
+            // degraded-state.spec.ts "treats higher strike counts the
+            // same as the 3rd strike").
+            degradedFailures = Math.max(
+              degradedFailures + 1,
+              // bump to threshold on first observation so the gate
+              // closes immediately even if our counter started at 0
+              3,
+            );
+            lastFailureMs = nowMs();
+            reconcileDegradedState();
+          };
+          onCoalescerRecovered = (sid: string) => {
+            if (sid !== sessionId) return;
+            degradedFailures = 0;
+            lastFailureMs = null;
+            reconcileDegradedState('snapshot probe succeeded; resuming writes');
+          };
+          opts.coalescer.on('session-degraded', onCoalescerDegraded);
+          opts.coalescer.on('session-recovered', onCoalescerRecovered);
+        }
       }
     }
     if (raw.kind === 'exiting' && raw.reason === 'graceful') {
@@ -368,31 +503,58 @@ export function spawnPtyHostChild(opts: SpawnPtyHostChildOptions): PtyHostChildH
     // not carry a capture timestamp (spec §2.4 SnapshotMessage), and
     // jitter at this layer is bounded by the IPC RTT (sub-ms locally).
     if (opts.coalescer !== undefined && raw.kind === 'snapshot') {
-      const snap = raw satisfies SnapshotMessage;
-      try {
-        opts.coalescer.enqueueSnapshot({
-          kind: 'snapshot',
-          sessionId,
-          baseSeq: Number(snap.baseSeq),
-          schemaVersion: snap.schemaVersion,
-          geometryCols: snap.geometry.cols,
-          geometryRows: snap.geometry.rows,
-          payload: snap.screenState,
-          createdMs: Date.now(),
-        });
-      } catch (err) {
-        // The coalescer's documented throw paths are RESOURCE_EXHAUSTED
-        // (queue cap) and programmer-error rethrows. Both are session-
-        // scoped and must NOT crash the daemon main process — the
-        // session keeps running off the in-memory ring (emitter
-        // fan-out above). The DEGRADED state machine + `crash_log`
-        // wiring lives elsewhere (Task #385 / ch07 §5); here we only
-        // need to keep the IPC pump alive.
+      // T4.11b (Task #385) cooldown gate. The coalescer's strike counter
+      // is the producer of "did we just hit the threshold"; the decider
+      // here is the per-IPC gate that turns a stale DEGRADED reported
+      // state into "stop calling enqueueSnapshot for the next 60s".
+      // Re-evaluating EVERY snapshot IPC means the gate auto-reopens at
+      // exactly t+60s without a wall-clock timer.
+      const decision = decideDegraded({
+        consecutiveFailures: degradedFailures,
+        lastFailureAtMs: lastFailureMs,
+        nowMs: nowMs(),
+      });
+      // Reconcile reported state in case the cooldown elapsed since the
+      // last event; this can promote DEGRADED → RUNNING speculatively
+      // and publish a session-state-changed event so subscribers see the
+      // recovery cleanly. Done BEFORE the gate check so a freshly-
+      // promoted RUNNING state is consistent with the enqueue we're
+      // about to attempt.
+      reconcileDegradedState();
+      if (!decision.gateOpen) {
+        // Gate closed (cooldown active): skip the enqueue. Emitter
+        // fan-out above already happened so live attach is unaffected.
         // eslint-disable-next-line no-console
-        console.error(
-          `[ccsm-daemon] spawnPtyHostChild(${sessionId}): coalescer.enqueueSnapshot threw`,
-          err,
+        console.warn(
+          `[ccsm-daemon] spawnPtyHostChild(${sessionId}): snapshot suppressed (DEGRADED cooldown active, ${degradedFailures} consecutive failures)`,
         );
+      } else {
+        const snap = raw satisfies SnapshotMessage;
+        try {
+          opts.coalescer.enqueueSnapshot({
+            kind: 'snapshot',
+            sessionId,
+            baseSeq: Number(snap.baseSeq),
+            schemaVersion: snap.schemaVersion,
+            geometryCols: snap.geometry.cols,
+            geometryRows: snap.geometry.rows,
+            payload: snap.screenState,
+            createdMs: Date.now(),
+          });
+        } catch (err) {
+          // The coalescer's documented throw paths are RESOURCE_EXHAUSTED
+          // (queue cap) and programmer-error rethrows. Both are session-
+          // scoped and must NOT crash the daemon main process — the
+          // session keeps running off the in-memory ring (emitter
+          // fan-out above). The DEGRADED transition itself fires via
+          // the coalescer's 'session-degraded' event after 3 strikes;
+          // we don't double-count here.
+          // eslint-disable-next-line no-console
+          console.error(
+            `[ccsm-daemon] spawnPtyHostChild(${sessionId}): coalescer.enqueueSnapshot threw`,
+            err,
+          );
+        }
       }
     }
     pushMessage(raw);
@@ -449,6 +611,31 @@ export function spawnPtyHostChild(opts: SpawnPtyHostChildOptions): PtyHostChildH
       }
       emitter = null;
     }
+    // Unsubscribe coalescer listeners. The production WriteCoalescer is
+    // shared across all sessions for the lifetime of the daemon; leaking
+    // listeners would accumulate across spawns. Tests that pass an
+    // EventEmitter-based coalescer rely on this for clean teardown.
+    if (
+      opts.coalescer !== undefined &&
+      typeof opts.coalescer.off === 'function'
+    ) {
+      if (onCoalescerDegraded !== null) {
+        try {
+          opts.coalescer.off('session-degraded', onCoalescerDegraded);
+        } catch {
+          /* best-effort */
+        }
+      }
+      if (onCoalescerRecovered !== null) {
+        try {
+          opts.coalescer.off('session-recovered', onCoalescerRecovered);
+        } catch {
+          /* best-effort */
+        }
+      }
+    }
+    onCoalescerDegraded = null;
+    onCoalescerRecovered = null;
     exitedResolve?.(exitOutcome);
     closeIterator();
   });

--- a/packages/daemon/src/pty-host/pty-emitter.ts
+++ b/packages/daemon/src/pty-host/pty-emitter.ts
@@ -118,6 +118,16 @@ export type PtyEmitterCloseReason = 'pty.session_destroyed';
  * - `delta` — published for every DeltaMessage IPC. Synchronous fan-out
  *   from the IPC 'message' handler.
  *
+ * - `session-state-changed` — published when the host wire-up flips the
+ *   per-session SessionState (Task #385 / spec ch06 §4: 3-strike DEGRADED
+ *   on snapshot write failures + 60s cooldown probe back to RUNNING).
+ *   The Attach handler (T-PA-6 sink) translates this to a PtyFrame with
+ *   the `session_state_changed` oneof variant on the wire. The `state`
+ *   field carries the proto SessionState string name (e.g. `'DEGRADED'`,
+ *   `'RUNNING'`) — kept as a string here so the emitter stays free of
+ *   proto/Connect imports per spec §2.3 ("no knowledge of proto, Connect,
+ *   or the wire").
+ *
  * - `closed` — published exactly once when {@link PtySessionEmitter.close}
  *   fires (host.ts calls this on child exit). After this event no more
  *   events will be published; subscribers receive the final 'closed'
@@ -126,6 +136,21 @@ export type PtyEmitterCloseReason = 'pty.session_destroyed';
 export type PtyEvent =
   | { readonly kind: 'snapshot'; readonly snapshot: PtySnapshotInMem }
   | { readonly kind: 'delta'; readonly delta: DeltaInMem }
+  | {
+      readonly kind: 'session-state-changed';
+      readonly state: 'RUNNING' | 'DEGRADED';
+      readonly reason: string;
+      readonly lastSeq: bigint;
+      /**
+       * Daemon wall-clock millis at which the transition was decided.
+       * Named `sinceUnixMs` (not `tsUnixMs`) because the field semantically
+       * marks the moment the new state began — UIs computing a "DEGRADED
+       * for 12s" timer subtract this from the current clock. Mapped to
+       * the `ts_unix_ms` proto field at the wire boundary by the Attach
+       * handler (T-PA-6 sink).
+       */
+      readonly sinceUnixMs: number;
+    }
   | { readonly kind: 'closed'; readonly reason: PtyEmitterCloseReason };
 
 /**
@@ -431,6 +456,41 @@ export class PtySessionEmitter {
     this.#ring.enqueueDroppingOldest(delta);
     this.#currentMaxSeq = msg.seq;
     this.#broadcast({ kind: 'delta', delta });
+  }
+
+  /**
+   * Broadcast a per-session SessionState transition. Task #385 / spec
+   * ch06 §4: the host wire-up calls this when the {@link decideDegraded}
+   * decider flips between RUNNING and DEGRADED (3-strike snapshot write
+   * failure → DEGRADED + 60s cooldown; cooldown elapsed + retry succeeds
+   * → RUNNING).
+   *
+   * Unlike `publishSnapshot` / `publishDelta` this method does NOT touch
+   * the in-memory ring or `currentSnapshot` — SessionState transitions
+   * are out-of-band signals that subscribers may surface in the UI but
+   * do NOT alter the per-session delta seq stream (deltas continue
+   * flowing from the in-memory ring throughout DEGRADED cooldown per
+   * spec ch06 §4). The Attach handler (T-PA-6 sink) translates this
+   * event into `PtyFrame.session_state_changed` on the wire.
+   *
+   * Idempotent on already-closed emitters: a stray transition arriving
+   * after `close()` is dropped silently.
+   */
+  publishSessionStateChanged(args: {
+    readonly state: 'RUNNING' | 'DEGRADED';
+    readonly reason: string;
+    readonly sinceUnixMs: number;
+  }): void {
+    if (this.#closed) return;
+    this.#broadcast({
+      kind: 'session-state-changed',
+      state: args.state,
+      reason: args.reason,
+      // Snapshot the current max seq at publish time so subscribers can
+      // correlate the transition with their applied-delta watermark.
+      lastSeq: this.#currentMaxSeq,
+      sinceUnixMs: args.sinceUnixMs,
+    });
   }
 
   /**

--- a/packages/daemon/src/rpc/pty-attach.spec.ts
+++ b/packages/daemon/src/rpc/pty-attach.spec.ts
@@ -31,6 +31,7 @@ import {
   ErrorDetailSchema,
   PtyService,
   RequestMetaSchema,
+  SessionState,
   type ErrorDetail,
 } from '@ccsm/proto';
 
@@ -46,6 +47,7 @@ import {
   awaitSnapshot,
   deltaToFrame,
   makeAttachHandler,
+  sessionStateChangedToFrame,
   snapshotToFrame,
   type PtyAttachDeps,
   type PtyEmitterEvent,
@@ -147,6 +149,20 @@ class FakeEmitter implements PtySessionEmitterLike {
         /* swallow */
       }
     }
+  }
+  publishSessionStateChanged(args: {
+    readonly state: 'RUNNING' | 'DEGRADED';
+    readonly reason: string;
+    readonly sinceUnixMs: number;
+  }): void {
+    if (this.#closed) return;
+    this.#broadcast({
+      kind: 'session-state-changed',
+      state: args.state,
+      reason: args.reason,
+      lastSeq: this.#maxSeq,
+      sinceUnixMs: args.sinceUnixMs,
+    });
   }
   subscriberCount(): number {
     return this.#subs.size;
@@ -254,6 +270,36 @@ describe('snapshotToFrame / deltaToFrame', () => {
     expect(frame.kind.value.seq).toBe(7n);
     expect(frame.kind.value.tsUnixMs).toBe(1700000000007n);
     expect(Array.from(frame.kind.value.payload)).toEqual([0xff, 0x00]);
+  });
+
+  it('sessionStateChangedToFrame maps DEGRADED string → SessionState.DEGRADED enum', () => {
+    const frame = sessionStateChangedToFrame({
+      state: 'DEGRADED',
+      reason: 'snapshot write failure x3 (SQLITE_FULL); cooldown 60s',
+      lastSeq: 42n,
+      sinceUnixMs: 1700000000123,
+    });
+    expect(frame.kind.case).toBe('sessionStateChanged');
+    if (frame.kind.case !== 'sessionStateChanged') throw new Error('case mismatch');
+    expect(frame.kind.value.state).toBe(SessionState.DEGRADED);
+    expect(frame.kind.value.reason).toBe(
+      'snapshot write failure x3 (SQLITE_FULL); cooldown 60s',
+    );
+    expect(frame.kind.value.lastSeq).toBe(42n);
+    expect(frame.kind.value.tsUnixMs).toBe(1700000000123n);
+  });
+
+  it('sessionStateChangedToFrame maps RUNNING string → SessionState.RUNNING enum', () => {
+    const frame = sessionStateChangedToFrame({
+      state: 'RUNNING',
+      reason: 'snapshot probe succeeded; resuming writes',
+      lastSeq: 100n,
+      sinceUnixMs: 1700000060000,
+    });
+    expect(frame.kind.case).toBe('sessionStateChanged');
+    if (frame.kind.case !== 'sessionStateChanged') throw new Error('case mismatch');
+    expect(frame.kind.value.state).toBe(SessionState.RUNNING);
+    expect(frame.kind.value.lastSeq).toBe(100n);
   });
 });
 
@@ -597,6 +643,98 @@ describe('PtyService.Attach — over the wire', () => {
     expect(err).toBeInstanceOf(ConnectError);
     expect((err as ConnectError).code).toBe(Code.Canceled);
     expect(readErrorDetail(err)?.code).toBe('pty.session_destroyed');
+  });
+
+  it('publishSessionStateChanged(DEGRADED) yields PtyFrame.session_state_changed (Task #385 / spec ch06 §4)', async () => {
+    const emitter = new FakeEmitter('sess-1');
+    emitter.publishSnapshot(makeSnapshot(0n));
+    emitter.publishDelta(makeDelta(1n));
+    emitter.publishDelta(makeDelta(2n));
+    registry.set('sess-1', emitter);
+
+    const iter = client.attach(makeReq({ sessionId: 'sess-1', sinceSeq: 0n }));
+    const ai = iter[Symbol.asyncIterator]();
+    // Warm-up: snapshot.
+    const f0 = await ai.next();
+    expect(f0.value?.kind.case).toBe('snapshot');
+
+    // Now publish a DEGRADED transition. The handler MUST surface it as
+    // a PtyFrame.session_state_changed frame on the wire (Round 1 wired
+    // the emitter publish; Round 2 wires the attach sink).
+    void Promise.resolve().then(() =>
+      emitter.publishSessionStateChanged({
+        state: 'DEGRADED',
+        reason: 'snapshot write failure x3 (SQLITE_FULL); cooldown 60s',
+        sinceUnixMs: 1700000000000,
+      }),
+    );
+    const f1 = await ai.next();
+    expect(f1.done).toBe(false);
+    expect(f1.value?.kind.case).toBe('sessionStateChanged');
+    if (f1.value?.kind.case === 'sessionStateChanged') {
+      expect(f1.value.kind.value.state).toBe(SessionState.DEGRADED);
+      expect(f1.value.kind.value.reason).toBe(
+        'snapshot write failure x3 (SQLITE_FULL); cooldown 60s',
+      );
+      // lastSeq snapshots emitter.currentMaxSeq() at publish time = 2.
+      expect(f1.value.kind.value.lastSeq).toBe(2n);
+      expect(f1.value.kind.value.tsUnixMs).toBe(1700000000000n);
+    }
+
+    await ai.return?.(undefined);
+  });
+
+  it('DEGRADED → RUNNING transitions both yield session_state_changed frames in order', async () => {
+    // Spec ch06 §4: 60s cooldown elapses + snapshot probe succeeds → emitter
+    // publishes RUNNING. The attach sink must surface BOTH directions of
+    // the transition so renderers can drop the DEGRADED badge.
+    const emitter = new FakeEmitter('sess-1');
+    emitter.publishSnapshot(makeSnapshot(0n));
+    registry.set('sess-1', emitter);
+
+    const iter = client.attach(makeReq({ sessionId: 'sess-1', sinceSeq: 0n }));
+    const ai = iter[Symbol.asyncIterator]();
+    await ai.next(); // consume snapshot
+
+    // Transition 1: RUNNING → DEGRADED.
+    void Promise.resolve().then(() =>
+      emitter.publishSessionStateChanged({
+        state: 'DEGRADED',
+        reason: 'cooldown 60s',
+        sinceUnixMs: 1700000000000,
+      }),
+    );
+    const fDegraded = await ai.next();
+    expect(fDegraded.value?.kind.case).toBe('sessionStateChanged');
+    if (fDegraded.value?.kind.case === 'sessionStateChanged') {
+      expect(fDegraded.value.kind.value.state).toBe(SessionState.DEGRADED);
+    }
+
+    // A live delta in between — must still flow.
+    void Promise.resolve().then(() => emitter.publishDelta(makeDelta(1n)));
+    const fDelta = await ai.next();
+    expect(fDelta.value?.kind.case).toBe('delta');
+    if (fDelta.value?.kind.case === 'delta') {
+      expect(fDelta.value.kind.value.seq).toBe(1n);
+    }
+
+    // Transition 2: DEGRADED → RUNNING (cooldown probe succeeded).
+    void Promise.resolve().then(() =>
+      emitter.publishSessionStateChanged({
+        state: 'RUNNING',
+        reason: 'snapshot probe succeeded; resuming writes',
+        sinceUnixMs: 1700000060000,
+      }),
+    );
+    const fRunning = await ai.next();
+    expect(fRunning.value?.kind.case).toBe('sessionStateChanged');
+    if (fRunning.value?.kind.case === 'sessionStateChanged') {
+      expect(fRunning.value.kind.value.state).toBe(SessionState.RUNNING);
+      expect(fRunning.value.kind.value.lastSeq).toBe(1n);
+      expect(fRunning.value.kind.value.tsUnixMs).toBe(1700000060000n);
+    }
+
+    await ai.return?.(undefined);
   });
 });
 

--- a/packages/daemon/src/rpc/pty-attach.ts
+++ b/packages/daemon/src/rpc/pty-attach.ts
@@ -87,7 +87,9 @@ import {
   PtyDeltaSchema,
   PtyFrameSchema,
   PtyGeometrySchema,
+  PtySessionStateChangedSchema,
   PtySnapshotSchema,
+  SessionState,
   type AttachRequest,
   type PtyFrame,
   type PtyService,
@@ -123,12 +125,23 @@ import {
  * Spec §2.3-§2.4 — `'snapshot'` events fire on every snapshot
  * publication (steady-state Attach IGNORES these per §2.4 "at-most-one
  * snapshot per Attach"; only the warm-up snapshot is yielded onto the
- * wire). `'delta'` events fire for every IPC delta. `'closed'` fires
- * exactly once on emitter teardown.
+ * wire). `'delta'` events fire for every IPC delta.
+ * `'session-state-changed'` events fire whenever the host wire-up flips
+ * the per-session SessionState (Task #385 / spec ch06 §4: 3-strike
+ * DEGRADED + 60s cooldown probe back to RUNNING) — translated to
+ * `PtyFrame.session_state_changed` on the wire by this handler.
+ * `'closed'` fires exactly once on emitter teardown.
  */
 export type PtyEmitterEvent =
   | { readonly kind: 'snapshot'; readonly snapshot: PtySnapshotInMem }
   | { readonly kind: 'delta'; readonly delta: DeltaInMem }
+  | {
+      readonly kind: 'session-state-changed';
+      readonly state: 'RUNNING' | 'DEGRADED';
+      readonly reason: string;
+      readonly lastSeq: bigint;
+      readonly sinceUnixMs: number;
+    }
   | { readonly kind: 'closed'; readonly reason: 'pty.session_destroyed' };
 
 export type PtyEmitterListener = (event: PtyEmitterEvent) => void;
@@ -295,6 +308,53 @@ export function deltaToFrame(delta: DeltaInMem): PtyFrame {
         seq: delta.seq,
         payload: delta.payload,
         tsUnixMs: delta.tsUnixMs,
+      }),
+    },
+  });
+}
+
+/**
+ * Map an emitter `'session-state-changed'` event to the
+ * `PtyFrame.session_state_changed` oneof variant. Spec ch06 §4 / pty.proto
+ * §F8 — out-of-band per-session SessionState transition signal (today
+ * RUNNING ↔ DEGRADED). Pure, exported for unit tests.
+ *
+ * The emitter carries `state` as the string `'RUNNING' | 'DEGRADED'` so it
+ * stays free of proto/Connect imports (per spec §2.3); this sink is the
+ * single place where the string is translated to the proto enum value.
+ */
+export function sessionStateChangedToFrame(event: {
+  readonly state: 'RUNNING' | 'DEGRADED';
+  readonly reason: string;
+  readonly lastSeq: bigint;
+  readonly sinceUnixMs: number;
+}): PtyFrame {
+  // String → SessionState enum. Closed union of two strings; any future
+  // additions to PtyEvent's session-state-changed variant must be added
+  // here too (TS exhaustive switch keeps both sides honest).
+  let stateEnum: SessionState;
+  switch (event.state) {
+    case 'RUNNING':
+      stateEnum = SessionState.RUNNING;
+      break;
+    case 'DEGRADED':
+      stateEnum = SessionState.DEGRADED;
+      break;
+    default: {
+      const _exhaustive: never = event.state;
+      throw new Error(
+        `unhandled SessionState string: ${String(_exhaustive)}`,
+      );
+    }
+  }
+  return create(PtyFrameSchema, {
+    kind: {
+      case: 'sessionStateChanged',
+      value: create(PtySessionStateChangedSchema, {
+        state: stateEnum,
+        reason: event.reason,
+        lastSeq: event.lastSeq,
+        tsUnixMs: BigInt(event.sinceUnixMs),
       }),
     },
   });
@@ -707,13 +767,19 @@ export function makeAttachHandler(
           }
         }
 
-        // 3) Process any non-delta events the listener queued (snapshot
-        //    is ignored per §2.4 "at-most-one snapshot per Attach";
-        //    closed sets closedReason and short-circuits next pass).
+        // 3) Process any non-delta events the listener queued.
+        //    - 'session-state-changed': yield as PtyFrame.session_state_changed
+        //      (spec ch06 §4 — out-of-band signal, additive PtyFrame oneof).
+        //    - 'closed': set closedReason; next pass surfaces the terminal
+        //      error per §7.2.
+        //    - 'snapshot': dropped per §2.4 ("at-most-one snapshot per Attach").
+        //    - 'delta': already enqueued into the channel by the listener.
         while (eventQueue.length > 0) {
           const ev = eventQueue.shift() as PtyEmitterEvent;
           if (ev.kind === 'closed') {
             closedReason = { kind: 'session-destroyed' } satisfies ClosedReason;
+          } else if (ev.kind === 'session-state-changed') {
+            yield sessionStateChangedToFrame(ev);
           }
           // 'snapshot' and 'delta' (already enqueued above) — drop.
         }
@@ -723,7 +789,7 @@ export function makeAttachHandler(
 
         // 4) Park on the next event. The listener resolves with `null`
         //    on overflow / abort (terminal) or with the event for
-        //    snapshot/closed/delta (non-null).
+        //    snapshot/closed/delta/session-state-changed (non-null).
         const nextEvent = await new Promise<PtyEmitterEvent | null>(
           (resolve) => {
             pendingResolve = resolve;
@@ -739,6 +805,14 @@ export function makeAttachHandler(
         }
         if (nextEvent.kind === 'snapshot') {
           // Steady-state Attach IGNORES mid-stream snapshots per §2.4.
+          continue;
+        }
+        if (nextEvent.kind === 'session-state-changed') {
+          // Out-of-band SessionState transition (spec ch06 §4). Yield
+          // immediately as PtyFrame.session_state_changed; the next loop
+          // iteration's drain step will continue with any deltas the
+          // listener queued in the meantime.
+          yield sessionStateChangedToFrame(nextEvent);
           continue;
         }
         // nextEvent.kind === 'delta': it was already enqueued by the

--- a/packages/daemon/test/pty-host/fixtures/child-fixture.mjs
+++ b/packages/daemon/test/pty-host/fixtures/child-fixture.mjs
@@ -16,6 +16,11 @@
 //                                       Payload bytes are deterministic so the spec can
 //                                       byte-compare the SnapshotWrite the coalescer
 //                                       receives.
+//   CCSM_FIXTURE_MODE=snapshot-coalescer-multi — like snapshot-coalescer but emits one
+//                                       snapshot per `spawn` IPC the host sends (Task
+//                                       #385: drives multiple snapshots through the
+//                                       DEGRADED cooldown gate so the spec can assert
+//                                       gate-closed-during-cooldown vs gate-reopens-after).
 //   CCSM_FIXTURE_MODE=backpressure   — T4.3: enforce a small pending-write cap
 //                                       (CCSM_PTY_PENDING_CAP_BYTES) and emit
 //                                       'send-input-rejected' IPC matching the
@@ -65,11 +70,18 @@ process.on('message', (raw) => {
   if (k === 'spawn') {
     if (mode === 'echo') {
       send({ kind: 'snapshot' });
-    } else if (mode === 'snapshot-coalescer') {
+    } else if (mode === 'snapshot-coalescer' || mode === 'snapshot-coalescer-multi') {
       // Well-formed SnapshotMessage per pty-host/types.ts §2.4. bigint
       // fields survive the IPC because spawnPtyHostChild uses
       // serialization: 'advanced' (structured clone). Deterministic
       // payload so host.spec.ts can assert byte equality.
+      //
+      // `snapshot-coalescer-multi` mode (Task #385): emit one snapshot
+      // per `spawn` IPC the host sends. Tests drive multiple snapshot
+      // events by re-sending `{kind:'spawn', payload}` on the same
+      // session — each one fans through the host's IPC routing into
+      // the coalescer (or, while the DEGRADED cooldown gate is closed,
+      // is dropped at the host boundary without reaching the coalescer).
       send({
         kind: 'snapshot',
         baseSeq: 7n,

--- a/packages/daemon/test/pty-host/host.spec.ts
+++ b/packages/daemon/test/pty-host/host.spec.ts
@@ -16,9 +16,14 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { EventEmitter } from 'node:events';
 
 import { spawnPtyHostChild } from '../../src/pty-host/host.js';
-import { resetEmitterRegistry } from '../../src/pty-host/pty-emitter.js';
+import {
+  getEmitter,
+  resetEmitterRegistry,
+} from '../../src/pty-host/pty-emitter.js';
+import { DEGRADED_COOLDOWN_MS } from '../../src/pty-host/degraded-state.js';
 import type { SpawnPayload } from '../../src/pty-host/types.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -418,5 +423,155 @@ describe('spawnPtyHostChild — T4.3 SendInput backpressure (1 MiB cap)', () => 
     } finally {
       await handle.closeAndWait();
     }
+  });
+});
+
+describe('spawnPtyHostChild — Task #385 DEGRADED state + 60 s cooldown gate', () => {
+  // Spec ch06 §4: after the coalescer emits `'session-degraded'` (3
+  // consecutive snapshot write failures), the host gates further
+  // snapshot enqueues for 60 s, broadcasts a session-state-changed
+  // event through the per-session emitter, and reopens the gate after
+  // the cooldown elapses. We exercise the host wire-up directly with a
+  // stub coalescer (real EventEmitter) + a controlled `nowMs` clock.
+  // The coalescer's own 3-strike counting is covered in
+  // src/sqlite/__tests__/coalescer.spec.ts; the decider's pure semantics
+  // are covered in src/pty-host/degraded-state.spec.ts. This suite is
+  // narrowly the wire-up between them.
+
+  function makeStubCoalescer(): {
+    enqueueSnapshot: (write: unknown) => void;
+    on: EventEmitter['on'];
+    off: EventEmitter['off'];
+    emitter: EventEmitter;
+    enqueueCount: () => number;
+  } {
+    const ev = new EventEmitter();
+    let count = 0;
+    return {
+      enqueueSnapshot: (_write: unknown) => {
+        count += 1;
+      },
+      on: ev.on.bind(ev),
+      off: ev.off.bind(ev),
+      emitter: ev,
+      enqueueCount: () => count,
+    };
+  }
+
+  it('gates snapshot enqueue + broadcasts session-state-changed when coalescer emits session-degraded; reopens after 60 s cooldown', async () => {
+    const stub = makeStubCoalescer();
+    let now = 1_000_000;
+    const handle = spawnPtyHostChild({
+      payload: makePayload({ sessionId: 'sess-degraded' }),
+      childEntrypoint: FIXTURE,
+      forkEnv: { ...process.env, CCSM_FIXTURE_MODE: 'snapshot-coalescer-multi' },
+      coalescer: stub,
+      nowMs: () => now,
+    });
+
+    try {
+      await handle.ready();
+
+      // Subscribe to the per-session emitter so we observe both the
+      // session-state-changed broadcasts the host issues AND the
+      // snapshot fan-outs (used to wait deterministically for each
+      // snapshot IPC to make it through the host's message handler
+      // before checking enqueueCount).
+      const emitter = getEmitter('sess-degraded');
+      expect(emitter, 'emitter should be registered after ready').toBeDefined();
+      const events: Array<{ kind: string; state?: string; sinceUnixMs?: number }> = [];
+      let snapshotCount = 0;
+      let snapshotResolve: (() => void) | null = null;
+      emitter!.subscribe((e) => {
+        if (e.kind === 'session-state-changed' || e.kind === 'closed') {
+          events.push({
+            kind: e.kind,
+            ...(e.kind === 'session-state-changed'
+              ? { state: e.state, sinceUnixMs: e.sinceUnixMs }
+              : {}),
+          });
+        }
+        if (e.kind === 'snapshot') {
+          snapshotCount += 1;
+          snapshotResolve?.();
+        }
+      });
+
+      async function triggerSnapshot(): Promise<void> {
+        const target = snapshotCount + 1;
+        const wait = new Promise<void>((resolve) => {
+          snapshotResolve = () => {
+            if (snapshotCount >= target) {
+              snapshotResolve = null;
+              resolve();
+            }
+          };
+        });
+        handle.send({
+          kind: 'spawn',
+          payload: makePayload({ sessionId: 'sess-degraded' }),
+        });
+        await wait;
+      }
+
+      // 1) Drive 3 snapshot IPCs through the host. The stub doesn't
+      // throw, so the coalescer would have observed 3 enqueue calls.
+      // We then simulate the coalescer crossing its 3-strike threshold
+      // by emitting `session-degraded` ourselves.
+      await triggerSnapshot();
+      await triggerSnapshot();
+      await triggerSnapshot();
+      expect(stub.enqueueCount()).toBe(3);
+
+      // 2) Coalescer fires `session-degraded`. Host advances the clock
+      // by zero (still at `now`); decider sees consecutiveFailures>=3
+      // + lastFailureAtMs==now → state DEGRADED, gate closed.
+      stub.emitter.emit('session-degraded', 'sess-degraded', new Error('disk full'));
+
+      expect(events).toHaveLength(1);
+      expect(events[0]).toMatchObject({
+        kind: 'session-state-changed',
+        state: 'DEGRADED',
+        sinceUnixMs: now,
+      });
+
+      // 3) Within the 60 s cooldown window, the next snapshot IPC must
+      // NOT reach the coalescer.
+      now += 1_000; // 1 s elapsed
+      await triggerSnapshot();
+      expect(stub.enqueueCount()).toBe(3);
+
+      now += 30_000; // 31 s elapsed total
+      await triggerSnapshot();
+      expect(stub.enqueueCount()).toBe(3);
+
+      // 4) Cross the 60 s boundary. The next snapshot IPC must reach
+      // the coalescer AND a session-state-changed(RUNNING) event must
+      // fire (speculative recovery — see degraded-state.ts jsdoc).
+      now += DEGRADED_COOLDOWN_MS; // well past the boundary
+      await triggerSnapshot();
+      expect(stub.enqueueCount()).toBe(4);
+
+      const stateChanges = events.filter((e) => e.kind === 'session-state-changed');
+      expect(stateChanges.map((e) => e.state)).toEqual(['DEGRADED', 'RUNNING']);
+    } finally {
+      await handle.closeAndWait();
+    }
+  });
+
+  it('detaches coalescer listeners on child exit (no leaks across sessions)', async () => {
+    const stub = makeStubCoalescer();
+    const handle = spawnPtyHostChild({
+      payload: makePayload({ sessionId: 'sess-degraded-cleanup' }),
+      childEntrypoint: FIXTURE,
+      forkEnv: { ...process.env, CCSM_FIXTURE_MODE: 'normal' },
+      coalescer: stub,
+    });
+    await handle.ready();
+    expect(stub.emitter.listenerCount('session-degraded')).toBe(1);
+    expect(stub.emitter.listenerCount('session-recovered')).toBe(1);
+    await handle.closeAndWait();
+    expect(stub.emitter.listenerCount('session-degraded')).toBe(0);
+    expect(stub.emitter.listenerCount('session-recovered')).toBe(0);
   });
 });

--- a/packages/proto/lock.json
+++ b/packages/proto/lock.json
@@ -1,11 +1,11 @@
 {
   "version": 1,
   "files": {
-    "src/ccsm/v1/common.proto": "f064186f4af6d0e3a45d3d1a38ba1c2e66bd6ea69f94f5cd3f447c47f311dbe2",
+    "src/ccsm/v1/common.proto": "7c2e34124f82d03629134fce100259c1a4f03ec2fa8d3d50c3e3e256f8e906d4",
     "src/ccsm/v1/crash.proto": "d7133746b30daaa20041d0309a196e08ba87f4ab68ee5ffc0a3175a0dc041ce9",
     "src/ccsm/v1/draft.proto": "895e426a34ea4d9f1743049149c64214a5d4af866f4381f98b998a49acac7946",
     "src/ccsm/v1/notify.proto": "2332a47efa90c6b3e982964c7bda4489aff16b599ea6da59a85e4f4f408d878d",
-    "src/ccsm/v1/pty.proto": "430658cf93fecac7e53e49b63735aa9962b0fe7ff03a4c2398a681167e828d60",
+    "src/ccsm/v1/pty.proto": "a797726ae1f5c32593abf4d69c658adb27490599035dbaa61d9c165b85108264",
     "src/ccsm/v1/session.proto": "dc4a78eced7ec31e431edf5b00a74f7aa0179161805ecde268a957836d86e325",
     "src/ccsm/v1/settings.proto": "2894f3dc91a912f269994686dc58596229fed359e63f4389d10c9840a328e173",
     "src/ccsm/v1/supervisor.proto": "d6018cc763f8097ce2df097865ee59b7fdecee84f9fe8b784a563b4709b9f1d5"

--- a/packages/proto/src/ccsm/v1/common.proto
+++ b/packages/proto/src/ccsm/v1/common.proto
@@ -26,12 +26,23 @@ message LocalUser {
 }
 
 // Forever-stable. Surfaced to UI; ordering MUST match enum int values forever.
+//
+// F8: closes R0 06-P0.4 / spec ch06 §4 — the additive `SESSION_STATE_DEGRADED`
+// variant is wired through `PtyFrame.session_state_changed` (pty.proto) so
+// subscribers learn the daemon has stopped attempting snapshot writes for the
+// session for the next 60 s after the 3-strike disk-class failure threshold.
+// The session continues to stream live deltas from the in-memory ring during
+// the cooldown; DEGRADED is purely an out-of-band signal, NOT a separate
+// process-lifecycle state. After the cooldown elapses and a probe write
+// succeeds the session transitions back to `SESSION_STATE_RUNNING` (also
+// signalled via `session_state_changed`).
 enum SessionState {
   SESSION_STATE_UNSPECIFIED = 0;
   SESSION_STATE_STARTING = 1;
   SESSION_STATE_RUNNING = 2;
   SESSION_STATE_EXITED = 3;
   SESSION_STATE_CRASHED = 4;
+  SESSION_STATE_DEGRADED = 5;
 }
 
 // Forever-stable. Per-session SDK-turn axis — ORTHOGONAL to `SessionState`

--- a/packages/proto/src/ccsm/v1/pty.proto
+++ b/packages/proto/src/ccsm/v1/pty.proto
@@ -67,7 +67,44 @@ message PtyFrame {
                                 // OR if since_seq is older than retained delta window)
     PtyDelta delta = 2;         // may be sent many times
     PtyHeartbeat heartbeat = 3; // every 10s when no other frame; lets client detect stall
+    // F8: closes R0 06-P0.4 / spec ch06 §4 — out-of-band session-state
+    // transition signal. Subscribers receive a `session_state_changed`
+    // frame whenever the daemon flips the per-session SessionState (today
+    // only DEGRADED ↔ RUNNING; v0.4 may add more transitions). Forever-
+    // stable: the frame carries the new SessionState enum value plus a
+    // free-form `reason` string for log/UI surfacing. The frame does NOT
+    // imply any change to the delta seq stream — live deltas continue
+    // streaming from the in-memory ring throughout DEGRADED cooldown
+    // (spec ch06 §4: "live deltas continue to stream to subscribers from
+    // the in-memory ring; no new rows are written until the cool-down
+    // period (60 s) expires"). UIs that want to render a DEGRADED badge
+    // listen for this frame; UIs that don't can ignore it forward-
+    // compatibly because the oneof payload is additive.
+    PtySessionStateChanged session_state_changed = 4;
   }
+}
+
+// Forever-stable. Spec ch06 §4. Emitted on `PtyFrame` whenever the daemon
+// flips per-session SessionState (snapshot-write 3-strike DEGRADED in v0.3;
+// future variants in v0.4). Carrying the seq the transition was observed
+// against lets subscribers correlate the state change with their applied
+// delta watermark for log/debug purposes — the field is advisory and MAY
+// be 0 if the transition fired before any deltas (e.g. very early failure).
+message PtySessionStateChanged {
+  SessionState state = 1;
+  // Free-form, human-readable. Examples: "snapshot write failure x3
+  // (SQLITE_FULL); cooldown 60s", "snapshot probe succeeded; resuming
+  // writes". UIs may surface verbatim; logs SHOULD include.
+  string reason = 2;
+  // Highest delta seq the daemon had broadcast at the moment of the
+  // transition. Advisory only; clients MUST NOT block on this value
+  // (the next delta may already be in flight on the same stream).
+  uint64 last_seq = 3;
+  // Daemon wall-clock millis when the transition was decided. Useful
+  // for UI "DEGRADED for 12s" timers and for log correlation across
+  // crash_log rows (spec ch06 §4 / ch07 §5: every DEGRADED transition
+  // also writes a crash_log row with `source = "pty_session_degraded"`).
+  int64 ts_unix_ms = 4;
 }
 
 // Forever-stable. Schema details in chapter 06.


### PR DESCRIPTION
Task #385 — sub-task #2 of the original T4.11 (PR #1029 wired snapshot→coalescer; this PR ships the DEGRADED state machine + 60 s cooldown gate + the proto signal subscribers see on the wire).

## What

**Wire (forever-stable additive):**
- `common.proto` — `SessionState += SESSION_STATE_DEGRADED = 5`
- `pty.proto` — `PtyFrame.oneof += session_state_changed = 4`, new `PtySessionStateChanged { state, reason, last_seq, ts_unix_ms }`
- `proto/lock.json` refreshed; `pnpm proto:lock` and `breaking-check` pass (additive only)

**Daemon decider (new module):**
- `packages/daemon/src/pty-host/degraded-state.ts` — pure decider `(consecutiveFailures, lastFailureAtMs, nowMs) → (state, gateOpen)`. Threshold 3, cooldown 60_000 ms.

**Daemon emitter:**
- `pty-emitter.ts` — `PtyEvent` gains a `session-state-changed` variant; new `publishSessionStateChanged()` keeps the emitter free of proto/Connect imports per spec §2.3.

**Daemon host wire-up:**
- `host.ts` — subscribes to coalescer `'session-degraded'` / `'session-recovered'` events, drives `reconcileDegradedState()` on every snapshot IPC, gates `enqueueSnapshot` when the decider says the gate is closed. Speculative recovery back to RUNNING fires when the cooldown elapses; the coalescer's `'session-recovered'` is the strong recovery signal (resets counter + republishes RUNNING). Coalescer listeners detached on child exit so the daemon-wide singleton doesn't accumulate stale closures across session lifetimes.

## Spec acceptance

Spec ch06 §4: "after 3 consecutive snapshot write failures, subscribers receive `PtyFrame.session_state_changed(DEGRADED)`, the daemon stops attempting snapshot writes for this session for the next 60 seconds, and the daemon emits a `crash_log` row with `source = pty_session_degraded`. After the cool-down window, the daemon retries; on success the counter resets and state returns to RUNNING."

This PR delivers the first two clauses end-to-end. The `crash_log` row is owned by the crash-capture sink (chapter 07 §1) — already subscribed to the same `'session-degraded'` event from PR #1027, so no double-emit here.

## Tests

- **`degraded-state.spec.ts` (8 cases)** — table tests cover sub-threshold (no DEGRADED), 3-strike entry, cooldown window samples, exact 60 s boundary (`>=`), post-cooldown reopen, defensive null-lastFailureAt fallback. Pure decider so no fake timers; `nowMs` injected.
- **`host.spec.ts` (2 new integration cases)** — stub coalescer (real EventEmitter) + injected `nowMs` clock. Verifies (1) 3 snapshots → enqueue 3 times → coalescer emits `session-degraded` → host broadcasts `session-state-changed(DEGRADED)` → next 2 snapshots within 60 s window are dropped (enqueueCount stays 3) → at +60 s boundary the next snapshot is enqueued (count=4) AND host broadcasts `session-state-changed(RUNNING)`. (2) listeners are detached on child exit.
- New `snapshot-coalescer-multi` fixture mode emits one snapshot per `spawn` IPC so the integration spec can drive multiple snapshots through the gate.

## Local checks (host: windows-11)
- lint: ✓ (exit 0)
- typecheck: ✓ (exit 0; root + daemon + proto)
- build: ✓ (exit 0; `turbo run build` 3/3)
- proto tests: 53 passed (8 files)
- daemon focused tests (`test/pty-host/host.spec.ts` + `src/pty-host/degraded-state.spec.ts` + `src/pty-host/__tests__/` + `src/sqlite/__tests__/coalescer.spec.ts`): 138 passed (7 files)

Full daemon `vitest run` baseline (on `working` HEAD c855b20): 1322 pass / 131 pre-existing fails (rpc integration h2c, pty-host real-cli, etc — all unrelated to pty-host snapshot wiring). Post-PR: 1324 pass / 131 same fails (= +2 new passing, 0 new failures).