### PR TITLE
feat(sea-smoke)(#79): post-install daemon e2e smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,3 +310,70 @@ jobs:
       - name: Coverage (electron renderer — 60% gate)
         working-directory: packages/electron
         run: npx vitest run --coverage
+
+  # Task #79 / T7.8 — tools/sea-smoke/ post-install daemon end-to-end smoke.
+  # Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md ch10 §7.
+  #
+  # Runs the smoke harness on the three OSes the installer ships to. The
+  # END-TO-END exercise (start service → /healthz → Hello → CreateSession
+  # → Attach 'ok' → Stop) requires a real installed `ccsm-daemon` binary
+  # placed by the per-OS installer + service registration; that wiring
+  # lands with the e2e-installer-{win,mac,linux} self-hosted jobs (T7.4 /
+  # T7.5 own the install side). This job runs the smoke binary's
+  # typecheck on all three OSes so the harness itself never silently
+  # breaks ahead of the installer jobs. When T7.4 wires the real
+  # installer round-trip jobs, they will invoke
+  # `pnpm --filter @ccsm/sea-smoke run smoke` AFTER the install step;
+  # this job's matrix shape is identical so the wiring is one-line.
+  #
+  # Why three OS matrix even though no real daemon runs here yet: the
+  # smoke uses platform-locked paths and service-manager commands
+  # (lib/service-log.ts buildCaptureCommand). A POSIX-only typecheck
+  # would let a Windows-only TypeScript or import regression slip in. Per
+  # spec ch10 §6 the installer matrix is windows + macos + linux; this
+  # job mirrors that explicitly.
+  sea-smoke:
+    name: sea-smoke (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, macos-14, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.2
+      # Frozen lockfile — adding tools/sea-smoke as a workspace member
+      # already updated pnpm-lock.yaml; further drift fails this step.
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+      # Generate proto bindings so @ccsm/proto resolves during typecheck.
+      - name: Generate proto
+        run: pnpm --filter @ccsm/proto run gen
+      - name: Typecheck sea-smoke harness
+        run: pnpm --filter @ccsm/sea-smoke run typecheck
+      # Sanity dry-run: invoke the harness with skipStart + skipStop +
+      # an unreachable supervisor. The smoke MUST exit non-zero with the
+      # `/healthz never returned 200` message — if it crashes earlier
+      # (TypeScript ESM resolution / platform-paths typo / proto import
+      # regression) the regression surfaces here without needing the
+      # installer self-hosted runner. Exit-code is asserted via shell.
+      - name: Dry-run (expect /healthz timeout)
+        shell: bash
+        working-directory: tools/sea-smoke
+        run: |
+          set +e
+          node --import tsx -e "
+          import('./main.ts').then(async (m) => {
+            const code = await m.runSmoke({ skipStart: true, skipStop: true });
+            process.exit(code === 1 ? 0 : 99);
+          }).catch((e) => { console.error('import-fail', e); process.exit(98); });
+          "
+

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,13 +233,13 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2))
+        version: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0))
       wait-on:
         specifier: ^8.0.1
         version: 8.0.5
       webpack:
         specifier: ^5.97.1
-        version: 5.106.2(webpack-cli@6.0.1)
+        version: 5.106.2(esbuild@0.27.7)(webpack-cli@6.0.1)
       webpack-cli:
         specifier: ^6.0.1
         version: 6.0.1(webpack-dev-server@5.2.3)(webpack@5.106.2)
@@ -345,6 +345,31 @@ importers:
       '@xterm/headless':
         specifier: ^5.5.0
         version: 5.5.0
+
+  tools/sea-smoke:
+    dependencies:
+      '@bufbuild/protobuf':
+        specifier: ^2.12.0
+        version: 2.12.0
+      '@ccsm/proto':
+        specifier: workspace:*
+        version: link:../../packages/proto
+      '@connectrpc/connect':
+        specifier: ^2.1.1
+        version: 2.1.1(@bufbuild/protobuf@2.12.0)
+      '@connectrpc/connect-node':
+        specifier: ^2.1.1
+        version: 2.1.1(@bufbuild/protobuf@2.12.0)(@connectrpc/connect@2.1.1(@bufbuild/protobuf@2.12.0))
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.19.17
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
 
 packages:
 
@@ -715,6 +740,162 @@ packages:
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
+
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
 
   '@eslint-community/eslint-utils@4.9.1':
     resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
@@ -3202,6 +3383,11 @@ packages:
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3549,6 +3735,9 @@ packages:
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
@@ -5019,6 +5208,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
     engines: {node: '>= 0.4'}
@@ -5514,6 +5706,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tsyringe@4.10.0:
     resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
@@ -6449,6 +6646,84 @@ snapshots:
   '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
@@ -8119,7 +8394,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2))
+      vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0))
 
   '@vitest/expect@4.1.5':
     dependencies:
@@ -8130,13 +8405,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2))':
+  '@vitest/mocker@4.1.5(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.1.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.10(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2)
+      vite: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)
 
   '@vitest/pretty-format@4.1.5':
     dependencies:
@@ -8240,17 +8515,17 @@ snapshots:
 
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.106.2)':
     dependencies:
-      webpack: 5.106.2(webpack-cli@6.0.1)
+      webpack: 5.106.2(esbuild@0.27.7)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.3)(webpack@5.106.2)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.106.2)':
     dependencies:
-      webpack: 5.106.2(webpack-cli@6.0.1)
+      webpack: 5.106.2(esbuild@0.27.7)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.3)(webpack@5.106.2)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.3)(webpack@5.106.2)':
     dependencies:
-      webpack: 5.106.2(webpack-cli@6.0.1)
+      webpack: 5.106.2(esbuild@0.27.7)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.3)(webpack@5.106.2)
     optionalDependencies:
       webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
@@ -8902,7 +9177,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.4
     optionalDependencies:
-      webpack: 5.106.2(webpack-cli@6.0.1)
+      webpack: 5.106.2(esbuild@0.27.7)(webpack-cli@6.0.1)
 
   css-select@4.3.0:
     dependencies:
@@ -9312,6 +9587,35 @@ snapshots:
 
   es6-error@4.1.1:
     optional: true
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -9748,6 +10052,10 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
 
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
@@ -9892,7 +10200,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.106.2(webpack-cli@6.0.1)
+      webpack: 5.106.2(esbuild@0.27.7)(webpack-cli@6.0.1)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -10880,7 +11188,7 @@ snapshots:
       postcss: 8.5.13
       semver: 7.7.4
     optionalDependencies:
-      webpack: 5.106.2(webpack-cli@6.0.1)
+      webpack: 5.106.2(esbuild@0.27.7)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - typescript
 
@@ -11204,6 +11512,8 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   resolve@1.22.12:
     dependencies:
@@ -11648,7 +11958,7 @@ snapshots:
 
   style-loader@4.0.0(webpack@5.106.2):
     dependencies:
-      webpack: 5.106.2(webpack-cli@6.0.1)
+      webpack: 5.106.2(esbuild@0.27.7)(webpack-cli@6.0.1)
 
   sumchecker@3.0.1:
     dependencies:
@@ -11709,13 +12019,15 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.5.0(webpack@5.106.2):
+  terser-webpack-plugin@5.5.0(esbuild@0.27.7)(webpack@5.106.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.46.2
-      webpack: 5.106.2(webpack-cli@6.0.1)
+      webpack: 5.106.2(esbuild@0.27.7)(webpack-cli@6.0.1)
+    optionalDependencies:
+      esbuild: 0.27.7
 
   terser@5.46.2:
     dependencies:
@@ -11797,11 +12109,18 @@ snapshots:
       semver: 7.7.4
       source-map: 0.7.6
       typescript: 5.9.3
-      webpack: 5.106.2(webpack-cli@6.0.1)
+      webpack: 5.106.2(esbuild@0.27.7)(webpack-cli@6.0.1)
 
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tsyringe@4.10.0:
     dependencies:
@@ -11944,7 +12263,7 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
-  vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2):
+  vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -11953,14 +12272,16 @@ snapshots:
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 22.19.17
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
       terser: 5.46.2
+      tsx: 4.21.0
 
-  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2)):
+  vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(@vitest/coverage-v8@4.1.5)(happy-dom@15.11.7)(jsdom@29.1.1)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.5
-      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2))
+      '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0))
       '@vitest/pretty-format': 4.1.5
       '@vitest/runner': 4.1.5
       '@vitest/snapshot': 4.1.5
@@ -11977,7 +12298,7 @@ snapshots:
       tinyexec: 1.1.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@22.19.17)(jiti@2.6.1)(terser@5.46.2)
+      vite: 8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -12031,7 +12352,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.106.2(webpack-cli@6.0.1)
+      webpack: 5.106.2(esbuild@0.27.7)(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
     optionalDependencies:
       webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack-cli@6.0.1)(webpack@5.106.2)
@@ -12045,7 +12366,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.106.2(webpack-cli@6.0.1)
+      webpack: 5.106.2(esbuild@0.27.7)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - tslib
 
@@ -12080,7 +12401,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.2)
       ws: 8.20.0
     optionalDependencies:
-      webpack: 5.106.2(webpack-cli@6.0.1)
+      webpack: 5.106.2(esbuild@0.27.7)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.3)(webpack@5.106.2)
     transitivePeerDependencies:
       - bufferutil
@@ -12097,7 +12418,7 @@ snapshots:
 
   webpack-sources@3.4.1: {}
 
-  webpack@5.106.2(webpack-cli@6.0.1):
+  webpack@5.106.2(esbuild@0.27.7)(webpack-cli@6.0.1):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -12120,7 +12441,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.5.0(webpack@5.106.2)
+      terser-webpack-plugin: 5.5.0(esbuild@0.27.7)(webpack@5.106.2)
       watchpack: 2.5.1
       webpack-sources: 3.4.1
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "packages/*"
+  - "tools/sea-smoke"

--- a/tools/sea-smoke/README.md
+++ b/tools/sea-smoke/README.md
@@ -1,0 +1,47 @@
+# tools/sea-smoke
+
+Post-install daemon end-to-end smoke. Spec: `docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md` chapter 10 §7. Task T7.8 (#79).
+
+## What it does
+
+Runs the **actual installed `ccsm-daemon` binary** placed by the real per-OS installer (msi / pkg / deb / rpm) — NOT a `node bundle.js` invocation. That is the entire point of this script: it proves the sea binary, the per-OS service registration, and the Listener A descriptor wiring all work end-to-end against the same artefacts that ship to users.
+
+Step list (verbatim from spec ch10 §7):
+
+1. Start the OS service (or reuse the installer-started service):
+   - linux: `systemctl start ccsm-daemon`
+   - mac: `launchctl kickstart system/com.ccsm.daemon`
+   - win: `Start-Service ccsm-daemon`
+2. Poll Supervisor `/healthz` (per-OS UDS / named-pipe path) for HTTP 200 within 10 s.
+3. Read `listener-a.json`, dial Listener A, call `Hello` — assert `proto_version` matches.
+4. `CreateSession({ claude_args: ["echo", "ok"] })` — assert returned `Session.id` non-empty.
+5. Subscribe to `PtyService.Attach({ session_id })` — assert at least one delta arrives within 5 s containing the literal bytes `ok`.
+6. Stop the daemon — assert process exits within 5 s.
+7. Exit non-zero on any step failure; capture per-OS service-manager log on failure (same capture rule as ch10 §5 step 7).
+
+## Invocation
+
+```bash
+node --import tsx tools/sea-smoke/main.ts
+```
+
+(or `pnpm --filter @ccsm/sea-smoke run smoke`)
+
+The CI `.github/workflows/ci.yml` `sea-smoke` matrix job runs this AFTER each per-OS installer round-trip job has placed the daemon and registered the service. See spec ch10 §6 for the matrix shape.
+
+## Layout
+
+- `main.ts` — orchestrator (steps 1–6 + step 7 failure path)
+- `lib/healthz-wait.ts` — `/healthz` poller (10 s budget, 250 ms interval)
+- `lib/service-log.ts` — per-OS service-manager log dump on failure (`journalctl` / `log show` / `Get-WinEvent`)
+
+Service-manager commands and `/healthz` capture command are sourced from the locked spec ch10 §5 step 7 strings (mirrored in `packages/daemon/build/install/post-install-healthz.{sh,ps1}`).
+
+## Why a separate workspace package vs inlining in `tools/`
+
+Two reasons:
+
+1. The smoke needs typed Connect-RPC clients from `@ccsm/proto`. A standalone script under `tools/` cannot resolve workspace deps without a `package.json` of its own.
+2. The smoke is a sea-binary candidate (per spec ch10 §7 the script is "reused by the manual mac/linux pre-tag installer smoke and by the manual arm64 smoke step"). Future packaging into a single-file binary needs a per-package build boundary.
+
+Lives under `tools/` (not `packages/`) because it does not ship to end users — it is a CI / pre-tag verification tool only.

--- a/tools/sea-smoke/lib/healthz-wait.ts
+++ b/tools/sea-smoke/lib/healthz-wait.ts
@@ -1,0 +1,133 @@
+// tools/sea-smoke/lib/healthz-wait.ts
+//
+// Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//       chapter 10 §7 step 2 — "Poll Supervisor /healthz (per-OS UDS path
+//       from chapter 02 §2) for HTTP 200 within 10 s; fail otherwise".
+//
+// SRP: producer (issues HTTP probes) + decider (timeout vs 200) wrapped
+// behind a single waitForHealthz() async function. No service-manager
+// commands here — that lives in service-log.ts; no transport dialing —
+// that lives in main.ts. This file owns ONE concern: "supervisor said
+// ready within budget". Re-callable from any caller (the CI smoke,
+// post-install scripts in the future) without dragging the smoke graph.
+//
+// Implementation note: node:http's request() accepts `socketPath` for
+// both POSIX UDS files and Windows named pipes (libuv binds either to
+// the same uv_pipe_t). The Host: header value is irrelevant for UDS but
+// node:http requires SOMETHING — we pass 'localhost'. This mirrors the
+// production probe in packages/daemon/build/install/post-install-healthz.sh
+// (curl --unix-socket) and the Windows raw-pipe variant in
+// post-install-healthz.ps1 (which can't use Invoke-WebRequest because
+// PowerShell lacks named-pipe transport in IWR).
+
+import { request as httpRequest } from 'node:http';
+
+/**
+ * Result of a single /healthz probe. `status: 0` means "no response"
+ * (connection refused, ENOENT on the socket path, per-probe timeout, etc.) —
+ * distinguishable from a real HTTP failure status like 503.
+ */
+export interface HealthzProbeResult {
+  readonly status: number;
+  readonly body: string;
+}
+
+export interface WaitForHealthzOptions {
+  /**
+   * Supervisor UDS path on POSIX, named-pipe path on Windows
+   * (`\\.\pipe\ccsm-supervisor`). Per spec ch03 §7 the supervisor is
+   * UDS-only on every OS — there is no loopback-TCP fallback.
+   */
+  readonly address: string;
+  /** Total budget in ms. Spec ch10 §7 step 2 mandates 10s. */
+  readonly timeoutMs?: number;
+  /** Per-probe interval in ms. Defaults to 500ms (20 probes per 10s budget). */
+  readonly intervalMs?: number;
+  /** Per-probe socket connect/read timeout. Defaults to 1000ms. */
+  readonly perProbeTimeoutMs?: number;
+  /** Optional progress sink — receives one line per probe. */
+  readonly onProbe?: (attempt: number, status: number, elapsedMs: number) => void;
+}
+
+/**
+ * Issue a single HTTP GET /healthz over the given socket path. Resolves
+ * with the parsed status code + body. Never throws — connection failures
+ * surface as `{ status: 0, body: '' }` so the polling loop above can keep
+ * retrying without try/catch noise.
+ */
+export function probeHealthz(
+  address: string,
+  perProbeTimeoutMs: number,
+): Promise<HealthzProbeResult> {
+  return new Promise((resolve) => {
+    const req = httpRequest(
+      {
+        socketPath: address,
+        method: 'GET',
+        path: '/healthz',
+        // node:http requires a host header when using socketPath; the
+        // supervisor server ignores its value (UDS / pipe is the auth
+        // boundary, not the Host: line).
+        headers: { host: 'localhost' },
+        timeout: perProbeTimeoutMs,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString('utf8'),
+          }),
+        );
+        res.on('error', () => resolve({ status: 0, body: '' }));
+      },
+    );
+    req.on('error', () => resolve({ status: 0, body: '' }));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve({ status: 0, body: '' });
+    });
+    req.end();
+  });
+}
+
+/**
+ * Poll Supervisor /healthz until either (a) HTTP 200 is observed, or
+ * (b) the wall-clock budget elapses. Returns the final probe result.
+ *
+ * Spec ch10 §7 step 2: budget is 10s; on timeout the caller MUST capture
+ * the per-OS service-manager log (service-log.ts) and exit non-zero.
+ */
+export async function waitForHealthz(
+  opts: WaitForHealthzOptions,
+): Promise<HealthzProbeResult> {
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const intervalMs = opts.intervalMs ?? 500;
+  const perProbeTimeoutMs = opts.perProbeTimeoutMs ?? 1_000;
+  const start = Date.now();
+  let attempt = 0;
+  let last: HealthzProbeResult = { status: 0, body: '' };
+
+  while (Date.now() - start < timeoutMs) {
+    attempt += 1;
+    last = await probeHealthz(opts.address, perProbeTimeoutMs);
+    if (opts.onProbe) {
+      opts.onProbe(attempt, last.status, Date.now() - start);
+    }
+    if (last.status === 200) {
+      return last;
+    }
+    // Sleep until the next interval boundary OR the deadline, whichever
+    // comes first. Avoids a final useless sleep past the budget.
+    const remaining = timeoutMs - (Date.now() - start);
+    if (remaining <= 0) break;
+    await sleep(Math.min(intervalMs, remaining));
+  }
+
+  return last;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms).unref());
+}

--- a/tools/sea-smoke/lib/service-log.ts
+++ b/tools/sea-smoke/lib/service-log.ts
@@ -1,0 +1,128 @@
+// tools/sea-smoke/lib/service-log.ts
+//
+// Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//       chapter 10 §7 step 7 — "capture per-OS service-manager log on
+//       failure (same capture rule as §5 step 7)".
+// §5 step 7 capture commands (sourced verbatim from
+// packages/daemon/build/install/post-install-healthz.{sh,ps1}):
+//   linux: journalctl -u ccsm-daemon.service -n 200 --no-pager
+//   mac:   log show --predicate 'process == "ccsm-daemon"' --last 5m
+//   win:   Get-WinEvent -LogName Application -MaxEvents 200
+//          | Where-Object { $_.ProviderName -like '*ccsm*' }
+//
+// SRP: single sink — `dumpServiceLog()` runs the spec-locked command for
+// the current OS, pipes its stdout+stderr to our stderr (so the CI runner
+// archives it under the failed-step's annotations), and returns. It does
+// NOT decide whether to dump (caller does, on failure only) and it does
+// NOT compose service-manager start/stop (that lives in main.ts).
+//
+// Both the spec and post-install-healthz.sh leave "log capture failed"
+// non-fatal — a missing journalctl on a stripped container is no reason
+// to mask the upstream /healthz timeout. We mirror that: any exec error
+// is logged to stderr but does not throw.
+
+import { spawn } from 'node:child_process';
+
+export type SmokePlatform = 'linux' | 'darwin' | 'win32';
+
+export interface DumpServiceLogOptions {
+  readonly platform?: SmokePlatform;
+  /** Override the service unit name (defaults to `ccsm-daemon`). */
+  readonly serviceName?: string;
+  /** Tail length. Spec ch10 §5 step 7 pins 200. */
+  readonly tailLines?: number;
+  /** Override the writable stream the dump streams to. Defaults to stderr. */
+  readonly out?: NodeJS.WritableStream;
+}
+
+/**
+ * Run the per-OS service-manager log capture command (spec ch10 §7 + §5
+ * step 7) and stream its output to stderr (or the injected `out` sink).
+ * Never throws: log capture is best-effort diagnostic, not a hard gate.
+ */
+export async function dumpServiceLog(opts: DumpServiceLogOptions = {}): Promise<void> {
+  const platform = opts.platform ?? (process.platform as SmokePlatform);
+  const service = opts.serviceName ?? 'ccsm-daemon';
+  const tail = opts.tailLines ?? 200;
+  const out = opts.out ?? process.stderr;
+
+  const cmd = buildCaptureCommand(platform, service, tail);
+  if (cmd === null) {
+    out.write(`[sea-smoke] service-log dump unsupported on platform=${platform}\n`);
+    return;
+  }
+
+  out.write(`[sea-smoke] capturing service log: ${cmd.echo}\n`);
+  await new Promise<void>((resolve) => {
+    const child = spawn(cmd.exe, cmd.args, {
+      // Inherit stderr so PowerShell / journalctl errors surface; stdout
+      // we capture and forward so the dump is line-buffered cleanly.
+      stdio: ['ignore', 'pipe', 'pipe'],
+      // shell=false: spawn the binary directly. The args arrays already
+      // separate every token; using shell=true would re-introduce quoting
+      // surprises on Windows.
+      shell: false,
+    });
+    child.stdout.on('data', (chunk: Buffer) => out.write(chunk));
+    child.stderr.on('data', (chunk: Buffer) => out.write(chunk));
+    child.on('error', (err) => {
+      out.write(`[sea-smoke] service-log capture spawn failed: ${String(err)}\n`);
+      resolve();
+    });
+    child.on('close', (code) => {
+      if (code !== 0) {
+        out.write(`[sea-smoke] service-log capture exited code=${String(code)} (best-effort)\n`);
+      }
+      resolve();
+    });
+  });
+}
+
+interface CaptureCommand {
+  readonly exe: string;
+  readonly args: ReadonlyArray<string>;
+  /** Human-readable echo of the command (for the [sea-smoke] log line). */
+  readonly echo: string;
+}
+
+/**
+ * Compose the platform-locked capture command. Pure: no I/O, no spawn —
+ * unit-testable by asserting the (exe, args) tuple matches the spec ch10
+ * §5 step 7 strings verbatim. Returns `null` on unsupported platforms so
+ * the caller can decide what to do (we just log "unsupported").
+ */
+export function buildCaptureCommand(
+  platform: SmokePlatform,
+  serviceName: string,
+  tailLines: number,
+): CaptureCommand | null {
+  if (platform === 'linux') {
+    const args = ['-u', `${serviceName}.service`, '-n', String(tailLines), '--no-pager'];
+    return { exe: 'journalctl', args, echo: `journalctl ${args.join(' ')}` };
+  }
+  if (platform === 'darwin') {
+    // Spec ch10 §5 step 7 mac branch: `log show --predicate 'process ==
+    // "ccsm-daemon"' --last 5m`. The `--last` window is 5 minutes
+    // (regardless of `tailLines`); `tailLines` would re-tail the
+    // line-buffered output but the spec command does not pipe through
+    // tail, so we omit it for fidelity.
+    const args = [
+      'show',
+      '--predicate',
+      `process == "${serviceName}"`,
+      '--last',
+      '5m',
+    ];
+    return { exe: 'log', args, echo: `log ${args.join(' ')}` };
+  }
+  if (platform === 'win32') {
+    // Spec ch10 §5 step 7 windows branch — invoked through pwsh so the
+    // pipeline below executes in a real PowerShell process (cmd.exe
+    // can't pipe Get-WinEvent into Where-Object). Falls back to
+    // `powershell` if `pwsh` is missing — both honor the same -Command.
+    const ps = `Get-WinEvent -LogName Application -MaxEvents ${String(tailLines)} | Where-Object { $_.ProviderName -like '*${serviceName}*' } | Format-List`;
+    const args = ['-NoProfile', '-NonInteractive', '-Command', ps];
+    return { exe: 'pwsh', args, echo: `pwsh -Command "${ps}"` };
+  }
+  return null;
+}

--- a/tools/sea-smoke/main.ts
+++ b/tools/sea-smoke/main.ts
@@ -1,0 +1,505 @@
+// tools/sea-smoke/main.ts
+//
+// Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//       chapter 10 §7 — `tools/sea-smoke/`. Invoked at the END of each
+//       e2e-installer-{win,mac,linux} CI job AFTER the installer has
+//       placed the daemon and registered the per-OS service.
+//
+// Step list (verbatim from spec ch10 §7 — DO NOT reorder; the steps are
+// the contract a sea-binary smoke must satisfy):
+//
+//   1. Start the OS service (or reuse the installer-started service):
+//        systemctl start ccsm-daemon
+//        launchctl kickstart system/com.ccsm.daemon
+//        Start-Service ccsm-daemon
+//   2. Poll Supervisor /healthz (per-OS UDS / pipe path) for HTTP 200
+//      within 10s; fail otherwise.
+//   3. Open Listener A via descriptor (ch03 §1) and call Hello RPC;
+//      assert proto_version matches expected.
+//   4. CreateSession({ command: "echo ok" }) — assert returned
+//      Session.id non-empty.
+//   5. Subscribe to PtyService.Attach({ session_id }) and assert at
+//      least one delta arrives within 5s containing the literal bytes
+//      "ok".
+//   6. Stop the daemon:
+//        systemctl stop ccsm-daemon
+//        launchctl bootout system/com.ccsm.daemon
+//        Stop-Service ccsm-daemon
+//      assert process exits within 5s.
+//   7. Exit non-zero on any step failure; capture per-OS service-manager
+//      log on failure (same capture rule as §5 step 7).
+//
+// Deliberately NOT a vitest spec: this is a sea-binary-style smoke that
+// runs the actual built ccsm-daemon placed by the real installer. There
+// is no in-process daemon to import; there is no test runner to drive.
+// The wire to drive: real Supervisor UDS + real Listener A. Run via
+// `node --import tsx tools/sea-smoke/main.ts` from the CI installer job.
+//
+// SRP: this file is the orchestrator (decider + sink). The two pure
+// helpers under lib/ own:
+//   - lib/healthz-wait.ts: producer (HTTP probes) + decider (timeout vs 200)
+//   - lib/service-log.ts:  sink (per-OS service-manager log dump)
+// The transport-bridge equivalent (UDS / named-pipe Connect dial) is
+// inlined here because it is single-purpose to this smoke; if a third
+// caller appears it migrates to lib/.
+//
+// Layer 1 / 5-tier (re-evaluated for transport dial):
+//   tier 1 — repo helper that dials UDS Connect from a Node script: NONE.
+//            Renderer side uses an Electron main-process http2 bridge
+//            (transport-bridge.ts) that is NOT reusable here.
+//   tier 2 — node:net + node:http2 stdlib: COVERS IT. We open a net
+//            socket via createConnection and feed it to
+//            createConnectTransport via nodeOptions. Same pattern
+//            connect-node uses internally for h2c-tcp; we override the
+//            connection factory.
+//   tier 3 — @connectrpc/connect-node already in deps: ✓ (used).
+// → tier 2/3 covers; no new dep.
+
+import { connect as netConnect } from 'node:net';
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+
+import { create } from '@bufbuild/protobuf';
+import { Code, ConnectError, createClient } from '@connectrpc/connect';
+import { createConnectTransport } from '@connectrpc/connect-node';
+import {
+  CreateSessionRequestSchema,
+  HelloRequestSchema,
+  PROTO_VERSION,
+  PtyService,
+  RequestMetaSchema,
+  SessionService,
+  type AttachRequest,
+  AttachRequestSchema,
+} from '@ccsm/proto';
+
+import { waitForHealthz } from './lib/healthz-wait.js';
+import { dumpServiceLog, type SmokePlatform } from './lib/service-log.js';
+
+// ---------------------------------------------------------------------------
+// Per-OS constants. Sourced from spec ch07 §2 (state-dir layout) +
+// post-install-healthz.{sh,ps1} (supervisor address) + ch10 §7 (service
+// commands).
+// ---------------------------------------------------------------------------
+
+interface PlatformPaths {
+  /** Supervisor UDS / named-pipe path (ch07 §2 — supervisor address). */
+  readonly supervisorAddress: string;
+  /** Listener A descriptor file path (ch07 §2 — Daemon state root). */
+  readonly descriptorPath: string;
+  /** Service start command. */
+  readonly startCmd: ServiceCommand;
+  /** Service stop command. */
+  readonly stopCmd: ServiceCommand;
+}
+
+interface ServiceCommand {
+  readonly exe: string;
+  readonly args: ReadonlyArray<string>;
+}
+
+function platformPaths(platform: SmokePlatform): PlatformPaths {
+  if (platform === 'linux') {
+    return {
+      supervisorAddress: '/run/ccsm/supervisor.sock',
+      descriptorPath: '/var/lib/ccsm/listener-a.json',
+      startCmd: { exe: 'systemctl', args: ['start', 'ccsm-daemon'] },
+      stopCmd: { exe: 'systemctl', args: ['stop', 'ccsm-daemon'] },
+    };
+  }
+  if (platform === 'darwin') {
+    return {
+      supervisorAddress: '/var/run/com.ccsm.daemon/supervisor.sock',
+      descriptorPath: '/Library/Application Support/ccsm/listener-a.json',
+      startCmd: {
+        exe: 'launchctl',
+        args: ['kickstart', 'system/com.ccsm.daemon'],
+      },
+      stopCmd: {
+        exe: 'launchctl',
+        args: ['bootout', 'system/com.ccsm.daemon'],
+      },
+    };
+  }
+  // win32
+  return {
+    supervisorAddress: '\\\\.\\pipe\\ccsm-supervisor',
+    // Per spec ch07 §2: %PROGRAMDATA%\ccsm. Fallback to default if env
+    // missing on the runner.
+    descriptorPath: `${process.env.PROGRAMDATA ?? 'C:\\ProgramData'}\\ccsm\\listener-a.json`,
+    startCmd: { exe: 'powershell', args: ['-NoProfile', '-Command', 'Start-Service ccsm-daemon'] },
+    stopCmd: { exe: 'powershell', args: ['-NoProfile', '-Command', 'Stop-Service ccsm-daemon'] },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Listener A descriptor — minimal reader (the canonical writer is
+// packages/daemon/src/listeners/descriptor.ts; we ship a structural reader
+// here to avoid a workspace dep on @ccsm/daemon, which would drag the
+// whole daemon build into the smoke binary).
+// ---------------------------------------------------------------------------
+
+interface DescriptorV1Lite {
+  readonly version: 1;
+  readonly transport:
+    | 'KIND_UDS'
+    | 'KIND_NAMED_PIPE'
+    | 'KIND_TCP_LOOPBACK_H2C'
+    | 'KIND_TCP_LOOPBACK_H2_TLS';
+  readonly address: string;
+  readonly tlsCertFingerprintSha256: string | null;
+  readonly supervisorAddress: string;
+  readonly boot_id: string;
+}
+
+async function readDescriptor(path: string): Promise<DescriptorV1Lite> {
+  const raw = await readFile(path, 'utf8');
+  const parsed = JSON.parse(raw) as DescriptorV1Lite;
+  if (parsed.version !== 1) {
+    throw new Error(`descriptor at ${path} has unsupported version=${String(parsed.version)}`);
+  }
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// Connect transport for the descriptor — supports UDS / named-pipe /
+// loopback h2c (descriptor enum closed per ch03 §1a). TLS variant is
+// rejected: the smoke runs against the spec-default transport and will
+// fail loud if the descriptor unexpectedly carries TLS (signals a
+// listener-A mis-route worth flagging at the smoke layer).
+// ---------------------------------------------------------------------------
+
+function transportForDescriptor(desc: DescriptorV1Lite) {
+  if (desc.transport === 'KIND_TCP_LOOPBACK_H2C') {
+    // address is "host:port"; pass straight to baseUrl.
+    return createConnectTransport({
+      httpVersion: '2',
+      baseUrl: `http://${desc.address}`,
+    });
+  }
+  if (desc.transport === 'KIND_UDS' || desc.transport === 'KIND_NAMED_PIPE') {
+    // h2c over UDS / named pipe. Connect-node forwards `nodeOptions` to
+    // node:http2 connect; we override `createConnection` so the http2
+    // session opens against the named socket rather than a host:port.
+    return createConnectTransport({
+      httpVersion: '2',
+      // baseUrl host is irrelevant once createConnection is overridden,
+      // but Node URL requires a syntactically valid value. The path
+      // segment ('/') is the Connect prefix.
+      baseUrl: 'http://localhost',
+      nodeOptions: {
+        createConnection: () => netConnect(desc.address),
+      },
+    });
+  }
+  throw new Error(`unsupported descriptor transport for sea-smoke: ${desc.transport}`);
+}
+
+// ---------------------------------------------------------------------------
+// Service-manager primitives. Wraps spawn() so the orchestrator stays
+// readable. Stop has a 5s budget per spec ch10 §7 step 6; start has a
+// 10s budget (the wait on /healthz takes the heavy lifting).
+// ---------------------------------------------------------------------------
+
+async function runService(cmd: ServiceCommand, budgetMs: number): Promise<{ code: number | null; ms: number }> {
+  const started = Date.now();
+  return new Promise((resolve) => {
+    const child = spawn(cmd.exe, cmd.args, { stdio: ['ignore', 'pipe', 'pipe'], shell: false });
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGKILL');
+    }, budgetMs);
+    child.stdout.on('data', (b: Buffer) => process.stderr.write(b));
+    child.stderr.on('data', (b: Buffer) => process.stderr.write(b));
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      process.stderr.write(`[sea-smoke] spawn ${cmd.exe} failed: ${String(err)}\n`);
+      resolve({ code: -1, ms: Date.now() - started });
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      const ms = Date.now() - started;
+      if (timedOut) {
+        process.stderr.write(`[sea-smoke] ${cmd.exe} ${cmd.args.join(' ')} exceeded ${String(budgetMs)}ms budget\n`);
+      }
+      resolve({ code, ms });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator
+// ---------------------------------------------------------------------------
+
+interface SmokeOptions {
+  /** Override the platform — used by tests; defaults to process.platform. */
+  readonly platform?: SmokePlatform;
+  /** Skip step 1 (start). Useful when the installer already started it. */
+  readonly skipStart?: boolean;
+  /** Skip step 6 (stop). Useful for local debugging. */
+  readonly skipStop?: boolean;
+  /** Override the expected proto_version — defaults to PROTO_VERSION. */
+  readonly expectedProtoVersion?: number;
+}
+
+export async function runSmoke(opts: SmokeOptions = {}): Promise<number> {
+  const platform = opts.platform ?? (process.platform as SmokePlatform);
+  if (platform !== 'linux' && platform !== 'darwin' && platform !== 'win32') {
+    process.stderr.write(`[sea-smoke] unsupported platform: ${platform}\n`);
+    return 1;
+  }
+  const paths = platformPaths(platform);
+
+  process.stderr.write(`[sea-smoke] starting on platform=${platform}\n`);
+  process.stderr.write(`[sea-smoke]   supervisor=${paths.supervisorAddress}\n`);
+  process.stderr.write(`[sea-smoke]   descriptor=${paths.descriptorPath}\n`);
+
+  // ----- step 1: start service -----
+  if (!opts.skipStart) {
+    process.stderr.write(`[sea-smoke] step 1: ${paths.startCmd.exe} ${paths.startCmd.args.join(' ')}\n`);
+    const startRes = await runService(paths.startCmd, 10_000);
+    if (startRes.code !== 0) {
+      process.stderr.write(`[sea-smoke] FAIL: service start exited code=${String(startRes.code)} after ${String(startRes.ms)}ms\n`);
+      await dumpServiceLog({ platform });
+      return 1;
+    }
+  } else {
+    process.stderr.write('[sea-smoke] step 1: skipped (skipStart)\n');
+  }
+
+  // ----- step 2: wait /healthz 200 within 10s -----
+  process.stderr.write('[sea-smoke] step 2: poll /healthz (budget 10s)\n');
+  const healthz = await waitForHealthz({
+    address: paths.supervisorAddress,
+    timeoutMs: 10_000,
+    intervalMs: 250,
+    onProbe: (attempt, status, elapsedMs) => {
+      if (attempt === 1 || status === 200 || attempt % 4 === 0) {
+        process.stderr.write(`[sea-smoke]   probe #${String(attempt)} status=${String(status)} elapsed=${String(elapsedMs)}ms\n`);
+      }
+    },
+  });
+  if (healthz.status !== 200) {
+    process.stderr.write(`[sea-smoke] FAIL: /healthz never returned 200 (last=${String(healthz.status)})\n`);
+    await dumpServiceLog({ platform });
+    return 1;
+  }
+  process.stderr.write('[sea-smoke] step 2: /healthz 200 OK\n');
+
+  // ----- step 3: open Listener A + Hello -----
+  process.stderr.write('[sea-smoke] step 3: read descriptor + Hello\n');
+  let descriptor: DescriptorV1Lite;
+  try {
+    descriptor = await readDescriptor(paths.descriptorPath);
+  } catch (err) {
+    process.stderr.write(`[sea-smoke] FAIL: cannot read descriptor at ${paths.descriptorPath}: ${String(err)}\n`);
+    await dumpServiceLog({ platform });
+    return 1;
+  }
+  process.stderr.write(
+    `[sea-smoke]   descriptor transport=${descriptor.transport} address=${descriptor.address} boot_id=${descriptor.boot_id}\n`,
+  );
+  const transport = transportForDescriptor(descriptor);
+  const sessionClient = createClient(SessionService, transport);
+  const expectedVersion = opts.expectedProtoVersion ?? PROTO_VERSION;
+  try {
+    const hello = await sessionClient.hello(
+      create(HelloRequestSchema, {
+        meta: makeMeta(),
+        clientKind: 'sea-smoke',
+        protoMinVersion: expectedVersion,
+      }),
+    );
+    if (hello.protoVersion !== expectedVersion) {
+      process.stderr.write(
+        `[sea-smoke] FAIL: Hello.proto_version=${String(hello.protoVersion)} expected=${String(expectedVersion)}\n`,
+      );
+      await dumpServiceLog({ platform });
+      return 1;
+    }
+    process.stderr.write(
+      `[sea-smoke] step 3: Hello OK daemon_version=${hello.daemonVersion} proto_version=${String(hello.protoVersion)} listener=${hello.listenerId}\n`,
+    );
+  } catch (err) {
+    process.stderr.write(`[sea-smoke] FAIL: Hello RPC failed: ${formatConnectError(err)}\n`);
+    await dumpServiceLog({ platform });
+    return 1;
+  }
+
+  // ----- step 4: CreateSession({ command: "echo ok" }) -----
+  // Spec ch10 §7 step 4 uses the shorthand `command: "echo ok"`. The
+  // CreateSession wire (ch04 §3 / session.proto) does not expose a
+  // `command` field directly — claude_args carries the argv that the
+  // daemon prepends with the resolved claude binary. For this smoke we
+  // stand in with a `claude_args` that the daemon's spawn path will
+  // forward to the underlying shell — the assertion is "id non-empty",
+  // not "echo executes on bare bash". The Attach delta containing 'ok'
+  // (step 5) is the actual exec proof.
+  process.stderr.write('[sea-smoke] step 4: CreateSession\n');
+  let sessionId = '';
+  try {
+    const created = await sessionClient.createSession(
+      create(CreateSessionRequestSchema, {
+        meta: makeMeta(),
+        cwd: platform === 'win32' ? 'C:\\' : '/',
+        claudeArgs: ['echo', 'ok'],
+      }),
+    );
+    sessionId = created.session?.id ?? '';
+    if (sessionId.length === 0) {
+      process.stderr.write('[sea-smoke] FAIL: CreateSession returned empty session.id\n');
+      await dumpServiceLog({ platform });
+      return 1;
+    }
+    process.stderr.write(`[sea-smoke] step 4: CreateSession OK id=${sessionId}\n`);
+  } catch (err) {
+    process.stderr.write(`[sea-smoke] FAIL: CreateSession failed: ${formatConnectError(err)}\n`);
+    await dumpServiceLog({ platform });
+    return 1;
+  }
+
+  // ----- step 5: Attach + assert delta containing 'ok' within 5s -----
+  process.stderr.write('[sea-smoke] step 5: Attach (budget 5s)\n');
+  const ptyClient = createClient(PtyService, transport);
+  const attachReq: AttachRequest = create(AttachRequestSchema, {
+    meta: makeMeta(),
+    sessionId,
+    sinceSeq: 0n,
+    requiresAck: false,
+  });
+  const attachOk = await waitForOkDelta(ptyClient, attachReq, 5_000);
+  if (!attachOk) {
+    process.stderr.write('[sea-smoke] FAIL: Attach did not deliver a delta containing "ok" within 5s\n');
+    await dumpServiceLog({ platform });
+    return 1;
+  }
+  process.stderr.write('[sea-smoke] step 5: Attach delta contained "ok" OK\n');
+
+  // ----- step 6: stop + 5s budget -----
+  let stopFailure = false;
+  if (!opts.skipStop) {
+    process.stderr.write(`[sea-smoke] step 6: ${paths.stopCmd.exe} ${paths.stopCmd.args.join(' ')}\n`);
+    const stopRes = await runService(paths.stopCmd, 5_000);
+    if (stopRes.code !== 0) {
+      process.stderr.write(`[sea-smoke] FAIL: service stop exited code=${String(stopRes.code)} after ${String(stopRes.ms)}ms\n`);
+      stopFailure = true;
+    } else {
+      process.stderr.write(`[sea-smoke] step 6: service stopped in ${String(stopRes.ms)}ms\n`);
+    }
+  } else {
+    process.stderr.write('[sea-smoke] step 6: skipped (skipStop)\n');
+  }
+
+  if (stopFailure) {
+    await dumpServiceLog({ platform });
+    return 1;
+  }
+
+  process.stderr.write('[sea-smoke] all steps passed\n');
+  return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMeta() {
+  return create(RequestMetaSchema, {
+    requestId: cryptoRandomUuid(),
+    clientVersion: '0.3.0-sea-smoke',
+    clientSendUnixMs: BigInt(Date.now()),
+  });
+}
+
+function cryptoRandomUuid(): string {
+  // Avoid an extra import — node:crypto.randomUUID is available since
+  // Node 14.17 and unconditionally on Node 22 (engines >=22 per repo).
+  // eslint-disable-next-line @typescript-eslint/no-require-imports -- intentional dynamic to avoid extra import
+  return (globalThis as { crypto?: { randomUUID?: () => string } }).crypto?.randomUUID?.() ??
+    // Fallback for older runtimes: not security-sensitive, observability only.
+    `xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`.replace(/[xy]/g, (c) => {
+      const r = (Math.random() * 16) | 0;
+      const v = c === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+}
+
+function formatConnectError(err: unknown): string {
+  if (err instanceof ConnectError) {
+    return `${Code[err.code] ?? String(err.code)}: ${err.message}`;
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Subscribe to the Attach stream and resolve `true` as soon as a delta
+ * payload contains the literal bytes "ok"; resolve `false` if the budget
+ * elapses first. Always tears down the iterator before returning so the
+ * underlying http2 stream does not leak past the smoke's lifetime.
+ */
+async function waitForOkDelta(
+  ptyClient: ReturnType<typeof createClient<typeof PtyService>>,
+  req: AttachRequest,
+  budgetMs: number,
+): Promise<boolean> {
+  const abort = new AbortController();
+  const deadline = setTimeout(() => abort.abort(), budgetMs).unref();
+  try {
+    const stream = ptyClient.attach(req, { signal: abort.signal });
+    for await (const frame of stream) {
+      const k = frame.kind;
+      // PtyFrame is a oneof of { snapshot, delta, heartbeat }. Both
+      // snapshot.screen_state and delta.payload are byte sequences that
+      // could carry the smoke literal — but spec ch10 §7 step 5 says
+      // "delta contains 'ok'", so we only look at delta payloads.
+      if (k.case === 'delta') {
+        const payload = k.value.payload;
+        if (containsBytes(payload, 'ok')) {
+          return true;
+        }
+      }
+    }
+    return false;
+  } catch (err) {
+    if (abort.signal.aborted) return false;
+    process.stderr.write(`[sea-smoke]   Attach stream errored: ${formatConnectError(err)}\n`);
+    return false;
+  } finally {
+    clearTimeout(deadline);
+    if (!abort.signal.aborted) abort.abort();
+  }
+}
+
+function containsBytes(haystack: Uint8Array, needle: string): boolean {
+  if (haystack.length < needle.length) return false;
+  const buf = Buffer.isBuffer(haystack) ? haystack : Buffer.from(haystack);
+  return buf.includes(needle);
+}
+
+// ---------------------------------------------------------------------------
+// Entry point — only run when invoked directly, not when imported by a
+// unit test or by an orchestrator wrapper.
+// ---------------------------------------------------------------------------
+
+const isDirectInvoke = (() => {
+  try {
+    const argv1 = process.argv[1] ?? '';
+    // tsx rewrites the URL; substring match on the file basename is the
+    // most reliable cross-loader signal.
+    return argv1.endsWith('main.ts') || argv1.endsWith('main.js');
+  } catch {
+    return false;
+  }
+})();
+
+if (isDirectInvoke) {
+  runSmoke()
+    .then((code) => {
+      process.exit(code);
+    })
+    .catch((err) => {
+      process.stderr.write(`[sea-smoke] fatal: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+      process.exit(1);
+    });
+}

--- a/tools/sea-smoke/package.json
+++ b/tools/sea-smoke/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@ccsm/sea-smoke",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Post-install daemon end-to-end smoke (T7.8 / spec ch10 §7). Invoked by e2e-installer-{win,mac,linux} jobs AFTER the installer has placed the ccsm-daemon binary and registered the per-OS service. NOT a unit test — runs the real installed service via systemctl / launchctl / Start-Service, polls Supervisor /healthz over UDS or named pipe, then exercises Hello + CreateSession + Attach + Stop end-to-end.",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "smoke": "node --import tsx main.ts"
+  },
+  "dependencies": {
+    "@bufbuild/protobuf": "^2.12.0",
+    "@ccsm/proto": "workspace:*",
+    "@connectrpc/connect": "^2.1.1",
+    "@connectrpc/connect-node": "^2.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.5",
+    "tsx": "^4.20.6",
+    "typescript": "^5.7.3"
+  }
+}

--- a/tools/sea-smoke/tsconfig.json
+++ b/tools/sea-smoke/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["main.ts", "lib/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Closes Task #79 (T7.8). Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md ch10 §7.

## Summary

- New workspace package `tools/sea-smoke` (pnpm member added) — post-install daemon end-to-end smoke binary.
- `main.ts` orchestrates the spec ch10 §7 step list: service start -> /healthz 200 in 10s -> Hello (proto_version match) -> CreateSession (echo ok) -> Attach delta contains 'ok' within 5s -> Stop within 5s -> non-zero exit + per-OS service-manager log dump on any failure.
- `lib/healthz-wait.ts` — single-concern /healthz poller over UDS / named-pipe (node:http `socketPath`, never throws).
- `lib/service-log.ts` — single-concern per-OS log dump (`journalctl` / `log show` / `Get-WinEvent`), commands sourced verbatim from spec ch10 §5 step 7.
- `.github/workflows/ci.yml` — new `sea-smoke` matrix job (ubuntu-22.04 + macos-14 + windows-latest), runs typecheck + sanity dry-run (skipStart + skipStop, expects /healthz timeout exit=1). Real end-to-end against an installed daemon will plug in from T7.4 / T7.5 self-hosted installer jobs by appending `pnpm --filter @ccsm/sea-smoke run smoke` after the install step.

## Layer 1 / 5-tier

- Layer 1 6-question OK — proceeding.
- Tier 2/3: UDS / named-pipe Connect dial uses `node:net.connect` + `@connectrpc/connect-node` `nodeOptions.createConnection` (already a dep). No new packages.
- Listener A descriptor read with a local structural reader (16 lines) to avoid pulling `@ccsm/daemon` into the smoke binary.

## Local checks (host: windows-11)

- lint: n/a (sea-smoke is a new workspace not yet in the root lint glob; per dev.md typecheck is the binding gate for new ts modules).
- typecheck: ✓ `pnpm --filter @ccsm/sea-smoke run typecheck` exit 0.
- unit tests: n/a (this is an integration smoke against a real installed daemon, not a unit-testable module — the CI dry-run is the smoke's self-test).
- sanity dry-run (windows-11): `node --import tsx -e "import('./main.ts').then(m => m.runSmoke({skipStart:true, skipStop:true}))"` -> expected `/healthz timeout` -> wrapper exit 0 (verified, asserts runSmoke returned 1).

CI matrix expectation: lint + typecheck + test jobs unchanged (sea-smoke deps are workspace-isolated; `pnpm-lock.yaml` only added the new importer block + a couple of existing-version peer-id fan-out lines). New `sea-smoke (ubuntu-22.04 / macos-14 / windows-latest)` matrix should pass on all three.

Continuation of stalled dev session: prior dev had written all six files (main.ts + lib/* + package.json + tsconfig + README + ci.yml + workspace + lockfile) but never staged, committed, or pushed. This PR commits that work as-is and adds nothing on top — the dry-run wrapper in ci.yml was already present in the staged ci.yml diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)