### PR TITLE
feat(daemon)(#339): SessionService.CreateSession Connect handler

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -410,6 +410,20 @@ export async function runStartup(
     // the post-destroy row state is visible to ListSessions / GetSession
     // on the same boot.
     const destroyHandlerDeps = { manager: sessionManager };
+    // Wave-3 §6.9 sub-task 6 (Task #339) — wire SessionService.CreateSession
+    // on top of the SessionService overlay. Audit #228 sub-task 6
+    // (docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md): pre-#339
+    // CreateSession was a stub on the wire even though
+    // `SessionManager.create()` (T3.2 / #38) is fully implemented. Reuse
+    // the SAME `sessionManager` so a CreateSession publishes `created`
+    // to the same in-memory event bus the WatchSessions stream subscribes
+    // to (round-trip: create one -> watcher sees `created` event) and the
+    // new row is immediately visible to ListSessions / GetSession on the
+    // same boot. PTY spawn for the freshly-created session is OUT OF SCOPE
+    // here (Task #359 wires `attachPtyHost` separately so the unary
+    // handler stays decoupled from the spawn lifecycle — see
+    // `sessions/create-handler.ts` SCOPE note).
+    const createSessionDeps = { manager: sessionManager };
     // Wave-3 #349 — wire SettingsService + DraftService production
     // overlays (spec #337 §6.1 step 1). Both services share the same
     // `db` handle (drafts ride on the `settings` table under key
@@ -437,6 +451,7 @@ export async function runStartup(
         destroyHandlerDeps,
         settingsDeps,
         draftDeps,
+        createSessionDeps,
         // Order matters: bearer→PeerInfo deposit MUST run before
         // peerCredAuthInterceptor (which reads PEER_INFO_KEY and
         // derives Principal). `requestMetaInterceptor` is prepended by

--- a/packages/daemon/src/rpc/router.ts
+++ b/packages/daemon/src/rpc/router.ts
@@ -60,6 +60,10 @@ import {
 } from '@ccsm/proto';
 
 import {
+  makeCreateSessionHandler,
+  type CreateSessionDeps,
+} from '../sessions/create-handler.js';
+import {
   makeDestroySessionHandler,
   type DestroySessionDeps,
 } from '../sessions/destroy-handler.js';
@@ -166,29 +170,33 @@ export function registerHelloHandler(
 /**
  * Register the v0.3 SessionService handlers that have landed so far —
  * Hello (T2.3), WatchSessions (T3.3), the read pair ListSessions /
- * GetSession (Wave 3 §6.9 sub-task 5 / Task #336) and DestroySession
- * (Wave 3 §6.9 sub-task 7 / Task #338) — under a SINGLE
+ * GetSession (Wave 3 §6.9 sub-task 5 / Task #336), DestroySession
+ * (Wave 3 §6.9 sub-task 7 / Task #338) and CreateSession (Wave 3 §6.9
+ * sub-task 6 / Task #339) — under a SINGLE
  * `router.service(SessionService, ...)` call.
  *
  * Why a combined registration (not multiple `service()` calls): per
  * Connect-ES `ConnectRouter.service` semantics, calling
  * `service(desc, impl)` more than once for the same descriptor REPLACES
  * the prior registration (the router is a path-keyed map). Registering
- * Hello, then WatchSessions, then ListSessions/GetSession/DestroySession
- * in separate calls would silently drop the earlier ones. The
- * Hello-only path (`registerHelloHandler` above) is preserved for callers
- * that have not yet wired a SessionManager (existing test fixtures);
- * production startup wiring (T1.7) uses this combined form.
+ * Hello, then WatchSessions, then ListSessions/GetSession/DestroySession/
+ * CreateSession in separate calls would silently drop the earlier ones.
+ * The Hello-only path (`registerHelloHandler` above) is preserved for
+ * callers that have not yet wired a SessionManager (existing test
+ * fixtures); production startup wiring (T1.7) uses this combined form.
  *
- * `readHandlersDeps` and `destroyHandlerDeps` are optional so existing
- * callers (test fixtures that built `{ helloDeps, watchSessionsDeps }`
- * before #336 / #338 landed) keep compiling without churn. In production
- * startup wiring (T1.7) all four are always supplied off the same
- * `SessionManager` instance — single owner of the sessions table; a
- * DestroySession publishes to the same in-memory event bus the
- * WatchSessions stream subscribes to.
+ * `readHandlersDeps`, `destroyHandlerDeps` and `createSessionDeps` are
+ * optional so existing callers (test fixtures that built
+ * `{ helloDeps, watchSessionsDeps }` before the per-overlay sub-tasks
+ * landed) keep compiling without churn. In production startup wiring
+ * (T1.7) all five are always supplied off the same `SessionManager`
+ * instance — single owner of the sessions table; a CreateSession
+ * publishes `created` to the same in-memory event bus the
+ * WatchSessions stream subscribes to (round-trip: create one ->
+ * watcher sees `created` event), and the new row is immediately visible
+ * to ListSessions / GetSession on the same boot.
  *
- * Methods not yet implemented (CreateSession, RenameSession, ...) remain
+ * Methods not yet implemented (RenameSession, ImportSession, ...) remain
  * `Unimplemented` per the Connect router's "absent method →
  * Unimplemented" rule, exactly as in the stub-only path.
  */
@@ -199,6 +207,7 @@ export function registerSessionService(
     readonly watchSessionsDeps: WatchSessionsDeps;
     readonly readHandlersDeps?: ReadHandlersDeps;
     readonly destroyHandlerDeps?: DestroySessionDeps;
+    readonly createSessionDeps?: CreateSessionDeps;
   },
 ): ConnectRouter {
   const impl: Parameters<typeof router.service<typeof SessionService>>[1] = {
@@ -211,6 +220,9 @@ export function registerSessionService(
   }
   if (deps.destroyHandlerDeps !== undefined) {
     impl.destroySession = makeDestroySessionHandler(deps.destroyHandlerDeps);
+  }
+  if (deps.createSessionDeps !== undefined) {
+    impl.createSession = makeCreateSessionHandler(deps.createSessionDeps);
   }
   router.service(SessionService, impl);
   return router;
@@ -256,6 +268,7 @@ export function makeDaemonRoutes(
   settingsDeps?: SettingsServiceDeps,
   draftDeps?: DraftServiceDeps,
   ptyAttachDeps?: PtyAttachDeps,
+  createSessionDeps?: CreateSessionDeps,
 ): (router: ConnectRouter) => void {
   return (router: ConnectRouter): void => {
     registerStubServices(router);
@@ -265,6 +278,7 @@ export function makeDaemonRoutes(
         watchSessionsDeps,
         readHandlersDeps,
         destroyHandlerDeps,
+        createSessionDeps,
       });
     } else {
       registerHelloHandler(router, helloDeps);
@@ -369,6 +383,25 @@ export interface CreateDaemonNodeAdapterOptions extends ConnectRouterOptions {
    */
   readonly destroyHandlerDeps?: DestroySessionDeps;
   /**
+   * When set (and `helloDeps` + `watchSessionsDeps` are also set),
+   * installs the Wave 3 §6.9 sub-task 6 (Task #339) CreateSession
+   * handler in the same SessionService registration as Hello +
+   * WatchSessions + read pair + DestroySession (see
+   * `registerSessionService` for the "registering twice replaces"
+   * caveat). Reuses the SAME `SessionManager` instance the other
+   * SessionService overlays use so a CreateSession publishes a
+   * `created` event to the same in-memory bus the WatchSessions stream
+   * subscribes to (round-trip: create one -> watcher sees `created`)
+   * and the new row is immediately visible to ListSessions /
+   * GetSession on the same boot. PTY spawn for the freshly-created
+   * session is OUT OF SCOPE here — Task #359 wires
+   * `attachPtyHost` separately so this unary handler stays decoupled
+   * from the spawn lifecycle (see `create-handler.ts` SCOPE note).
+   * Tests that don't need the create wire-up simply omit it and the
+   * method stays `Unimplemented`.
+   */
+  readonly createSessionDeps?: CreateSessionDeps;
+  /**
    * When set, installs the Wave-3 SettingsService overlay (Task #349 /
    * audit #228 sub-task 9 / spec #337 §6.1 step 1) on top of the
    * stubs. Both `GetSettings` and `UpdateSettings` ship in this
@@ -444,6 +477,7 @@ export function createDaemonNodeAdapter(
     settingsDeps,
     draftDeps,
     ptyAttachDeps,
+    createSessionDeps,
     interceptors: callerInterceptors,
     ...rest
   } = options;
@@ -458,6 +492,7 @@ export function createDaemonNodeAdapter(
           settingsDeps,
           draftDeps,
           ptyAttachDeps,
+          createSessionDeps,
         )
       : stubRoutes;
   const interceptors = [

--- a/packages/daemon/src/sessions/create-handler.ts
+++ b/packages/daemon/src/sessions/create-handler.ts
@@ -1,0 +1,223 @@
+// packages/daemon/src/sessions/create-handler.ts
+//
+// Wave-3 Task #339 — production SessionService.CreateSession Connect handler
+// (audit #228 sub-task 6).
+//
+// Audit reference: docs/superpowers/specs/2026-05-04-rpc-stub-gap-audit.md
+// (sub-task #6). Pre-#339 SessionService.CreateSession was the T2.2 empty
+// stub on the wire (`router.ts:STUB_SERVICES`), returning Connect
+// `Code.Unimplemented` despite `SessionManager.create()` (T3.2 / #38)
+// being fully implemented and unit-tested. This file is the thin adapter
+// from the proto request shape onto `SessionManager.create()` and back to
+// the proto `CreateSessionResponse`. Mirrors the read pair in
+// `sessions/read-handlers.ts`, the destroy handler in
+// `sessions/destroy-handler.ts` (Wave 3 §6.9 sub-task 7 / Task #338),
+// and the WatchSessions stream handler in `sessions/watch-sessions.ts`
+// (T3.3 / PR #939).
+//
+// Spec refs:
+//   - packages/proto/src/ccsm/v1/session.proto
+//     CreateSessionRequest = `{ meta, cwd, env, claude_args,
+//     initial_geometry }`; CreateSessionResponse = `{ meta, session }`
+//     where `session` is the just-persisted `Session` row in STARTING
+//     state (the canonical post-create proto rendering — same mapper the
+//     WatchSessions stream uses for `created` events).
+//   - docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+//     ch04 §3 (CreateSession unary RPC; principal-scoped via
+//     peerCredAuthInterceptor + SessionManager.create's owner_id wiring;
+//     the `Session.owner` echoed in the response is the caller's
+//     LocalUser variant — same shape the WatchSessions `created` event
+//     carries so a client that runs Create + WatchSessions in parallel
+//     sees identical row attribution on both paths).
+//     ch05 §6 (session create flow: id := ULID(), state := STARTING,
+//     INSERT row, publish `created` event on the in-memory bus).
+//
+// SCOPE — what this PR does NOT do:
+//   - Spawn the pty-host child for the new session. PTY spawn lifecycle
+//     is owned by Task #359 (the `attachPtyHost` call sequence runs after
+//     CreateSession returns; the new session sits in STARTING until the
+//     pty-host bridge transitions it to RUNNING). Wiring CreateSession
+//     unary RPC unblocks the v0.3 client's "create then attach" flow
+//     without coupling the unary handler to PTY spawn (the spawn path
+//     is async and would otherwise force this handler to either block on
+//     PTY ready or invent a separate "creating" state — both are spec
+//     mis-shapes). v0.3 ship plan: Create returns the STARTING row; the
+//     client immediately opens a PtyService.Attach stream against the
+//     new session id; #359 wires the spawn so the Attach stream's first
+//     frame reflects real PTY output.
+//
+// SRP layering — three roles kept separate (dev.md §2):
+//   * decider:  `decodeCreateRequest(req)` — pure. Takes the proto
+//               message and returns the manager's `CreateSessionInput`
+//               (snake_case row shape, JSON-encoded env / args). No DB,
+//               no event bus, no proto rendering. Exported so unit tests
+//               can pin the encode independently.
+//   * producer: `SessionManager.create(input, caller)` — already
+//               implemented in T3.2 / #38; this handler does NOT ship a
+//               new producer. The manager is the single source of truth
+//               for the row INSERT + event-bus publish.
+//   * sink:     `makeCreateSessionHandler(deps)` — Connect handler that
+//               reads the principal from `HandlerContext`, calls the
+//               decider + producer, and renders the proto
+//               `CreateSessionResponse` via the existing
+//               `sessionRowToProto` (same mapper the WatchSessions
+//               stream uses — single proto-mapping seam).
+//
+// Layer 1 — alternatives checked:
+//   - Re-implement row -> proto translation locally. Rejected:
+//     `sessionRowToProto` from `watch-sessions.ts` is already the
+//     canonical mapper (handles `LocalUser` owner attribution and the
+//     `exit_code === -1` sentinel). Reusing it keeps a single mapper —
+//     a future field addition only edits one place.
+//   - Pass the proto `CreateSessionRequest` directly into
+//     `SessionManager.create`. Rejected: the manager is intentionally
+//     proto-agnostic (see `sessions/types.ts` header) so unit tests do
+//     not need a proto fixture and the v0.3 / v0.4 wire shapes can
+//     evolve independently of the in-process row shape. The adapter
+//     (this file) is the right seam.
+//   - Spawn the pty-host child inline as part of CreateSession. Rejected:
+//     scope creep into Task #359 (see SCOPE note above).
+//   - Validate cwd existence / readability inside the handler. Rejected
+//     for v0.3: spec ch05 §6 places filesystem validation in the
+//     pty-host spawn path (#359), not the unary RPC — Create returns the
+//     STARTING row regardless of whether cwd is reachable, and the
+//     pty-host's spawn failure surfaces via the `ended` event with
+//     `reason='crashed'`. Coupling validation into the unary handler
+//     would either duplicate the spawn path's check or let the two
+//     diverge (classic dual source-of-truth bug).
+
+import { create } from '@bufbuild/protobuf';
+import {
+  Code,
+  ConnectError,
+  type HandlerContext,
+  type ServiceImpl,
+} from '@connectrpc/connect';
+
+import {
+  CreateSessionResponseSchema,
+  type CreateSessionRequest,
+  type SessionService,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, type Principal as AuthPrincipal } from '../auth/index.js';
+
+import type { ISessionManager } from './SessionManager.js';
+import type { CreateSessionInput } from './types.js';
+import { sessionRowToProto } from './watch-sessions.js';
+
+// ---------------------------------------------------------------------------
+// Decider — proto request -> manager input (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * Default geometry when the client omits `initial_geometry`. 80x24 is
+ * the historical terminal default; the pty-host spawn (#359) re-emits a
+ * resize event when the renderer measures its actual viewport so this
+ * value is only the "before-first-resize" floor. Exported so tests can
+ * pin the same default the production handler uses.
+ */
+export const DEFAULT_GEOMETRY_COLS = 80;
+export const DEFAULT_GEOMETRY_ROWS = 24;
+
+/**
+ * Translate a proto `CreateSessionRequest` into the row-shape input that
+ * `SessionManager.create` consumes.
+ *
+ * Encoding choices (mirrors `sessions/types.ts:CreateSessionInput`):
+ *   - `env` (proto3 `map<string,string>`) is JSON-encoded to a stable
+ *     stringified-object so the better-sqlite3 TEXT column round-trips
+ *     without per-row parsing on read. The encode is deterministic
+ *     because we sort keys before stringifying — keeps the on-disk
+ *     bytes byte-identical for the same logical input across boots
+ *     (helpful for crash/reboot row-equality checks).
+ *   - `claude_args` (proto3 `repeated string`) is JSON-encoded as an
+ *     array literal — order is part of the contract (argv positional
+ *     semantics) so we do NOT sort.
+ *   - `initial_geometry` is optional on the wire. When unset, we apply
+ *     the 80x24 default (see DEFAULT_GEOMETRY_* above). When the client
+ *     sets `cols` or `rows` to 0 we ALSO fall back to the default —
+ *     a 0-dimension PTY would crash xterm-headless on first paint and
+ *     surface as a confusing "session created then immediately died"
+ *     to the user (the right semantics is "treat 0 as 'I don't care,
+ *     use a sane default'").
+ */
+export function decodeCreateRequest(req: CreateSessionRequest): CreateSessionInput {
+  // Sort env keys for deterministic JSON. proto3 `map<>` iteration order
+  // is not guaranteed; sorted output is so a re-encode of the same map
+  // produces byte-identical TEXT in SQLite.
+  const sortedEnv: Record<string, string> = {};
+  for (const key of Object.keys(req.env).sort()) {
+    sortedEnv[key] = req.env[key];
+  }
+  const cols =
+    req.initialGeometry && req.initialGeometry.cols > 0
+      ? req.initialGeometry.cols
+      : DEFAULT_GEOMETRY_COLS;
+  const rows =
+    req.initialGeometry && req.initialGeometry.rows > 0
+      ? req.initialGeometry.rows
+      : DEFAULT_GEOMETRY_ROWS;
+  return {
+    cwd: req.cwd,
+    env_json: JSON.stringify(sortedEnv),
+    claude_args_json: JSON.stringify(req.claudeArgs),
+    geometry_cols: cols,
+    geometry_rows: rows,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Sink — Connect handler
+// ---------------------------------------------------------------------------
+
+export interface CreateSessionDeps {
+  readonly manager: ISessionManager;
+}
+
+/**
+ * Build the Connect `ServiceImpl<typeof SessionService>['createSession']`
+ * handler. Reads `PRINCIPAL_KEY` from the HandlerContext (the
+ * `peerCredAuthInterceptor` deposited it before the handler runs),
+ * decodes the proto request into the manager's row-shape input, calls
+ * `manager.create(input, principal)`, and renders the response via the
+ * shared `sessionRowToProto` mapper.
+ *
+ * Mirrors the posture of the read / destroy handlers: a missing
+ * principal is a daemon wiring bug surfaced as `Internal` rather than
+ * `Unauthenticated` (the auth interceptor would have rejected the call
+ * before this handler ran if the caller were unauthenticated).
+ *
+ * Errors raised by `manager.create()` propagate unchanged — v0.3
+ * SessionManager.create has no documented failure mode beyond the SQLite
+ * INSERT itself (PRIMARY KEY collision on the freshly-generated 26-char
+ * ULID is statistically zero; a real SQLite error is `Code.Internal`).
+ */
+export function makeCreateSessionHandler(
+  deps: CreateSessionDeps,
+): ServiceImpl<typeof SessionService>['createSession'] {
+  return async function createSession(
+    req: CreateSessionRequest,
+    handlerContext: HandlerContext,
+  ) {
+    const principal: AuthPrincipal | null = handlerContext.values.get(PRINCIPAL_KEY);
+    if (principal === null) {
+      throw new ConnectError(
+        'CreateSession handler invoked without peerCredAuthInterceptor in chain ' +
+          '(PRINCIPAL_KEY=null) — daemon wiring bug',
+        Code.Internal,
+      );
+    }
+
+    const input = decodeCreateRequest(req);
+    const row = deps.manager.create(input, principal);
+
+    return create(CreateSessionResponseSchema, {
+      // Echo request meta unchanged — same convention as Hello,
+      // GetCrashLog, ListSessions, GetSession, DestroySession. Clients
+      // correlate on request_id round-trip per spec ch04 §2.
+      meta: req.meta,
+      session: sessionRowToProto(row, principal),
+    });
+  };
+}

--- a/packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts
+++ b/packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts
@@ -102,6 +102,7 @@ import {
   DraftService,
   GetCrashLogRequestSchema,
   OwnerFilter,
+  PtyGeometrySchema,
   RequestMetaSchema,
   SessionService,
   SettingsSchema,
@@ -508,6 +509,73 @@ describe('daemon-boot end-to-end (Task #208)', () => {
     expect(raised, 'expected ConnectError on unknown session id').not.toBeNull();
     expect(raised!.code).not.toBe(Code.Unimplemented);
     expect(raised!.code).toBe(Code.PermissionDenied);
+  });
+
+  // Wave 3 §6.9 sub-task 6 (Task #339) — SessionService.CreateSession.
+  // Production wire-up regression: pre-#339 the Connect router returned
+  // `Code.Unimplemented` for SessionService.CreateSession even though
+  // `SessionManager.create()` (T3.2 / #38) was fully implemented. This
+  // assertion proves:
+  //   1. the create-handler overlay is installed in the production
+  //      bind hook (`makeRouterBindHook({ createSessionDeps })`);
+  //   2. the unary call returns a populated `Session` (id ULID-shaped,
+  //      cwd echoed, owner = caller's LocalUser principal, state =
+  //      STARTING per spec ch05 §6);
+  //   3. request_id round-trips per spec ch04 §2.
+  // PTY spawn for the freshly-created session is OUT OF SCOPE here
+  // (Task #359 wires `attachPtyHost` separately — see
+  // `sessions/create-handler.ts` SCOPE note).
+  it('Listener-A.SessionService.CreateSession does NOT return Unimplemented + round-trips a Session (Task #339)', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    expect(r.listenerA).not.toBeNull();
+    const desc = r.listenerA!.descriptor();
+    if (desc.kind !== 'KIND_TCP_LOOPBACK_H2C') return;
+    const baseUrl = `http://127.0.0.1:${desc.port}`;
+
+    // `sessions.owner_id` is FK -> `principals.id` (db/migrations/001_initial.sql
+    // L46). Production peer-cred middleware upserts the row on connect (T1.3),
+    // but the boot-e2e test bearer-token path resolves to
+    // `{ kind: 'local-user', uid: 'test', ... }` without exercising that
+    // upsert. Seed the row directly so the FK check on `manager.create`
+    // (called from inside the CreateSession handler) passes — same pattern
+    // the WatchSessions smoke uses below.
+    r.db
+      .prepare(
+        `INSERT OR IGNORE INTO principals (id, kind, display_name, first_seen_ms, last_seen_ms)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run('local-user:test', 'local-user', 'test', Date.now(), Date.now());
+
+    const client = makeSessionClient(baseUrl);
+    const meta = newMeta();
+    const resp = await client.createSession({
+      meta,
+      cwd: setup.tmpRoot, // a real, readable path on every CI leg
+      env: { CCSM_E2E: '1' },
+      claudeArgs: ['--help'],
+      initialGeometry: create(PtyGeometrySchema, { cols: 100, rows: 30 }),
+    });
+    // Reaching this line proves we did NOT get Code.Unimplemented (the
+    // pre-#339 stub baseline would have thrown ConnectError before
+    // resp was assigned). Sanity-check the payload shape now.
+    expect(resp.session).toBeDefined();
+    const sess = resp.session!;
+    // ULID-shaped id (26 chars Crockford-base32 — see SessionManager
+    // `newSessionId`). Just check length + character class to keep
+    // this assertion stable against future generator implementation
+    // tweaks.
+    expect(sess.id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+    expect(sess.cwd).toBe(setup.tmpRoot);
+    // STARTING == 1 in the proto SessionState enum (common.proto +
+    // sessions/types.ts forever-stable mapping). v0.3 SessionManager
+    // emits STARTING on create; T4.x transitions to RUNNING.
+    expect(sess.state).toBe(1);
+    // Owner principal is the local-user variant the test bearer token
+    // resolves to; we just assert the oneof case is set so a future
+    // proto change to the variant tag fails this loud.
+    expect(sess.owner?.kind?.case).toBe('localUser');
+    expect(resp.meta?.requestId).toBe(meta.requestId);
   });
 
   it('rejects unauthenticated calls (no bearer token) with Code.Unauthenticated', async () => {


### PR DESCRIPTION
## Summary

Wave-3 §6.9 sub-task 6 / audit #228 sub-task 6. Pre-#339 the Connect router returned `Code.Unimplemented` for `SessionService.CreateSession` even though `SessionManager.create()` (T3.2 / #38) was fully implemented. This PR adds the thin proto-to-row adapter and wires it into the production overlay alongside Hello / WatchSessions / read-pair / DestroySession.

- `packages/daemon/src/sessions/create-handler.ts` (NEW): pure `decodeCreateRequest` (proto -> CreateSessionInput; sorts env keys; defaults 80x24 geometry on 0/unset) + `makeCreateSessionHandler` (Connect ServiceImpl reading PRINCIPAL_KEY, calling manager.create, rendering via the shared `sessionRowToProto`).
- `packages/daemon/src/rpc/router.ts`: optional `createSessionDeps` plumbed through `registerSessionService`, `makeDaemonRoutes`, `CreateDaemonNodeAdapterOptions`.
- `packages/daemon/src/index.ts`: production startup constructs `createSessionDeps` off the SAME `sessionManager` every other SessionService overlay uses.
- `packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts`: new it() asserts the unary call no longer returns Unimplemented and round-trips a populated `Session` (ULID-shaped id, cwd echoed, state=STARTING, owner=localUser variant, request_id round-trip).

**Out of scope**: PTY spawn for the freshly-created session — Task #359 wires `attachPtyHost` separately.

## Local checks (host: windows-11)

- lint (daemon): 0 errors (warnings only — pre-existing).
- typecheck (daemon): only failure is pre-existing in `test/rpc/errors.spec.ts` (verified by stash/typecheck on origin/working).
- daemon-boot-end-to-end.spec.ts: **23/23 pass** (was 22/23 before this PR; new #339 case is the +1).
- Wider daemon vitest: pre-existing failures in 5 unrelated files (verified by stash on origin/working).

## Test plan

- [x] daemon-boot-end-to-end #339 case passes
- [x] All 22 other cases still pass (no regression)
- [x] CreateSession publishes `created` to the same SessionEventBus WatchSessions subscribes to (single SessionManager instance — guaranteed by index.ts construction)