### PR TITLE
feat(daemon)(#49): T4.13 per-subscriber AckPty backlog + AckPty handler

### DIFF
--- a/packages/daemon/src/pty-host/__tests__/fanout.spec.ts
+++ b/packages/daemon/src/pty-host/__tests__/fanout.spec.ts
@@ -1,0 +1,266 @@
+// Per-session subscriber fanout + per-subscriber ack backlog — Task #49 / T4.13.
+//
+// Spec ref: docs/superpowers/specs/2026-05-04-pty-attach-handler.md
+//   §2.3 (per-session emitter fan-out to subscribers)
+//   §4.2 (AckSubscriberState shape)
+//   §4.3 (channel.size at ACK_CHANNEL_CAPACITY (== 4096) ⇒ overflow ⇒
+//         RESOURCE_EXHAUSTED to the wire)
+//   §6.1 / §6.2 (subscriber registry lookup by (principalKey, sessionId))
+//
+// What this file covers (in addition to the existing unit tests in
+// `ack-state.spec.ts` and `pty-attach.spec.ts`):
+//
+//   1. `PtySessionEmitter` fans every `publishDelta` to EVERY live
+//      subscriber synchronously (the per-session subscriber broadcast
+//      contract that this task wires the Attach handler into).
+//
+//   2. `BoundedChannel(ACK_CHANNEL_CAPACITY)` accepts exactly 4096
+//      enqueues and the 4097th returns `'overflow'` — the
+//      load-bearing primitive behind the §4.3 RESOURCE_EXHAUSTED
+//      mapping. Pinning this at the unit level keeps the constant
+//      from drifting silently (changing `ACK_CHANNEL_CAPACITY` without
+//      re-tuning the in-memory ring would break the
+//      "kick + reconnect on overflow" recovery invariant per spec
+//      §4.5).
+//
+//   3. Subscriber registry round-trip — Attach handler registers a
+//      live `AckSubscriberState` under `(principalKey, sessionId)` and
+//      the AckPty handler can find it via `findFirstAckSubscriber`.
+//      After unregister, the lookup returns `undefined` (the §6.2
+//      no-op path the AckPty handler relies on).
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  ACK_CHANNEL_CAPACITY,
+  AckSubscriberState,
+  BoundedChannel,
+  findFirstAckSubscriber,
+  registerAckSubscriber,
+  resetAckSubscriberRegistry,
+  unregisterAckSubscriber,
+} from '../ack-state.js';
+import {
+  PtySessionEmitter,
+  resetEmitterRegistry,
+  type PtyEvent,
+} from '../pty-emitter.js';
+import type { DeltaMessage, SnapshotMessage } from '../types.js';
+
+afterEach(() => {
+  resetEmitterRegistry();
+  resetAckSubscriberRegistry();
+});
+
+function makeSnapshotIpc(baseSeq: bigint): SnapshotMessage {
+  return {
+    kind: 'snapshot',
+    baseSeq,
+    geometry: { cols: 80, rows: 24 },
+    screenState: new Uint8Array(0),
+    schemaVersion: 1,
+  };
+}
+function makeDeltaIpc(seq: bigint, payload = new Uint8Array([0xab])): DeltaMessage {
+  return {
+    kind: 'delta',
+    seq,
+    tsUnixMs: 1700000000000n + seq,
+    payload,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. PtySessionEmitter — per-session subscriber fan-out
+// ---------------------------------------------------------------------------
+
+describe('PtySessionEmitter — per-session subscriber fan-out', () => {
+  it('publishDelta synchronously broadcasts to every live subscriber', () => {
+    const emitter = new PtySessionEmitter('sess-fanout-1');
+    const eventsA: PtyEvent[] = [];
+    const eventsB: PtyEvent[] = [];
+    const eventsC: PtyEvent[] = [];
+
+    emitter.subscribe((e) => eventsA.push(e));
+    emitter.subscribe((e) => eventsB.push(e));
+    emitter.subscribe((e) => eventsC.push(e));
+
+    expect(emitter.subscriberCount()).toBe(3);
+
+    emitter.publishSnapshot(makeSnapshotIpc(0n));
+    emitter.publishDelta(makeDeltaIpc(1n));
+    emitter.publishDelta(makeDeltaIpc(2n));
+
+    for (const events of [eventsA, eventsB, eventsC]) {
+      expect(events).toHaveLength(3);
+      expect(events[0]?.kind).toBe('snapshot');
+      expect(events[1]?.kind).toBe('delta');
+      expect(events[2]?.kind).toBe('delta');
+    }
+  });
+
+  it('unsubscribed listeners stop receiving events; remaining subscribers unaffected', () => {
+    const emitter = new PtySessionEmitter('sess-fanout-2');
+    const eventsA: PtyEvent[] = [];
+    const eventsB: PtyEvent[] = [];
+
+    const unsubA = emitter.subscribe((e) => eventsA.push(e));
+    emitter.subscribe((e) => eventsB.push(e));
+
+    emitter.publishDelta(makeDeltaIpc(1n));
+    unsubA();
+    emitter.publishDelta(makeDeltaIpc(2n));
+
+    expect(eventsA).toHaveLength(1);
+    expect(eventsB).toHaveLength(2);
+    expect(emitter.subscriberCount()).toBe(1);
+  });
+
+  it('close() broadcasts the terminal "closed" event to every subscriber exactly once', () => {
+    const emitter = new PtySessionEmitter('sess-fanout-3');
+    const eventsA: PtyEvent[] = [];
+    const eventsB: PtyEvent[] = [];
+    emitter.subscribe((e) => eventsA.push(e));
+    emitter.subscribe((e) => eventsB.push(e));
+
+    emitter.close();
+    expect(emitter.isClosed()).toBe(true);
+    expect(eventsA).toHaveLength(1);
+    expect(eventsB).toHaveLength(1);
+    expect(eventsA[0]?.kind).toBe('closed');
+    expect(eventsB[0]?.kind).toBe('closed');
+
+    // Idempotent: a second close does NOT re-broadcast.
+    emitter.close();
+    expect(eventsA).toHaveLength(1);
+    expect(eventsB).toHaveLength(1);
+
+    // Subsequent publish* calls are no-ops on a closed emitter.
+    emitter.publishDelta(makeDeltaIpc(1n));
+    expect(eventsA).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. BoundedChannel — backlog>4096 ⇒ 'overflow' (RESOURCE_EXHAUSTED at wire)
+// ---------------------------------------------------------------------------
+
+describe('BoundedChannel(ACK_CHANNEL_CAPACITY) — §4.3 overflow', () => {
+  it('ACK_CHANNEL_CAPACITY is the spec-pinned 4096', () => {
+    expect(ACK_CHANNEL_CAPACITY).toBe(4096);
+  });
+
+  it('accepts exactly ACK_CHANNEL_CAPACITY enqueues; the next call returns "overflow"', () => {
+    const channel = new BoundedChannel<number>(ACK_CHANNEL_CAPACITY);
+    for (let i = 0; i < ACK_CHANNEL_CAPACITY; i += 1) {
+      expect(channel.enqueue(i)).toBe('ok');
+    }
+    expect(channel.size).toBe(ACK_CHANNEL_CAPACITY);
+    expect(channel.isFull).toBe(true);
+    expect(channel.enqueue(99999)).toBe('overflow');
+    // Overflow does NOT mutate the channel — size unchanged.
+    expect(channel.size).toBe(ACK_CHANNEL_CAPACITY);
+  });
+
+  it('after one dequeue the channel accepts one more enqueue (FIFO recovery)', () => {
+    const channel = new BoundedChannel<number>(ACK_CHANNEL_CAPACITY);
+    for (let i = 0; i < ACK_CHANNEL_CAPACITY; i += 1) {
+      channel.enqueue(i);
+    }
+    expect(channel.enqueue(0)).toBe('overflow');
+    expect(channel.dequeue()).toBe(0); // FIFO head
+    expect(channel.size).toBe(ACK_CHANNEL_CAPACITY - 1);
+    expect(channel.enqueue(ACK_CHANNEL_CAPACITY)).toBe('ok');
+    expect(channel.size).toBe(ACK_CHANNEL_CAPACITY);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. AckSubscriberState — backlog math at the §4.3 boundary
+// ---------------------------------------------------------------------------
+
+describe('AckSubscriberState — backlog at the §4.3 boundary', () => {
+  it('unackedBacklog equals capacity when the subscriber has delivered ACK_CHANNEL_CAPACITY frames without ack', () => {
+    const sub = new AckSubscriberState({
+      subscriberId: 'sub-1',
+      sessionId: 'sess-1',
+      initialSeq: 0n,
+    });
+    for (let i = 1; i <= ACK_CHANNEL_CAPACITY; i += 1) {
+      sub.onDelivered(BigInt(i));
+    }
+    expect(sub.lastDeliveredSeq).toBe(BigInt(ACK_CHANNEL_CAPACITY));
+    expect(sub.lastAckedSeq).toBe(0n);
+    expect(sub.unackedBacklog).toBe(BigInt(ACK_CHANNEL_CAPACITY));
+  });
+
+  it('after a full ack of the 4096th delivered frame backlog returns to zero', () => {
+    const sub = new AckSubscriberState({
+      subscriberId: 'sub-2',
+      sessionId: 'sess-2',
+      initialSeq: 0n,
+    });
+    for (let i = 1; i <= ACK_CHANNEL_CAPACITY; i += 1) {
+      sub.onDelivered(BigInt(i));
+    }
+    const verdict = sub.onAck(BigInt(ACK_CHANNEL_CAPACITY));
+    expect(verdict.kind).toBe('ok');
+    expect(sub.unackedBacklog).toBe(0n);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Per-(principalKey, sessionId) subscriber registry round-trip
+// ---------------------------------------------------------------------------
+
+describe('subscriber registry — register / lookup / unregister', () => {
+  it('registerAckSubscriber + findFirstAckSubscriber round-trip', () => {
+    const sub = new AckSubscriberState({
+      subscriberId: 'sub-3',
+      sessionId: 'sess-reg-1',
+      initialSeq: 0n,
+    });
+    expect(findFirstAckSubscriber('local-user:1000', 'sess-reg-1')).toBeUndefined();
+    registerAckSubscriber('local-user:1000', sub);
+    expect(findFirstAckSubscriber('local-user:1000', 'sess-reg-1')).toBe(sub);
+    // Different principal — same sessionId — does NOT match.
+    expect(findFirstAckSubscriber('local-user:2000', 'sess-reg-1')).toBeUndefined();
+    // Different sessionId — same principal — does NOT match.
+    expect(findFirstAckSubscriber('local-user:1000', 'sess-other')).toBeUndefined();
+  });
+
+  it('multiple subscribers under the same key yield insertion order (spec §6.1 "FIRST matching")', () => {
+    const subA = new AckSubscriberState({
+      subscriberId: 'a',
+      sessionId: 'sess-multi',
+      initialSeq: 0n,
+    });
+    const subB = new AckSubscriberState({
+      subscriberId: 'b',
+      sessionId: 'sess-multi',
+      initialSeq: 0n,
+    });
+    registerAckSubscriber('local-user:1000', subA);
+    registerAckSubscriber('local-user:1000', subB);
+    expect(findFirstAckSubscriber('local-user:1000', 'sess-multi')).toBe(subA);
+
+    // Removing the first promotes the second.
+    expect(unregisterAckSubscriber('local-user:1000', subA)).toBe(true);
+    expect(findFirstAckSubscriber('local-user:1000', 'sess-multi')).toBe(subB);
+
+    // Removing the second clears the bucket entirely.
+    expect(unregisterAckSubscriber('local-user:1000', subB)).toBe(true);
+    expect(findFirstAckSubscriber('local-user:1000', 'sess-multi')).toBeUndefined();
+  });
+
+  it('unregister is idempotent — removing twice returns false the second time', () => {
+    const sub = new AckSubscriberState({
+      subscriberId: 'sub-x',
+      sessionId: 'sess-idem',
+      initialSeq: 0n,
+    });
+    registerAckSubscriber('local-user:1000', sub);
+    expect(unregisterAckSubscriber('local-user:1000', sub)).toBe(true);
+    expect(unregisterAckSubscriber('local-user:1000', sub)).toBe(false);
+  });
+});

--- a/packages/daemon/src/pty-host/ack-state.ts
+++ b/packages/daemon/src/pty-host/ack-state.ts
@@ -361,3 +361,110 @@ export interface DeltaEnvelope {
   readonly tsUnixMs: bigint;
   readonly payload: Uint8Array;
 }
+
+// ---------------------------------------------------------------------------
+// Per-(principalKey, sessionId) subscriber registry — Task #49 / T4.13.
+// ---------------------------------------------------------------------------
+//
+// The Attach handler (`requires_ack=true` path) instantiates an
+// {@link AckSubscriberState} per server-streaming RPC, registers it under
+// the calling principal + session, and unregisters in `finally`. The
+// AckPty companion handler (spec §6.1) looks the subscriber up by the
+// SAME (principalKey, sessionId) tuple — `principalKey` because v0.4
+// multi-principal needs subscriber isolation; `sessionId` because every
+// AckPty RPC carries `session_id`.
+//
+// Multi-Attach overlap: spec §6.1 says "the AckPty handler looks it up
+// by (principalKey, session_id) returning the FIRST matching subscriber
+// whose channel has been awaiting an ack". Implementation-wise: each
+// (principalKey, sessionId) maps to an INSERTION-ORDERED set; FIRST
+// here means "earliest still-attached subscriber". Reattach overlap is
+// rare and the wrong-stream ack is benign per spec ("the right
+// subscriber will hit a stalled-ack watchdog within 30s").
+//
+// SRP (dev.md §2): this is pure data + pure mutators (Map insert /
+// delete / lookup). No I/O, no proto, no Connect imports. The
+// rpc/pty-attach.ts and rpc/ackpty.ts handlers compose this.
+
+/**
+ * Composite key string used as the registry Map key. Format:
+ * `${principalKey}\x1f${sessionId}` — a single ASCII US (0x1f) separator
+ * keeps the encoding unambiguous (neither principalKey nor sessionId
+ * may contain US per their respective format docs: principalKey is
+ * `<kind>:<uid|sid>`; sessionId is a ULID — both ASCII-safe).
+ */
+function registryKey(principalKey: string, sessionId: string): string {
+  return `${principalKey}\x1f${sessionId}`;
+}
+
+const SUBSCRIBER_REGISTRY = new Map<string, Set<AckSubscriberState>>();
+
+/**
+ * Register a subscriber under the (principalKey, sessionId) tuple.
+ * Insertion-ordered into a Set so {@link findFirstAckSubscriber} returns
+ * the earliest-attached overlap candidate per spec §6.1.
+ *
+ * Idempotent on re-registering the same instance (Set semantics).
+ */
+export function registerAckSubscriber(
+  principalKey: string,
+  subscriber: AckSubscriberState,
+): void {
+  const key = registryKey(principalKey, subscriber.sessionId);
+  let bucket = SUBSCRIBER_REGISTRY.get(key);
+  if (bucket === undefined) {
+    bucket = new Set<AckSubscriberState>();
+    SUBSCRIBER_REGISTRY.set(key, bucket);
+  }
+  bucket.add(subscriber);
+}
+
+/**
+ * Remove a subscriber from the registry. Called from the Attach
+ * handler's `finally` block on stream teardown. Returns `true` if the
+ * subscriber was registered (and is now removed); `false` if it was
+ * already gone (idempotent — safe to re-enter from a defensive cleanup
+ * path).
+ */
+export function unregisterAckSubscriber(
+  principalKey: string,
+  subscriber: AckSubscriberState,
+): boolean {
+  const key = registryKey(principalKey, subscriber.sessionId);
+  const bucket = SUBSCRIBER_REGISTRY.get(key);
+  if (bucket === undefined) return false;
+  const removed = bucket.delete(subscriber);
+  if (bucket.size === 0) {
+    SUBSCRIBER_REGISTRY.delete(key);
+  }
+  return removed;
+}
+
+/**
+ * Look up the FIRST (earliest-registered, still-attached) ack subscriber
+ * for a (principalKey, sessionId). Returns `undefined` if no subscriber
+ * is registered — the AckPty handler maps that to a no-op OK reply per
+ * spec §6.2 (covers `requires_ack=false` Attach, post-disconnect race,
+ * and badly-ordered clients uniformly).
+ *
+ * Set iteration order is insertion order in V8 / per ECMAScript spec —
+ * FIRST is well-defined.
+ */
+export function findFirstAckSubscriber(
+  principalKey: string,
+  sessionId: string,
+): AckSubscriberState | undefined {
+  const bucket = SUBSCRIBER_REGISTRY.get(registryKey(principalKey, sessionId));
+  if (bucket === undefined) return undefined;
+  for (const sub of bucket) return sub;
+  return undefined;
+}
+
+/**
+ * Test seam: clear the registry. NOT for production use. Unit tests
+ * call this in `afterEach` so subscribers from one `it` case do not
+ * leak into the next.
+ */
+export function resetAckSubscriberRegistry(): void {
+  SUBSCRIBER_REGISTRY.clear();
+}

--- a/packages/daemon/src/pty-host/host.ts
+++ b/packages/daemon/src/pty-host/host.ts
@@ -16,8 +16,14 @@
 //
 // SRP: this module is a *producer* of child handles (lifecycle events).
 // It does NOT decide UTF-8 env (that is `spawn-env.ts`), it does NOT
-// touch SQLite (T5.x), and it does NOT fan delta bytes out to Connect
-// streams (T4.13). Each of those is a separate module.
+// touch SQLite (T5.x), and it does NOT own per-subscriber Connect-stream
+// fan-out (the per-session in-memory broadcast lives in
+// `pty-emitter.ts`'s `PtySessionEmitter`; per-subscriber backpressure +
+// AckPty watermark live in `rpc/pty-attach.ts` per Task #49 / T4.13).
+// host.ts only routes child→host IPC `delta` / `snapshot` IPCs into the
+// per-session emitter (and into the SQLite coalescer when one is
+// injected for T4.11a); the emitter itself fans them out to every
+// subscribed Attach stream.
 
 import { fork, type ChildProcess } from 'node:child_process';
 import { fileURLToPath } from 'node:url';

--- a/packages/daemon/src/rpc/pty-attach.spec.ts
+++ b/packages/daemon/src/rpc/pty-attach.spec.ts
@@ -46,6 +46,7 @@ import {
   ATTACH_FAST_PATH_BUFFER_SIZE,
   awaitSnapshot,
   deltaToFrame,
+  makeAckPtyHandler,
   makeAttachHandler,
   sessionStateChangedToFrame,
   snapshotToFrame,
@@ -54,6 +55,10 @@ import {
   type PtyEmitterListener,
   type PtySessionEmitterLike,
 } from './pty-attach.js';
+import {
+  AckPtyRequestSchema,
+} from '@ccsm/proto';
+import { resetAckSubscriberRegistry } from '../pty-host/ack-state.js';
 
 // ---------------------------------------------------------------------------
 // Fake emitter — mirrors PR #1027 PtySessionEmitter contract for the
@@ -753,3 +758,233 @@ async function drainExpectError(iter: AsyncIterable<unknown>): Promise<ConnectEr
   }
   throw new Error('expected the stream to error, but it ended cleanly');
 }
+
+// ---------------------------------------------------------------------------
+// AckPty handler — Task #49 / T4.13 (spec §6).
+// ---------------------------------------------------------------------------
+
+function makeFullPtyTransport(
+  registry: Map<string, FakeEmitter>,
+): ReturnType<typeof createRouterTransport> {
+  const deps: PtyAttachDeps = {
+    getEmitter: (id) => registry.get(id),
+  };
+  return createRouterTransport(
+    (router) => {
+      router.service(PtyService, {
+        attach: makeAttachHandler(deps),
+        ackPty: makeAckPtyHandler(deps),
+      });
+    },
+    {
+      router: { interceptors: [depositPrincipal] },
+    },
+  );
+}
+
+describe('PtyService.AckPty handler — spec §6', () => {
+  afterEach(() => {
+    // The Attach handler registers subscribers in a module-level Map
+    // keyed by (principalKey, sessionId); resetting between cases keeps
+    // a stranded listener from one `it` from being found by the next.
+    resetAckSubscriberRegistry();
+  });
+
+  it('§6.2 — no live ack subscriber (requires_ack=false attach) ⇒ OK with daemon_max_seq', async () => {
+    const emitter = new FakeEmitter('sess-ack-1');
+    emitter.publishSnapshot(makeSnapshot(0n));
+    emitter.publishDelta(makeDelta(1n));
+    emitter.publishDelta(makeDelta(2n));
+    const registry = new Map([['sess-ack-1', emitter]]);
+    const transport = makeFullPtyTransport(registry);
+    const client = createClient(PtyService, transport);
+
+    const res = await client.ackPty(
+      create(AckPtyRequestSchema, {
+        meta: create(RequestMetaSchema, { requestId: 'req-1' }),
+        sessionId: 'sess-ack-1',
+        appliedSeq: 5n, // intentionally bogus — §6.2 path ignores it
+      }),
+    );
+    expect(res.daemonMaxSeq).toBe(2n);
+  });
+
+  it('unknown session id ⇒ Code.NotFound + pty.session_not_found', async () => {
+    const registry = new Map<string, FakeEmitter>();
+    const transport = makeFullPtyTransport(registry);
+    const client = createClient(PtyService, transport);
+
+    await expect(
+      client.ackPty(
+        create(AckPtyRequestSchema, {
+          meta: create(RequestMetaSchema, { requestId: 'req-2' }),
+          sessionId: 'sess-missing',
+          appliedSeq: 0n,
+        }),
+      ),
+    ).rejects.toMatchObject({
+      code: Code.NotFound,
+    });
+  });
+
+  it('§6.1 — happy path advances lastAckedSeq + returns daemon_max_seq', async () => {
+    const emitter = new FakeEmitter('sess-ack-2');
+    emitter.publishSnapshot(makeSnapshot(0n));
+    const registry = new Map([['sess-ack-2', emitter]]);
+    const transport = makeFullPtyTransport(registry);
+    const client = createClient(PtyService, transport);
+
+    // Open a requires_ack=true Attach, drain warm-up snapshot + 2
+    // deltas, then send AckPty.
+    const stream = client.attach(makeReq({ sessionId: 'sess-ack-2', requiresAck: true }));
+    const ai = stream[Symbol.asyncIterator]();
+    const fSnap = await ai.next();
+    expect(fSnap.value?.kind.case).toBe('snapshot');
+
+    emitter.publishDelta(makeDelta(1n));
+    emitter.publishDelta(makeDelta(2n));
+    const fD1 = await ai.next();
+    expect(fD1.value?.kind.case).toBe('delta');
+    const fD2 = await ai.next();
+    expect(fD2.value?.kind.case).toBe('delta');
+
+    const ack = await client.ackPty(
+      create(AckPtyRequestSchema, {
+        meta: create(RequestMetaSchema, { requestId: 'req-3' }),
+        sessionId: 'sess-ack-2',
+        appliedSeq: 2n,
+      }),
+    );
+    expect(ack.daemonMaxSeq).toBe(2n);
+
+    // Idempotent re-ack at the same seq is benign (spec §6.1 "applied_seq
+    // == lastAckedSeq is benign").
+    const ack2 = await client.ackPty(
+      create(AckPtyRequestSchema, {
+        meta: create(RequestMetaSchema, { requestId: 'req-3b' }),
+        sessionId: 'sess-ack-2',
+        appliedSeq: 2n,
+      }),
+    );
+    expect(ack2.daemonMaxSeq).toBe(2n);
+
+    await ai.return?.(undefined);
+  });
+
+  it('§6.1 overrun — applied_seq > lastDeliveredSeq ⇒ Code.InvalidArgument + pty.ack_overrun', async () => {
+    const emitter = new FakeEmitter('sess-ack-3');
+    emitter.publishSnapshot(makeSnapshot(0n));
+    const registry = new Map([['sess-ack-3', emitter]]);
+    const transport = makeFullPtyTransport(registry);
+    const client = createClient(PtyService, transport);
+
+    const stream = client.attach(makeReq({ sessionId: 'sess-ack-3', requiresAck: true }));
+    const ai = stream[Symbol.asyncIterator]();
+    await ai.next(); // warm-up snapshot
+    emitter.publishDelta(makeDelta(1n));
+    await ai.next(); // delta 1 (lastDeliveredSeq=1)
+
+    let caught: ConnectError | null = null;
+    try {
+      await client.ackPty(
+        create(AckPtyRequestSchema, {
+          meta: create(RequestMetaSchema, { requestId: 'req-4' }),
+          sessionId: 'sess-ack-3',
+          appliedSeq: 5n, // > lastDeliveredSeq (1n)
+        }),
+      );
+    } catch (err) {
+      if (err instanceof ConnectError) caught = err;
+      else throw err;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught?.code).toBe(Code.InvalidArgument);
+    expect(readErrorDetail(caught)?.code).toBe('pty.ack_overrun');
+
+    await ai.return?.(undefined);
+  });
+
+  it('§6.1 regress — applied_seq < lastAckedSeq ⇒ Code.InvalidArgument + pty.ack_regress', async () => {
+    const emitter = new FakeEmitter('sess-ack-4');
+    emitter.publishSnapshot(makeSnapshot(0n));
+    const registry = new Map([['sess-ack-4', emitter]]);
+    const transport = makeFullPtyTransport(registry);
+    const client = createClient(PtyService, transport);
+
+    const stream = client.attach(makeReq({ sessionId: 'sess-ack-4', requiresAck: true }));
+    const ai = stream[Symbol.asyncIterator]();
+    await ai.next(); // snapshot
+    emitter.publishDelta(makeDelta(1n));
+    emitter.publishDelta(makeDelta(2n));
+    await ai.next();
+    await ai.next(); // lastDeliveredSeq=2
+
+    // Advance lastAckedSeq to 2.
+    await client.ackPty(
+      create(AckPtyRequestSchema, {
+        meta: create(RequestMetaSchema, { requestId: 'req-5a' }),
+        sessionId: 'sess-ack-4',
+        appliedSeq: 2n,
+      }),
+    );
+
+    // Now try to regress to 1.
+    let caught: ConnectError | null = null;
+    try {
+      await client.ackPty(
+        create(AckPtyRequestSchema, {
+          meta: create(RequestMetaSchema, { requestId: 'req-5b' }),
+          sessionId: 'sess-ack-4',
+          appliedSeq: 1n,
+        }),
+      );
+    } catch (err) {
+      if (err instanceof ConnectError) caught = err;
+      else throw err;
+    }
+    expect(caught).not.toBeNull();
+    expect(caught?.code).toBe(Code.InvalidArgument);
+    expect(readErrorDetail(caught)?.code).toBe('pty.ack_regress');
+
+    await ai.return?.(undefined);
+  });
+
+  it('subscriber unregisters after Attach stream ends — late AckPty falls through to §6.2 no-op', async () => {
+    const emitter = new FakeEmitter('sess-ack-5');
+    emitter.publishSnapshot(makeSnapshot(0n));
+    const registry = new Map([['sess-ack-5', emitter]]);
+    const transport = makeFullPtyTransport(registry);
+    const client = createClient(PtyService, transport);
+
+    const ac = new AbortController();
+    const stream = client.attach(makeReq({ sessionId: 'sess-ack-5', requiresAck: true }), {
+      signal: ac.signal,
+    });
+    const ai = stream[Symbol.asyncIterator]();
+    await ai.next(); // snapshot
+    ac.abort();
+    // Drain to terminal so the server-side finally block runs the
+    // registry unregister before we send the next AckPty.
+    try {
+      for (;;) {
+        const r = await ai.next();
+        if (r.done === true) break;
+      }
+    } catch {
+      // Aborted — expected.
+    }
+
+    // After teardown, AckPty for this principal+session must fall to
+    // §6.2 (OK with daemon_max_seq, no validation against the (now
+    // unregistered) subscriber). A garbage applied_seq must NOT trip
+    // overrun/regress.
+    const res = await client.ackPty(
+      create(AckPtyRequestSchema, {
+        meta: create(RequestMetaSchema, { requestId: 'req-6' }),
+        sessionId: 'sess-ack-5',
+        appliedSeq: 9999n,
+      }),
+    );
+    expect(res.daemonMaxSeq).toBe(0n);
+  });
+});

--- a/packages/daemon/src/rpc/pty-attach.ts
+++ b/packages/daemon/src/rpc/pty-attach.ts
@@ -81,6 +81,7 @@ import {
   type HandlerContext,
   type ServiceImpl,
 } from '@connectrpc/connect';
+import { randomUUID } from 'node:crypto';
 
 import {
   ErrorDetailSchema,
@@ -90,12 +91,15 @@ import {
   PtySessionStateChangedSchema,
   PtySnapshotSchema,
   SessionState,
+  type AckPtyRequest,
+  type AckPtyResponse,
   type AttachRequest,
   type PtyFrame,
   type PtyService,
 } from '@ccsm/proto';
+import { AckPtyResponseSchema, RequestMetaSchema } from '@ccsm/proto';
 
-import { PRINCIPAL_KEY } from '../auth/index.js';
+import { PRINCIPAL_KEY, principalKey as toPrincipalKey } from '../auth/index.js';
 import {
   decideAttachResume,
   type DeltaInMem,
@@ -104,7 +108,11 @@ import {
 } from '../pty-host/attach-decider.js';
 import {
   ACK_CHANNEL_CAPACITY,
+  AckSubscriberState,
   BoundedChannel,
+  findFirstAckSubscriber,
+  registerAckSubscriber,
+  unregisterAckSubscriber,
 } from '../pty-host/ack-state.js';
 
 // ---------------------------------------------------------------------------
@@ -235,7 +243,9 @@ export type PtyAttachErrorCode =
   | 'pty.attach_too_far_behind'
   | 'pty.attach_future_seq'
   | 'pty.session_destroyed'
-  | 'pty.subscriber_channel_full';
+  | 'pty.subscriber_channel_full'
+  | 'pty.ack_overrun'
+  | 'pty.ack_regress';
 
 const PTY_ERROR_CODE_TO_CONNECT: Record<PtyAttachErrorCode, Code> = {
   // §1 (this handler) — session id resolves to no live emitter. Map to
@@ -251,6 +261,11 @@ const PTY_ERROR_CODE_TO_CONNECT: Record<PtyAttachErrorCode, Code> = {
   'pty.session_destroyed': Code.Canceled,
   // §4.3 — `requires_ack=true` per-subscriber channel overflow.
   'pty.subscriber_channel_full': Code.ResourceExhausted,
+  // §6.1 — AckPty applied_seq > lastDeliveredSeq (client claimed to
+  // have applied a frame the daemon never sent).
+  'pty.ack_overrun': Code.InvalidArgument,
+  // §6.1 — AckPty applied_seq < lastAckedSeq (regressing ack).
+  'pty.ack_regress': Code.InvalidArgument,
 };
 
 function ptyError(
@@ -641,6 +656,34 @@ export function makeAttachHandler(
       ? 'pty.subscriber_channel_full'
       : 'pty.subscriber_channel_full';
 
+    // §4.2 / §6 — Task #49 / T4.13: per-subscriber ack-state. Constructed
+    // ONLY for `requires_ack=true` Attach streams. Registered under
+    // (principalKey, sessionId) so the AckPty companion handler can
+    // look it up by the same tuple (spec §6.1). The `requires_ack=false`
+    // fast path skips this entirely — AckPty for those subscribers is a
+    // no-op OK reply per §6.2 (covered by `findFirstAckSubscriber`
+    // returning undefined).
+    //
+    // `lastDeliveredSeq` advances via `subscriber.onDelivered(seq)` after
+    // every delta this generator yields onto the wire (both warm-up and
+    // steady-state). `lastAckedSeq` advances via the AckPty handler.
+    // `unackedBacklog = lastDeliveredSeq - lastAckedSeq` is the spec §4.3
+    // watchdog input; the producer-side overflow guard (channel.size at
+    // capacity) fires first in normal operation, but `unackedBacklog` is
+    // the load-bearing value AckPty queries on every tick.
+    const principalCanonicalKey = toPrincipalKey(principal);
+    const ackSubscriber: AckSubscriberState | null = requiresAck
+      ? new AckSubscriberState({
+          subscriberId: randomUUID(),
+          sessionId,
+          initialSeq: sinceSeq,
+          channelCapacity: ACK_CHANNEL_CAPACITY,
+        })
+      : null;
+    if (ackSubscriber !== null) {
+      registerAckSubscriber(principalCanonicalKey, ackSubscriber);
+    }
+
     // Producer→consumer rendezvous primitive. The emitter listener
     // resolves a pending `next()`; if no consumer is waiting it appends
     // to the channel. Mirrors the watch-sessions.ts adapter shape
@@ -712,6 +755,17 @@ export function makeAttachHandler(
       } else {
         // deltas_only — replay the (sinceSeq, currentMaxSeq] slice.
         for (const delta of verdict.deltas) {
+          // §4.2 onDelivered BEFORE the yield: at the moment the
+          // generator surrenders the frame to the Connect transport
+          // it is committed to deliver — even if the client cancels
+          // mid-await, no later delta is ever sent. Bumping the
+          // watermark first means an AckPty arriving in the same tick
+          // (e.g. the renderer pipelines acks aggressively) sees a
+          // consistent (lastDeliveredSeq, lastAckedSeq) snapshot and
+          // does not spuriously trip §6.1 ack_overrun.
+          if (ackSubscriber !== null) {
+            ackSubscriber.onDelivered(delta.seq);
+          }
           yield deltaToFrame(delta);
         }
       }
@@ -727,6 +781,9 @@ export function makeAttachHandler(
         while (true) {
           const delta = channel.dequeue();
           if (delta === undefined) break;
+          if (ackSubscriber !== null) {
+            ackSubscriber.onDelivered(delta.seq);
+          }
           yield deltaToFrame(delta);
         }
 
@@ -822,6 +879,13 @@ export function makeAttachHandler(
       detachAbort();
       unsubscribe();
       channel.clear();
+      // Task #49 / T4.13: drop the per-subscriber ack-state from the
+      // (principalKey, sessionId) registry so a late AckPty RPC for this
+      // closed stream falls through to the spec §6.2 no-op path. Safe to
+      // call when ackSubscriber is null (requires_ack=false fast path).
+      if (ackSubscriber !== null) {
+        unregisterAckSubscriber(principalCanonicalKey, ackSubscriber);
+      }
       // Wake any straggler resolver so a Promise we're not awaiting
       // does not pin GC. (Defensive — by construction we never `await`
       // after entering `finally`.)
@@ -831,5 +895,115 @@ export function makeAttachHandler(
         resolve(null);
       }
     }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// AckPty companion handler — Task #49 / T4.13 (spec §6).
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the `PtyService.AckPty` unary handler. Spec
+ * `2026-05-04-pty-attach-handler.md` §6.
+ *
+ * Lookup is by `(principalKey(principal), session_id)` against the
+ * module-level subscriber registry that the Attach handler populates on
+ * `requires_ack=true` streams. When no subscriber is registered (the
+ * three §6.2 cases — `requires_ack=false`, post-disconnect race,
+ * out-of-order client) the handler returns OK with
+ * `daemon_max_seq = emitter.currentMaxSeq` and does NOT touch any state.
+ *
+ * Validation failures (`pty.ack_overrun`, `pty.ack_regress`) become
+ * `Code.InvalidArgument` ConnectError responses with the same
+ * forever-stable error code strings the renderer instruments on. The
+ * pure decider lives on {@link AckSubscriberState.onAck}; this handler
+ * is the (sink) wire boundary that converts the decider verdict to
+ * Connect responses.
+ */
+export function makeAckPtyHandler(
+  deps: PtyAttachDeps,
+): ServiceImpl<typeof PtyService>['ackPty'] {
+  return async function ackPty(
+    req: AckPtyRequest,
+    handlerContext: HandlerContext,
+  ): Promise<AckPtyResponse> {
+    // Defensive: peerCredAuthInterceptor MUST have run. Mirrors the
+    // posture in `attach` above + hello.ts / watch-sessions.ts.
+    const principal = handlerContext.values.get(PRINCIPAL_KEY);
+    if (principal === null) {
+      throw new ConnectError(
+        'PtyService.AckPty handler invoked without peerCredAuthInterceptor in chain ' +
+          '(PRINCIPAL_KEY=null) — daemon wiring bug',
+        Code.Internal,
+      );
+    }
+
+    const sessionId = req.sessionId;
+    if (sessionId.length === 0) {
+      throw ptyError(
+        'pty.session_not_found',
+        'AckPtyRequest.session_id MUST be non-empty',
+      );
+    }
+
+    // §6.1 lookup: (principalKey, sessionId) → first matching ack
+    // subscriber. The emitter is consulted in BOTH §6.1 (advance
+    // watermark + return daemon_max_seq) and §6.2 (no-op return
+    // daemon_max_seq) so we resolve it up front.
+    const emitter = deps.getEmitter(sessionId);
+    if (emitter === undefined) {
+      // Spec §6.2 covers the "no live subscriber" case as a no-op OK,
+      // BUT a totally unknown session id is distinct from "session
+      // exists, no ack subscriber on this principal". The Attach
+      // handler maps unknown id to NotFound; mirroring that here keeps
+      // the two RPCs symmetric for the typo case while still allowing
+      // §6.2 no-op behavior when the session exists but the calling
+      // principal has no live `requires_ack=true` Attach.
+      throw ptyError(
+        'pty.session_not_found',
+        `no live pty session with id=${sessionId}`,
+        { session_id: sessionId },
+      );
+    }
+
+    const subscriber = findFirstAckSubscriber(
+      toPrincipalKey(principal),
+      sessionId,
+    );
+
+    if (subscriber === undefined) {
+      // §6.2 — no-op OK reply. Covers requires_ack=false subscriber,
+      // post-disconnect race, and out-of-order AckPty (RPC arrives
+      // before the matching Attach). All three return the same shape:
+      // OK with daemon_max_seq and no state mutation.
+      return create(AckPtyResponseSchema, {
+        meta: create(RequestMetaSchema, {}),
+        daemonMaxSeq: emitter.currentMaxSeq(),
+      });
+    }
+
+    // §6.1 — validated ack on a live `requires_ack=true` subscriber.
+    const verdict = subscriber.onAck(req.appliedSeq);
+    if (verdict.kind === 'rejected') {
+      throw ptyError(
+        verdict.reason,
+        verdict.reason === 'pty.ack_overrun'
+          ? `applied_seq=${verdict.appliedSeq} exceeds last_delivered_seq=${verdict.lastDeliveredSeq}; ` +
+              'client cannot ack a frame the daemon never sent'
+          : `applied_seq=${verdict.appliedSeq} regresses below last_acked_seq=${verdict.lastAckedSeq}; ` +
+              'acks must be monotonically non-decreasing',
+        {
+          session_id: sessionId,
+          applied_seq: String(verdict.appliedSeq),
+          last_delivered_seq: String(verdict.lastDeliveredSeq),
+          last_acked_seq: String(verdict.lastAckedSeq),
+        },
+      );
+    }
+
+    return create(AckPtyResponseSchema, {
+      meta: create(RequestMetaSchema, {}),
+      daemonMaxSeq: emitter.currentMaxSeq(),
+    });
   };
 }

--- a/packages/daemon/src/rpc/router.ts
+++ b/packages/daemon/src/rpc/router.ts
@@ -81,7 +81,7 @@ import { registerCrashService, type CrashServiceDeps } from './crash/register.js
 import { registerDraftService, type DraftServiceDeps } from './draft/register.js';
 import { makeHelloHandler, type HelloDeps } from './hello.js';
 import { requestMetaInterceptor } from './middleware/request-meta.js';
-import { makeAttachHandler, type PtyAttachDeps } from './pty-attach.js';
+import { makeAttachHandler, makeAckPtyHandler, type PtyAttachDeps } from './pty-attach.js';
 import {
   registerSettingsService,
   type SettingsServiceDeps,
@@ -230,10 +230,11 @@ export function registerSessionService(
 
 /**
  * Register the v0.3 PtyService.Attach handler (Wave 3 §6.9 sub-task 10 /
- * Task #355 / spec `2026-05-04-pty-attach-handler.md` §9.2 T-PA-6).
+ * Task #355 / spec `2026-05-04-pty-attach-handler.md` §9.2 T-PA-6) AND
+ * the AckPty companion handler (Task #49 / T4.13 / spec §6).
  *
- * REPLACES the stub `{}` registration for PtyService with `{ attach }`.
- * Other PtyService methods (SendInput / Resize / AckPty /
+ * REPLACES the stub `{}` registration for PtyService with
+ * `{ attach, ackPty }`. Other PtyService methods (SendInput / Resize /
  * CheckClaudeAvailable) stay `Code.Unimplemented` per the
  * "absent-method → unimplemented" Connect router rule until their
  * owning tasks land. The combined-registration caveat that applies to
@@ -248,6 +249,7 @@ export function registerPtyService(
 ): ConnectRouter {
   router.service(PtyService, {
     attach: makeAttachHandler(deps),
+    ackPty: makeAckPtyHandler(deps),
   });
   return router;
 }


### PR DESCRIPTION
Closes Task #49 / T4.13.

Wires the per-(principalKey, sessionId) ack-subscriber registry into
the existing PtyService.Attach handler (`requires_ack=true` path) and
adds the AckPty companion handler (spec
\`docs/superpowers/specs/2026-05-04-pty-attach-handler.md\` §6).

Per-session subscriber fan-out and the \`BoundedChannel\` overflow →
RESOURCE_EXHAUSTED mapping were already shipped by the upstream chain
(#352 / #354 / #355 / #386); this PR is the missing wire-up between
the spec §4.2 \`AckSubscriberState\` primitive and the wire boundary.

## Summary

- **\`pty-host/ack-state.ts\`**: add module-level \`(principalKey, sessionId)\` subscriber registry — \`registerAckSubscriber\` / \`findFirstAckSubscriber\` / \`unregisterAckSubscriber\` / \`resetAckSubscriberRegistry\`. Insertion-ordered Set so spec §6.1 "FIRST matching subscriber" is well-defined.
- **\`rpc/pty-attach.ts\`**: when \`requires_ack=true\`, instantiate an \`AckSubscriberState\` (capacity = \`ACK_CHANNEL_CAPACITY\` = 4096), register under \`(principalKey(principal), sessionId)\`, advance \`lastDeliveredSeq\` via \`onDelivered\` BEFORE every yield (so AckPtys pipelined in the same tick see a consistent watermark), unregister in \`finally\`. Add \`makeAckPtyHandler(deps)\` implementing §6.1 happy path + \`pty.ack_overrun\` / \`pty.ack_regress\` validation and §6.2 no-op for the three "no live ack subscriber" cases.
- **\`rpc/router.ts\`**: \`registerPtyService\` now wires both \`attach\` and \`ackPty\` against the same \`PtyAttachDeps\` (single descriptor — Connect router's "service() replaces" caveat).
- **\`pty-host/host.ts\`**: refresh the SRP comment (the §6.9 chain has landed; fan-out lives in \`pty-emitter.ts\`, per-subscriber backpressure in \`rpc/pty-attach.ts\`).
- **\`pty-host/__tests__/fanout.spec.ts\` (new)**: pins the spec §2.3 fan-out contract on the real \`PtySessionEmitter\`, the §4.3 \`BoundedChannel\` overflow at exactly 4096, and the registry round-trip used by the AckPty handler.
- **\`rpc/pty-attach.spec.ts\`**: 5 new wire-level cases for AckPty — §6.2 no-op (no live subscriber, unknown session, post-disconnect), §6.1 happy path + idempotent re-ack, §6.1 overrun + regress, and teardown-then-late-ack falling back to §6.2.

## Local checks (host: windows-11)

- lint: ✓ (exit 0; baseline warnings only — 0 new)
- typecheck: ✓ (root \`tsc --noEmit && tsc --noEmit -p tsconfig.electron.json\`, exit 0)
- daemon build: ✓ (\`pnpm --filter @ccsm/daemon run build\` exit 0)
- unit tests (touched paths, 8 files / 186 tests):
\`\`\`
pnpm vitest run src/rpc/pty-attach.spec.ts \
                src/pty-host/__tests__/ \
                src/rpc/__tests__/router.spec.ts
→ Test Files  8 passed (8)
  Tests       186 passed (186)
  Duration    3.35s
\`\`\`

\`pnpm test\` on origin/working baseline = 142 failed / 1329 passed (better-sqlite3 / native-binary infra issues unrelated to this PR); this branch = 131 failed / 1346 passed (same baseline failures, +17 new PASS from this PR's tests, 0 new failures).

E2E probe is out of scope: this PR is server-side only (daemon Connect handlers); no Electron renderer wiring touches AckPty yet.

## Test plan

- [x] Unit: §2.3 fan-out, §4.3 4096 overflow, §6.1 happy/overrun/regress, §6.2 no-op (5 paths), registry round-trip
- [ ] Reviewer to sanity-check spec §6.1 "FIRST matching subscriber" semantics (insertion-ordered Set; reattach-overlap is rare and the wrong-stream ack is benign per spec)