### PR TITLE
feat(daemon)(#359): wire CreateSession → spawnPtyHostChild + watchPtyHostChildLifecycle

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -58,6 +58,7 @@ import { LISTENER_A_HELLO_ID } from './rpc/hello.js';
 import { makeRouterBindHook } from './rpc/bind.js';
 import { upsertSettingsBoot } from './rpc/settings/store.js';
 import { SessionManager, type ISessionManager } from './sessions/SessionManager.js';
+import { makeProductionAttachPtyHost } from './pty-host/attach-on-create.js';
 import { statePaths } from './state-dir/paths.js';
 import {
   Shutdown,
@@ -423,7 +424,23 @@ export async function runStartup(
     // here (Task #359 wires `attachPtyHost` separately so the unary
     // handler stays decoupled from the spawn lifecycle — see
     // `sessions/create-handler.ts` SCOPE note).
-    const createSessionDeps = { manager: sessionManager };
+    // same boot. Task #359 wires `attachPtyHost` here so the new row
+    // gets a per-session pty-host child fork + lifecycle watcher
+    // chained to `SessionManager.markEnded` on child exit.
+    // `CCSM_PTY_HOST_CHILD_ENTRYPOINT` is the test seam: the
+    // daemon-boot e2e injects the pty-host fixture (vitest cannot
+    // `child_process.fork` `child.ts` without a tsx loader); production
+    // omits the env and `host.ts` resolves `dist/pty-host/child.js`
+    // via `import.meta.url` math.
+    const createSessionDeps = {
+      manager: sessionManager,
+      attachPtyHost: makeProductionAttachPtyHost({
+        manager: sessionManager,
+        childEntrypoint: process.env.CCSM_PTY_HOST_CHILD_ENTRYPOINT,
+        onError: (where, err) =>
+          log(`attachPtyHost ${where} step threw: ${String(err)}`),
+      }),
+    };
     // Wave-3 #349 — wire SettingsService + DraftService production
     // overlays (spec #337 §6.1 step 1). Both services share the same
     // `db` handle (drafts ride on the `settings` table under key

--- a/packages/daemon/src/pty-host/attach-on-create.ts
+++ b/packages/daemon/src/pty-host/attach-on-create.ts
@@ -1,0 +1,261 @@
+// packages/daemon/src/pty-host/attach-on-create.ts
+//
+// Wave-3 §6.9 sub-task 8 / Task #359 — production `attachPtyHost` factory.
+//
+// Wires the freshly-INSERTed SessionRow (from `SessionManager.create` /
+// the CreateSession Connect handler in `sessions/create-handler.ts`) into
+// the per-session pty-host child lifecycle:
+//
+//   1. `spawnPtyHostChild(...)` — fork the per-session child
+//      (`child_process.fork`, see `host.ts`). Returns a
+//      {@link PtyHostChildHandle} carrying the IPC channel + lifecycle
+//      promises.
+//   2. Wait for the child's `ready` IPC, then send `{kind:'spawn',
+//      payload}` so the child enters its post-spawn state (logs the
+//      resolved per-OS argv via #41's `computeSpawnArgv` decider, emits
+//      the synthetic initial snapshot per §3.3, etc.).
+//   3. Install `watchPtyHostChildLifecycle(handle, { manager })` so any
+//      child exit (graceful close OR crash) is mapped through
+//      `decideSessionEnd` → `SessionManager.markEnded(...)` → `should_be_running=0`
+//      + new terminal state + `SessionEvent.ended` published on the bus.
+//
+// SCOPE — what this module is and is NOT:
+//
+//   * IS: a thin glue producer that closes the loop CreateSession →
+//     pty-host child → markEnded. It owns NO new state. The
+//     `spawnPtyHostChild` handle (#41 / PR #1004 dependency) owns the
+//     child; the watcher (#42 / PR #1005) owns the child→manager bridge;
+//     the `SessionManager` (#38) owns the row CRUD + event bus. This
+//     file just chains them.
+//
+//   * IS: the production wire to the in-memory pty-host registry — the
+//     `'spawn'` IPC wakes up the per-session child so the in-memory
+//     `PtySessionEmitter` is registered (host.ts T-PA-5) and a future
+//     `PtyService.Attach` stream from the renderer immediately finds an
+//     emitter to subscribe to.
+//
+//   * IS NOT: a snapshot codec / xterm-headless integration — those land
+//     inside `child.ts` (T4.6+) and are reachable through this same
+//     spawn payload without any changes here (`screenState` is opaque
+//     bytes per `types.ts`).
+//
+//   * IS NOT: a respawn / supervision loop — spec ch06 §1 v0.3 ship rule
+//     "no respawn"; the watcher's `markEnded` is the ONLY post-exit
+//     write. A new `claude` invocation requires a fresh CreateSession
+//     RPC.
+//
+//   * IS NOT: a cwd / executable existence validator — spec ch05 §6
+//     places filesystem validation in the spawn path and surfaces the
+//     failure as `SessionEvent.ended { reason='crashed' }` via the
+//     watcher, not as a synchronous CreateSession error (see
+//     `create-handler.ts` SCOPE note for the alternatives that were
+//     rejected).
+//
+// SRP layering (dev.md §3):
+//   * decider:  `decodeSpawnPayload(row)` — pure. Parses
+//               `env_json` / `claude_args_json` back into the `SpawnPayload`
+//               shape `host.ts` consumes. Exported so tests can pin it
+//               independently of the spawn side effect.
+//   * producer: `spawnPtyHostChild(...)` from `host.ts` (#41 / PR #1004
+//               supplies the per-OS argv decider that runs INSIDE the
+//               child via `child.ts:handleSpawn` → `computeSpawnArgv`).
+//               This file does NOT call `computeSpawnArgv` directly —
+//               the child owns the argv shape (single ownership), the
+//               host-side payload is the higher-level
+//               `(sessionId, cwd, claudeArgs, cols, rows)` tuple.
+//   * sink:     `watchPtyHostChildLifecycle(handle, { manager })` from
+//               #42 / PR #1005. The watcher's job is exit→markEnded;
+//               this file just installs it.
+//
+// Layer 1 — alternatives checked:
+//   - Inline the spawn + watch into `create-handler.ts`. Rejected:
+//     keeps the Connect handler proto-aware ONLY (decode request, call
+//     manager, encode response). Wiring into the pty-host module belongs
+//     in the pty-host module — the dependency arrow points the right way
+//     (`sessions/create-handler.ts` knows about an injected
+//     `attachPtyHost` callback; the implementation lives here so
+//     `sessions/` does not import `pty-host/`).
+//   - Make `SessionManager.create` own the spawn. Rejected: SessionManager
+//     owns row CRUD + event bus; spawn is a pty-host concern. Same
+//     argument the spec ch06 §1 cross-wiring boundary rejects (see
+//     `lifecycle-watcher.ts` Layer 1 note).
+//   - Block CreateSession on the child's `ready` IPC. Rejected: ch05 §6
+//     CreateSession returns immediately with the STARTING row; the
+//     pty-host bridge transitions it to RUNNING asynchronously. Coupling
+//     the unary RPC to the IPC handshake would either invent a "creating"
+//     intermediate state (spec mis-shape) or balloon p99 latency on a
+//     handler the client expects to be sub-millisecond.
+//   - Resolve the child entrypoint differently per env. Adopted via the
+//     `childEntrypoint` option (the daemon-boot e2e injects the
+//     `child-fixture.mjs` so vitest can fork the same JS the host.spec
+//     fixture uses, since `child.ts` is not loadable by `node` directly
+//     under the daemon's vitest config). Production omits the override
+//     and `host.ts` falls back to its `defaultChildEntrypoint()` which
+//     resolves `dist/pty-host/child.js` via `import.meta.url` math.
+
+import { spawnPtyHostChild, type PtyHostChildHandle } from './host.js';
+import { watchPtyHostChildLifecycle } from './lifecycle-watcher.js';
+import type { SpawnPayload } from './types.js';
+
+import type { ISessionManager } from '../sessions/SessionManager.js';
+import type { SessionRow } from '../sessions/types.js';
+
+/**
+ * Pure decider: build the `SpawnPayload` the pty-host child expects from
+ * a freshly-created `SessionRow`. The row carries `env_json` /
+ * `claude_args_json` as TEXT (better-sqlite3 column type — see
+ * `sessions/types.ts`); we parse them back into the structured shape the
+ * IPC envelope consumes.
+ *
+ * Robustness: if either JSON column fails to parse (corrupted row,
+ * forward-incompat row format) we fall back to empty values rather than
+ * throwing — the alternative is a CreateSession that succeeds at the row
+ * level but never spawns a child, leaving an orphan STARTING row. With
+ * the fallback the child still spawns; if the child then crashes
+ * because of bogus args, the lifecycle watcher transitions the row to
+ * CRASHED through the normal path.
+ */
+export function decodeSpawnPayload(row: SessionRow): SpawnPayload {
+  let envExtra: Record<string, string> | undefined;
+  try {
+    const parsed = JSON.parse(row.env_json) as unknown;
+    if (parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const out: Record<string, string> = {};
+      for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof v === 'string') out[k] = v;
+      }
+      envExtra = out;
+    }
+  } catch {
+    envExtra = undefined;
+  }
+  let claudeArgs: readonly string[] = [];
+  try {
+    const parsed = JSON.parse(row.claude_args_json) as unknown;
+    if (Array.isArray(parsed)) {
+      claudeArgs = parsed.filter((x): x is string => typeof x === 'string');
+    }
+  } catch {
+    claudeArgs = [];
+  }
+  return {
+    sessionId: row.id,
+    cwd: row.cwd,
+    claudeArgs,
+    cols: row.geometry_cols,
+    rows: row.geometry_rows,
+    envExtra,
+  };
+}
+
+/** Dependencies for the production `attachPtyHost` factory. */
+export interface AttachPtyHostFactoryDeps {
+  /**
+   * SessionManager whose `markEnded` the lifecycle watcher will call on
+   * child exit. Production wires the same singleton the SessionService
+   * Connect handlers use (single owner of the sessions table — see
+   * `index.ts` `sessionManager` construction).
+   */
+  readonly manager: Pick<ISessionManager, 'markEnded'>;
+  /**
+   * Override the child entrypoint script. Production omits this and
+   * `host.ts` resolves `dist/pty-host/child.js` from `import.meta.url`.
+   * The daemon-boot e2e (`daemon-boot-end-to-end.spec.ts`) injects the
+   * `child-fixture.mjs` so vitest can fork plain ESM JS — `child.ts` is
+   * not loadable by `node` directly under the daemon's vitest config
+   * (no tsx loader). Read at factory-construction time, not per-call,
+   * so the same value applies to every spawned session in this boot.
+   */
+  readonly childEntrypoint?: string;
+  /**
+   * Override the env passed to the forked child (NOT the env handed to
+   * `claude`). Tests use this to flip `CCSM_FIXTURE_MODE`. Production
+   * leaves it `undefined` to inherit `process.env` verbatim.
+   */
+  readonly forkEnv?: Readonly<Record<string, string | undefined>>;
+  /**
+   * Optional structured-error reporter. Forwarded into both the
+   * `spawnPtyHostChild` failure path (synchronous `fork` errors) AND
+   * the lifecycle watcher's `kill` / `markEnded` step failures. Default:
+   * `console.error` with a stable `[ccsm-daemon]` prefix matching the
+   * watcher's own default.
+   */
+  readonly onError?: (
+    where: 'spawn' | 'send-spawn' | 'kill' | 'markEnded',
+    err: unknown,
+  ) => void;
+}
+
+const DEFAULT_ON_ERROR = (
+  where: 'spawn' | 'send-spawn' | 'kill' | 'markEnded',
+  err: unknown,
+): void => {
+  console.error(`[ccsm-daemon] attachPtyHost ${where} step threw`, err);
+};
+
+/**
+ * Build the production `attachPtyHost` callback the CreateSession
+ * Connect handler invokes after `SessionManager.create` returns the
+ * freshly-INSERTed row.
+ *
+ * The returned callback is FIRE-AND-FORGET: it spawns the child, kicks
+ * off the `ready → spawn IPC → watcher install` chain, and returns.
+ * Errors anywhere in that chain are routed to `onError`; they do NOT
+ * propagate back to the caller (CreateSession must succeed at the row
+ * level even if the child fork fails — the lifecycle watcher will
+ * surface the failure via a CRASHED state + `SessionEvent.ended`).
+ *
+ * Returns the {@link PtyHostChildHandle} for tests / the boot e2e to
+ * inspect (`handle.pid` for the process-tree assertion). Production
+ * callers ignore the return value.
+ */
+export function makeProductionAttachPtyHost(
+  deps: AttachPtyHostFactoryDeps,
+): (row: SessionRow) => PtyHostChildHandle | null {
+  const onError = deps.onError ?? DEFAULT_ON_ERROR;
+  return function attachPtyHost(row: SessionRow): PtyHostChildHandle | null {
+    let handle: PtyHostChildHandle;
+    try {
+      handle = spawnPtyHostChild({
+        payload: decodeSpawnPayload(row),
+        childEntrypoint: deps.childEntrypoint,
+        forkEnv: deps.forkEnv,
+      });
+    } catch (err) {
+      onError('spawn', err);
+      return null;
+    }
+    // Install the exit→markEnded watcher BEFORE we send `'spawn'` so a
+    // child that crashes the moment it observes the spawn IPC is still
+    // captured — `handle.exited()` is wired at construction time inside
+    // `spawnPtyHostChild` regardless.
+    watchPtyHostChildLifecycle(handle, {
+      manager: deps.manager,
+      onError: (where, err) => onError(where, err),
+    });
+    // Send `'spawn'` AFTER the child's `ready` IPC. `host.ts` rejects a
+    // pre-ready `send` (channel may not yet be hot); awaiting `ready()`
+    // also gives the per-session emitter time to register so a parallel
+    // PtyService.Attach stream finds it.
+    handle
+      .ready()
+      .then(() => {
+        try {
+          handle.send({
+            kind: 'spawn',
+            payload: decodeSpawnPayload(row),
+          });
+        } catch (err) {
+          onError('send-spawn', err);
+        }
+      })
+      .catch((err) => {
+        // `ready()` rejects when the child exits before sending its
+        // `ready` IPC. The watcher above already chained `markEnded` to
+        // `handle.exited()`, so the row will transition to CRASHED via
+        // the normal path; we just log the early-exit for triage.
+        onError('send-spawn', err);
+      });
+    return handle;
+  };
+}

--- a/packages/daemon/src/sessions/create-handler.ts
+++ b/packages/daemon/src/sessions/create-handler.ts
@@ -32,19 +32,27 @@
 //     ch05 §6 (session create flow: id := ULID(), state := STARTING,
 //     INSERT row, publish `created` event on the in-memory bus).
 //
-// SCOPE — what this PR does NOT do:
-//   - Spawn the pty-host child for the new session. PTY spawn lifecycle
-//     is owned by Task #359 (the `attachPtyHost` call sequence runs after
-//     CreateSession returns; the new session sits in STARTING until the
-//     pty-host bridge transitions it to RUNNING). Wiring CreateSession
-//     unary RPC unblocks the v0.3 client's "create then attach" flow
-//     without coupling the unary handler to PTY spawn (the spawn path
-//     is async and would otherwise force this handler to either block on
-//     PTY ready or invent a separate "creating" state — both are spec
-//     mis-shapes). v0.3 ship plan: Create returns the STARTING row; the
-//     client immediately opens a PtyService.Attach stream against the
-//     new session id; #359 wires the spawn so the Attach stream's first
-//     frame reflects real PTY output.
+// SCOPE — Task #359 update:
+//   - PTY spawn is now wired here via the optional `attachPtyHost` dep
+//     (see `CreateSessionDeps` below). When supplied, the handler calls
+//     `attachPtyHost(row, principal)` AFTER `manager.create` returns
+//     the freshly-INSERTed row. The callback is FIRE-AND-FORGET: it
+//     forks the per-session pty-host child (`spawnPtyHostChild`, T4.1)
+//     and installs the lifecycle watcher (`watchPtyHostChildLifecycle`,
+//     T4.4) so any child exit transitions the row to its terminal state
+//     via `SessionManager.markEnded`. CreateSession DOES NOT block on
+//     the child's `ready` IPC — the row is returned in STARTING state
+//     and the pty-host bridge transitions it to RUNNING asynchronously
+//     (spec ch05 §6 / ch06 §1).
+//   - When `attachPtyHost` is omitted (existing test fixtures /
+//     workflows that pre-date #359), the handler keeps the pre-#359
+//     behavior: row is INSERTed + `created` published, no child fork.
+//     Callers that want the row but no child (e.g. unit tests) just
+//     omit the dep.
+//   - Validation of cwd existence / executable resolution still lives
+//     in the pty-host spawn path (#359's `attachPtyHost`), surfaced via
+//     `SessionEvent.ended { reason='crashed' }` rather than synchronous
+//     CreateSession errors — same alternatives-rejected logic as before.
 //
 // SRP layering — three roles kept separate (dev.md §2):
 //   * decider:  `decodeCreateRequest(req)` — pure. Takes the proto
@@ -103,7 +111,7 @@ import {
 import { PRINCIPAL_KEY, type Principal as AuthPrincipal } from '../auth/index.js';
 
 import type { ISessionManager } from './SessionManager.js';
-import type { CreateSessionInput } from './types.js';
+import type { CreateSessionInput, SessionRow } from './types.js';
 import { sessionRowToProto } from './watch-sessions.js';
 
 // ---------------------------------------------------------------------------
@@ -173,6 +181,26 @@ export function decodeCreateRequest(req: CreateSessionRequest): CreateSessionInp
 
 export interface CreateSessionDeps {
   readonly manager: ISessionManager;
+  /**
+   * Optional Task #359 hook: invoked AFTER `manager.create` returns the
+   * freshly-INSERTed row. Production wires this to
+   * `makeProductionAttachPtyHost({ manager })` from
+   * `pty-host/attach-on-create.ts` — the callback forks a per-session
+   * pty-host child (`spawnPtyHostChild`, T4.1 / #41) and installs the
+   * lifecycle watcher (`watchPtyHostChildLifecycle`, T4.4 / #42) so the
+   * row transitions to its terminal state when the child exits.
+   *
+   * The callback MUST be fire-and-forget: any error is its own
+   * responsibility (the production factory routes errors to its
+   * `onError` log sink). Throwing synchronously from this callback
+   * propagates as a Connect `Internal` to the CreateSession caller —
+   * the row is already INSERTed at that point so the caller will see a
+   * row from a subsequent ListSessions even if the spawn never fired.
+   *
+   * Tests that don't need the spawn wire-up simply omit this field;
+   * the handler keeps the pre-#359 row-only behavior.
+   */
+  readonly attachPtyHost?: (row: SessionRow, principal: AuthPrincipal) => void;
 }
 
 /**
@@ -211,6 +239,19 @@ export function makeCreateSessionHandler(
 
     const input = decodeCreateRequest(req);
     const row = deps.manager.create(input, principal);
+
+    // Task #359: kick off the per-session pty-host child + lifecycle
+    // watcher AFTER the row is INSERTed (so the child has a row to
+    // markEnded against on exit) and BEFORE we render the response (so
+    // a parallel PtyService.Attach stream from the same client finds
+    // the per-session emitter already registered by the time it
+    // dispatches). The callback is fire-and-forget — see CreateSessionDeps
+    // jsdoc. Omitted in test fixtures that exercise only the row CRUD
+    // path; production `index.ts` wires it via
+    // `makeProductionAttachPtyHost`.
+    if (deps.attachPtyHost !== undefined) {
+      deps.attachPtyHost(row, principal);
+    }
 
     return create(CreateSessionResponseSchema, {
       // Echo request meta unchanged — same convention as Hello,

--- a/packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts
+++ b/packages/daemon/test/integration/daemon-boot-end-to-end.spec.ts
@@ -164,6 +164,20 @@ async function setupBootEnv(): Promise<BootEnv> {
       ? `\\\\.\\pipe\\ccsm-daemon-boot-e2e-${process.pid}-${Date.now()}`
       : join(tmpRoot, 'supervisor.sock');
   process.env.CCSM_VERSION = '0.3.0-e2e-test';
+  // Task #359: production CreateSession wires `attachPtyHost` which
+  // forks a per-session pty-host child via `child_process.fork`.
+  // `child.ts` is not loadable by `node` directly under vitest (no tsx
+  // loader); point the production factory at the same `child-fixture.mjs`
+  // the host.spec uses so the e2e exercises the full spawn → ready →
+  // exit → markEnded chain on real IPC bytes. Production omits the env
+  // and `host.ts` falls back to `dist/pty-host/child.js`.
+  process.env.CCSM_PTY_HOST_CHILD_ENTRYPOINT = join(
+    HERE,
+    '..',
+    'pty-host',
+    'fixtures',
+    'child-fixture.mjs',
+  );
   return { tmpRoot, origEnv };
 }
 
@@ -576,6 +590,256 @@ describe('daemon-boot end-to-end (Task #208)', () => {
     // proto change to the variant tag fails this loud.
     expect(sess.owner?.kind?.case).toBe('localUser');
     expect(resp.meta?.requestId).toBe(meta.requestId);
+  });
+
+  // Wave-3 §6.9 sub-task 8 / Task #359 — CreateSession wires
+  // `attachPtyHost` (`spawnPtyHostChild` + `watchPtyHostChildLifecycle`).
+  // Pre-#359 the CreateSession handler INSERTed the row + published
+  // `created` but did NOT fork the per-session pty-host child, so the
+  // row sat in STARTING forever and the WatchSessions stream never saw
+  // `ended`. Two assertions:
+  //
+  //   1. process-tree probe: after CreateSession returns, the daemon
+  //      process has at least one extra child (the pty-host fork) it
+  //      did NOT have before the call. Uses `tasklist` on win32 and
+  //      `ps` on POSIX — both cross-OS executables that ship with the
+  //      base OS install. Tolerant of races: the child may exit between
+  //      the CreateSession ack and our probe (the fixture's `normal`
+  //      mode keeps the child alive until `close`), so the assertion
+  //      uses `>=` rather than `==` against a captured baseline.
+  //
+  //   2. crash → ended event: a child crash (fixture `CCSM_FIXTURE_MODE
+  //      =crash` — ready then `process.exit(137)`) propagates through
+  //      `watchPtyHostChildLifecycle` → `decideSessionEnd` →
+  //      `SessionManager.markEnded` and the `SessionEvent.ended` lands
+  //      on the WatchSessions stream the renderer subscribes to. This
+  //      is the load-bearing wire for the v0.3 client's "session
+  //      crashed" UX — without #359 the row stays STARTING and the UI
+  //      never updates.
+  //
+  // The fixture is injected via `CCSM_PTY_HOST_CHILD_ENTRYPOINT` set in
+  // `setupBootEnv` (vitest cannot fork `child.ts` directly); the boot
+  // here uses `normal` mode by default but the second `it` re-runs
+  // with `crash` mode in the forked child via the env override.
+  it('Task #359 — CreateSession forks a per-session pty-host child (process-tree probe)', async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    expect(r.listenerA).not.toBeNull();
+    const desc = r.listenerA!.descriptor();
+    if (desc.kind !== 'KIND_TCP_LOOPBACK_H2C') return;
+    const baseUrl = `http://127.0.0.1:${desc.port}`;
+
+    r.db
+      .prepare(
+        `INSERT OR IGNORE INTO principals (id, kind, display_name, first_seen_ms, last_seen_ms)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run('local-user:test', 'local-user', 'test', Date.now(), Date.now());
+
+    // Capture child pids of the daemon test process BEFORE CreateSession.
+    // Differencing against the post-create snapshot pins the new fork
+    // even if the test runner has its own children. We do not assert
+    // exact count — just "strictly more after than before", which
+    // tolerates concurrent vitest workers spawning their own children.
+    const { spawnSync } = await import('node:child_process');
+    function listChildPids(parentPid: number): number[] {
+      if (process.platform === 'win32') {
+        // wmic is deprecated on Win11 23H2 but `tasklist /v` doesn't
+        // expose ParentPID. Use `wmic process where (ParentProcessId=PID) get ProcessId`
+        // via PowerShell as the cross-Win-version path.
+        const r = spawnSync(
+          'powershell.exe',
+          [
+            '-NoProfile',
+            '-Command',
+            `Get-CimInstance Win32_Process -Filter "ParentProcessId=${parentPid}" | Select-Object -ExpandProperty ProcessId`,
+          ],
+          { encoding: 'utf8' },
+        );
+        if (r.status !== 0) return [];
+        return r.stdout
+          .split(/\r?\n/)
+          .map((s) => Number.parseInt(s.trim(), 10))
+          .filter((n) => Number.isFinite(n) && n > 0);
+      }
+      // POSIX: `ps -o pid= --ppid <pid>` is portable across linux/mac.
+      const r = spawnSync('ps', ['-o', 'pid=', '--ppid', String(parentPid)], {
+        encoding: 'utf8',
+      });
+      if (r.status !== 0) return [];
+      return r.stdout
+        .split(/\r?\n/)
+        .map((s) => Number.parseInt(s.trim(), 10))
+        .filter((n) => Number.isFinite(n) && n > 0);
+    }
+
+    const before = new Set(listChildPids(process.pid));
+
+    const client = makeSessionClient(baseUrl);
+    await client.createSession({
+      meta: newMeta(),
+      cwd: setup.tmpRoot,
+      env: {},
+      claudeArgs: ['--help'],
+      initialGeometry: create(PtyGeometrySchema, { cols: 80, rows: 24 }),
+    });
+
+    // The fork happens synchronously inside the CreateSession handler
+    // (spawnPtyHostChild returns a handle immediately), but `ps` /
+    // `wmic` queries need a moment to see the new entry. Poll for up
+    // to 2s with 50ms cadence; bail the moment we see a delta.
+    const deadline = Date.now() + 2000;
+    let after: Set<number> = new Set();
+    let sawNewChild = false;
+    while (Date.now() < deadline) {
+      after = new Set(listChildPids(process.pid));
+      const newPids = [...after].filter((p) => !before.has(p));
+      if (newPids.length >= 1) {
+        sawNewChild = true;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    expect(
+      sawNewChild,
+      `expected at least one new child of pid=${process.pid} after CreateSession; ` +
+        `before=[${[...before].join(',')}] after=[${[...after].join(',')}]`,
+    ).toBe(true);
+  });
+
+  it('Task #359 — child crash propagates SessionEvent.ended through WatchSessions', { timeout: 15000 }, async () => {
+    expect(result).not.toBeNull();
+    const r = result!;
+    expect(r.listenerA).not.toBeNull();
+    const desc = r.listenerA!.descriptor();
+    if (desc.kind !== 'KIND_TCP_LOOPBACK_H2C') return;
+    const baseUrl = `http://127.0.0.1:${desc.port}`;
+
+    r.db
+      .prepare(
+        `INSERT OR IGNORE INTO principals (id, kind, display_name, first_seen_ms, last_seen_ms)
+         VALUES (?, ?, ?, ?, ?)`,
+      )
+      .run('local-user:test', 'local-user', 'test', Date.now(), Date.now());
+
+    // Flip the fixture into crash mode for THIS test only by mutating
+    // the env the daemon-side `attachPtyHost` reads when it forks the
+    // child. The daemon snapshotted CCSM_PTY_HOST_CHILD_ENTRYPOINT at
+    // boot, but `forkEnv` in the production factory is `undefined`
+    // which means `host.ts` inherits `process.env` per-call — so a
+    // mutation here lands in the next fork.
+    const prevMode = process.env.CCSM_FIXTURE_MODE;
+    process.env.CCSM_FIXTURE_MODE = 'crash';
+
+    try {
+      // Open a WatchSessions stream BEFORE CreateSession so we don't
+      // miss the `created` → `ended` sequence. Use the same OWN scope
+      // the renderer uses.
+      const ac = new AbortController();
+      const client = makeSessionClient(baseUrl);
+      const stream = client.watchSessions(
+        create(WatchSessionsRequestSchema, {
+          meta: newMeta(),
+          scope: WatchScope.OWN,
+        }),
+        { signal: ac.signal },
+      );
+      const iterator = stream[Symbol.asyncIterator]();
+
+      // Wait for the bus subscription to land before CreateSession (same
+      // pattern the WatchSessions smoke uses above) so the `created`
+      // event is not raced past.
+      const sessionManagerCast = r.sessionManager as unknown as {
+        readonly eventBus: { readonly listenerCount: (k: string) => number };
+      };
+      const subscribeDeadline = Date.now() + 5000;
+      while (
+        sessionManagerCast.eventBus.listenerCount('local-user:test') === 0 &&
+        Date.now() < subscribeDeadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+
+      const created = await client.createSession({
+        meta: newMeta(),
+        cwd: setup.tmpRoot,
+        env: {},
+        claudeArgs: ['--help'],
+        initialGeometry: create(PtyGeometrySchema, { cols: 80, rows: 24 }),
+      });
+      const sessionId = created.session!.id;
+
+      // Drain events until we see the proto SessionEvent that the
+      // bus's `ended` wire-mapping produces, with a hard upper bound so
+      // a regression where ended never fires surfaces as a clean test
+      // fail rather than a hung suite. The crash fixture exits
+      // ~immediately after `ready`, so 10s is generous (cross-OS
+      // process startup overhead can push the create→ready→exit→
+      // markEnded chain past the 5s default).
+      //
+      // Wire shape note (`watch-sessions.ts:eventToProto` + spec ch06
+      // §1): the in-memory `'ended'` bus event maps to the proto oneof
+      // case `updated` carrying the full Session row — clients
+      // distinguish "child died" from "user-initiated DestroySession"
+      // by inspecting the post-update `state` field (CRASHED for crash,
+      // EXITED for graceful close), not by the oneof tag. The test
+      // therefore matches on `(kind.case === 'updated' && state ===
+      // CRASHED)` rather than a dedicated `ended` tag.
+      //
+      // Implementation note: we keep ONE in-flight `iterator.next()`
+      // promise at a time. Calling `iterator.next()` twice without
+      // awaiting violates the async-iterator contract (the second call
+      // races with the first and may swallow events). The outer
+      // deadline-race uses a single sentinel timeout that cancels the
+      // whole loop, not per-iteration races.
+      const STATE_CRASHED = 4; // sessions/types.ts SessionState.CRASHED
+      let endedSeen = false;
+      let endedReason: string | undefined;
+
+      let timeoutHandle: NodeJS.Timeout | undefined;
+      const timeoutPromise = new Promise<{ kind: 'timeout' }>((resolve) => {
+        timeoutHandle = setTimeout(() => resolve({ kind: 'timeout' }), 10000);
+      });
+      try {
+        while (!endedSeen) {
+          const winner = await Promise.race([
+            iterator.next().then((ev) => ({ kind: 'event' as const, ev })),
+            timeoutPromise,
+          ]);
+          if (winner.kind === 'timeout') break;
+          const ev = winner.ev;
+          if (ev.done) break;
+          const value = ev.value as {
+            kind: { case: string; value: { id: string; state?: number } };
+          };
+          if (
+            value.kind.case === 'updated' &&
+            value.kind.value.id === sessionId &&
+            value.kind.value.state === STATE_CRASHED
+          ) {
+            endedSeen = true;
+            endedReason = String(value.kind.value.state);
+            break;
+          }
+        }
+      } finally {
+        if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+        ac.abort();
+        await iterator.return?.(undefined).catch(() => {});
+      }
+
+      expect(
+        endedSeen,
+        `expected SessionEvent.ended for session ${sessionId} within 5s; ` +
+          `reason=${endedReason ?? '(none)'}`,
+      ).toBe(true);
+    } finally {
+      if (prevMode === undefined) {
+        delete process.env.CCSM_FIXTURE_MODE;
+      } else {
+        process.env.CCSM_FIXTURE_MODE = prevMode;
+      }
+    }
   });
 
   it('rejects unauthenticated calls (no bearer token) with Code.Unauthenticated', async () => {


### PR DESCRIPTION
## Task #359 — close the CreateSession ↔ pty-host loop

Wave-3 §6.9 sub-task 8. Pre-#359 SessionService.CreateSession (#339)
INSERTed the row + published `created` but did NOT fork a per-session
pty-host child, so the row sat in STARTING forever and the renderer's
Sidebar never observed `ended` on crash. This PR wires the loop
end-to-end using the libraries that landed in #41 (PR #1004 spawn-argv)
and #42 (PR #1005 lifecycle-watcher).

## What lands

- **New `packages/daemon/src/pty-host/attach-on-create.ts`** —
  `makeProductionAttachPtyHost({ manager, childEntrypoint?, forkEnv?, onError? })`
  factory returns a fire-and-forget callback `(row) =>
  PtyHostChildHandle | null`. Forks the per-session child via
  `spawnPtyHostChild` (#41 / PR #1004), installs
  `watchPtyHostChildLifecycle(handle, { manager })` (#42 / PR #1005)
  so `markEnded` runs on child exit, and sends `{kind:'spawn',
  payload}` after the child's `ready` IPC. Includes pure
  `decodeSpawnPayload(row)` decider (parses `env_json` /
  `claude_args_json` back to the SpawnPayload shape).

- **`sessions/create-handler.ts`** — `CreateSessionDeps.attachPtyHost?`
  injection. Connect handler invokes it AFTER `manager.create` returns
  the row. Optional so existing test fixtures that don't need spawn
  keep the pre-#359 row-only path.

- **`index.ts` runStartup** — wires the production factory into
  `createSessionDeps`. `CCSM_PTY_HOST_CHILD_ENTRYPOINT` is the test
  seam (the daemon-boot e2e injects `child-fixture.mjs`; production
  omits and `host.ts` resolves `dist/pty-host/child.js` via
  `import.meta.url`).

- **`daemon-boot-end-to-end.spec.ts`** — two new assertions:
  1. **process-tree probe** — diff of `ps`/wmic ParentProcessId
     before vs after CreateSession proves the per-session pty-host
     fork landed.
  2. **crash → ended event** — fixture `CCSM_FIXTURE_MODE=crash`
     (ready then exit 137) propagates through the watcher →
     `markEnded` (state=CRASHED) → bus `ended` event → wire
     `updated`. The bus event `'ended'` maps to proto oneof case
     `updated` (`watch-sessions.ts:eventToProto`); the test
     distinguishes child-died from user-initiated DestroySession by
     `state === CRASHED` rather than a dedicated tag.

## SRP layering (dev.md §3)

- decider: `decodeSpawnPayload(row)` — pure, no I/O.
- producer: `spawnPtyHostChild` (#41) — host owns the child fork.
- sink: `watchPtyHostChildLifecycle` (#42) — owns child→manager bridge.

`attach-on-create.ts` is a single chaining glue producer. No new state.

## Coordination with parallel dev-49

dev-49 changes `pty-host/host.ts` / `child.ts` / `types.ts` /
`rpc/router.ts` / `rpc/pty-attach.ts`. This PR touches `index.ts` /
`sessions/create-handler.ts` / new `pty-host/attach-on-create.ts` /
`test/integration/daemon-boot-end-to-end.spec.ts`. Zero file overlap
with dev-49's surface; rebase risk is limited to the import lists in
`index.ts` (the `makeProductionAttachPtyHost` import sits next to the
`SessionManager` import already there).

## Local checks (host: windows-11)
- lint: ✓ (exit 0; no new warnings on changed files)
- typecheck: ✓ (exit 0)
- vitest (relevant): ✓ 108/108 passed across `daemon-boot-end-to-end` +
  `lifecycle-watcher` + `host` + `sessions/` specs (35.6s)
  - daemon-boot-e2e: 25/25 passed including the two new Task #359 it
    blocks (process-tree probe + crash → ended)
- 7 pre-existing failures in unrelated specs
  (`watch-sessions-wired`, `crash-getlog-wired`, `crash-watch-wired`,
  `test-crash-integration`, `descriptor/schema`,
  `rpc/__tests__/integration`) verified as baseline via patch-stash
  repro: identical 7 failures with attach-on-create + index/handler
  changes reverted. They are afterEach hook timeouts unrelated to
  CreateSession wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)