### PR TITLE
tools(release): T8.15a release-candidate.sh — gate-a/b real, gate-c/d placeholder (#414)

### DIFF
--- a/tools/release-candidate.sh
+++ b/tools/release-candidate.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# tools/release-candidate.sh — v0.3 ship-gate orchestrator (T8.15a).
+#
+# Spec: ch13 §2 phase 11. Drives the four release-candidate gates in
+# strict order and, only if all four pass, emits a `git tag v0.3.0 <SHA>`
+# suggestion for the user to run by hand.
+#
+# Gate matrix for v0.3 (see Task #414):
+#   gate-a (IPC residue)        — REAL  (delegates to lint:no-ipc, T8.1).
+#   gate-b (SIGKILL + Snapshot) — REAL  (runs sigkill-reattach + snapshot
+#                                        codec specs, T8.3 / T8.5).
+#   gate-c (pty-soak 1h)        — PLACEHOLDER (T8.4 not yet shipped, see #415).
+#   gate-d (installer roundtrip)— PLACEHOLDER (T8.6 followup, see #415).
+#
+# Placeholders WARN + exit 0 on purpose: v0.3 ship plan is "4 dogfood
+# items + minisign as the only hard blocker"; pty-soak and installer
+# roundtrip are v0.4 concerns. Anything stricter would gate v0.3 on
+# infrastructure that does not exist yet.
+#
+# Exit codes:
+#   0  — all gates green, tag suggestion printed.
+#   1  — a real gate (a or b) failed; no tag suggestion.
+#   2  — internal driver error (missing helper script, bad cwd, etc.).
+#
+# Usage:
+#   bash tools/release-candidate.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LIB_DIR="${SCRIPT_DIR}/release-candidate/lib"
+
+# Allow tests to substitute a fake lib dir to mock individual gates.
+LIB_DIR="${CCSM_RC_LIB_DIR:-${LIB_DIR}}"
+
+cd "${REPO_ROOT}"
+
+if [[ ! -d "${LIB_DIR}" ]]; then
+  echo "release-candidate: helper dir missing: ${LIB_DIR}" >&2
+  exit 2
+fi
+
+GATES=(
+  "gate-a:IPC residue (lint:no-ipc)"
+  "gate-b:SIGKILL reattach + SnapshotV1"
+  "gate-c:pty-soak 1h"
+  "gate-d:installer roundtrip"
+)
+
+echo "=============================================="
+echo " release-candidate.sh — v0.3 ship-gate driver"
+echo " repo: ${REPO_ROOT}"
+echo " sha:  $(git rev-parse HEAD 2>/dev/null || echo '<no git>')"
+echo "=============================================="
+
+for entry in "${GATES[@]}"; do
+  gate_id="${entry%%:*}"
+  gate_desc="${entry#*:}"
+  gate_script="${LIB_DIR}/${gate_id}.sh"
+
+  echo ""
+  echo "----- ${gate_id}: ${gate_desc} -----"
+
+  if [[ ! -x "${gate_script}" && ! -f "${gate_script}" ]]; then
+    echo "release-candidate: ${gate_id} script missing: ${gate_script}" >&2
+    exit 2
+  fi
+
+  rc=0
+  bash "${gate_script}" || rc=$?
+  if [[ "${rc}" -ne 0 ]]; then
+    echo ""
+    echo "FAIL: ${gate_id} (${gate_desc}) exited ${rc}" >&2
+    echo "release-candidate: aborting; no tag suggestion emitted." >&2
+    exit 1
+  fi
+
+  echo "OK: ${gate_id}"
+done
+
+echo ""
+echo "----- emit-tag -----"
+bash "${LIB_DIR}/emit-tag.sh"

--- a/tools/release-candidate/lib/emit-tag.sh
+++ b/tools/release-candidate/lib/emit-tag.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# emit-tag.sh — final step of release-candidate.sh.
+#
+# We deliberately do NOT execute `git tag` ourselves. v0.3 ship plan
+# (frozen) keeps tag emission as a manual user step so the human always
+# eyeballs the SHA before a tag is created (and minisign signing is
+# done in a separate, gated workflow). This script just prints the
+# exact command the user should run.
+
+set -euo pipefail
+
+VERSION="${CCSM_RC_VERSION:-v0.3.0}"
+SHA="$(git rev-parse HEAD)"
+
+cat <<EOF
+All gates green. Suggested next step:
+
+    git tag ${VERSION} ${SHA}
+    git push origin ${VERSION}
+
+Reminder: ${VERSION} push triggers the release workflow. Make sure
+minisign secrets are configured before pushing the tag.
+EOF

--- a/tools/release-candidate/lib/gate-a.sh
+++ b/tools/release-candidate/lib/gate-a.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+#
+# gate-a.sh — IPC residue gate.
+#
+# Delegates to T8.1's `pnpm lint:no-ipc` (which itself calls
+# tools/lint-no-ipc.sh). Forbidden IPC patterns in electron/ or src/
+# fail this gate; nothing else does.
+#
+# A gate-a failure means the v0.3 Electron-thin / daemon-fat split has
+# regressed and the build is shipping ipcMain/ipcRenderer/contextBridge
+# residue. Hard fail — there is no v0.3 ship without this being green.
+
+set -euo pipefail
+
+# Allow override (used by release-candidate.spec.ts to inject a stub).
+LINT_CMD="${CCSM_RC_GATE_A_CMD:-pnpm lint:no-ipc}"
+
+echo "gate-a: running '${LINT_CMD}'"
+# shellcheck disable=SC2086
+${LINT_CMD}

--- a/tools/release-candidate/lib/gate-b.sh
+++ b/tools/release-candidate/lib/gate-b.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# gate-b.sh — SIGKILL reattach + SnapshotV1 gate.
+#
+# Two halves:
+#   (1) SIGKILL → pty reattach e2e (T8.3, packages/electron/test/e2e/
+#       sigkill-reattach.spec.ts). Verifies that killing the daemon
+#       under load and bringing it back does not lose pty buffer state.
+#   (2) SnapshotV1 codec round-trip (T8.5, packages/snapshot-codec
+#       encoder + decoder specs). Verifies that the wire format the
+#       reattach path depends on still round-trips byte-for-byte.
+#
+# Both must be green for v0.3 ship — losing buffer state on daemon
+# crash is the central bet of the Electron-thin/daemon-fat refactor.
+
+set -euo pipefail
+
+# Allow override (used by release-candidate.spec.ts to inject a stub).
+if [[ -n "${CCSM_RC_GATE_B_CMD:-}" ]]; then
+  echo "gate-b: running override '${CCSM_RC_GATE_B_CMD}'"
+  # shellcheck disable=SC2086
+  ${CCSM_RC_GATE_B_CMD}
+  exit $?
+fi
+
+echo "gate-b: (1/2) SnapshotV1 codec round-trip"
+pnpm --filter @ccsm/snapshot-codec exec vitest run \
+  src/__tests__/encoder.spec.ts \
+  src/__tests__/decoder.spec.ts
+
+echo "gate-b: (2/2) SIGKILL reattach e2e"
+pnpm --filter @ccsm/electron exec vitest run \
+  test/e2e/sigkill-reattach.spec.ts

--- a/tools/release-candidate/lib/gate-c.sh
+++ b/tools/release-candidate/lib/gate-c.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# gate-c.sh — pty-soak 1h gate. PLACEHOLDER for v0.3.
+#
+# Real implementation depends on T8.4 (.github/workflows/pty-soak.yml,
+# tracked as #416 → #92 reopen). PR #880 was the first attempt and was
+# CLOSED without merging, so there is no workflow for this script to
+# pin against (no name, no input schema, no artifact path).
+#
+# v0.3 ship policy (manager 2026-05-05): pty-soak is NOT one of the 4
+# dogfood gates. Shipping v0.3 on placeholder gate-c is intentional and
+# documented in Task #414 / #415. Real impl lands in v0.4 ship cycle.
+#
+# Exit 0 (WARN, not FAIL) so the orchestrator continues to gate-d / emit-tag.
+
+set -euo pipefail
+
+cat <<'WARN'
+WARN: gate-c (pty-soak 1h) is a PLACEHOLDER for v0.3.
+      Real implementation blocked on T8.4 (#416, pty-soak.yml).
+      See Task #415 for the v0.4 followup.
+      Treating as PASS for v0.3 ship — this is the documented plan.
+WARN
+
+exit 0

--- a/tools/release-candidate/lib/gate-d.sh
+++ b/tools/release-candidate/lib/gate-d.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+#
+# gate-d.sh — installer roundtrip gate. PLACEHOLDER for v0.3.
+#
+# Real implementation depends on T8.6 (.github/workflows/installer-
+# roundtrip.yml, tracked as #417 → #95 followup). PR #902 merged the
+# tools/installer-roundtrip.sh / .ps1 *shell* but NOT the workflow yml,
+# so there is no CI surface for this script to pin against.
+#
+# v0.3 ship policy (manager 2026-05-05): installer roundtrip is NOT one
+# of the 4 dogfood gates. v0.3 ships on macOS+linux with a documented
+# asymmetric gate set (see ch12 §4.4 and tools/installer-roundtrip.sh).
+#
+# Exit 0 (WARN, not FAIL) so the orchestrator continues to emit-tag.
+
+set -euo pipefail
+
+cat <<'WARN'
+WARN: gate-d (installer roundtrip) is a PLACEHOLDER for v0.3.
+      Real implementation blocked on T8.6 (#417, installer-roundtrip.yml).
+      See Task #415 for the v0.4 followup.
+      Treating as PASS for v0.3 ship — this is the documented plan.
+WARN
+
+exit 0

--- a/tools/test/release-candidate.spec.ts
+++ b/tools/test/release-candidate.spec.ts
@@ -1,0 +1,203 @@
+/**
+ * tools/test/release-candidate.spec.ts
+ *
+ * Spec: docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+ * ch13 §2 phase 11 (release-candidate orchestrator).
+ * Task #414 (T8.15a) — gate-a/b real, gate-c/d placeholder for v0.3 ship.
+ *
+ * Forever-stable shape + behavior gate for tools/release-candidate.sh.
+ * We assert:
+ *
+ *   1. All six files exist at spec-pinned paths (driver + 4 gate libs +
+ *      emit-tag).
+ *   2. Driver runs all four gates in order and prints emit-tag suggestion
+ *      when every gate passes (we substitute the lib dir via
+ *      CCSM_RC_LIB_DIR so this stays hermetic — no real lint:no-ipc, no
+ *      real vitest invocation, no minute-long test runs).
+ *   3. Driver exits non-zero and does NOT print the tag suggestion when
+ *      any real gate (a or b) fails.
+ *   4. Placeholder gates (c and d) print WARN + exit 0 — guarding the
+ *      "v0.3 ships on placeholders, v0.4 lands real impl (#415)" plan
+ *      from accidental tightening.
+ *
+ * We invoke bash via `bash` on the PATH (Git Bash on Windows, system
+ * bash elsewhere). The driver scripts are pure POSIX shell — no
+ * platform-specific tools — so this works cross-OS in the same matrix
+ * the rest of tools/test/*.spec.ts already runs in.
+ *
+ * Run with:
+ *   npx vitest run --config tools/vitest.config.ts \
+ *     tools/test/release-candidate.spec.ts
+ */
+
+import { spawnSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const DRIVER = join(REPO_ROOT, 'tools', 'release-candidate.sh');
+const LIB_DIR = join(REPO_ROOT, 'tools', 'release-candidate', 'lib');
+
+function read(p: string): string {
+  return readFileSync(p, 'utf8');
+}
+
+function runDriver(env: Record<string, string>): {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+} {
+  const r = spawnSync('bash', [DRIVER], {
+    cwd: REPO_ROOT,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+  return { status: r.status, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+describe('tools/release-candidate.sh (spec ch13 §2 phase 11, T8.15a / #414)', () => {
+  describe('files exist at spec-pinned paths', () => {
+    it('tools/release-candidate.sh present', () => {
+      expect(existsSync(DRIVER)).toBe(true);
+    });
+    for (const name of ['gate-a.sh', 'gate-b.sh', 'gate-c.sh', 'gate-d.sh', 'emit-tag.sh']) {
+      it(`tools/release-candidate/lib/${name} present`, () => {
+        expect(existsSync(join(LIB_DIR, name))).toBe(true);
+      });
+    }
+  });
+
+  describe('placeholder gates document v0.3 ship policy', () => {
+    it('gate-c.sh WARNs and exits 0 (placeholder, see #415)', () => {
+      const r = spawnSync('bash', [join(LIB_DIR, 'gate-c.sh')], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toMatch(/WARN: gate-c .* PLACEHOLDER/);
+      expect(r.stdout).toMatch(/#415/);
+    });
+
+    it('gate-d.sh WARNs and exits 0 (placeholder, see #415)', () => {
+      const r = spawnSync('bash', [join(LIB_DIR, 'gate-d.sh')], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toMatch(/WARN: gate-d .* PLACEHOLDER/);
+      expect(r.stdout).toMatch(/#415/);
+    });
+
+    it('gate-c source explicitly references #416 (T8.4 reopen blocker)', () => {
+      expect(read(join(LIB_DIR, 'gate-c.sh'))).toMatch(/#416/);
+    });
+
+    it('gate-d source explicitly references #417 (T8.6 followup blocker)', () => {
+      expect(read(join(LIB_DIR, 'gate-d.sh'))).toMatch(/#417/);
+    });
+  });
+
+  describe('driver orchestration (mocked lib dir)', () => {
+    let mockLib: string;
+
+    beforeEach(() => {
+      mockLib = mkdtempSync(join(tmpdir(), 'ccsm-rc-mock-'));
+    });
+
+    afterEach(() => {
+      rmSync(mockLib, { recursive: true, force: true });
+    });
+
+    function writeStub(name: string, body: string) {
+      const p = join(mockLib, name);
+      writeFileSync(p, `#!/usr/bin/env bash\nset -e\n${body}\n`, 'utf8');
+      chmodSync(p, 0o755);
+    }
+
+    function writeAllPassing() {
+      writeStub('gate-a.sh', "echo 'mock gate-a OK'");
+      writeStub('gate-b.sh', "echo 'mock gate-b OK'");
+      writeStub('gate-c.sh', "echo 'mock gate-c OK'");
+      writeStub('gate-d.sh', "echo 'mock gate-d OK'");
+      writeStub('emit-tag.sh', "echo 'git tag v0.3.0 deadbeef'");
+    }
+
+    it('runs all four gates in order then emit-tag when everything passes', () => {
+      writeAllPassing();
+      const r = runDriver({ CCSM_RC_LIB_DIR: mockLib });
+      expect(r.status).toBe(0);
+      // Gate ordering must be a → b → c → d → emit-tag.
+      const idxA = r.stdout.indexOf('gate-a:');
+      const idxB = r.stdout.indexOf('gate-b:');
+      const idxC = r.stdout.indexOf('gate-c:');
+      const idxD = r.stdout.indexOf('gate-d:');
+      const idxEmit = r.stdout.indexOf('emit-tag');
+      expect(idxA).toBeGreaterThanOrEqual(0);
+      expect(idxB).toBeGreaterThan(idxA);
+      expect(idxC).toBeGreaterThan(idxB);
+      expect(idxD).toBeGreaterThan(idxC);
+      expect(idxEmit).toBeGreaterThan(idxD);
+      expect(r.stdout).toMatch(/git tag v0\.3\.0/);
+    });
+
+    it('exits non-zero and skips emit-tag when gate-a fails', () => {
+      writeAllPassing();
+      writeStub('gate-a.sh', "echo 'mock gate-a FAIL' >&2; exit 1");
+      const r = runDriver({ CCSM_RC_LIB_DIR: mockLib });
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toMatch(/FAIL: gate-a/);
+      expect(r.stdout).not.toMatch(/git tag v0\.3\.0/);
+      // gate-b should NOT have run after gate-a failed.
+      expect(r.stdout).not.toMatch(/gate-b:/);
+    });
+
+    it('exits non-zero and skips emit-tag when gate-b fails', () => {
+      writeAllPassing();
+      writeStub('gate-b.sh', "echo 'mock gate-b FAIL' >&2; exit 1");
+      const r = runDriver({ CCSM_RC_LIB_DIR: mockLib });
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toMatch(/FAIL: gate-b/);
+      expect(r.stdout).not.toMatch(/git tag v0\.3\.0/);
+    });
+
+    it('exits with code 2 when a gate script is missing', () => {
+      writeAllPassing();
+      rmSync(join(mockLib, 'gate-c.sh'));
+      const r = runDriver({ CCSM_RC_LIB_DIR: mockLib });
+      expect(r.status).toBe(2);
+      expect(r.stderr).toMatch(/gate-c script missing/);
+    });
+  });
+
+  describe('emit-tag content', () => {
+    it('prints a git tag suggestion (v0.3.0 by default) without executing it', () => {
+      const r = spawnSync('bash', [join(LIB_DIR, 'emit-tag.sh')], {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toMatch(/git tag v0\.3\.0 [0-9a-f]{7,40}/);
+      expect(r.stdout).toMatch(/minisign/i);
+    });
+
+    it('honors CCSM_RC_VERSION override', () => {
+      const r = spawnSync('bash', [join(LIB_DIR, 'emit-tag.sh')], {
+        cwd: REPO_ROOT,
+        env: { ...process.env, CCSM_RC_VERSION: 'v0.3.1-rc1' },
+        encoding: 'utf8',
+      });
+      expect(r.status).toBe(0);
+      expect(r.stdout).toMatch(/git tag v0\.3\.1-rc1 /);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Spec: ch13 §2 phase 11. v0.3 ship-gate orchestrator. Drives 4 gates in
strict order; emits a `git tag v0.3.0 <SHA>` suggestion only if every
gate passes. Does not exec `git tag` itself — the human eyeballs the
SHA before tagging (and minisign signing happens in a separate, gated
workflow).

Per Task #414 split (manager 2026-05-05):
- gate-a (IPC residue):        REAL, delegates to T8.1 `lint:no-ipc`.
- gate-b (SIGKILL+SnapshotV1): REAL, runs `sigkill-reattach.spec.ts`
  + the snapshot-codec encoder/decoder specs.
- gate-c (pty-soak 1h):        **PLACEHOLDER**, blocked on T8.4
  (#416 → reopened #92, pty-soak.yml). WARN + exit 0.
- gate-d (installer roundtrip): **PLACEHOLDER**, blocked on T8.6
  (#417 → followup of #95, installer-roundtrip.yml). WARN + exit 0.

Real impl for gate-c/d lives in **#415** (v0.4 ship cycle). v0.3 ship
plan ("4 dogfood items + minisign as the only hard blocker") does not
need pty-soak / installer roundtrip in the gate set, so v0.3 ships
on placeholder c/d intentionally and documents that fact in both gate
script bodies (so accidentally tightening them later is loud).

## Files
- `tools/release-candidate.sh` — main driver (gate loop + fail-fast).
- `tools/release-candidate/lib/gate-{a,b,c,d}.sh` — per-gate scripts.
- `tools/release-candidate/lib/emit-tag.sh` — prints suggested
  `git tag` command (does not exec it).
- `tools/test/release-candidate.spec.ts` — 16 specs covering shape,
  ordering, fail-fast on gate-a/b failure, missing-script error path,
  placeholder WARN content, and emit-tag override via `CCSM_RC_VERSION`.

## Local checks (host: windows-11)
- lint: ✓ (exit 0, 0 errors / 66 preexisting warnings unrelated)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0, FULL TURBO cache hit)
- tools spec: ✓ `Test Files 1 passed (1) / Tests 16 passed (16) / Duration 5.22s`
- gate-a real run (`pnpm lint:no-ipc`): ✓ `PASS: zero IPC residue under electron / src / packages/electron/src`
- gate-b real run (snapshot-codec): ✓ `Test Files 2 passed (2) / Tests 45 passed (45)`
- gate-b real run (sigkill-reattach): ✓ `Test Files 1 passed (1) / Tests 2 passed | 1 skipped (3)`
- end-to-end driver run on working tip: ✓ all 4 gates green, emit-tag prints `git tag v0.3.0 9b58ec5522f7d7be1b6ac17bb89969dd507f9745`
- driver fail-injection (`CCSM_RC_GATE_A_CMD=false`): ✓ exits 1 with `FAIL: gate-a (IPC residue (lint:no-ipc)) exited 1` and no tag suggestion
- e2e (full): **skipped** — this PR adds only `tools/*.sh` + 1 `tools/test/*.spec.ts`. No `electron/`, `src/`, or `packages/*` application code touched. The new spec runs under `tools/vitest.config.ts` (already exercised in CI matrix), not under the e2e harness.
- `npm test` (full turbo): 4 daemon RPC integration specs fail on working tip — same `Code.Unimplemented` failures present pre-PR, completely unrelated to `tools/release-candidate.sh`. Not introduced here.

## Reverse-verify (driver fail-fast)
- inject `CCSM_RC_GATE_A_CMD=false` → driver → FAIL: `FAIL: gate-a (IPC residue (lint:no-ipc)) exited 1` + `DRIVER_EXIT=1`
- restore (no env override) → driver → PASS: all 4 gates green, `git tag v0.3.0 <sha>` printed

## Test plan
- [ ] CI green on `working` matrix (ubuntu / macos / windows).
- [ ] Reviewer can `bash tools/release-candidate.sh` locally on `working` tip and see the same 4-gate pass + tag suggestion.
- [ ] Reviewer confirms gate-c/d WARN copy explicitly references #415 / #416 / #417 so the next person tightening these gates lands on the followup task, not on a silent assumption.