### PR TITLE
ci(pty-soak): add .github/workflows/pty-soak.yml ship-gate (c) workflow (Task #416)

### DIFF
--- a/.github/workflows/pty-soak.yml
+++ b/.github/workflows/pty-soak.yml
@@ -1,0 +1,105 @@
+name: pty-soak
+
+# Ship-gate (c) per docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+# chapter 12 §4.3 — 1-hour zero-loss PTY soak. Canonical test path locked in
+# chapter 15 §3 #28: packages/daemon/test/integration/pty-soak-1h.spec.ts.
+#
+# Triggers (per spec ch11 §6 + Task #416):
+#   * workflow_dispatch — manual on-demand (e.g. release-tag promotion gate per
+#     chapter 13 §5: tag is promoted only after the soak run on that exact
+#     commit is green).
+#   * schedule (07:00 UTC daily) — nightly opt-in matching the chapter 11 §6
+#     CI matrix sketch. Non-blocking for PRs (regressions caught the next
+#     morning).
+#
+# Status (T8.4 reopen): the spec scaffolds at packages/daemon/test/integration/
+# pty-soak-{1h,10m,shared}.ts already self-skip via `describe.skipIf` until the
+# T4.x driver (pty-soak-driver.ts) lands — see pty-soak-shared.ts comment for
+# the exact gating contract. This workflow ships now so chapter 11 §6 CI can
+# pin the canonical path immediately and Task #235 ship-gate verification has
+# a target; the job goes from "skipped sentinel reports T4.x reason" to "real
+# 60-min run" automatically once the driver merges, with no edit here.
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 07:00 UTC daily. Drives the nightly variant per chapter 11 §6.
+    - cron: '0 7 * * *'
+
+concurrency:
+  # Single in-flight run per ref. A second push that lands while a soak is
+  # running cancels the older one — the soak is a 60+ min job and double-booking
+  # the runner gives no useful signal.
+  group: pty-soak-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  pty-soak-1h:
+    name: pty-soak-1h (ship-gate (c))
+    # Per spec ch11 §6 + tools/runners/README.md: the 1-hour soak runs on a
+    # self-hosted runner labeled `[self-hosted, ccsm-soak]` so background CPU
+    # contention from the GitHub-hosted shared pool doesn't introduce timing
+    # flakes (the gate samples SendInput RTT p99 < 5 ms — very flake-prone on
+    # noisy hardware).
+    #
+    # Until the self-hosted runner is provisioned (tracked in infra repo), the
+    # workflow is dispatched manually and the ccsm-soak label is required; a
+    # missing label leaves the job queued, which is the intended fail-soft (a
+    # vacuous green on `ubuntu-latest` would defeat the whole gate).
+    runs-on: [self-hosted, ccsm-soak]
+    # 60-min soak + 15-min slack for boot + final byte-equality comparison +
+    # log upload. Matches the _runners-template.yml reference.
+    timeout-minutes: 75
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.2
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
+
+      # Generate proto bindings — daemon's tsc emit needs them present even
+      # when the soak skips (the spec file imports `./pty-soak-shared.js`
+      # which lives next to the daemon test sources and is built with the
+      # daemon tsc).
+      - name: Generate proto
+        run: pnpm --filter @ccsm/proto run gen
+
+      # Run only the 1h spec by file path. The spec self-skips via
+      # `describe.skipIf(!dependenciesPresent().ready)` until the T4.x driver
+      # lands; while skipped a sentinel `it('reports gating reason')` records
+      # WHY it skipped in vitest --reporter=verbose output (so a vacuous green
+      # is impossible — either the soak runs or the sentinel names the gap).
+      #
+      # The 10m smoke variant runs in the per-PR ci.yml suite; this workflow
+      # is dedicated to the nightly/on-demand 1h variant.
+      - name: Run pty-soak-1h
+        working-directory: packages/daemon
+        run: pnpm exec vitest run --reporter=verbose test/integration/pty-soak-1h.spec.ts
+
+      # Always upload artifacts — when the soak runs, callers want the
+      # cadence samples + SendInput RTT histogram + memory trace; when it
+      # skips, the verbose reporter output documents the gating reason.
+      - name: Upload soak artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pty-soak-1h-${{ github.run_id }}
+          path: |
+            packages/daemon/test-results/**
+            packages/daemon/coverage/**
+          if-no-files-found: warn
+          retention-days: 14


### PR DESCRIPTION
## Summary

T8.4 reopen (Task #416). Adds the dedicated GitHub Actions workflow for the 1-hour PTY zero-loss soak that ship-gate (c) requires per design spec ch12 §4.3.

## Scope

NEW file (1):
- `.github/workflows/pty-soak.yml` — `workflow_dispatch` + nightly cron (07:00 UTC), runs on `[self-hosted, ccsm-soak]` per spec ch11 §6 + `tools/runners/README.md`, uploads test-results/coverage as artifact, 75 min timeout (60 min soak + 15 min slack matching `_runners-template.yml`).

## NOT in scope (already shipped)

The task spec listed 4 NEW files but 3 of them already exist on `origin/working` at `c354dd4`:
- `packages/daemon/test/integration/pty-soak-1h.spec.ts`
- `packages/daemon/test/integration/pty-soak-10m.spec.ts`
- `packages/daemon/test/integration/pty-soak-shared.ts`

These were merged via PR #894 (consolidation batch). The original PR #880 path bug — `pre-Wave-0d.4 src/pty/pty-host.ts` made `existsSync` always false and silently skipped ship-gate (c) — was already fixed by **PR #964 (a8a1c1a)** which:
- Moved the probe to `src/pty-host/host.ts` (the post-Wave-0d.4 canonical location).
- Removed the silent `skipIf` fallback so a missing pty-host now throws instead of vacuous-greening.
- Added a `T4.6 / T4.10 driver-not-landed` named-skip with sentinel `it('reports gating reason')` test.

So this PR only ships the genuinely-missing piece — the workflow yml.

## Workflow shape decisions

- **Triggers** — `workflow_dispatch` (manual on-demand for release-tag promotion gate per ch13 §5) + `schedule` cron (nightly per ch11 §6). Per-PR runs continue to use the 10m smoke variant in `ci.yml`; this workflow is the dedicated 1h variant.
- **Runner** — `[self-hosted, ccsm-soak]` (NOT `ubuntu-latest`). Gate samples SendInput RTT p99 < 5 ms which is very flake-prone on the GitHub-hosted shared pool. Missing label as fail-soft (job stays queued) is intentional — vacuous green on shared runners would defeat the gate.
- **Invocation** — `pnpm exec vitest run --reporter=verbose test/integration/pty-soak-1h.spec.ts` (NOT a `pnpm run test:pty-soak` script; that script does not exist on tip and adding it would touch `packages/daemon/package.json` which is out of scope).
- **Artifact upload** runs `if: always()` so the verbose reporter output documents the gating reason even when the suite skips.

## Local checks (host: windows-11)

- lint (daemon): pass (0 errors, 66 pre-existing warnings)
- typecheck (daemon): pass
- yaml syntax: validated via `python -c "yaml.safe_load(...)"`
- pty-soak specs: `2 passed | 2 skipped (4)` with skip reason matching `/T4\./`
- reverse-verify: temporarily flipped sentinel `expect(probe.reason).toMatch(/T4\./)` to `/NEVER_MATCH_XYZ/` → spec FAILED with the real probe.reason; restored → spec PASSED. Confirms the spec is not vacuously green.

## PR #880 path bug — what was fixed where

Per task spec, here's the path-bug audit relative to PR #880:

| Concern | Location in PR #880 | Status now |
|---|---|---|
| `PTY_HOST_PATH` pointed at `src/pty/pty-host.ts` (never existed) | `pty-soak-shared.ts` line referencing the path | Fixed by PR #964: now `src/pty-host/host.ts` (post-Wave-0d.4 canonical) |
| Silent `skipIf` fallback when probe failed | `pty-soak-shared.ts` `dependenciesPresent()` | Fixed by PR #964: now THROWS on missing pty-host (regression, not skip) |
| Missing dist-path fallback for built CI runs | `pty-soak-shared.ts` | Fixed by PR #964: probes both `src/pty-host/host.ts` AND `dist/pty-host/host.js` |
| Missing named-skip sentinel for T4.x gap | both `.spec.ts` files | Fixed by PR #894: each spec has a paired `describe.skipIf(probe.ready)('... skipped — pending dependencies')` block with `it('reports gating reason')` test |

This PR adds no spec changes; the spec corrections were carried by PRs #894 / #964.

## Test plan

- [x] yaml syntax valid
- [x] daemon typecheck pass
- [x] daemon lint pass
- [x] pty-soak specs pass with skip reason
- [x] reverse-verify (spec can fail)
- [ ] CI green on this PR
- [ ] (post-merge, when self-hosted runner provisioned) manual `gh workflow run pty-soak.yml` produces a real 60-min run after T4.x driver lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)