### PR TITLE
test(e2e): no-skipif-cheat — fix marker probes + harness sentinel skips (Task #343)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -122,17 +122,24 @@ jobs:
       - name: Build
         run: npm run build:app
       - name: Run e2e
-        # E2E_SKIP=harness-real-cli — public CI runners have no `claude`
-        # CLI installed AND no Anthropic auth tokens, so every case in
-        # harness-real-cli that calls waitForTerminalReady deterministically
-        # times out (the renderer falls through to ClaudeMissingGuide and
-        # never mounts <TerminalPane>). The harness stays runnable locally
-        # via `node scripts/harness-real-cli.mjs` (or `npm run probe:e2e`
-        # without the env var) for the dev / dogfood loop, where the user's
-        # ~/.claude is real. (#726)
+        # Task #343 (Wave M3.5-CHECK no-skipif-cheat) — removed
+        # `E2E_SKIP=harness-real-cli`. The blanket skip env was a
+        # vacuously-green gate (the harness ran zero cases on every CI
+        # run). The harness now sentinel-skips itself in-process when
+        # `claude` is missing from PATH and `CCSM_CLAUDE_BIN` is unset
+        # (see `scripts/harness-real-cli.mjs:detectClaudeBin`), printing
+        # a `[SENTINEL-SKIP] harness-real-cli` line in the summary so the
+        # gating reason is visible in CI logs. Public CI runners still
+        # have neither the binary nor Anthropic auth, so the net effect
+        # on green-CI matches the prior env (whole harness skipped) but
+        # the skip is now an explicit, auditable sentinel rather than a
+        # silent E2E_SKIP entry. Locally `pnpm run probe:e2e` keeps the
+        # full harness (the dev's PATH normally has `claude`).
+        # Per-case skips inside the harness (currently:
+        # session-state-becomes-idle pending PR-A renderer cutover, see
+        # #265 followup) are surfaced as `[SENTINEL-SKIP]` rows in the
+        # final HARNESS SUMMARY table.
         run: npm run probe:e2e
-        env:
-          E2E_SKIP: harness-real-cli
       - name: Upload e2e logs on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/docs/milestones/M3.5-no-skipif-cheat.md
+++ b/docs/milestones/M3.5-no-skipif-cheat.md
@@ -1,0 +1,178 @@
+# M3.5-CHECK: no-skipif-cheat — Task #343 acceptance record
+
+Scope: refined scope A (manager decision 2026-05-05). Round 1 push back
+flagged that the originally-spec'd `it.skipIf(...)` flips would hard-fail
+v0.3 ship by depending on T4.6 driver / T8.7 claude-sim fixture / T8.3-T8.5
+spec bodies that are all multi-wave implementation work, not editor-touch
+fixes. Manager adopted dev recommendation A: fix the marker-probe stale
+paths (the actual vacuous-green root cause), surface harness-real-cli's
+gating reasons via in-process sentinels, and add an aliased
+`reports gating reason` sentinel to `sigkill-reattach.spec.ts`.
+
+The four hard-fail spec bodies (sigkill-reattach, pty-soak-reconnect,
+pty-soak-1h, pty-soak-10m) remain `describe.skipIf(...)`-gated; after this
+PR they continue to skip but with **truthful** marker reasons (no longer
+vacuous-green) and downstream implementation followup is enumerated below.
+
+---
+
+## A.1 — sigkill-reattach.spec.ts marker-probe stale-path fix
+
+The `existsSync(...)` probes in `packages/electron/test/e2e/sigkill-reattach.spec.ts`
+were checking three pre-rename paths, every one returning false on every CI
+run, which made `SHOULD_SKIP` unconditionally true regardless of whether the
+underlying dependency had landed. This is the same vacuous-green failure
+mode Task #209 corrected in the soak harness.
+
+Probe path corrections:
+
+| dep | old marker (stale) | new marker (current tree) | source |
+| --- | --- | --- | --- |
+| T1.4 Listener A | `packages/daemon/src/listeners/listener-a.ts` | `packages/daemon/src/listeners/factory.ts` | T1.4 PR #912 rename |
+| T6.2 transport surface | `packages/electron/src/rpc/transport.ts` | `packages/electron/src/rpc/clients.ts` AND `.../queries.ts` | T6.3 PR #915 split |
+| SnapshotV1 encoder | `packages/daemon/src/pty/snapshot-v1.ts` | `packages/snapshot-codec/src/index.ts` | T4.7 #44 PR #1021 extract |
+
+T8.7 claude-sim fixture (`packages/daemon/test/fixtures/claude-sim/bin/...`)
+and the Playwright launch fixture
+(`packages/electron/test/e2e/_fixtures/launch.ts`) markers stay unchanged —
+those dependencies have not landed yet, so `MISSING_MARKERS` is still
+non-empty and the suite still skips. The difference is the skip reason now
+honestly reads `awaiting dependencies: T8.7 claude-sim fixture, Playwright
+_electron.launch fixture` instead of a five-item list of files that all
+already exist under different names.
+
+### Reverse-verify (A.1)
+
+In the current tree the spec body is `describe.skipIf(SHOULD_SKIP)(...)`,
+so the body itself does not run yet — it cannot fail-when-broken until
+T8.7 + the Playwright fixture land. What the marker-path fix unlocks is
+the **sentinel** layer:
+
+- **Before A.1**: every marker probed a non-existent path, so
+  `MISSING_MARKERS = [<all 5>]`, `SHOULD_SKIP = true`, and the sentinel
+  `it('reports a stable skip reason ...')` passed via the
+  `awaiting dependencies` arm. If someone deleted a `describe.skipIf`
+  branch entirely the sentinel still passed — the marker layer was inert.
+- **After A.1**: probes resolve correctly. With T1.4/T6.2/SnapshotV1 all
+  present (current tree), `MISSING_MARKERS = ['T8.7 claude-sim fixture',
+  'Playwright _electron.launch fixture']`. When the remaining two
+  dependencies land, `MISSING_MARKERS = []` AND `SHOULD_SKIP = false`,
+  which **forces the spec body to run**. Today the body throws
+  `'T8.3 implementation pending — see header comment §IMPLEMENTATION
+  OUTLINE.'` so the suite immediately turns red the moment the markers
+  resolve, which is the correct contract: no silent flip from "skipped"
+  to "vacuously green".
+
+The new aliased sentinel `it('reports gating reason', ...)` adds a
+secondary guard: when `SHOULD_SKIP = true` AND the manual override env is
+unset, it asserts `MISSING_MARKERS.length > 0`. So the
+"someone set `SHOULD_SKIP = true` with empty marker list" failure mode
+(which would let the suite quietly skip with no reason) now fails this
+sentinel, not the main suite.
+
+---
+
+## A.2 — harness-real-cli `E2E_SKIP` flip + per-case sentinel
+
+Two changes:
+
+1. **`.github/workflows/e2e.yml`**: removed `env: E2E_SKIP: harness-real-cli`
+   from the `Run e2e` step. The blanket skip env was a vacuous-green gate
+   (the harness ran zero cases on every CI run, so every assertion in it
+   was meaningless). Replaced with an in-harness preflight (`detectClaudeBin`
+   in `scripts/harness-real-cli.mjs`): when neither `CCSM_CLAUDE_BIN` env is
+   set nor `claude` is on `PATH`, the harness prints
+   `[SENTINEL-SKIP] harness-real-cli — no claude binary on PATH ...` to the
+   summary and `process.exit(0)`. Net effect on a public CI runner is
+   identical to the prior env (whole harness skipped, exit 0), but the skip
+   is now an explicit, greppable sentinel rather than a silent env-flag
+   bypass. Locally (`pnpm run probe:e2e`) the dev's shell PATH normally has
+   `claude`, so the harness now actually runs end-to-end — which is the
+   load-bearing change versus the prior state where the env was set
+   verbatim in CI but devs running the same target locally got the same
+   skip and never noticed.
+
+2. **`scripts/harness-real-cli.mjs:caseSessionStateBecomesIdle`**: replaced
+   the hard `throw new Error('window.ccsmSession.onState not exposed by
+   preload (PR-A wiring missing)')` with a sentinel soft-skip that records
+   the reason on `globalThis.__ccsmHarnessSentinelSkips`. The runner
+   summary surfaces the entry as a
+   `[SENTINEL-SKIP] session-state-becomes-idle ...` line. Pattern aligns
+   with `pty-soak-1h.spec.ts:78` `it('reports gating reason', ...)`.
+
+   Reason text: *"PR-A renderer cutover followup pending — see #265
+   followup"*. Tracked: PR-A series (renderer-side preload `ccsmSession.onState`
+   wiring).
+
+### Implementation gap vs. literal task spec
+
+The task spec said *"`harness-real-cli` 的 `session-state-becomes-idle` 类
+用例改 `it.skipIf(!hasPreloadOnState, "...")` + sentinel"*. The literal
+form (`it.skipIf`) is vitest API; `scripts/harness-real-cli.mjs` is a
+hand-rolled `.mjs` runner, not a vitest spec — it has no `it` / `describe`
+/ `skipIf`. The implementation translates the intent (sentinel-style
+soft-skip surfaced in the summary) to the runner's actual control flow
+(early `return` from the case function plus a sentinel array the runner
+prints in the SUMMARY table).
+
+---
+
+## A.3 — sigkill-reattach.spec.ts `reports gating reason` sentinel
+
+Added `it('reports gating reason', ...)` inside the existing
+`describe('T8.3 sigkill-reattach — skip-marker self-check', ...)` block.
+The case name is intentionally identical to `pty-soak-1h.spec.ts:78` so
+both ship-gate sentinels surface under the same greppable name regardless
+of which dependency is missing. The pre-existing `it('reports a stable
+skip reason while dependencies are pending', ...)` is kept to preserve
+backward-compatible test name pinning for any tooling that filtered on it.
+
+The new `reports gating reason` adds a defence the original sentinel
+lacked: when `SHOULD_SKIP = true` AND `SKIP_OVERRIDE = false`, it asserts
+`MISSING_MARKERS.length > 0`. The failure mode it catches: a future patch
+that flips `SHOULD_SKIP = true` while `MISSING_MARKERS` is empty (e.g.
+deleting a marker check by accident) would have quietly skipped the suite
+with the original sentinel; now it fails the new one.
+
+---
+
+## A.4 — ci.yml stale spec line: NOT TOUCHED
+
+The original task spec said `ci.yml:188 continue-on-error: true` was a
+vacuous-green knob to flip. Inspection of `ci.yml` shows line 208 carries
+an inline comment that explicitly explains *why* `continue-on-error` is
+intentionally NOT used there. The task spec entry is stale relative to the
+current `ci.yml`. No edit was made to `ci.yml` in this PR. Logged here so
+a future spec scrub can drop the stale line without re-investigating.
+
+## A.5 — snapshot-roundtrip stale spec line: NOT TOUCHED
+
+The original task spec said the spike harness's snapshot-roundtrip
+`describe.skip` at line 28 should flip to a live `describe`. Inspection of
+the spike-harness file's header `§STATUS` block shows the line is already
+a live `describe(...)` (no `.skip`). The task spec entry is stale relative
+to the current spike-harness. No edit was made to the spike-harness in
+this PR. Logged here so a future spec scrub can drop the stale line.
+
+---
+
+## Out of scope — followups for full ship-gate (b)/(c) execution
+
+The four spec bodies that `describe.skipIf` to skipped in the current tree
+remain skipped after this PR (with truthful marker reasons). Each requires
+multi-wave implementation work tracked separately:
+
+| spec | gating dependency | followup task sketch |
+| --- | --- | --- |
+| `packages/electron/test/e2e/sigkill-reattach.spec.ts` body | T8.7 claude-sim fixture + `_fixtures/launch.ts` Playwright boilerplate (T6.6 / T8.x) | one followup task per dep; sigkill body lands once both markers resolve |
+| `packages/electron/test/e2e/pty-soak-reconnect.spec.ts` body | T8.5 (this spec) waits on T8.3 marker (the sigkill spec's existence) — already met; remaining gating is the same T8.7 + launch-fixture pair | folds into the same followup as sigkill body |
+| `packages/daemon/test/integration/pty-soak-1h.spec.ts` body | T4.6 driver (`pty-soak-shared.ts:loadSoakDriver` real impl) + T8.7 claude-sim | T4.6 driver task + T8.7 fixture task |
+| `packages/daemon/test/integration/pty-soak-10m.spec.ts` body | same as 1h (10m is the per-PR smoke variant) | folds into the T4.6 + T8.7 followups |
+
+These four are NOT part of Task #343's PR. Per the v0.3 zero-rework rule
+(`feedback_v03_zero_rework.md`), the marker-probe fix in this PR ensures
+they cannot quietly flip to vacuously-green when those followups land —
+the moment `MISSING_MARKERS` empties, the spec bodies run. If a followup
+PR wires the marker but forgets to land the body implementation, the body
+will throw `'T8.3 implementation pending'` (or the matching error) and the
+suite will turn red the same CI run.

--- a/packages/electron/test/e2e/sigkill-reattach.spec.ts
+++ b/packages/electron/test/e2e/sigkill-reattach.spec.ts
@@ -158,20 +158,31 @@
 // shows up as a failing test rather than a vacuously-green skip.
 //
 //   T1.4  — Listener A bind + descriptor write
-//           marker: `packages/daemon/src/listeners/listener-a.ts`
-//           Without it the daemon never writes `listener-a.json`, so the
+//           marker: `packages/daemon/src/listeners/factory.ts`
+//           (Originally `listener-a.ts`; renamed by T1.4 PR #912 — the
+//           factory module is the loader the daemon entrypoint imports
+//           to bind Listener A and write `listener-a.json`.)
+//           Without it the daemon never writes the descriptor, so the
 //           Electron renderer has no transport descriptor to read.
 //
-//   T6.2  — Electron-side Connect-RPC transport bridge
-//           marker: `packages/electron/src/rpc/transport.ts` exists AND
-//                   exports `createDaemonTransport`.
-//           Without it the renderer has no Connect transport to drive
-//           `SessionService.Create` / `PtyService.Attach`.
+//   T6.2  — Electron-side Connect-RPC transport surface
+//           marker: `packages/electron/src/rpc/clients.ts` AND
+//                   `packages/electron/src/rpc/queries.ts`
+//           (Originally a single `transport.ts`; T6.3 PR #915 split it
+//           into the typed client factory (`clients.ts`) and the React
+//           Query bindings (`queries.ts`). Both files are load-bearing
+//           for `SessionService.Create` / `PtyService.Attach` to be
+//           reachable from the renderer; either being absent invalidates
+//           the dependency.)
 //
 //   ch06 §2 SnapshotV1 encoder
-//           marker: `packages/daemon/src/pty/snapshot-v1.ts`
-//           The byte-equality assertion in step 7 IS the gate; without
-//           the encoder there is no comparator.
+//           marker: `packages/snapshot-codec/src/index.ts`
+//           (Originally `packages/daemon/src/pty/snapshot-v1.ts`; T4.7
+//           PR #1021 extracted the encoder into the standalone
+//           `@ccsm/snapshot-codec` package so the daemon and the
+//           Electron-side replay both consume the same bytes-in/bytes-out
+//           module. The byte-equality assertion in step 7 IS the gate;
+//           without the encoder there is no comparator.)
 //
 //   T8.7  — `claude-sim` deterministic workload fixture
 //           marker: `packages/daemon/test/fixtures/claude-sim/bin/claude-sim`
@@ -231,13 +242,16 @@ const REPO_ROOT = join(__dirname, '..', '..', '..', '..');
 // during test collection.
 
 const T1_4_LISTENER_A_MARKER = join(
-  REPO_ROOT, 'packages', 'daemon', 'src', 'listeners', 'listener-a.ts',
+  REPO_ROOT, 'packages', 'daemon', 'src', 'listeners', 'factory.ts',
 );
-const T6_2_TRANSPORT_MARKER = join(
-  REPO_ROOT, 'packages', 'electron', 'src', 'rpc', 'transport.ts',
+const T6_2_TRANSPORT_CLIENTS_MARKER = join(
+  REPO_ROOT, 'packages', 'electron', 'src', 'rpc', 'clients.ts',
+);
+const T6_2_TRANSPORT_QUERIES_MARKER = join(
+  REPO_ROOT, 'packages', 'electron', 'src', 'rpc', 'queries.ts',
 );
 const SNAPSHOT_V1_ENCODER_MARKER = join(
-  REPO_ROOT, 'packages', 'daemon', 'src', 'pty', 'snapshot-v1.ts',
+  REPO_ROOT, 'packages', 'snapshot-codec', 'src', 'index.ts',
 );
 const T8_7_CLAUDE_SIM_MARKER_POSIX = join(
   REPO_ROOT, 'packages', 'daemon', 'test', 'fixtures', 'claude-sim', 'bin', 'claude-sim',
@@ -248,9 +262,16 @@ const PLAYWRIGHT_FIXTURE_MARKER = join(
 );
 
 const MISSING_MARKERS: string[] = [];
-if (!existsSync(T1_4_LISTENER_A_MARKER)) MISSING_MARKERS.push('T1.4 Listener A');
-if (!existsSync(T6_2_TRANSPORT_MARKER)) MISSING_MARKERS.push('T6.2 transport bridge');
-if (!existsSync(SNAPSHOT_V1_ENCODER_MARKER)) MISSING_MARKERS.push('SnapshotV1 encoder (ch06 §2)');
+if (!existsSync(T1_4_LISTENER_A_MARKER)) MISSING_MARKERS.push('T1.4 Listener A (factory.ts)');
+if (
+  !existsSync(T6_2_TRANSPORT_CLIENTS_MARKER) ||
+  !existsSync(T6_2_TRANSPORT_QUERIES_MARKER)
+) {
+  MISSING_MARKERS.push('T6.2 transport surface (clients.ts + queries.ts)');
+}
+if (!existsSync(SNAPSHOT_V1_ENCODER_MARKER)) {
+  MISSING_MARKERS.push('SnapshotV1 encoder (@ccsm/snapshot-codec)');
+}
 if (
   !existsSync(T8_7_CLAUDE_SIM_MARKER_POSIX) &&
   !existsSync(T8_7_CLAUDE_SIM_MARKER_WIN)
@@ -304,6 +325,26 @@ describe.skipIf(SHOULD_SKIP)(
 // is visible as a failing test rather than a quietly-passing skip. This
 // mirrors the pattern in `pty-soak-reconnect.spec.ts` (T8.5).
 describe('T8.3 sigkill-reattach — skip-marker self-check', () => {
+  it('reports gating reason', () => {
+    // Aliased name kept in lockstep with `pty-soak-1h.spec.ts:78`'s
+    // `it('reports gating reason', ...)` so both ship-gate sentinels
+    // surface under a stable, greppable test name regardless of which
+    // dependency is missing.
+    if (SHOULD_SKIP) {
+      expect(SKIP_REASON).toMatch(/awaiting dependencies|manual override/);
+      // Also assert MISSING_MARKERS is non-empty when not overridden, so a
+      // future bug that flips SHOULD_SKIP=true with empty MISSING_MARKERS
+      // (e.g. someone deletes a marker check without wiring the impl)
+      // fails THIS test instead of vacuously passing.
+      if (!SKIP_OVERRIDE) {
+        expect(MISSING_MARKERS.length).toBeGreaterThan(0);
+      }
+      console.log(`[T8.3] suite skipped — ${SKIP_REASON}`);
+    } else {
+      expect(MISSING_MARKERS).toEqual([]);
+    }
+  });
+
   it('reports a stable skip reason while dependencies are pending', () => {
     if (SHOULD_SKIP) {
       expect(SKIP_REASON).toMatch(/awaiting dependencies|manual override/);

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -45,6 +45,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -550,6 +551,35 @@ async function caseSessionStateBecomesIdle({ electronApp: _electronApp, win, tem
     { timeout: 30000 },
   );
 
+  // Probe whether the PR-A renderer cutover (preload `window.ccsmSession.onState`)
+  // has landed. While that wiring is pending, this case soft-skips with a
+  // sentinel marker so the harness exit stays clean and the skip reason is
+  // visible in CI logs / artifact triage. This mirrors the
+  // `pty-soak-1h.spec.ts:78` `it('reports gating reason', ...)` sentinel
+  // pattern. Tracked: Task #265 followup (PR-A renderer cutover).
+  const hasPreloadOnState = await win.evaluate(() => {
+    const api = /** @type {any} */ (globalThis).window?.ccsmSession;
+    return Boolean(api && typeof api.onState === 'function');
+  });
+  if (!hasPreloadOnState) {
+    const reason =
+      'session-state-becomes-idle skipped — PR-A renderer cutover followup pending ' +
+      '(window.ccsmSession.onState not exposed by preload). See #265 followup.';
+    console.log(`[HARNESS]   [SENTINEL-SKIP] ${reason}`);
+    // `globalThis.__ccsmHarnessSentinelSkips` is read by the runner summary
+    // below to surface the skip in the final table.
+    /** @type {any} */
+    const g = globalThis;
+    if (!Array.isArray(g.__ccsmHarnessSentinelSkips)) {
+      g.__ccsmHarnessSentinelSkips = [];
+    }
+    g.__ccsmHarnessSentinelSkips.push({
+      case: 'session-state-becomes-idle',
+      reason,
+    });
+    return;
+  }
+
   // Install the renderer-side event log BEFORE any session spawns so we
   // catch the very first state event for this sid.
   await win.evaluate(() => {
@@ -566,7 +596,24 @@ async function caseSessionStateBecomesIdle({ electronApp: _electronApp, win, tem
   });
   const apiMissing = await win.evaluate(() => Boolean(window.__sessionStateApiMissing));
   if (apiMissing) {
-    throw new Error('window.ccsmSession.onState not exposed by preload (PR-A wiring missing)');
+    // Defence in depth: the preflight probe above should have caught this.
+    // If we get here, the API disappeared between probe and install — keep
+    // it as a sentinel skip rather than a hard fail to preserve the
+    // "no vacuously-green, but no spurious red either" stance.
+    const reason =
+      'session-state-becomes-idle skipped — window.ccsmSession.onState ' +
+      'disappeared between preflight probe and event-log install (race). See #265 followup.';
+    console.log(`[HARNESS]   [SENTINEL-SKIP] ${reason}`);
+    /** @type {any} */
+    const g = globalThis;
+    if (!Array.isArray(g.__ccsmHarnessSentinelSkips)) {
+      g.__ccsmHarnessSentinelSkips = [];
+    }
+    g.__ccsmHarnessSentinelSkips.push({
+      case: 'session-state-becomes-idle',
+      reason,
+    });
+    return;
   }
 
   const { sid } = await seedSession(win, { name: 'state-probe-active', cwd: tempDir });
@@ -3464,7 +3511,62 @@ const CASE_REGISTRY = [
 // Runner
 // ============================================================================
 
+/**
+ * Detect whether the upstream `claude` CLI binary is reachable. Mirrors the
+ * resolution logic in `scripts/probe-helpers/harness-runner.mjs:resolveClaudeBin`
+ * so the two harness flavours behave identically:
+ *   1. `CCSM_CLAUDE_BIN` env override — explicit absolute path.
+ *   2. Walk `PATH` looking for `claude` / `claude.exe` / `claude.cmd`.
+ * Returns the resolved path on hit, null on miss.
+ *
+ * Used to gate the entire harness at the runner level: with no binary on
+ * PATH every case that calls `waitForTerminalReady` deterministically times
+ * out (the renderer falls through to ClaudeMissingGuide and never mounts
+ * <TerminalPane>). Public CI runners have neither the binary nor Anthropic
+ * auth, so we sentinel-skip the whole harness with exit 0 + a marker line
+ * the runner table picks up. Locally (`pnpm run probe:e2e`) the user's
+ * shell PATH normally has `claude`, so the harness runs fully.
+ *
+ * @returns {string | null}
+ */
+function detectClaudeBin() {
+  const override = process.env.CCSM_CLAUDE_BIN;
+  if (override && existsSync(override)) return override;
+  const exts = process.platform === 'win32' ? ['.exe', '.cmd', '.bat', ''] : [''];
+  const dirs = (process.env.PATH ?? '').split(path.delimiter).filter(Boolean);
+  for (const d of dirs) {
+    for (const ext of exts) {
+      const p = path.join(d, `claude${ext}`);
+      try {
+        const stat = statSync(p);
+        if (stat.isFile()) return p;
+      } catch { /* miss */ }
+    }
+  }
+  return null;
+}
+
 async function main() {
+  // ---- preflight: harness-real-cli requires the upstream `claude` binary ----
+  // Without it every shared case times out at waitForTerminalReady. Sentinel-skip
+  // the entire harness with a clear marker line + exit 0 so run-all-e2e.mjs
+  // counts it as a passed-but-skipped harness rather than a 27-failure cascade.
+  // The legacy `E2E_SKIP=harness-real-cli` env in `.github/workflows/e2e.yml`
+  // is removed in this same PR (Task #343) — this preflight replaces it with
+  // an in-harness sentinel that surfaces the gating reason in CI logs.
+  const claudeBin = detectClaudeBin();
+  if (!claudeBin) {
+    const reason =
+      'no `claude` binary on PATH and CCSM_CLAUDE_BIN unset — public CI runners ' +
+      'have no upstream Claude CLI installed AND no Anthropic auth tokens. ' +
+      'Override locally with `CCSM_CLAUDE_BIN=/abs/path/to/claude` to force a run.';
+    console.log('\n===== HARNESS SUMMARY =====');
+    console.log(`  [SENTINEL-SKIP] harness-real-cli — ${reason}`);
+    console.log('  total: 0/0 passed (entire harness sentinel-skipped)');
+    process.exit(0);
+  }
+  console.log(`[HARNESS] preflight: claude binary at ${claudeBin}`);
+
   const { only, skip } = parseArgs(process.argv);
   const selected = CASE_REGISTRY.filter((c) => {
     if (only && !only.includes(c.name)) return false;
@@ -3545,11 +3647,21 @@ async function main() {
   const totalMs = Date.now() - harnessStart;
   const passed = results.filter((r) => r.ok).length;
   const failed = results.length - passed;
+  /** @type {Array<{case: string, reason: string}>} */
+  const sentinelSkips = Array.isArray(/** @type {any} */ (globalThis).__ccsmHarnessSentinelSkips)
+    ? /** @type {any} */ (globalThis).__ccsmHarnessSentinelSkips
+    : [];
   console.log('\n===== HARNESS SUMMARY =====');
   for (const r of results) {
     console.log(`  ${r.ok ? 'PASS' : 'FAIL'}  ${r.name.padEnd(34)} ${r.ms}ms`);
   }
+  for (const s of sentinelSkips) {
+    console.log(`  [SENTINEL-SKIP] ${s.case.padEnd(34)} ${s.reason}`);
+  }
   console.log(`  total: ${passed}/${results.length} passed, ${(totalMs / 1000).toFixed(1)}s wall`);
+  if (sentinelSkips.length > 0) {
+    console.log(`  sentinel-skipped cases: ${sentinelSkips.length}`);
+  }
   process.exit(failed === 0 ? 0 : 1);
 }
 


### PR DESCRIPTION
## Summary

Task #343 [M3.5-CHECK] refined scope A. Round 1 push back accepted by manager 2026-05-05 — the originally-spec'd `it.skipIf(...)` flips would have hard-failed v0.3 ship by depending on T4.6 driver / T8.7 claude-sim fixture / multiple spec bodies that are multi-wave implementation work. This PR delivers the actual vacuous-green fix (marker-probe stale paths) plus harness sentinels.

- A.1 — sigkill-reattach.spec.ts marker paths corrected (listener-a→factory.ts, transport.ts→clients.ts+queries.ts, daemon snapshot-v1.ts→packages/snapshot-codec). Same vacuous-green class as Task #209.
- A.2 — `.github/workflows/e2e.yml` removed `E2E_SKIP=harness-real-cli`; replaced with in-harness `detectClaudeBin` preflight + per-case sentinel for `session-state-becomes-idle` (PR-A renderer cutover followup, #265).
- A.3 — added `it('reports gating reason', ...)` sentinel to `sigkill-reattach.spec.ts` (name aligned with `pty-soak-1h.spec.ts:78`).
- A.4 / A.5 — task spec entries for `ci.yml:188` and snapshot-roundtrip `.skip` are stale vs current tree; not touched. Rationale + per-line evidence in `docs/milestones/M3.5-no-skipif-cheat.md`.
- Out of scope (followups documented): T4.6 driver, T8.7 claude-sim fixture, T6.6/T8.x Playwright launch fixture — these gate the four spec bodies that remain `describe.skipIf`-skipped (now with truthful marker reasons).

## Local checks (host: windows-11)

- lint: ✓ (exit 0, 0 errors / 66 unrelated daemon warnings)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0, full turbo cache hit)
- unit tests: 4 daemon `src/rpc/__tests__/integration.spec.ts` failures are **pre-existing on origin/working** (verified by `git checkout -- . && rerun → same failures`) — H2C loopback router bind hook timeout, unrelated to this PR's scope (e2e marker / harness sentinel).
- sigkill-reattach.spec.ts (the spec this PR edits): `3 passed | 1 skipped (4)` — sentinels green, main suite still skipped on T8.7 + Playwright fixture (truthful reason).
- e2e (probe:e2e): `harness-dnd PASS`, `harness-ui PASS (14/14)`. `harness-real-cli` now actually runs (was a no-op `E2E_SKIP` before this PR); it hits the runner-level 5-min HARNESS_TIMEOUT in the local pool-2 worktree because some `waitForTerminalReady` calls fall through to ClaudeMissingGuide (the `terminal-pane-mounted` UI probe shows `claudeAvailable=false` in this pool's env even with `claude.cmd` on PATH). This is baseline behaviour exposed by the un-skip — not a regression introduced here. Per Task #343 acceptance: *"harness-real-cli 真跑 (除 session-state-becomes-idle skipIf+sentinel)"* — confirmed: the harness now genuinely executes its cases instead of silent E2E_SKIP no-op.

## Reverse-verify (A.1)

```
# Before: 5 stale markers always missing; SHOULD_SKIP perma-true.
# After (current tree, T8.7 + launch.ts genuinely missing):
$ npx vitest run -t 'reports a stable skip reason' packages/electron/test/e2e/sigkill-reattach.spec.ts
   stdout: [T8.3] suite skipped — awaiting dependencies:
           T8.7 claude-sim fixture, Playwright _electron.launch fixture
   ✓ 1 passed

# Reverse: stub the two missing markers → SHOULD_SKIP=false → body runs:
$ mkdir -p packages/daemon/test/fixtures/claude-sim/bin && touch .../claude-sim.exe
$ mkdir -p packages/electron/test/e2e/_fixtures && echo '// stub' > .../_fixtures/launch.ts
$ npx vitest run packages/electron/test/e2e/sigkill-reattach.spec.ts
   FAIL  T8.3 sigkill-reattach — ship-gate (b) [subprocess]
         > daemon survives Electron SIGKILL; reattach yields ...
   Error: T8.3 implementation pending — see header comment §IMPLEMENTATION OUTLINE.
   ✓ marker layer correctly unblocks the body when deps land.

# Cleanup: rm -rf the stubs → back to `3 passed | 1 skipped (4)`.
```

## Reverse-verify (A.2 sentinel skip)

```
$ env -u CCSM_CLAUDE_BIN PATH=/c/Windows/System32 node scripts/harness-real-cli.mjs
===== HARNESS SUMMARY =====
  [SENTINEL-SKIP] harness-real-cli — no `claude` binary on PATH and CCSM_CLAUDE_BIN unset ...
  total: 0/0 passed (entire harness sentinel-skipped)
$ echo $?
0
```

## Test plan

- [x] sigkill-reattach.spec.ts marker probes resolve to current tree paths (verified by reverse-verify above)
- [x] sigkill-reattach.spec.ts adds `reports gating reason` sentinel asserting `MISSING_MARKERS.length > 0` when `SHOULD_SKIP=true && !SKIP_OVERRIDE`
- [x] harness-real-cli sentinel-skips harness when no claude binary on PATH (exit 0 + `[SENTINEL-SKIP]` summary line)
- [x] harness-real-cli `caseSessionStateBecomesIdle` soft-skips on missing preload API (PR-A followup #265) instead of hard-throwing
- [x] e2e.yml `Run e2e` step no longer carries `env: E2E_SKIP: harness-real-cli`; harness now genuinely executes on CI when claude binary is present
- [x] doc `docs/milestones/M3.5-no-skipif-cheat.md` records every reverse-verify, the stale-spec rationale for A.4/A.5, and the followup-task sketch for the four still-skipped spec bodies

🤖 Generated with [Claude Code](https://claude.com/claude-code)