### PR TITLE
ci(release): add minisign step + align secret names (Task #425)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,6 +166,69 @@ jobs:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
 
+      # Install minisign so we can produce .minisig sidecars for each
+      # release artifact. Placeholder-safe: if MINISIGN_PRIVATE_KEY isn't
+      # configured we skip signing entirely (WARN, no fail) per v0.3 ship
+      # non-negotiable "builds MUST continue unsigned if absent".
+      - name: Install minisign
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ matrix.platform }}" in
+            linux)
+              sudo apt-get update -y
+              sudo apt-get install -y minisign
+              ;;
+            mac)
+              brew install minisign
+              ;;
+            win)
+              # Pre-built Windows binary from upstream (jedisct1/minisign).
+              curl -fsSL -o minisign.zip https://github.com/jedisct1/minisign/releases/download/0.11/minisign-0.11-win64.zip
+              unzip -o minisign.zip -d "$RUNNER_TEMP/minisign"
+              echo "$RUNNER_TEMP/minisign/minisign-win64" >> "$GITHUB_PATH"
+              ;;
+          esac
+          minisign -v || "$RUNNER_TEMP/minisign/minisign-win64/minisign.exe" -v || true
+
+      # Sign each release artifact with minisign. Produces a .minisig sidecar
+      # next to each binary in release/. continue-on-error keeps the workflow
+      # green even if signing fails — sidecars are nice-to-have for v0.3, the
+      # hard ship gate is the artifact itself.
+      - name: Sign artifacts with minisign
+        id: minisign
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        continue-on-error: true
+        shell: bash
+        env:
+          MINISIGN_PRIVATE_KEY: ${{ secrets.MINISIGN_PRIVATE_KEY }}
+          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
+        run: |
+          set -uo pipefail
+          if [ -z "${MINISIGN_PRIVATE_KEY:-}" ] || [ -z "${MINISIGN_PASSWORD:-}" ]; then
+            echo "::warning title=minisign skipped::MINISIGN_PRIVATE_KEY / MINISIGN_PASSWORD not configured. No .minisig sidecars will be produced."
+            exit 0
+          fi
+          # Materialize the secret key to a temp file (minisign needs a file path).
+          KEY_FILE="$RUNNER_TEMP/minisign.key"
+          printf '%s' "$MINISIGN_PRIVATE_KEY" > "$KEY_FILE"
+          chmod 600 "$KEY_FILE"
+          shopt -s nullglob
+          signed=0
+          # Sign every shippable artifact; skip metadata yml / blockmap.
+          for f in release/*.exe release/*.dmg release/*.zip release/*.AppImage release/*.deb release/*.rpm; do
+            [ -f "$f" ] || continue
+            echo "Signing $f"
+            echo "$MINISIGN_PASSWORD" | minisign -S -s "$KEY_FILE" -m "$f" -t "ccsm release artifact $(basename "$f")"
+            signed=$((signed + 1))
+          done
+          rm -f "$KEY_FILE"
+          echo "Signed $signed artifact(s)."
+          if [ "$signed" -eq 0 ]; then
+            echo "::warning title=minisign no-op::No matching artifacts found in release/ to sign."
+          fi
+
       - name: Upload artifacts to workflow run
         uses: actions/upload-artifact@v4
         with:
@@ -179,6 +242,7 @@ jobs:
             release/*.rpm
             release/*.yml
             release/*.blockmap
+            release/*.minisig
           if-no-files-found: error
           retention-days: 14
 
@@ -201,5 +265,6 @@ jobs:
             release/*.rpm
             release/latest*.yml
             release/*.blockmap
+            release/*.minisig
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/milestones/M4-ship-ready-acceptance.md
+++ b/docs/milestones/M4-ship-ready-acceptance.md
@@ -72,7 +72,8 @@ All gates green. Suggested next step:
     git push origin v0.3.0
 
 Reminder: v0.3.0 push triggers the release workflow. Make sure
-minisign secrets are configured before pushing the tag.
+minisign secrets (MINISIGN_PRIVATE_KEY + MINISIGN_PASSWORD) are
+configured in GitHub repo secrets before pushing the tag.
 ```
 
 The driver: (i) walks 4 gates in strict order; (ii) gate-a/b execute REAL pnpm lint + REAL vitest specs; (iii) gate-c/d emit WARN-then-PASS with explicit `#416` / `#417` followup citations matching `#415` — exactly the documented v0.3 ship plan; (iv) `emit-tag.sh` prints the `git tag v0.3.0 <SHA>` suggestion when all gates green. Exit code 0.
@@ -342,6 +343,6 @@ git tag v0.3.0 6f0687ff4e33f9aa39ef2a6de9ddbe17bf9118f3
 git push origin v0.3.0
 ```
 
-Reminder (per emit-tag.sh): `v0.3.0` push triggers `.github/workflows/release.yml`. Confirm minisign secret (`MINISIGN_SECRET_KEY` + `MINISIGN_SECRET_PASSWORD`) is configured in GitHub repo secrets before pushing the tag — `release.yml` minisign step is placeholder-safe per PR #780 (T7.0a fix), so missing secret will WARN-skip rather than hard-fail, but the tag should ship with sidecars.
+Reminder (per emit-tag.sh): `v0.3.0` push triggers `.github/workflows/release.yml`. Confirm minisign secrets (`MINISIGN_PRIVATE_KEY` + `MINISIGN_PASSWORD`) are configured in GitHub repo secrets before pushing the tag — `release.yml` minisign step is placeholder-safe per Task #425, so missing secret will WARN-skip rather than hard-fail, but the tag should ship with sidecars.
 
 This PR does **not** push the tag. The `git tag` command is for the manager to execute manually after merging this M4 acceptance doc.

--- a/tools/release-candidate/lib/emit-tag.sh
+++ b/tools/release-candidate/lib/emit-tag.sh
@@ -20,5 +20,6 @@ All gates green. Suggested next step:
     git push origin ${VERSION}
 
 Reminder: ${VERSION} push triggers the release workflow. Make sure
-minisign secrets are configured before pushing the tag.
+minisign secrets (MINISIGN_PRIVATE_KEY + MINISIGN_PASSWORD) are
+configured in GitHub repo secrets before pushing the tag.
 EOF


### PR DESCRIPTION
## Summary
- Adds a placeholder-safe minisign signing step to `.github/workflows/release.yml`: per-OS install (apt / brew / upstream zip), signs every shippable artifact in `release/` with `MINISIGN_PRIVATE_KEY` + `MINISIGN_PASSWORD`, attaches the `.minisig` sidecars to both the workflow artifact upload and the draft GitHub Release. Missing secret WARNs and exits 0 — builds never fail on signing.
- Aligns secret names with what is actually configured in the repo (verifier confirmed `MINISIGN_PRIVATE_KEY` + `MINISIGN_PASSWORD`, not `_SECRET_*`): updates `docs/milestones/M4-ship-ready-acceptance.md` and `tools/release-candidate/lib/emit-tag.sh` so manual operators see the right names.
- Closes the v0.3 ship hard-blocker T7-MINISIGN. One PR, one closure.

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(...)"` on release.yml — parses cleanly
- [x] `yamllint` on release.yml (with project rule overrides) — passes
- [x] `bash -n tools/release-candidate/lib/emit-tag.sh` — syntax OK
- [x] Dry-run placeholder-safe path with `MINISIGN_PRIVATE_KEY` / `MINISIGN_PASSWORD` unset — emits `::warning` and exits 0
- [x] `grep -r 'MINISIGN_SECRET_KEY\|MINISIGN_SECRET_PASSWORD' .` — zero hits
- [x] `tools/test/release-candidate.spec.ts` `/minisign/i` regex still matches updated reminder text
- [ ] CI `Release` workflow only triggers on tag push / manual dispatch — full validation deferred to next `v*` tag, but `verify` + `build` jobs run on this PR via existing CI matrix