### PR TITLE
chore(lint): add lint:no-worker-threads gate for pty-host (Task #428)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,7 +167,7 @@ jobs:
         run: npm run lint:no-ipc
 
       - name: Lint (no worker_threads in pty-host) — ch15 §3 #25
-        run: pnpm lint:no-worker-threads
+        run: npm run lint:no-worker-threads
 
       - name: Typecheck
         run: npm run typecheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,9 @@ jobs:
       - name: Lint (no IPC residue)
         run: npm run lint:no-ipc
 
+      - name: Lint (no worker_threads in pty-host) — ch15 §3 #25
+        run: pnpm lint:no-worker-threads
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:app": "vitest run",
     "lint:app": "eslint . --ext .ts,.tsx",
     "lint:no-ipc": "bash tools/lint-no-ipc.sh",
+    "lint:no-worker-threads": "bash tools/lint-no-worker-threads.sh",
     "lint:spec-code-lock": "bash tools/check-spec-code-lock.sh",
     "prelint:app": "node scripts/gen-proto.mjs",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.electron.json",

--- a/tools/lint-no-worker-threads.sh
+++ b/tools/lint-no-worker-threads.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# tools/lint-no-worker-threads.sh — regression gate for pty-host worker_threads.
+#
+# Enforces ch15 §3 #25: no worker_threads in pty-host.
+#
+# pivot pty per-session 边界永远走 child_process.fork (永久边界)。回到
+# worker_threads.Worker 是 ch15 §3 #25 明令禁止的 forbidden pattern, 因为
+# Worker 跟主进程共享 V8 isolate 边界过浅, native pty 崩会带塌整个 daemon。
+#
+# Greps the pty-host source tree for forbidden references:
+#   - literal `worker_threads`
+#   - `from 'worker_threads'` / `from "worker_threads"`
+#   - `require('worker_threads')` / `require("worker_threads")`
+#   - `new Worker(`
+#
+# Comment lines (//, *, #) are skipped — comments mentioning forbidden symbols
+# (e.g. "// previously used worker_threads, see ch15 §3 #25") do not constitute
+# Worker use. Mirrors the carve-out in tools/lint-no-ipc.sh.
+#
+# Exit non-zero on any match. Output format per finding:
+#   <file>:<line>:<matched-line>
+#
+# Cross-platform: POSIX-portable bash + grep + find. No bash globstar; no
+# GNU-specific find flags. Verified on Git Bash on Windows.
+#
+# SPEC REFERENCES
+#   - chapter 15 §3 #25 — pty-host worker_threads forbidden pattern
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# Both legacy and current pty-host locations. Spec calls out
+# packages/daemon/src/pty-host/ (current) and apps/daemon/src/pty-host/
+# (forward-compat for any future relocation).
+SCAN_DIRS=(
+  "${REPO_ROOT}/packages/daemon/src/pty-host"
+  "${REPO_ROOT}/apps/daemon/src/pty-host"
+)
+
+# Forbidden patterns — extended-regex alternation.
+#   - worker_threads               — module name (catches import 'worker_threads',
+#                                     require('worker_threads'), and any string ref)
+#   - new[[:space:]]+Worker\(      — instantiation of a Worker
+FORBIDDEN='worker_threads|new[[:space:]]+Worker\('
+
+# Comment-line prefix regex — same shape as lint-no-ipc.sh.
+COMMENT_PREFIX='^[[:space:]]*(//|\*|#)'
+
+# Filter out scan dirs that don't exist.
+existing_dirs=()
+for d in "${SCAN_DIRS[@]}"; do
+  if [ -d "${d}" ]; then
+    existing_dirs+=("${d}")
+  fi
+done
+
+if [ "${#existing_dirs[@]}" -eq 0 ]; then
+  echo "PASS: none of the scan dirs (${SCAN_DIRS[*]}) exist"
+  exit 0
+fi
+
+# Enumerate candidate source files.
+candidate_files="$(
+  find "${existing_dirs[@]}" \
+    \( -type d \( -name node_modules -o -name dist -o -name build \) -prune \) -o \
+    -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' -o -name '*.jsx' \) -print
+)"
+
+if [ -z "${candidate_files}" ]; then
+  echo "PASS: no .ts/.tsx/.js/.jsx files under ${existing_dirs[*]}"
+  exit 0
+fi
+
+# Run grep across the candidate set, then strip comment-only matches.
+raw_hits="$(
+  printf '%s\n' "${candidate_files}" \
+    | xargs grep -EHn -- "${FORBIDDEN}" 2>/dev/null \
+    || true
+)"
+
+hits=""
+if [ -n "${raw_hits}" ]; then
+  hits="$(
+    printf '%s\n' "${raw_hits}" \
+      | while IFS= read -r line; do
+          [ -z "${line}" ] && continue
+          content="$(printf '%s' "${line}" | sed -E 's/^.*:[0-9]+://')"
+          if ! printf '%s' "${content}" | grep -Eq "${COMMENT_PREFIX}"; then
+            printf '%s\n' "${line}"
+          fi
+        done
+  )"
+fi
+
+if [ -n "${hits}" ]; then
+  echo "FAIL: forbidden worker_threads / Worker references found in pty-host:"
+  echo "${hits}"
+  echo ""
+  echo "See chapter 15 §3 #25. pty-host per-session boundary must be child_process.fork, never worker_threads.Worker."
+  exit 1
+fi
+
+echo "PASS: zero worker_threads residue under ${existing_dirs[*]}"
+exit 0


### PR DESCRIPTION
## Summary

Adds `tools/lint-no-worker-threads.sh` + `pnpm lint:no-worker-threads` script wiring to enforce ch15 §3 #25:

> pty-host per-session boundary must be `child_process.fork` (permanent boundary). Reverting to `worker_threads.Worker` is a forbidden pattern — Worker shares the V8 isolate boundary too shallowly, so a native pty crash takes the whole daemon down.

Until now there was no test/lint preventing that regression. This PR adds one.

Mirrors `tools/lint-no-ipc.sh` shape:
- POSIX-portable bash + grep + find (no GNU-specific flags); verified on Git Bash on Windows.
- Forbidden patterns: literal `worker_threads`, `from 'worker_threads'`, `require('worker_threads')`, `new Worker(`.
- Comment carve-out (`//`, `*`, `#`) so historical references in comments don't trip the gate.
- Scans `packages/daemon/src/pty-host/` (current location) and `apps/daemon/src/pty-host/` (forward-compat for any future relocation).
- Exit non-zero on match, output `<file>:<line>:<matched>`.

## Spec ref

- ch15 §3 #25 — pty-host worker_threads forbidden pattern

## Local checks (host: windows-11)

- lint: OK (turbo, 0 errors)
- typecheck: OK (exit 0)
- build / unit / e2e: skipped per dev.md §3 step 2 carve-out — only shell script + package.json `scripts` field changed, no `.ts/.tsx` touched.

## Acceptance verification

All three acceptance scenarios run locally:

1. **Clean repo** → `pnpm lint:no-worker-threads` exits 0
   ```
   PASS: zero worker_threads residue under .../packages/daemon/src/pty-host
   ```
2. **Draft `new Worker(...)` appended to `packages/daemon/src/pty-host/host.ts`** (reverted, not committed) → exits 1
   ```
   FAIL: forbidden worker_threads / Worker references found in pty-host:
   .../packages/daemon/src/pty-host/host.ts:914:const _w = new Worker("./foo.js");
   ```
3. **Comment-only mention** `// previously used worker_threads, see ch15 §3 #25` appended → exits 0
   ```
   PASS: zero worker_threads residue under .../packages/daemon/src/pty-host
   ```

## Test plan

- [x] Clean repo passes
- [x] Real `new Worker(` triggers FAIL with file:line output
- [x] Comment carve-out prevents false positives
- [x] `pnpm lint:no-worker-threads` script runs (exit 0 on clean repo)
- [ ] CI green across linux/macOS/windows matrix

Task #428