### PR TITLE
tools(migration): add check-migration-additivity.sh — forbid NOT NULL w/o DEFAULT in 002+_*.sql (Task #432)

### DIFF
--- a/packages/daemon/test/fixtures/migration-additivity/bad/002_bad-add-not-null-no-default.sql
+++ b/packages/daemon/test/fixtures/migration-additivity/bad/002_bad-add-not-null-no-default.sql
@@ -1,0 +1,6 @@
+-- bad fixture: ADD COLUMN with NOT NULL but NO DEFAULT.
+-- Expected: tools/check-migration-additivity.sh exits non-zero.
+-- This shape would fail at sqlite migration time on any DB with existing
+-- rows in `sessions`, because there is no value to back-fill.
+
+ALTER TABLE sessions ADD COLUMN priority INTEGER NOT NULL;

--- a/packages/daemon/test/fixtures/migration-additivity/good/002_good-add-with-default.sql
+++ b/packages/daemon/test/fixtures/migration-additivity/good/002_good-add-with-default.sql
@@ -1,0 +1,5 @@
+-- good fixture: ADD COLUMN with NOT NULL AND DEFAULT.
+-- Expected: tools/check-migration-additivity.sh exits zero for this file.
+-- DEFAULT clause means existing rows are back-filled at migration time.
+
+ALTER TABLE sessions ADD COLUMN priority INTEGER NOT NULL DEFAULT 0;

--- a/packages/daemon/test/fixtures/migration-additivity/good/003_good-create-table-not-null.sql
+++ b/packages/daemon/test/fixtures/migration-additivity/good/003_good-create-table-not-null.sql
@@ -1,0 +1,10 @@
+-- good fixture: CREATE TABLE with NOT NULL columns (no DEFAULT).
+-- Expected: tools/check-migration-additivity.sh exits zero — new tables
+-- have no pre-existing rows to back-fill, so NOT NULL without DEFAULT is
+-- safe.
+
+CREATE TABLE feature_flags (
+  name       TEXT PRIMARY KEY,
+  enabled    INTEGER NOT NULL,
+  updated_ms INTEGER NOT NULL
+);

--- a/packages/daemon/test/fixtures/migration-additivity/good/004_good-add-nullable.sql
+++ b/packages/daemon/test/fixtures/migration-additivity/good/004_good-add-nullable.sql
@@ -1,0 +1,5 @@
+-- good fixture: ADD COLUMN that is nullable (no NOT NULL).
+-- Expected: tools/check-migration-additivity.sh exits zero — nullable
+-- columns are always safe to add (existing rows get NULL).
+
+ALTER TABLE sessions ADD COLUMN annotation TEXT;

--- a/tools/check-migration-additivity.sh
+++ b/tools/check-migration-additivity.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# tools/check-migration-additivity.sh
+#
+# Enforces ch15 §3 #13: NOT NULL column on existing table requires DEFAULT.
+#
+# FOREVER-STABLE per docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md
+# chapter 15 §3 item #13. v0.3 ships `001_initial.sql` as the immutable baseline
+# (locked by tools/check-migration-locks.sh). v0.4+ migrations land additively
+# as `00[2-9]_*.sql` (and onward). Any post-baseline migration that adds a
+# `NOT NULL` column to an existing table WITHOUT a `DEFAULT` clause would
+# break upgrades for users with existing rows — sqlite cannot back-fill a
+# value, and the migration would abort mid-flight.
+#
+# What it does:
+#   1. Scan packages/daemon/src/db/migrations/00[2-9]_*.sql (v0.4+ migrations).
+#      `001_*.sql` is the v0.3 baseline and is exempt — it is locked separately
+#      by tools/check-migration-locks.sh and has no pre-existing rows to back-
+#      fill against.
+#   2. Normalize each file: strip line comments (`-- ...`) and block comments
+#      (`/* ... */`), collapse all whitespace runs to a single space.
+#   3. Split on `;` to get individual statements.
+#   4. For each `ALTER TABLE ... ADD COLUMN ...` statement, assert that if the
+#      column is `NOT NULL`, it also has a `DEFAULT` clause. New tables
+#      (`CREATE TABLE`) are exempt because they have no pre-existing rows to
+#      back-fill — `NOT NULL` without `DEFAULT` is fine on a brand-new table.
+#
+# Compatibility: bash 3.2+, POSIX grep + sed + awk. Runs on Linux/macOS GHA
+# runners and Git Bash on Windows. No new npm deps, no SQL parser dep —
+# regex on normalized SQL is sufficient for the simple `ADD COLUMN` shape
+# the spec produces.
+#
+# Override for fixture testing: set `MIGRATIONS_DIR` env var to point at a
+# fixture directory to validate the script's own logic.
+
+set -euo pipefail
+
+MIGRATIONS_DIR="${MIGRATIONS_DIR:-packages/daemon/src/db/migrations}"
+
+log() { printf '[check-migration-additivity] %s\n' "$*" >&2; }
+fail() { log "FAIL: $*"; exit 1; }
+
+if [ ! -d "$MIGRATIONS_DIR" ]; then
+  fail "migrations dir not found: $MIGRATIONS_DIR"
+fi
+
+# Glob 002_*.sql through 009_*.sql. v0.3 baseline (001_*.sql) is exempt.
+# `nullglob`-style behavior via a guard: if no matches, the literal pattern
+# survives and we skip the loop.
+shopt -s nullglob 2>/dev/null || true
+
+VIOLATIONS=0
+SCANNED=0
+
+for sql_file in "$MIGRATIONS_DIR"/00[2-9]_*.sql; do
+  [ -f "$sql_file" ] || continue
+  SCANNED=$((SCANNED + 1))
+
+  # Normalize:
+  #   - strip /* ... */ block comments (greedy across lines via tr to single line first)
+  #   - strip -- line comments
+  #   - collapse all whitespace (incl newlines) to a single space
+  normalized="$(
+    sed -e 's:/\*[^*]*\*\+\([^/*][^*]*\*\+\)*/::g' "$sql_file" \
+      | sed -e 's/--[^\n]*$//' \
+      | tr '\n' ' ' \
+      | tr -s '[:space:]' ' '
+  )"
+
+  # Split on `;` and inspect each statement.
+  # Use awk to emit one statement per line so we can grep ALTER TABLE rows.
+  while IFS= read -r stmt; do
+    # Trim leading/trailing whitespace
+    stmt="$(printf '%s' "$stmt" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+    [ -z "$stmt" ] && continue
+
+    # Only ALTER TABLE ... ADD COLUMN statements are constrained. CREATE TABLE
+    # is exempt (new table = no pre-existing rows to back-fill). Match case-
+    # insensitively against the normalized form.
+    upper="$(printf '%s' "$stmt" | tr '[:lower:]' '[:upper:]')"
+    case "$upper" in
+      *"ALTER TABLE"*"ADD COLUMN"*|*"ALTER TABLE"*"ADD "*)
+        # Continue to NOT NULL / DEFAULT check below.
+        ;;
+      *)
+        continue
+        ;;
+    esac
+
+    # Check NOT NULL presence.
+    case "$upper" in
+      *"NOT NULL"*) ;;
+      *) continue ;;
+    esac
+
+    # NOT NULL is present — assert DEFAULT is also present in the same statement.
+    case "$upper" in
+      *"DEFAULT"*)
+        # OK — has DEFAULT.
+        ;;
+      *)
+        log "VIOLATION in $sql_file:"
+        log "  statement: $stmt"
+        log "  reason: ADD COLUMN with NOT NULL but no DEFAULT — would break upgrade for existing rows"
+        VIOLATIONS=$((VIOLATIONS + 1))
+        ;;
+    esac
+  done <<EOF
+$(printf '%s' "$normalized" | awk 'BEGIN{RS=";"} {print}')
+EOF
+done
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  fail "$VIOLATIONS NOT NULL-without-DEFAULT violation(s) across $SCANNED migration file(s)"
+fi
+
+log "OK: scanned $SCANNED migration file(s) under $MIGRATIONS_DIR (no 00[2-9]_*.sql violations)"
+exit 0


### PR DESCRIPTION
## Summary

Closes ch15 §3 #13 enforcement gap (P13 in `docs/superpowers/specs/ch15-section3-enforcement-audit.md`):

> v0.4 (or any post-ship migration) MUST NOT add a NOT NULL column to a v0.3 table without DEFAULT.

`migration-lock.spec.ts` only locks existing files; nothing constrains future ones. This PR adds `tools/check-migration-additivity.sh` (mirror of `tools/check-migration-locks.sh` shape — POSIX bash + sed + awk, no new deps).

### Logic
- Scans `packages/daemon/src/db/migrations/00[2-9]_*.sql` (v0.3 baseline `001_*.sql` is locked separately and exempt).
- Normalizes each file (strip `--` line comments, `/* */` block comments, collapse whitespace).
- Splits on `;`, inspects each statement.
- `ALTER TABLE ... ADD COLUMN` with `NOT NULL` must also have `DEFAULT` clause.
- `CREATE TABLE` is exempt (new table = no pre-existing rows to back-fill).
- Override hook: `MIGRATIONS_DIR` env var lets tests point at fixture dirs.

### Fixtures (`packages/daemon/test/fixtures/migration-additivity/`)
- `bad/002_bad-add-not-null-no-default.sql` → script exits non-zero
- `good/002_good-add-with-default.sql` → exits zero
- `good/003_good-create-table-not-null.sql` → exits zero (new table)
- `good/004_good-add-nullable.sql` → exits zero (nullable)

### CI wiring
Not added in this PR — script is callable but not yet wired into `.github/workflows/ci.yml`. Spec task only asks for the enforcer + fixtures. Wiring can land in a follow-up alongside the first real `002_*.sql` migration.

## Local checks (host: windows-11 / Git Bash)
- lint: ✓ (exit 0, 66 warnings 0 errors)
- typecheck: ✓ (exit 0)
- build: skipped — PR adds only `.sh` + `.sql` fixtures, no `.ts/.tsx` touched (per dev.md §3 step 2 skip condition)
- unit tests: skipped — same reason as build
- e2e: skipped — same reason as build

### Acceptance evidence (per task spec)
```
=== test bad (expect non-zero) ===
[check-migration-additivity] VIOLATION in .../bad/002_bad-add-not-null-no-default.sql:
[check-migration-additivity]   statement: ALTER TABLE sessions ADD COLUMN priority INTEGER NOT NULL
[check-migration-additivity]   reason: ADD COLUMN with NOT NULL but no DEFAULT — would break upgrade for existing rows
[check-migration-additivity] FAIL: 1 NOT NULL-without-DEFAULT violation(s) across 1 migration file(s)
exit=1

=== test good (expect zero) ===
[check-migration-additivity] OK: scanned 3 migration file(s) under .../good (no 00[2-9]_*.sql violations)
exit=0

=== test production migrations (expect zero) ===
[check-migration-additivity] OK: scanned 0 migration file(s) under packages/daemon/src/db/migrations (no 00[2-9]_*.sql violations)
exit=0
```

Also robustness-tested mixed file (one bad + one good + create-table + nullable in same file): correctly flags only the bad statement.

## Test plan
- [x] bad fixture → exit 1
- [x] 3 good fixtures → exit 0
- [x] production migrations dir (0001 baseline only) → exit 0
- [x] mixed-statement file flags only the violating statement
- [x] script header contains required `# Enforces ch15 §3 #13: ...` line
- [x] POSIX bash + grep + sed verified on Git Bash on Windows