### PR TITLE
lint(daemon): add ccsm/no-client-kind-branch ESLint rule (Task #430)

### DIFF
--- a/packages/daemon/eslint-plugins/__tests__/no-client-kind-branch.spec.ts
+++ b/packages/daemon/eslint-plugins/__tests__/no-client-kind-branch.spec.ts
@@ -1,0 +1,103 @@
+// Spec for the local ESLint plugin `ccsm/no-client-kind-branch`.
+// Covers spec ch15 §3 #24 — `HelloRequest.client_kind` and
+// `HelloResponse.listener_id` are open-string observability fields;
+// daemon MUST NOT branch on them. Reads (logging / debug) are allowed.
+//
+// Mirrors the shape of `no-listener-slot-mutation.spec.ts`: ESLint's
+// built-in RuleTester for default-parser fixtures, plus a tiny
+// `@typescript-eslint/parser` suite to prove the rule works against TS
+// source as it appears in `packages/daemon/src/**/*.ts`.
+
+import { describe, it } from 'vitest';
+import { RuleTester } from 'eslint';
+import tsparser from '@typescript-eslint/parser';
+import { rule } from '../ccsm-no-client-kind-branch.js';
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+const tsTester = new RuleTester({
+  languageOptions: {
+    parser: tsparser,
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+describe('ccsm/no-client-kind-branch', () => {
+  it('runs RuleTester (default parser)', () => {
+    tester.run('no-client-kind-branch', rule, {
+      valid: [
+        // 1. Pure read into a logger payload — observability, allowed.
+        { code: 'log.info({client_kind: req.client_kind});' },
+        // 2. Read into a local — no control-flow gate.
+        { code: 'const k = req.client_kind;' },
+        // 3. Read of listener_id into a metric tag.
+        { code: 'metrics.tag("lid", res.listener_id);' },
+        // 4. Branch on an unrelated field is fine.
+        { code: 'if (req.principal === "owner") { doThing(); }' },
+        // 5. switch on an unrelated field is fine.
+        { code: 'switch (req.proto_version) { case 1: break; }' },
+        // 6. Comparing an unrelated property named similarly is unrelated.
+        { code: 'if (req.client_kind_label === "ui") {}' },
+      ],
+      invalid: [
+        // 1. switch on req.client_kind — classic violation.
+        {
+          code: "switch (req.client_kind) { case 'electron': break; }",
+          errors: [{ messageId: 'switchBranch', data: { prop: 'client_kind' } }],
+        },
+        // 2. switch on res.listener_id.
+        {
+          code: "switch (res.listener_id) { case 'A': break; }",
+          errors: [{ messageId: 'switchBranch', data: { prop: 'listener_id' } }],
+        },
+        // 3. if (req.client_kind === 'electron') — comparison branch.
+        {
+          code: "if (req.client_kind === 'electron') { doElectron(); }",
+          errors: [{ messageId: 'compareBranch', data: { prop: 'client_kind' } }],
+        },
+        // 4. Reverse-order comparison ('A' === res.listener_id).
+        {
+          code: "if ('A' === res.listener_id) { doA(); }",
+          errors: [{ messageId: 'compareBranch', data: { prop: 'listener_id' } }],
+        },
+        // 5. Ternary / ConditionalExpression branch.
+        {
+          code: "const x = req.client_kind === 'cli' ? 1 : 2;",
+          errors: [{ messageId: 'compareBranch', data: { prop: 'client_kind' } }],
+        },
+        // 6. !== inequality also counts as control-flow gating.
+        {
+          code: "if (req.client_kind !== 'electron') { fallback(); }",
+          errors: [{ messageId: 'compareBranch', data: { prop: 'client_kind' } }],
+        },
+      ],
+    });
+  });
+
+  it('runs RuleTester (typescript-eslint parser)', () => {
+    tsTester.run('no-client-kind-branch', rule, {
+      valid: [
+        // TS-typed read into logger — observability allowed.
+        {
+          code: 'const req = {} as { client_kind: string }; log.info({client_kind: req.client_kind});',
+        },
+      ],
+      invalid: [
+        {
+          code: "const req = {} as { client_kind: string }; if (req.client_kind === 'electron') { doIt(); }",
+          errors: [{ messageId: 'compareBranch', data: { prop: 'client_kind' } }],
+        },
+        {
+          code: "const res = {} as { listener_id: string }; switch (res.listener_id) { case 'A': break; }",
+          errors: [{ messageId: 'switchBranch', data: { prop: 'listener_id' } }],
+        },
+      ],
+    });
+  });
+});

--- a/packages/daemon/eslint-plugins/ccsm-no-client-kind-branch.js
+++ b/packages/daemon/eslint-plugins/ccsm-no-client-kind-branch.js
@@ -1,0 +1,107 @@
+// Local ESLint plugin: ccsm/no-client-kind-branch
+//
+// Spec ch15 §3 #24 — `HelloRequest.client_kind` and
+// `HelloResponse.listener_id` are deliberately open `string` fields
+// reserved for OBSERVABILITY ONLY (logging / metrics / debugging).
+// The daemon MUST NOT derive control-flow from their values: no
+// behavior should change based on whether `client_kind === 'electron'`,
+// nor on a `switch (req.client_kind)` discriminant. Any such branch
+// re-introduces the closed-enum coupling the open-string design
+// explicitly avoids and would force schema co-evolution between client
+// and daemon every time a new caller type appears.
+//
+// Read uses are explicitly allowed (e.g. `log.info({client_kind:
+// req.client_kind})`, `const k = req.client_kind`) — only control-flow
+// branching counts as a violation.
+//
+// Conservative AST heuristic — flag two shapes:
+//   1. `SwitchStatement` whose `discriminant` is a `MemberExpression`
+//      with `property.name in {client_kind, listener_id}`.
+//   2. `IfStatement` / `ConditionalExpression` whose `test` is a
+//      `BinaryExpression` (`==` / `===` / `!=` / `!==`) with one side
+//      a `MemberExpression` whose `property.name in {client_kind,
+//      listener_id}`.
+//
+// SRP: this is a pure decider. No I/O, no fixers — every match is a
+// design-level violation that must be removed (or, in the very rare
+// case where a branch is legitimately observability-driven and the
+// reviewer agrees, a per-line eslint-disable with justification).
+
+const FORBIDDEN_PROPS = new Set(['client_kind', 'listener_id']);
+
+/** True for `<expr>.client_kind` / `<expr>.listener_id` (non-computed). */
+function isForbiddenMemberRead(node) {
+  if (!node || node.type !== 'MemberExpression') return false;
+  if (node.computed) return false;
+  if (!node.property || node.property.type !== 'Identifier') return false;
+  return FORBIDDEN_PROPS.has(node.property.name);
+}
+
+/** Pull the forbidden property name from a MemberExpression, or null. */
+function forbiddenPropName(node) {
+  if (!isForbiddenMemberRead(node)) return null;
+  return node.property.name;
+}
+
+const COMPARISON_OPS = new Set(['==', '===', '!=', '!==']);
+
+function checkBinaryTest(context, testNode, hostNode) {
+  if (!testNode || testNode.type !== 'BinaryExpression') return;
+  if (!COMPARISON_OPS.has(testNode.operator)) return;
+  const leftProp = forbiddenPropName(testNode.left);
+  const rightProp = forbiddenPropName(testNode.right);
+  const prop = leftProp || rightProp;
+  if (!prop) return;
+  context.report({
+    node: hostNode,
+    messageId: 'compareBranch',
+    data: { prop },
+  });
+}
+
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Forbid daemon control-flow branching on HelloRequest.client_kind / HelloResponse.listener_id (open-string observability fields per spec ch15 §3 #24). Read for logging/metrics is allowed.',
+      recommended: true,
+    },
+    messages: {
+      switchBranch:
+        '`switch` on `{{prop}}` is forbidden — this field is open-string observability only (spec ch15 §3 #24). Do not derive behavior from it; the daemon must treat all client_kind/listener_id values uniformly.',
+      compareBranch:
+        'Branching on `{{prop}}` (===/==/!=/!==) is forbidden — this field is open-string observability only (spec ch15 §3 #24). Read it for logging/metrics, but do not gate behavior on its value.',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      SwitchStatement(node) {
+        const prop = forbiddenPropName(node.discriminant);
+        if (!prop) return;
+        context.report({
+          node,
+          messageId: 'switchBranch',
+          data: { prop },
+        });
+      },
+      IfStatement(node) {
+        checkBinaryTest(context, node.test, node);
+      },
+      ConditionalExpression(node) {
+        checkBinaryTest(context, node.test, node);
+      },
+    };
+  },
+};
+
+const plugin = {
+  meta: { name: 'ccsm-no-client-kind-branch', version: '0.1.0' },
+  rules: {
+    'no-client-kind-branch': rule,
+  },
+};
+
+export default plugin;
+export { rule };

--- a/packages/daemon/eslint.config.js
+++ b/packages/daemon/eslint.config.js
@@ -15,8 +15,26 @@
 //     `**/listener-b.ts` (the single v0.4 file allowed to publish into
 //     slot 1) via a trailing override block. Bypass surface is grep-able
 //     here so reviewers can audit it as a single point.
+//   - Task #430 (#230-6 / P24) `ccsm/no-client-kind-branch` — forbids
+//     daemon control-flow branching on `HelloRequest.client_kind` /
+//     `HelloResponse.listener_id` (open-string observability fields per
+//     spec ch15 §3 #24). Read for logging / metrics is allowed; only
+//     `switch (req.client_kind)` and `req.client_kind === 'X'` /
+//     `req.listener_id !== 'A'` style branches are flagged. Scoped to
+//     `packages/daemon/src/**` via a trailing override block.
 import rootConfig from '../../eslint.config.js';
-import ccsmPlugin from './eslint-plugins/ccsm-no-listener-slot-mutation.js';
+import ccsmListenerSlotPlugin from './eslint-plugins/ccsm-no-listener-slot-mutation.js';
+import ccsmNoClientKindBranchPlugin from './eslint-plugins/ccsm-no-client-kind-branch.js';
+
+// Combine local plugin rules under a single `ccsm` namespace so the
+// flat config exposes them as `ccsm/<rule-name>` to ESLint.
+const ccsmPlugin = {
+  meta: { name: 'ccsm', version: '0.1.0' },
+  rules: {
+    ...ccsmListenerSlotPlugin.rules,
+    ...ccsmNoClientKindBranchPlugin.rules,
+  },
+};
 
 export default [
   ...rootConfig,
@@ -42,6 +60,16 @@ export default [
         ],
       }],
       'ccsm/no-listener-slot-mutation': 'error',
+    },
+  },
+  {
+    // ccsm/no-client-kind-branch is scoped to daemon source — tests
+    // and eslint-plugins/** don't need the guard (and the spec
+    // fixtures intentionally exercise the very patterns the rule
+    // forbids).
+    files: ['src/**/*.ts'],
+    rules: {
+      'ccsm/no-client-kind-branch': 'error',
     },
   },
   {


### PR DESCRIPTION
## Summary

Adds local ESLint rule `ccsm/no-client-kind-branch` enforcing spec ch15 §3 #24: the daemon MUST NOT derive control-flow from `HelloRequest.client_kind` or `HelloResponse.listener_id` (open-string observability fields). Reads for logging / metrics remain allowed.

Without a lint-time guard, every v0.4 PR has to catch accidental branches by eye.

## Design

Mirrors the existing `ccsm/no-listener-slot-mutation` plugin shape — pure decider AST visitor, no I/O, no fixers. Two patterns flagged:

1. `SwitchStatement` whose `discriminant` is `<expr>.client_kind` / `<expr>.listener_id`.
2. `IfStatement` / `ConditionalExpression` whose `test` is a `BinaryExpression` (`==` / `===` / `!=` / `!==`) with one side a forbidden member access.

Reads (`log.info({client_kind: req.client_kind})`, `const k = req.client_kind`) are explicitly NOT flagged.

## Files

- NEW `packages/daemon/eslint-plugins/ccsm-no-client-kind-branch.js` (~110 LOC incl. comments).
- NEW `packages/daemon/eslint-plugins/__tests__/no-client-kind-branch.spec.ts` (6 valid + 6 invalid default-parser fixtures, 1 valid + 2 invalid TS-parser fixtures).
- MODIFY `packages/daemon/eslint.config.js` — fold both local plugins into one `ccsm` namespace; scope new rule to `src/**/*.ts` (plugin spec fixtures intentionally exercise the forbidden patterns).

Daemon source is currently clean — `grep -rE 'client_kind|listener_id' packages/daemon/src` only matches doc comments in `rpc/hello.ts`. Rule lights up at zero new violations.

## Local checks (host: windows-11)
- lint (`pnpm --filter @ccsm/daemon run lint`): exit 0 (66 pre-existing warnings, 0 errors)
- typecheck (`pnpm --filter @ccsm/daemon run typecheck`): exit 0
- plugin specs (`npx vitest run --root packages/daemon eslint-plugins`): 2 files / 4 tests passed in 2.32s
- full daemon test suite: 1518 passed / 6 failed — the 6 failures are pre-existing on `working` (RPC integration / wire tests, all `Code.Unimplemented` / loopback-bind related, none touch the lint plugin). Verified by stashing the diff and re-running: identical 6/1518.

## Test plan
- [x] RuleTester confirms positive fixtures report
- [x] RuleTester confirms negative (read-only) fixtures do not report
- [x] Rule registered under `ccsm/` namespace, scoped to `src/**/*.ts`
- [x] daemon `lint` script exits 0 against current src

Task #430