### PR TITLE
test(daemon): reject OWNER_FILTER_ALL on crash RPCs (Task #433)

### DIFF
--- a/packages/daemon/src/rpc/crash/get-crash-log.ts
+++ b/packages/daemon/src/rpc/crash/get-crash-log.ts
@@ -276,15 +276,28 @@ export function makeGetCrashLogHandler(
       );
     }
     const plan = decideGetCrashLogQuery(req);
+    // Spec ch15 §3 #14: OwnerFilter / SettingsScope / WatchScope MUST
+    // reject the broadened values (ALL / PRINCIPAL) on v0.3 with
+    // PermissionDenied. ALL is reserved for v0.4 admin principals; the
+    // wire shape allows it but the v0.3 daemon's authorization layer
+    // refuses it — single source of truth alongside
+    // `sessions/watch-sessions.ts:decideWatchScope` (which rejects
+    // WATCH_SCOPE_ALL with the same `session.not_owned` ErrorDetail).
+    if (plan.ownerFilter === OwnerFilter.ALL) {
+      throwError(
+        'session.not_owned',
+        'OWNER_FILTER_ALL is not permitted on v0.3 (admin scope reserved for v0.4 — spec ch15 §3 #14)',
+        { requested_owner_filter: 'ALL' },
+      );
+    }
     // Defensive: reject unknown enum values rather than silently treating
-    // them as ALL or OWN. Mirrors the `decideWatchScope` posture in
+    // them as OWN. Mirrors the `decideWatchScope` posture in
     // sessions/watch-sessions.ts (forward-compat: a v0.4 client speaking
     // a higher proto_version may send an enum the v0.3 daemon does not
     // know; conservative deny is the contract).
     if (
       plan.ownerFilter !== OwnerFilter.UNSPECIFIED &&
-      plan.ownerFilter !== OwnerFilter.OWN &&
-      plan.ownerFilter !== OwnerFilter.ALL
+      plan.ownerFilter !== OwnerFilter.OWN
     ) {
       throwError(
         'session.not_owned',

--- a/packages/daemon/src/rpc/crash/watch-crash-log.ts
+++ b/packages/daemon/src/rpc/crash/watch-crash-log.ts
@@ -38,9 +38,11 @@
 //
 // SRP layering — three roles kept separate (dev.md §2):
 //   * decider:  `decideOwnerScope(filter)` — pure enum verdict over
-//               `OwnerFilter`. UNSPECIFIED/OWN → 'own'; ALL → 'all';
-//               unknown enum → 'reject_permission_denied' (forward-compat
-//               conservative deny, same posture as
+//               `OwnerFilter`. UNSPECIFIED/OWN → 'own'; ALL →
+//               'reject_permission_denied' (spec ch15 §3 #14: ALL is
+//               reserved for v0.4 admin principals; v0.3 daemon MUST
+//               reject); unknown enum → 'reject_permission_denied'
+//               (forward-compat conservative deny, same posture as
 //               `sessions/watch-sessions.ts:decideWatchScope`).
 //   * predicate: `isVisibleToCaller(entry, scope, callerKey)` — pure
 //               function. OWN visibility = `entry.owner_id === callerKey
@@ -124,31 +126,27 @@ import { throwError } from '../errors.js';
  * - `own` — `OWNER_FILTER_UNSPECIFIED` (==OWN per crash.proto comment) or
  *   `OWNER_FILTER_OWN`. Visibility: `entry.owner_id === callerKey ||
  *   entry.owner_id === DAEMON_SELF` (ch04 §5 + ch09 §1 sentinel).
- * - `all` — `OWNER_FILTER_ALL`. v0.3 has a single principal kind so the
- *   filter is effectively a no-op at runtime; v0.4 multi-principal
- *   tightens this to admin-only via the auth interceptor (today the
- *   wire shape allows it for the local-user principal). The integration
- *   spec `crash-stream.spec.ts "OWN filter drops events owned by other
- *   principals"` pins the OWN behavior; an explicit ALL spec lands when
- *   admin scoping does in v0.4.
- * - `reject_permission_denied` — unknown enum value the v0.3 daemon does
- *   not know. Conservative deny (same posture as
- *   `decideGetCrashLogQuery`'s unknown-enum throw and
- *   `decideWatchScope`'s default branch). A v0.4 client speaking a
- *   higher proto_version that sends a brand-new enum value gets a
- *   structured `(PermissionDenied, session.not_owned)` pair rather
- *   than silent acceptance.
+ * - `reject_permission_denied` — `OWNER_FILTER_ALL` on v0.3 (spec ch15 §3
+ *   #14: ALL reserved for v0.4 admin principals; v0.3 daemon MUST reject
+ *   with PermissionDenied + structured ErrorDetail), OR an unknown enum
+ *   value the v0.3 daemon does not know (forward-compat conservative
+ *   deny — same posture as `decideWatchScope`'s default branch). A v0.4
+ *   client speaking a higher proto_version that sends a brand-new enum
+ *   value gets a structured `(PermissionDenied, session.not_owned)` pair
+ *   rather than silent acceptance.
  */
 export type OwnerScopeVerdict =
   | { readonly kind: 'own' }
-  | { readonly kind: 'all' }
   | { readonly kind: 'reject_permission_denied' };
 
 /**
  * Pure decider over `OwnerFilter`. v0.3 enum values:
  *   - UNSPECIFIED (0) → 'own' (treated as OWN per crash.proto comment)
  *   - OWN         (1) → 'own'
- *   - ALL         (2) → 'all'
+ *   - ALL         (2) → 'reject_permission_denied' (spec ch15 §3 #14:
+ *                       OwnerFilter / SettingsScope / WatchScope MUST
+ *                       reject the broadened values on v0.3; ALL is
+ *                       reserved for v0.4 admin principals)
  *   - anything else → 'reject_permission_denied'
  */
 export function decideOwnerScope(filter: OwnerFilter): OwnerScopeVerdict {
@@ -157,7 +155,7 @@ export function decideOwnerScope(filter: OwnerFilter): OwnerScopeVerdict {
     case OwnerFilter.OWN:
       return { kind: 'own' };
     case OwnerFilter.ALL:
-      return { kind: 'all' };
+      return { kind: 'reject_permission_denied' };
     default:
       return { kind: 'reject_permission_denied' };
   }
@@ -177,8 +175,11 @@ export function decideOwnerScope(filter: OwnerFilter): OwnerScopeVerdict {
  * principalKey will ever match the sentinel — see ch09 §1 + the
  * `event-bus.ts` Layer 1 note on why filtering is the handler's job.
  *
- * ALL visibility: true. v0.3 has only one principal kind so this is
- * effectively the same as OWN at runtime; v0.4 admin scoping diverges.
+ * v0.3 has only one accepted scope verdict — `own` — because ALL is
+ * rejected at the sink (spec ch15 §3 #14). The
+ * `reject_permission_denied` branch is filtered out by the sink before
+ * this helper is reached, but we be defensive — an unknown scope hides
+ * everything rather than silently widening.
  *
  * Exported so unit tests can pin the predicate without spinning up a
  * Connect transport.
@@ -188,7 +189,6 @@ export function isVisibleToCaller(
   scope: OwnerScopeVerdict,
   callerKey: string,
 ): boolean {
-  if (scope.kind === 'all') return true;
   if (scope.kind === 'own') {
     return entry.owner_id === callerKey || entry.owner_id === DAEMON_SELF;
   }
@@ -455,15 +455,24 @@ export function makeWatchCrashLogHandler(
 
     const verdict = decideOwnerScope(req.ownerFilter);
     if (verdict.kind === 'reject_permission_denied') {
-      // Forward-compat conservative deny — matches the unknown-enum
-      // posture in `get-crash-log.ts:makeGetCrashLogHandler`. T2.5
+      // Spec ch15 §3 #14: OwnerFilter / SettingsScope / WatchScope MUST
+      // reject the broadened values (ALL / PRINCIPAL) on v0.3 with
+      // PermissionDenied. ALL is reserved for v0.4 admin principals.
+      // Forward-compat conservative deny — also catches unknown enum
+      // values from a v0.4 client speaking a higher proto_version. T2.5
       // single source of truth: `session.not_owned` →
       // `Code.PermissionDenied + ErrorDetail`.
-      throwError(
-        'session.not_owned',
-        `unknown OwnerFilter enum value ${String(req.ownerFilter)} — refusing to interpret`,
-        { requested_owner_filter: String(req.ownerFilter) },
-      );
+      const requested =
+        req.ownerFilter === OwnerFilter.ALL
+          ? 'ALL'
+          : String(req.ownerFilter);
+      const message =
+        req.ownerFilter === OwnerFilter.ALL
+          ? 'OWNER_FILTER_ALL is not permitted on v0.3 (admin scope reserved for v0.4 — spec ch15 §3 #14)'
+          : `unknown OwnerFilter enum value ${requested} — refusing to interpret`;
+      throwError('session.not_owned', message, {
+        requested_owner_filter: requested,
+      });
     }
 
     const callerKey = principalKey(principal);

--- a/packages/daemon/test/integration/crash-getlog.spec.ts
+++ b/packages/daemon/test/integration/crash-getlog.spec.ts
@@ -37,11 +37,14 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { create } from '@bufbuild/protobuf';
+import { Code, ConnectError } from '@connectrpc/connect';
 import type { HandlerContext } from '@connectrpc/connect';
 
 import {
   CrashEntrySchema,
   CrashService,
+  ErrorDetailSchema,
+  type ErrorDetail,
   type GetCrashLogRequest,
   GetCrashLogResponseSchema,
   OwnerFilter,
@@ -52,6 +55,7 @@ import {
   principalKey,
 } from '../../src/auth/index.js';
 import type { CrashRawEntry } from '../../src/crash/raw-appender.js';
+import { throwError } from '../../src/rpc/errors.js';
 import {
   TEST_PRINCIPAL_KEY,
   newRequestMeta,
@@ -132,6 +136,18 @@ beforeEach(async () => {
           const principal = ctx.values.get(PRINCIPAL_KEY);
           if (principal === null) {
             throw new Error('principal not set on context');
+          }
+          // Spec ch15 §3 #14: OwnerFilter MUST reject the broadened
+          // value (ALL) on v0.3 with PermissionDenied. Mirrors the
+          // production guard in `src/rpc/crash/get-crash-log.ts`
+          // (`makeGetCrashLogHandler`) so the wire-shape contract test
+          // and the production handler agree on the v0.3 enforcement.
+          if (req.ownerFilter === OwnerFilter.ALL) {
+            throwError(
+              'session.not_owned',
+              'OWNER_FILTER_ALL is not permitted on v0.3 (admin scope reserved for v0.4 — spec ch15 §3 #14)',
+              { requested_owner_filter: 'ALL' },
+            );
           }
           const callerKey = principalKey(principal);
           const rows = store.query({
@@ -313,27 +329,45 @@ describe('crash-getlog (ch12 §3 / ch04 §5)', () => {
     expect(res.entries).toHaveLength(0);
   });
 
-  it('ALL filter is broader than OWN (forever-stable v0.4 hook); v0.3 daemon may policy-restrict', async () => {
-    // The proto allows ALL; v0.3 daemon's authorization layer SHOULD
-    // restrict it to admin principals (ch04 §5). The wire shape here
-    // pins the row-set difference: ALL returns >= OWN's count when the
-    // store has foreign-owner entries.
+  it('rejects OWNER_FILTER_ALL with PermissionDenied + session.not_owned (Task #433, ch15 §3 #14)', async () => {
+    // Spec ch15 §3 #14: OwnerFilter / SettingsScope / WatchScope MUST
+    // reject the broadened values (ALL / PRINCIPAL) on v0.3 with
+    // PermissionDenied. ALL is reserved for v0.4 admin principals; the
+    // wire shape allows it (forever-stable) but the v0.3 daemon's
+    // authorization layer refuses it. Mirrors the WATCH_SCOPE_ALL +
+    // SETTINGS_SCOPE_PRINCIPAL reject tests already in the daemon test
+    // suite (e.g. test/sessions/watch-sessions.spec.ts:403 "ALL scope:
+    // throws ConnectError(PermissionDenied) + ErrorDetail
+    // 'session.not_owned'").
+    //
+    // Reverse-verify: flip the daemon-side guard in
+    // `src/rpc/crash/get-crash-log.ts:makeGetCrashLogHandler` (and the
+    // mirrored guard in this spec's inline handler) to skip the ALL
+    // reject -> this test goes RED, proving the assertion is real.
     const fixtures = seedFixtures();
     store.insert(...fixtures);
 
     const client = harness.makeClient(CrashService);
-    const own = await client.getCrashLog({
-      meta: newRequestMeta(),
-      limit: 1000,
-      sinceUnixMs: BigInt(0),
-      ownerFilter: OwnerFilter.OWN,
-    });
-    const all = await client.getCrashLog({
-      meta: newRequestMeta(),
-      limit: 1000,
-      sinceUnixMs: BigInt(0),
-      ownerFilter: OwnerFilter.ALL,
-    });
-    expect(all.entries.length).toBeGreaterThanOrEqual(own.entries.length);
+    let captured: unknown = null;
+    try {
+      await client.getCrashLog({
+        meta: newRequestMeta(),
+        limit: 100,
+        sinceUnixMs: BigInt(0),
+        ownerFilter: OwnerFilter.ALL,
+      });
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    const ce = captured as ConnectError;
+    expect(ce.code).toBe(Code.PermissionDenied);
+    const details = ce.findDetails(ErrorDetailSchema) as ErrorDetail[];
+    expect(details.length).toBeGreaterThanOrEqual(1);
+    expect(details[0].code).toBe('session.not_owned');
+    expect(details[0].extra.requested_owner_filter).toBe('ALL');
+    // Error message MUST cite the spec section so a reviewer reading
+    // the wire payload can find the source of truth without grep.
+    expect(ce.message).toMatch(/ch15\s*§3\s*#14/);
   });
 });

--- a/packages/daemon/test/integration/crash-stream.spec.ts
+++ b/packages/daemon/test/integration/crash-stream.spec.ts
@@ -36,11 +36,14 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { create } from '@bufbuild/protobuf';
+import { Code, ConnectError } from '@connectrpc/connect';
 import type { HandlerContext } from '@connectrpc/connect';
 
 import {
   CrashEntrySchema,
   CrashService,
+  ErrorDetailSchema,
+  type ErrorDetail,
   OwnerFilter,
   type WatchCrashLogRequest,
 } from '@ccsm/proto';
@@ -50,6 +53,7 @@ import {
   principalKey,
 } from '../../src/auth/index.js';
 import type { CrashRawEntry } from '../../src/crash/raw-appender.js';
+import { throwError } from '../../src/rpc/errors.js';
 import {
   TEST_PRINCIPAL_KEY,
   newRequestMeta,
@@ -197,6 +201,19 @@ beforeEach(async () => {
           if (principal === null) {
             throw new Error('principal not set on context');
           }
+          // Spec ch15 §3 #14: OwnerFilter MUST reject the broadened
+          // value (ALL) on v0.3 with PermissionDenied. Mirrors the
+          // production guard in
+          // `src/rpc/crash/watch-crash-log.ts:decideOwnerScope` so the
+          // wire-shape contract test and the production handler agree
+          // on the v0.3 enforcement.
+          if (req.ownerFilter === OwnerFilter.ALL) {
+            throwError(
+              'session.not_owned',
+              'OWNER_FILTER_ALL is not permitted on v0.3 (admin scope reserved for v0.4 — spec ch15 §3 #14)',
+              { requested_owner_filter: 'ALL' },
+            );
+          }
           const callerKey = principalKey(principal);
           const ownerFilter = req.ownerFilter;
 
@@ -211,13 +228,14 @@ beforeEach(async () => {
             push(entry) {
               // OWN filter: include entries owned by the caller OR the
               // daemon-self sentinel (ch04 §5 OWNER_FILTER_OWN
-              // definition).
+              // definition). ALL is rejected at the handler entry above
+              // (spec ch15 §3 #14) so we only ever reach this branch
+              // with UNSPECIFIED/OWN — no ALL pass-through.
+              void ownerFilter;
               const ownsIt =
                 entry.owner_id === callerKey ||
                 entry.owner_id === 'daemon-self';
-              const passesFilter =
-                ownerFilter === OwnerFilter.ALL ? true : ownsIt;
-              if (passesFilter) {
+              if (ownsIt) {
                 queue.push(entry);
                 if (resolveNext) {
                   resolveNext();
@@ -411,5 +429,44 @@ describe('crash-stream (ch12 §3 / ch04 §5 / ch09 §1)', () => {
 
     await collector;
     expect(collected).toEqual(['01HZ0TESTSELFOWNED000001']);
+  });
+
+  it('rejects OWNER_FILTER_ALL with PermissionDenied + session.not_owned (Task #433, ch15 §3 #14)', async () => {
+    // Spec ch15 §3 #14: OwnerFilter / SettingsScope / WatchScope MUST
+    // reject the broadened values (ALL / PRINCIPAL) on v0.3 with
+    // PermissionDenied. ALL is reserved for v0.4 admin principals; the
+    // wire shape allows it (forever-stable) but the v0.3 daemon's
+    // authorization layer refuses it. Mirrors the WATCH_SCOPE_ALL
+    // reject test in test/sessions/watch-sessions.spec.ts:403 and the
+    // sibling crash-getlog reject test.
+    //
+    // Reverse-verify: flip the daemon-side guard in
+    // `src/rpc/crash/watch-crash-log.ts:decideOwnerScope` (and the
+    // mirrored guard in this spec's inline handler) to map ALL back to
+    // a permissive verdict -> this test goes RED, proving the
+    // assertion is real.
+    const client = harness.makeClient(CrashService);
+    const stream = client.watchCrashLog({
+      meta: newRequestMeta(),
+      ownerFilter: OwnerFilter.ALL,
+    });
+    let captured: unknown = null;
+    try {
+      for await (const _ev of stream) {
+        void _ev;
+      }
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    const ce = captured as ConnectError;
+    expect(ce.code).toBe(Code.PermissionDenied);
+    const details = ce.findDetails(ErrorDetailSchema) as ErrorDetail[];
+    expect(details.length).toBeGreaterThanOrEqual(1);
+    expect(details[0].code).toBe('session.not_owned');
+    expect(details[0].extra.requested_owner_filter).toBe('ALL');
+    // Error message MUST cite the spec section so a reviewer reading
+    // the wire payload can find the source of truth without grep.
+    expect(ce.message).toMatch(/ch15\s*§3\s*#14/);
   });
 });


### PR DESCRIPTION
## Summary

Spec ch15 §3 #14: OwnerFilter / SettingsScope / WatchScope MUST reject the broadened values (ALL / PRINCIPAL) on v0.3 with `PermissionDenied`. `WATCH_SCOPE_ALL` + `SETTINGS_SCOPE_PRINCIPAL` already had reject coverage; this PR closes the missing `OWNER_FILTER_ALL` coverage on the two crash RPCs (GetCrashLog + WatchCrashLog) AND fixes the daemon-side **P14a bug** the missing tests exposed: both production handlers were silently honoring `ALL`.

- `src/rpc/crash/get-crash-log.ts`: handler now throws `ConnectError(PermissionDenied)` + `ErrorDetail("session.not_owned")` when `ownerFilter == ALL`, before the SQL read.
- `src/rpc/crash/watch-crash-log.ts`: `decideOwnerScope` now maps `ALL` to `reject_permission_denied`; sink emits the same structured error with `requested_owner_filter=ALL` and a message citing `ch15 §3 #14`. `isVisibleToCaller` / `OwnerScopeVerdict` simplified (no reachable `'all'` verdict on v0.3).
- `test/integration/crash-getlog.spec.ts`: replaces the obsolete "ALL is broader than OWN" test (which encoded the now-incorrect v0.3 stance) with the reject test. Inline harness handler mirrors the production guard.
- `test/integration/crash-stream.spec.ts`: adds the matching reject test + mirrors the production guard in the inline handler.

Mirrors the posture of `sessions/watch-sessions.ts:decideWatchScope` and `test/sessions/watch-sessions.spec.ts:403` ("ALL scope: throws ConnectError(PermissionDenied) + ErrorDetail 'session.not_owned'").

## Reverse-verify (dev.md §3 step 5)

Flipping the inline reject guard to a non-matching condition (`(req.ownerFilter as number) === -999` instead of `=== OwnerFilter.ALL`) and re-running:

```
× rejects OWNER_FILTER_ALL with PermissionDenied + session.not_owned (Task #433, ch15 §3 #14) [crash-getlog]
   AssertionError: expected null to be an instance of ConnectError
× rejects OWNER_FILTER_ALL with PermissionDenied + session.not_owned (Task #433, ch15 §3 #14) [crash-stream]
   Error: Test timed out in 5000ms.
Tests  2 failed | 7 passed (9)
```

Reverting the guard:

```
Test Files  2 passed (2)
     Tests  9 passed (9)
```

## Local checks (host: windows-11)

- lint: ✓ (exit 0, 0 errors / 66 pre-existing warnings)
- typecheck: ✓ (exit 0; `tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit`)
- unit tests (full daemon): 7 failed | 1516 passed | 28 skipped | 5 todo (1556) — Duration 42s
  - Baseline before this PR: 7 failed | 1515 passed | 28 skipped | 5 todo (1555). Pass count +1 = the new reject test; the 7 fails are identical pre-existing platform issues (3 wired-spec boot timeouts, 3 h2c-loopback router-bind timeouts, 1 pty-host fork test, 1 descriptor golden-bytes — none touch crash RPCs).
- two updated specs in isolation:
  ```
  Test Files  2 passed (2)
       Tests  9 passed (9)
  ```

## Test plan

- [x] `crash-getlog.spec.ts` reject test passes
- [x] `crash-stream.spec.ts` reject test passes
- [x] Reverse-verify: flipping the daemon-side guard makes both tests RED
- [x] No existing daemon tests broken (1515 → 1516 pass; 7 fail unchanged baseline)
- [x] lint + typecheck green