### PR TITLE
fix(proto): LF-normalize .proto SHA in lock.mjs/lock-check.mjs (#450)

### DIFF
--- a/packages/proto/scripts/lock-check.mjs
+++ b/packages/proto/scripts/lock-check.mjs
@@ -39,7 +39,10 @@ function toPosix(p) {
 }
 
 function sha256OfFile(path) {
-  return createHash('sha256').update(readFileSync(path)).digest('hex');
+  // Mirror lock.mjs: UTF-8 read + CRLF -> LF normalization so Windows and
+  // Linux compute identical hashes regardless of git autocrlf behavior.
+  const content = readFileSync(path, 'utf8').replace(/\r\n/g, '\n');
+  return createHash('sha256').update(content, 'utf8').digest('hex');
 }
 
 function main() {

--- a/packages/proto/scripts/lock.mjs
+++ b/packages/proto/scripts/lock.mjs
@@ -4,10 +4,11 @@
 //
 // Regenerate packages/proto/lock.json from packages/proto/src/**/*.proto.
 //
-// Walks the src tree, computes SHA256 of each .proto file (raw bytes — no
-// normalization, hash is over the exact on-disk content), and writes the
-// result to lock.json sorted by relative POSIX path. Pair with lock-check.mjs
-// (CI / pre-commit) to detect unintended schema drift.
+// Walks the src tree, computes SHA256 of each .proto file (UTF-8 content with
+// CRLF normalized to LF — so Windows checkouts produce the same hash as Linux
+// regardless of git autocrlf settings), and writes the result to lock.json
+// sorted by relative POSIX path. Pair with lock-check.mjs (CI / pre-commit)
+// to detect unintended schema drift.
 //
 // Usage: pnpm --filter @ccsm/proto run lock
 
@@ -38,7 +39,10 @@ function toPosix(p) {
 }
 
 function sha256OfFile(path) {
-  return createHash('sha256').update(readFileSync(path)).digest('hex');
+  // Read as UTF-8 and normalize CRLF -> LF so Windows checkouts (where git
+  // autocrlf may have rewritten line endings) produce the same hash as Linux.
+  const content = readFileSync(path, 'utf8').replace(/\r\n/g, '\n');
+  return createHash('sha256').update(content, 'utf8').digest('hex');
 }
 
 function main() {


### PR DESCRIPTION
## Summary

Both `packages/proto/scripts/lock.mjs` and `lock-check.mjs` hashed `.proto` files as raw bytes. On Windows checkouts with CRLF line endings, this produced different SHAs than Linux and caused spurious `lock.json` drift.

Task #447 / PR #1054 fixed the working baseline symptom but not the root cause — the next `.proto` edit + Windows regenerate would have re-introduced the drift.

This PR reads as UTF-8 and normalizes `\r\n` -> `\n` before hashing in both scripts (writer + checker stay in lockstep).

## Verification

- On this Windows host, `pnpm --filter @ccsm/proto run lock-check` -> `OK (8 .proto files match lock.json)` against Linux-computed `lock.json` (proves normalization is consistent across OS).
- Re-running `pnpm --filter @ccsm/proto run lock` produces zero diff to existing `lock.json`.

## Local checks (host: windows-11)

- lint: ok (0 errors, 66 preexisting warnings)
- typecheck: ok (exit 0)
- build / unit / e2e: skipped — change is to two `.mjs` build scripts only, no `.ts`/`.tsx` touched, no runtime impact (per dev.md §3 step 2 skip rule for non-runtime config).
- lock-check: OK (8 .proto files match lock.json)
- lock regen: zero diff

## Out of scope

- `lock.json` regeneration if any drift surfaces (separate downstream task).

Refs Task #450