### PR TITLE
fix(daemon): plumb CCSM_STATE_DIR through to db + crashRaw paths (Task #446)

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -59,7 +59,7 @@ import { makeRouterBindHook } from './rpc/bind.js';
 import { upsertSettingsBoot } from './rpc/settings/store.js';
 import { SessionManager, type ISessionManager } from './sessions/SessionManager.js';
 import { makeProductionAttachPtyHost } from './pty-host/attach-on-create.js';
-import { statePaths } from './state-dir/paths.js';
+import { statePathsFromRoot } from './state-dir/paths.js';
 import {
   Shutdown,
   installShutdownHandlers,
@@ -189,11 +189,15 @@ export async function runStartup(
   lifecycle.advanceTo(Phase.OPENING_DB);
 
   // T5.7 / Task #60 — corrupt-DB recovery (ch07 §6). MUST run BEFORE any
-  // other code opens the SQLite file. We resolve the canonical state paths
-  // here (not from `env.paths`) because the entrypoint env shape predates
-  // T5.3's `statePaths()` and only carries a `stateDir` string; the spec
-  // pins the DB and crash-raw filenames to this module's constants.
-  const sp = statePaths();
+  // other code opens the SQLite file. Task #446: rebase the canonical file
+  // layout onto `env.paths.stateDir` so `CCSM_STATE_DIR` (honoured by
+  // `buildDaemonEnv`) actually flows through to the DB / crash-raw paths.
+  // Pre-#446 we called `statePaths()` here, which only reads `PROGRAMDATA`
+  // (per spec ch07 §2 + `paths.spec.ts` FORBIDDEN env keys) and silently
+  // dropped the override. `env.ts` is the single source of truth for
+  // `stateDir`; `statePathsFromRoot` reapplies the canonical filenames
+  // (`ccsm.db`, `crash-raw.ndjson`, `listener-a.json`) under it.
+  const sp = statePathsFromRoot(env.paths.stateDir);
   const recovery = checkAndRecover({
     dbPath: sp.db,
     crashRawPath: sp.crashRaw,

--- a/packages/daemon/src/state-dir/paths.ts
+++ b/packages/daemon/src/state-dir/paths.ts
@@ -74,6 +74,28 @@ export function statePaths(
   env: NodeJS.ProcessEnv = process.env,
 ): StatePaths {
   const root = stateRoot(platform, env);
+  return statePathsFromRoot(root, platform);
+}
+
+/**
+ * Compute the spec ch07 §2 file layout under an explicit `root`. Pure: no
+ * `process.env` reads, no I/O. Use this when the caller already resolved a
+ * state root from `DaemonEnv.paths.stateDir` (which honours
+ * `CCSM_STATE_DIR`) and needs the canonical filenames (`ccsm.db`,
+ * `crash-raw.ndjson`, `listener-a.json`) under that root with the
+ * platform-correct path separator.
+ *
+ * Task #446: `index.ts` previously called `statePaths()` with no args,
+ * which silently bypassed `CCSM_STATE_DIR` because the resolver only
+ * recognises `PROGRAMDATA` (per spec ch07 §2 / paths.spec.ts FORBIDDEN
+ * env keys). The env-var override surface lives in `env.ts` (single source
+ * of truth for `stateDir`); this helper lets callers reapply it without
+ * teaching `paths.ts` to read env vars.
+ */
+export function statePathsFromRoot(
+  root: string,
+  platform: StateDirPlatform = process.platform,
+): StatePaths {
   // Use platform-correct join so win32 uses `\` and POSIX uses `/`. Tests
   // assert posix-style on linux/darwin and either `\` or `/` on win32.
   const join = platform === 'win32' ? path.win32.join : path.posix.join;

--- a/packages/daemon/test/state-dir/env-consistency.spec.ts
+++ b/packages/daemon/test/state-dir/env-consistency.spec.ts
@@ -23,7 +23,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { buildDaemonEnv } from '../../src/env.js';
-import { statePaths } from '../../src/state-dir/paths.js';
+import { statePaths, statePathsFromRoot } from '../../src/state-dir/paths.js';
 
 const SAVED_ENV: Record<string, string | undefined> = {};
 const ENV_KEYS = ['CCSM_STATE_DIR', 'PROGRAMDATA'] as const;
@@ -119,6 +119,40 @@ describe('env.paths.stateDir vs statePaths().root — single source of truth (ch
     withPlatform('linux', () => {
       const env = buildDaemonEnv();
       expect(env.paths.stateDir).toBe('/tmp/ccsm-override');
+    });
+  });
+
+  // Task #446: regression — `index.ts` previously called `statePaths()` with
+  // no args to resolve `dbPath` and `crashRawPath`, which silently bypassed
+  // `CCSM_STATE_DIR` (paths.ts only honours `PROGRAMDATA`). The fix is to
+  // rebase via `statePathsFromRoot(env.paths.stateDir)`. This spec asserts
+  // that the rebased layout points the DB and crash-raw NDJSON under the
+  // override root, NOT under `/var/lib/ccsm` / `%PROGRAMDATA%\ccsm`.
+  it('Task #446: statePathsFromRoot(env.paths.stateDir) honours CCSM_STATE_DIR for db + crashRaw', () => {
+    process.env.CCSM_STATE_DIR = '/tmp/test1';
+    withPlatform('linux', () => {
+      const env = buildDaemonEnv();
+      const sp = statePathsFromRoot(env.paths.stateDir, 'linux');
+      expect(sp.root).toBe('/tmp/test1');
+      expect(sp.db).toBe('/tmp/test1/ccsm.db');
+      expect(sp.crashRaw).toBe('/tmp/test1/crash-raw.ndjson');
+      expect(sp.descriptor).toBe('/tmp/test1/listener-a.json');
+      // Negative: the bare `statePaths()` resolver still ignores the env
+      // (proves the bypass surface is in the call site, not in paths.ts).
+      const bare = statePaths('linux');
+      expect(bare.db).toBe('/var/lib/ccsm/ccsm.db');
+      expect(bare.db).not.toBe(sp.db);
+    });
+  });
+
+  it('Task #446: win32 statePathsFromRoot uses backslash join under override', () => {
+    process.env.CCSM_STATE_DIR = 'D:\\custom\\ccsm';
+    withPlatform('win32', () => {
+      const env = buildDaemonEnv();
+      const sp = statePathsFromRoot(env.paths.stateDir, 'win32');
+      expect(sp.root).toBe('D:\\custom\\ccsm');
+      expect(sp.db).toBe('D:\\custom\\ccsm\\ccsm.db');
+      expect(sp.crashRaw).toBe('D:\\custom\\ccsm\\crash-raw.ndjson');
     });
   });
 });


### PR DESCRIPTION
## Summary
- index.ts:196 called `statePaths()` with no args, which only honours `PROGRAMDATA` (paths.spec.ts FORBIDDEN env keys per spec ch07 §2). `CCSM_STATE_DIR` (resolved by `buildDaemonEnv` into `env.paths.stateDir`) was silently dropped — db, recovery, crash-raw replay, and crash-capture sinks all wrote under the per-OS default.
- Adds `statePathsFromRoot(root, platform?)` to `state-dir/paths.ts` (pure, no env reads — paths.spec FROZEN contract preserved).
- index.ts now calls `statePathsFromRoot(env.paths.stateDir)` so the env-resolved root flows through to all downstream paths.

## Test plan
- [x] Adds linux + win32 env-consistency specs proving `CCSM_STATE_DIR` flows to `sp.db` / `sp.crashRaw` / `sp.descriptor`.
- [x] Negative assertion: bare `statePaths()` still ignores `CCSM_STATE_DIR` (proves bypass surface lives in the call site, not in paths.ts — paths.spec.ts FROZEN contract intact).

## Local checks (host: windows-11)
- lint: exit 0 (warnings only, no errors — preexisting)
- typecheck: exit 0
- state-dir specs: 23 passed (includes 2 new Task #446 cases)
- baseline note: `test/descriptor/schema.spec.ts:187` golden mismatch is pre-existing on origin/working (verified by checking out clean), unrelated to this PR

## Scope
Followup to dogfood phase 1.5 finding. Surgical 3-file change: paths.ts (add new export, no behaviour change to existing `statePaths`), index.ts (one call-site swap), env-consistency.spec.ts (regression cases).