### PR TITLE
test(daemon/rpc): unit specs for settings keys/store/get pure deciders (Task #434)

### DIFF
--- a/packages/daemon/src/rpc/settings/__tests__/get-decider.spec.ts
+++ b/packages/daemon/src/rpc/settings/__tests__/get-decider.spec.ts
@@ -1,0 +1,47 @@
+// packages/daemon/src/rpc/settings/__tests__/get-decider.spec.ts
+//
+// Task #434 (T8.14b-4) — rpc/ coverage push for the pure
+// `decideGetSettings` decider in `../get.ts`. Spec #337 §4.1 +
+// settings.proto:36: scope UNSPECIFIED + GLOBAL proceed; PRINCIPAL
+// rejects with InvalidArgument in v0.3 (additively allowed in v0.4).
+// The Connect handler sink is exercised by the daemon-boot e2e — these
+// specs lock the per-scope verdict so the v0.4 additive widen-to-allow
+// for PRINCIPAL is a single-line change with a single-line test diff.
+
+import { create } from '@bufbuild/protobuf';
+import { describe, expect, it } from 'vitest';
+
+import {
+  GetSettingsRequestSchema,
+  SettingsScope,
+} from '@ccsm/proto';
+
+import { decideGetSettings } from '../get.js';
+
+describe('decideGetSettings (Task #434 — pure decider, spec #337 §4.1)', () => {
+  it('returns ok for UNSPECIFIED and GLOBAL scopes (hot path)', () => {
+    const reqUnspecified = create(GetSettingsRequestSchema, {
+      scope: SettingsScope.UNSPECIFIED,
+    });
+    expect(decideGetSettings(reqUnspecified)).toEqual({ kind: 'ok' });
+
+    const reqGlobal = create(GetSettingsRequestSchema, {
+      scope: SettingsScope.GLOBAL,
+    });
+    expect(decideGetSettings(reqGlobal)).toEqual({ kind: 'ok' });
+  });
+
+  it('rejects PRINCIPAL scope (v0.4 only) with reject_scope verdict carrying the offending value', () => {
+    // Error branch: v0.3 acceptance §7 #4 — PRINCIPAL is reserved for
+    // v0.4 additive widening. The decider returns the verdict tagged
+    // with the rejected enum value so the sink can format an
+    // InvalidArgument message without re-deriving it.
+    const req = create(GetSettingsRequestSchema, {
+      scope: SettingsScope.PRINCIPAL,
+    });
+    expect(decideGetSettings(req)).toEqual({
+      kind: 'reject_scope',
+      scope: SettingsScope.PRINCIPAL,
+    });
+  });
+});

--- a/packages/daemon/src/rpc/settings/__tests__/keys.spec.ts
+++ b/packages/daemon/src/rpc/settings/__tests__/keys.spec.ts
@@ -1,0 +1,46 @@
+// packages/daemon/src/rpc/settings/__tests__/keys.spec.ts
+//
+// Task #434 (T8.14b-4) — rpc/ coverage push for the SRP-decomposed key
+// vocabulary in `../keys.ts`. The constants and helpers exported there
+// are the forever-stable storage-key surface (spec #337 §2.4): every
+// settings/draft row on disk is named via these strings, so a silent
+// drift here orphans rows on upgrade. These specs pin the contract
+// without touching any handler — pure-data assertions only.
+
+import { describe, expect, it } from 'vitest';
+
+import { DRAFT_PREFIX, draftKey, ULID_RE, UI_PREFS_PREFIX } from '../keys.js';
+
+describe('keys.ts — forever-stable storage-key vocabulary (Task #434)', () => {
+  it('draftKey concatenates the canonical "draft:" prefix to the session id', () => {
+    // Spec #337 §2.4 reserves the bare `draft:` prefix; nothing else
+    // (no `v2:` segment, no JSON envelope) lives in the key. If that
+    // ever changes the spec must amend §2.4 and this assertion gates
+    // the rename — review-time visible, not a silent migration.
+    const sid = '01J0000000000000000000ABCD';
+    expect(draftKey(sid)).toBe(`draft:${sid}`);
+    expect(draftKey(sid).startsWith(DRAFT_PREFIX)).toBe(true);
+    // The bare `draft:` prefix is intentionally distinct from
+    // `ui_prefs.draft:` so GetSettings cannot confuse a draft row for
+    // a ui_prefs entry (spec §2.2 + §9 q6).
+    expect(draftKey(sid).startsWith(UI_PREFS_PREFIX)).toBe(false);
+  });
+
+  it('ULID_RE accepts a valid Crockford ULID and rejects malformed ids', () => {
+    // Defence-in-depth gate (spec #337 §8.3) — better-sqlite3 already
+    // bound-protects against SQL injection, but the regex stops garbage
+    // ids at the wire boundary before any storage row is written.
+    // Hot path: well-formed ULID accepted.
+    expect(ULID_RE.test('01J0000000000000000000ABCD')).toBe(true);
+
+    // Error branches:
+    // - too short
+    expect(ULID_RE.test('01J')).toBe(false);
+    // - lowercase letters (Crockford ULID is upper-only)
+    expect(ULID_RE.test('01j0000000000000000000abcd')).toBe(false);
+    // - reserved letters in Crockford alphabet (I/L/O/U)
+    expect(ULID_RE.test('01J000000000000000000000IL')).toBe(false);
+    // - empty string
+    expect(ULID_RE.test('')).toBe(false);
+  });
+});

--- a/packages/daemon/src/rpc/settings/__tests__/store-decode.spec.ts
+++ b/packages/daemon/src/rpc/settings/__tests__/store-decode.spec.ts
@@ -1,0 +1,79 @@
+// packages/daemon/src/rpc/settings/__tests__/store-decode.spec.ts
+//
+// Task #434 (T8.14b-4) — rpc/ coverage push for the pure
+// `rowsToSettings` decider in `../store.ts`. Spec #337 §2.4
+// forward-tolerance + §4.1: GetSettings reconstructs the proto Settings
+// message from the on-disk row stream, skipping draft rows and
+// surfacing unknown keys via the optional onUnknown callback rather
+// than throwing. These specs pin both branches without spinning up
+// sqlite (the producer `readSettingsRows` is a thin SELECT).
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { rowsToSettings } from '../store.js';
+import { DRAFT_PREFIX, SETTINGS_KEYS, UI_PREFS_PREFIX } from '../keys.js';
+
+describe('rowsToSettings (Task #434 — pure decider, spec #337 §2.4 / §4.1)', () => {
+  it('projects known scalar / message / ui_prefs rows into the proto Settings shape', () => {
+    // Hot path: feed the decider one row of each shape it knows about.
+    // We intentionally include a draft:* row to verify the skip branch
+    // (spec §4.1 step 2 — drafts owned by DraftService).
+    const rows = [
+      { key: SETTINGS_KEYS.locale, value: JSON.stringify('zh-CN') },
+      {
+        key: SETTINGS_KEYS.defaultGeometry,
+        value: JSON.stringify({ cols: 100, rows: 30 }),
+      },
+      {
+        key: SETTINGS_KEYS.crashRetention,
+        value: JSON.stringify({ max_entries: 500, max_age_days: 30 }),
+      },
+      { key: SETTINGS_KEYS.sentryEnabled, value: JSON.stringify(false) },
+      {
+        key: `${UI_PREFS_PREFIX}appearance.theme`,
+        value: JSON.stringify('dark'),
+      },
+      // draft row — MUST be skipped, not surfaced via onUnknown
+      {
+        key: `${DRAFT_PREFIX}01J0000000000000000000ABCD`,
+        value: JSON.stringify({ text: 'hi', updated_unix_ms: 1 }),
+      },
+    ];
+
+    const onUnknown = vi.fn();
+    const settings = rowsToSettings(rows, { onUnknown });
+
+    expect(settings.locale).toBe('zh-CN');
+    expect(settings.defaultGeometry?.cols).toBe(100);
+    expect(settings.defaultGeometry?.rows).toBe(30);
+    expect(settings.crashRetention?.maxEntries).toBe(500);
+    expect(settings.crashRetention?.maxAgeDays).toBe(30);
+    expect(settings.sentryEnabled).toBe(false);
+    expect(settings.uiPrefs).toEqual({ 'appearance.theme': 'dark' });
+    // Draft row took the early `continue` (NOT the unknown branch).
+    expect(onUnknown).not.toHaveBeenCalled();
+  });
+
+  it('forwards unknown keys to onUnknown without throwing (spec §2.4 forward-tolerance)', () => {
+    // Error branch: a key the v0.3 daemon does not recognise (e.g. a
+    // v0.4 additive row read on a downgrade) must NOT throw — proto3
+    // unknown-field semantics applied at the storage layer. The optional
+    // callback fires for observability, the proto Settings comes back
+    // with default-only values for unrecognised slots, and the call
+    // returns normally. Corrupt-JSON rows hit the same forward-tolerant
+    // path (skip).
+    const rows = [
+      { key: 'future_v04_only_key', value: JSON.stringify('whatever') },
+      // Corrupt JSON row — silently skipped per the inner try/catch.
+      { key: SETTINGS_KEYS.locale, value: '{not valid json' },
+    ];
+
+    const onUnknown = vi.fn();
+    const settings = rowsToSettings(rows, { onUnknown });
+
+    expect(onUnknown).toHaveBeenCalledTimes(1);
+    expect(onUnknown).toHaveBeenCalledWith('future_v04_only_key');
+    // Locale row was corrupt; default empty string survives.
+    expect(settings.locale).toBe('');
+  });
+});

--- a/packages/daemon/src/rpc/settings/__tests__/store-encode.spec.ts
+++ b/packages/daemon/src/rpc/settings/__tests__/store-encode.spec.ts
@@ -1,0 +1,150 @@
+// packages/daemon/src/rpc/settings/__tests__/store-encode.spec.ts
+//
+// Task #434 (T8.14b-4) — rpc/ coverage push for the pure
+// `encodeUpdatePatch` decider in `../store.ts`. Spec #337 §4.2: every
+// UpdateSettings call funnels through this function before any
+// transaction runs, so the cap-and-clamp policy + daemon-derived
+// rejection contract MUST be unit-testable without a sqlite handle.
+//
+// The companion sink (`applySettingsWrites` + `makeUpdateSettingsHandler`)
+// is exercised by the integration boot e2e — duplicating wire shape
+// here would just slow CI without adding signal. Hot path covered:
+// scalar UPSERT + map UPSERT/DELETE + clamp ceilings. Error branch:
+// daemon-derived rejection.
+
+import { create } from '@bufbuild/protobuf';
+import { describe, expect, it } from 'vitest';
+
+import {
+  CrashRetentionSchema,
+  PtyGeometrySchema,
+  SettingsSchema,
+} from '@ccsm/proto';
+
+import { CAPS, encodeUpdatePatch } from '../store.js';
+import { SETTINGS_KEYS, UI_PREFS_PREFIX } from '../keys.js';
+
+describe('encodeUpdatePatch (Task #434 — pure decider, spec #337 §4.2)', () => {
+  it('emits one UPSERT per touched scalar with JSON-encoded values', () => {
+    // Hot path: client supplies locale + default_geometry + a ui_prefs
+    // entry. Decider returns one upsert each, all values JSON-encoded
+    // per spec §2.3 (uniform-encoding rule).
+    const patch = create(SettingsSchema, {
+      locale: 'en-US',
+      defaultGeometry: create(PtyGeometrySchema, { cols: 80, rows: 24 }),
+      uiPrefs: { 'appearance.theme': 'dark' },
+    });
+
+    const result = encodeUpdatePatch(patch);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+
+    const ops = [...result.ops];
+    // locale
+    const localeOp = ops.find((o) => o.key === SETTINGS_KEYS.locale);
+    expect(localeOp).toEqual({
+      kind: 'upsert',
+      key: SETTINGS_KEYS.locale,
+      value: JSON.stringify('en-US'),
+    });
+    // default_geometry — dotted JSON shape exactly as the reader expects
+    const geomOp = ops.find((o) => o.key === SETTINGS_KEYS.defaultGeometry);
+    expect(geomOp).toEqual({
+      kind: 'upsert',
+      key: SETTINGS_KEYS.defaultGeometry,
+      value: JSON.stringify({ cols: 80, rows: 24 }),
+    });
+    // ui_prefs entry — full key uses the canonical prefix
+    const themeOp = ops.find(
+      (o) => o.key === `${UI_PREFS_PREFIX}appearance.theme`,
+    );
+    expect(themeOp).toEqual({
+      kind: 'upsert',
+      key: `${UI_PREFS_PREFIX}appearance.theme`,
+      value: JSON.stringify('dark'),
+    });
+  });
+
+  it('clamps crash_retention max_entries / max_age_days to the spec ceilings', () => {
+    // Spec §4.2 + settings.proto:121-123 — caps applied at write time so
+    // the table never holds an out-of-range value. We push values past
+    // both ceilings and assert the encoded JSON carries the clamped
+    // numbers (NOT the originals).
+    const patch = create(SettingsSchema, {
+      crashRetention: create(CrashRetentionSchema, {
+        maxEntries: 999_999, // > 10000 cap
+        maxAgeDays: 365,     // > 90 cap
+      }),
+    });
+
+    const result = encodeUpdatePatch(patch);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+
+    const op = result.ops.find(
+      (o) => o.key === SETTINGS_KEYS.crashRetention,
+    );
+    expect(op?.kind).toBe('upsert');
+    if (op?.kind !== 'upsert') return;
+    const decoded = JSON.parse(op.value) as {
+      max_entries: number;
+      max_age_days: number;
+    };
+    expect(decoded.max_entries).toBe(CAPS.crashRetentionMaxEntries);
+    expect(decoded.max_age_days).toBe(CAPS.crashRetentionMaxAgeDays);
+  });
+
+  it('emits a DELETE op for ui_prefs entries with empty-string values', () => {
+    // Spec §4.2 last bullet: empty string == "client asked to forget
+    // this key". We staple a single forget alongside a regular upsert
+    // to verify the discriminator switch fires per-entry.
+    const patch = create(SettingsSchema, {
+      uiPrefs: {
+        'composer.fontSizePx': '14',
+        'notify.enabled': '', // forget signal
+      },
+    });
+
+    const result = encodeUpdatePatch(patch);
+    expect(result.kind).toBe('ok');
+    if (result.kind !== 'ok') return;
+
+    const forget = result.ops.find(
+      (o) => o.key === `${UI_PREFS_PREFIX}notify.enabled`,
+    );
+    expect(forget).toEqual({
+      kind: 'delete',
+      key: `${UI_PREFS_PREFIX}notify.enabled`,
+    });
+    const upsert = result.ops.find(
+      (o) => o.key === `${UI_PREFS_PREFIX}composer.fontSizePx`,
+    );
+    expect(upsert?.kind).toBe('upsert');
+  });
+
+  it('rejects writes carrying daemon-derived fields with reject_daemon_derived', () => {
+    // Spec §4.2 + acceptance §7 #5: client cannot set
+    // `user_home_path` or `detected_claude_default_model`. Either
+    // touched-with-non-empty value triggers the rejection terminal so
+    // the handler can map to InvalidArgument WITHOUT applying any of
+    // the other fields in the same patch (no partial writes).
+    const patchHome = create(SettingsSchema, {
+      userHomePath: '/tmp/spoof-home',
+      locale: 'en-US', // would be a valid op if we got past the gate
+    });
+    const homeResult = encodeUpdatePatch(patchHome);
+    expect(homeResult).toEqual({
+      kind: 'reject_daemon_derived',
+      key: SETTINGS_KEYS.userHomePath,
+    });
+
+    const patchModel = create(SettingsSchema, {
+      detectedClaudeDefaultModel: 'claude-spoofed',
+    });
+    const modelResult = encodeUpdatePatch(patchModel);
+    expect(modelResult).toEqual({
+      kind: 'reject_daemon_derived',
+      key: SETTINGS_KEYS.detectedClaudeDefaultModel,
+    });
+  });
+});


### PR DESCRIPTION
## Task #434 — T8.14b-4 rpc/ coverage push

Adds **10 unit specs across 4 new files** covering the SRP-decomposed pure deciders in the daemon `rpc/settings/` surface. Pushes `rpc/` coverage toward the 80% target while staying disjoint from Task #437 (streaming / error scope).

## Files (only spec, no src changes)

| Spec file | it | Covers |
|---|---|---|
| `packages/daemon/src/rpc/settings/__tests__/keys.spec.ts` | 2 | `draftKey` prefix shape, `ULID_RE` accept/reject matrix |
| `packages/daemon/src/rpc/settings/__tests__/store-encode.spec.ts` | 4 | `encodeUpdatePatch` happy path, `crash_retention` clamp ceilings, `ui_prefs` DELETE-on-empty, daemon-derived rejection (`user_home_path` + `detected_claude_default_model`) |
| `packages/daemon/src/rpc/settings/__tests__/store-decode.spec.ts` | 2 | `rowsToSettings` happy path (scalar + message + ui_prefs + draft-skip), forward-tolerant unknown-key + corrupt-JSON branches |
| `packages/daemon/src/rpc/settings/__tests__/get-decider.spec.ts` | 2 | `decideGetSettings` ok for UNSPECIFIED/GLOBAL, `reject_scope` verdict for PRINCIPAL (v0.4-only) |

## src files exercised (READ-only)

- packages/daemon/src/rpc/settings/keys.ts (draftKey, ULID_RE)
- packages/daemon/src/rpc/settings/store.ts (encodeUpdatePatch, rowsToSettings, CAPS)
- packages/daemon/src/rpc/settings/get.ts (decideGetSettings)

Each it covers hot path or an explicit error branch (clamp ceiling / daemon-derived reject / unknown-key tolerance / PRINCIPAL scope reject). Sink layers (makeGet/UpdateSettingsHandler, applySettingsWrites) stay covered by the daemon-boot e2e — duplicating Connect plumbing here would not add signal.

## Reverse-verify (clamp branch)

- Drop the clamp branch in clampInt (store.ts) → store-encode clamp spec FAILS (expected 999999 to be 10000).
- Restore → all 10 tests PASS.

## Local checks (host: windows-11)

- typecheck: pass (tsc --noEmit -p tsconfig.json, exit 0)
- lint: pass (eslint clean on new files)
- new specs: 4 passed (4) | 10 passed (10) in 1.5s
- full daemon src/rpc + test/rpc: 128 passed | 1 skipped | 3 failed — the 3 failures live in src/rpc/__tests__/integration.spec.ts (h2c-loopback bind) and reproduce on origin/working baseline without these changes (untouched scope).

## Scope guardrails

- No src/ changes — task brief forbade.
- Disjoint from Task #437 (streaming crash/watch-*, errors.ts).
- Net diff: +322 lines, 4 new files.
- 10 it total = upper bound from brief.