### PR TITLE
test(daemon/crash): cover fileSink helper (Task #435)

### DIFF
--- a/packages/daemon/src/crash/sources-file-sink.spec.ts
+++ b/packages/daemon/src/crash/sources-file-sink.spec.ts
@@ -1,0 +1,92 @@
+// Unit tests for `fileSink` (sources.ts) — Task #435 coverage push.
+//
+// Why this file exists:
+//   - The crash/ subsystem is heavily covered (event-bus, pruner-decider,
+//     pruner, raw-appender, capture sources, rate-limit, integration RPC,
+//     pty-host) — ~118 spec passing on origin/working.
+//   - `installCaptureSources`, `truncateUtf8`, `newCrashId`, `CAPTURE_SOURCES`,
+//     `DAEMON_SELF`, `SqliteRateLimiter` all have direct or indirect specs.
+//   - The one un-tested public export was `fileSink(path)` — a tiny binding
+//     helper around `appendCrashRaw` that the orchestrator wires into
+//     `installCaptureSources({ sink: fileSink(path) })`. Without a direct
+//     spec, a regression that swaps the closure or drops the entry would
+//     only surface at integration time.
+//
+// Scope: 3 specs covering hot path + error branch.
+
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { fileSink } from './sources.js';
+import type { CrashRawEntry } from './raw-appender.js';
+
+function makeEntry(id: string): CrashRawEntry {
+  return {
+    id,
+    ts_ms: 1_700_000_000_000,
+    source: 'uncaughtException',
+    summary: `summary for ${id}`,
+    detail: 'stack trace here',
+    labels: { errorName: 'TestError' },
+    owner_id: 'daemon-self',
+  };
+}
+
+describe('fileSink', () => {
+  it('returns a sink that appends one NDJSON line per call to the bound path', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ccsm-file-sink-'));
+    const path = join(dir, 'crash-raw.ndjson');
+    try {
+      const sink = fileSink(path);
+      sink(makeEntry('id-1'));
+      sink(makeEntry('id-2'));
+      sink(makeEntry('id-3'));
+
+      const lines = readFileSync(path, 'utf8').split('\n').filter((l) => l.length > 0);
+      expect(lines).toHaveLength(3);
+      // Each line must be valid JSON carrying the entry's id.
+      const ids = lines.map((l) => (JSON.parse(l) as { id: string }).id);
+      expect(ids).toEqual(['id-1', 'id-2', 'id-3']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('binds the path at factory time so two sinks write to independent files', () => {
+    // Guard against a refactor that accidentally globalises the path closure.
+    const dirA = mkdtempSync(join(tmpdir(), 'ccsm-file-sink-a-'));
+    const dirB = mkdtempSync(join(tmpdir(), 'ccsm-file-sink-b-'));
+    const pathA = join(dirA, 'crash-raw.ndjson');
+    const pathB = join(dirB, 'crash-raw.ndjson');
+    try {
+      const sinkA = fileSink(pathA);
+      const sinkB = fileSink(pathB);
+
+      sinkA(makeEntry('a-only'));
+      sinkB(makeEntry('b-only'));
+      sinkA(makeEntry('a-second'));
+
+      const linesA = readFileSync(pathA, 'utf8').split('\n').filter((l) => l.length > 0);
+      const linesB = readFileSync(pathB, 'utf8').split('\n').filter((l) => l.length > 0);
+
+      const idsA = linesA.map((l) => (JSON.parse(l) as { id: string }).id);
+      const idsB = linesB.map((l) => (JSON.parse(l) as { id: string }).id);
+      expect(idsA).toEqual(['a-only', 'a-second']);
+      expect(idsB).toEqual(['b-only']);
+    } finally {
+      rmSync(dirA, { recursive: true, force: true });
+      rmSync(dirB, { recursive: true, force: true });
+    }
+  });
+
+  it('propagates the underlying openSync error when the parent directory does not exist', () => {
+    // The FATAL caller relies on errors surfacing rather than being swallowed
+    // (see raw-appender.ts header comment — "better to surface 'we tried and
+    // failed' than silently lose the event"). Verify fileSink does NOT trap
+    // the error inside its closure.
+    const sink = fileSink('/nonexistent-dir-for-task-435/does/not/exist/crash.ndjson');
+    expect(() => sink(makeEntry('will-fail'))).toThrow(/ENOENT|no such file/i);
+  });
+});


### PR DESCRIPTION
## Scope self-check (Task #435 spec required)

Research baseline reported `crash/` as **1 spec / 5 src / 1503 lines**.
Reality on origin/working (`bb4d7b3`):

```
$ ls packages/daemon/src/crash/
event-bus.spec.ts         (colocated, 9 it)
event-bus.ts
pruner-decider.ts
pruner.ts
raw-appender.ts
sources.ts

$ find packages/daemon -path "*crash*" -name "*.spec.ts"
packages/daemon/src/crash/event-bus.spec.ts                     (9 it)
packages/daemon/src/rpc/crash/__tests__/get-raw-crash-log.spec.ts
packages/daemon/test/crash/capture.spec.ts                      (19 it)
packages/daemon/test/crash/crash-raw-recovery.spec.ts           (9 it)
packages/daemon/test/crash/pruner-decider.spec.ts               (12 it)
packages/daemon/test/crash/pruner.spec.ts                       (13 it)
packages/daemon/test/crash/rate-limit.spec.ts                   (8 it)
packages/daemon/test/integration/crash-getlog-wired.spec.ts
packages/daemon/test/integration/crash-getlog.spec.ts
packages/daemon/test/integration/crash-stream.spec.ts
packages/daemon/test/integration/crash-watch-wired.spec.ts
packages/daemon/test/pty-host/test-crash-integration.spec.ts
```

Total: ~118 spec passing on origin/working baseline (`Tests 116 passed | 8 skipped` for `pnpm --filter @ccsm/daemon test crash` minus 2 pre-existing integration failures unrelated to this task).

**All 5 src already have direct unit + integration coverage.** Reusing the Task #435 spec instruction "如已大部分覆盖, 缩 scope 到真缺口 + 在 PR body 报告 manager。不要重复劳动".

## True gap identified

Greping `packages/daemon` spec files for each public export of `src/crash/sources.ts` showed **`fileSink(path)` had zero direct spec** — it is the tiny binding helper consumed by `installCaptureSources({ sink: fileSink(path) })`. A regression that swaps the closure or drops the entry would only surface at integration time.

All other public exports (`installCaptureSources`, `truncateUtf8`, `newCrashId`, `CAPTURE_SOURCES`, `DAEMON_SELF`, `SqliteRateLimiter`, `SQLITE_RATE_LIMIT_MS`, every CrashRawEntry interface) are covered.

## Changes

- `packages/daemon/src/crash/sources-file-sink.spec.ts` — NEW (92 lines, 3 it)
  - hot path: 3 entries, NDJSON line per call, ids round-trip
  - factory binding: two sinks write to independent files (closure regression guard)
  - error branch: openSync ENOENT propagates (FATAL caller policy)

No `src/` behavior changed (READ-only as task spec required).

Files modified: 1 NEW, 0 src/ touched
Spec count: 3 (well under the ≤10 cap)
Lines: 92 (well under the ≤500 cap)

## Local checks (host: windows-11)

- lint: ✓ (exit 0; 0 errors, 66 pre-existing warnings)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0; @ccsm/proto + @ccsm/snapshot-codec + @ccsm/daemon all green)
- crash specs (full): `Test Files 12 passed | 2 failed (14)` / `Tests 119 passed | 2 failed (121)` — the 2 failures are pre-existing on origin/working (`crash-getlog-wired` + `crash-watch-wired` integration probes return Code.Unimplemented; unrelated to this PR)
- new file alone: `Test Files 1 passed (1) / Tests 3 passed (3)` in 889ms

## Reverse-verify

Stubbed `fileSink` to drop the entry instead of calling `appendCrashRaw`:

```diff
 export function fileSink(path: string): CrashSink {
-  return (entry) => appendCrashRaw(path, entry);
+  return (_entry) => { /* REVERSE-VERIFY: drop entry */ };
 }
```

Result: `Test Files 1 failed (1) / Tests 3 failed (3)` — all 3 specs detect the regression.
Restored: `Test Files 1 passed (1) / Tests 3 passed (3)`.

Refs: Task #435