### PR TITLE
test(daemon/rpc): streaming + error mapping coverage (Task #437)

### DIFF
--- a/packages/daemon/src/rpc/draft/__tests__/get-handler.spec.ts
+++ b/packages/daemon/src/rpc/draft/__tests__/get-handler.spec.ts
@@ -1,0 +1,200 @@
+// packages/daemon/src/rpc/draft/__tests__/get-handler.spec.ts
+//
+// Task #437 (T8.14b-5) — rpc/ coverage push for the production
+// `DraftService.GetDraft` handler. The Wave-3 settings-roundtrip
+// integration spec exercises the happy path of GetDraft over the wire
+// (settings overlay end-to-end) but the per-branch error mapping for
+// `assertOwnsSession` (the shared ownership gate at the top of every
+// draft handler) and the `decodeDraftValue` JSON-tolerance branch never
+// got direct unit coverage. These specs pin the error mapping so a
+// future change to `errors.ts` STANDARD_ERROR_MAP or `assertOwnsSession`
+// rejection ordering surfaces here, not as a remote-host symptom.
+//
+// Scope (one branch per `it`):
+//   1. invalid ULID session_id            → Code.InvalidArgument
+//   2. unknown session_id (no row)         → Code.PermissionDenied + session.not_owned
+//      (deliberately no NotFound — spec §4.3 + get.ts:104-106 prevents
+//      session-existence leak to non-owners)
+//   3. owner mismatch                      → Code.PermissionDenied + session.not_owned
+//   4. row absent in settings table        → empty-draft response
+//   5. row present + corrupt JSON          → fallback empty-draft (forward-tolerant)
+//
+// SCOPE: pure unit — uses an in-memory sqlite (`openDatabase(':memory:')
+// + runMigrations`) so the handler runs against a real schema; no
+// Connect transport plumbing needed because we exercise the handler
+// function directly with a stub HandlerContext.
+
+import { create } from '@bufbuild/protobuf';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  Code,
+  ConnectError,
+  createContextValues,
+  type HandlerContext,
+} from '@connectrpc/connect';
+
+import {
+  ErrorDetailSchema,
+  GetDraftRequestSchema,
+  RequestMetaSchema,
+  type ErrorDetail,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, principalKey, type Principal } from '../../../auth/index.js';
+import { openDatabase, type SqliteDatabase } from '../../../db/sqlite.js';
+import { runMigrations } from '../../../db/migrations/runner.js';
+import { applySettingsWrites } from '../../settings/store.js';
+import { draftKey } from '../../settings/keys.js';
+import { makeGetDraftHandler } from '../get.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const VALID_ULID_A = '01J0000000000000000000ABCD';
+const VALID_ULID_B = '01J000000000000000000WXYZ0';
+const PRINCIPAL_ALICE: Principal = {
+  kind: 'local-user',
+  uid: '1000',
+  displayName: 'alice',
+};
+const PRINCIPAL_BOB: Principal = {
+  kind: 'local-user',
+  uid: '1001',
+  displayName: 'bob',
+};
+
+let db: SqliteDatabase;
+
+beforeEach(() => {
+  db = openDatabase(':memory:');
+  runMigrations(db);
+  // Seed principals + sessions rows the gate needs. The session is owned
+  // by Alice; Bob is the foreign principal used in the owner-mismatch case.
+  db.exec(`INSERT INTO principals (id, kind, display_name, first_seen_ms, last_seen_ms) VALUES
+    ('${principalKey(PRINCIPAL_ALICE)}', 'local-user', 'alice', 0, 0),
+    ('${principalKey(PRINCIPAL_BOB)}', 'local-user', 'bob', 0, 0);`);
+  db.prepare(
+    `INSERT INTO sessions (id, owner_id, state, cwd, env_json, claude_args_json,
+      geometry_cols, geometry_rows, created_ms, last_active_ms)
+     VALUES (?, ?, 1, '/tmp', '{}', '[]', 80, 24, 0, 0)`,
+  ).run(VALID_ULID_A, principalKey(PRINCIPAL_ALICE));
+});
+
+afterEach(() => {
+  db.close();
+});
+
+function ctxWith(principal: Principal | null): HandlerContext {
+  // Minimal HandlerContext stub — the handler only reads `.values.get`.
+  // createContextValues() returns the same shape Connect's router
+  // constructs; pre-seed it with the principal under PRINCIPAL_KEY.
+  const values = createContextValues();
+  if (principal !== null) {
+    values.set(PRINCIPAL_KEY, principal);
+  } else {
+    values.set(PRINCIPAL_KEY, null);
+  }
+  return { values } as HandlerContext;
+}
+
+function makeReq(sessionId: string) {
+  return create(GetDraftRequestSchema, {
+    meta: create(RequestMetaSchema, { requestId: 'rid-1' }),
+    sessionId,
+  });
+}
+
+function expectErrorDetailCode(err: ConnectError, expected: string): void {
+  const details = err.findDetails(ErrorDetailSchema) as ErrorDetail[];
+  expect(details.length).toBeGreaterThanOrEqual(1);
+  expect(details[0].code).toBe(expected);
+}
+
+// ---------------------------------------------------------------------------
+// Specs
+// ---------------------------------------------------------------------------
+
+describe('DraftService.GetDraft — assertOwnsSession + decodeDraftValue (Task #437)', () => {
+  it('rejects malformed session_id with Code.InvalidArgument (get.ts:85-90)', async () => {
+    const handler = makeGetDraftHandler({ db });
+    const ctx = ctxWith(PRINCIPAL_ALICE);
+
+    let captured: unknown = null;
+    try {
+      await handler(makeReq('not-a-ulid'), ctx);
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    expect((captured as ConnectError).code).toBe(Code.InvalidArgument);
+  });
+
+  it('hides existence of unknown session: returns session.not_owned (PermissionDenied) per spec §4.3', async () => {
+    // Spec §4.3 + get.ts:104-106 — the handler MUST NOT distinguish
+    // "session does not exist" from "session is owned by another
+    // principal" to a non-owner. Both surface as PermissionDenied with
+    // ErrorDetail.code = "session.not_owned".
+    const handler = makeGetDraftHandler({ db });
+    const ctx = ctxWith(PRINCIPAL_ALICE);
+
+    let captured: unknown = null;
+    try {
+      await handler(makeReq(VALID_ULID_B), ctx); // VALID_ULID_B has no row
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    const err = captured as ConnectError;
+    expect(err.code).toBe(Code.PermissionDenied);
+    expectErrorDetailCode(err, 'session.not_owned');
+  });
+
+  it('rejects non-owner with Code.PermissionDenied + session.not_owned (get.ts:113-118)', async () => {
+    const handler = makeGetDraftHandler({ db });
+    // Alice owns VALID_ULID_A; Bob is calling.
+    const ctx = ctxWith(PRINCIPAL_BOB);
+
+    let captured: unknown = null;
+    try {
+      await handler(makeReq(VALID_ULID_A), ctx);
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    const err = captured as ConnectError;
+    expect(err.code).toBe(Code.PermissionDenied);
+    expectErrorDetailCode(err, 'session.not_owned');
+    // Extra carries session_id + caller's principal key per get.ts:115-118.
+    const detail = (err.findDetails(ErrorDetailSchema) as ErrorDetail[])[0];
+    expect(detail.extra.session_id).toBe(VALID_ULID_A);
+    expect(detail.extra.principal).toBe(principalKey(PRINCIPAL_BOB));
+  });
+
+  it('returns empty-draft response when no draft row exists (get.ts:154-160)', async () => {
+    // Owner gate passes; settings table has no `draft:<sid>` row.
+    const handler = makeGetDraftHandler({ db });
+    const ctx = ctxWith(PRINCIPAL_ALICE);
+    const resp = await handler(makeReq(VALID_ULID_A), ctx);
+
+    expect(resp.text).toBe('');
+    expect(resp.updatedUnixMs).toBe(0n);
+    expect(resp.meta?.requestId).toBe('rid-1');
+  });
+
+  it('falls back to empty-draft when row value is corrupt JSON (forward-tolerant per §2.4)', async () => {
+    // Seed a draft row whose value is NOT valid JSON. decodeDraftValue
+    // (get.ts:127-145) must NOT crash — it returns the empty-draft
+    // shape so the handler ships a wire response rather than throwing.
+    applySettingsWrites(db, [
+      { kind: 'upsert', key: draftKey(VALID_ULID_A), value: '{not json' },
+    ]);
+
+    const handler = makeGetDraftHandler({ db });
+    const ctx = ctxWith(PRINCIPAL_ALICE);
+    const resp = await handler(makeReq(VALID_ULID_A), ctx);
+
+    expect(resp.text).toBe('');
+    expect(resp.updatedUnixMs).toBe(0n);
+  });
+});

--- a/packages/daemon/src/rpc/draft/__tests__/update-handler.spec.ts
+++ b/packages/daemon/src/rpc/draft/__tests__/update-handler.spec.ts
@@ -1,0 +1,138 @@
+// packages/daemon/src/rpc/draft/__tests__/update-handler.spec.ts
+//
+// Task #437 (T8.14b-5) — rpc/ coverage push for the production
+// `DraftService.UpdateDraft` handler. The Wave-3 settings-roundtrip
+// integration spec exercises end-to-end UPSERT round-trips but the
+// per-branch behaviour (DELETE-on-empty-text vs UPSERT-on-non-empty,
+// clock injection for `updated_unix_ms`) was never pinned at the unit
+// level. These specs lock the spec §4.4 + draft.proto:31 contract so a
+// future refactor of the row vocabulary can't silently drift.
+//
+// Scope (one branch per `it`):
+//   1. empty `text` ⇒ DELETE row; response carries updated_unix_ms = 0
+//   2. non-empty `text` ⇒ UPSERT row; response carries the injected ts
+//   3. clock injection: the `now` dep controls `updated_unix_ms`
+//
+// Re-uses the same in-memory sqlite + seed pattern as the GetDraft
+// spec; see comments there for the rationale.
+
+import { create } from '@bufbuild/protobuf';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createContextValues, type HandlerContext } from '@connectrpc/connect';
+
+import {
+  RequestMetaSchema,
+  UpdateDraftRequestSchema,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, principalKey, type Principal } from '../../../auth/index.js';
+import { openDatabase, type SqliteDatabase } from '../../../db/sqlite.js';
+import { runMigrations } from '../../../db/migrations/runner.js';
+import { applySettingsWrites, readOneSettingsRow } from '../../settings/store.js';
+import { draftKey } from '../../settings/keys.js';
+import { makeUpdateDraftHandler } from '../update.js';
+
+const VALID_ULID_A = '01J0000000000000000000ABCD';
+const PRINCIPAL_ALICE: Principal = {
+  kind: 'local-user',
+  uid: '1000',
+  displayName: 'alice',
+};
+
+let db: SqliteDatabase;
+
+beforeEach(() => {
+  db = openDatabase(':memory:');
+  runMigrations(db);
+  db.exec(`INSERT INTO principals (id, kind, display_name, first_seen_ms, last_seen_ms) VALUES
+    ('${principalKey(PRINCIPAL_ALICE)}', 'local-user', 'alice', 0, 0);`);
+  db.prepare(
+    `INSERT INTO sessions (id, owner_id, state, cwd, env_json, claude_args_json,
+      geometry_cols, geometry_rows, created_ms, last_active_ms)
+     VALUES (?, ?, 1, '/tmp', '{}', '[]', 80, 24, 0, 0)`,
+  ).run(VALID_ULID_A, principalKey(PRINCIPAL_ALICE));
+});
+
+afterEach(() => {
+  db.close();
+});
+
+function ctxWith(principal: Principal | null): HandlerContext {
+  const values = createContextValues();
+  values.set(PRINCIPAL_KEY, principal);
+  return { values } as HandlerContext;
+}
+
+function makeReq(sessionId: string, text: string) {
+  return create(UpdateDraftRequestSchema, {
+    meta: create(RequestMetaSchema, { requestId: 'rid-update' }),
+    sessionId,
+    text,
+  });
+}
+
+describe('DraftService.UpdateDraft — DELETE/UPSERT branches + clock (Task #437)', () => {
+  it('empty text ⇒ DELETE row + response.updated_unix_ms = 0 (update.ts:42-49)', async () => {
+    // Pre-seed a draft so the DELETE branch has something to remove.
+    applySettingsWrites(db, [
+      {
+        kind: 'upsert',
+        key: draftKey(VALID_ULID_A),
+        value: JSON.stringify({ text: 'old', updated_unix_ms: 100 }),
+      },
+    ]);
+    expect(readOneSettingsRow(db, draftKey(VALID_ULID_A))).not.toBeNull();
+
+    const handler = makeUpdateDraftHandler({
+      db,
+      now: () => 12345, // injected, but DELETE branch must NOT call it
+    });
+    const resp = await handler(makeReq(VALID_ULID_A, ''), ctxWith(PRINCIPAL_ALICE));
+
+    expect(resp.updatedUnixMs).toBe(0n);
+    expect(resp.meta?.requestId).toBe('rid-update');
+    // Row gone — DELETE took effect.
+    expect(readOneSettingsRow(db, draftKey(VALID_ULID_A))).toBeNull();
+  });
+
+  it('non-empty text ⇒ UPSERT row + response.updated_unix_ms reflects the injected clock (update.ts:50-61)', async () => {
+    const handler = makeUpdateDraftHandler({
+      db,
+      now: () => 999_888_777,
+    });
+    const resp = await handler(
+      makeReq(VALID_ULID_A, 'hello world'),
+      ctxWith(PRINCIPAL_ALICE),
+    );
+
+    expect(resp.updatedUnixMs).toBe(999_888_777n);
+
+    // Row is JSON-encoded { text, updated_unix_ms } per draft storage shape.
+    const row = readOneSettingsRow(db, draftKey(VALID_ULID_A));
+    expect(row).not.toBeNull();
+    const parsed = JSON.parse(row!.value) as {
+      text: string;
+      updated_unix_ms: number;
+    };
+    expect(parsed.text).toBe('hello world');
+    expect(parsed.updated_unix_ms).toBe(999_888_777);
+  });
+
+  it('clock dep defaults to Date.now when omitted (update.ts:38)', async () => {
+    // No `now` override — handler MUST call `Date.now` and surface a
+    // plausible epoch-millis value (positive, within a few seconds of
+    // wallclock around the call).
+    const handler = makeUpdateDraftHandler({ db });
+    const before = Date.now();
+    const resp = await handler(
+      makeReq(VALID_ULID_A, 'use default clock'),
+      ctxWith(PRINCIPAL_ALICE),
+    );
+    const after = Date.now();
+
+    // Response timestamp is BigInt; widen for comparison.
+    const ts = Number(resp.updatedUnixMs);
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+});


### PR DESCRIPTION
## Task #437 (T8.14b-5)

rpc/ coverage push focused on **error-mapping** branches the existing
suite leaves uncovered. Streaming side was investigated and rejected
as out of scope — see baseline self-check.

## Baseline self-check (host: windows-11)

`rg -c '^\s*(it|test)\(' packages/daemon/src/rpc/**/*.spec.ts packages/daemon/test/**/*.spec.ts` (109 it across 18 files):

| Surface | File | Existing it | Verdict |
|---|---|---:|---|
| `errors.ts` | `test/rpc/errors.spec.ts` | 11 | full (closed-enum + Connect Code + extra) |
| `hello.ts` | `test/rpc/hello.spec.ts` | 10 | full (decider + sink + wire) |
| `pty-attach.ts` (streaming) | `src/rpc/pty-attach.spec.ts` | 29 | full (snapshot/delta/ack/abort/overflow + AckPty) |
| `crash/get-raw-crash-log.ts` (streaming) | `src/rpc/crash/__tests__/...` | 5 | full |
| `middleware/request-meta.ts` | `test/rpc/middleware/...` | 20 | full (decider + unary + streaming) |
| `bind.ts` | `src/rpc/__tests__/integration.spec.ts` | 3 | covered (TLS reject + host !=127.0.0.1 + h2c-loopback) |
| `router.ts` | `src/rpc/__tests__/router.spec.ts` + `integration.spec.ts` | 4 | covered (every service registered + Unimplemented over wire) |
| `settings/store.ts` + `keys.ts` | `src/rpc/settings/__tests__/...` | 10 | partial — Task #431 owns the gap |
| **`crash/get-crash-log.ts`** (unary) | — | 0 | **gap, but excluded** (#435 owns crash/) |
| **`crash/watch-crash-log.ts`** (streaming) | — | 0 | **gap, but excluded** (#435 owns crash/) |
| **`draft/get.ts`** (unary + ownership gate) | — | 0 | **GAP — fixed here (5 it)** |
| **`draft/update.ts`** (unary + DELETE/UPSERT branches) | — | 0 | **GAP — fixed here (3 it)** |
| `draft/register.ts` | — | 0 | trivial (3-line `router.service` call); covered transitively |

Streaming: every streaming handler in rpc/ already has direct unit
coverage (`pty-attach.spec.ts` 29 it, `get-raw-crash-log.spec.ts` 5 it,
`request-meta.spec.ts` covers streaming first-message validation 3 it).
The remaining streaming surface (`crash/watch-crash-log.ts`) is excluded
by the task scope (#435 owns crash/).

Error mapping: the missing branches are concentrated in `draft/*` —
ownership gate (Code.InvalidArgument / PermissionDenied / Internal),
existence-hiding for non-owners, and forward-tolerant JSON decode.
Two spec files, 8 it total (≤8 cap).

## Changes

- `packages/daemon/src/rpc/draft/__tests__/get-handler.spec.ts` (5 it)
- `packages/daemon/src/rpc/draft/__tests__/update-handler.spec.ts` (3 it)

No `src/` behaviour changes. The `crash/`, `pty-attach.ts`, `errors.ts`,
`hello.ts`, `bind.ts`, `router.ts`, `settings/*`, `middleware/*` files
are untouched (per task boundary + #431/#435/#436 conflict avoidance).

## Local checks (host: windows-11)

- lint: PASS (0 errors, 66 baseline warnings unrelated)
- typecheck: PASS (`tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit`)
- build: PASS (`tsc -p tsconfig.json`)
- new specs (`vitest run src/rpc/draft/__tests__/`):
  ```
  Test Files  2 passed (2)
       Tests  8 passed (8)
    Duration  3.60s
  ```
- adjacent rpc/ specs (`vitest run src/rpc/draft/ src/rpc/__tests__/router.spec.ts src/rpc/pty-attach.spec.ts`):
  ```
  Test Files  4 passed (4)
       Tests  68 passed (68)
  ```

## Reverse-verify (per-branch — coverage push, not bug fix)

Not a bug fix, so no `git stash` reverse-verify required by dev.md §3.
Each new `it` exercises a distinct branch in the source code; deleting
a single line of the new specs would silently regress the corresponding
source branch. Spot-check evidence (the gate is real):

- Mutating `assertOwnsSession`'s ULID guard from `!ULID_RE.test(sessionId)`
  to `false` causes the first `it` to fail with InvalidArgument no
  longer being thrown.
- Removing the `if (owner === null)` branch causes the unknown-session
  `it` to FAIL (it would now throw InvalidArgument from the
  callerKey-mismatch path with a `null` `owner` rather than the
  PermissionDenied path).

## Pre-existing failures (not introduced here)

`vitest run` (full daemon) reports 6 fails / 1557 passes — all in
`test/integration/*-wired.spec.ts`, `test/pty-host/test-crash-integration.spec.ts`,
and `src/rpc/__tests__/integration.spec.ts`. These fail on plain
`origin/working` (verified by checking out clean and re-running before
adding the new specs). This PR does not touch any of those files or
their dependencies.