### PR TITLE
build(daemon,electron): add prebuild proto-gen hook + fix Node version doc (Task #460)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,5 +2,5 @@
 
 ## Local development
 
-- Use Node 20.x for local builds. CI runs on 20.x.
+- Use Node 22.x for local builds. CI runs on 22.x.
 - On Windows, native modules require VS Build Tools with C++/CX SDK (full VS 2022, not just BuildTools).

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -5,8 +5,10 @@
   "type": "module",
   "description": "CCSM daemon (headless RPC server). Skeleton only; implementation lands in subsequent T0.x / T1.x tasks per design spec ch11.",
   "scripts": {
+    "prebuild": "node ../../scripts/gen-proto.mjs",
     "build": "tsc -p tsconfig.json",
     "lint": "eslint \"src/**/*.ts\" \"eslint-plugins/**/*.{js,ts}\" \"build/**/*.ts\"",
+    "pretypecheck": "node ../../scripts/gen-proto.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit",
     "test": "vitest run",
     "pretest": "node ../../scripts/ensure-native-abi.mjs node",

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -11,6 +11,7 @@
   "main": "dist/main/protocol-app.js",
   "scripts": {
     "lint": "eslint \"test/**/*.ts\"",
+    "pretypecheck": "node ../../scripts/gen-proto.mjs",
     "typecheck": "tsc -p tsconfig.test.json --noEmit",
     "test": "vitest run",
     "build:mac": "electron-builder --mac --config electron-builder.yml",


### PR DESCRIPTION
## Why

Task #457 dev round-1 hit 9 TS errors in a fresh worktree because `cd packages/daemon && pnpm build` runs `tsc -p tsconfig.json` directly, bypassing turbo. `turbo.json`'s `build.dependsOn = ["@ccsm/proto#gen"]` only fires from the root `npm run build`, so per-package builds in fresh worktrees fail until proto is generated by hand.

`scripts/gen-proto.mjs` is already idempotent (~1ms no-op when `gen/ts/` is populated), so wiring it as a `prebuild` / `pretypecheck` npm hook is essentially free on warm worktrees and self-healing on cold ones.

CONTRIBUTING.md said "Node 20.x" but `package.json` engines is `>=22 <23` and CI runs 22 — doc was stale.

## Changes

- `packages/daemon/package.json`: add `prebuild` + `pretypecheck` running `node ../../scripts/gen-proto.mjs`
- `packages/electron/package.json`: add `pretypecheck` running same (electron has no `build` script that runs tsc directly; only `typecheck` does)
- `CONTRIBUTING.md`: Node 20.x → Node 22.x

## Boundary (mutex)

- Did NOT touch root `package.json` (#428)
- Did NOT touch `packages/daemon/src/` (#431/#436/#437)
- Did NOT touch `turbo.json` (prebuild hook is sufficient)
- Did NOT add `setup-worktree.sh` (followup)
- Did NOT add CI smoke (followup)

## Local checks (host: windows-11)

After deleting `packages/proto/gen/ts/`:

```
$ cd packages/daemon && pnpm build
> @ccsm/daemon@0.0.0 prebuild
> node ../../scripts/gen-proto.mjs

> @ccsm/daemon@0.0.0 build
> tsc -p tsconfig.json
(exit 0)
```

After deleting `packages/proto/gen/ts/`:

```
$ cd packages/daemon && pnpm typecheck
> @ccsm/daemon@0.0.0 pretypecheck
> node ../../scripts/gen-proto.mjs

> @ccsm/daemon@0.0.0 typecheck
> tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit
(exit 0)
```

After deleting `packages/proto/gen/ts/`:

```
$ cd packages/electron && pnpm typecheck
> @ccsm/electron@0.0.0 pretypecheck
> node ../../scripts/gen-proto.mjs

> @ccsm/electron@0.0.0 typecheck
> tsc -p tsconfig.test.json --noEmit
(exit 0)
```

## Reverse-verify (hook is real, not silently skipped)

Temporarily pointed daemon `prebuild` at `node ../../scripts/not-exist.mjs`:

```
$ cd packages/daemon && pnpm build
> @ccsm/daemon@0.0.0 prebuild
> node ../../scripts/not-exist.mjs

Error: Cannot find module 'C:\...\pool-10\scripts\not-exist.mjs'
    code: 'MODULE_NOT_FOUND'
ELIFECYCLE  Command failed with exit code 1.
```

Restored to `gen-proto.mjs` and re-ran (after deleting `gen/ts/`): build passes again (output shown above). Hook truly gates the build.