### PR TITLE
chore(dev-infra): enforce Node 22 via engine-strict + doc nvm/.nvmrc (Task #445)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,11 @@
 # native build fails with MSB8020 on fresh checkouts. Pin to 0 to use the
 # default MSVC toolset.
 clang=0
+
+# Enforce package.json `engines` (currently `node >=22.0.0 <23`) at install
+# time. Without this, npm/pnpm only emit an EBADENGINE *warn* — easy to
+# miss, and dev sessions on Node 24 silently break native modules
+# (better-sqlite3 NODE_MODULE_VERSION 145 vs Node 22's 127). With
+# engine-strict, mismatched Node versions abort `pnpm install` with a
+# clear error, pointing developers to `.nvmrc`. See Task #445.
+engine-strict=true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,5 +2,7 @@
 
 ## Local development
 
-- Use Node 22.x for local builds. CI runs on 22.x.
+- Use **Node 22.x** for local builds (pinned in `.nvmrc`, currently `22.18.0`). CI runs the same version via `actions/setup-node` with `node-version-file: .nvmrc`.
+- Recommended: install [nvm](https://github.com/nvm-sh/nvm) (macOS/Linux), [nvm-windows](https://github.com/coreybutler/nvm-windows), or [fnm](https://github.com/Schniz/fnm), then run `nvm use` / `fnm use` in the repo root — both auto-pick up `.nvmrc`.
+- `engine-strict=true` is set in repo `.npmrc`, so `pnpm install` will **abort** (not just warn) on a Node major outside `>=22.0.0 <23`. This prevents the `better-sqlite3` `NODE_MODULE_VERSION` mismatch that hits Node 24 users (Task #445).
 - On Windows, native modules require VS Build Tools with C++/CX SDK (full VS 2022, not just BuildTools).

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To disable after opting in: open Settings → Notifications and uncheck "Send cr
 
 ## Development
 
-Requires Node 20+ and `npm`. The native module `better-sqlite3` is rebuilt for Electron's ABI on `npm install` via `electron-builder install-app-deps`.
+Requires Node 22.x (see `.nvmrc`, currently `22.18.0`) and `npm` / `pnpm`. The native module `better-sqlite3` is rebuilt for Electron's ABI on `npm install` via `electron-builder install-app-deps`. Other Node majors will be rejected at install time (`engine-strict=true` in `.npmrc`); use `nvm use` / `fnm use` in the repo root to switch.
 
 ```bash
 npm install


### PR DESCRIPTION
## Why

Task #445 follow-up. Dogfood phase 1.5 hit a `better-sqlite3` `NODE_MODULE_VERSION 145` (Node 24) vs `127` (Node 22) ABI mismatch because nothing forced the dev shell onto the pinned Node version. `.nvmrc` (`22.18.0`) and `engines.node` (`>=22.0.0 <23`) already exist, and CI workflows already use `node-version-file: .nvmrc`, but local installs only emitted an EBADENGINE *warning* — easy to miss, and the install proceeded into a broken native-module rebuild.

## Changes

- **`.npmrc`**: add `engine-strict=true` so `pnpm install` **aborts** with a clear error on Node majors outside `>=22.0.0 <23`, instead of warning and continuing.
- **`README.md`**: replace stale `Node 20+` (contradicts `.nvmrc`) with `Node 22.x (see .nvmrc)` and mention `engine-strict` + `nvm` / `fnm`.
- **`CONTRIBUTING.md`**: link to nvm / nvm-windows / fnm and explain the `engine-strict` guard.

No production code, no `.ts`/`.tsx`, no workflow changes — pure dev-infra hardening. ABI behavior for SEA / installer-bundled Node is unchanged (those ship their own pinned runtime).

## Acceptance (from Task #445)

> `node --version` not in `.nvmrc` range → `pnpm install` gives EBADENGINE warn

Strengthened: `pnpm install` now **aborts** with a clear error (better than a warn — warn was the exact UX that let dogfood phase 1.5 break).

## Reverse-verify

Cannot install a second Node version on this Windows host without nvm GUI (banned per `dev.md`), so verified by **temporarily flipping `engines.node` to `>=24.0.0`** on the host's Node `v22.18.0`:

```
$ pnpm install --frozen-lockfile
 ERR_PNPM_UNSUPPORTED_ENGINE  Unsupported environment (bad pnpm and/or Node.js version)

Your Node version is incompatible with "...\ccsm-worktrees\pool-3".

Expected version: >=24.0.0
Got: v22.18.0
```

`package.json` restored, `git diff package.json` clean.

Without `engine-strict=true` this would have been a warn, not an abort — directly proves the guard works.

## Local checks (host: windows-11)

- lint: ✓ (exit 0, 66 pre-existing warnings, 0 errors)
- typecheck: ✓ (exit 0, both `tsconfig.json` and `tsconfig.electron.json`)
- build: ✓ (exit 0, 3/3 turbo tasks)
- unit tests: skipped per `dev.md` §3 step 2 (no `.ts`/`.tsx` touched). Spot-checked anyway: 1557 pass / 6 pre-existing fails (RPC integration `Listener A Unimplemented` — unrelated to this PR, exist on `origin/working`).
- e2e: skipped per `dev.md` §3 step 2 (no `.ts`/`.tsx` touched).

## Notes for reviewer

- The 6 pre-existing unit test fails (`crash-getlog-wired`, `crash-watch-wired`, `watch-sessions-wired`, 3x `rpc/integration`) all complain `does NOT return Code.Unimplemented` — RPC wiring drift, unrelated to a `.npmrc` / docs PR. Worth a separate task if not already tracked.