### PR TITLE
test(daemon/crash): move pruner/raw-appender/sources specs into src/__tests__ for unit coverage gate (Task #474)

### DIFF
--- a/packages/daemon/src/crash/__tests__/capture.spec.ts
+++ b/packages/daemon/src/crash/__tests__/capture.spec.ts
@@ -1,4 +1,4 @@
-// packages/daemon/test/crash/capture.spec.ts
+// packages/daemon/src/crash/__tests__/capture.spec.ts
 //
 // Table-driven tests for crash capture sources (spec ch09 §6.2).
 //
@@ -40,7 +40,7 @@ import {
   installCaptureSources,
   newCrashId,
   truncateUtf8,
-} from '../../src/crash/sources.js';
+} from '../sources.js';
 
 // ---------------------------------------------------------------------------
 // Shared fixtures.

--- a/packages/daemon/src/crash/__tests__/crash-raw-recovery.spec.ts
+++ b/packages/daemon/src/crash/__tests__/crash-raw-recovery.spec.ts
@@ -1,4 +1,4 @@
-// packages/daemon/test/crash/crash-raw-recovery.spec.ts
+// packages/daemon/src/crash/__tests__/crash-raw-recovery.spec.ts
 //
 // Boot-replay recovery for crash-raw.ndjson — covers the silent-loss
 // failure modes called out by spec ch09 §6.2:
@@ -24,12 +24,12 @@ import * as path from 'node:path';
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
-import { openDatabase, type SqliteDatabase } from '../../src/db/sqlite.js';
+import { openDatabase, type SqliteDatabase } from '../../db/sqlite.js';
 import {
   appendCrashRaw,
   replayCrashRawOnBoot,
   type CrashRawEntry,
-} from '../../src/crash/raw-appender.js';
+} from '../raw-appender.js';
 
 // ---------------------------------------------------------------------------
 // Test fixtures: a fresh tmp dir per test holding the NDJSON file + a

--- a/packages/daemon/src/crash/__tests__/pruner.spec.ts
+++ b/packages/daemon/src/crash/__tests__/pruner.spec.ts
@@ -1,4 +1,4 @@
-// packages/daemon/test/crash/pruner.spec.ts
+// packages/daemon/src/crash/__tests__/pruner.spec.ts
 //
 // Sink tests for the crash retention pruner (Task #64 / T5.12).
 //
@@ -8,14 +8,14 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { openDatabase, type SqliteDatabase } from '../../src/db/sqlite.js';
-import { runMigrations } from '../../src/db/migrations/runner.js';
+import { openDatabase, type SqliteDatabase } from '../../db/sqlite.js';
+import { runMigrations } from '../../db/migrations/runner.js';
 import {
   CrashPruner,
   PRUNE_INTERVAL_MS,
   STARTUP_WARMUP_MS,
   type PrunerLogger,
-} from '../../src/crash/pruner.js';
+} from '../pruner.js';
 
 function makeDb(): SqliteDatabase {
   const db = openDatabase(':memory:');

--- a/packages/daemon/src/crash/__tests__/rate-limit.spec.ts
+++ b/packages/daemon/src/crash/__tests__/rate-limit.spec.ts
@@ -1,4 +1,4 @@
-// packages/daemon/test/crash/rate-limit.spec.ts
+// packages/daemon/src/crash/__tests__/rate-limit.spec.ts
 //
 // `sqlite_op` rate-limit (spec ch09 §1: "one entry per ~60s per code-class
 // to prevent flooding"). Kept separate from capture.spec.ts because it
@@ -15,7 +15,7 @@ import {
   type SqliteErrorBus,
   type SqliteErrorInfo,
   installCaptureSources,
-} from '../../src/crash/sources.js';
+} from '../sources.js';
 
 function makeFakeSqliteBus(): {
   bus: SqliteErrorBus;


### PR DESCRIPTION
## Summary

Move 4 already-existing spec files from `packages/daemon/test/crash/` into `packages/daemon/src/crash/__tests__/` so they count toward the unit-coverage gate (the gate's vitest config — `vitest.config.coverage.ts` — only includes `src/**/*.spec.ts` and `src/**/__tests__/**/*.spec.ts`, not `test/**`).

No production code changed; no test logic changed. Only file locations + matching import paths (`../../src/crash/...` -> `../...`, `../../src/db/...` -> `../../db/...`).

## Coverage delta on src/crash

`pnpm exec vitest run --coverage --config vitest.config.coverage.ts`:

| File                    | before  | after  |
| ----------------------- | ------- | ------ |
| **src/crash (folder)**  | 14.10%  | 94.19% |
| pruner.ts               |  0.00%  | 96.87% |
| raw-appender.ts         | 12.12%  | 96.96% |
| sources.ts              | 12.65%  | 88.60% |
| event-bus.ts            | 94.11%  | 94.11% |

All three target files (per Task #474 scope) exceed the 75% line-coverage threshold. pruner-decider is left at its current `test/crash` location (per task spec — Task #435 already shipped the filter-decider portion; pruner-decider is now indirectly ~100% covered via pruner.spec.ts).

## Reverse-verify

baseline (no spec files in src/__tests__/, only test/crash/):
- src/crash folder line coverage: **14.10%**
- pruner.ts: **0%** | raw-appender.ts: **12.12%** | sources.ts: **12.65%**

after (specs moved into src/__tests__/):
- src/crash folder line coverage: **94.19%**
- pruner.ts: **96.87%** | raw-appender.ts: **96.96%** | sources.ts: **88.60%**

## Local checks (host: windows-11)
- lint: OK (exit 0, 0 errors / 67 pre-existing warnings)
- typecheck: OK (`tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit`, exit 0)
- build: OK (`turbo build` exit 0)
- daemon coverage gate: OK — `pnpm exec vitest run --coverage --config vitest.config.coverage.ts`, 1049 passed | 11 skipped
  - global lines coverage: 67.62% (gate threshold 60%)
  - src/crash line coverage: **94.19%** (well above the 75% Task #474 bar)

Pre-existing baseline failures unrelated to this change (verified by stash check before edit + by `git diff --stat` showing the change set is just 4 file renames + import path tweaks):
- `@ccsm/proto:test` — proto lock.json drift on origin/working (Task #447 already in flight on stash@{0})
- `test/integration/{crash-getlog,crash-watch,watch-sessions}-wired.spec.ts` — Listener-A bind racing on Windows runner (unrelated)
- `src/rpc/__tests__/integration.spec.ts` — same Listener-A bind issue

This PR touches no `.ts` source — pure test-file relocation — so cannot have introduced these failures.