### PR TITLE
test(daemon/sessions): cover SessionManager + handlers to ~100% (Task #473)

### DIFF
--- a/packages/daemon/src/sessions/__tests__/SessionManager.spec.ts
+++ b/packages/daemon/src/sessions/__tests__/SessionManager.spec.ts
@@ -1,0 +1,363 @@
+// Task #473 (T8.14b-7b) — sessions/ coverage push.
+//
+// Unit tests for `sessions/SessionManager.ts`. Uses a real in-memory
+// better-sqlite3 instance (`openDatabase(':memory:')` + runMigrations)
+// so the manager runs against the actual `sessions` table schema —
+// faster than mocking the prepared-statement surface and exercises the
+// real FK + NOT NULL constraints.
+//
+// Coverage:
+//   - newSessionId(): 26-char Crockford-base32 shape, time-encoded
+//     prefix is lexicographically sortable, range guard (negative /
+//     >2^48-1) throws RangeError
+//   - encodeBase32 (via newSessionId / buildSessionRow round-trips)
+//   - buildSessionRow(): pure shape; defaults per spec ch05 §6
+//   - SessionManager.create: INSERTs row, publishes 'created' event
+//   - SessionManager.get: returns row when owned; throws session.not_owned
+//     when missing; throws session.not_owned when foreign-owned
+//   - SessionManager.list: filters by owner_id, ORDER BY created_ms ASC
+//   - SessionManager.destroy: flips state→EXITED + should_be_running=0;
+//     emits 'destroyed' event
+//   - SessionManager.markEnded: graceful→EXITED, crashed→CRASHED;
+//     null exit_code → -1; idempotent on repeat call (no event); throws
+//     for unknown id
+//   - SessionManager.subscribe: scoped via principalKey(caller)
+//   - eventBus getter: returns the underlying bus
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Code, ConnectError } from '@connectrpc/connect';
+
+import { ErrorDetailSchema, type ErrorDetail } from '@ccsm/proto';
+
+import { principalKey, type Principal } from '../../auth/principal.js';
+import { runMigrations } from '../../db/migrations/runner.js';
+import { openDatabase, type SqliteDatabase } from '../../db/sqlite.js';
+
+import { SessionEventBus } from '../event-bus.js';
+import {
+  SessionManager,
+  buildSessionRow,
+  newSessionId,
+} from '../SessionManager.js';
+import { SessionState, type SessionEvent } from '../types.js';
+
+const ALICE: Principal = { kind: 'local-user', uid: '1000', displayName: 'alice' };
+const BOB: Principal = { kind: 'local-user', uid: '1001', displayName: 'bob' };
+
+let db: SqliteDatabase;
+
+beforeEach(() => {
+  db = openDatabase(':memory:');
+  runMigrations(db);
+  db.exec(`INSERT INTO principals (id, kind, display_name, first_seen_ms, last_seen_ms) VALUES
+    ('${principalKey(ALICE)}', 'local-user', 'alice', 0, 0),
+    ('${principalKey(BOB)}', 'local-user', 'bob', 0, 0);`);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+function makeManager(opts: { now?: () => number; ids?: string[] } = {}) {
+  const ids = opts.ids ? [...opts.ids] : null;
+  return new SessionManager(db, {
+    now: opts.now,
+    newId: ids ? () => ids.shift() ?? newSessionId(opts.now ?? Date.now) : undefined,
+  });
+}
+
+const INPUT = {
+  cwd: '/tmp',
+  env_json: '{}',
+  claude_args_json: '[]',
+  geometry_cols: 80,
+  geometry_rows: 24,
+} as const;
+
+// ---------------------------------------------------------------------------
+// id generator
+// ---------------------------------------------------------------------------
+
+describe('newSessionId', () => {
+  it('produces 26 Crockford-base32 chars', () => {
+    const id = newSessionId(() => 1700000000000);
+    expect(id).toHaveLength(26);
+    expect(id).toMatch(/^[0-9A-HJKMNP-TV-Z]{26}$/);
+  });
+
+  it('time-prefix is lexicographically sortable', () => {
+    const a = newSessionId(() => 1000);
+    const b = newSessionId(() => 2000);
+    expect(a.slice(0, 10) < b.slice(0, 10)).toBe(true);
+  });
+
+  it('throws on negative ms (encodeTime range guard)', () => {
+    expect(() => newSessionId(() => -1)).toThrow(RangeError);
+  });
+
+  it('throws on > 2^48-1 ms (encodeTime range guard)', () => {
+    expect(() => newSessionId(() => 0x1_0000_0000_0000)).toThrow(RangeError);
+  });
+
+  it('throws on non-integer ms', () => {
+    expect(() => newSessionId(() => 1.5)).toThrow(RangeError);
+  });
+
+  it('default now uses Date.now', () => {
+    // Just confirm the no-arg form returns a parseable id; do not pin
+    // the actual timestamp because it depends on real wall clock.
+    const id = newSessionId();
+    expect(id).toHaveLength(26);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildSessionRow — pure
+// ---------------------------------------------------------------------------
+
+describe('buildSessionRow', () => {
+  it('produces row with spec defaults (state=STARTING, exit_code=-1, should_be_running=1)', () => {
+    const row = buildSessionRow(INPUT, ALICE, 'id-1', 1234);
+    expect(row).toEqual({
+      id: 'id-1',
+      owner_id: 'local-user:1000',
+      state: SessionState.STARTING,
+      cwd: '/tmp',
+      env_json: '{}',
+      claude_args_json: '[]',
+      geometry_cols: 80,
+      geometry_rows: 24,
+      exit_code: -1,
+      created_ms: 1234,
+      last_active_ms: 1234,
+      should_be_running: 1,
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SessionManager
+// ---------------------------------------------------------------------------
+
+describe('SessionManager.create', () => {
+  it('INSERTs row and emits created event', () => {
+    const m = makeManager({ now: () => 100, ids: ['ID-A'] });
+    const events: SessionEvent[] = [];
+    m.subscribe(ALICE, (ev) => events.push(ev));
+
+    const row = m.create(INPUT, ALICE);
+    expect(row.id).toBe('ID-A');
+    expect(row.owner_id).toBe('local-user:1000');
+    expect(row.state).toBe(SessionState.STARTING);
+    expect(row.created_ms).toBe(100);
+
+    // Persisted in SQLite
+    const persisted = db.prepare('SELECT id, owner_id, state FROM sessions WHERE id = ?').get('ID-A');
+    expect(persisted).toEqual({ id: 'ID-A', owner_id: 'local-user:1000', state: SessionState.STARTING });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ kind: 'created', session: row });
+  });
+
+  it('uses default now/newId when options omitted', () => {
+    const m = new SessionManager(db);
+    const row = m.create(INPUT, ALICE);
+    expect(row.id).toHaveLength(26);
+    expect(row.created_ms).toBeGreaterThan(0);
+  });
+
+  it('accepts an injected eventBus and publishes through it', () => {
+    const bus = new SessionEventBus();
+    const fn = vi.fn();
+    bus.subscribe('local-user:1000', fn);
+    const m = new SessionManager(db, { eventBus: bus, ids: ['X'] } as never);
+    // The above options shape isn't typed for `ids`; use the explicit
+    // newId override path instead.
+    const m2 = new SessionManager(db, {
+      eventBus: bus,
+      newId: () => 'EVTBUS-1',
+      now: () => 1,
+    });
+    m2.create(INPUT, ALICE);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(m.eventBus).toBe(bus); // getter exposes the same instance
+  });
+});
+
+describe('SessionManager.get', () => {
+  it('returns row when caller owns it', () => {
+    const m = makeManager({ now: () => 100, ids: ['G-1'] });
+    m.create(INPUT, ALICE);
+    const row = m.get('G-1', ALICE);
+    expect(row.id).toBe('G-1');
+  });
+
+  it('throws session.not_owned (PermissionDenied) when row missing', () => {
+    const m = makeManager();
+    let captured: unknown = null;
+    try {
+      m.get('does-not-exist', ALICE);
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    expect((captured as ConnectError).code).toBe(Code.PermissionDenied);
+    const details = (captured as ConnectError).findDetails(ErrorDetailSchema) as ErrorDetail[];
+    expect(details[0].code).toBe('session.not_owned');
+  });
+
+  it('throws session.not_owned when row owned by another principal', () => {
+    const m = makeManager({ ids: ['ALICE-OWNED'] });
+    m.create(INPUT, ALICE);
+    let captured: unknown = null;
+    try {
+      m.get('ALICE-OWNED', BOB);
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    expect((captured as ConnectError).code).toBe(Code.PermissionDenied);
+  });
+});
+
+describe('SessionManager.list', () => {
+  it('returns only the caller-owned rows, ordered by created_ms ASC', () => {
+    let t = 100;
+    const m = makeManager({ now: () => t, ids: ['A1', 'B1', 'A2'] });
+    m.create(INPUT, ALICE);
+    t = 200;
+    m.create(INPUT, BOB);
+    t = 300;
+    m.create(INPUT, ALICE);
+
+    const aliceRows = m.list(ALICE);
+    expect(aliceRows.map((r) => r.id)).toEqual(['A1', 'A2']);
+    const bobRows = m.list(BOB);
+    expect(bobRows.map((r) => r.id)).toEqual(['B1']);
+  });
+
+  it('returns empty array for principal with no rows', () => {
+    const m = makeManager();
+    expect(m.list(ALICE)).toEqual([]);
+  });
+});
+
+describe('SessionManager.destroy', () => {
+  it('flips state→EXITED + should_be_running=0 and emits destroyed event', () => {
+    const m = makeManager({ now: () => 500, ids: ['D-1'] });
+    m.create(INPUT, ALICE);
+
+    const events: SessionEvent[] = [];
+    m.subscribe(ALICE, (ev) => events.push(ev));
+
+    const destroyed = m.destroy('D-1', ALICE);
+    expect(destroyed.state).toBe(SessionState.EXITED);
+    expect(destroyed.should_be_running).toBe(0);
+    expect(destroyed.last_active_ms).toBe(500);
+
+    const persisted = db.prepare('SELECT state, should_be_running FROM sessions WHERE id = ?').get('D-1');
+    expect(persisted).toEqual({ state: SessionState.EXITED, should_be_running: 0 });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('destroyed');
+  });
+
+  it('throws session.not_owned if caller does not own the row', () => {
+    const m = makeManager({ ids: ['DOWNED'] });
+    m.create(INPUT, ALICE);
+    expect(() => m.destroy('DOWNED', BOB)).toThrow(ConnectError);
+  });
+});
+
+describe('SessionManager.markEnded', () => {
+  it('graceful → state EXITED, exit_code preserved, should_be_running=0', () => {
+    const m = makeManager({ now: () => 700, ids: ['E-G'] });
+    m.create(INPUT, ALICE);
+
+    const events: SessionEvent[] = [];
+    m.subscribe(ALICE, (ev) => events.push(ev));
+
+    const ended = m.markEnded('E-G', { reason: 'graceful', exit_code: 0 });
+    expect(ended.state).toBe(SessionState.EXITED);
+    expect(ended.exit_code).toBe(0);
+    expect(ended.should_be_running).toBe(0);
+    expect(ended.last_active_ms).toBe(700);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('ended');
+    if (events[0].kind === 'ended') {
+      expect(events[0].reason).toBe('graceful');
+    }
+  });
+
+  it('crashed → state CRASHED', () => {
+    const m = makeManager({ ids: ['E-C'] });
+    m.create(INPUT, ALICE);
+    const ended = m.markEnded('E-C', { reason: 'crashed', exit_code: 137 });
+    expect(ended.state).toBe(SessionState.CRASHED);
+    expect(ended.exit_code).toBe(137);
+  });
+
+  it('null exit_code → persisted as -1 sentinel', () => {
+    const m = makeManager({ ids: ['E-N'] });
+    m.create(INPUT, ALICE);
+    const ended = m.markEnded('E-N', { reason: 'graceful', exit_code: null });
+    expect(ended.exit_code).toBe(-1);
+  });
+
+  it('idempotent: second call with same terminal state returns without re-emitting', () => {
+    const m = makeManager({ ids: ['E-IDEMP'] });
+    m.create(INPUT, ALICE);
+
+    m.markEnded('E-IDEMP', { reason: 'graceful', exit_code: 0 });
+
+    const events: SessionEvent[] = [];
+    m.subscribe(ALICE, (ev) => events.push(ev));
+
+    const second = m.markEnded('E-IDEMP', { reason: 'graceful', exit_code: 0 });
+    expect(second.state).toBe(SessionState.EXITED);
+    expect(events).toHaveLength(0); // no re-emit
+  });
+
+  it('throws Error (NOT ConnectError) for unknown id', () => {
+    const m = makeManager();
+    expect(() => m.markEnded('nope', { reason: 'graceful', exit_code: 0 })).toThrow(/no row/);
+  });
+});
+
+describe('SessionManager.subscribe', () => {
+  it('only delivers events for the caller principal', () => {
+    const m = makeManager({ ids: ['S-1', 'S-2'] });
+    const aliceEvents: SessionEvent[] = [];
+    const bobEvents: SessionEvent[] = [];
+    m.subscribe(ALICE, (e) => aliceEvents.push(e));
+    m.subscribe(BOB, (e) => bobEvents.push(e));
+
+    m.create(INPUT, ALICE);
+    m.create(INPUT, BOB);
+
+    expect(aliceEvents).toHaveLength(1);
+    expect(bobEvents).toHaveLength(1);
+    expect(aliceEvents[0].session.owner_id).toBe('local-user:1000');
+    expect(bobEvents[0].session.owner_id).toBe('local-user:1001');
+  });
+
+  it('returns unsubscribe handle that detaches the listener', () => {
+    const m = makeManager({ ids: ['U-1', 'U-2'] });
+    const fn = vi.fn();
+    const off = m.subscribe(ALICE, fn);
+    m.create(INPUT, ALICE);
+    expect(fn).toHaveBeenCalledTimes(1);
+    off();
+    m.create(INPUT, ALICE);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SessionManager.eventBus getter', () => {
+  it('exposes the underlying bus instance', () => {
+    const bus = new SessionEventBus();
+    const m = new SessionManager(db, { eventBus: bus });
+    expect(m.eventBus).toBe(bus);
+  });
+});

--- a/packages/daemon/src/sessions/__tests__/event-bus.spec.ts
+++ b/packages/daemon/src/sessions/__tests__/event-bus.spec.ts
@@ -1,0 +1,196 @@
+// Task #473 (T8.14b-7b) — sessions/ coverage push.
+//
+// Unit tests for the in-process principal-scoped pub/sub bus
+// (`sessions/event-bus.ts`). Covers:
+//   - subscribe()/unsubscribe() lifecycle (idempotent unsubscribe,
+//     listenerCount transitions, principalKey validation)
+//   - publish() fanout (principal scoping, snapshot iteration so a
+//     listener that unsubscribes mid-dispatch does not skip its peers,
+//     no-op publish when no subscribers, listener exception isolation
+//     via onListenerError)
+//   - default onListenerError logs to console.error with the stable
+//     `[ccsm-daemon]` prefix
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SessionEventBus } from '../event-bus.js';
+import { SessionState, type SessionEvent, type SessionRow } from '../types.js';
+
+function makeRow(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: '01J0000000000000000000ABCD',
+    owner_id: 'local-user:1000',
+    state: SessionState.STARTING,
+    cwd: '/tmp',
+    env_json: '{}',
+    claude_args_json: '[]',
+    geometry_cols: 80,
+    geometry_rows: 24,
+    exit_code: -1,
+    created_ms: 0,
+    last_active_ms: 0,
+    should_be_running: 1,
+    ...overrides,
+  };
+}
+
+function created(row: SessionRow): SessionEvent {
+  return { kind: 'created', session: row };
+}
+
+describe('SessionEventBus.subscribe', () => {
+  it('rejects empty principalKey', () => {
+    const bus = new SessionEventBus();
+    expect(() => bus.subscribe('', () => {})).toThrow(TypeError);
+  });
+
+  it('rejects non-string principalKey', () => {
+    const bus = new SessionEventBus();
+    // @ts-expect-error — runtime check; we deliberately pass wrong type.
+    expect(() => bus.subscribe(42, () => {})).toThrow(TypeError);
+  });
+
+  it('listenerCount tracks add/remove transitions', () => {
+    const bus = new SessionEventBus();
+    expect(bus.listenerCount('local-user:1000')).toBe(0);
+    const off1 = bus.subscribe('local-user:1000', () => {});
+    expect(bus.listenerCount('local-user:1000')).toBe(1);
+    const off2 = bus.subscribe('local-user:1000', () => {});
+    expect(bus.listenerCount('local-user:1000')).toBe(2);
+    off1();
+    expect(bus.listenerCount('local-user:1000')).toBe(1);
+    off2();
+    expect(bus.listenerCount('local-user:1000')).toBe(0);
+  });
+
+  it('unsubscribe is idempotent', () => {
+    const bus = new SessionEventBus();
+    const off = bus.subscribe('local-user:1000', () => {});
+    expect(bus.listenerCount('local-user:1000')).toBe(1);
+    off();
+    expect(bus.listenerCount('local-user:1000')).toBe(0);
+    off(); // second call no-op
+    expect(bus.listenerCount('local-user:1000')).toBe(0);
+  });
+
+  it('unsubscribe of an entry whose principal already cleared is a no-op', () => {
+    const bus = new SessionEventBus();
+    const fn = vi.fn();
+    const off = bus.subscribe('local-user:1000', fn);
+    // Publishing to an unrelated principal does NOT remove the entry,
+    // but we want to exercise the "set was cleared externally" path.
+    // Replace the internal map entry by unsubscribing then re-subscribing
+    // a different listener — calling off() now finds a set that doesn't
+    // contain `fn`, exercises the .delete(listener) branch.
+    off();
+    bus.subscribe('local-user:1000', () => {});
+    off(); // already-inactive handle, no-op
+    expect(bus.listenerCount('local-user:1000')).toBe(1);
+  });
+});
+
+describe('SessionEventBus.publish — principal scoping (security boundary)', () => {
+  it('only delivers to listeners whose principal matches the row owner', () => {
+    const bus = new SessionEventBus();
+    const aliceListener = vi.fn();
+    const bobListener = vi.fn();
+    bus.subscribe('local-user:1000', aliceListener);
+    bus.subscribe('local-user:1001', bobListener);
+
+    const row = makeRow({ owner_id: 'local-user:1000' });
+    bus.publish(created(row));
+
+    expect(aliceListener).toHaveBeenCalledTimes(1);
+    expect(aliceListener).toHaveBeenCalledWith(created(row));
+    expect(bobListener).not.toHaveBeenCalled();
+  });
+
+  it('publish with no subscribers is a no-op (early return)', () => {
+    const bus = new SessionEventBus();
+    expect(() => bus.publish(created(makeRow()))).not.toThrow();
+  });
+
+  it('publish with empty subscriber set after off() is a no-op', () => {
+    const bus = new SessionEventBus();
+    const off = bus.subscribe('local-user:1000', () => {});
+    off();
+    expect(() => bus.publish(created(makeRow()))).not.toThrow();
+  });
+
+  it('snapshot iteration: a listener that unsubscribes itself does not skip peers', () => {
+    const bus = new SessionEventBus();
+    const order: string[] = [];
+    const off1 = bus.subscribe('local-user:1000', () => {
+      order.push('first');
+      off1(); // unsubscribe during dispatch
+    });
+    bus.subscribe('local-user:1000', () => {
+      order.push('second');
+    });
+
+    bus.publish(created(makeRow()));
+    expect(order).toEqual(['first', 'second']);
+  });
+
+  it('same listener subscribed twice fires twice (no de-dup)', () => {
+    const bus = new SessionEventBus();
+    const fn = vi.fn();
+    bus.subscribe('local-user:1000', fn);
+    bus.subscribe('local-user:1000', fn);
+    // Set semantics: the same function identity de-dupes inside the Set
+    // → exactly one invocation. Pin this so a future "allow duplicate
+    // subscriptions" change is a deliberate decision.
+    bus.publish(created(makeRow()));
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SessionEventBus.publish — listener error isolation', () => {
+  it('one listener throwing does not break fanout to peers', () => {
+    const onErr = vi.fn();
+    const bus = new SessionEventBus({ onListenerError: onErr });
+    const second = vi.fn();
+    bus.subscribe('local-user:1000', () => {
+      throw new Error('boom');
+    });
+    bus.subscribe('local-user:1000', second);
+
+    bus.publish(created(makeRow()));
+    expect(onErr).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+    const [err, ev] = onErr.mock.calls[0];
+    expect((err as Error).message).toBe('boom');
+    expect((ev as SessionEvent).kind).toBe('created');
+  });
+
+  it('default onListenerError logs to console.error with stable prefix', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const bus = new SessionEventBus();
+      bus.subscribe('local-user:1000', () => {
+        throw new Error('boom');
+      });
+      bus.publish(created(makeRow()));
+      expect(spy).toHaveBeenCalledTimes(1);
+      const args = spy.mock.calls[0];
+      expect(String(args[0])).toContain('[ccsm-daemon]');
+      expect(String(args[0])).toContain('SessionEventBus listener threw');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('SessionEventBus — listenerCount edge cases', () => {
+  let bus: SessionEventBus;
+  beforeEach(() => {
+    bus = new SessionEventBus();
+  });
+  afterEach(() => {
+    // No-op — bus has no resources beyond JS heap.
+  });
+
+  it('returns 0 for an unknown principal', () => {
+    expect(bus.listenerCount('local-user:none')).toBe(0);
+  });
+});

--- a/packages/daemon/src/sessions/__tests__/handlers.spec.ts
+++ b/packages/daemon/src/sessions/__tests__/handlers.spec.ts
@@ -1,0 +1,374 @@
+// Task #473 (T8.14b-7b) — sessions/ coverage push.
+//
+// Unit tests for the unary SessionService Connect handlers:
+//   - sessions/read-handlers.ts (ListSessions + GetSession)
+//   - sessions/create-handler.ts (CreateSession + decodeCreateRequest)
+//   - sessions/destroy-handler.ts (DestroySession)
+//
+// Posture: invoke each handler function directly with a stub
+// HandlerContext (the same `createContextValues()` shape Connect's
+// router hands to handlers in production). The SessionManager underneath
+// is a real instance over an in-memory sqlite — exercises the full
+// row INSERT / SELECT / UPDATE path and the `sessionRowToProto` mapper.
+
+import { create } from '@bufbuild/protobuf';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  Code,
+  ConnectError,
+  createContextValues,
+  type HandlerContext,
+} from '@connectrpc/connect';
+
+import {
+  CreateSessionRequestSchema,
+  DestroySessionRequestSchema,
+  ErrorDetailSchema,
+  GetSessionRequestSchema,
+  ListSessionsRequestSchema,
+  RequestMetaSchema,
+  type ErrorDetail,
+} from '@ccsm/proto';
+import { PtyGeometrySchema } from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, principalKey, type Principal } from '../../auth/index.js';
+import { runMigrations } from '../../db/migrations/runner.js';
+import { openDatabase, type SqliteDatabase } from '../../db/sqlite.js';
+
+import {
+  DEFAULT_GEOMETRY_COLS,
+  DEFAULT_GEOMETRY_ROWS,
+  decodeCreateRequest,
+  makeCreateSessionHandler,
+} from '../create-handler.js';
+import { makeDestroySessionHandler } from '../destroy-handler.js';
+import {
+  makeGetSessionHandler,
+  makeListSessionsHandler,
+} from '../read-handlers.js';
+import { SessionManager } from '../SessionManager.js';
+
+const ALICE: Principal = { kind: 'local-user', uid: '1000', displayName: 'alice' };
+const BOB: Principal = { kind: 'local-user', uid: '1001', displayName: 'bob' };
+
+let db: SqliteDatabase;
+let manager: SessionManager;
+
+beforeEach(() => {
+  db = openDatabase(':memory:');
+  runMigrations(db);
+  db.exec(`INSERT INTO principals (id, kind, display_name, first_seen_ms, last_seen_ms) VALUES
+    ('${principalKey(ALICE)}', 'local-user', 'alice', 0, 0),
+    ('${principalKey(BOB)}', 'local-user', 'bob', 0, 0);`);
+  manager = new SessionManager(db, {
+    now: () => 1700000000000,
+    newId: ((): (() => string) => {
+      let n = 0;
+      return () => `01J000000000000000000${String(n++).padStart(5, '0')}`;
+    })(),
+  });
+});
+
+afterEach(() => {
+  db.close();
+});
+
+function ctxWith(principal: Principal | null): HandlerContext {
+  const values = createContextValues();
+  values.set(PRINCIPAL_KEY, principal as Principal);
+  return { values } as HandlerContext;
+}
+
+function expectErrorDetail(err: ConnectError, code: string) {
+  const details = err.findDetails(ErrorDetailSchema) as ErrorDetail[];
+  expect(details.length).toBeGreaterThanOrEqual(1);
+  expect(details[0].code).toBe(code);
+}
+
+// ===========================================================================
+// decodeCreateRequest (pure)
+// ===========================================================================
+
+describe('decodeCreateRequest', () => {
+  it('sorts env keys for deterministic JSON', () => {
+    const req = create(CreateSessionRequestSchema, {
+      cwd: '/tmp',
+      env: { ZED: 'z', ALPHA: 'a', mid: 'm' },
+      claudeArgs: ['--foo', '--bar'],
+      initialGeometry: create(PtyGeometrySchema, { cols: 120, rows: 40 }),
+    });
+    const out = decodeCreateRequest(req);
+    expect(out.env_json).toBe('{"ALPHA":"a","ZED":"z","mid":"m"}');
+    // claude_args order PRESERVED (argv positional)
+    expect(out.claude_args_json).toBe('["--foo","--bar"]');
+    expect(out.geometry_cols).toBe(120);
+    expect(out.geometry_rows).toBe(40);
+    expect(out.cwd).toBe('/tmp');
+  });
+
+  it('applies 80x24 default when initial_geometry omitted', () => {
+    const req = create(CreateSessionRequestSchema, {
+      cwd: '/x',
+      env: {},
+      claudeArgs: [],
+    });
+    const out = decodeCreateRequest(req);
+    expect(out.geometry_cols).toBe(DEFAULT_GEOMETRY_COLS);
+    expect(out.geometry_rows).toBe(DEFAULT_GEOMETRY_ROWS);
+  });
+
+  it('treats geometry cols=0 / rows=0 as default (not zero)', () => {
+    const req = create(CreateSessionRequestSchema, {
+      cwd: '/x',
+      env: {},
+      claudeArgs: [],
+      initialGeometry: create(PtyGeometrySchema, { cols: 0, rows: 0 }),
+    });
+    const out = decodeCreateRequest(req);
+    expect(out.geometry_cols).toBe(DEFAULT_GEOMETRY_COLS);
+    expect(out.geometry_rows).toBe(DEFAULT_GEOMETRY_ROWS);
+  });
+
+  it('takes only one explicit dimension and defaults the other', () => {
+    const req = create(CreateSessionRequestSchema, {
+      cwd: '/x',
+      env: {},
+      claudeArgs: [],
+      initialGeometry: create(PtyGeometrySchema, { cols: 200, rows: 0 }),
+    });
+    const out = decodeCreateRequest(req);
+    expect(out.geometry_cols).toBe(200);
+    expect(out.geometry_rows).toBe(DEFAULT_GEOMETRY_ROWS);
+  });
+});
+
+// ===========================================================================
+// CreateSession handler
+// ===========================================================================
+
+describe('makeCreateSessionHandler', () => {
+  function req() {
+    return create(CreateSessionRequestSchema, {
+      meta: create(RequestMetaSchema, { requestId: 'req-1' }),
+      cwd: '/home/alice',
+      env: { K: 'V' },
+      claudeArgs: [],
+      initialGeometry: create(PtyGeometrySchema, { cols: 100, rows: 30 }),
+    });
+  }
+
+  it('happy path: INSERTs row, echoes meta, returns proto Session', async () => {
+    const handler = makeCreateSessionHandler({ manager });
+    const resp = await handler(req(), ctxWith(ALICE));
+    expect(resp.meta?.requestId).toBe('req-1');
+    expect(resp.session).toBeDefined();
+    expect(resp.session?.id).toBe('01J00000000000000000000000');
+    expect(resp.session?.cwd).toBe('/home/alice');
+    expect(resp.session?.owner?.kind?.case).toBe('localUser');
+  });
+
+  it('null principal → Code.Internal (daemon wiring bug)', async () => {
+    const handler = makeCreateSessionHandler({ manager });
+    let captured: unknown = null;
+    try {
+      await handler(req(), ctxWith(null));
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    expect((captured as ConnectError).code).toBe(Code.Internal);
+  });
+
+  it('attachPtyHost callback fires with the freshly INSERTed row + principal', async () => {
+    const calls: Array<{ rowId: string; uid: string }> = [];
+    const handler = makeCreateSessionHandler({
+      manager,
+      attachPtyHost: (row, principal) => {
+        calls.push({ rowId: row.id, uid: principal.uid });
+      },
+    });
+    await handler(req(), ctxWith(ALICE));
+    expect(calls).toHaveLength(1);
+    expect(calls[0].uid).toBe('1000');
+    expect(calls[0].rowId).toBeDefined();
+  });
+});
+
+// ===========================================================================
+// DestroySession handler
+// ===========================================================================
+
+describe('makeDestroySessionHandler', () => {
+  it('happy path: returns echoed meta, flips row to should_be_running=0', async () => {
+    const created = manager.create(
+      { cwd: '/x', env_json: '{}', claude_args_json: '[]', geometry_cols: 80, geometry_rows: 24 },
+      ALICE,
+    );
+    const handler = makeDestroySessionHandler({ manager });
+    const resp = await handler(
+      create(DestroySessionRequestSchema, {
+        meta: create(RequestMetaSchema, { requestId: 'req-d' }),
+        sessionId: created.id,
+      }),
+      ctxWith(ALICE),
+    );
+    expect(resp.meta?.requestId).toBe('req-d');
+
+    const row = db.prepare('SELECT should_be_running FROM sessions WHERE id = ?').get(created.id) as {
+      should_be_running: number;
+    };
+    expect(row.should_be_running).toBe(0);
+  });
+
+  it('null principal → Code.Internal', async () => {
+    const handler = makeDestroySessionHandler({ manager });
+    let captured: unknown = null;
+    try {
+      await handler(
+        create(DestroySessionRequestSchema, { sessionId: 'x' }),
+        ctxWith(null),
+      );
+    } catch (e) {
+      captured = e;
+    }
+    expect((captured as ConnectError).code).toBe(Code.Internal);
+  });
+
+  it('foreign session_id → session.not_owned (PermissionDenied)', async () => {
+    const owned = manager.create(
+      { cwd: '/x', env_json: '{}', claude_args_json: '[]', geometry_cols: 80, geometry_rows: 24 },
+      ALICE,
+    );
+    const handler = makeDestroySessionHandler({ manager });
+    let captured: unknown = null;
+    try {
+      await handler(
+        create(DestroySessionRequestSchema, { sessionId: owned.id }),
+        ctxWith(BOB),
+      );
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    expect((captured as ConnectError).code).toBe(Code.PermissionDenied);
+    expectErrorDetail(captured as ConnectError, 'session.not_owned');
+  });
+});
+
+// ===========================================================================
+// Read handlers (List / Get)
+// ===========================================================================
+
+describe('makeListSessionsHandler', () => {
+  it('returns only caller-owned sessions, echoes meta', async () => {
+    manager.create(
+      { cwd: '/a', env_json: '{}', claude_args_json: '[]', geometry_cols: 80, geometry_rows: 24 },
+      ALICE,
+    );
+    manager.create(
+      { cwd: '/b', env_json: '{}', claude_args_json: '[]', geometry_cols: 80, geometry_rows: 24 },
+      BOB,
+    );
+    manager.create(
+      { cwd: '/a2', env_json: '{}', claude_args_json: '[]', geometry_cols: 80, geometry_rows: 24 },
+      ALICE,
+    );
+
+    const handler = makeListSessionsHandler({ manager });
+    const resp = await handler(
+      create(ListSessionsRequestSchema, {
+        meta: create(RequestMetaSchema, { requestId: 'list-1' }),
+      }),
+      ctxWith(ALICE),
+    );
+    expect(resp.meta?.requestId).toBe('list-1');
+    expect(resp.sessions?.length).toBe(2);
+    expect((resp.sessions ?? []).every((s) => s.owner?.kind?.case === 'localUser')).toBe(true);
+  });
+
+  it('echoes empty meta defaults when request omits meta', async () => {
+    const handler = makeListSessionsHandler({ manager });
+    const resp = await handler(
+      create(ListSessionsRequestSchema, {}),
+      ctxWith(ALICE),
+    );
+    expect(resp.meta?.requestId).toBe('');
+    expect(resp.meta?.clientVersion).toBe('');
+  });
+
+  it('null principal → Code.Internal', async () => {
+    const handler = makeListSessionsHandler({ manager });
+    let captured: unknown = null;
+    try {
+      await handler(create(ListSessionsRequestSchema, {}), ctxWith(null));
+    } catch (e) {
+      captured = e;
+    }
+    expect((captured as ConnectError).code).toBe(Code.Internal);
+  });
+});
+
+describe('makeGetSessionHandler', () => {
+  it('happy path: returns proto Session for owned row', async () => {
+    const row = manager.create(
+      { cwd: '/here', env_json: '{}', claude_args_json: '[]', geometry_cols: 80, geometry_rows: 24 },
+      ALICE,
+    );
+    const handler = makeGetSessionHandler({ manager });
+    const resp = await handler(
+      create(GetSessionRequestSchema, {
+        meta: create(RequestMetaSchema, { requestId: 'get-1' }),
+        sessionId: row.id,
+      }),
+      ctxWith(ALICE),
+    );
+    expect(resp.session?.id).toBe(row.id);
+    expect(resp.session?.cwd).toBe('/here');
+    expect(resp.meta?.requestId).toBe('get-1');
+  });
+
+  it('foreign session_id → session.not_owned', async () => {
+    const row = manager.create(
+      { cwd: '/x', env_json: '{}', claude_args_json: '[]', geometry_cols: 80, geometry_rows: 24 },
+      ALICE,
+    );
+    const handler = makeGetSessionHandler({ manager });
+    let captured: unknown = null;
+    try {
+      await handler(
+        create(GetSessionRequestSchema, { sessionId: row.id }),
+        ctxWith(BOB),
+      );
+    } catch (e) {
+      captured = e;
+    }
+    expect((captured as ConnectError).code).toBe(Code.PermissionDenied);
+    expectErrorDetail(captured as ConnectError, 'session.not_owned');
+  });
+
+  it('unknown session_id → session.not_owned (no NotFound leak)', async () => {
+    const handler = makeGetSessionHandler({ manager });
+    let captured: unknown = null;
+    try {
+      await handler(
+        create(GetSessionRequestSchema, { sessionId: 'never-existed' }),
+        ctxWith(ALICE),
+      );
+    } catch (e) {
+      captured = e;
+    }
+    expect((captured as ConnectError).code).toBe(Code.PermissionDenied);
+    expectErrorDetail(captured as ConnectError, 'session.not_owned');
+  });
+
+  it('null principal → Code.Internal', async () => {
+    const handler = makeGetSessionHandler({ manager });
+    let captured: unknown = null;
+    try {
+      await handler(create(GetSessionRequestSchema, { sessionId: 'x' }), ctxWith(null));
+    } catch (e) {
+      captured = e;
+    }
+    expect((captured as ConnectError).code).toBe(Code.Internal);
+  });
+});

--- a/packages/daemon/src/sessions/__tests__/watch-sessions.spec.ts
+++ b/packages/daemon/src/sessions/__tests__/watch-sessions.spec.ts
@@ -1,0 +1,501 @@
+// Task #473 (T8.14b-7b) — sessions/ coverage push.
+//
+// Unit tests for `sessions/watch-sessions.ts`:
+//   - decideWatchScope (pure decider over WatchScope enum)
+//   - sessionRowToProto / sessionEventToProto (mappers)
+//   - subscribeAsAsyncIterable (push→pull adapter, abort, overflow,
+//     return/throw iterator hooks)
+//   - makeWatchSessionsHandler (Connect server-streaming handler):
+//     happy path, ALL→PermissionDenied, null principal→Internal,
+//     abort signal cleanup
+//
+// All tests run against a real SessionManager over an in-memory sqlite
+// so the bus + manager interactions exercise production code paths.
+
+import { create } from '@bufbuild/protobuf';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  Code,
+  ConnectError,
+  createContextValues,
+  type HandlerContext,
+} from '@connectrpc/connect';
+
+import {
+  ErrorDetailSchema,
+  WatchScope,
+  WatchSessionsRequestSchema,
+  type ErrorDetail,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, principalKey, type Principal } from '../../auth/index.js';
+import { runMigrations } from '../../db/migrations/runner.js';
+import { openDatabase, type SqliteDatabase } from '../../db/sqlite.js';
+
+import { SessionManager } from '../SessionManager.js';
+import {
+  DEFAULT_WATCH_BUFFER_SIZE,
+  decideWatchScope,
+  makeWatchSessionsHandler,
+  sessionEventToProto,
+  sessionRowToProto,
+  subscribeAsAsyncIterable,
+} from '../watch-sessions.js';
+import { SessionState, type SessionEvent, type SessionRow } from '../types.js';
+import type { ISessionManager } from '../SessionManager.js';
+import type { Unsubscribe } from '../event-bus.js';
+
+const ALICE: Principal = { kind: 'local-user', uid: '1000', displayName: 'Alice' };
+const BOB: Principal = { kind: 'local-user', uid: '1001', displayName: 'Bob' };
+
+let db: SqliteDatabase;
+let manager: SessionManager;
+
+beforeEach(() => {
+  db = openDatabase(':memory:');
+  runMigrations(db);
+  db.exec(`INSERT INTO principals (id, kind, display_name, first_seen_ms, last_seen_ms) VALUES
+    ('${principalKey(ALICE)}', 'local-user', 'alice', 0, 0),
+    ('${principalKey(BOB)}', 'local-user', 'bob', 0, 0);`);
+  let n = 0;
+  manager = new SessionManager(db, {
+    now: () => 1700000000000,
+    newId: () => `01J000000000000000000${String(n++).padStart(5, '0')}`,
+  });
+});
+
+afterEach(() => {
+  db.close();
+});
+
+function makeRow(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: '01J0000000000000000000XXXX',
+    owner_id: 'local-user:1000',
+    state: SessionState.STARTING,
+    cwd: '/tmp',
+    env_json: '{}',
+    claude_args_json: '[]',
+    geometry_cols: 80,
+    geometry_rows: 24,
+    exit_code: -1,
+    created_ms: 100,
+    last_active_ms: 100,
+    should_be_running: 1,
+    ...overrides,
+  };
+}
+
+// ===========================================================================
+// decideWatchScope
+// ===========================================================================
+
+describe('decideWatchScope', () => {
+  it('UNSPECIFIED → accept', () => {
+    expect(decideWatchScope(WatchScope.UNSPECIFIED)).toEqual({ kind: 'accept' });
+  });
+
+  it('OWN → accept', () => {
+    expect(decideWatchScope(WatchScope.OWN)).toEqual({ kind: 'accept' });
+  });
+
+  it('ALL → reject_permission_denied', () => {
+    expect(decideWatchScope(WatchScope.ALL)).toEqual({
+      kind: 'reject_permission_denied',
+    });
+  });
+
+  it('unknown enum value → reject_permission_denied (forward-compat default-deny)', () => {
+    expect(decideWatchScope(99 as WatchScope)).toEqual({
+      kind: 'reject_permission_denied',
+    });
+  });
+});
+
+// ===========================================================================
+// sessionRowToProto / sessionEventToProto
+// ===========================================================================
+
+describe('sessionRowToProto', () => {
+  it('maps row fields onto proto Session', () => {
+    const proto = sessionRowToProto(
+      makeRow({ id: 'PROTO-1', cwd: '/x', state: SessionState.RUNNING, created_ms: 5, last_active_ms: 10 }),
+      ALICE,
+    );
+    expect(proto.id).toBe('PROTO-1');
+    expect(proto.cwd).toBe('/x');
+    expect(proto.state).toBe(SessionState.RUNNING);
+    expect(proto.createdUnixMs).toBe(5n);
+    expect(proto.lastActiveUnixMs).toBe(10n);
+    expect(proto.owner?.kind.case).toBe('localUser');
+    if (proto.owner?.kind.case === 'localUser') {
+      expect(proto.owner.kind.value.uid).toBe('1000');
+      expect(proto.owner.kind.value.displayName).toBe('Alice');
+    }
+  });
+
+  it('exit_code = -1 sentinel → unset on the wire', () => {
+    const proto = sessionRowToProto(makeRow({ exit_code: -1 }), ALICE);
+    expect(proto.exitCode).toBeUndefined();
+  });
+
+  it('exit_code = 0 (graceful exit) → preserved through sentinel guard', () => {
+    const proto = sessionRowToProto(makeRow({ exit_code: 0 }), ALICE);
+    expect(proto.exitCode).toBe(0);
+  });
+
+  it('non-zero exit_code preserved', () => {
+    const proto = sessionRowToProto(makeRow({ exit_code: 137 }), ALICE);
+    expect(proto.exitCode).toBe(137);
+  });
+});
+
+describe('sessionEventToProto', () => {
+  it('created → proto.kind.case = "created" carrying full Session', () => {
+    const ev: SessionEvent = { kind: 'created', session: makeRow({ id: 'C-1' }) };
+    const proto = sessionEventToProto(ev, ALICE);
+    expect(proto.kind.case).toBe('created');
+    if (proto.kind.case === 'created') {
+      expect(proto.kind.value.id).toBe('C-1');
+    }
+  });
+
+  it('destroyed → proto.kind.case = "destroyed" carrying session_id only', () => {
+    const ev: SessionEvent = { kind: 'destroyed', session: makeRow({ id: 'D-1' }) };
+    const proto = sessionEventToProto(ev, ALICE);
+    expect(proto.kind.case).toBe('destroyed');
+    if (proto.kind.case === 'destroyed') {
+      expect(proto.kind.value).toBe('D-1');
+    }
+  });
+
+  it('ended (graceful) → proto.kind.case = "updated" carrying full Session', () => {
+    const ev: SessionEvent = {
+      kind: 'ended',
+      reason: 'graceful',
+      session: makeRow({ id: 'U-1', state: SessionState.EXITED, exit_code: 0 }),
+    };
+    const proto = sessionEventToProto(ev, ALICE);
+    expect(proto.kind.case).toBe('updated');
+    if (proto.kind.case === 'updated') {
+      expect(proto.kind.value.id).toBe('U-1');
+      expect(proto.kind.value.state).toBe(SessionState.EXITED);
+    }
+  });
+
+  it('ended (crashed) → proto.kind.case = "updated"', () => {
+    const ev: SessionEvent = {
+      kind: 'ended',
+      reason: 'crashed',
+      session: makeRow({ id: 'U-2', state: SessionState.CRASHED, exit_code: 139 }),
+    };
+    const proto = sessionEventToProto(ev, ALICE);
+    expect(proto.kind.case).toBe('updated');
+  });
+
+  it('unknown kind → throws (exhaustive check)', () => {
+    expect(() =>
+      sessionEventToProto({ kind: 'mystery' } as unknown as SessionEvent, ALICE),
+    ).toThrow(/unhandled SessionEvent kind/);
+  });
+});
+
+// ===========================================================================
+// subscribeAsAsyncIterable
+// ===========================================================================
+
+describe('subscribeAsAsyncIterable', () => {
+  it('exports DEFAULT_WATCH_BUFFER_SIZE = 1024', () => {
+    expect(DEFAULT_WATCH_BUFFER_SIZE).toBe(1024);
+  });
+
+  it('next() resolves immediately when an event is buffered', async () => {
+    const iter = subscribeAsAsyncIterable(manager, ALICE)[Symbol.asyncIterator]();
+    manager.create(
+      { cwd: '/x', env_json: '{}', claude_args_json: '[]', geometry_cols: 80, geometry_rows: 24 },
+      ALICE,
+    );
+    const r = await iter.next();
+    expect(r.done).toBe(false);
+    expect(r.value.kind).toBe('created');
+    await iter.return?.();
+  });
+
+  it('next() awaits and resolves when an event is published later', async () => {
+    const iter = subscribeAsAsyncIterable(manager, ALICE)[Symbol.asyncIterator]();
+    const pending = iter.next();
+    // Defer publish so the resolver is installed first.
+    setImmediate(() => {
+      manager.create(
+        { cwd: '/y', env_json: '{}', claude_args_json: '[]', geometry_cols: 80, geometry_rows: 24 },
+        ALICE,
+      );
+    });
+    const r = await pending;
+    expect(r.done).toBe(false);
+    expect(r.value.kind).toBe('created');
+    await iter.return?.();
+  });
+
+  it('only delivers events for the caller principal (bus filter)', async () => {
+    const iter = subscribeAsAsyncIterable(manager, ALICE)[Symbol.asyncIterator]();
+    // Publish to BOB first — should NOT be observed by Alice's iterator.
+    manager.create(
+      { cwd: '/b', env_json: '{}', claude_args_json: '[]', geometry_cols: 80, geometry_rows: 24 },
+      BOB,
+    );
+    manager.create(
+      { cwd: '/a', env_json: '{}', claude_args_json: '[]', geometry_cols: 80, geometry_rows: 24 },
+      ALICE,
+    );
+    const r = await iter.next();
+    expect(r.value.session.cwd).toBe('/a'); // not '/b'
+    await iter.return?.();
+  });
+
+  it('signal abort: pre-aborted signal yields done immediately', async () => {
+    const ac = new AbortController();
+    ac.abort();
+    const iter = subscribeAsAsyncIterable(manager, ALICE, { signal: ac.signal })[
+      Symbol.asyncIterator
+    ]();
+    const r = await iter.next();
+    expect(r.done).toBe(true);
+  });
+
+  it('signal abort while awaiting next() resolves with done', async () => {
+    const ac = new AbortController();
+    const iter = subscribeAsAsyncIterable(manager, ALICE, { signal: ac.signal })[
+      Symbol.asyncIterator
+    ]();
+    const pending = iter.next();
+    ac.abort();
+    const r = await pending;
+    expect(r.done).toBe(true);
+  });
+
+  it('return() detaches subscription and resolves done', async () => {
+    const iter = subscribeAsAsyncIterable(manager, ALICE)[Symbol.asyncIterator]();
+    // Install a pending next() so return() can resolve it.
+    const pending = iter.next();
+    const r = await iter.return?.();
+    expect(r?.done).toBe(true);
+    // pending should also resolve done
+    const p = await pending;
+    expect(p.done).toBe(true);
+  });
+
+  it('return() called without a pending next() still resolves done', async () => {
+    const iter = subscribeAsAsyncIterable(manager, ALICE)[Symbol.asyncIterator]();
+    const r = await iter.return?.();
+    expect(r?.done).toBe(true);
+  });
+
+  it('throw() rejects pending next() and detaches subscription', async () => {
+    const iter = subscribeAsAsyncIterable(manager, ALICE)[Symbol.asyncIterator]();
+    const pending = iter.next();
+    const err = new Error('explicit-throw');
+    await expect(iter.throw?.(err)).rejects.toBe(err);
+    await expect(pending).rejects.toBe(err);
+  });
+
+  it('throw() with no pending next() still rethrows', async () => {
+    const iter = subscribeAsAsyncIterable(manager, ALICE)[Symbol.asyncIterator]();
+    const err = new Error('no-pending');
+    await expect(iter.throw?.(err)).rejects.toBe(err);
+  });
+
+  it('buffer overflow → ResourceExhausted on next()', async () => {
+    // Use a stub manager that gives us synchronous handle on the listener.
+    let capturedListener: ((ev: SessionEvent) => void) | null = null;
+    const stubManager: ISessionManager = {
+      create: (() => {
+        throw new Error('not used');
+      }) as never,
+      get: (() => {
+        throw new Error('not used');
+      }) as never,
+      list: (() => []) as never,
+      destroy: (() => {
+        throw new Error('not used');
+      }) as never,
+      markEnded: (() => {
+        throw new Error('not used');
+      }) as never,
+      subscribe: ((_caller: Principal, listener: (ev: SessionEvent) => void) => {
+        capturedListener = listener;
+        const off: Unsubscribe = () => {};
+        return off;
+      }) as never,
+    };
+
+    const iter = subscribeAsAsyncIterable(stubManager, ALICE, { bufferSize: 2 })[
+      Symbol.asyncIterator
+    ]();
+    // Push 3 events synchronously without any consumer → exceeds size 2.
+    const ev = { kind: 'created' as const, session: makeRow() };
+    capturedListener!(ev);
+    capturedListener!(ev);
+    capturedListener!(ev); // overflow
+
+    // Drain buffered events first (2 of them) then the overflow error fires.
+    const r1 = await iter.next();
+    expect(r1.done).toBe(false);
+    const r2 = await iter.next();
+    expect(r2.done).toBe(false);
+    let captured: unknown = null;
+    try {
+      await iter.next();
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    expect((captured as ConnectError).code).toBe(Code.ResourceExhausted);
+  });
+
+  it('after done=true, listener is a no-op (additional publishes ignored)', async () => {
+    let capturedListener: ((ev: SessionEvent) => void) | null = null;
+    const stubManager: ISessionManager = {
+      create: (() => {
+        throw new Error();
+      }) as never,
+      get: (() => {
+        throw new Error();
+      }) as never,
+      list: (() => []) as never,
+      destroy: (() => {
+        throw new Error();
+      }) as never,
+      markEnded: (() => {
+        throw new Error();
+      }) as never,
+      subscribe: ((_caller: Principal, listener: (ev: SessionEvent) => void) => {
+        capturedListener = listener;
+        return () => {};
+      }) as never,
+    };
+    const iter = subscribeAsAsyncIterable(stubManager, ALICE)[Symbol.asyncIterator]();
+    await iter.return?.();
+    // Listener should ignore the publish without error.
+    expect(() => capturedListener!({ kind: 'created', session: makeRow() })).not.toThrow();
+  });
+
+  it('done branch in next() returns done after return() then drained buffer', async () => {
+    // Set up: subscribe → publish → drain → return → next must return done.
+    const iter = subscribeAsAsyncIterable(manager, ALICE)[Symbol.asyncIterator]();
+    manager.create(
+      { cwd: '/x', env_json: '{}', claude_args_json: '[]', geometry_cols: 80, geometry_rows: 24 },
+      ALICE,
+    );
+    await iter.next(); // drain
+    // Don't call return(); instead use abort to set done=true with empty buffer.
+    const ac = new AbortController();
+    const iter2 = subscribeAsAsyncIterable(manager, ALICE, { signal: ac.signal })[
+      Symbol.asyncIterator
+    ]();
+    ac.abort();
+    const r = await iter2.next();
+    expect(r.done).toBe(true);
+  });
+});
+
+// ===========================================================================
+// makeWatchSessionsHandler — the Connect server-streaming handler
+// ===========================================================================
+
+function ctxWith(principal: Principal | null, signal?: AbortSignal): HandlerContext {
+  const values = createContextValues();
+  values.set(PRINCIPAL_KEY, principal as Principal);
+  return { values, signal: signal ?? new AbortController().signal } as HandlerContext;
+}
+
+describe('makeWatchSessionsHandler', () => {
+  it('null principal → ConnectError(Internal)', async () => {
+    const handler = makeWatchSessionsHandler({ manager });
+    const gen = handler(
+      create(WatchSessionsRequestSchema, { scope: WatchScope.OWN }),
+      ctxWith(null),
+    )[Symbol.asyncIterator]();
+    let captured: unknown = null;
+    try {
+      await gen.next();
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    expect((captured as ConnectError).code).toBe(Code.Internal);
+  });
+
+  it('WATCH_SCOPE_ALL → ConnectError(PermissionDenied) + session.not_owned', async () => {
+    const handler = makeWatchSessionsHandler({ manager });
+    const gen = handler(
+      create(WatchSessionsRequestSchema, { scope: WatchScope.ALL }),
+      ctxWith(ALICE),
+    )[Symbol.asyncIterator]();
+    let captured: unknown = null;
+    try {
+      await gen.next();
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    expect((captured as ConnectError).code).toBe(Code.PermissionDenied);
+    const details = (captured as ConnectError).findDetails(ErrorDetailSchema) as ErrorDetail[];
+    expect(details[0].code).toBe('session.not_owned');
+  });
+
+  it('OWN scope: yields proto SessionEvent for created session', async () => {
+    const ac = new AbortController();
+    const handler = makeWatchSessionsHandler({ manager });
+    const gen = handler(
+      create(WatchSessionsRequestSchema, { scope: WatchScope.OWN }),
+      ctxWith(ALICE, ac.signal),
+    )[Symbol.asyncIterator]();
+    const pending = gen.next();
+    setImmediate(() => {
+      manager.create(
+        { cwd: '/x', env_json: '{}', claude_args_json: '[]', geometry_cols: 80, geometry_rows: 24 },
+        ALICE,
+      );
+    });
+    const r = await pending;
+    expect(r.done).toBe(false);
+    expect(r.value?.kind.case).toBe('created');
+    ac.abort();
+    // Drain to clean exit
+    await gen.next().catch(() => {});
+    await gen.return?.(undefined);
+  });
+
+  it('UNSPECIFIED scope is also accepted (treated as OWN)', async () => {
+    const ac = new AbortController();
+    const handler = makeWatchSessionsHandler({ manager });
+    const gen = handler(
+      create(WatchSessionsRequestSchema, { scope: WatchScope.UNSPECIFIED }),
+      ctxWith(ALICE, ac.signal),
+    )[Symbol.asyncIterator]();
+    const pending = gen.next();
+    setImmediate(() => {
+      manager.create(
+        { cwd: '/y', env_json: '{}', claude_args_json: '[]', geometry_cols: 80, geometry_rows: 24 },
+        ALICE,
+      );
+    });
+    const r = await pending;
+    expect(r.done).toBe(false);
+    ac.abort();
+    await gen.return?.(undefined);
+  });
+
+  it('signal abort → handler exits cleanly', async () => {
+    const ac = new AbortController();
+    ac.abort(); // pre-abort
+    const handler = makeWatchSessionsHandler({ manager });
+    const gen = handler(
+      create(WatchSessionsRequestSchema, { scope: WatchScope.OWN }),
+      ctxWith(ALICE, ac.signal),
+    )[Symbol.asyncIterator]();
+    const r = await gen.next();
+    expect(r.done).toBe(true);
+  });
+});


### PR DESCRIPTION
Task #473 (T8.14b-7b) — daemon `src/sessions/` coverage push.

## Summary

Adds 4 co-located unit specs under `packages/daemon/src/sessions/__tests__/`
(86 new test cases, 1,434 LOC of test code) that lift the unit-coverage
gate measurement of `src/sessions/` from **1.73% → 100% lines / 100%
funcs / 99.16% stmts / 97.41% branches**. No `src/` changes.

Files added:
- `event-bus.spec.ts` — subscribe lifecycle, principal-scoped fanout
  (security boundary), snapshot iteration during dispatch (a listener
  unsubscribing itself does not skip peers), listener exception
  isolation, default `[ccsm-daemon]` console.error fallback.
- `SessionManager.spec.ts` — real in-memory sqlite (`openDatabase(':memory:')
  + runMigrations` mirroring the pattern from `rpc/draft/__tests__/`).
  Covers `newSessionId` 26-char Crockford-base32 shape, time-prefix
  lexicographic order, encodeTime range guards (negative / >2^48-1 /
  non-integer); `buildSessionRow` defaults per spec ch05 §6;
  `SessionManager.{create,get,list,destroy}` happy path + ownership
  rejection (`session.not_owned` PermissionDenied + ErrorDetail);
  `markEnded` graceful→EXITED / crashed→CRASHED / null exit_code → -1
  sentinel / idempotent on repeat / Error on unknown id; subscribe
  principal scoping; `eventBus` getter.
- `handlers.spec.ts` — `decodeCreateRequest` sort/default branches
  (env keys sorted, claudeArgs preserved, geometry defaults on omit /
  cols=0 / rows=0); CreateSession / DestroySession / ListSessions /
  GetSession Connect handlers driven directly with a stub
  `HandlerContext` (`createContextValues`); covers null-principal
  → `Code.Internal`, foreign / unknown session_id → `session.not_owned`,
  meta echo, `attachPtyHost` callback fire-and-forget hook.
- `watch-sessions.spec.ts` — `decideWatchScope` (UNSPECIFIED / OWN /
  ALL / unknown enum); `sessionRowToProto` exit_code sentinel and
  owner attribution; `sessionEventToProto` exhaustive variants
  (`created` / `destroyed` / `ended` (graceful + crashed) /
  unknown-throws); `subscribeAsAsyncIterable` push→pull adapter
  (buffered fast path, awaiting next() resolves on later publish,
  bus principal filter, pre-aborted signal, post-aborted signal,
  `return()` / `throw()` iterator hooks, buffer overflow →
  ResourceExhausted, post-done listener no-op); the streaming
  `makeWatchSessionsHandler` (null principal → Internal, ALL → PD +
  session.not_owned, OWN happy path, UNSPECIFIED accepted, signal
  abort exit).

## Local checks (host: windows-11)
- lint (daemon): exit 0 (1 unrelated pre-existing warning)
- typecheck (daemon): exit 0
- build (daemon): exit 0
- root build (turbo): 3/3 successful (cached)
- unit (daemon, coverage gate): `Test Files 95 passed` / `Tests 1081 passed | 11 skipped`
- sessions/ specs in isolation: `4 passed` / `86 tests passed`

## Coverage (vitest.config.coverage.ts, src/sessions/ section)

Before (origin/working at 61bf7cb):
```
 src/sessions      |    1.67 |        0 |       0 |    1.73
  SessionManager.ts|       0 |        0 |       0 |       0 | 77-469
  create-handler.ts|   11.76 |        0 |       0 |   11.76 | 157-256
  destroy-handler.ts|      0 |        0 |       0 |       0 | 134-154
  event-bus.ts     |       0 |        0 |       0 |       0 | 78-162
  read-handlers.ts |       0 |        0 |       0 |       0 | 99-164
  watch-sessions.ts|    1.04 |        0 |       0 |    1.06 | 131-232,295-478
```

After:
```
 src/sessions      |   99.16 |    97.41 |     100 |     100
  event-bus.ts     |   96.77 |    95.23 |     100 |     100 | 122
  watch-sessions.ts|   98.95 |    95.55 |     100 |     100 | 341,469
  (other files     |     100 |     ...  |     100 |     100)
```

Daemon-wide impact: 62.86% → 68.66% lines (well above the 60%
threshold; spec ch12 §6 ship target is 80% — closer now).

## Reverse-verify (Task #473 is a coverage push, not a bug fix, so the
"stash fix → fail" form does not apply; proxy demonstration: removing
one new `it` measurably drops coverage)

Removed `SessionManager.markEnded > crashed → state CRASHED` from
SessionManager.spec.ts and re-ran coverage:

```
 src/sessions      |   99.16 |    96.55 |     100 |     100
  SessionManager.ts|     100 |    96.42 |     100 |     100 | 416
```

Branches dropped 97.41 → 96.55 with line **416** (`reason === 'crashed'
? CRASHED : EXITED`) becoming uncovered — confirming the spec is
exercising real branches. Reverted before commit.

## Pre-existing failures NOT introduced by this PR

Default `pnpm --filter @ccsm/daemon test` (which runs the full
`vitest.config.ts` include set covering `test/**`) shows 7 unrelated
failures on this worktree — verified to also fail with my new specs
removed (untarred to `/tmp` and re-run). They are listener-bind /
descriptor-roundtrip tests that have nothing to do with the
`sessions/` row CRUD path:
- `test/descriptor/schema.spec.ts`
- `test/integration/{crash-getlog,crash-watch,watch-sessions}-wired.spec.ts`
- `src/rpc/__tests__/integration.spec.ts` (3 wire-up cases)

Skipping `probe:e2e` because this PR adds zero `src/` or `electron/`
behavior — only `*.spec.ts` files under the daemon package — so no
e2e codepath can be affected.

## Test plan
- [x] `pnpm --filter @ccsm/daemon lint` → 0 errors
- [x] `pnpm --filter @ccsm/daemon typecheck` → exit 0
- [x] `pnpm --filter @ccsm/daemon build` → exit 0
- [x] `pnpm --filter @ccsm/daemon test --coverage --config vitest.config.coverage.ts` → src/sessions/ at 100% lines
- [x] reverse-verify: deleting one new `it` drops branches measurably