### PR TITLE
fix: daemon SEA exe Database constructor wrapper (T480)

### DIFF
--- a/packages/daemon/build/build-sea.ps1
+++ b/packages/daemon/build/build-sea.ps1
@@ -31,7 +31,8 @@ try {
     throw 'dist/index.js missing after tsc'
   }
 
-  # Step 2: esbuild bundle.
+  # Step 2: esbuild bundle. Task #480: better-sqlite3 wrapper bundled in
+  # (only `bindings` external, unreachable in SEA — see build-sea.sh).
   Step 'esbuild bundle'
   npx --yes esbuild dist/index.js `
     --bundle `
@@ -39,7 +40,7 @@ try {
     --target=node22 `
     --format=cjs `
     --outfile=dist/bundle.cjs `
-    --external:better-sqlite3 `
+    --external:bindings `
     --external:node-pty `
     --external:*.node
   if ($LASTEXITCODE -ne 0) { throw "esbuild exited $LASTEXITCODE" }

--- a/packages/daemon/build/build-sea.sh
+++ b/packages/daemon/build/build-sea.sh
@@ -57,6 +57,10 @@ fi
 
 # Step 2: esbuild bundle. `--platform=node` + `--format=cjs` so sea's main
 # can `require()` it. Native modules (.node) are external (per T7.2 plan).
+# Task #480: better-sqlite3 wrapper (pure JS) is BUNDLED in (no longer
+# external) so the SEA daemon has a real Database constructor; only the
+# `bindings` shim is external (unreachable in SEA mode — native-loader
+# force-injects nativeBinding so wrapper never calls bindings()).
 echo "[build-sea] esbuild bundle"
 ( cd "$PKG_DIR" && npx --yes esbuild dist/index.js \
   --bundle \
@@ -64,7 +68,7 @@ echo "[build-sea] esbuild bundle"
   --target=node22 \
   --format=cjs \
   --outfile=dist/bundle.cjs \
-  --external:better-sqlite3 \
+  --external:bindings \
   --external:node-pty \
   --external:*.node )
 

--- a/packages/daemon/build/bundle-for-sea-spec.mjs
+++ b/packages/daemon/build/bundle-for-sea-spec.mjs
@@ -112,7 +112,14 @@ function bundleIfStale() {
       '--target=node22',
       '--format=cjs',
       '--outfile=dist/bundle.cjs',
-      '--external:better-sqlite3',
+      // Task #480 — better-sqlite3 wrapper (lib/index.js → lib/database.js
+      // + methods/*) is now bundled INTO bundle.cjs so the SEA daemon has
+      // a real `Database` constructor at runtime. The native-loader (SEA
+      // mode) calls `require('better-sqlite3')` and force-injects the raw
+      // .node addon as `nativeBinding`, so the wrapper's `bindings()`
+      // fallback never runs. Keep `bindings` external (esbuild emits a
+      // `require("bindings")` stub that is unreachable in SEA mode).
+      '--external:bindings',
       '--external:node-pty',
       '--external:*.node',
     ],

--- a/packages/daemon/src/native-loader.ts
+++ b/packages/daemon/src/native-loader.ts
@@ -27,6 +27,18 @@ import * as path from 'node:path';
 import { isSea } from 'node:sea';
 
 import type BetterSqlite3 from 'better-sqlite3';
+// Task #480 — value import of the better-sqlite3 JS wrapper. esbuild bundles
+// this into `dist/bundle.cjs` for the SEA carrier, so the SEA daemon has a
+// real `Database` constructor at runtime (the napi `.node` only exposes a
+// raw `addon.Database` — without the wrapper `new Database(path)` throws
+// `Database2 is not a constructor`, dev report from PR #1066). The wrapper
+// itself does NOT load the .node addon at module-eval time — it lazily
+// resolves it inside `Database()` only when `nativeBinding == null`. We
+// always pass `nativeBinding` in SEA mode (see `loadNative`), so the
+// wrapper's `bindings('better_sqlite3.node')` fallback (which fails inside
+// SEA — `bindings` walks the FS for `build/Release/`) is never executed.
+// In dev/test the same wrapper resolves the .node via `bindings` normally.
+import * as betterSqlite3Module from 'better-sqlite3';
 // `node-pty` types are not a hard dep yet (T4.2+). Keep the type-side soft so
 // this module compiles before that lands.
 type NodePtyModule = typeof import('node-pty');
@@ -61,6 +73,13 @@ const DEV_PACKAGE_NAME: Record<NativeAddonName, string> = {
 /**
  * `.node` filenames that ship in `<install-dir>/native/` next to the sea
  * binary. Spec ch10 §2 example block locks these names.
+ *
+ * NOTE: in SEA mode `loadNative('better_sqlite3')` returns a wrapped
+ * `Database` constructor, NOT this raw napi addon directly — the upstream
+ * better-sqlite3 JS wrapper (`lib/database.js`) provides all the user-
+ * facing methods (`prepare` / `transaction` / `pragma` / ...). We bundle
+ * that JS wrapper into `dist/bundle.cjs` and hand it the raw napi addon
+ * via the `nativeBinding` option (see Task #480 / `loadBetterSqlite3Sea`).
  */
 const SEA_NATIVE_FILENAME: Record<NativeAddonName, string> = {
   better_sqlite3: './better_sqlite3.node',
@@ -121,8 +140,74 @@ export function loadNative<K extends NativeAddonName>(name: K): NativeAddonMap[K
     return cached as NativeAddonMap[K];
   }
   const req = getRequire();
-  const spec = isSea() ? SEA_NATIVE_FILENAME[name] : DEV_PACKAGE_NAME[name];
-  const mod = req(spec) as NativeAddonMap[K];
+  let mod: NativeAddonMap[K];
+  if (isSea() && name === 'better_sqlite3') {
+    // Task #480 — SEA-mode better-sqlite3 wrapper bridge.
+    //
+    // In SEA mode `req('./better_sqlite3.node')` returns the *raw napi
+    // addon* (an object exposing `Database` + `setErrorConstructor` +
+    // `isInitialized` flag — NOT a constructor on its own). The user-
+    // facing `Database` constructor lives in better-sqlite3's JS wrapper
+    // at `lib/database.js` (`new Database(filename, options)` →
+    // `new addon.Database(filename, ..., 8 args)`). Without the wrapper,
+    // `new Database(...)` throws `Database2 is not a constructor` (Task
+    // #463 follow-up: dev report from PR #1066 traced the SEA crash to
+    // this exact gap after migrations were unblocked).
+    //
+    // We bundle the JS wrapper into `dist/bundle.cjs` (esbuild now drops
+    // `--external:better-sqlite3`, see `build/bundle-for-sea-spec.mjs` +
+    // `build/build-sea.{sh,ps1}`). Here we:
+    //   1. Resolve the bundled wrapper via the workspace require — in
+    //      SEA this is the bundled-in CJS exports; in dev this is the
+    //      installed package (same identity).
+    //   2. Force-inject the SEA-loaded raw napi addon as the wrapper's
+    //      `nativeBinding` option on every construction. The wrapper's
+    //      `bindings('better_sqlite3.node')` fallback (which fails in
+    //      SEA — `bindings` package walks the filesystem looking for
+    //      build/Release/*.node) is therefore never executed.
+    //   3. Preserve the wrapper's static `SqliteError` export so callers
+    //      that do `Database.SqliteError` keep working.
+    const rawAddon = req(SEA_NATIVE_FILENAME[name]) as object;
+    // The wrapper comes from the top-of-file `import * as
+    // betterSqlite3Module from 'better-sqlite3'` so esbuild bundles it
+    // into `dist/bundle.cjs`. A `req('better-sqlite3')` here would NOT
+    // work in SEA: `createRequire` cannot resolve npm packages once
+    // postjected (no `node_modules` next to `process.execPath`). The
+    // import binding is what threads the wrapper through the bundler.
+    // CJS interop: `import * as` of a CJS module yields the namespace
+    // whose `default` is the module.exports value (the Database fn). Some
+    // bundler/loader combos also expose the function on the namespace
+    // itself, so try `default` first, then the namespace.
+    type BetterSqlite3Constructor = new (
+      filename: string | Buffer,
+      options?: { nativeBinding?: object | string } & Record<string, unknown>,
+    ) => unknown;
+    const ns = betterSqlite3Module as unknown as {
+      default?: BetterSqlite3Constructor & { SqliteError?: unknown };
+    } & BetterSqlite3Constructor & { SqliteError?: unknown };
+    const WrappedDatabase = (ns.default ?? ns) as BetterSqlite3Constructor & {
+      SqliteError?: unknown;
+    };
+    function Database(this: unknown, filename: string | Buffer, options?: Record<string, unknown>) {
+      // Always call as `new` — the upstream wrapper auto-news on plain
+      // call but going through `Reflect.construct` is cleaner and keeps
+      // `new.target` set correctly (matters for the wrapper's own
+      // `new.target == null` re-entry guard).
+      const merged = { ...(options ?? {}), nativeBinding: rawAddon };
+      // Reflect.construct returns the constructed instance.
+      return Reflect.construct(WrappedDatabase, [filename, merged], Database);
+    }
+    // Preserve prototype + static surface so `instanceof Database` and
+    // `Database.SqliteError` keep matching the upstream API.
+    Database.prototype = WrappedDatabase.prototype;
+    if (WrappedDatabase.SqliteError !== undefined) {
+      (Database as unknown as { SqliteError: unknown }).SqliteError = WrappedDatabase.SqliteError;
+    }
+    mod = Database as unknown as NativeAddonMap[K];
+  } else {
+    const spec = isSea() ? SEA_NATIVE_FILENAME[name] : DEV_PACKAGE_NAME[name];
+    mod = req(spec) as NativeAddonMap[K];
+  }
   cache.set(name, mod);
   return mod;
 }

--- a/packages/daemon/test/integration/daemon-sea-boot.spec.ts
+++ b/packages/daemon/test/integration/daemon-sea-boot.spec.ts
@@ -152,4 +152,52 @@ describe('daemon SEA bundle (Task #463)', () => {
     const expectedB64 = sqlBytes.toString('base64');
     expect(bundle).toContain(expectedB64);
   });
+
+  it('better-sqlite3 JS wrapper is inlined so SEA boot reaches READY (Task #480)', () => {
+    // Task #480 follow-up to Task #463: even with migrations inlined, the
+    // daemon SEA exe died at OPENING_DB with `Database2 is not a
+    // constructor` because esbuild had `--external:better-sqlite3`,
+    // leaving only the raw napi `.node` (which exposes
+    // `addon.Database` — NOT a top-level constructor). The fix bundles
+    // the better-sqlite3 JS wrapper (`lib/database.js`) into bundle.cjs
+    // and force-injects the SEA-loaded raw addon as `nativeBinding` from
+    // `native-loader.ts`. Reverse-verify: dropping the value-import of
+    // `better-sqlite3` from native-loader (or restoring
+    // `--external:better-sqlite3` in bundle-for-sea-spec.mjs /
+    // build-sea.{sh,ps1}) makes both checks below fail.
+    const bundle = readBundleOrFail();
+
+    // 1. The wrapper's user-facing validation messages live in
+    // `lib/database.js` and only get into bundle.cjs when esbuild has
+    // bundled the wrapper. The "Misspelled option" string is short,
+    // unique, and stable across better-sqlite3 versions (>= v7.0.0).
+    expect(
+      bundle,
+      'better-sqlite3 wrapper not bundled — restore the value `import * as ' +
+        "betterSqlite3Module from 'better-sqlite3'` in native-loader.ts and " +
+        "drop `--external:better-sqlite3` from the esbuild invocation in " +
+        'build/bundle-for-sea-spec.mjs + build/build-sea.{sh,ps1}.',
+    ).toContain('Misspelled option "readOnly" should be "readonly"');
+
+    // 2. The SEA-mode bridge in native-loader.ts must force-inject
+    // `nativeBinding` so the wrapper's filesystem-walking
+    // `bindings('better_sqlite3.node')` fallback never executes inside
+    // SEA. The literal `nativeBinding: rawAddon` (or `nativeBinding`
+    // shorthand) compiles to a property write on the merged options
+    // object — esbuild keeps the property name verbatim.
+    expect(
+      bundle,
+      'native-loader did not force-inject nativeBinding for SEA mode — see ' +
+        'src/native-loader.ts SEA branch (Task #480).',
+    ).toMatch(/nativeBinding\s*:/);
+
+    // 3. The raw napi addon path (`./better_sqlite3.node`) is the value
+    // SEA-mode `loadNative('better_sqlite3')` passes to its createRequire
+    // (rooted at `<install-dir>/native/`). The literal must survive into
+    // bundle.cjs — esbuild keeps the `SEA_NATIVE_FILENAME` table verbatim
+    // because the lookup is dynamic (`req(SEA_NATIVE_FILENAME[name])`).
+    // If this literal disappears the daemon will boot with no addon at
+    // all and explode at the first `db.prepare(...)` call.
+    expect(bundle).toMatch(/["']\.\/better_sqlite3\.node["']/);
+  });
 });


### PR DESCRIPTION
Task #480 — P0-SHIP-BLOCKER follow-up to Task #463 (PR #1066).

## Problem

After PR #1066 inlined SQL migrations and unblocked the daemon SEA exe past `LOADING_CONFIG`, the daemon advanced to `OPENING_DB` but crashed with:

```
TypeError: Database2 is not a constructor
```

Root cause (per dev #463 round-3 / round-4 reports): `--external:better-sqlite3` in the esbuild invocation left only the raw napi `.node` addon in `bundle.cjs`. That addon exposes `addon.Database` (a constructor on the addon object) but is **not itself** a top-level constructor — the user-facing `Database` constructor lives in better-sqlite3's JS wrapper (`lib/database.js`), which never made it into the SEA bundle. `new Database(path)` therefore exploded.

## Spec choice — A (bundle the JS wrapper)

A: bundle/inline `lib/index.js` wrapper into bundle.cjs (analogous to the #463 inline-migrations approach) — chosen.
B: tiny adapter in native-loader that reimplements the wrapper API around the raw napi addon — rejected.

Why A over B: the wrapper is ~400 lines of public API surface (`prepare`, `transaction`, `pragma`, `backup`, `serialize`, `function`, `aggregate`, `table`, `loadExtension`, `exec`, `close`, `defaultSafeIntegers`, `unsafeMode`, `SqliteError`, plus an 8-arg `addon.Database(filename, ..., buffer)` splat). Reimplementing it inline would be 400 lines of upstream API duplication that breaks on every better-sqlite3 patch. Bundling the upstream wrapper costs +28kb in `bundle.cjs` (470kb → 498kb) and zero ongoing maintenance — clearly the right side of dev.md §1 step 2 "don't reinvent" gradient (tier 4: "抄开源").

## Implementation

- **`packages/daemon/build/bundle-for-sea-spec.mjs` + `build/build-sea.{sh,ps1}`** — drop `--external:better-sqlite3`; only `bindings` + `node-pty` + `*.node` stay external. The wrapper is pure JS so esbuild bundles its 12 source files into `bundle.cjs`.
- **`packages/daemon/src/native-loader.ts`** — add a value `import * as betterSqlite3Module from 'better-sqlite3'` (esbuild needs a static import to follow; `req('better-sqlite3')` would not work in SEA because `createRequire` cannot resolve npm packages once postjected). In the SEA branch of `loadNative('better_sqlite3')`, force-inject the SEA-loaded raw napi addon as the wrapper's `nativeBinding` option on every construction, bypassing the wrapper's `bindings('better_sqlite3.node')` fallback (which fails in SEA — the `bindings` package walks the filesystem for `build/Release/`). Preserve `Database.SqliteError` static + prototype chain so `instanceof Database` keeps matching.
- **dev/test mode is unchanged** — the new branch is gated on `isSea() && name === 'better_sqlite3'`; non-SEA callers go through the original `req(DEV_PACKAGE_NAME[name])` path.

`node-pty` has the same wrapper/raw-addon split and will need the same treatment when SEA boot reaches its phase. Per Task #480 spec, that is intentionally deferred to a separate task.

## Files

- `packages/daemon/src/native-loader.ts` — value-import + SEA branch with `nativeBinding` injection.
- `packages/daemon/build/build-sea.sh` — `--external:better-sqlite3` → `--external:bindings`.
- `packages/daemon/build/build-sea.ps1` — same.
- `packages/daemon/build/bundle-for-sea-spec.mjs` — same (so the test bundle matches the SEA build artifact).
- `packages/daemon/test/integration/daemon-sea-boot.spec.ts` — new case asserting (1) the wrapper is bundled (`Misspelled option "readOnly" should be "readonly"` — wrapper-only string), (2) `nativeBinding:` force-injection compiled into bundle, (3) raw `./better_sqlite3.node` literal preserved for runtime resolution from `<install-dir>/native/`.

## Local checks (host: windows-11)

- lint: ✓ (exit 0, 67 pre-existing warnings, 0 errors)
- typecheck: ✓ (exit 0, both `tsconfig.json` + `tsconfig.test.json`)
- build: ✓ (exit 0, `turbo run build` — all 3 packages)
- daemon unit + integration tests: `Tests  6 failed | 1727 passed | 20 skipped | 5 todo (1758)`

The 6 failures are **pre-existing** on `origin/working` and unrelated to #480. Verified by `git diff > /tmp/t480.patch && git checkout -- . && pnpm --filter @ccsm/daemon test` before re-applying the patch:

```
baseline:  Tests  6 failed | 1726 passed
this PR:   Tests  6 failed | 1727 passed   (+1 = the new daemon-sea-boot case)
```

The 6 failing specs (`crash-getlog-wired`, `crash-watch-wired`, `watch-sessions-wired`, and 3 cases in `rpc/__tests__/integration.spec.ts`) all fail with the same `Hook timed out in 10000ms` / Listener-A binding symptom and are independent of the native-loader change.

## Reverse-verify

```
$ sed -i "s/'--external:bindings'/'--external:better-sqlite3'/" build/bundle-for-sea-spec.mjs
$ rm dist/bundle.cjs && node build/bundle-for-sea-spec.mjs && npx vitest run test/integration/daemon-sea-boot.spec.ts
...
FAIL  test/integration/daemon-sea-boot.spec.ts > better-sqlite3 JS wrapper is inlined so SEA boot reaches READY (Task #480)
   180|     ).toContain('Misspelled option "readOnly" should be "readonly"');
       |       ^

Tests  1 failed | 2 passed (3)
```

```
$ <restore fix> && rm dist/bundle.cjs && node build/bundle-for-sea-spec.mjs && npx vitest run test/integration/daemon-sea-boot.spec.ts
...
Test Files  1 passed (1)
     Tests  3 passed (3)
```

## Test plan

- [x] daemon unit + integration tests
- [x] new `daemon-sea-boot.spec.ts` wrapper-bundled case
- [x] reverse-verify (drop fix → spec FAILs; restore → PASSes)
- [ ] CI matrix (ubuntu/macos/windows) — pending