### PR TITLE
docs(daemon/bench): add [BENCH-INFO] tags + skip policy note (T493)

### DIFF
--- a/packages/daemon/test/bench/README.md
+++ b/packages/daemon/test/bench/README.md
@@ -40,3 +40,8 @@ this PR is on the hook for.
 All numbers here are **advisory**. The one blocking perf gate is SendInput
 p99, and that is enforced by the dedicated soak harness (Task #92), not by
 this bench suite.
+
+## Bench skip policy
+
+5 个 bench skip 是 perf gate, 不是 ship gate。v0.4 接通后 unskip (Task #468)。
+v0.3 PR CI 不跑 bench, audit 脚本 (Task #494) 验注释 tag 合规。

--- a/packages/daemon/test/bench/cold-start.bench.ts
+++ b/packages/daemon/test/bench/cold-start.bench.ts
@@ -1,4 +1,5 @@
 // packages/daemon/test/bench/cold-start.bench.ts
+// [BENCH-INFO: deferred to v0.4 — see Task #468 for real wire-up after T1.7 Supervisor /healthz]
 //
 // T8.13 — daemon cold-start latency: spawn(daemon) -> GET /healthz returns
 // 200 with {ready: true}. Wall-clock ms, single-shot per iteration.

--- a/packages/daemon/test/bench/hello-rtt.bench.ts
+++ b/packages/daemon/test/bench/hello-rtt.bench.ts
@@ -1,4 +1,5 @@
 // packages/daemon/test/bench/hello-rtt.bench.ts
+// [BENCH-INFO: deferred to v0.4 — see Task #468 for real wire-up after T1.7 Supervisor /healthz]
 //
 // T8.13 — Hello RPC round-trip latency. Single client, sequential calls,
 // p50/p99 reported by tinybench's built-in samples histogram.

--- a/packages/daemon/test/bench/rss.bench.ts
+++ b/packages/daemon/test/bench/rss.bench.ts
@@ -1,4 +1,5 @@
 // packages/daemon/test/bench/rss.bench.ts
+// [BENCH-INFO: deferred to v0.4 — see Task #468 for real wire-up after T1.7 Supervisor /healthz]
 //
 // T8.13 — daemon resident-set memory after warmup. Spawns the daemon,
 // runs a representative warmup workload (N sessions opened, M Hello

--- a/packages/daemon/test/bench/sendinput-rtt.bench.ts
+++ b/packages/daemon/test/bench/sendinput-rtt.bench.ts
@@ -1,4 +1,5 @@
 // packages/daemon/test/bench/sendinput-rtt.bench.ts
+// [BENCH-INFO: deferred to v0.4 — see Task #468 for real wire-up after T1.7 Supervisor /healthz]
 //
 // T8.13 — SendInput end-to-end round-trip: client writes 1 byte via
 // SendInput, daemon forwards to pty-host, pty echoes, daemon streams the

--- a/packages/daemon/test/bench/snapshot-encode.bench.ts
+++ b/packages/daemon/test/bench/snapshot-encode.bench.ts
@@ -1,4 +1,5 @@
 // packages/daemon/test/bench/snapshot-encode.bench.ts
+// [BENCH-INFO: deferred to v0.4 — see Task #468 for real wire-up after T1.7 Supervisor /healthz]
 //
 // T8.13 — SnapshotV1 encode throughput in bytes/sec. Pure-CPU bench:
 // build a representative terminal snapshot (e.g. 80x24 with mixed


### PR DESCRIPTION
## Why

Task #493 — zero-skip blocker MARK pass for v0.3 ship: the 5 `bench.skip`
files in `packages/daemon/test/bench/` are not deleted and not wired up;
they are perf-gate (not ship-gate) and are deferred to v0.4. Adding an
inline `[BENCH-INFO: ...]` tag at the top of each file makes the deferral
explicit and machine-verifiable (Task #494 audit).

## Changes

- 5 `*.bench.ts` files — added `// [BENCH-INFO: deferred to v0.4 — see Task #468 for real wire-up after T1.7 Supervisor /healthz]` as the second comment line (immediately after the path comment).
- `packages/daemon/test/bench/README.md` — appended a `## Bench skip policy` section documenting that bench is perf-gate (not ship-gate), v0.3 PR CI does not run bench, and Task #494 audit verifies the tag.
- No bench logic changes. vitest config unchanged (bench already excluded from default `test` run).

## Local checks (host: windows-11)

- lint: exit 0 (0 errors, only pre-existing warnings)
- typecheck: exit 0 (`tsc --noEmit && tsc --noEmit -p tsconfig.electron.json`)
- build: skipped — diff is comments + markdown only, no `.ts` runtime code touched
- unit tests: skipped — same rationale (no runtime change)
- e2e: skipped — same rationale

Per dev protocol §3 step 2 skip clause: "改的是纯 markdown / i18n bundle / .github 配置, 没碰任何 .ts/.tsx" — here the only `.ts` edits are leading-comment additions inside files that vitest's default test runner does not even include (`*.bench.ts` is bench-only).