### PR TITLE
docs(harness): tag session-state soft-skip with [PLATFORM-GATE] (T497)

### DIFF
--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -561,6 +561,7 @@ async function caseSessionStateBecomesIdle({ electronApp: _electronApp, win, tem
     const api = /** @type {any} */ (globalThis).window?.ccsmSession;
     return Boolean(api && typeof api.onState === 'function');
   });
+  // [PLATFORM-GATE: requires PR-A wave (Connect-RPC session-state subscription stream + renderer cutover); v0.3 ch15 §3 #29 forbids new IPC bridge; M3.5-acceptance §A.2 confirms PR-A pending; un-soft-skip in #467 (deferred v0.4)]
   if (!hasPreloadOnState) {
     const reason =
       'session-state-becomes-idle skipped — PR-A renderer cutover followup pending ' +
@@ -595,6 +596,7 @@ async function caseSessionStateBecomesIdle({ electronApp: _electronApp, win, tem
     });
   });
   const apiMissing = await win.evaluate(() => Boolean(window.__sessionStateApiMissing));
+  // [PLATFORM-GATE: requires PR-A wave (Connect-RPC session-state subscription stream + renderer cutover); v0.3 ch15 §3 #29 forbids new IPC bridge; M3.5-acceptance §A.2 confirms PR-A pending; un-soft-skip in #467 (deferred v0.4)]
   if (apiMissing) {
     // Defence in depth: the preflight probe above should have caught this.
     // If we get here, the API disappeared between probe and install — keep


### PR DESCRIPTION
## Why

Dev #467 push back: the PR-A wave (Connect-RPC session-state subscription stream + renderer cutover) cannot land in v0.3 — v0.3 ch15 §3 #29 forbids new IPC bridge, M3.5-acceptance §A.2 confirms PR-A pending. The two `caseSessionStateBecomesIdle` soft-skip branches in `scripts/harness-real-cli.mjs` therefore have to stay through v0.3.

The zero-skip audit (#494) requires every skip to carry a tag explaining the gate. This PR adds a `[PLATFORM-GATE: ...]` marker comment above each of the two soft-skip branches, mirroring the semantics established in Task #495. Un-soft-skipping is tracked in #467 and deferred to v0.4.

## Files

- `scripts/harness-real-cli.mjs` — added two `[PLATFORM-GATE: requires PR-A wave (Connect-RPC session-state subscription stream + renderer cutover); v0.3 ch15 §3 #29 forbids new IPC bridge; M3.5-acceptance §A.2 confirms PR-A pending; un-soft-skip in #467 (deferred v0.4)]` comments above the `if (!hasPreloadOnState)` and `if (apiMissing)` soft-skip branches inside `caseSessionStateBecomesIdle`.

No harness logic / soft-skip behaviour changes. The whole-harness `sentinel-skip` block is out of scope (that is Task #495).

## Cross-refs

- Tracks change-to-real fix in #467 (deferred to v0.4).
- Satisfies the zero-skip audit gate in #494.

## Local checks (host: windows-11)

- lint: passes (0 errors; 67 pre-existing warnings, none added by this PR)
- build/typecheck/unit/e2e: skipped per dev.md §3 step 2 exemption — diff is comment-only inside an `.mjs` script, no `.ts/.tsx` touched.