### PR TITLE
docs(test): add [PLATFORM-GATE] tags to all skipIf gates (T495)

### DIFF
--- a/packages/daemon/build/__tests__/sign-scripts.spec.ts
+++ b/packages/daemon/build/__tests__/sign-scripts.spec.ts
@@ -139,6 +139,7 @@ describe('packages/daemon/build/sign-*.{sh,ps1} (spec ch10 §3, T7.3)', () => {
     // themselves are placeholder-safe (exit 0 + WARN on wrong host), but
     // the tests assert tool-trace output that the wrong host can't emit.
     // skipIf keeps the assertion on the matching host only.
+    // [PLATFORM-GATE: codesign + xcrun notarytool only available on macOS]
     it.skipIf(process.platform !== 'darwin')(
       'sign-mac.sh dry-run prints codesign + xcrun notarytool traces (darwin only)',
       () => {
@@ -160,6 +161,7 @@ describe('packages/daemon/build/sign-*.{sh,ps1} (spec ch10 §3, T7.3)', () => {
       },
     );
 
+    // [PLATFORM-GATE: debsigs / rpm / gpg toolchain only present on Linux runners]
     it.skipIf(process.platform !== 'linux')(
       'sign-linux.sh dry-run prints debsigs + rpm --addsign + gpg --detach-sign traces (linux only)',
       () => {

--- a/packages/daemon/src/listeners/__tests__/factory.spec.ts
+++ b/packages/daemon/src/listeners/__tests__/factory.spec.ts
@@ -223,6 +223,7 @@ describe('defaultBindHook — loopbackTcp end-to-end', () => {
   });
 });
 
+// [PLATFORM-GATE: POSIX UDS not available on Windows]
 describe.skipIf(!POSIX)('defaultBindHook — uds end-to-end (POSIX only)', () => {
   let dir: string;
   let sockPath: string;

--- a/packages/daemon/src/rpc/__tests__/integration.spec.ts
+++ b/packages/daemon/src/rpc/__tests__/integration.spec.ts
@@ -69,6 +69,7 @@ function planLoopback(): BindDescriptor {
 }
 
 describe('router bind hook — over-the-wire Unimplemented', () => {
+  // [PLATFORM-GATE: POSIX UDS not available on Windows]
   it.skipIf(isWin)('serves Unimplemented via h2c-UDS (POSIX)', async () => {
     const hook = makeRouterBindHook();
     const planned = planUds();

--- a/packages/daemon/src/state-dir/__tests__/paths.spec.ts
+++ b/packages/daemon/src/state-dir/__tests__/paths.spec.ts
@@ -122,6 +122,7 @@ describe('ensureStateDir — mkdir + mode (linux only; skip on win32)', () => {
     }
   });
 
+  // [PLATFORM-GATE: POSIX 0700 mkdir mode semantics not applicable on Windows]
   it.skipIf(skip)('creates the root + descriptors subdir with mode 0700', async () => {
     // Build a sandbox + monkey-patch the linux root for this single call by
     // rewriting `process.cwd()` is invasive — instead we create a tmp dir,
@@ -144,6 +145,7 @@ describe('ensureStateDir — mkdir + mode (linux only; skip on win32)', () => {
     expect(descStat.mode & 0o777).toBe(0o700);
   });
 
+  // [PLATFORM-GATE: POSIX 0700 mkdir mode semantics not applicable on Windows]
   it.skipIf(skip)('ensureStateDir is idempotent on repeat invocation', async () => {
     // Simulate by mkdir-ing the same dir twice with recursive; should not throw.
     const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ccsm-state-dir-'));
@@ -155,6 +157,7 @@ describe('ensureStateDir — mkdir + mode (linux only; skip on win32)', () => {
     ).resolves.toBeUndefined();
   });
 
+  // [PLATFORM-GATE: POSIX 0700 mkdir mode semantics not applicable on Windows]
   it.skipIf(skip)('exposes a callable ensureStateDir for the running platform', async () => {
     // We can't write to /var/lib/ccsm in CI, but we *can* assert the
     // function signature + that it returns a StatePaths object whose root

--- a/packages/daemon/src/transport/__tests__/h2-named-pipe.spec.ts
+++ b/packages/daemon/src/transport/__tests__/h2-named-pipe.spec.ts
@@ -11,6 +11,7 @@ import { bindH2NamedPipe, normalizePipePath } from '../h2-named-pipe.js';
 import type { BoundTransport } from '../types.js';
 
 const isWin = platform() === 'win32';
+// [PLATFORM-GATE: Windows named pipe API unavailable on POSIX]
 const describeWin = isWin ? describe : describe.skip;
 
 let bound: BoundTransport | null = null;
@@ -94,6 +95,7 @@ describeWin('bindH2NamedPipe (win32)', () => {
 });
 
 describe('bindH2NamedPipe (POSIX guard)', () => {
+  // [PLATFORM-GATE: POSIX-only routing-hint check; skip on Windows where the bind succeeds]
   it.skipIf(isWin)('throws synchronously on POSIX with a routing-hint message', async () => {
     const server = createServer();
     await expect(bindH2NamedPipe(server, { pipeName: 'never-binds' })).rejects.toThrow(

--- a/packages/daemon/src/transport/__tests__/h2-tls.spec.ts
+++ b/packages/daemon/src/transport/__tests__/h2-tls.spec.ts
@@ -63,12 +63,14 @@ try {
 }
 
 describe('computeCertFingerprint', () => {
+  // [PLATFORM-GATE: h2 TLS requires cert fixture (HAVE_CERT)]
   it.skipIf(!HAVE_CERT)('matches the SHA-256 of the DER form of the cert', () => {
     const fp = computeCertFingerprint(TEST_CERT_PEM);
     expect(fp).toBe(TEST_CERT_FINGERPRINT);
     expect(fp).toMatch(/^[0-9a-f]{64}$/);
   });
 
+  // [PLATFORM-GATE: h2 TLS requires cert fixture (HAVE_CERT)]
   it.skipIf(!HAVE_CERT)('accepts a Buffer in addition to a string', () => {
     const buf = Buffer.from(TEST_CERT_PEM, 'utf8');
     expect(computeCertFingerprint(buf)).toBe(TEST_CERT_FINGERPRINT);
@@ -76,6 +78,7 @@ describe('computeCertFingerprint', () => {
 });
 
 describe('bindH2Tls', () => {
+  // [PLATFORM-GATE: h2 TLS requires cert fixture (HAVE_CERT)]
   it.skipIf(!HAVE_CERT)(
     'binds an ephemeral 127.0.0.1 TLS port and surfaces port + fingerprint',
     async () => {
@@ -99,6 +102,7 @@ describe('bindH2Tls', () => {
     },
   );
 
+  // [PLATFORM-GATE: h2 TLS requires cert fixture (HAVE_CERT)]
   it.skipIf(!HAVE_CERT)(
     'serves an end-to-end h2 request with the pinned cert',
     async () => {
@@ -141,6 +145,7 @@ describe('bindH2Tls', () => {
     },
   );
 
+  // [PLATFORM-GATE: h2 TLS requires cert fixture (HAVE_CERT)]
   it.skipIf(!HAVE_CERT)('rejects non-loopback host at runtime', async () => {
     const server = createSecureServer({ cert: TEST_CERT_PEM, key: TEST_KEY_PEM });
     await expect(
@@ -153,6 +158,7 @@ describe('bindH2Tls', () => {
     ).rejects.toThrow(/MUST be 127\.0\.0\.1/);
   });
 
+  // [PLATFORM-GATE: h2 TLS requires cert fixture (HAVE_CERT)]
   it.skipIf(!HAVE_CERT)('rejects out-of-range port', async () => {
     const server = createSecureServer({ cert: TEST_CERT_PEM, key: TEST_KEY_PEM });
     await expect(
@@ -165,6 +171,7 @@ describe('bindH2Tls', () => {
     ).rejects.toThrow(/port out of range/);
   });
 
+  // [PLATFORM-GATE: h2 TLS requires cert fixture (HAVE_CERT)]
   it.skipIf(!HAVE_CERT)('close() is idempotent', async () => {
     const server = createSecureServer({ cert: TEST_CERT_PEM, key: TEST_KEY_PEM });
     bound = await bindH2Tls(server, {

--- a/packages/daemon/src/transport/__tests__/h2c-uds.spec.ts
+++ b/packages/daemon/src/transport/__tests__/h2c-uds.spec.ts
@@ -13,6 +13,7 @@ import { bindH2cUds } from '../h2c-uds.js';
 import type { BoundTransport } from '../types.js';
 
 const isWin = platform() === 'win32';
+// [PLATFORM-GATE: POSIX UDS not available on Windows]
 const describePosix = isWin ? describe.skip : describe;
 
 let bound: BoundTransport | null = null;
@@ -129,6 +130,7 @@ describePosix('bindH2cUds (POSIX)', () => {
 });
 
 describe('bindH2cUds (win32 guard)', () => {
+  // [PLATFORM-GATE: Windows-only routing-hint check; skip on POSIX where the bind succeeds]
   it.skipIf(!isWin)('throws synchronously on win32 with a routing-hint message', async () => {
     const server = createServer();
     await expect(bindH2cUds(server, { path: '/tmp/should-not-bind' })).rejects.toThrow(

--- a/packages/daemon/test/db/migration-lock.spec.ts
+++ b/packages/daemon/test/db/migration-lock.spec.ts
@@ -43,6 +43,7 @@ function sha256OfFile(path: string): string {
 // runs. Instead we read it as text and parse the MIGRATION_LOCKS entries.
 const lockedTsExists = existsSync(LOCKED_TS_PATH);
 
+// [PLATFORM-GATE: requires generated db/locked.ts (skip when source not present in this build)]
 describe.skipIf(!lockedTsExists)('migration-lock (runtime self-check)', () => {
   // Parse `MIGRATION_LOCKS` entries from locked.ts source text. We accept
   // either object-literal form (`'<file>': '<hex>'`) or a Map/array form

--- a/packages/daemon/test/integration/pty-soak-10m.spec.ts
+++ b/packages/daemon/test/integration/pty-soak-10m.spec.ts
@@ -27,6 +27,7 @@ import {
 
 const probe = dependenciesPresent();
 
+// [PLATFORM-GATE: requires T4 pty soak harness dependencies (probe.ready)]
 describe.skipIf(!probe.ready)('pty-soak-10m (phase-5 smoke variant)', () => {
   // 5-minute slack on top of the soak window for boot + final byte-equality.
   const TIMEOUT_MS = SOAK_DURATION_10M_MS + 5 * 60 * 1000;
@@ -49,6 +50,7 @@ describe.skipIf(!probe.ready)('pty-soak-10m (phase-5 smoke variant)', () => {
   );
 });
 
+// [PLATFORM-GATE: gating-reason marker; only runs when soak harness deps are missing]
 describe.skipIf(probe.ready)('pty-soak-10m (skipped — pending dependencies)', () => {
   it('reports gating reason', () => {
     expect(probe.reason).toMatch(/T4\./);

--- a/packages/daemon/test/integration/pty-soak-1h.spec.ts
+++ b/packages/daemon/test/integration/pty-soak-1h.spec.ts
@@ -47,6 +47,7 @@ const probe = dependenciesPresent();
 
 // `nightly` tag: spec runners may filter by tag (`vitest run --testNamePattern`)
 // to keep this out of the per-PR run. The 10m smoke variant is per-PR.
+// [PLATFORM-GATE: requires T4 pty soak harness dependencies (probe.ready)]
 describe.skipIf(!probe.ready)(`pty-soak-1h (ship-gate (c)) [nightly]`, () => {
   // Vitest test-level timeout. Add a 5-minute slack on top of the soak
   // duration for boot, shutdown, and final byte-equality comparison.
@@ -74,6 +75,7 @@ describe.skipIf(!probe.ready)(`pty-soak-1h (ship-gate (c)) [nightly]`, () => {
 // When the suite is skipped, leave a single sentinel test that records WHY
 // it was skipped (so `vitest --reporter=verbose` makes the gating reason
 // visible in CI output without polluting the regular test list).
+// [PLATFORM-GATE: gating-reason marker; only runs when soak harness deps are missing]
 describe.skipIf(probe.ready)('pty-soak-1h (skipped — pending dependencies)', () => {
   it('reports gating reason', () => {
     expect(probe.reason).toMatch(/T4\./);

--- a/packages/daemon/test/integration/rpc/clients-transport-matrix.spec.ts
+++ b/packages/daemon/test/integration/rpc/clients-transport-matrix.spec.ts
@@ -353,6 +353,7 @@ describe('rpc/clients-transport-matrix (T8.11; spec ch12 §3)', () => {
   for (const matrixCase of cases) {
     // Use Vitest's per-case skip so the run reports the skip reason — much
     // friendlier than silently absent tests when triaging a Linux CI log.
+    // [PLATFORM-GATE: per-case skip when transport unavailable on this host (matrixCase.skipReason)]
     const block = matrixCase.skipReason ? describe.skip : describe;
 
     block(`${matrixCase.label} (${matrixCase.descriptorKind})`, () => {

--- a/packages/daemon/test/integration/watchdog-linux.spec.ts
+++ b/packages/daemon/test/integration/watchdog-linux.spec.ts
@@ -28,6 +28,7 @@ import { startSystemdWatchdog, WATCHDOG_INTERVAL_MS } from '../../src/watchdog/s
 const isRealSystemdHost =
   process.platform === 'linux' && existsSync('/run/systemd/system');
 
+// [PLATFORM-GATE: requires Linux host with live systemd (/run/systemd/system)]
 describe.skipIf(!isRealSystemdHost)('systemd watchdog (real systemd host)', () => {
   it('spawns systemd-notify without error when NOTIFY_SOCKET points at the live socket', async () => {
     // The live notify socket on a Type=notify service is `/run/systemd/notify`.

--- a/packages/daemon/test/lock/segmentation-cadence.spec.ts
+++ b/packages/daemon/test/lock/segmentation-cadence.spec.ts
@@ -81,6 +81,7 @@ function* walkTs(root: string): Generator<string> {
 
 const cadenceFileExists = existsSync(CADENCE_FILE_ABS);
 
+// [PLATFORM-GATE: requires generated cadence source file (skip when not present in this build)]
 describe.skipIf(!cadenceFileExists)(
   'pty segmentation cadence (single source file lock)',
   () => {

--- a/packages/electron/test/e2e/pty-soak-reconnect.spec.ts
+++ b/packages/electron/test/e2e/pty-soak-reconnect.spec.ts
@@ -201,6 +201,7 @@ const SKIP_REASON = SKIP_OVERRIDE
 // `describe.skipIf(...)` keeps the suite present in the report (so CI can
 // observe the skip count + reason) while preventing any of its lifecycle
 // hooks from running. Vitest 4.x supports `skipIf` natively.
+// [PLATFORM-GATE: requires built service binary + Playwright electron fixture; otherwise skipped pending dependencies]
 describe.skipIf(SHOULD_SKIP)(
   `T8.5 pty-soak-reconnect — Electron-side companion to ship-gate (c)`,
   () => {

--- a/packages/electron/test/e2e/sigkill-reattach.spec.ts
+++ b/packages/electron/test/e2e/sigkill-reattach.spec.ts
@@ -297,6 +297,7 @@ const SERVICE_VARIANT = process.env.CCSM_E2E_SERVICE === '1';
 // `describe.skipIf(...)` keeps the suite present in the report (so CI can
 // observe the skip count + reason) while preventing any of its lifecycle
 // hooks from running. Vitest 4.x supports `skipIf` natively.
+// [PLATFORM-GATE: requires built service binary + Playwright electron fixture; otherwise skipped pending dependencies]
 describe.skipIf(SHOULD_SKIP)(
   `T8.3 sigkill-reattach — ship-gate (b) [${SERVICE_VARIANT ? 'service-installed' : 'subprocess'}]`,
   () => {

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -3548,6 +3548,7 @@ function detectClaudeBin() {
 
 async function main() {
   // ---- preflight: harness-real-cli requires the upstream `claude` binary ----
+  // [PLATFORM-GATE: requires local claude CLI + Anthropic auth (CCSM_CLAUDE_BIN or `claude` on PATH)]
   // Without it every shared case times out at waitForTerminalReady. Sentinel-skip
   // the entire harness with a clear marker line + exit 0 so run-all-e2e.mjs
   // counts it as a passed-but-skipped harness rather than a 27-failure cascade.

--- a/tools/test/installer-roundtrip-allowlist.spec.ts
+++ b/tools/test/installer-roundtrip-allowlist.spec.ts
@@ -152,6 +152,7 @@ describe('installer-roundtrip.ps1 (integration smoke)', () => {
     }
   })();
 
+  // [PLATFORM-GATE: pwsh not installed (PowerShell installer requires pwsh on PATH)]
   it.skipIf(!pwshAvailable)('PS1 -DryRun reports PASS for both variants', () => {
     const r = spawnSync(
       'pwsh',
@@ -168,6 +169,7 @@ describe('installer-roundtrip.ps1 (integration smoke)', () => {
     expect(r.stdout).toMatch(/variant=0 residue count: 5/);
   });
 
+  // [PLATFORM-GATE: pwsh not installed (PowerShell installer requires pwsh on PATH)]
   it.skipIf(!pwshAvailable)(
     'PS1 -DryRun stays fail-closed when global allowlist is empty (mocked via env)',
     () => {

--- a/tools/test/update-flow-allowlist.spec.ts
+++ b/tools/test/update-flow-allowlist.spec.ts
@@ -67,6 +67,7 @@ describe('update-flow.spec.{sh,ps1} — files exist', () => {
 });
 
 describe('update-flow.spec.sh (dry-run)', () => {
+  // [PLATFORM-GATE: bash not installed (POSIX shell scripts require bash on PATH)]
   it.skipIf(!bashAvailable)('main script --dry-run exits 0', () => {
     const r = spawnSync('bash', [SH_MAIN, '--dry-run', '--simulate-healthz=pass'], {
       encoding: 'utf8',
@@ -81,6 +82,7 @@ describe('update-flow.spec.sh (dry-run)', () => {
     expect(r.stdout).toMatch(/update flow complete/);
   });
 
+  // [PLATFORM-GATE: bash not installed (POSIX shell scripts require bash on PATH)]
   it.skipIf(!bashAvailable)('main script --dry-run + simulate-healthz=fail triggers rollback path', () => {
     const r = spawnSync(
       'bash',
@@ -100,6 +102,7 @@ describe('update-flow.spec.sh (dry-run)', () => {
     expect(r.stdout).toMatch(/"owner_id":"daemon-self"/);
   });
 
+  // [PLATFORM-GATE: bash not installed (POSIX shell scripts require bash on PATH)]
   it.skipIf(!bashAvailable)('lib/stop-with-escalation.sh --dry-run exits 0', () => {
     const r = spawnSync(
       'bash',
@@ -110,6 +113,7 @@ describe('update-flow.spec.sh (dry-run)', () => {
     expect(r.stdout).toMatch(/polite stop/);
   });
 
+  // [PLATFORM-GATE: bash not installed (POSIX shell scripts require bash on PATH)]
   it.skipIf(!bashAvailable)('lib/rename-prev.sh --dry-run exits 0', () => {
     const r = spawnSync(
       'bash',
@@ -120,6 +124,7 @@ describe('update-flow.spec.sh (dry-run)', () => {
     expect(r.stdout).toMatch(/install root: \/tmp\/nope/);
   });
 
+  // [PLATFORM-GATE: bash not installed (POSIX shell scripts require bash on PATH)]
   it.skipIf(!bashAvailable)('lib/rollback.sh --dry-run prints update_rollback NDJSON', () => {
     const r = spawnSync(
       'bash',
@@ -138,6 +143,7 @@ describe('update-flow.spec.sh (dry-run)', () => {
     expect(r.stdout).toMatch(/"summary":"update_rollback: test"/);
   });
 
+  // [PLATFORM-GATE: bash not installed (POSIX shell scripts require bash on PATH)]
   it.skipIf(!bashAvailable)('lib/rollback.sh propagates non-zero exit when bash forces it', () => {
     // Sanity: prove the spec can FAIL (per task acceptance criterion). Run
     // bash with `set -e` and `false` to confirm spawnSync surfaces
@@ -149,6 +155,7 @@ describe('update-flow.spec.sh (dry-run)', () => {
 });
 
 describe('update-flow.spec.ps1 (dry-run)', () => {
+  // [PLATFORM-GATE: pwsh not installed (PowerShell scripts require pwsh on PATH)]
   it.skipIf(!pwshAvailable)('main script -DryRun exits 0', () => {
     const r = spawnSync(
       'pwsh',
@@ -165,6 +172,7 @@ describe('update-flow.spec.ps1 (dry-run)', () => {
     expect(r.stdout).toMatch(/update flow complete/);
   });
 
+  // [PLATFORM-GATE: pwsh not installed (PowerShell scripts require pwsh on PATH)]
   it.skipIf(!pwshAvailable)('main script -DryRun -SimulateHealthz fail triggers rollback', () => {
     const r = spawnSync(
       'pwsh',
@@ -182,6 +190,7 @@ describe('update-flow.spec.ps1 (dry-run)', () => {
     expect(r.stdout).toMatch(/"owner_id":\s*"daemon-self"/);
   });
 
+  // [PLATFORM-GATE: pwsh not installed (PowerShell scripts require pwsh on PATH)]
   it.skipIf(!pwshAvailable)('lib/stop-with-escalation.ps1 -DryRun parses + exits 0', () => {
     const r = spawnSync(
       'pwsh',
@@ -192,6 +201,7 @@ describe('update-flow.spec.ps1 (dry-run)', () => {
     expect(r.stdout).toMatch(/polite stop/);
   });
 
+  // [PLATFORM-GATE: pwsh not installed (PowerShell scripts require pwsh on PATH)]
   it.skipIf(!pwshAvailable)('lib/rename-prev.ps1 -DryRun parses + exits 0', () => {
     const r = spawnSync(
       'pwsh',
@@ -209,6 +219,7 @@ describe('update-flow.spec.ps1 (dry-run)', () => {
     expect(r.stdout).toMatch(/install root:/);
   });
 
+  // [PLATFORM-GATE: pwsh not installed (PowerShell scripts require pwsh on PATH)]
   it.skipIf(!pwshAvailable)('lib/rollback.ps1 -DryRun prints update_rollback NDJSON', () => {
     const r = spawnSync(
       'pwsh',
@@ -232,6 +243,7 @@ describe('update-flow.spec.ps1 (dry-run)', () => {
     expect(r.stdout).toMatch(/update_rollback: test/);
   });
 
+  // [PLATFORM-GATE: pwsh not installed (PowerShell scripts require pwsh on PATH)]
   it.skipIf(!pwshAvailable)('main ps1 parses without syntax errors', () => {
     const r = spawnSync(
       'pwsh',


### PR DESCRIPTION
## Why

Zero-skip blocker (KEEP class): 28 it.skipIf + multiple describe.skip + harness sentinel-skip sites are all legitimate platform/feature gates. They must stay, but need a uniform tag so the upcoming Task #494 audit script can fail any naked skip that lacks a justification.

This PR adds a single-line comment of the form

\`\`\`
// [PLATFORM-GATE: <short reason>]
\`\`\`

immediately above every skipIf / describe.skip / sentinel-skip site found in the repo. No test logic changes.

## Files (18 files, 43 tags added)

- packages/daemon/src/transport/__tests__/h2-tls.spec.ts (7x HAVE_CERT)
- packages/daemon/src/transport/__tests__/h2-named-pipe.spec.ts (2x win32 named pipe)
- packages/daemon/src/transport/__tests__/h2c-uds.spec.ts (2x POSIX UDS)
- packages/daemon/src/rpc/__tests__/integration.spec.ts (1x POSIX UDS)
- packages/daemon/src/listeners/__tests__/factory.spec.ts (1x POSIX UDS)
- packages/daemon/src/state-dir/__tests__/paths.spec.ts (3x POSIX 0700 mode)
- packages/daemon/build/__tests__/sign-scripts.spec.ts (2x darwin / linux signing toolchain)
- packages/daemon/test/db/migration-lock.spec.ts (1x generated db/locked.ts)
- packages/daemon/test/lock/segmentation-cadence.spec.ts (1x generated cadence file)
- packages/daemon/test/integration/watchdog-linux.spec.ts (1x real systemd host)
- packages/daemon/test/integration/pty-soak-1h.spec.ts (2x soak harness deps)
- packages/daemon/test/integration/pty-soak-10m.spec.ts (2x soak harness deps)
- packages/daemon/test/integration/rpc/clients-transport-matrix.spec.ts (1x per-case skipReason)
- packages/electron/test/e2e/sigkill-reattach.spec.ts (1x service binary + Playwright fixture)
- packages/electron/test/e2e/pty-soak-reconnect.spec.ts (1x service binary + Playwright fixture)
- tools/test/update-flow-allowlist.spec.ts (12x bash/pwsh availability)
- tools/test/installer-roundtrip-allowlist.spec.ts (2x pwsh availability)
- scripts/harness-real-cli.mjs (1x harness sentinel-skip — requires local claude CLI)

Sites located via:

\`\`\`
grep -rn "\.skipIf\|describe\.skip\|sentinel-skip" packages/ tools/ scripts/ \
  --include='*.ts' --include='*.mjs' | grep -v node_modules | grep -v dist
\`\`\`

## Reverse-verify

Skipped this round: the audit script (Task #494) has not landed yet, so there is no executable check to bounce a missing tag against. Once #494 is merged, deleting any one of the new tag comments and re-running the audit MUST report a failure for that site. Reviewer can spot-check on-merge.

## Local checks (host: windows-11)

- lint: ok (exit 0; only pre-existing unused-disable warnings, none introduced by this PR)
- typecheck: ok (exit 0; tsc --noEmit + tsc --noEmit -p tsconfig.electron.json)
- unit / e2e: not applicable — comments-only change, no logic touched

## Out of scope

- The audit script itself (Task #494)
- Any decision to remove a skip — every site KEEPs its existing skipIf

## audit-table override (ch15 §3 forever-stable)

audit-override: packages/daemon/test/integration/pty-soak-1h.spec.ts -- ch15 §3 row 28 forever-stable path is unchanged; this PR only adds a `// [PLATFORM-GATE: ...]` comment above the existing `describe.skipIf` (no rename, no logic change, no skip removal). Comment-only doc tagging is forward-safe per Task #495 spec.
