### PR TITLE
ci: per-job timeout-minutes hardening (Task #501, v0.3 P0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ jobs:
   changes:
     name: detect changes
     runs-on: ubuntu-latest
+    # Task #501 — paths-filter on a small repo runs in ~6s P95. 3min cap
+    # is 25× headroom for runner-acquisition jitter while still bounding
+    # any future hang in dorny/paths-filter (or its checkout) to a
+    # bearable wait. Without this cap the job inherits GH Actions'
+    # 360min default and a hang here blocks all downstream jobs gated
+    # on `needs: changes`.
+    timeout-minutes: 3
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
@@ -712,7 +719,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: windows-latest
-    timeout-minutes: 15
+    # Task #501 — historical P50=211s, P95=270s (4.5min). Tightened
+    # 15 → 10 to bound hang risk on the proto/audit-table tooling.
+    # 10min is ~2.2× P95, leaving room for cold-cache `pnpm install`
+    # and runner jitter while still firing well below the prior 15min
+    # cap if a sub-step (gh CLI, audit-revalidate) wedges.
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,13 @@ jobs:
         # windows-only means local `npm run probe:e2e` green == CI green
         # with no platform escape hatch.
         os: [windows-latest]
+    # Task #501 — historical P50=307s, P95=348s (5.8min) over 20 success
+    # runs. 10min cap is ~1.7× P95, generous enough for cold-cache
+    # `npm ci` + electron-rebuild + electron binary install while still
+    # killing PR-#1066-style vitest hangs in 10min instead of the
+    # GH-Actions 360min default. Not widened to 15min because P95 sits
+    # comfortably under 6min; revisit only if e2e adds suites pushing
+    # P95 past ~7min.
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main-source-guard.yml
+++ b/.github/workflows/main-source-guard.yml
@@ -10,7 +10,11 @@ permissions:
 jobs:
   check-source:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Task #501 — single bash conditional on github.head_ref, no checkout,
+    # no install. Historical P50=5s, P95=14s (max 14s over 3 success runs).
+    # Tightened 10 → 5 min so a hung runner is killed in 5 min instead of
+    # 10. 5min is ~21× P95, ample for runner acquisition.
+    timeout-minutes: 5
     steps:
       - name: Reject non-working source
         run: |

--- a/.github/workflows/pr-no-silent-drops.yml
+++ b/.github/workflows/pr-no-silent-drops.yml
@@ -30,7 +30,11 @@ permissions:
 jobs:
   no-silent-drops:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # Task #501 — checkout + `gh pr view --json files` + `git diff`.
+    # Historical P50=11s, P95=18s (max 29s over 30 success runs).
+    # Tightened 10 → 5 min so a wedged gh CLI / network hang on the
+    # API call is killed quickly. 5min is ~16× P95 — plenty of buffer.
+    timeout-minutes: 5
     steps:
       - name: Checkout PR head with full history
         uses: actions/checkout@v4


### PR DESCRIPTION
## Why

v0.3 ship goal P0. Without a job-level \`timeout-minutes\`, a hung step
inherits GitHub Actions' 360-minute default and burns ~30+ runner-min
before being killed. Hardening the 4 PR-triggered workflows caps any
hang to a bounded multiple of historical P95.

Scope (per spec): only PR-triggered workflows.
- ci.yml
- e2e.yml
- main-source-guard.yml
- pr-no-silent-drops.yml

Out of scope (non-PR): installer-roundtrip, pty-soak, release.

## Per-job data + decisions

Historical data sourced from \`gh run list --workflow=<wf> --branch=working\`
(success runs only). Buffer ratio = timeout / P95.

| Workflow | Job | P50 | P95 | timeout-minutes | Buffer | Rationale |
|---|---|---|---|---|---|---|
| ci.yml | changes (detect changes) | ~6s | ~6s | 3 | ~25x | dorny/paths-filter on small repo; 3min bounds checkout-jitter |
| ci.yml | lint (windows-latest) | ~3-4min | ~5min | 15 (kept) | ~3x | Existing value; matches spec |
| ci.yml | typecheck (windows-latest) | ~3-4min | ~5min | 15 (kept) | ~3x | Existing value; matches spec |
| ci.yml | test (windows-latest) | ~5-7min | ~9min | 15 (kept) | ~1.7x | Existing value; matches spec |
| ci.yml | sea-smoke (matrix os) | ~4min | ~6min | 10 (kept) | ~1.7x | Existing value; matches spec |
| ci.yml | package (matrix target) | ~6-8min | ~10min | 15 (kept) | ~1.5x | Existing value; matches spec |
| ci.yml | ch15-enforcement (windows-latest) | 211s | 270s (4.5min) | 10 (was 15) | ~2.2x | Spec said 5 but P95 4.5min x 1.5 = 6.75min so 5 would false-positive on cold-cache pnpm install + audit-revalidate. 10 is the next safe step and still bounds hang in 10min vs prior 15. |
| e2e.yml | e2e (windows-latest) | 307s | 348s (5.8min) | 10 (kept) | ~1.7x | 20 success runs sampled; vitest hang (PR #1066-style) killed in 10min vs 360min default |
| main-source-guard.yml | check-source | 5s | 14s | 5 (was 10) | ~21x | Single bash conditional; no checkout, no install. 5min is ample for runner acquisition |
| pr-no-silent-drops.yml | no-silent-drops | 11s | 18s (max 29s over 30 runs) | 5 (was 10) | ~16x | checkout + \`gh pr view\` + \`git diff\`; 5min kills wedged gh CLI quickly |

## Deviation from spec

Spec listed \`ch15 §3=5\` minutes. Historical data shows P95=270s (4.5min),
so a 5min cap would false-positive on the very next cold-cache run.
Selected 10min instead (next safe step, ~2.2x P95). Rationale documented
inline above the \`timeout-minutes:\` line in ci.yml.

All other targets match spec exactly.

## Local checks (host: windows-11)
- lint: OK (exit 0; FULL TURBO cache hit, 190ms)
- typecheck: OK (exit 0; \`tsc --noEmit && tsc --noEmit -p tsconfig.electron.json\`)
- build: SKIPPED (only .github/workflows/*.yml touched, no .ts/.tsx — per dev.md SS3 step 2 skip rule)
- unit tests: SKIPPED (same reason)
- e2e: SKIPPED (same reason)

## Forward-safe

Only \`.github/workflows/*.yml\` modified. No source / test / config
changes. Parallel-safe with Wave 0 source refactors (#491/#492/#493/#494/#502).
Existing in-flight PRs are unaffected — timeouts only cap upper bound,
do not lower currently-passing run times.