### PR TITLE
ci(ch15-enforcement): add pnpm-store cache (Task #513)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -758,14 +758,44 @@ jobs:
           git rm --cached -r --quiet .
           git reset --hard HEAD
 
+      # pnpm/action-setup MUST come before actions/setup-node so that
+      # setup-node's `cache: 'pnpm'` can locate the pnpm shim when
+      # computing the cache key.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.2
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          # Task #513 (FOLLOWUP-C, v0.3 ship CI-speed) — turn on the
+          # built-in pnpm cache. Keys ~/.npm-style metadata + the pnpm
+          # store directory off pnpm-lock.yaml, so a cache hit skips the
+          # network fetch portion of `pnpm install --frozen-lockfile`.
+          # Pairs with the explicit actions/cache step below that caches
+          # the resolved pnpm store directory so `pnpm install` only does
+          # symlink reconciliation on a warm hit.
+          cache: 'pnpm'
 
-      - uses: pnpm/action-setup@v4
+      # Task #513 (FOLLOWUP-C) — explicit pnpm store cache, mirrors the
+      # lint/typecheck/test jobs' node_modules cache pattern (line 92,
+      # 159, 279). Setup-node's `cache: 'pnpm'` already keys on
+      # pnpm-lock.yaml; this step adds restore-keys fallback so a stale
+      # cache is restored when the lockfile changes (pnpm reconciles only
+      # the diff). Eval target: ch15-enforcement wall-time 190s -> ~165s.
+      - name: Resolve pnpm store path
+        id: pnpm_store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
-          version: 10.33.2
+          path: ${{ steps.pnpm_store.outputs.path }}
+          key: pnpm-${{ runner.os }}-${{ runner.arch }}-node22-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            pnpm-${{ runner.os }}-${{ runner.arch }}-node22-
 
       - name: Install deps
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary

FOLLOWUP-C of the v0.3 ship CI-speed series. The `ch15-enforcement` job currently runs `pnpm install --frozen-lockfile` cold on every PR, with no cache layer. Wall-time eval: ~190s, with install dominating.

This PR wires two cache layers, mirroring the lint/typecheck/test jobs' `node_modules` cache pattern (lines 92, 159, 279 of `ci.yml`):

1. **`actions/setup-node` `cache: 'pnpm'`** — built-in cache keyed off `pnpm-lock.yaml`; skips the network fetch portion of `pnpm install`. Requires `pnpm/action-setup` to run BEFORE `setup-node` so the pnpm shim is discoverable when computing the cache key, so the two steps are reordered.

2. **`actions/cache@v4` over the resolved pnpm store path** with a `restore-keys` fallback (`pnpm-<os>-<arch>-node22-`). On a lockfile change, a stale store is still restored and `pnpm install` reconciles only the diff instead of cold-fetching everything.

Eval target: 190s -> ~165s wall on the next `ch15-enforcement` run.

## Local checks (host: windows-11)
- lint: OK (exit 0, 84 pre-existing warnings)
- typecheck: OK (exit 0)
- build / unit / e2e: skipped per `dev.md` §3 step 2 — change is `.github` config only, no `.ts`/`.tsx` touched.

## Acceptance
- `ch15-enforcement` job log shows cache hit on Setup pnpm + Cache pnpm store steps (cold first run will populate; second run validates).
- Wall-time drops from ~190s to ~165s once the cache warms.

## Notes
Hot-file with #510 (PR #1080, also touches `ci.yml`). PR #1080 is still open at push time; if it merges first, this PR may need a trivial rebase.