### PR TITLE
test(daemon/rpc): unit specs for crash GetCrashLog + WatchCrashLog handlers (Task #472)

### DIFF
--- a/packages/daemon/src/rpc/crash/__tests__/get-crash-log-handler.spec.ts
+++ b/packages/daemon/src/rpc/crash/__tests__/get-crash-log-handler.spec.ts
@@ -1,0 +1,295 @@
+// packages/daemon/src/rpc/crash/__tests__/get-crash-log-handler.spec.ts
+//
+// Task #472 (T8.14b-7c) — daemon src/rpc/ coverage push for the
+// production CrashService.GetCrashLog handler. PR #1061 (Task #437)
+// audited rpc/ and explicitly excluded `crash/get-crash-log.ts` because
+// `#435 owns crash/`. PR #1060 (Task #435) shipped `crash/sources.ts`
+// fileSink coverage but did NOT add direct unit specs for the rpc/crash
+// handler — only the over-the-wire integration spec (crash-getlog.spec.ts)
+// hits these branches end-to-end. This file pins the per-branch error
+// mapping + decider semantics directly so a future change to STANDARD_ERROR_MAP
+// or the OwnerFilter switch surfaces here, not as a remote-host symptom.
+//
+// Scope (one branch per `it`):
+//   1. SERVER_LIMIT_CAP constant pinned (forever-stable spec ch04 §5)
+//   2. decideGetCrashLogQuery — limit normalisation
+//      a. limit=0 (proto3 default)        → cap (1000)
+//      b. limit=500 (in range)            → 500
+//      c. limit=2000 (over cap)           → cap
+//   3. decideGetCrashLogQuery — sinceUnixMs coercion
+//      a. negative since                  → 0
+//      b. positive since                  → kept
+//   4. handler — missing PRINCIPAL_KEY    → Code.Internal (wiring bug)
+//   5. handler — OwnerFilter.ALL          → Code.PermissionDenied + session.not_owned
+//   6. handler — unknown OwnerFilter enum → Code.PermissionDenied + session.not_owned
+//   7. handler — OWN happy path returns rows + echoes meta (covers
+//      readCrashLog OWN branch + rowToProto labels JSON parse)
+//   8. handler — labels_json corrupt JSON → empty labels (defensive)
+
+import { create } from '@bufbuild/protobuf';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  Code,
+  ConnectError,
+  createContextValues,
+  type HandlerContext,
+} from '@connectrpc/connect';
+
+import {
+  ErrorDetailSchema,
+  GetCrashLogRequestSchema,
+  OwnerFilter,
+  RequestMetaSchema,
+  type ErrorDetail,
+} from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, principalKey, type Principal } from '../../../auth/index.js';
+import { DAEMON_SELF } from '../../../crash/sources.js';
+import { openDatabase, type SqliteDatabase } from '../../../db/sqlite.js';
+import { runMigrations } from '../../../db/migrations/runner.js';
+import {
+  decideGetCrashLogQuery,
+  makeGetCrashLogHandler,
+  SERVER_LIMIT_CAP,
+} from '../get-crash-log.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PRINCIPAL_ALICE: Principal = {
+  kind: 'local-user',
+  uid: '1000',
+  displayName: 'alice',
+};
+const PRINCIPAL_BOB: Principal = {
+  kind: 'local-user',
+  uid: '1001',
+  displayName: 'bob',
+};
+
+let db: SqliteDatabase;
+
+beforeEach(() => {
+  db = openDatabase(':memory:');
+  runMigrations(db);
+});
+
+afterEach(() => {
+  db.close();
+});
+
+function ctxWith(principal: Principal | null): HandlerContext {
+  const values = createContextValues();
+  values.set(PRINCIPAL_KEY, principal);
+  return { values } as HandlerContext;
+}
+
+function makeReq(opts: {
+  limit?: number;
+  sinceUnixMs?: bigint;
+  ownerFilter?: OwnerFilter;
+  requestId?: string;
+} = {}) {
+  return create(GetCrashLogRequestSchema, {
+    meta: create(RequestMetaSchema, { requestId: opts.requestId ?? 'rid-1' }),
+    sinceUnixMs: opts.sinceUnixMs ?? 0n,
+    limit: opts.limit ?? 0,
+    ownerFilter: opts.ownerFilter ?? OwnerFilter.UNSPECIFIED,
+  });
+}
+
+function insertCrashRow(opts: {
+  id: string;
+  ts_ms: number;
+  source: string;
+  summary: string;
+  detail: string;
+  labels_json: string;
+  owner_id: string;
+}): void {
+  db.prepare(
+    `INSERT INTO crash_log (id, ts_ms, source, summary, detail, labels_json, owner_id)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    opts.id,
+    opts.ts_ms,
+    opts.source,
+    opts.summary,
+    opts.detail,
+    opts.labels_json,
+    opts.owner_id,
+  );
+}
+
+function expectErrorDetailCode(err: ConnectError, expected: string): void {
+  const details = err.findDetails(ErrorDetailSchema) as ErrorDetail[];
+  expect(details.length).toBeGreaterThanOrEqual(1);
+  expect(details[0].code).toBe(expected);
+}
+
+// ---------------------------------------------------------------------------
+// Specs
+// ---------------------------------------------------------------------------
+
+describe('CrashService.GetCrashLog — constants (Task #472)', () => {
+  it('SERVER_LIMIT_CAP is 1000 (forever-stable per spec ch04 §5)', () => {
+    expect(SERVER_LIMIT_CAP).toBe(1000);
+  });
+});
+
+describe('CrashService.GetCrashLog — decideGetCrashLogQuery (Task #472)', () => {
+  it('normalises limit=0 (proto3 default) to SERVER_LIMIT_CAP', () => {
+    const plan = decideGetCrashLogQuery(makeReq({ limit: 0 }));
+    expect(plan.effectiveLimit).toBe(SERVER_LIMIT_CAP);
+  });
+
+  it('keeps limit in range [1, cap-1] verbatim', () => {
+    const plan = decideGetCrashLogQuery(makeReq({ limit: 500 }));
+    expect(plan.effectiveLimit).toBe(500);
+  });
+
+  it('caps oversized limit at SERVER_LIMIT_CAP', () => {
+    const plan = decideGetCrashLogQuery(makeReq({ limit: 2000 }));
+    expect(plan.effectiveLimit).toBe(SERVER_LIMIT_CAP);
+  });
+
+  it('coerces negative since_unix_ms to 0 (defensive — column never holds negatives)', () => {
+    const plan = decideGetCrashLogQuery(makeReq({ sinceUnixMs: -1234n }));
+    expect(plan.sinceUnixMs).toBe(0);
+  });
+
+  it('keeps positive since_unix_ms (round-tripped through Number)', () => {
+    const plan = decideGetCrashLogQuery(makeReq({ sinceUnixMs: 1_700_000_000_000n }));
+    expect(plan.sinceUnixMs).toBe(1_700_000_000_000);
+  });
+
+  it('passes ownerFilter through unchanged (decider does not enforce policy)', () => {
+    const plan = decideGetCrashLogQuery(makeReq({ ownerFilter: OwnerFilter.ALL }));
+    expect(plan.ownerFilter).toBe(OwnerFilter.ALL);
+  });
+});
+
+describe('CrashService.GetCrashLog — handler error mapping (Task #472)', () => {
+  it('throws Code.Internal when PRINCIPAL_KEY is missing (daemon wiring bug)', async () => {
+    const handler = makeGetCrashLogHandler({ db });
+    let captured: unknown = null;
+    try {
+      await handler(makeReq(), ctxWith(null));
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    expect((captured as ConnectError).code).toBe(Code.Internal);
+  });
+
+  it('rejects OwnerFilter.ALL with Code.PermissionDenied + session.not_owned (spec ch15 §3 #14)', async () => {
+    const handler = makeGetCrashLogHandler({ db });
+    let captured: unknown = null;
+    try {
+      await handler(
+        makeReq({ ownerFilter: OwnerFilter.ALL }),
+        ctxWith(PRINCIPAL_ALICE),
+      );
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    const err = captured as ConnectError;
+    expect(err.code).toBe(Code.PermissionDenied);
+    expectErrorDetailCode(err, 'session.not_owned');
+    const detail = (err.findDetails(ErrorDetailSchema) as ErrorDetail[])[0];
+    expect(detail.extra.requested_owner_filter).toBe('ALL');
+  });
+
+  it('rejects unknown OwnerFilter enum (forward-compat conservative deny)', async () => {
+    const handler = makeGetCrashLogHandler({ db });
+    let captured: unknown = null;
+    try {
+      // 99 is not a known OwnerFilter value; cast to drive the unknown-enum branch.
+      await handler(
+        makeReq({ ownerFilter: 99 as unknown as OwnerFilter }),
+        ctxWith(PRINCIPAL_ALICE),
+      );
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    const err = captured as ConnectError;
+    expect(err.code).toBe(Code.PermissionDenied);
+    expectErrorDetailCode(err, 'session.not_owned');
+    const detail = (err.findDetails(ErrorDetailSchema) as ErrorDetail[])[0];
+    expect(detail.extra.requested_owner_filter).toBe('99');
+  });
+});
+
+describe('CrashService.GetCrashLog — OWN happy path + rowToProto (Task #472)', () => {
+  it('OWN returns caller rows + DAEMON_SELF rows in ts-DESC order, echoes meta', async () => {
+    insertCrashRow({
+      id: 'A',
+      ts_ms: 100,
+      source: 'sqlite_open',
+      summary: 'old',
+      detail: 'd',
+      labels_json: '{}',
+      owner_id: principalKey(PRINCIPAL_ALICE),
+    });
+    insertCrashRow({
+      id: 'B',
+      ts_ms: 300,
+      source: 'claude_exit',
+      summary: 'newest',
+      detail: 'd',
+      labels_json: '{"k":"v","drop":42,"k2":"v2"}',
+      owner_id: DAEMON_SELF,
+    });
+    insertCrashRow({
+      id: 'C',
+      ts_ms: 200,
+      source: 'foreign',
+      summary: 'hidden',
+      detail: 'd',
+      labels_json: '{}',
+      owner_id: principalKey(PRINCIPAL_BOB),
+    });
+
+    const handler = makeGetCrashLogHandler({ db });
+    const resp = await handler(
+      makeReq({ ownerFilter: OwnerFilter.OWN, requestId: 'rid-2' }),
+      ctxWith(PRINCIPAL_ALICE),
+    );
+
+    expect(resp.meta?.requestId).toBe('rid-2');
+    // Bob's row C is filtered out by SQL (owner_id IN (alice, daemon-self)).
+    // Order: ts DESC -> B(300), A(100).
+    const entries = resp.entries ?? [];
+    const ids = entries.map((e) => e.id);
+    expect(ids).toEqual(['B', 'A']);
+    // rowToProto: only string-valued labels survive the filter.
+    const bLabels = entries[0].labels;
+    expect(bLabels).toEqual({ k: 'v', k2: 'v2' });
+    expect(entries[0].tsUnixMs).toBe(300n);
+    expect(entries[0].ownerId).toBe(DAEMON_SELF);
+  });
+
+  it('rowToProto falls back to empty labels on corrupt JSON (defensive)', async () => {
+    insertCrashRow({
+      id: 'X',
+      ts_ms: 1,
+      source: 's',
+      summary: 'sum',
+      detail: 'det',
+      labels_json: '{not json',
+      owner_id: principalKey(PRINCIPAL_ALICE),
+    });
+    const handler = makeGetCrashLogHandler({ db });
+    const resp = await handler(
+      makeReq({ ownerFilter: OwnerFilter.OWN }),
+      ctxWith(PRINCIPAL_ALICE),
+    );
+    const entries = resp.entries ?? [];
+    expect(entries.length).toBe(1);
+    expect(entries[0].labels).toEqual({});
+    expect(entries[0].summary).toBe('sum');
+  });
+});

--- a/packages/daemon/src/rpc/crash/__tests__/watch-crash-log-handler.spec.ts
+++ b/packages/daemon/src/rpc/crash/__tests__/watch-crash-log-handler.spec.ts
@@ -1,0 +1,394 @@
+// packages/daemon/src/rpc/crash/__tests__/watch-crash-log-handler.spec.ts
+//
+// Task #472 (T8.14b-7c) — daemon src/rpc/ coverage push for the
+// production CrashService.WatchCrashLog server-streaming handler. PR #1061
+// (Task #437) audited rpc/ and excluded `crash/watch-crash-log.ts` because
+// `#435 owns crash/`. PR #1060 (Task #435) shipped fileSink coverage but
+// did NOT add a direct unit spec for the rpc/crash watch handler — the
+// only direct unit spec for streaming RPCs in src/rpc/ today is
+// `pty-attach.spec.ts` and `crash/__tests__/get-raw-crash-log.spec.ts`.
+// `test/integration/crash-stream.spec.ts` covers it end-to-end but is
+// pre-existing-flaky on the same hook-timeout pattern as the other wired
+// integration specs (see PR #1060 / #1061 PR bodies).
+//
+// Scope (one branch per `it`):
+//   1. decideOwnerScope — UNSPECIFIED → 'own'
+//   2. decideOwnerScope — OWN         → 'own'
+//   3. decideOwnerScope — ALL         → 'reject_permission_denied' (spec ch15 §3 #14)
+//   4. decideOwnerScope — unknown     → 'reject_permission_denied' (forward-compat)
+//   5. isVisibleToCaller — entry owned by caller passes
+//   6. isVisibleToCaller — entry owned by DAEMON_SELF passes
+//   7. isVisibleToCaller — entry owned by other principal hidden
+//   8. isVisibleToCaller — reject_permission_denied scope hides everything
+//   9. rawEntryToProto — labels are copied (mutation isolation)
+//  10. subscribeAsAsyncIterable — emit-then-pull yields filtered events in order
+//  11. subscribeAsAsyncIterable — visibility filter rejects non-matching
+//      events at the boundary (they never enter the buffer)
+//  12. subscribeAsAsyncIterable — bufferSize overflow throws ResourceExhausted
+//      from next() and detaches the listener
+//  13. subscribeAsAsyncIterable — abort signal closes iterator with done:true
+//      and detaches listener
+//  14. handler — missing PRINCIPAL_KEY → Code.Internal
+//  15. handler — OwnerFilter.ALL       → Code.PermissionDenied + session.not_owned
+//  16. handler — unknown enum          → Code.PermissionDenied + session.not_owned
+//  17. handler — happy path: emits → handler yields proto entry; abort closes generator
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  Code,
+  ConnectError,
+  createContextValues,
+  type HandlerContext,
+} from '@connectrpc/connect';
+
+import {
+  ErrorDetailSchema,
+  OwnerFilter,
+  type ErrorDetail,
+} from '@ccsm/proto';
+import { create } from '@bufbuild/protobuf';
+import { WatchCrashLogRequestSchema, RequestMetaSchema } from '@ccsm/proto';
+
+import { PRINCIPAL_KEY, principalKey, type Principal } from '../../../auth/index.js';
+import { CrashEventBus } from '../../../crash/event-bus.js';
+import type { CrashRawEntry } from '../../../crash/raw-appender.js';
+import { DAEMON_SELF } from '../../../crash/sources.js';
+import {
+  DEFAULT_WATCH_BUFFER_SIZE,
+  decideOwnerScope,
+  isVisibleToCaller,
+  makeWatchCrashLogHandler,
+  rawEntryToProto,
+  subscribeAsAsyncIterable,
+} from '../watch-crash-log.js';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PRINCIPAL_ALICE: Principal = {
+  kind: 'local-user',
+  uid: '1000',
+  displayName: 'alice',
+};
+const ALICE_KEY = principalKey(PRINCIPAL_ALICE);
+const BOB_KEY = 'local-user:1001';
+
+function entry(opts: Partial<CrashRawEntry> & { id: string; owner_id: string }): CrashRawEntry {
+  return {
+    id: opts.id,
+    ts_ms: opts.ts_ms ?? 1,
+    source: opts.source ?? 'sqlite_open',
+    summary: opts.summary ?? 'sum',
+    detail: opts.detail ?? 'det',
+    labels: opts.labels ?? {},
+    owner_id: opts.owner_id,
+  };
+}
+
+function ctxWith(
+  principal: Principal | null,
+  signal?: AbortSignal,
+): HandlerContext {
+  const values = createContextValues();
+  values.set(PRINCIPAL_KEY, principal);
+  return {
+    values,
+    signal: signal ?? new AbortController().signal,
+  } as HandlerContext;
+}
+
+function makeReq(filter: OwnerFilter = OwnerFilter.OWN) {
+  return create(WatchCrashLogRequestSchema, {
+    meta: create(RequestMetaSchema, { requestId: 'rid-1' }),
+    ownerFilter: filter,
+  });
+}
+
+function expectErrorDetailCode(err: ConnectError, expected: string): void {
+  const details = err.findDetails(ErrorDetailSchema) as ErrorDetail[];
+  expect(details.length).toBeGreaterThanOrEqual(1);
+  expect(details[0].code).toBe(expected);
+}
+
+// ---------------------------------------------------------------------------
+// decideOwnerScope
+// ---------------------------------------------------------------------------
+
+describe('CrashService.WatchCrashLog — decideOwnerScope (Task #472)', () => {
+  it('UNSPECIFIED maps to own (treated as OWN per crash.proto comment)', () => {
+    expect(decideOwnerScope(OwnerFilter.UNSPECIFIED)).toEqual({ kind: 'own' });
+  });
+  it('OWN maps to own', () => {
+    expect(decideOwnerScope(OwnerFilter.OWN)).toEqual({ kind: 'own' });
+  });
+  it('ALL maps to reject_permission_denied (spec ch15 §3 #14)', () => {
+    expect(decideOwnerScope(OwnerFilter.ALL)).toEqual({
+      kind: 'reject_permission_denied',
+    });
+  });
+  it('unknown enum maps to reject_permission_denied (forward-compat conservative deny)', () => {
+    expect(decideOwnerScope(99 as unknown as OwnerFilter)).toEqual({
+      kind: 'reject_permission_denied',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isVisibleToCaller
+// ---------------------------------------------------------------------------
+
+describe('CrashService.WatchCrashLog — isVisibleToCaller (Task #472)', () => {
+  it('OWN scope: entry owned by caller is visible', () => {
+    const e = entry({ id: '1', owner_id: ALICE_KEY });
+    expect(isVisibleToCaller(e, { kind: 'own' }, ALICE_KEY)).toBe(true);
+  });
+  it('OWN scope: entry owned by DAEMON_SELF is visible (ch09 §1 sentinel)', () => {
+    const e = entry({ id: '2', owner_id: DAEMON_SELF });
+    expect(isVisibleToCaller(e, { kind: 'own' }, ALICE_KEY)).toBe(true);
+  });
+  it('OWN scope: entry owned by another principal is hidden', () => {
+    const e = entry({ id: '3', owner_id: BOB_KEY });
+    expect(isVisibleToCaller(e, { kind: 'own' }, ALICE_KEY)).toBe(false);
+  });
+  it('reject_permission_denied scope hides everything (defensive — sink filtered first)', () => {
+    const e = entry({ id: '4', owner_id: ALICE_KEY });
+    expect(
+      isVisibleToCaller(e, { kind: 'reject_permission_denied' }, ALICE_KEY),
+    ).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rawEntryToProto
+// ---------------------------------------------------------------------------
+
+describe('CrashService.WatchCrashLog — rawEntryToProto (Task #472)', () => {
+  it('copies labels (downstream proto mutation must not affect source)', () => {
+    const src = entry({
+      id: 'A',
+      ts_ms: 42,
+      owner_id: ALICE_KEY,
+      labels: { k: 'v' },
+    });
+    const proto = rawEntryToProto(src);
+    expect(proto.id).toBe('A');
+    expect(proto.tsUnixMs).toBe(42n);
+    expect(proto.labels).toEqual({ k: 'v' });
+    // Mutate proto labels — source must not change.
+    proto.labels.k = 'mutated';
+    expect(src.labels.k).toBe('v');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// subscribeAsAsyncIterable
+// ---------------------------------------------------------------------------
+
+describe('CrashService.WatchCrashLog — subscribeAsAsyncIterable (Task #472)', () => {
+  it('default buffer size is 1024 (matches WatchSessions adapter)', () => {
+    expect(DEFAULT_WATCH_BUFFER_SIZE).toBe(1024);
+  });
+
+  it('yields filtered events in emit order', async () => {
+    const bus = new CrashEventBus();
+    const iter = subscribeAsAsyncIterable(bus, {
+      visible: () => true,
+    })[Symbol.asyncIterator]();
+
+    const e1 = entry({ id: '1', owner_id: ALICE_KEY });
+    const e2 = entry({ id: '2', owner_id: ALICE_KEY });
+    bus.emitCrashAdded(e1);
+    bus.emitCrashAdded(e2);
+
+    const r1 = await iter.next();
+    const r2 = await iter.next();
+    expect(r1.value?.id).toBe('1');
+    expect(r2.value?.id).toBe('2');
+
+    await iter.return?.(undefined);
+    expect(bus.listenerCount()).toBe(0);
+  });
+
+  it('drops events at the boundary when visible() returns false (buffer never grows)', async () => {
+    const bus = new CrashEventBus();
+    const iter = subscribeAsAsyncIterable(bus, {
+      visible: (e) => e.owner_id === ALICE_KEY,
+      bufferSize: 2,
+    })[Symbol.asyncIterator]();
+
+    // Emit 5 invisible events — they MUST NOT exhaust the bufferSize=2 limit.
+    for (let i = 0; i < 5; i++) {
+      bus.emitCrashAdded(entry({ id: `bob${i}`, owner_id: BOB_KEY }));
+    }
+    // Now emit one visible event — should be readable.
+    bus.emitCrashAdded(entry({ id: 'alice-1', owner_id: ALICE_KEY }));
+
+    const r = await iter.next();
+    expect(r.value?.id).toBe('alice-1');
+    await iter.return?.(undefined);
+  });
+
+  it('overflow past bufferSize closes the stream with Code.ResourceExhausted', async () => {
+    const bus = new CrashEventBus();
+    const iter = subscribeAsAsyncIterable(bus, {
+      visible: () => true,
+      bufferSize: 2,
+    })[Symbol.asyncIterator]();
+
+    // Emit 3 events without consuming — bufferSize=2 should trip overflow on
+    // the 3rd. Listener detaches itself when overflow fires.
+    bus.emitCrashAdded(entry({ id: '1', owner_id: ALICE_KEY }));
+    bus.emitCrashAdded(entry({ id: '2', owner_id: ALICE_KEY }));
+    bus.emitCrashAdded(entry({ id: '3', owner_id: ALICE_KEY }));
+
+    expect(bus.listenerCount()).toBe(0);
+
+    // Drain the 2 buffered events first.
+    const r1 = await iter.next();
+    const r2 = await iter.next();
+    expect(r1.value?.id).toBe('1');
+    expect(r2.value?.id).toBe('2');
+
+    // The 3rd next() throws the bufferError.
+    let captured: unknown = null;
+    try {
+      await iter.next();
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    expect((captured as ConnectError).code).toBe(Code.ResourceExhausted);
+  });
+
+  it('aborted signal closes iterator with done:true and detaches listener', async () => {
+    const bus = new CrashEventBus();
+    const ac = new AbortController();
+    const iter = subscribeAsAsyncIterable(bus, {
+      visible: () => true,
+      signal: ac.signal,
+    })[Symbol.asyncIterator]();
+
+    expect(bus.listenerCount()).toBe(1);
+
+    // Pending next() then abort — should resolve with done:true.
+    const pending = iter.next();
+    ac.abort();
+    const r = await pending;
+    expect(r.done).toBe(true);
+    expect(bus.listenerCount()).toBe(0);
+  });
+
+  it('pre-aborted signal yields done:true immediately and never subscribes', async () => {
+    const bus = new CrashEventBus();
+    const ac = new AbortController();
+    ac.abort();
+    const iter = subscribeAsAsyncIterable(bus, {
+      visible: () => true,
+      signal: ac.signal,
+    })[Symbol.asyncIterator]();
+
+    const r = await iter.next();
+    expect(r.done).toBe(true);
+    // Listener was attached then immediately removed by onAbort().
+    expect(bus.listenerCount()).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// makeWatchCrashLogHandler — sink
+// ---------------------------------------------------------------------------
+
+describe('CrashService.WatchCrashLog — handler error mapping (Task #472)', () => {
+  let bus: CrashEventBus;
+  beforeEach(() => {
+    bus = new CrashEventBus();
+  });
+  afterEach(() => {
+    expect(bus.listenerCount()).toBe(0);
+  });
+
+  it('throws Code.Internal when PRINCIPAL_KEY is missing', async () => {
+    const handler = makeWatchCrashLogHandler({ bus });
+    const gen = handler(makeReq(), ctxWith(null))[Symbol.asyncIterator]();
+    let captured: unknown = null;
+    try {
+      await gen.next();
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    expect((captured as ConnectError).code).toBe(Code.Internal);
+  });
+
+  it('rejects OwnerFilter.ALL with Code.PermissionDenied + session.not_owned', async () => {
+    const handler = makeWatchCrashLogHandler({ bus });
+    const gen = handler(makeReq(OwnerFilter.ALL), ctxWith(PRINCIPAL_ALICE))[
+      Symbol.asyncIterator
+    ]();
+    let captured: unknown = null;
+    try {
+      await gen.next();
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    const err = captured as ConnectError;
+    expect(err.code).toBe(Code.PermissionDenied);
+    expectErrorDetailCode(err, 'session.not_owned');
+    const detail = (err.findDetails(ErrorDetailSchema) as ErrorDetail[])[0];
+    expect(detail.extra.requested_owner_filter).toBe('ALL');
+  });
+
+  it('rejects unknown OwnerFilter enum with Code.PermissionDenied + session.not_owned', async () => {
+    const handler = makeWatchCrashLogHandler({ bus });
+    const gen = handler(
+      makeReq(99 as unknown as OwnerFilter),
+      ctxWith(PRINCIPAL_ALICE),
+    )[Symbol.asyncIterator]();
+    let captured: unknown = null;
+    try {
+      await gen.next();
+    } catch (err) {
+      captured = err;
+    }
+    expect(captured).toBeInstanceOf(ConnectError);
+    const err = captured as ConnectError;
+    expect(err.code).toBe(Code.PermissionDenied);
+    expectErrorDetailCode(err, 'session.not_owned');
+    const detail = (err.findDetails(ErrorDetailSchema) as ErrorDetail[])[0];
+    expect(detail.extra.requested_owner_filter).toBe('99');
+  });
+});
+
+describe('CrashService.WatchCrashLog — handler happy path (Task #472)', () => {
+  it('emits visible bus events as proto CrashEntry; abort closes generator cleanly', async () => {
+    const bus = new CrashEventBus();
+    const ac = new AbortController();
+    const handler = makeWatchCrashLogHandler({ bus });
+    const gen = handler(
+      makeReq(OwnerFilter.OWN),
+      ctxWith(PRINCIPAL_ALICE, ac.signal),
+    )[Symbol.asyncIterator]();
+
+    // Kick the generator (registers the bus listener) before emitting.
+    const firstPending = gen.next();
+    // Emit one alice event + one foreign event (filtered out).
+    bus.emitCrashAdded(entry({ id: 'self-1', ts_ms: 7, owner_id: DAEMON_SELF }));
+    bus.emitCrashAdded(entry({ id: 'bob-1', owner_id: BOB_KEY }));
+
+    const first = await firstPending;
+    expect(first.done).toBe(false);
+    const v = first.value;
+    expect(v).toBeDefined();
+    expect(v?.id).toBe('self-1');
+    expect(v?.tsUnixMs).toBe(7n);
+
+    // Abort -> next() resolves done:true; bus listener detaches.
+    const secondPending = gen.next();
+    ac.abort();
+    const second = await secondPending;
+    expect(second.done).toBe(true);
+    expect(bus.listenerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Task #472 (T8.14b-7c)

src/rpc/ coverage push for the production CrashService handlers that PR
#1061 (Task #437) explicitly excluded as `#435 owns crash/`. PR #1060
(Task #435) shipped `crash/sources.ts` fileSink coverage but did NOT
add direct unit specs for the rpc/crash handlers — only the wire
integration spec hits these branches end-to-end. This PR fills the gap.

## Baseline self-check (host: windows-11)

`ls packages/daemon/src/rpc/crash/__tests__/` on origin/working showed
only `get-raw-crash-log.spec.ts`. Confirmed by reading PR #1061 body
("`crash/get-crash-log.ts` (unary) — gap, but excluded (#435 owns crash/)";
"`crash/watch-crash-log.ts` (streaming) — gap, but excluded (#435 owns crash/)")
and PR #1060 files (only `crash/sources-file-sink.spec.ts`, 0 rpc/ touched).

## Changes

- `packages/daemon/src/rpc/crash/__tests__/get-crash-log-handler.spec.ts` (12 it)
  - SERVER_LIMIT_CAP = 1000 pin
  - `decideGetCrashLogQuery`: limit normalisation (0 / in-range / over-cap),
    `sinceUnixMs` coercion (negative -> 0, positive kept), ownerFilter
    pass-through (decider does not enforce policy)
  - handler error mapping: missing PRINCIPAL_KEY -> `Code.Internal`,
    `OwnerFilter.ALL` -> `Code.PermissionDenied` + `session.not_owned`,
    unknown enum -> `Code.PermissionDenied` + `session.not_owned`
  - OWN happy path: SQL filter excludes foreign principals, includes
    DAEMON_SELF, ts-DESC ordering, `req.meta` echoed, `rowToProto`
    labels JSON parse + non-string drop
  - `rowToProto` corrupt JSON falls back to empty labels (defensive)

- `packages/daemon/src/rpc/crash/__tests__/watch-crash-log-handler.spec.ts` (19 it)
  - `decideOwnerScope`: 4 enum branches (UNSPECIFIED/OWN -> own; ALL ->
    reject; unknown -> reject)
  - `isVisibleToCaller`: caller-owned, DAEMON_SELF sentinel, foreign
    hidden, `reject_permission_denied` scope hides everything
  - `rawEntryToProto`: labels are copied (downstream proto mutation does
    not affect source)
  - `subscribeAsAsyncIterable`: `DEFAULT_WATCH_BUFFER_SIZE = 1024` pin,
    FIFO emit-then-pull, visibility filter at boundary (non-matching
    events never enter the buffer — invisible storm cannot exhaust),
    bufferSize overflow throws `Code.ResourceExhausted` from `next()`
    and detaches the bus listener, abort signal closes iterator with
    `done:true` and detaches, pre-aborted signal yields done immediately
  - handler error mapping: missing PRINCIPAL_KEY, ALL, unknown enum
  - handler happy path: emit -> handler yields proto entry; abort closes
    generator cleanly + listener detaches

No `src/` behaviour changed (READ-only per task spec).

Files: 2 NEW, 0 src/ touched. **No hot-file collision** with #464 PR
#1069 (it touches `src/rpc/router.ts` + `src/rpc/pty/check-claude-available.ts`;
this PR only adds files under `src/rpc/crash/__tests__/`).

## Local checks (host: windows-11)

- lint: PASS (0 errors, 67 baseline warnings unrelated)
- typecheck: PASS (`tsc -p tsconfig.json --noEmit && tsc -p tsconfig.test.json --noEmit`)
- build: not applicable (test-only files; pretest already ran the
  inline-migrations + sea-bundle tooling)
- new specs alone (`vitest run src/rpc/crash/__tests__/get-crash-log-handler.spec.ts src/rpc/crash/__tests__/watch-crash-log-handler.spec.ts`):
  ```
  Test Files  2 passed (2)
       Tests  31 passed (31)
    Duration  ~2.3s
  ```
- daemon full test (`pnpm --filter @ccsm/daemon test`):
  ```
  Test Files  5 failed | 150 passed | 1 skipped (156)
       Tests  7 failed | 1770 passed | 20 skipped | 5 todo (1802)
  ```
  All 7 failures pre-existing on origin/working (`test/integration/*-wired.spec.ts`
  + `bundle/no-jwt-in-v03` host-load timeout — passes in isolation:
  `Test Files 1 passed (1) / Tests 3 passed (3) / 1.26s`). Same baseline
  noted in PR #1060 + #1061 PR bodies. **No new failures introduced.**

## Reverse-verify (per-branch — coverage push, not a bug fix)

Not a bug fix, so no reverse-verify required by dev.md §3. Each new
`it` exercises a distinct branch in source. Spot-check evidence the
gates are real:

- Mutating `decideGetCrashLogQuery` to ignore the cap (`effectiveLimit
  = rawLimit`) causes the over-cap and limit=0 specs to FAIL.
- Removing the `OwnerFilter.ALL` `throwError` branch in
  `makeGetCrashLogHandler` causes the ALL-rejection spec to FAIL
  (handler would return rows).
- Replacing the visibility filter in `subscribeAsAsyncIterable` with
  `() => true` causes the boundary-drop spec to overflow at
  `bufferSize=2`.

Refs: Task #472, depends on PR #1061 (merged), companion to PR #1060.