### PR TITLE
docs(daemon/bench): add [BENCH-INFO] tags + skip policy note (T493) [rebased from #1073]

### DIFF
--- a/packages/daemon/test/bench/README.md
+++ b/packages/daemon/test/bench/README.md
@@ -40,3 +40,8 @@ this PR is on the hook for.
 All numbers here are **advisory**. The one blocking perf gate is SendInput
 p99, and that is enforced by the dedicated soak harness (Task #92), not by
 this bench suite.
+
+## Bench skip policy
+
+5 个 bench skip 是 perf gate, 不是 ship gate。v0.4 接通后 unskip (Task #468)。
+v0.3 PR CI 不跑 bench, audit 脚本 (Task #494) 验注释 tag 合规。

--- a/packages/daemon/test/bench/cold-start.bench.ts
+++ b/packages/daemon/test/bench/cold-start.bench.ts
@@ -1,4 +1,5 @@
 // packages/daemon/test/bench/cold-start.bench.ts
+// [BENCH-INFO: deferred to v0.4 — see Task #468 for real wire-up after T1.7 Supervisor /healthz]
 //
 // T8.13 — daemon cold-start latency: spawn(daemon) -> GET /healthz returns
 // 200 with {ready: true}. Wall-clock ms, single-shot per iteration.

--- a/packages/daemon/test/bench/hello-rtt.bench.ts
+++ b/packages/daemon/test/bench/hello-rtt.bench.ts
@@ -1,4 +1,5 @@
 // packages/daemon/test/bench/hello-rtt.bench.ts
+// [BENCH-INFO: deferred to v0.4 — see Task #468 for real wire-up after T1.7 Supervisor /healthz]
 //
 // T8.13 — Hello RPC round-trip latency. Single client, sequential calls,
 // p50/p99 reported by tinybench's built-in samples histogram.

--- a/packages/daemon/test/bench/rss.bench.ts
+++ b/packages/daemon/test/bench/rss.bench.ts
@@ -1,4 +1,5 @@
 // packages/daemon/test/bench/rss.bench.ts
+// [BENCH-INFO: deferred to v0.4 — see Task #468 for real wire-up after T1.7 Supervisor /healthz]
 //
 // T8.13 — daemon resident-set memory after warmup. Spawns the daemon,
 // runs a representative warmup workload (N sessions opened, M Hello

--- a/packages/daemon/test/bench/sendinput-rtt.bench.ts
+++ b/packages/daemon/test/bench/sendinput-rtt.bench.ts
@@ -1,4 +1,5 @@
 // packages/daemon/test/bench/sendinput-rtt.bench.ts
+// [BENCH-INFO: deferred to v0.4 — see Task #468 for real wire-up after T1.7 Supervisor /healthz]
 //
 // T8.13 — SendInput end-to-end round-trip: client writes 1 byte via
 // SendInput, daemon forwards to pty-host, pty echoes, daemon streams the

--- a/packages/daemon/test/bench/snapshot-encode.bench.ts
+++ b/packages/daemon/test/bench/snapshot-encode.bench.ts
@@ -1,4 +1,5 @@
 // packages/daemon/test/bench/snapshot-encode.bench.ts
+// [BENCH-INFO: deferred to v0.4 — see Task #468 for real wire-up after T1.7 Supervisor /healthz]
 //
 // T8.13 — SnapshotV1 encode throughput in bytes/sec. Pure-CPU bench:
 // build a representative terminal snapshot (e.g. 80x24 with mixed


### PR DESCRIPTION
Cherry-picked from #1073 onto current origin/working tip (working history was squash-rewritten, original #1073 lost共同祖先 → cannot rebase).

Original commit: 3a5b087 (#1073)
Re-based as: 5655cdd

Original PR #1073 will be closed in favor of this one.

## Why
v0.3 zero-skip blocker MARK pass: 5 bench.skip files in packages/daemon/test/bench/ are not deleted and not wired up; they're perf-gate (not ship-gate) and are deferred to v0.4 (Task #468). Each gets [BENCH-INFO] header tag for audit (Task #494).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>