### PR TITLE
ci: exclude v0.4 e2e specs from v0.3 PR vitest run (T492) [rebased from #1076]

### DIFF
--- a/packages/electron/test/e2e/pty-soak-reconnect.spec.ts
+++ b/packages/electron/test/e2e/pty-soak-reconnect.spec.ts
@@ -1,3 +1,4 @@
+// [V0.4: real impl in #484, excluded from v0.3 PR e2e job — see Task #492]
 // T8.5 — Electron-side companion to the daemon `pty-soak-1h` ship-gate (c).
 // Canonical path locked by design spec ch12 §4.3 (single source of truth):
 //   "Electron-side reattach companion: packages/electron/test/e2e/pty-soak-reconnect.spec.ts"

--- a/packages/electron/test/e2e/sigkill-reattach.spec.ts
+++ b/packages/electron/test/e2e/sigkill-reattach.spec.ts
@@ -1,3 +1,4 @@
+// [V0.4: real impl in #484, excluded from v0.3 PR e2e job — see Task #492]
 // T8.3 — Ship-gate (b): daemon survives Electron SIGKILL.
 //
 // Canonical path locked by design spec ch12 §4.2 (single source of truth):

--- a/packages/electron/vitest.config.ts
+++ b/packages/electron/vitest.config.ts
@@ -15,7 +15,7 @@
 //   npx vitest run --config packages/electron/vitest.config.ts
 
 import { fileURLToPath } from 'node:url';
-import { defineConfig } from 'vitest/config';
+import { defineConfig, configDefaults } from 'vitest/config';
 
 // CI installs deps with `npm ci --legacy-peer-deps` (see ci.yml "Install
 // deps") but the repo root `package.json` has no `workspaces` field — only
@@ -43,6 +43,21 @@ export default defineConfig({
       'src/**/*.spec.tsx',
       'test/**/*.spec.ts',
       'test/**/*.spec.tsx',
+    ],
+    // Task #492 — exclude v0.4 placeholder e2e specs from the v0.3 PR
+    // vitest run. Both files implement ship-gate (b)/(c) but the real
+    // bodies are wrapped in `describe.skipIf(...)` placeholders pending
+    // Task #484 (v0.4). On a v0.3 PR they would surface as SKIPPED rows in
+    // the test report, which violates the v0.3 ship-gate "zero skip"
+    // blocker. Excluding them at the collection layer makes them neither
+    // PASS nor SKIP — they're simply not picked up. The spec files remain
+    // git-tracked so v0.4 #484 can drop these two glob entries to re-enable
+    // collection (DROP-safe revert ≤ 5 lines). Do NOT delete the spec
+    // files; do NOT add `.skip` inside them.
+    exclude: [
+      ...configDefaults.exclude,
+      'test/e2e/sigkill-reattach.spec.ts',
+      'test/e2e/pty-soak-reconnect.spec.ts',
     ],
     globals: false,
     // E2E specs spawn real Electron + daemon subprocesses (per-PR variant


### PR DESCRIPTION
Cherry-picked from #1076 onto current origin/working (working history was squash-rewritten).

Original commit: 36a5ad8 (#1076)

## Why
v0.3 ship-gate zero-skip blocker: ship-gate (b) sigkill-reattach + (c) pty-soak-reconnect are v0.4 真做 (#483/#484), v0.3 不能让它们出现在 PR 必跑 e2e job 里。Workflow 层 file-pattern 排除, v0.4 markers 落地时只删排除行 (DROP-safe).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>