### PR TITLE
chore(electron): delete orphan read-default-model.ts shim (Task #518)

### DIFF
--- a/electron/agent/read-default-model.ts
+++ b/electron/agent/read-default-model.ts
@@ -1,4 +1,0 @@
-// TODO(wave0d/agent-cleanup): orphan re-export shim — no current consumer.
-// Real implementation lives in packages/daemon/src/agent/read-default-model.ts.
-// Safe to delete from electron/ when a consumer is rewired (or sooner).
-export * from '../../packages/daemon/src/agent/read-default-model';


### PR DESCRIPTION
## Summary
- DELETE `electron/agent/read-default-model.ts` — orphan ESM re-export shim (4 lines: just `export * from '../../packages/daemon/src/agent/read-default-model'`)
- Wave 0 cleanup Phase 1 (forward-safe: pure deletion, no consumer)
- Real implementation lives in `packages/daemon/src/agent/read-default-model.ts` (untouched)

## Orphan verification
```
$ git grep "agent/read-default-model"
.v0.2-only-files:electron/agent/read-default-model.ts
electron/agent/read-default-model.ts:// Real implementation lives in packages/daemon/src/agent/read-default-model.ts.
electron/agent/read-default-model.ts:export * from '../../packages/daemon/src/agent/read-default-model';
```
Only self-references + the `.v0.2-only-files` audit marker. Zero `import` / `require` consumers.

## audit-override
audit-override: electron/agent/read-default-model.ts (DELETE) -- Wave 0 cleanup Phase 1 per audit verdict; orphan shim no consumer (verified via git grep); reviewer: manager-self-approve

## Local checks (host: windows-11)
- lint: OK (exit 0)
- typecheck: OK (exit 0, `tsc --noEmit && tsc --noEmit -p tsconfig.electron.json` both pass)
- build: OK (exit 0, ` 3 successful, 3 total` turbo)
- unit tests: PRE-EXISTING BASELINE FAILURE — NOT caused by this PR
  - 197 tests fail with `MigrationLockMismatchError: migration lock mismatch for 001_initial.sql: expected sha256=f76859d5..., actual=70838422...`
  - Verified: diff vs origin/working is solely `electron/agent/read-default-model.ts | 4 ----`. A 4-line deletion of an unused ESM re-export cannot influence db migration sha checks.
  - Both `001_initial.sql` and `src/db/locked.ts` were last touched by `2c89554` (Task #501 merge) on origin/working — baseline is born mismatched.
  - Action requested: manager schedule a separate task to fix the `locked.ts` sha vs `001_initial.sql` content drift; out of scope for this delete-only PR.
- e2e (full suite): harness-dnd PASS, harness-ui PASS (14/14), harness-real-cli timeout — pre-existing pty/terminal flake (`waitForTerminalReady ... terminal not ready ... within 60000ms`) on `alt-screen-fits-visible-viewport`, `session-rename-writes-jsonl`, `session-title-syncs-from-jsonl`. Same orphan-deletion argument: cannot affect pty subsystem.

## Acceptance
- [x] file does not exist
- [x] tsc + lint clean
- [x] `git grep "agent/read-default-model"` returns only deleted-file self-refs (which disappear after merge)