### PR TITLE
t7.4-fix(#462): WiX template wix5 schema + esbuild PATH + node-pty staging

### DIFF
--- a/packages/daemon/build/__tests__/install-scripts.spec.ts
+++ b/packages/daemon/build/__tests__/install-scripts.spec.ts
@@ -101,16 +101,30 @@ describe('packages/daemon/build/install/** (spec ch10 §5, T7.4)', () => {
 
     it('declares failure actions: restart x2 + none (ch10 §5.1)', () => {
       // Spec: "restart on first/second failure, run-program on third".
-      // We use Action="none" on third to avoid spawning a recovery exe
-      // until the operator inspects (the installer rollback path is the
+      // We use ThirdFailureActionType="none" to avoid spawning a recovery
+      // exe until the operator inspects (the installer rollback path is the
       // recovery boundary). PR body explains the deviation if reviewer
       // wants the spec literal "run-program".
-      expect(wxs).toMatch(/<ServiceConfigFailureActions/);
-      expect(wxs).toMatch(/Action="restart"[\s\S]*?DelayInSeconds="5"/);
+      //
+      // Task #462 (wix5 migration): WiX 5 dropped the native
+      // <ServiceConfigFailureActions> attribute spelling we used to use
+      // (ResetPeriodInSeconds / Failure DelayInSeconds) and the recommended
+      // replacement is <util:ServiceConfig FirstFailureActionType=...
+      // SecondFailureActionType=... ResetPeriodInDays=... /> per the
+      // WIX1149 advisory. Asserting on the util element here.
+      expect(wxs).toMatch(/<util:ServiceConfig[\s\S]*?FirstFailureActionType="restart"/);
+      expect(wxs).toMatch(/<util:ServiceConfig[\s\S]*?SecondFailureActionType="restart"/);
+      expect(wxs).toMatch(/<util:ServiceConfig[\s\S]*?ThirdFailureActionType="none"/);
     });
 
-    it('declares ServiceSidType="restricted" (ch10 §5.1 verified by sc qsidtype)', () => {
-      expect(wxs).toMatch(/ServiceSidType="restricted"/);
+    it('declares ServiceSid="restricted" (ch10 §5.1 verified by sc qsidtype)', () => {
+      // Task #462 (wix5 migration): WiX 5 dropped the
+      // util:ServiceConfig/@ServiceSidType attribute and moved per-service
+      // SID type onto the native <ServiceConfig> element via the renamed
+      // ServiceSid attribute (values: none/restricted/unrestricted).
+      // sc qsidtype output is unchanged ("RESTRICTED") — only the WiX
+      // surface moved.
+      expect(wxs).toMatch(/<ServiceConfig[\s\S]*?ServiceSid="restricted"/);
     });
 
     it('creates %PROGRAMDATA%\\ccsm state directory with DACL', () => {

--- a/packages/daemon/build/build-sea.ps1
+++ b/packages/daemon/build/build-sea.ps1
@@ -33,8 +33,12 @@ try {
 
   # Step 2: esbuild bundle. Task #480: better-sqlite3 wrapper bundled in
   # (only `bindings` external, unreachable in SEA — see build-sea.sh).
+  # Task #462 fix: use `pnpm exec esbuild` so we resolve to the workspace's
+  # pinned esbuild (devDependency of @ccsm/daemon) via .pnpm bin shim, instead
+  # of `npx --yes esbuild` which on Windows tries to download and frequently
+  # fails (PATH / npm registry / cache permissions).
   Step 'esbuild bundle'
-  npx --yes esbuild dist/index.js `
+  pnpm exec esbuild dist/index.js `
     --bundle `
     --platform=node `
     --target=node22 `

--- a/packages/daemon/build/install/win/Product.wxs.template
+++ b/packages/daemon/build/install/win/Product.wxs.template
@@ -104,38 +104,42 @@
                       Account="NT AUTHORITY\LocalService"
                       Vital="yes">
         <!--
-          ServiceConfig (WiX 4 schema) — failure actions per ch10 §5.1.
-          Restart on first + second failure (60 s reset window); on third
-          failure, do nothing (operator inspection). The MSI must NOT
-          configure a destructive RunCommand for the third action — the
-          installer's healthz-fail rollback path (ch10 §5 step 7) is the
-          recovery boundary.
+          util:ServiceConfig (WiX 5 schema) — failure actions.
+            - Restart on first + second failure (1 day reset window — wix5
+              util uses DAYS, not seconds, for the reset period).
+            - Third failure: none (operator inspection). The MSI must NOT
+              configure a destructive RunCommand for the third action — the
+              installer's healthz-fail rollback path (ch10 §5 step 7) is the
+              recovery boundary.
+
+          WiX 5 dropped native <ServiceConfigFailureActions>'s old attribute
+          spelling (ResetPeriodInSeconds / DelayInSeconds) and removed
+          ServiceSidType from util:ServiceConfig — per-service SID type now
+          lives on the native <ServiceConfig> element via the new ServiceSid
+          attribute (see below).
         -->
-        <ServiceConfigFailureActions Id="CcsmDaemonFailure"
-                                     ResetPeriodInSeconds="60">
-          <Failure Action="restart" DelayInSeconds="5" />
-          <Failure Action="restart" DelayInSeconds="30" />
-          <Failure Action="none"   DelayInSeconds="0" />
-        </ServiceConfigFailureActions>
+        <util:ServiceConfig FirstFailureActionType="restart"
+                            SecondFailureActionType="restart"
+                            ThirdFailureActionType="none"
+                            ResetPeriodInDays="1"
+                            RestartServiceDelayInSeconds="5" />
 
         <!--
-          ServiceConfig (WiX 4 element) — apply at install + reinstall.
-          DelayedAutoStart=no: we want immediate auto-start so /healthz
-          comes up within the installer's 10 s budget.
+          Native ServiceConfig (WiX 5):
+            - DelayedAutoStart="no": immediate auto-start so /healthz comes
+              up within the installer's 10 s budget.
+            - ServiceSid="restricted": SCM SID type "restricted" so the
+              service SID has write access only to objects ACL'd for it
+              (state dir DACL above grants ccsm-daemon SID Modify on
+              STATEDIR). Replaces the WiX 4-era util:ServiceConfig
+              ServiceSidType attribute. Verified by ch10 §5.1 ship-gate:
+              `sc qsidtype ccsm-daemon` returns RESTRICTED.
         -->
         <ServiceConfig DelayedAutoStart="no"
+                       ServiceSid="restricted"
                        OnInstall="yes"
                        OnReinstall="yes" />
       </ServiceInstall>
-
-      <!--
-        util:ServiceConfig — sets SCM SID type "restricted" so the service
-        SID has write access only to objects ACL'd for it (state dir DACL
-        below grants ccsm-daemon SID Modify on STATEDIR). Verified by
-        ch10 §5.1 ship-gate: `sc qsidtype ccsm-daemon` returns RESTRICTED.
-      -->
-      <util:ServiceConfig ServiceName="ccsm-daemon"
-                          ServiceSidType="restricted" />
 
       <ServiceControl Id="CcsmDaemonControl"
                       Name="ccsm-daemon"
@@ -166,14 +170,27 @@
 
     <!--
       State directory (%PROGRAMDATA%\ccsm) — ch07 §2 win32 row.
-      <CreateFolder> + <util:PermissionEx> set the DACL per ch10 §5.1:
+
+      WiX 5 schema notes:
+        - Component <Condition> moved from child element to attribute form.
+        - Component Guid="*" requires a File KeyPath; CreateFolder-only
+          components must use an explicit, stable GUID (never regenerate
+          across releases — these GUIDs travel through MajorUpgrade).
+        - DACL is set via the WiX 5 NATIVE <PermissionEx Sddl="..."/>
+          element (not util:PermissionEx). In wix5 the Sddl attribute moved
+          to the native PermissionEx; util:PermissionEx switched to a
+          user/permission-bit model (User + GenericAll/Read/etc.) without
+          Sddl. SDDL string keeps the DACL self-documenting and 1:1 with
+          the spec — preferred over expanding into multiple per-principal
+          util:PermissionEx children.
+
+      DACL grants per ch10 §5.1 (unchanged from prior schema):
         - LocalService: Modify (so the daemon can write listener-a.json,
           ccsm.db, crash-raw.ndjson).
         - BUILTIN\Users: Read on the directory and on listener-a.json
           specifically (so per-user Electron can read the descriptor
           without joining a group).
-      Permanent="yes" + the REMOVEUSERDATA-gated component below handles
-      the "remove on /qn REMOVEUSERDATA=1" matrix.
+        - BUILTIN\Administrators: Full control.
 
       The descriptor file itself (listener-a.json) is written by the
       daemon at boot (ch07 §2.1, T1.6); the installer creates the
@@ -181,33 +198,28 @@
     -->
     <Component Id="StateDir"
                Directory="STATEDIR"
-               Guid="*">
+               Guid="3e2f7a14-8d6b-4c9a-9f5d-2a1b6c8e7d4f"
+               Condition='NOT REMOVEUSERDATA OR REMOVEUSERDATA="0"'>
       <CreateFolder>
-        <util:PermissionEx Sddl="D:PAI(A;OICI;FA;;;LS)(A;OICI;0x1200a9;;;BU)(A;OICI;FA;;;BA)" />
+        <PermissionEx Id="StateDirAcl" Sddl="D:PAI(A;OICI;FA;;;LS)(A;OICI;0x1200a9;;;BU)(A;OICI;FA;;;BA)" />
       </CreateFolder>
-      <!--
-        Component is permanent unless REMOVEUSERDATA=1. Achieved via two
-        components controlled by Condition; this component holds the DACL
-        and stays put.
-      -->
-      <Condition>NOT REMOVEUSERDATA OR REMOVEUSERDATA="0"</Condition>
     </Component>
 
     <Component Id="StateDirRemovable"
                Directory="STATEDIR"
-               Guid="*">
+               Guid="7c4e9b25-1a3f-4e58-b6c0-9d8e2f5a3b71"
+               Condition='REMOVEUSERDATA="1"'>
       <CreateFolder>
-        <util:PermissionEx Sddl="D:PAI(A;OICI;FA;;;LS)(A;OICI;0x1200a9;;;BU)(A;OICI;FA;;;BA)" />
+        <PermissionEx Id="StateDirRemovableAcl" Sddl="D:PAI(A;OICI;FA;;;LS)(A;OICI;0x1200a9;;;BU)(A;OICI;FA;;;BA)" />
       </CreateFolder>
       <util:RemoveFolderEx On="uninstall" Property="STATEDIR" />
-      <Condition>REMOVEUSERDATA="1"</Condition>
     </Component>
 
     <Component Id="DescriptorsDir"
                Directory="DESCRIPTORSDIR"
-               Guid="*">
+               Guid="b9d6f238-5e1c-4a87-8f2d-3c4b1e6a9d50">
       <CreateFolder>
-        <util:PermissionEx Sddl="D:PAI(A;OICI;FA;;;LS)(A;OICI;0x1200a9;;;BU)(A;OICI;FA;;;BA)" />
+        <PermissionEx Id="DescriptorsDirAcl" Sddl="D:PAI(A;OICI;FA;;;LS)(A;OICI;0x1200a9;;;BU)(A;OICI;FA;;;BA)" />
       </CreateFolder>
     </Component>
 

--- a/packages/daemon/build/stage-native.ps1
+++ b/packages/daemon/build/stage-native.ps1
@@ -59,6 +59,7 @@ if (-not $bsqOk) {
 # node-pty — optional until T4.2 wires the actual spawn path.
 if (Test-Path (Join-Path $PkgDir 'node_modules/node-pty')) {
   Copy-FirstMatch -AddonName 'node-pty' -TargetFilename 'pty.node' -Candidates @(
+    "node_modules/node-pty/prebuilds/$pa/pty.node",
     "node_modules/node-pty/prebuilds/$pa/node-pty.node",
     "node_modules/node-pty/prebuilds/$pa/node.napi.node",
     'node_modules/node-pty/build/Release/pty.node'

--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -40,6 +40,7 @@
     "@connectrpc/connect-node": "^2.1.1",
     "@types/better-sqlite3": "^7.6.12",
     "ajv": "^8.20.0",
+    "esbuild": "^0.27.7",
     "prebuildify": "^6.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
       ajv:
         specifier: ^8.20.0
         version: 8.20.0
+      esbuild:
+        specifier: ^0.27.7
+        version: 0.27.7
       prebuildify:
         specifier: ^6.0.1
         version: 6.0.1


### PR DESCRIPTION
## Summary

Three Windows MSI build blockers fixed so `pnpm package:win-msi` produces a clean MSI on a dev box (Task #462, blocks dogfood #457):

- **WiX 5 schema migration** in `Product.wxs.template`:
  - Failure actions: native `<ServiceConfigFailureActions ResetPeriodInSeconds=... DelayInSeconds=...>` -> `<util:ServiceConfig FirstFailureActionType=... ResetPeriodInDays=... RestartServiceDelayInSeconds=...>` (the WIX1149-blessed replacement; wix5 dropped the `In-Seconds` spelling).
  - Per-service SID: `util:ServiceConfig/@ServiceSidType` -> native `ServiceConfig/@ServiceSid="restricted"` (wix5 moved it; `sc qsidtype` output unchanged).
  - DACL: `util:PermissionEx/@Sddl` -> native wxs `<PermissionEx Sddl="...">` with explicit `Id` per element to avoid `MsiLockPermissionsEx` row collisions; wix5 moved SDDL onto native and switched `util:PermissionEx` to a user/permission-bit model.
  - Component conditions: child `<Condition>` element -> `Component/@Condition` attribute (single-quoted to keep nested `"1"` SDDL readable without `&quot;`).
  - Component GUIDs: `Guid="*"` -> three explicit stable GUIDs on the `CreateFolder`-only components (StateDir, StateDirRemovable, DescriptorsDir). Wix5 rejects auto-GUID when `KeyPath` is a Directory; these GUIDs survive `MajorUpgrade` and must NEVER change.
- **esbuild PATH** in `build-sea.ps1`: `npx --yes esbuild` -> `pnpm exec esbuild` (npx fetched-from-network on Windows often dies on registry/cache permissions). Added `esbuild ^0.27.7` to `packages/daemon` devDeps so `pnpm exec` from that workspace can resolve it via the .pnpm bin shim (it was previously transitive through terser-webpack-plugin only).
- **node-pty staging** in `stage-native.ps1`: added `node_modules/node-pty/prebuilds/$pa/pty.node` as the FIRST candidate. node-pty 1.1.0 ships `pty.node` directly under `prebuilds/win32-x64/` — the previous candidate filenames (`node-pty.node`, `node.napi.node`) never existed for this version. Older fallbacks kept for forward-compat.

Test fixture updates in `build/__tests__/install-scripts.spec.ts` to match the new wix5 element/attribute names (failure-actions assertion now hits `util:ServiceConfig/@FirstFailureActionType` etc.; SID assertion now hits `ServiceConfig/@ServiceSid`).

## Local checks (host: windows-11)
- lint: ✓ (exit 0; 0 errors, 67 warnings — all pre-existing)
- typecheck: ✓ (exit 0)
- daemon vitest install + uninstall scopes: 121/121 passed
- `pnpm --filter @ccsm/daemon run build:sea:win`: ✓ end-to-end (esbuild bundle 498 KB → postject → stage-native produces both `better_sqlite3.node` + `pty.node`)
- `pnpm package:win-msi`: MSI built at `packages/daemon/dist/ccsm-setup-0.2.0-x64.msi` (450 KB). The downstream `verify-signing.ps1` step exits 20 (NotSigned) — out of scope for #462 (signing is T7.3 / #82, dogfood has no `WIN_CERT_PFX`). MSI build itself is clean.

Reverse-verified the 5 baseline integration test fails on `origin/working` are pre-existing flake (not introduced by this PR; tested with patch-file save/restore per dev.md §2).

## Test plan
- [ ] Reviewer with elevated shell: install MSI (`msiexec /i ccsm-setup-0.2.0-x64.msi /qn /l*v install.log`) → `sc query ccsm-daemon` shows RUNNING → `sc qsidtype ccsm-daemon` shows RESTRICTED → uninstall (`msiexec /x .../qn`) leaves `%PROGRAMDATA%\ccsm` intact (default `REMOVEUSERDATA=0`) → re-uninstall with `REMOVEUSERDATA=1` removes it.
- [ ] CI windows matrix runs `package-win-msi` job through to MSI artifact.

Blocks: #457 (dogfood)

🤖 Generated with [Claude Code](https://claude.com/claude-code)