### PR TITLE
test(snapshot-codec): flip 4 it.todo to real production-codec assertions (Task #524)

### DIFF
--- a/packages/daemon/test/pty/snapshot-codec.spec.ts
+++ b/packages/daemon/test/pty/snapshot-codec.spec.ts
@@ -80,6 +80,19 @@ import {
   zstdDecompressSync,
 } from 'node:zlib';
 
+import {
+  CODEC_GZIP as PROD_CODEC_GZIP,
+  CODEC_ZSTD as PROD_CODEC_ZSTD,
+  CURSOR_STYLE_BLOCK as PROD_CURSOR_STYLE_BLOCK,
+  decodeSnapshotV1,
+  encodeSnapshotV1,
+  type BufferLike,
+  type BufferNamespaceLike,
+  type CellLike,
+  type LineLike,
+  type ModesLike,
+  type XtermHeadlessLike,
+} from '@ccsm/snapshot-codec';
 import { describe, expect, it } from 'vitest';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -462,26 +475,214 @@ describe('SnapshotV1 golden binary — ch15 §3 #5 forbidden-pattern fixture (L7
 });
 
 // ---------------------------------------------------------------------------
-// Forward-compat hooks for T4.6 (encoder), T4.7 (decoder), T4.8 (codec
-// wrappers). These flip from `it.todo` to real assertions when the
-// production modules at `packages/snapshot-codec/src/` land.
+// T4.6 / T4.7 / T4.8 production-codec integration. The production modules
+// at `packages/snapshot-codec/src/` are now landed (Tasks #44, #46, #52),
+// so the previous `it.todo` placeholders flip to real assertions that
+// exercise `@ccsm/snapshot-codec`'s {encodeSnapshotV1, decodeSnapshotV1}
+// against the same byte-level contract this spec locks via wrap()/unwrap().
+//
+// Note on inner byte-equality vs. structural equality: the production
+// encoder always emits at least ONE attrs_palette entry (the default-attrs
+// tuple seeded by the first cell scanned, even on an "empty" terminal).
+// `buildCanonicalInner()` above models a 0-entry palette to keep the spec
+// generator hand-derivable from ch06 §2 prose. Both layouts are
+// spec-conformant; therefore production-vs-spec assertions compare the
+// stable observable fields (cols/rows/cursor/viewport/modes-bitmap and the
+// outer-wrapper round-trip) rather than naive byte-level equality of the
+// inner payload.
 // ---------------------------------------------------------------------------
 
-describe('SnapshotV1 production-codec integration — pending downstream tasks', () => {
-  it.todo(
-    'T4.6 (Task #46): @ccsm/snapshot-codec encoder produces the canonical inner ' +
-      'bytes from an empty 80x24 xterm-headless terminal',
-  );
-  it.todo(
-    'T4.7 (Task #44): @ccsm/snapshot-codec decoder applied to the golden zstd wire ' +
-      'yields an xterm-headless state matching the source state',
-  );
-  it.todo(
-    'T4.7 (Task #44): @ccsm/snapshot-codec decoder applied to the golden gzip wire ' +
-      'yields the same xterm-headless state as the zstd wire',
-  );
-  it.todo(
-    'T4.8 (Task #52): @ccsm/snapshot-codec wrap()/unwrap() produce wire bytes ' +
-      'byte-identical to this spec’s reference wrap() for both codecs',
-  );
+/**
+ * Build a structurally-typed `XtermHeadlessLike` representing an empty
+ * 80x24 terminal with all-default attrs / cursor / modes — the same logical
+ * state `buildCanonicalInner()` describes. Used to drive the production
+ * `encodeSnapshotV1` without pulling in `@xterm/headless` as a test dep.
+ */
+function buildEmpty80x24Terminal(): XtermHeadlessLike {
+  const emptyCell: CellLike = {
+    getWidth: () => 1,
+    getChars: () => '',
+    getCode: () => 0,
+    getFgColor: () => 0,
+    getBgColor: () => 0,
+    isFgRGB: () => false,
+    isBgRGB: () => false,
+    isFgPalette: () => false,
+    isBgPalette: () => false,
+    isFgDefault: () => true,
+    isBgDefault: () => true,
+    isBold: () => 0,
+    isItalic: () => 0,
+    isUnderline: () => 0,
+    isBlink: () => 0,
+    isInverse: () => 0,
+    isDim: () => 0,
+    isStrikethrough: () => 0,
+    isInvisible: () => 0,
+  };
+  const emptyLine: LineLike = {
+    length: 80,
+    isWrapped: false,
+    getCell: () => emptyCell,
+  };
+  const buffer: BufferLike = {
+    cursorX: 0,
+    cursorY: 0,
+    baseY: 0,
+    length: 24,
+    getLine: (y) => (y >= 0 && y < 24 ? emptyLine : undefined),
+    getNullCell: () => emptyCell,
+  };
+  const ns: BufferNamespaceLike = {
+    active: buffer,
+    normal: buffer,
+    alternate: {} as BufferLike,
+  };
+  const modes: ModesLike = {
+    applicationCursorKeysMode: false,
+    applicationKeypadMode: false,
+    bracketedPasteMode: false,
+    mouseTrackingMode: 'none',
+    originMode: false,
+    wraparoundMode: true,
+  };
+  return { cols: 80, rows: 24, buffer: ns, modes };
+}
+
+describe('SnapshotV1 production-codec integration (T4.6 / T4.7 / T4.8)', () => {
+  it('T4.6 (Task #46): @ccsm/snapshot-codec encoder produces a spec-conformant inner payload from an empty 80x24 terminal', () => {
+    // Encode via the production encoder, then compare the spec-relevant
+    // outer + inner fields against this spec's reference layout. We do
+    // NOT byte-compare the full inner against `buildCanonicalInner()` —
+    // see the file-header note about attrs_palette: the production
+    // encoder always emits ≥1 palette entry (the default-attrs tuple).
+    const wire = encodeSnapshotV1(buildEmpty80x24Terminal(), {
+      codec: PROD_CODEC_ZSTD,
+    });
+
+    // Outer header — must match this spec's lock-contract byte-for-byte.
+    expect(Buffer.from(wire.subarray(0, 4))).toEqual(OUTER_MAGIC);
+    expect(wire[4]).toBe(CODEC_ZSTD);
+    expect(Buffer.from(wire.subarray(5, 5 + RESERVED_BYTES))).toEqual(
+      Buffer.alloc(RESERVED_BYTES),
+    );
+    const innerLen = Buffer.from(wire).readUInt32LE(8);
+    expect(innerLen).toBe(wire.byteLength - OUTER_HEADER_LEN);
+
+    // Decompress the codec=1 (zstd) inner via this spec's local helpers
+    // (proves the encoder's inner stream is consumable by an independent
+    // implementation — the whole point of locking the wire format).
+    const inner = Buffer.from(zstdDecompressSync(wire.subarray(OUTER_HEADER_LEN)));
+    expect(inner.subarray(0, 4).toString('ascii')).toBe('CSS1');
+    expect(inner.readUInt16LE(4)).toBe(80); // cols
+    expect(inner.readUInt16LE(6)).toBe(24); // rows
+    expect(inner.readUInt32LE(8)).toBe(0); // cursor_row
+    expect(inner.readUInt32LE(12)).toBe(0); // cursor_col
+    expect(inner.readUInt8(16)).toBe(1); // cursor_visible
+    expect(inner.readUInt8(17)).toBe(0); // cursor_style = block
+    expect(inner.readUInt32LE(18)).toBe(0); // scrollback_lines
+    expect(inner.readUInt32LE(22)).toBe(24); // viewport_lines
+  });
+
+  it('T4.7 (Task #44): @ccsm/snapshot-codec decoder applied to the golden zstd wire yields the canonical 80x24 state', () => {
+    const buf = readFileSync(GOLDEN_PATH);
+    const { wireZstd } = parseGolden(buf);
+    // `subarray` returns a view sharing the parent buffer; `decodeSnapshotV1`
+    // takes a Uint8Array, so the Node Buffer view passes structurally.
+    const decoded = decodeSnapshotV1(new Uint8Array(wireZstd));
+
+    expect(decoded.cols).toBe(80);
+    expect(decoded.rows).toBe(24);
+    expect(decoded.cursorRow).toBe(0);
+    expect(decoded.cursorCol).toBe(0);
+    expect(decoded.cursorVisible).toBe(true);
+    expect(decoded.cursorStyle).toBe(PROD_CURSOR_STYLE_BLOCK);
+    expect(decoded.scrollbackLines).toBe(0);
+    expect(decoded.viewportLines).toBe(24);
+    expect(decoded.lines).toHaveLength(24);
+    // Every viewport line is empty + not wrapped (matches buildCanonicalInner).
+    for (const line of decoded.lines) {
+      expect(line.cells).toHaveLength(0);
+      expect(line.wrapped).toBe(false);
+    }
+    // Modes bitmap is all-zero in the golden inner — every decoded boolean
+    // mode (besides cursorVisible which lives outside the bitmap) is false.
+    expect(decoded.modes.applicationCursor).toBe(false);
+    expect(decoded.modes.applicationKeypad).toBe(false);
+    expect(decoded.modes.altScreen).toBe(false);
+    expect(decoded.modes.bracketedPaste).toBe(false);
+    expect(decoded.modes.autoWrap).toBe(false);
+  });
+
+  it('T4.7 (Task #44): @ccsm/snapshot-codec decoder applied to the golden gzip wire yields the same state as the zstd wire', () => {
+    const buf = readFileSync(GOLDEN_PATH);
+    const { wireZstd, wireGzip } = parseGolden(buf);
+    const fromZstd = decodeSnapshotV1(new Uint8Array(wireZstd));
+    const fromGzip = decodeSnapshotV1(new Uint8Array(wireGzip));
+
+    // L6 codec-independence at the production-decoder layer: zstd and gzip
+    // wires MUST decode to structurally-identical SnapshotV1 state.
+    expect(fromGzip.cols).toBe(fromZstd.cols);
+    expect(fromGzip.rows).toBe(fromZstd.rows);
+    expect(fromGzip.cursorRow).toBe(fromZstd.cursorRow);
+    expect(fromGzip.cursorCol).toBe(fromZstd.cursorCol);
+    expect(fromGzip.cursorVisible).toBe(fromZstd.cursorVisible);
+    expect(fromGzip.cursorStyle).toBe(fromZstd.cursorStyle);
+    expect(fromGzip.scrollbackLines).toBe(fromZstd.scrollbackLines);
+    expect(fromGzip.viewportLines).toBe(fromZstd.viewportLines);
+    expect(fromGzip.attrsPalette).toEqual(fromZstd.attrsPalette);
+    expect(fromGzip.lines).toEqual(fromZstd.lines);
+    expect(fromGzip.modes).toEqual(fromZstd.modes);
+    expect(Buffer.from(fromGzip.rawModesBitmap).equals(Buffer.from(fromZstd.rawModesBitmap))).toBe(
+      true,
+    );
+  });
+
+  it('T4.8 (Task #52): @ccsm/snapshot-codec round-trip — both codecs are encoder→decoder lossless and outer wrappers conform to this spec', () => {
+    // Production-encoder output for the same logical state, both codecs:
+    const wireZstd = encodeSnapshotV1(buildEmpty80x24Terminal(), {
+      codec: PROD_CODEC_ZSTD,
+    });
+    const wireGzip = encodeSnapshotV1(buildEmpty80x24Terminal(), {
+      codec: PROD_CODEC_GZIP,
+    });
+
+    // Outer-wrapper layout MUST be the same shape this spec's wrap() emits:
+    // [CSS1][codec][reserved×3][innerLen u32 LE][inner]. We re-parse via
+    // the spec's parseWire() to prove the wire format is stable across
+    // implementations (any drift would surface here as a parse failure).
+    const parsedZstd = parseWire(Buffer.from(wireZstd));
+    expect(parsedZstd.codec).toBe(CODEC_ZSTD);
+    expect(parsedZstd.reserved.equals(Buffer.alloc(RESERVED_BYTES))).toBe(true);
+    expect(parsedZstd.innerLen).toBe(wireZstd.byteLength - OUTER_HEADER_LEN);
+
+    const parsedGzip = parseWire(Buffer.from(wireGzip));
+    expect(parsedGzip.codec).toBe(CODEC_GZIP);
+    expect(parsedGzip.reserved.equals(Buffer.alloc(RESERVED_BYTES))).toBe(true);
+    expect(parsedGzip.innerLen).toBe(wireGzip.byteLength - OUTER_HEADER_LEN);
+
+    // Round-trip via the production decoder — both wires decode and the
+    // decoded states are structurally identical (codec-independent inner).
+    const decZstd = decodeSnapshotV1(new Uint8Array(wireZstd));
+    const decGzip = decodeSnapshotV1(new Uint8Array(wireGzip));
+    expect(decZstd.cols).toBe(80);
+    expect(decZstd.rows).toBe(24);
+    expect(decGzip.cols).toBe(80);
+    expect(decGzip.rows).toBe(24);
+    expect(decGzip.attrsPalette).toEqual(decZstd.attrsPalette);
+    expect(decGzip.lines).toEqual(decZstd.lines);
+    expect(decGzip.modes).toEqual(decZstd.modes);
+
+    // Cross-check: re-wrapping the decoder's view of the inner via this
+    // spec's wrap() lands in the same outer shape (length-equal header,
+    // same codec byte, same reserved zeros). Inner compressed bytes can
+    // differ (zstd is deterministic but the inner-payload bytes differ
+    // between this spec's hand-built canonical inner and the encoder's
+    // 1-palette-entry inner — see the file-header note), so we assert on
+    // the shape, not byte-for-byte equality.
+    const innerFromZstd = Buffer.from(zstdDecompressSync(wireZstd.subarray(OUTER_HEADER_LEN)));
+    const reWrappedZstd = wrap(CODEC_ZSTD, innerFromZstd);
+    expect(parseWire(reWrappedZstd).codec).toBe(CODEC_ZSTD);
+    expect(parseWire(reWrappedZstd).reserved.equals(Buffer.alloc(RESERVED_BYTES))).toBe(true);
+  });
 });

--- a/packages/daemon/vitest.config.ts
+++ b/packages/daemon/vitest.config.ts
@@ -2,9 +2,24 @@
 // source they cover (vs. the root `tests/**/*.test.ts` convention used by
 // the legacy renderer/electron code). Daemon code is pure node — no jsdom.
 
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
+// Resolve `@ccsm/snapshot-codec` directly to its source entry so daemon
+// specs can import the production codec without requiring the sibling
+// package to be pre-built (matches the @ccsm/proto alias pattern in
+// vitest.config.coverage.ts; same root cause — npm ci on CI without a
+// `workspaces` field skips the pnpm symlink).
+const snapshotCodecSrcIndex = fileURLToPath(
+  new URL('../snapshot-codec/src/index.ts', import.meta.url),
+);
+
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@ccsm/snapshot-codec': snapshotCodecSrcIndex,
+    },
+  },
   test: {
     environment: 'node',
     // `eslint-plugins/**` holds the local ESLint plugin source + its


### PR DESCRIPTION
## Summary

Task #524 — R2 audit found 4 `it.todo` placeholders at
`packages/daemon/test/pty/snapshot-codec.spec.ts` L471-486 (T4.6 / T4.7 /
T4.8 forward-compat hooks). Production codec at
`packages/snapshot-codec/src/{encoder,decoder,index}.ts` (~1230 LOC) has
been landed for some time, so the placeholders are stale. v0.3 zero-skip
rule (memory `feedback_v03_no_skip_blocker`) treats `it.todo` as a
skip-class.

**Decision: flip all 4 to real `it()` blocks** (production code lands +
is testable; no need to delete).

## What flipped

| # | Old todo | New real test |
|---|----------|---------------|
| 1 | T4.6 encoder produces canonical inner from empty 80x24 | encode via `encodeSnapshotV1` of a fake 80x24 terminal, assert outer wrapper byte-conforms to lock-spec + zstd-decompressed inner carries spec magic + cols/rows/cursor/viewport |
| 2 | T4.7 decoder zstd → state matches | `decodeSnapshotV1(goldenZstdWire)` → assert cols=80, rows=24, cursor=(0,0,visible,block), viewportLines=24, all-empty lines, all-zero modes |
| 3 | T4.7 decoder gzip → same as zstd | `decodeSnapshotV1(goldenGzipWire)` structurally equals zstd decode (codec-independent inner per L6) |
| 4 | T4.8 wrap/unwrap byte-identical | round-trip both codecs through production encoder, parse outer via this spec's `parseWire()` to prove wire-format stability + decode round-trip |

## Why structural-equality, not byte-equality (T4.6 / T4.8)

The production encoder always emits **>=1 attrs_palette entry** (the
default-attrs tuple seeded by the first cell scanned). This spec's
`buildCanonicalInner()` models palette_len=0 to keep the spec generator
hand-derivable from ch06 §2 prose. Both layouts are spec-conformant;
asserting byte-equality of the inner payload would over-constrain the
encoder. The new tests assert the spec-relevant observable fields
(magic / cols / rows / cursor / viewport / modes-bitmap / outer
wrapper layout) — a file-header note above the new `describe` block
documents this.

## Vitest config change

`packages/daemon/vitest.config.ts` now aliases `@ccsm/snapshot-codec` to
`../snapshot-codec/src/index.ts`, mirroring the `@ccsm/proto` alias in
`vitest.config.coverage.ts`. Same root cause: monorepo lacks
`workspaces` field at root, so `npm ci` on CI doesn't symlink siblings.

## Local checks (host: windows-11)

- lint (daemon src): OK (exit 0; 67 pre-existing warnings, 0 errors)
- typecheck: OK (exit 0)
- daemon `test/pty/snapshot-codec.spec.ts`: **22 passed** (18 prior + 4 new)
- daemon full `pnpm -F @ccsm/daemon test`: 4 integration spec files fail
  with hook-timeouts (`crash-getlog-wired` / `crash-watch-wired` /
  `watch-sessions-wired` / `src/rpc integration.spec.ts`) — verified
  these **also fail on clean `origin/working`** (saved patch, reverted,
  re-ran — same 6 tests red), so pre-existing flakiness, **NOT
  introduced by this PR**.

## Test plan

- [x] `it.todo` count in file = 0 (only comment-string mentions remain)
- [x] All 4 new `it()` blocks pass locally
- [x] Lock-spec L1-L7 (18 prior tests) still green
- [x] `vitest.config.ts` alias verified (no other daemon spec broken by it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)