### PR TITLE
ci(#512): unify e2e.yml node_modules cache key with ci.yml + drift heal

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,37 +60,38 @@ jobs:
       # node-pty) from the cached tree, which is what the Electron e2e
       # actually loads.
       #
-      # CRITICAL: this cache key MUST be distinct from ci.yml's key. ci.yml
-      # runs `npm ci` with `ELECTRON_SKIP_BINARY_DOWNLOAD=1` (no electron
-      # binary) AND compiles native modules against Node 20's ABI
-      # (NODE_MODULE_VERSION 115). e2e needs the electron binary AND
-      # native modules built against Electron's ABI (NMV 145). Sharing a
-      # key meant whichever workflow won the race poisoned the other:
-      #   - ci.yml winning → e2e gets no electron binary + Node-20-ABI
-      #     `.node` files → main process throws ERR_DLOPEN_FAILED on
-      #     better-sqlite3 require during initDb() → BrowserWindow never
-      #     created → harness times out with the bare "no renderer window
-      #     appeared in time" error.
-      # The `e2e-` prefix isolates this workflow's cache entirely.
-      # (Task #913 healed the electron-binary half; Task #919 the
-      # native-module half.)
+      # Task #512 (FOLLOWUP-D, v0.3 ship CI-speed) — UNIFIED cache key
+      # with ci.yml (`nm-` prefix). Historical context: this used to be
+      # `nm-e2e-` to isolate from ci.yml because ci.yml writes a tree
+      # without the Electron binary AND with native modules compiled
+      # against Node 20's ABI (NMV 115), while e2e needs the Electron
+      # binary AND modules built against Electron's ABI (NMV 145). The
+      # cache poisoning was real (Task #913 / #919). The healing steps
+      # below — `Ensure Electron binary` (always re-runs `electron/install.js`,
+      # idempotent) and `Ensure native modules built for Electron ABI`
+      # (always re-runs `electron-rebuild`, no-op when ABI already matches)
+      # — already self-heal a poisoned ci.yml-written cache. With healing
+      # in place, isolating the cache key only forfeits cross-workflow
+      # cache hits on the dominant install cost (~70s/cache-miss PR).
+      # Adding ci.yml's `nm-` to restore-keys lets e2e benefit from any
+      # warm ci.yml cache; the explicit healing steps below bring the
+      # restored tree into Electron-ABI shape.
       - name: Cache node_modules
         id: nm_cache
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-e2e-${{ runner.os }}-${{ runner.arch }}-node22-${{ hashFiles('package-lock.json') }}
-          # Task #364 — fallback to any prior e2e node22 cache when lockfile
+          key: nm-${{ runner.os }}-${{ runner.arch }}-node22-${{ hashFiles('package-lock.json') }}
+          # Task #364 — fallback to any prior node22 cache when lockfile
           # hash changes. Cache hit rate was low because every dep bump
           # invalidates the primary key. With restore-keys, a stale cache
           # is restored and `npm ci` reconciles only the diff. Native
           # bindings carry old ABI from the stale cache; the
           # `npx electron-rebuild` step below always runs to realign with
-          # Electron's NMV. The `nm-e2e-` prefix is preserved (must NOT
-          # collide with ci.yml's `nm-` prefix — see comment block above
-          # about the cross-workflow cache poisoning incident).
+          # Electron's NMV. Task #512 unified the prefix with ci.yml so
+          # e2e can fall back to either workflow's most-recent cache.
           restore-keys: |
-            nm-e2e-${{ runner.os }}-${{ runner.arch }}-node22-
+            nm-${{ runner.os }}-${{ runner.arch }}-node22-
       - name: Cache Electron binary
         uses: actions/cache@v4
         with:
@@ -101,6 +102,27 @@ jobs:
       - name: Install deps
         if: steps.nm_cache.outputs.cache-hit != 'true'
         run: npm ci --legacy-peer-deps
+      # Task #512 (FOLLOWUP-D) — healing fallback for cross-workflow cache
+      # restore. With the unified `nm-` cache key (shared with ci.yml), a
+      # cache hit may restore a tree that was written by ci.yml against a
+      # slightly different package-lock.json (e.g. ci.yml ran on the merge
+      # base, e2e.yml runs on a PR commit that bumps a dep). `npm ls
+      # --depth=0` exits non-zero when the restored node_modules disagrees
+      # with the on-disk package-lock.json (missing/extra top-level deps);
+      # in that case we run a full `npm ci` to reconcile. On a healthy
+      # exact-key cache hit the `npm ls` call is ~1s and the install is
+      # skipped entirely. Stays inside the cache-hit branch so cache-miss
+      # PRs are handled by the install step above.
+      - name: Heal node_modules drift (cache-hit reconcile)
+        if: steps.nm_cache.outputs.cache-hit == 'true'
+        shell: bash
+        run: |
+          if ! npm ls --omit=optional --depth=0 >/dev/null 2>&1; then
+            echo "node_modules drifted from package-lock.json — running npm ci to reconcile"
+            npm ci --legacy-peer-deps
+          else
+            echo "node_modules matches package-lock.json — no reconcile needed"
+          fi
       # Ensure the Electron binary (`node_modules/electron/dist/`) is present.
       # The node_modules cache is shared with ci.yml, which runs `npm ci` with
       # ELECTRON_SKIP_BINARY_DOWNLOAD=1 — when ci.yml wins the race to write


### PR DESCRIPTION
Task #512 — FOLLOWUP-D, v0.3 ship CI-speed.

## Summary

- Switch `e2e.yml` `nm-e2e-` cache key to ci.yml's `nm-` prefix so the two workflows share warm caches; saves ~70s/cache-miss e2e PR by inheriting any warm ci.yml-written tree.
- Add corresponding `nm-` `restore-keys` fallback.
- Add `Heal node_modules drift (cache-hit reconcile)` step: on cache hit, runs `npm ls --omit=optional --depth=0`; if it exits non-zero (top-level dep mismatch with on-disk `package-lock.json`), re-runs `npm ci --legacy-peer-deps` to reconcile. Healthy exact-key hits stay ~1s.
- `ci.yml` unchanged — verified its three jobs (lint / typecheck / test) already use the unified `nm-` key + restore-keys at lines 97 / 164 / 284.

## Why this is safe now (history)

Task #913 / #919 originally mandated the `nm-e2e-` isolation because ci.yml writes a tree without the Electron binary AND with native modules compiled against Node 20's ABI (NMV 115); e2e needs the Electron binary AND modules built against Electron's ABI (NMV 145). Cache poisoning was real.

Mitigation today: the existing `Ensure Electron binary` and `Ensure native modules built for Electron ABI` steps run unconditionally on every job and are idempotent. They already self-heal a ci.yml-written tree into Electron-ABI shape before `npm run build:app` / `npm run probe:e2e`. With healing in place, key isolation only forfeits cross-workflow cache hits — the poisoning class is neutralized at the consumer side, not the cache key.

## Risk + new healing

Risk noted in task: cache hit may restore a tree written by ci.yml against a slightly different `package-lock.json` (e.g. ci.yml ran on the merge base while e2e.yml runs on a PR commit that bumps a dep). The new `Heal node_modules drift` step closes this: `npm ls --depth=0` is the canonical drift detector and `npm ci` is the canonical reconcile.

## Acceptance

- e2e.yml cache hit rate target: ≥ 80% (vs prior `nm-e2e-`-only key which only hit on a prior e2e run with same lockfile).
- 7-day observation: ~70s saved per cache-miss PR (the dominant Windows install cost).

## Local checks (host: windows-11)

- lint: ok (exit 0, 67 warnings, 0 errors)
- typecheck: ok (exit 0)
- build / unit / e2e: skipped per dev-protocol §3 #2 (yml-only edit, no `.ts`/`.tsx` touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)