### PR TITLE
spec: v0.3 ship plan (step -> shell unskip mapping)

### DIFF
--- a/docs/superpowers/specs/2026-05-05-v03-ship-plan.md
+++ b/docs/superpowers/specs/2026-05-05-v03-ship-plan.md
@@ -67,18 +67,19 @@ Notation: `A → B` means B is `blockedBy: A`. Parallel siblings (e.g. 3.1a / 3.
 
 ## Steps
 
-### STEP-3.0 — `lint:no-ipc` backstop wired + zero-IPC verification
+### STEP-3.0 — `lint:no-ipc` backstop verification (already wired)
+
+**Round 2 update**: ground-truthed against `working` HEAD. `tools/lint-no-ipc.sh`, `tools/.no-ipc-allowlist`, and the root `package.json` `lint:no-ipc` script ALL already exist; `package.json` chains it via `lint` (turbo) plus the standalone `lint:no-ipc` script. Allowlist contents already match ch08 §3.1 exactly (5 paths: `electron/__tests__/updater.test.ts`, `electron/notify/sinks/__tests__/toastSink.test.ts`, `electron/ipc-allowlisted/folder-picker.ts`, `electron/ipc-allowlisted/updater-ipc.ts`, `electron/ipc-allowlisted/preload-allowlisted.ts`). Script already greps the right token set (`ipcMain|ipcRenderer|contextBridge|additionalArguments|webContents\.send`) with comment-line carve-out, and `SCAN_DIRS` already includes `packages/electron/src`. **No new file work; this step collapses to "verify still green + add CI gate row if missing"**.
 
 - **Files**:
-  - `tools/lint-no-ipc.sh` (NEW or update; ch12 §3) — grep `packages/electron/src/` for `ipcMain|ipcRenderer|contextBridge|webContents\.send`, skip paths in `tools/.no-ipc-allowlist`.
-  - `tools/.no-ipc-allowlist` (NEW; per ch08 §3.1, exactly the 5 allowlisted paths verbatim).
-  - `package.json` add `"lint:no-ipc": "bash tools/lint-no-ipc.sh"` and chain into root `lint`.
-  - `.github/workflows/ci.yml` (the existing `lint` job already runs root `npm run lint`; verify only).
-  - Replace any stale comment text in `packages/electron/src/main/protocol-app.ts` and `packages/electron/src/renderer/components/DaemonNotRunningModal.tsx` that triggers a false positive (rephrase mentions of the banned tokens, or move to allowlist if functionally needed). Per ch08 §2, only true `ipcMain.handle` / `webContents.send` registrations count; doc comments must not trip the rule.
-- **Shells unskipped**: none (this is the backstop that lets ship-gate (a) become a `git rm` + `grep`, ch08 §1).
-- **Acceptance**: `npm run lint:no-ipc` exits 0 against `packages/electron/src/`; closes ship-gate **(a)** mechanically (lint passes ⇒ zero forbidden symbols).
+  - `tools/lint-no-ipc.sh` (VERIFY — already present; confirmed `SCAN_DIRS` includes `packages/electron/src`).
+  - `tools/.no-ipc-allowlist` (VERIFY — already present; confirmed the 5 ch08 §3.1 paths still listed).
+  - `package.json` (VERIFY — `lint:no-ipc` script already wired; root `lint` script chains it via turbo).
+  - `.github/workflows/ci.yml` (VERIFY — confirm the lint job runs `lint:no-ipc` either directly or via root `lint`; if not, add a `bash tools/lint-no-ipc.sh` step. This is the only file that may NEED a small modify.).
+- **Shells unskipped**: none (this is the standing backstop that makes ship-gate (a) a `git rm` + `grep`, ch08 §1).
+- **Acceptance**: `bash tools/lint-no-ipc.sh` exits 0 on `working` HEAD AND on the tip of the v0.3 ship branch; `npm run lint` (or the explicit `lint:no-ipc` step) runs it in CI; closes ship-gate **(a)** mechanically (lint passes ⇒ zero forbidden symbols).
 - **blockedBy**: none.
-- **PR size**: ~150 lines (mostly the shell script + allowlist file).
+- **PR size**: ~0-50 lines (only the `ci.yml` step IF the audit finds it missing; otherwise this step is a no-op verification with no PR — record the verification commit-SHA in the v0.3 release notes instead).
 
 ### STEP-3.1a — `SendInput` handler + UT
 
@@ -204,6 +205,20 @@ Notation: `A → B` means B is `blockedBy: A`. Parallel siblings (e.g. 3.1a / 3.
 
 ### STEP-3.5 — UI thin-client e2e (real daemon, real renderer)
 
+**Round 2 update — STEP-3.5 daemon-side dependency audit**: ground-truthed `packages/daemon/src/rpc/router.ts` against ch08 §3 disposition table. The daemon-side handlers thin-client.spec.ts actually exercises (CreateSession + Attach + DestroySession + SendInput + Resize) are either ALREADY wired on `working` HEAD or are landed by the STEP-3.1/3.2 chains in this plan. Specifically:
+
+| handler thin-client.spec.ts needs | status on `working` HEAD | source |
+|---|---|---|
+| `SessionService.CreateSession` | ✅ wired | `packages/daemon/src/sessions/create-handler.ts` (Wave-3 #339) |
+| `SessionService.DestroySession` | ✅ wired | `packages/daemon/src/sessions/destroy-handler.ts` (Wave-3 #338) |
+| `PtyService.Attach` + `AckPty` | ✅ wired | `packages/daemon/src/rpc/pty-attach.ts` (Wave-3 #355) |
+| pty-host spawn lifecycle (CreateSession → fork pty-host child → claude CLI) | ✅ wired | `packages/daemon/src/pty-host/{attach-on-create,host}.ts`; `index.ts` already injects `makeProductionAttachPtyHost(...)` |
+| `PtyService.SendInput` | landed by STEP-3.1a/b/c (this plan) | new |
+| `PtyService.Resize` | landed by STEP-3.2a/b/c (this plan) | new |
+| `PtyService.CheckClaudeAvailable` (modal precondition) | landed by STEP-3.3a/b/c (this plan) | new |
+
+**Result: no STEP-3.5-PRE infrastructure step is needed.** STEP-3.5's `blockedBy` is exactly STEP-3.1c + STEP-3.2c + STEP-3.3c + STEP-3.4 (as previously listed). Thin-client e2e fails fast if any of those upstream chains regress — no vapor dependency, no "other in-flight tasks" punt.
+
 - **Files**:
   - `packages/electron/test/e2e/thin-client.spec.ts` (NEW) — drives the app like a user; reuses 3.4 launch helper but boots against a real daemon (not the fake-daemon stub).
 - **Shells unskipped** (§3, all 4 rows):
@@ -280,7 +295,7 @@ Notation: `A → B` means B is `blockedBy: A`. Parallel siblings (e.g. 3.1a / 3.
   - `1h soak: report RSS high-water-mark`
   - `1h soak: report total wire bytes Listener A → renderer`
   - `1h soak: report SnapshotV1 size distribution (p50/p95/max)`
-- **Acceptance**: 3 specs run and emit metrics; **no pass/fail assertion**. Surfaces the design-doc 250 MB / 60 min wire budget number for review without enforcing it (per the shell's "design budget 250 MB is tracked, not enforced here").
+- **Acceptance**: 3 specs run and emit metrics; **no pass/fail assertion** on the bench numbers themselves. Surfaces the design-doc 250 MB / 60 min wire budget number for review without enforcing it (per the shell's "design budget 250 MB is tracked, not enforced here"). **Release-tag gate (round 2 add)**: before the v0.3 release tag is cut, the nightly job MUST have at least 1 successful execution and the resulting `bench-out/` artifact MUST be linked from the v0.3 release notes. Soft gate — if nightly fails for non-bench reasons (runner outage / network / unrelated infra), manager can override with a written note in the release PR; but the artifact link itself is required. Without the link, no v0.3 tag.
 - **blockedBy**: STEP-3.6 (needs the codec to instrument snapshot-size distribution).
 - **PR size**: ~300 lines.
 
@@ -291,15 +306,16 @@ Notation: `A → B` means B is `blockedBy: A`. Parallel siblings (e.g. 3.1a / 3.
 - **Cloudflare Tunnel + cloudflared sidecar lifecycle** — v0.4 (Listener B instantiation).
 - **CF Access JWT validation middleware** — v0.4 (Listener B factory).
 - **Multi-principal sessions** (anything other than `local-user`) — v0.4 (`cf-access:<sub>` derivation).
-- **Crash log network upload** — v0.4 (additive uploader; v0.3 ships local-only crash collector — already covered by existing `packages/daemon/src/rpc/crash/`, no shell row in `2026-05-05-v03-test-shells.md`).
+- **Crash log network upload** — v0.4 (additive uploader; v0.3 ships local-only crash collector — already wired in `packages/daemon/src/rpc/crash/register.ts` per `router.ts` overlay; no shell row in `2026-05-05-v03-test-shells.md`).
 - **`window.ccsm.*` settings/state cutover in legacy `src/`** — already done by PR #976/#980/#981/#982/#983 to `localStorage` per `feedback_wave0e_cutover_target_localStorage.md`. Not re-touched here.
-- **Forever-stable allowlisted IPC** (`cwd:pick`, `updates:*`, `update:downloaded`) — kept as-is per ch08 §3.1; STEP-3.0 enforces the allowlist file.
-- **`pty:list` / `pty:spawn` / `pty:get` / `pty:detach` / `pty:kill` / `pty:getBufferSnapshot` cutovers** — out of scope of this plan because no shell row in `2026-05-05-v03-test-shells.md` maps to them. Their daemon-side handlers (`SessionService.{ListSessions,CreateSession,GetSession,DestroySession}` + `PtyService.Attach`'s first frame, ch04 §6) are tracked by other in-flight tasks that must land before STEP-3.5 can pass. If any handler is missing at STEP-3.5 dispatch time, the gap surfaces as an e2e failure and gets a follow-up task — it is **not** silently absorbed.
-- **`SessionService.RenameSession` / `GetSessionTitle` / `ListProjectSessions` / `ListImportableSessions` / `ImportSession` / `NotifyService.{WatchNotifyEvents,MarkUserInput,SetActiveSid,SetFocused}` / `DraftService.{GetDraft,UpdateDraft}`** — required by ch08 §3 disposition table but no shell row in `2026-05-05-v03-test-shells.md` (the test-shells file deliberately scopes to ship-gate (a) RPC triple SendInput/Resize/CheckClaudeAvailable + boot/thin-client/sigkill/installer/dogfood). They are landed by other v0.3 tracks; not added here to avoid scope-creeping the test-shells contract.
+- **Forever-stable allowlisted IPC** (`cwd:pick`, `updates:*`, `update:downloaded`) — kept as-is per ch08 §3.1; STEP-3.0 enforces the allowlist file (already wired on `working`).
+- **`pty:list` / `pty:spawn` / `pty:get` / `pty:detach` / `pty:kill` / `pty:getBufferSnapshot` cutovers** — already wired on `working` HEAD via `SessionService.{ListSessions,GetSession,CreateSession,DestroySession}` (`packages/daemon/src/sessions/`) + `PtyService.Attach`'s first frame (`packages/daemon/src/rpc/pty-attach.ts`) + the production `attachPtyHost` (`packages/daemon/src/pty-host/attach-on-create.ts`, injected from `index.ts`). No additional v0.3 work needed; STEP-3.5 exercises them end-to-end.
+- **`SessionService.RenameSession` / `GetSessionTitle` / `ListProjectSessions` / `ListImportableSessions` / `ImportSession`** — required by ch08 §3 disposition table but **NOT** wired on `working` HEAD (verified: `router.ts` `registerSessionService` only attaches `hello/watchSessions/listSessions/getSession/destroySession/createSession`; the five title/import RPCs reach the router as `Unimplemented`). **No shell row in `2026-05-05-v03-test-shells.md` covers them**, and STEP-3.5 thin-client.spec.ts does not exercise them. **Coverage gap, flagged honestly here**: title/import features regress from v0.2 in v0.3 unless a follow-up shell + handler land. This plan does NOT add steps for them — adding them would scope-creep beyond the test-shells contract. Recommended action: open a separate spec PR to extend `2026-05-05-v03-test-shells.md` with title/import shells if the v0.3 ship intent considers these features in-scope; otherwise document the v0.2-feature-regression list per ch08 §2 disposition (d).
+- **`NotifyService.{WatchNotifyEvents, MarkUserInput, SetActiveSid, SetFocused}` / `DraftService.{GetDraft, UpdateDraft}`** — DraftService IS wired on `working` HEAD (`packages/daemon/src/rpc/draft/register.ts`); NotifyService is NOT wired (`router.ts` carries it only via `STUB_SERVICES` → all 4 methods reply `Unimplemented`). **No shell row in `2026-05-05-v03-test-shells.md` covers either, and STEP-3.5 does not exercise them**. Same posture as the title/import gap above: NotifyService notify-decider features (toast halo / focus-mute / OSC-title push) regress from v0.2 unless follow-up shells + handlers land. Out-of-scope of this plan; flagged for the v0.2-feature-regression list.
 
 ## Coverage check
 
-Total shells in `2026-05-05-v03-test-shells.md`:
+Total shells in `2026-05-05-v03-test-shells.md`: 37 across 9 sub-sections, mapped to 10 implementation steps (3.0 verifies; 3.1–3.10 implement). Round 2 audit: no new `[INFRASTRUCTURE]` step bucket needed — every daemon-side handler STEP-3.5 thin-client.spec.ts requires is either already wired on `working` HEAD (Session/Pty Attach/Destroy/Create + pty-host spawn) or landed by STEP-3.1/3.2 in this plan. Step total stays at **10**.
 
 | Section | Shells | Step(s) |
 |---|---|---|

--- a/docs/superpowers/specs/2026-05-05-v03-ship-plan.md
+++ b/docs/superpowers/specs/2026-05-05-v03-ship-plan.md
@@ -1,0 +1,315 @@
+# v0.3 ship plan (step → shell unskip mapping)
+
+**Date**: 2026-05-05
+**Status**: implementation TODO list. Not a redesign. Ground-truth design is `2026-05-03-v03-daemon-split-design.md`; ground-truth tests are `2026-05-05-v03-test-shells.md`.
+**Purpose**: pin the ordered list of implementation steps that take the v0.3 codebase from "all shells `it.skip`" to "all shells green + ship-gate (a)/(b)/(c)/(d) closed". Each step is one PR (`base = working`).
+
+## Inputs
+
+1. `docs/superpowers/specs/2026-05-05-v03-test-shells.md` — the 37 `it.skip` shells this plan unskips.
+2. `docs/superpowers/specs/2026-05-03-v03-daemon-split-design.md` — ship-gate (a)/(b)/(c)/(d), Chapter 04 RPC surface, Chapter 06 SnapshotV1 codec, Chapter 08 cutover plan, Chapter 10 installer.
+3. Current `packages/electron/src/` and `packages/daemon/src/rpc/` layout (surveyed 2026-05-05). Notable:
+   - `packages/proto/src/ccsm/v1/pty.proto` already declares `SendInput` (line 13), `Resize` (line 14), `CheckClaudeAvailable` (line 30).
+   - `packages/daemon/src/rpc/` ships `hello.ts` + `pty-attach.ts` + `bind.ts` + `router.ts` + `errors.ts` + `middleware/request-meta.ts` + `crash/` + `draft/` + `settings/`. **No** `pty-sendinput.ts`, `pty-resize.ts`, or `check-claude-available.ts` handler yet.
+   - `packages/electron/src/main/` ships `protocol-app.ts` (descriptor-fetch via `protocol.handle("app", ...)`, ch08 §4.1) + `transport-bridge.ts` (ch08 §4.2). Renderer ships `connection/{hello,reconnect,use-connection}.ts` + `components/{DaemonNotRunningModal,use-daemon-cold-start-modal}.tsx`.
+   - The only `contextBridge`/`ipcMain`/`ipcRenderer` grep hits in `packages/electron/src/` are documentation comments in `main/protocol-app.ts` and `renderer/components/DaemonNotRunningModal.tsx` — no actual IPC registrations remain. Step 3.0 closes the lint loop.
+4. `~/.claude/projects/C--Users-jiahuigu/memory/feedback_v03_zero_rework.md` — every line of v0.3 must be the final architecture; no transitional code.
+5. `~/.claude/projects/C--Users-jiahuigu/memory/feedback_wave0e_cutover_target_localStorage.md` — settings/state IPC hits → `localStorage`; **not** transport bridge / Connect-RPC. PTY/session class IPC is what this plan wires; settings/state are out of scope (already handled in PR #976/#980/#981/#982/#983).
+
+## Ship-gate baseline (verbatim from the design doc, frozen — do not reopen here)
+
+- **(a)** `packages/electron/src/` has zero `contextBridge` / `ipcMain` / `ipcRenderer` references; all IPC goes through Connect-RPC against Listener A.
+- **(b)** Daemon SIGKILL + restart mid-session → reattach → byte-identical xterm state.
+- **(c)** 1-hour `claude` workload + 3 Electron SIGKILLs (t=10m/25m/40m) → byte-identical replay; ≤ 250 MB / 60 min wire budget.
+- **(d)** Clean MSI install → run → uninstall leaves no service, no `%ProgramData%\ccsm`, no orphan PTY processes.
+
+Dogfood Set A is a CI gate (PASS/FAIL on Windows runner); Set B is informational bench (no assertion, nightly only).
+
+## Step DAG
+
+```
+STEP-3.0 (lint:no-ipc backstop)
+    │
+    ├──► STEP-3.1a (SendInput handler + UT)
+    │         │
+    │         └──► STEP-3.1b (SendInput Connect roundtrip)
+    │                   │
+    │                   └──► STEP-3.1c (useSendInput hook)
+    │
+    ├──► STEP-3.2a (Resize handler + UT)
+    │         │
+    │         └──► STEP-3.2b (Resize Connect roundtrip)
+    │                   │
+    │                   └──► STEP-3.2c (useResize hook + debounce)
+    │
+    └──► STEP-3.3a (CheckClaudeAvailable handler + UT)
+              │
+              └──► STEP-3.3b (CheckClaudeAvailable Connect roundtrip)
+                        │
+                        └──► STEP-3.3c (useCheckClaudeAvailable hook)
+
+STEP-3.4 (boot e2e harness + Hello roundtrip)        — depends on STEP-3.0
+    │
+    └──► STEP-3.5 (UI thin-client e2e)               — depends on 3.1c, 3.2c, 3.3c, 3.4
+
+STEP-3.6 (snapshot codec re-lock + daemon-replay UT) — depends on STEP-3.0
+    │
+    └──► STEP-3.7 (sigkill-reattach e2e)             — depends on 3.5, 3.6
+
+STEP-3.8 (MSI installer build + install/uninstall e2e, win32-only)
+                                                      — depends on 3.4 (boot e2e harness)
+
+STEP-3.9 (Dogfood Set A — CI gate)                   — depends on 3.5, 3.7, 3.8
+STEP-3.10 (Dogfood Set B — informational bench)      — depends on 3.6 (codec); independent of 3.8/3.9
+```
+
+Notation: `A → B` means B is `blockedBy: A`. Parallel siblings (e.g. 3.1a / 3.2a / 3.3a) may dispatch concurrently after 3.0 lands.
+
+## Steps
+
+### STEP-3.0 — `lint:no-ipc` backstop wired + zero-IPC verification
+
+- **Files**:
+  - `tools/lint-no-ipc.sh` (NEW or update; ch12 §3) — grep `packages/electron/src/` for `ipcMain|ipcRenderer|contextBridge|webContents\.send`, skip paths in `tools/.no-ipc-allowlist`.
+  - `tools/.no-ipc-allowlist` (NEW; per ch08 §3.1, exactly the 5 allowlisted paths verbatim).
+  - `package.json` add `"lint:no-ipc": "bash tools/lint-no-ipc.sh"` and chain into root `lint`.
+  - `.github/workflows/ci.yml` (the existing `lint` job already runs root `npm run lint`; verify only).
+  - Replace any stale comment text in `packages/electron/src/main/protocol-app.ts` and `packages/electron/src/renderer/components/DaemonNotRunningModal.tsx` that triggers a false positive (rephrase mentions of the banned tokens, or move to allowlist if functionally needed). Per ch08 §2, only true `ipcMain.handle` / `webContents.send` registrations count; doc comments must not trip the rule.
+- **Shells unskipped**: none (this is the backstop that lets ship-gate (a) become a `git rm` + `grep`, ch08 §1).
+- **Acceptance**: `npm run lint:no-ipc` exits 0 against `packages/electron/src/`; closes ship-gate **(a)** mechanically (lint passes ⇒ zero forbidden symbols).
+- **blockedBy**: none.
+- **PR size**: ~150 lines (mostly the shell script + allowlist file).
+
+### STEP-3.1a — `SendInput` handler + UT
+
+- **Files**:
+  - `packages/daemon/src/rpc/pty-sendinput.ts` (NEW) — handler exporting `makeSendInputHandler(deps)` that resolves the session by `sid` → asserts ownership (`principalKey(ctx.principal) === session.owner_id`, ch05 §5) → forwards bytes to the pty-host child writer.
+  - `packages/daemon/src/rpc/router.ts` — register the handler against `PtyService.SendInput`.
+  - `packages/daemon/src/rpc/__tests__/pty-sendinput-handler.spec.ts` (NEW) — unskip the 3 handler shells.
+- **Shells unskipped** (verbatim names from `2026-05-05-v03-test-shells.md` §2.1):
+  - `forwards utf-8 bytes to pty-host writer in order`
+  - `rejects with NOT_FOUND when sid is unknown`
+  - `rejects with PERMISSION_DENIED when principal mismatch`
+- **Acceptance**: 3 unit tests green; partially closes ship-gate **(a)** (the daemon side of `pty:input` cutover — ch08 §3 row `pty:input → PtyService.SendInput`).
+- **blockedBy**: STEP-3.0.
+- **PR size**: ~250 lines (handler + 3 specs + router wire-up).
+
+### STEP-3.1b — `SendInput` Connect-RPC roundtrip integration
+
+- **Files**:
+  - `packages/daemon/test/integration/rpc/pty-sendinput.spec.ts` (NEW) — spawn real daemon over loopback (ch03 §3 BindDescriptor `loopback-h2c`), open Attach stream, send input, observe echo.
+  - `packages/daemon/test/integration/helpers/spawn-daemon.ts` (NEW if absent; SHARED with all rpc/* integration tests in 3.x) — process spawner that launches `ccsm-daemon` against a temp `%ProgramData%`-equivalent dir, returns the descriptor + a teardown.
+- **Shells unskipped** (§2.1):
+  - `Connect roundtrip writes bytes to live pty-host and is read back via Attach stream`
+- **Acceptance**: 1 integration test green; full daemon-side `SendInput` path proven over the real Connect transport. Contributes to ship-gate **(a)** end-to-end coverage.
+- **blockedBy**: STEP-3.1a.
+- **PR size**: ~300 lines (spec + spawn-daemon helper, but the helper is reused by 3.2b / 3.3b).
+
+### STEP-3.1c — `useSendInput` renderer hook
+
+- **Files**:
+  - `packages/electron/src/renderer/connection/use-send-input.ts` (NEW) — TanStack Query mutation wrapping the proto-generated `PtyService.SendInput` client (ch08 §4 "wraps the proto-generated SessionService/PtyService/... clients in React Query hooks").
+  - `packages/electron/src/renderer/connection/__tests__/use-send-input.spec.ts` (NEW).
+- **Shells unskipped** (§2.1):
+  - `useSendInput dispatches against real Connect client and resolves`
+- **Acceptance**: hook test green; closes the renderer-side half of `pty:input` cutover. Contributes to ship-gate **(a)**.
+- **blockedBy**: STEP-3.1b.
+- **PR size**: ~150 lines.
+
+### STEP-3.2a — `Resize` handler + UT
+
+- **Files**:
+  - `packages/daemon/src/rpc/pty-resize.ts` (NEW) — `(cols, rows)` validation (`> 0`), ownership check, forward to `pty-host.resize(cols, rows)`.
+  - `packages/daemon/src/rpc/router.ts` — register.
+  - `packages/daemon/src/rpc/__tests__/pty-resize-handler.spec.ts` (NEW).
+- **Shells unskipped** (§2.2):
+  - `forwards (cols, rows) to pty-host resize()`
+  - `rejects with INVALID_ARGUMENT when cols/rows ≤ 0`
+  - `rejects with NOT_FOUND when sid is unknown`
+- **Acceptance**: 3 unit tests green; partially closes ship-gate **(a)** (`pty:resize → PtyService.Resize` cutover, ch08 §3).
+- **blockedBy**: STEP-3.0.
+- **PR size**: ~250 lines.
+
+### STEP-3.2b — `Resize` Connect-RPC roundtrip integration
+
+- **Files**:
+  - `packages/daemon/test/integration/rpc/pty-resize.spec.ts` (NEW) — drive `tput`-like prompt to confirm SIGWINCH reaches child.
+- **Shells unskipped** (§2.2):
+  - `Connect roundtrip resizes live pty and SIGWINCH reaches child`
+- **Acceptance**: 1 integration test green.
+- **blockedBy**: STEP-3.2a (and STEP-3.1b — re-uses the `spawn-daemon.ts` helper landed there; if 3.1b not yet merged, copy the helper here and dedup later).
+- **PR size**: ~150 lines.
+
+### STEP-3.2c — `useResize` renderer hook (with debounce)
+
+- **Files**:
+  - `packages/electron/src/renderer/connection/use-resize.ts` (NEW) — debounce 50ms → 1 RPC with last `(cols, rows)`. Use existing dep (e.g. `lodash.debounce` if already in workspace, else hand-roll the 8-line trailing debounce — Layer 1 tier 1/2 check during dev).
+  - `packages/electron/src/renderer/connection/__tests__/use-resize.spec.ts` (NEW).
+- **Shells unskipped** (§2.2):
+  - `useResize debounces rapid resizes and sends final dimensions only`
+- **Acceptance**: hook test green; closes the renderer half of `pty:resize`. Contributes to ship-gate **(a)**.
+- **blockedBy**: STEP-3.2b.
+- **PR size**: ~150 lines.
+
+### STEP-3.3a — `CheckClaudeAvailable` handler + UT
+
+- **Files**:
+  - `packages/daemon/src/rpc/check-claude-available.ts` (NEW) — inject a `resolver` dep (PATH lookup) + a `versionProbe` dep (spawn `claude --version` with 2s timeout).
+  - `packages/daemon/src/rpc/router.ts` — register.
+  - `packages/daemon/src/rpc/__tests__/check-claude-available-handler.spec.ts` (NEW).
+- **Shells unskipped** (§2.3):
+  - `returns available=true with version when claude on PATH`
+  - `returns available=false with reason when binary missing`
+  - `returns available=false with reason when version probe times out`
+- **Acceptance**: 3 unit tests green; closes daemon side of `pty:checkClaudeAvailable` cutover (ch08 §3). Contributes to ship-gate **(a)**.
+- **blockedBy**: STEP-3.0.
+- **PR size**: ~300 lines (handler + 3 specs; PATH lookup uses `node:child_process` + standard PATH walk, no new dep).
+
+### STEP-3.3b — `CheckClaudeAvailable` Connect-RPC roundtrip integration
+
+- **Files**:
+  - `packages/daemon/test/integration/rpc/check-claude-available.spec.ts` (NEW) — shape-only assertion (host-dependent boolean).
+- **Shells unskipped** (§2.3):
+  - `Connect roundtrip reports real claude binary status on this host`
+- **Acceptance**: 1 integration test green.
+- **blockedBy**: STEP-3.3a (re-uses 3.1b spawn-daemon helper).
+- **PR size**: ~120 lines.
+
+### STEP-3.3c — `useCheckClaudeAvailable` renderer hook + ClaudeMissingModal
+
+- **Files**:
+  - `packages/electron/src/renderer/connection/use-check-claude-available.ts` (NEW).
+  - `packages/electron/src/renderer/components/ClaudeMissingModal.tsx` (NEW) — analogous to `DaemonNotRunningModal.tsx`, sink-only.
+  - `packages/electron/src/renderer/connection/__tests__/use-check-claude-available.spec.ts` (NEW).
+- **Shells unskipped** (§2.3):
+  - `hook surfaces unavailable state and renders ClaudeMissingModal`
+- **Acceptance**: hook + modal test green; closes renderer half. Contributes to ship-gate **(a)**.
+- **blockedBy**: STEP-3.3b.
+- **PR size**: ~250 lines.
+
+### STEP-3.4 — Boot e2e harness + `Hello` roundtrip + version negotiation
+
+- **Files**:
+  - `packages/electron/test/e2e/helpers/launch.ts` (NEW) — real `_electron.launch` + cleanup (per `2026-05-05-v03-test-shells.md` §1 fixture note).
+  - `packages/electron/test/e2e/helpers/fake-daemon.ts` (NEW) — stub responding with controllable `Hello` (used by version-mismatch + daemon-absent rows).
+  - `packages/electron/test/e2e/boot.spec.ts` (NEW) — unskip all 4 boot rows.
+- **Shells unskipped** (§1, all 4 rows):
+  - `boots renderer and reaches "ready" within 5s`
+  - `Hello round-trip succeeds against real daemon listener A`
+  - `daemon-not-running modal renders when daemon absent`
+  - `version negotiation rejects too-old daemon with structured error`
+- **Acceptance**: 4 e2e tests green; closes ship-gate **(a)** for the boot path (renderer ↔ daemon over Connect, no IPC) + ch04 §3 version negotiation. Powers dogfood Set A row 1 (cold boot ≤ 5s).
+- **blockedBy**: STEP-3.0. (Independent of the SendInput/Resize/CheckClaudeAvailable triplets — boot only needs `Hello`, which already exists in `packages/daemon/src/rpc/hello.ts`.)
+- **PR size**: ~600 lines (harness + fake-daemon stub + 4 e2e specs). At the upper end — if review pushes back on size, split as 3.4a (harness + fake-daemon, no specs) and 3.4b (4 specs).
+
+### STEP-3.5 — UI thin-client e2e (real daemon, real renderer)
+
+- **Files**:
+  - `packages/electron/test/e2e/thin-client.spec.ts` (NEW) — drives the app like a user; reuses 3.4 launch helper but boots against a real daemon (not the fake-daemon stub).
+- **Shells unskipped** (§3, all 4 rows):
+  - `creates new session and shows prompt within 3s`
+  - `typed input renders on screen via real PTY echo`
+  - `window resize triggers Resize RPC and reflows xterm`
+  - `closing window terminates pty subprocesses on this host`
+- **Acceptance**: 4 e2e tests green. Closes ship-gate **(a)** end-to-end (every IPC class round-trips over Connect) and provides ship-gate **(d)** cleanup hint (last row).
+- **blockedBy**: STEP-3.1c, STEP-3.2c, STEP-3.3c, STEP-3.4.
+- **PR size**: ~400 lines.
+
+### STEP-3.6 — Snapshot codec re-lock + daemon-replay UT
+
+- **Files**:
+  - `packages/snapshot-codec/src/encode.ts` + `decode.ts` (NEW package per ch06 §6 "shared codec package has zero runtime dependencies beyond zstd"). Forever-stable per ch06.
+  - `packages/snapshot-codec/package.json`, `tsconfig.json`, `vitest.config.ts` (NEW).
+  - `packages/daemon/src/pty/snapshot.ts` — switch to import the shared codec (not duplicate the encoder).
+  - `packages/daemon/test/integration/pty-daemon-restart-replay.spec.ts` (NEW) — unskip the daemon-replay row.
+- **Shells unskipped** (§5 last row):
+  - `daemon restart mid-session replays delta log to byte-identical state`
+- **Acceptance**: 1 integration test green; partially closes ship-gate **(b)** (daemon-side replay path proven without electron). Codec is forever-stable per ch06 §2 + §11.
+- **blockedBy**: STEP-3.0.
+- **PR size**: ~600 lines (codec package + daemon switch + 1 spec). Split candidate: 3.6a (codec package + zero behavior change) / 3.6b (daemon switch + replay spec) if size > 600.
+
+### STEP-3.7 — Sigkill-reattach e2e (electron + daemon variants + 3-kill scenario)
+
+- **Files**:
+  - `packages/electron/test/e2e/helpers/workload.ts` (NEW; deterministic UTF-8/CJK/RTL workload generator per `2026-05-05-v03-test-shells.md` §5 fixture note).
+  - `packages/electron/test/e2e/sigkill-reattach.spec.ts` (NEW) — 3 e2e rows.
+- **Shells unskipped** (§5 first 3 rows):
+  - `Electron SIGKILL mid-session reattaches with byte-identical xterm screen state`
+  - `daemon SIGKILL mid-session reattaches with byte-identical xterm screen state`
+  - `triple Electron SIGKILL at t=10m/25m/40m of 1h workload yields byte-identical replay`
+- **Acceptance**: 3 e2e tests green (3rd uses CI-feasible reduced timing per the shell's parenthetical; full 1h goes to dogfood Set B). Closes ship-gate **(b)** (both variants) + ship-gate **(c)** (3-SIGKILL byte-equality) for the test surface.
+- **blockedBy**: STEP-3.5 (needs the launch helper + thin-client driving), STEP-3.6 (needs the locked codec).
+- **PR size**: ~500 lines.
+
+### STEP-3.8 — MSI installer build + install/uninstall e2e (Windows-only)
+
+- **Files**:
+  - `packages/daemon/build/msi.wixproj` or equivalent WiX/`electron-builder` config (NEW; ch10).
+  - `packages/daemon/build/scripts/build-msi.{ps1,sh}` (NEW).
+  - `packages/daemon/build/__tests__/msi-install.spec.ts` (NEW; Windows-only via `process.platform === "win32"` skip).
+  - `packages/daemon/build/__tests__/msi-uninstall.spec.ts` (NEW; same gate).
+  - `.github/workflows/ci.yml` — add a `build-msi` job on the Windows matrix entry that runs the build script before invoking the spec.
+- **Shells unskipped** (§4, all 4 rows):
+  - `msiexec /i installs ccsm-daemon service and starts it`
+  - `installed daemon answers Hello over Listener A within 5s of service start`
+  - `msiexec /x removes service and %ProgramData%\\ccsm tree`
+  - `uninstall reaps orphan claude pty subprocesses`
+- **Acceptance**: 4 specs green on the Windows runner (skipped on macOS/Linux runners). Closes ship-gate **(d)** + ship-gate **(a)** post-install row (row 2). Powers dogfood Set A row 2.
+- **blockedBy**: STEP-3.4 (needs the boot e2e harness for the post-install reach test).
+- **PR size**: ~700 lines (the MSI config + 2 specs + CI job). Split candidate: 3.8a (MSI build + CI job, no specs) / 3.8b (2 specs).
+
+### STEP-3.9 — Dogfood Set A (CI gate, Windows runner)
+
+- **Files**:
+  - `packages/electron/test/e2e/dogfood-set-a.spec.ts` (NEW) — 3 rows, all PASS/FAIL assertions.
+  - `.github/workflows/ci.yml` — wire a `dogfood-set-a` job on the Windows matrix entry; merge gate.
+- **Shells unskipped** (§6.1, all 3 rows):
+  - `cold boot to first prompt ≤ 5000ms on this CI host`
+  - `MSI install + run + uninstall round-trip exits clean`
+  - `SIGKILL-reattach byte-equality holds on this CI host`
+- **Acceptance**: 3 specs green on Windows runner; CI gate is now armed; v0.3 ship gate is met (assuming all prior steps green).
+- **blockedBy**: STEP-3.5 (cold-boot path), STEP-3.7 (sigkill-reattach), STEP-3.8 (MSI round-trip).
+- **PR size**: ~250 lines.
+
+### STEP-3.10 — Dogfood Set B (informational bench, nightly only)
+
+- **Files**:
+  - `packages/daemon/test/bench/dogfood-set-b.spec.ts` (NEW) — 3 rows, each writes JSON to `bench-out/` and asserts `expect(true).toBe(true)`.
+  - `.github/workflows/nightly.yml` (NEW or update) — run `dogfood-set-b` on the nightly schedule and upload `bench-out/` as an artifact; **NOT** wired to PR merge gate.
+- **Shells unskipped** (§6.2, all 3 rows):
+  - `1h soak: report RSS high-water-mark`
+  - `1h soak: report total wire bytes Listener A → renderer`
+  - `1h soak: report SnapshotV1 size distribution (p50/p95/max)`
+- **Acceptance**: 3 specs run and emit metrics; **no pass/fail assertion**. Surfaces the design-doc 250 MB / 60 min wire budget number for review without enforcing it (per the shell's "design budget 250 MB is tracked, not enforced here").
+- **blockedBy**: STEP-3.6 (needs the codec to instrument snapshot-size distribution).
+- **PR size**: ~300 lines.
+
+## Out of scope (explicitly deferred to v0.4 or already handled elsewhere)
+
+- **Web frontend** — v0.4 `packages/web` (`#215`).
+- **iOS frontend** — v0.4 `packages/ios`.
+- **Cloudflare Tunnel + cloudflared sidecar lifecycle** — v0.4 (Listener B instantiation).
+- **CF Access JWT validation middleware** — v0.4 (Listener B factory).
+- **Multi-principal sessions** (anything other than `local-user`) — v0.4 (`cf-access:<sub>` derivation).
+- **Crash log network upload** — v0.4 (additive uploader; v0.3 ships local-only crash collector — already covered by existing `packages/daemon/src/rpc/crash/`, no shell row in `2026-05-05-v03-test-shells.md`).
+- **`window.ccsm.*` settings/state cutover in legacy `src/`** — already done by PR #976/#980/#981/#982/#983 to `localStorage` per `feedback_wave0e_cutover_target_localStorage.md`. Not re-touched here.
+- **Forever-stable allowlisted IPC** (`cwd:pick`, `updates:*`, `update:downloaded`) — kept as-is per ch08 §3.1; STEP-3.0 enforces the allowlist file.
+- **`pty:list` / `pty:spawn` / `pty:get` / `pty:detach` / `pty:kill` / `pty:getBufferSnapshot` cutovers** — out of scope of this plan because no shell row in `2026-05-05-v03-test-shells.md` maps to them. Their daemon-side handlers (`SessionService.{ListSessions,CreateSession,GetSession,DestroySession}` + `PtyService.Attach`'s first frame, ch04 §6) are tracked by other in-flight tasks that must land before STEP-3.5 can pass. If any handler is missing at STEP-3.5 dispatch time, the gap surfaces as an e2e failure and gets a follow-up task — it is **not** silently absorbed.
+- **`SessionService.RenameSession` / `GetSessionTitle` / `ListProjectSessions` / `ListImportableSessions` / `ImportSession` / `NotifyService.{WatchNotifyEvents,MarkUserInput,SetActiveSid,SetFocused}` / `DraftService.{GetDraft,UpdateDraft}`** — required by ch08 §3 disposition table but no shell row in `2026-05-05-v03-test-shells.md` (the test-shells file deliberately scopes to ship-gate (a) RPC triple SendInput/Resize/CheckClaudeAvailable + boot/thin-client/sigkill/installer/dogfood). They are landed by other v0.3 tracks; not added here to avoid scope-creeping the test-shells contract.
+
+## Coverage check
+
+Total shells in `2026-05-05-v03-test-shells.md`:
+
+| Section | Shells | Step(s) |
+|---|---|---|
+| §1 Boot e2e | 4 | STEP-3.4 |
+| §2.1 SendInput | 3+1+1 = 5 | STEP-3.1a (3) / STEP-3.1b (1) / STEP-3.1c (1) |
+| §2.2 Resize | 3+1+1 = 5 | STEP-3.2a (3) / STEP-3.2b (1) / STEP-3.2c (1) |
+| §2.3 CheckClaudeAvailable | 3+1+1 = 5 | STEP-3.3a (3) / STEP-3.3b (1) / STEP-3.3c (1) |
+| §3 Thin-client | 4 | STEP-3.5 |
+| §4 Installer | 4 | STEP-3.8 |
+| §5 Sigkill-reattach | 4 (3 electron e2e + 1 daemon-side) | STEP-3.7 (3) / STEP-3.6 (1) |
+| §6.1 Dogfood Set A | 3 | STEP-3.9 |
+| §6.2 Dogfood Set B | 3 | STEP-3.10 |
+| **Total** | **37** | every shell mapped to exactly one step; no orphan, no double-unskip |


### PR DESCRIPTION
## Summary

Authors `docs/superpowers/specs/2026-05-05-v03-ship-plan.md` — the implementation TODO list (markdown-only, no code) that takes v0.3 from all-shells-`it.skip` to ship-gate (a)/(b)/(c)/(d) closed.

- 10 steps total; one PR per concern per `feedback_spec_task_size_discipline.md`. Each of the 3 ship-gate-(a) RPCs (SendInput / Resize / CheckClaudeAvailable) gets 3 separate steps (handler+UT / Connect-roundtrip / renderer hook) — not bundled.
- Every `it.skip` in `docs/superpowers/specs/2026-05-05-v03-test-shells.md` (37 shells across 6 sections) is mapped to exactly one step. Coverage table in the doc.
- Out-of-scope section explicitly defers v0.4 surfaces (web/iOS/cf-tunnel/multi-principal) and notes already-handled tracks (settings/state cutover via `localStorage` per `feedback_wave0e_cutover_target_localStorage.md`).

Ship-gate baseline restated verbatim from the design doc — not reopened. Where I found gaps that don't fit a shell row (e.g. NotifyService / DraftService cutovers from ch08 §3), they're flagged in `## Out of scope` rather than added as new steps, per the task spec.

## Local checks (host: Windows 11, mode: fast)

- lint: skipped (markdown-only PR, dev.md §3 step 1 跳过条件 + baseline `@ccsm/daemon` lint already red on `working` due to missing `build/**/*.ts` glob — unrelated to this PR)
- typecheck: skipped (no .ts/.tsx changed)
- build: skipped (no .ts/.tsx changed)
- unit tests: skipped (markdown-only)
- e2e: skipped (markdown-only)

## Test plan

- [ ] Reviewer confirms each of the 37 `it.skip` rows in `2026-05-05-v03-test-shells.md` appears exactly once in the plan's coverage table.
- [ ] Reviewer confirms ship-gate baseline section reproduces (a)/(b)/(c)/(d) verbatim from `2026-05-03-v03-daemon-split-design.md` §1.
- [ ] Reviewer confirms no step proposes transitional code or v0.4 features (per `feedback_v03_zero_rework.md`).
- [ ] Reviewer confirms each step has est PR size <= ~600-700 lines, with split candidates flagged where at the upper end.

Closes Task #538.