### PR TITLE
v0.3(wave1-A): daemon http server skeleton

### DIFF
--- a/daemon/api/index.ts
+++ b/daemon/api/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Endpoint registry for the daemon HTTP API.
+ *
+ * Wave-1 (this PR): only the always-on endpoints `/api/health` and
+ * `/api/version` registered from `daemon/main.ts`. This module is the
+ * extension point — wave-2 deciders/sinks will register their endpoints by
+ * calling `registerApi(router)` from here.
+ */
+
+import type { Router } from "../router";
+
+/**
+ * Register all wave-2+ API endpoints on the given router.
+ *
+ * Wave-1: intentionally empty. Wave-2 PRs will add route registrations here
+ * (e.g. `router.addRoute("POST", "/api/sessions", createSession)`).
+ */
+export function registerApi(_router: Router): void {
+  // Intentionally empty. Wave-2 dev fills in.
+}

--- a/daemon/main.ts
+++ b/daemon/main.ts
@@ -1,0 +1,109 @@
+/**
+ * Daemon entrypoint.
+ *
+ * Protocol contract with the Electron host process:
+ *  - The very first line on stdout is `PORT=<n>\n` where <n> is the bound port.
+ *  - All other operational logging goes to stderr (stdout is reserved for the
+ *    PORT line so the host can parse it without ambiguity).
+ *  - On SIGTERM / SIGINT the daemon closes the HTTP server gracefully and
+ *    exits 0.
+ *
+ * Wave-1 endpoints: GET /api/health, GET /api/version. Wave-2+ endpoints are
+ * registered via daemon/api/index.ts → registerApi().
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { registerApi } from "./api/index";
+import { startServer, type ServerHandle } from "./server";
+import { Router, type HandlerResult } from "./router";
+
+interface PackageJsonLike {
+  version?: string;
+  name?: string;
+}
+
+function readPackageVersion(): string {
+  // dist/daemon/main.js → ../../package.json (rootDir is the repo root).
+  const pkgPath = join(__dirname, "..", "..", "package.json");
+  try {
+    const raw = readFileSync(pkgPath, "utf8");
+    const pkg = JSON.parse(raw) as PackageJsonLike;
+    return pkg.version ?? "0.0.0";
+  } catch (err) {
+    process.stderr.write(
+      `[daemon] failed to read package.json at ${pkgPath}: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return "0.0.0";
+  }
+}
+
+function buildRouter(version: string): Router {
+  const router = new Router();
+
+  router.addRoute("GET", "/api/health", (): HandlerResult => {
+    return { status: 200, body: { ok: true } };
+  });
+
+  router.addRoute("GET", "/api/version", (): HandlerResult => {
+    return { status: 200, body: { version } };
+  });
+
+  registerApi(router);
+  return router;
+}
+
+function installShutdown(handle: ServerHandle): void {
+  let shuttingDown = false;
+  const shutdown = (signal: string): void => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    process.stderr.write(`[daemon] received ${signal}, shutting down\n`);
+    // Stop accepting new connections; existing keep-alive conns will be torn
+    // down by Node when there is no in-flight request.
+    handle.close().then(
+      () => {
+        process.stderr.write("[daemon] server closed cleanly\n");
+        process.exit(0);
+      },
+      (err: unknown) => {
+        process.stderr.write(
+          `[daemon] error during close: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        process.exit(1);
+      },
+    );
+    // Belt-and-suspenders: if close() hangs on lingering keep-alive sockets,
+    // force-exit after a short grace window so the host process is never stuck.
+    setTimeout(() => {
+      process.stderr.write("[daemon] forced exit after shutdown timeout\n");
+      process.exit(0);
+    }, 5_000).unref();
+  };
+  process.on("SIGTERM", () => shutdown("SIGTERM"));
+  process.on("SIGINT", () => shutdown("SIGINT"));
+}
+
+async function main(): Promise<void> {
+  const version = readPackageVersion();
+  const router = buildRouter(version);
+  const handle = await startServer({ router });
+
+  // PROTOCOL: first line on stdout MUST be `PORT=<n>\n`. Don't add prefix,
+  // don't buffer, don't conflate with logs.
+  process.stdout.write(`PORT=${handle.port}\n`);
+
+  installShutdown(handle);
+
+  process.stderr.write(
+    `[daemon] listening on 127.0.0.1:${handle.port} (version=${version})\n`,
+  );
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(
+    `[daemon] fatal: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
+  );
+  process.exit(1);
+});

--- a/daemon/router.ts
+++ b/daemon/router.ts
@@ -1,0 +1,56 @@
+/**
+ * Simple method+path → handler router for daemon HTTP server.
+ *
+ * Wave-1 skeleton: only exact-match routes (no params, no wildcards).
+ * Wave-2 deciders/sinks add routes via addRoute(); see daemon/api/index.ts.
+ */
+
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+export type HandlerResult =
+  | { status: 200; body: unknown }
+  | { status: 400; error: string }
+  | { status: 404; error: string }
+  | { status: 500; error: string };
+
+export type Handler = (
+  req: IncomingMessage,
+  body: unknown,
+) => HandlerResult | Promise<HandlerResult>;
+
+export interface Route {
+  method: string;
+  path: string;
+  handler: Handler;
+}
+
+export class Router {
+  private readonly routes = new Map<string, Handler>();
+
+  addRoute(method: string, path: string, handler: Handler): void {
+    const key = this.key(method, path);
+    if (this.routes.has(key)) {
+      throw new Error(`Route already registered: ${key}`);
+    }
+    this.routes.set(key, handler);
+  }
+
+  resolve(method: string, path: string): Handler | undefined {
+    return this.routes.get(this.key(method, path));
+  }
+
+  private key(method: string, path: string): string {
+    return `${method.toUpperCase()} ${path}`;
+  }
+}
+
+/** Write a HandlerResult to a ServerResponse with `application/json`. */
+export function writeJson(res: ServerResponse, result: HandlerResult): void {
+  res.statusCode = result.status;
+  res.setHeader("Content-Type", "application/json");
+  const payload =
+    result.status === 200
+      ? JSON.stringify(result.body)
+      : JSON.stringify({ error: result.error });
+  res.end(payload);
+}

--- a/daemon/server.ts
+++ b/daemon/server.ts
@@ -1,0 +1,153 @@
+/**
+ * Daemon HTTP server factory.
+ *
+ * Listens on 127.0.0.1:0 (random port). Exposes a handle that lets the caller
+ * read the bound port and perform a graceful shutdown.
+ *
+ * Wire protocol contract (see daemon/main.ts):
+ *  - All responses are `application/json`.
+ *  - 200 OK / 400 bad_request / 404 not_found / 500 internal_error.
+ *  - Request bodies, when present, are `application/json`.
+ */
+
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import type { AddressInfo } from "node:net";
+
+import { Router, writeJson, type HandlerResult } from "./router";
+
+const MAX_BODY_BYTES = 1 * 1024 * 1024; // 1 MiB; wave-1 endpoints are tiny.
+
+export interface ServerHandle {
+  server: Server;
+  port: number;
+  router: Router;
+  close: () => Promise<void>;
+}
+
+export interface CreateServerOptions {
+  router: Router;
+  host?: string;
+  port?: number;
+}
+
+export async function startServer(
+  opts: CreateServerOptions,
+): Promise<ServerHandle> {
+  const { router } = opts;
+  const host = opts.host ?? "127.0.0.1";
+  const port = opts.port ?? 0;
+
+  const server = createServer((req, res) => {
+    void handleRequest(router, req, res);
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    const onError = (err: Error): void => {
+      server.removeListener("listening", onListen);
+      reject(err);
+    };
+    const onListen = (): void => {
+      server.removeListener("error", onError);
+      resolve();
+    };
+    server.once("error", onError);
+    server.once("listening", onListen);
+    server.listen(port, host);
+  });
+
+  const addr = server.address() as AddressInfo | null;
+  if (!addr || typeof addr === "string") {
+    throw new Error("daemon: failed to bind server (no AddressInfo)");
+  }
+
+  const close = (): Promise<void> =>
+    new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+
+  return { server, port: addr.port, router, close };
+}
+
+async function handleRequest(
+  router: Router,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  try {
+    const method = req.method ?? "GET";
+    const url = req.url ?? "/";
+    // Strip query string; wave-1 endpoints don't read it.
+    const path = url.split("?", 1)[0] ?? "/";
+
+    const handler = router.resolve(method, path);
+    if (!handler) {
+      writeJson(res, { status: 404, error: "not_found" });
+      return;
+    }
+
+    let body: unknown = undefined;
+    if (method !== "GET" && method !== "HEAD") {
+      const parsed = await readJsonBody(req);
+      if (!parsed.ok) {
+        writeJson(res, { status: 400, error: parsed.error });
+        return;
+      }
+      body = parsed.value;
+    }
+
+    let result: HandlerResult;
+    try {
+      result = await handler(req, body);
+    } catch (err) {
+      process.stderr.write(
+        `[daemon] handler threw: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
+      );
+      writeJson(res, { status: 500, error: "internal_error" });
+      return;
+    }
+    writeJson(res, result);
+  } catch (err) {
+    process.stderr.write(
+      `[daemon] request pipeline error: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    if (!res.headersSent) {
+      writeJson(res, { status: 500, error: "internal_error" });
+    } else {
+      res.end();
+    }
+  }
+}
+
+type ParseResult =
+  | { ok: true; value: unknown }
+  | { ok: false; error: string };
+
+async function readJsonBody(req: IncomingMessage): Promise<ParseResult> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of req) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string);
+    total += buf.length;
+    if (total > MAX_BODY_BYTES) {
+      return { ok: false, error: "body_too_large" };
+    }
+    chunks.push(buf);
+  }
+  if (total === 0) {
+    return { ok: true, value: undefined };
+  }
+  const raw = Buffer.concat(chunks).toString("utf8");
+  try {
+    return { ok: true, value: JSON.parse(raw) };
+  } catch {
+    return { ok: false, error: "invalid_json" };
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -117,7 +117,7 @@ export default [
     }
   },
   {
-    files: ['electron/**/*.ts'],
+    files: ['electron/**/*.ts', 'daemon/**/*.ts'],
     languageOptions: {
       globals: {
         process: 'readonly',

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "dev:app": "wait-on http://localhost:4100 && tsc -p tsconfig.electron.json && electron .",
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "build": "npm run clean && tsc -p tsconfig.electron.json && webpack --mode production && node -e \"const fs=require('fs');const p='dist/renderer/bundle.js';const t=Date.now()/1000;fs.utimesSync(p,t,t)\"",
+    "build:daemon": "tsc -p tsconfig.daemon.json",
+    "dev:daemon": "node dist/daemon/main.js",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.electron.json",
     "lint": "eslint . --ext .ts,.tsx",
     "test": "vitest run",

--- a/tsconfig.daemon.json
+++ b/tsconfig.daemon.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "strict": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "lib": ["ES2022"]
+  },
+  "include": ["daemon/**/*"],
+  "exclude": ["daemon/**/__tests__/**"]
+}


### PR DESCRIPTION
v0.3 wave-1 dev-A: HTTP server skeleton for the soon-to-be-split daemon process. Wave-2 deciders/sinks will register endpoints into this router via `daemon/api/index.ts`.

## Files

NEW:
- `daemon/main.ts` — entry. Listens on `127.0.0.1:0` (random port). First stdout line is `PORT=<n>\n` (protocol contract with the Electron host). All other logs go to stderr. Registers `GET /api/health` and `GET /api/version`. Installs SIGTERM/SIGINT graceful-close handlers (5 s force-exit fallback).
- `daemon/server.ts` — `node:http` server factory. JSON body parser with a 1 MiB cap. 200 / 400 / 404 / 500 responses, all `Content-Type: application/json`.
- `daemon/router.ts` — small method+path → handler map (~50 LOC, 0 dep). Exact match only; wave-1 doesn't need params.
- `daemon/api/index.ts` — empty `registerApi(router)` extension point. Wave-2 dev fills it in.
- `tsconfig.daemon.json` — `target: ES2022`, `module: CommonJS`, `outDir: dist`, `include: daemon/**/*`.

MODIFY:
- `package.json` — added two scripts:
  - `build:daemon` → `tsc -p tsconfig.daemon.json`
  - `dev:daemon` → `node dist/daemon/main.js`
- `eslint.config.js` — extended the existing `electron/**/*.ts` node-globals override file glob to also cover `daemon/**/*.ts`. Without this, `__dirname` in `daemon/main.ts` triggers `no-undef`. This is the minimum config change required for the new module to lint clean. Flagging for reviewer awareness since it touches a file outside the spec's "Files" list — the alternative was a global comment in `daemon/main.ts`, which felt worse.

## Tier-2 (no new dep)

`node:http` + ~50 LOC of router covers the wave-1 surface. Express/Fastify would be tier-3 dep churn for zero benefit at this size; we can revisit if we exceed ~10 routes or need middleware.

## Acceptance

```
$ npm run build:daemon
> tsc -p tsconfig.daemon.json   (exit 0)

$ node dist/daemon/main.js > /tmp/d.out 2> /tmp/d.err &
$ head -1 /tmp/d.out
PORT=55537

$ curl -s http://127.0.0.1:55537/api/health
{"ok":true}

$ curl -s http://127.0.0.1:55537/api/version
{"version":"0.2.0"}

$ curl -s -w ' [HTTP=%{http_code}]' http://127.0.0.1:55537/api/missing
{"error":"not_found"} [HTTP=404]

$ cat /tmp/d.err
[daemon] listening on 127.0.0.1:55537 (version=0.2.0)
```

stderr stays out of stdout — protocol channel is clean.

## Local checks (host: Windows 11, mode: fast)
- lint: ✓ (0 errors; 91 pre-existing warnings unrelated)
- typecheck: ✓ (`tsc --noEmit && tsc --noEmit -p tsconfig.electron.json`)
- build: ✓ (`npm run build:daemon`)
- unit tests: skipped — no `*.spec.ts` exists for `daemon/**` and no shared module touched. Wave-2 will add tests when endpoints land.
- e2e: skipped — daemon process is not yet wired into Electron host (separate dev-B / wave-2 work). Probes can't reach this code path until the host launches it.

## Notes for reviewer
- Windows note: SIGTERM/SIGINT handlers are correctly installed but cannot be exercised from Git Bash on Windows because MSYS `kill` translates to `TerminateProcess`, bypassing Node's signal handlers. CI's Linux/macOS matrix exercises them properly.
- The `5_000` ms force-exit fallback in `installShutdown` is belt-and-suspenders for lingering keep-alive sockets; intentionally `unref()`'d so it never blocks a clean exit.
- POST/PUT/etc. to `/api/health` correctly returns 404 because the router keys on `${METHOD} ${path}` — wave-2 endpoints can therefore reuse the same path string under different verbs without collision.