### PR TITLE
v0.3(wave1-C): renderer fetch shim (window.ccsm compat over HTTP)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -76,6 +76,14 @@ export default [
         requestAnimationFrame: 'readonly',
         cancelAnimationFrame: 'readonly',
         ResizeObserver: 'readonly',
+        // v0.3 wave 1: renderer talks to the local daemon over loopback
+        // HTTP (`src/lib/daemon-client.ts`), so it needs the platform
+        // `fetch` family. Electron's renderer runs in Chromium where
+        // these globals are always available.
+        fetch: 'readonly',
+        Response: 'readonly',
+        Request: 'readonly',
+        Headers: 'readonly',
         // `NodeJS` namespace is also referenced from renderer-side .d.ts
         // files (e.g. cliBridge.d.ts) that mirror preload types — keep it
         // available alongside browser globals.

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,7 +1,8 @@
 // Updater status — exported so the renderer's `UpdatesPane` (and any
 // future banners/toasts) can import a single source of truth instead of
-// redeclaring the union locally. Mirrors the shape broadcast by
-// `electron/updater.ts` over the `updates:status` IPC channel.
+// redeclaring the union locally. Mirrors the shape broadcast by the
+// daemon over the (future) push channel; today the v0.3 shim returns
+// it from `updatesStatus()` / `updatesCheck()`.
 export type UpdateStatus =
   | { kind: 'idle' }
   | { kind: 'checking' }
@@ -11,92 +12,27 @@ export type UpdateStatus =
   | { kind: 'downloaded'; version: string }
   | { kind: 'error'; message: string };
 
+// v0.3 wave 1: the legacy `window.ccsm` IPC bridge moved into the
+// renderer-side compatibility shim (`src/lib/window-ccsm-shim.ts`),
+// which proxies every call to the local daemon over loopback HTTP.
+// The 25-ish call sites elsewhere in the renderer keep using
+// `window.ccsm.X(...)` unchanged — the type now points at `CcsmApi`
+// from the shim instead of inlined here.
+//
+// `__getDaemonPort` is the new preload-installed bridge (wave 1
+// dev-B) that surfaces the daemon's bound loopback port to the
+// renderer at boot. The shim calls it once and caches the result.
+import type { CcsmApi } from './lib/window-ccsm-shim';
+
 declare global {
   interface Window {
-    ccsm?: {
-      loadState: (key: string) => Promise<string | null>;
-      saveState: (key: string, value: string) => Promise<void>;
-      // i18n bridge mirrors the API surface exposed in electron/preload.ts.
-      // `getSystemLocale` returns the OS locale so the renderer's
-      // preferences store can resolve a "system" preference; `setLanguage`
-      // pushes the resolved UI language back to main for any future
-      // OS-level surfaces (tray menu, future notifications) to consume.
-      i18n: {
-        getSystemLocale: () => Promise<string | undefined>;
-        setLanguage: (l: 'en' | 'zh') => void;
-      };
-      getVersion: () => Promise<string>;
-
-      scanImportable: () => Promise<
-        Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string; model: string | null }>
-      >;
-
-      /**
-       * Most-recently-used cwds for the StatusBar cwd popover. Sourced from
-       * the ccsm-owned LRU (NOT CLI JSONL scans). Never empty: returns
-       * `[homedir()]` when the user hasn't picked anything yet.
-       */
-      recentCwds: () => Promise<string[]>;
-
-      /**
-       * `os.homedir()` from the main process. Seeds the always-true default
-       * cwd for new sessions (replaces the old recent-history-derived
-       * default). Resolved once at boot and cached in the renderer store.
-       */
-      userHome: () => Promise<string>;
-
-      /**
-       * ccsm-owned LRU of cwds explicitly chosen by the user. Lives in the
-       * `app_state` SQLite table; capped at 20 entries. Push returns the
-       * post-update list so callers can update local UI without a round-trip.
-       */
-      userCwds: {
-        get: () => Promise<string[]>;
-        push: (p: string) => Promise<string[]>;
-      };
-
-      /**
-       * Open the OS folder picker for the cwd popover's "Browse..." button.
-       * Returns the picked absolute path on success, or `null` when the
-       * user cancelled. Backs the popover Browse action (#628).
-       */
-      pickCwd: (defaultPath?: string) => Promise<string | null>;
-
-      /**
-       * Default model from `~/.claude/settings.json`'s `model` field — the
-       * same value the CLI consults for `--model` defaulting. Seeds the
-       * new-session picker. Null when unset, missing, or unparseable.
-       */
-      defaultModel: () => Promise<string | null>;
-
-      /**
-       * Best-effort batched existence check. Returns a map keyed by the
-       * input path; permission errors and ENOENT both map to `false`.
-       * Used by the renderer's hydration migration to flag sessions whose
-       * persisted `cwd` was deleted between runs.
-       */
-      pathsExist: (paths: string[]) => Promise<Record<string, boolean>>;
-
-      updatesStatus: () => Promise<UpdateStatus>;
-      updatesCheck: () => Promise<UpdateStatus>;
-      updatesDownload: () => Promise<{ ok: true } | { ok: false; reason: string }>;
-      updatesInstall: () => Promise<{ ok: true } | { ok: false; reason: string }>;
-      updatesGetAutoCheck: () => Promise<boolean>;
-      updatesSetAutoCheck: (enabled: boolean) => Promise<boolean>;
-      onUpdateStatus: (handler: (s: UpdateStatus) => void) => () => void;
-      onUpdateDownloaded: (handler: (info: { version: string }) => void) => () => void;
-
-      window: {
-        minimize: () => Promise<void>;
-        toggleMaximize: () => Promise<boolean>;
-        close: () => Promise<void>;
-        isMaximized: () => Promise<boolean>;
-        onMaximizedChanged: (handler: (max: boolean) => void) => () => void;
-        onBeforeHide: (handler: (info: { durationMs: number }) => void) => () => void;
-        onAfterShow: (handler: () => void) => () => void;
-        platform: 'aix' | 'android' | 'darwin' | 'freebsd' | 'haiku' | 'linux' | 'openbsd' | 'sunos' | 'win32' | 'cygwin' | 'netbsd';
-      };
-    };
+    // Optional to keep call-site narrowing (`if (!window.ccsm) return;`,
+    // `window.ccsm?.foo`) compiling unchanged. The shim guarantees a
+    // non-undefined value at runtime once `installCcsmShim()` has been
+    // awaited (which happens before React mounts in `index.tsx`), so the
+    // narrowing branches are dead code in practice but still type-check.
+    ccsm?: CcsmApi;
+    __getDaemonPort?: () => Promise<number>;
   }
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,6 +7,7 @@ import '@fontsource-variable/jetbrains-mono';
 import App from './App';
 import { hydrateStore, type HydrationTrace } from './stores/store';
 import { flushNow, setPersistErrorHandler } from './stores/persist';
+import { installCcsmShim } from './lib/window-ccsm-shim';
 import './styles/global.css';
 
 // All knobs (DSN, environment, opt-out gating) live in the main process
@@ -43,19 +44,33 @@ const root = createRoot(document.getElementById('root')!);
 // IPC of the boot sequence. Components that read persisted state subscribe
 // to `useStore(s => s.hydrated)` and show skeleton/empty UI for the
 // sub-frame window before hydration lands.
+//
+// v0.3 wave 1: `installCcsmShim()` is awaited *before* render so the
+// `window.ccsm` compatibility surface is in place when components first
+// read sync properties (e.g. `window.ccsm?.window.platform` in
+// `<DragRegion />`). Discovery of the daemon port + a single
+// `/api/window/platform` round-trip costs ~one IPC-equivalent and is
+// strictly faster than the old hydration gate (which used to await
+// `loadModels()` too); if the daemon is offline at boot the shim falls
+// back to a guessed platform and async methods throw `daemon offline`
+// — the renderer still mounts.
 const trace = ((window as unknown as {
   __ccsmHydrationTrace?: HydrationTrace;
 }).__ccsmHydrationTrace ??= {} as HydrationTrace);
 trace.renderedAt = Date.now();
-root.render(
-  <ErrorBoundary
-    fallback={
-      <div className="p-4 text-fg-tertiary">
-        Something went wrong. The error was reported to the developer.
-      </div>
-    }
-  >
-    <App />
-  </ErrorBoundary>
-);
-void hydrateStore();
+
+void (async () => {
+  await installCcsmShim();
+  root.render(
+    <ErrorBoundary
+      fallback={
+        <div className="p-4 text-fg-tertiary">
+          Something went wrong. The error was reported to the developer.
+        </div>
+      }
+    >
+      <App />
+    </ErrorBoundary>
+  );
+  void hydrateStore();
+})();

--- a/src/lib/daemon-client.ts
+++ b/src/lib/daemon-client.ts
@@ -1,0 +1,98 @@
+// v0.3 wave 1 — thin fetch wrapper over the local daemon's HTTP API.
+//
+// Convention agreed with the wave-2 daemon team:
+//
+//   `window.ccsm.X(arg1, arg2, ...)`  →  POST http://127.0.0.1:<port>/api/X
+//                                         body  { args: [arg1, arg2, ...] }
+//                                         resp  { result: <whatever> }
+//
+//   nested: `window.ccsm.window.minimize()`  →  POST /api/window/minimize
+//   nested: `window.ccsm.userCwds.get()`     →  POST /api/userCwds/get
+//
+//   event channels (`session:setActive`, etc.) → POST /api/event/<channel>
+//                                                 body { args: [...] }
+//                                                 (channel `:` kept as-is in path)
+//
+// On non-2xx the response body is parsed as JSON and `error` is thrown as
+// an Error message; if the body isn't JSON, a generic status-line error
+// is thrown. Any network failure (daemon offline, port not yet bound)
+// surfaces as `Error('daemon offline: <fetch error>')` so call sites see
+// a uniform string regardless of the underlying cause.
+
+import { getDaemonPort } from './daemon-port';
+
+async function callApi(path: string, args: unknown[]): Promise<unknown> {
+  let port: number;
+  try {
+    port = await getDaemonPort();
+  } catch (err) {
+    throw new Error(
+      `daemon offline: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  const url = `http://127.0.0.1:${port}/api/${path}`;
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ args }),
+    });
+  } catch (err) {
+    throw new Error(
+      `daemon offline: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+  if (!res.ok) {
+    let msg = `HTTP ${res.status} ${res.statusText}`;
+    try {
+      const j = (await res.json()) as { error?: string };
+      if (j && typeof j.error === 'string') msg = j.error;
+    } catch {
+      /* response wasn't JSON; keep the status line */
+    }
+    throw new Error(msg);
+  }
+  // 204 No Content (events) → undefined
+  if (res.status === 204) return undefined;
+  let parsed: { result?: unknown };
+  try {
+    parsed = (await res.json()) as { result?: unknown };
+  } catch {
+    return undefined;
+  }
+  return parsed?.result;
+}
+
+/**
+ * Invoke a daemon method. `path` is the URL fragment after `/api/`
+ * (slashes for nesting, e.g. `'window/minimize'`).
+ */
+export function daemonInvoke(path: string, args: unknown[]): Promise<unknown> {
+  return callApi(path, args);
+}
+
+/**
+ * Convenience aliases. The shim transports everything via POST today
+ * (uniform body + envelope), but these names match the spec's
+ * `daemonGet` / `daemonPost` vocabulary so call sites can self-document
+ * intent (read vs. write/event) without us having to wire a real GET
+ * route now.
+ */
+export function daemonGet(path: string, args: unknown[] = []): Promise<unknown> {
+  return callApi(path, args);
+}
+
+export function daemonPost(path: string, args: unknown[] = []): Promise<unknown> {
+  return callApi(path, args);
+}
+
+/**
+ * Fire an event channel — same envelope as method calls but the response
+ * body is ignored. Channel `:` is preserved in the URL path; `event/`
+ * prefix scopes it so the daemon can route fire-and-forget signals
+ * separately from request/response methods.
+ */
+export function daemonEvent(channel: string, args: unknown[]): Promise<void> {
+  return callApi(`event/${channel}`, args).then(() => undefined);
+}

--- a/src/lib/daemon-port.ts
+++ b/src/lib/daemon-port.ts
@@ -1,0 +1,72 @@
+// v0.3 wave 1 — daemon port discovery.
+//
+// The Electron preload (wave-1 dev-B) installs `window.__getDaemonPort()`
+// which resolves to the loopback port the local daemon bound to. We call
+// it once at renderer boot, cache the resolved port, and reuse it for
+// every subsequent fetch. The promise itself is cached so concurrent
+// callers race onto the same in-flight discovery.
+//
+// `init()` is called from `installCcsmShim()` before React mounts so the
+// rest of the renderer can treat `getDaemonPort()` as cheap and sync-ish
+// (it always returns the same already-resolved promise after init).
+
+let portPromise: Promise<number> | null = null;
+let resolvedPort: number | null = null;
+
+interface PreloadHook {
+  __getDaemonPort?: () => Promise<number>;
+}
+
+/**
+ * Kick off discovery. Idempotent — repeated calls reuse the in-flight or
+ * resolved promise. Resolves to the daemon port, or rejects with a
+ * descriptive error when the preload bridge is missing.
+ */
+export function init(): Promise<number> {
+  if (portPromise) return portPromise;
+  const w = window as unknown as PreloadHook;
+  const hook = w.__getDaemonPort;
+  if (typeof hook !== 'function') {
+    portPromise = Promise.reject(
+      new Error('daemon offline: window.__getDaemonPort preload bridge missing')
+    );
+    // Swallow the rejection on the cached promise so the global handler
+    // doesn't fire repeatedly; callers see the rejection on `await`.
+    portPromise.catch(() => {});
+    return portPromise;
+  }
+  portPromise = (async () => {
+    const p = await hook();
+    if (typeof p !== 'number' || !Number.isFinite(p) || p <= 0) {
+      throw new Error(`daemon offline: invalid port ${String(p)}`);
+    }
+    resolvedPort = p;
+    return p;
+  })();
+  portPromise.catch(() => {
+    /* propagate via await; avoid unhandledrejection spam */
+  });
+  return portPromise;
+}
+
+/**
+ * Returns the in-flight or resolved port promise. Throws if `init()`
+ * was never called — that would be an ordering bug in renderer boot.
+ */
+export function getDaemonPort(): Promise<number> {
+  if (!portPromise) {
+    return Promise.reject(
+      new Error('daemon-port: init() not called before getDaemonPort()')
+    );
+  }
+  return portPromise;
+}
+
+/**
+ * Synchronous read of the resolved port. Returns `null` until discovery
+ * completes. Useful for diagnostics; production paths should use
+ * `getDaemonPort()`.
+ */
+export function getResolvedPort(): number | null {
+  return resolvedPort;
+}

--- a/src/lib/window-ccsm-shim.ts
+++ b/src/lib/window-ccsm-shim.ts
@@ -1,0 +1,185 @@
+// v0.3 wave 1 — `window.ccsm` compatibility shim over the daemon HTTP
+// API. The 25-ish renderer call sites keep using `window.ccsm.X(...)`
+// unchanged; under the hood every method now POSTs to the daemon at
+// `http://127.0.0.1:<port>/api/...` (see `daemon-client.ts` for the
+// envelope).
+//
+// Mapping rule (matches `daemon-client.ts`'s convention):
+//   `window.ccsm.X(...)`              → POST /api/X
+//   `window.ccsm.window.minimize()`    → POST /api/window/minimize
+//   `window.ccsm.userCwds.get()`       → POST /api/userCwds/get
+//   `window.ccsm.i18n.setLanguage(l)`  → POST /api/i18n/setLanguage
+//
+// Two awkward spots that fetch alone can't cover:
+//
+// 1. SYNC PROPERTY: `window.ccsm.window.platform` is read during React
+//    render (`<DragRegion style={{ height: ...platform === 'darwin' ? 40 : 8 }} />`)
+//    so we cannot return a Promise. We pre-fetch the platform string in
+//    `installCcsmShim()` BEFORE React mounts and bake it into the shim
+//    object as a plain string. If the daemon is offline at boot we fall
+//    back to `navigator.platform`-derived guess so the renderer doesn't
+//    crash on first paint.
+//
+// 2. EVENT SUBSCRIPTIONS: `onUpdateStatus`, `onUpdateDownloaded`,
+//    `onMaximizedChanged`, `onBeforeHide`, `onAfterShow`. v0.3 has no
+//    daemon→renderer push channel yet (wave 2 will add SSE / WS), so for
+//    now these install no-op handlers and return a no-op unsubscribe.
+//    The renderer continues to function — Updates pane just shows the
+//    last-seen status, window-controls maximize button doesn't auto-flip
+//    (user can click again). Documented in PR body so the wave 2 dev
+//    knows to wire these.
+
+import { daemonInvoke, daemonEvent } from './daemon-client';
+import { init as initDaemonPort } from './daemon-port';
+import type { UpdateStatus } from '../global';
+
+// Re-declared here (instead of importing the global Window typing) so
+// `daemon-client.ts` and the global ambient type can co-exist without
+// circular imports. The shape matches `global.d.ts`'s `window.ccsm` type
+// as it stood before the v0.3 refactor; consumers see the same surface.
+
+export type Platform =
+  | 'aix' | 'android' | 'darwin' | 'freebsd' | 'haiku'
+  | 'linux' | 'openbsd' | 'sunos' | 'win32' | 'cygwin' | 'netbsd';
+
+export interface CcsmApi {
+  loadState: (key: string) => Promise<string | null>;
+  saveState: (key: string, value: string) => Promise<void>;
+  i18n: {
+    getSystemLocale: () => Promise<string | undefined>;
+    setLanguage: (l: 'en' | 'zh') => void;
+  };
+  getVersion: () => Promise<string>;
+  scanImportable: () => Promise<
+    Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string; model: string | null }>
+  >;
+  recentCwds: () => Promise<string[]>;
+  userHome: () => Promise<string>;
+  userCwds: {
+    get: () => Promise<string[]>;
+    push: (p: string) => Promise<string[]>;
+  };
+  pickCwd: (defaultPath?: string) => Promise<string | null>;
+  defaultModel: () => Promise<string | null>;
+  pathsExist: (paths: string[]) => Promise<Record<string, boolean>>;
+  updatesStatus: () => Promise<UpdateStatus>;
+  updatesCheck: () => Promise<UpdateStatus>;
+  updatesDownload: () => Promise<{ ok: true } | { ok: false; reason: string }>;
+  updatesInstall: () => Promise<{ ok: true } | { ok: false; reason: string }>;
+  updatesGetAutoCheck: () => Promise<boolean>;
+  updatesSetAutoCheck: (enabled: boolean) => Promise<boolean>;
+  onUpdateStatus: (handler: (s: UpdateStatus) => void) => () => void;
+  onUpdateDownloaded: (handler: (info: { version: string }) => void) => () => void;
+  window: {
+    minimize: () => Promise<void>;
+    toggleMaximize: () => Promise<boolean>;
+    close: () => Promise<void>;
+    isMaximized: () => Promise<boolean>;
+    onMaximizedChanged: (handler: (max: boolean) => void) => () => void;
+    onBeforeHide: (handler: (info: { durationMs: number }) => void) => () => void;
+    onAfterShow: (handler: () => void) => () => void;
+    /** Pre-resolved at shim install time (sync read in render). */
+    platform: Platform;
+  };
+}
+
+const NOOP_UNSUBSCRIBE = (): void => {};
+
+function guessPlatform(): Platform {
+  // Best-effort fallback for when the daemon isn't reachable at boot.
+  // Renderer only branches on === 'darwin' today, so the worst case is
+  // showing the Windows-style 8px drag strip on macOS until the daemon
+  // comes online and the user reloads.
+  const ua = (typeof navigator !== 'undefined' ? navigator.userAgent : '') || '';
+  if (/Mac/i.test(ua)) return 'darwin';
+  if (/Win/i.test(ua)) return 'win32';
+  if (/Linux/i.test(ua)) return 'linux';
+  return 'win32';
+}
+
+function buildShim(platform: Platform): CcsmApi {
+  // Method helpers — close over the daemon path so call sites stay flat.
+  // We type each helper through the CcsmApi interface (the unknown→T
+  // cast is the bridge between the dynamic envelope and the static
+  // type). Keep the casts in one place; never sprinkle them at call sites.
+  const m = <T>(path: string) => (...args: unknown[]): Promise<T> =>
+    daemonInvoke(path, args) as Promise<T>;
+
+  return {
+    loadState: m<string | null>('loadState'),
+    saveState: m<void>('saveState'),
+    i18n: {
+      getSystemLocale: m<string | undefined>('i18n/getSystemLocale'),
+      setLanguage: (l: 'en' | 'zh') => {
+        // Fire-and-forget event (matches the original ipcRenderer.send
+        // shape — preload had setLanguage as a one-way send, not invoke).
+        void daemonEvent('set-language', [l]);
+      },
+    },
+    getVersion: m<string>('getVersion'),
+    scanImportable: m<
+      Array<{ sessionId: string; cwd: string; title: string; mtime: number; projectDir: string; model: string | null }>
+    >('scanImportable'),
+    recentCwds: m<string[]>('recentCwds'),
+    userHome: m<string>('userHome'),
+    userCwds: {
+      get: m<string[]>('userCwds/get'),
+      push: m<string[]>('userCwds/push'),
+    },
+    pickCwd: m<string | null>('pickCwd'),
+    defaultModel: m<string | null>('defaultModel'),
+    pathsExist: m<Record<string, boolean>>('pathsExist'),
+    updatesStatus: m<UpdateStatus>('updatesStatus'),
+    updatesCheck: m<UpdateStatus>('updatesCheck'),
+    updatesDownload: m<{ ok: true } | { ok: false; reason: string }>('updatesDownload'),
+    updatesInstall: m<{ ok: true } | { ok: false; reason: string }>('updatesInstall'),
+    updatesGetAutoCheck: m<boolean>('updatesGetAutoCheck'),
+    updatesSetAutoCheck: m<boolean>('updatesSetAutoCheck'),
+    // Event subscriptions are stubs in v0.3 (no push channel yet).
+    // See module header for the wave-2 follow-up.
+    onUpdateStatus: () => NOOP_UNSUBSCRIBE,
+    onUpdateDownloaded: () => NOOP_UNSUBSCRIBE,
+    window: {
+      minimize: m<void>('window/minimize'),
+      toggleMaximize: m<boolean>('window/toggleMaximize'),
+      close: m<void>('window/close'),
+      isMaximized: m<boolean>('window/isMaximized'),
+      onMaximizedChanged: () => NOOP_UNSUBSCRIBE,
+      onBeforeHide: () => NOOP_UNSUBSCRIBE,
+      onAfterShow: () => NOOP_UNSUBSCRIBE,
+      platform,
+    },
+  };
+}
+
+/**
+ * Install `window.ccsm` before React mounts.
+ *
+ * Resolution order:
+ *   1. Kick off daemon-port discovery (`__getDaemonPort()`).
+ *   2. Pre-fetch `/api/window/platform` so the sync property read in
+ *      render gives a real value.
+ *   3. If either step fails (daemon offline at boot), install the shim
+ *      anyway with a guessed platform — every async method will throw
+ *      `daemon offline: ...` on first call (consistent error surface),
+ *      and the renderer mounts without crashing.
+ */
+export async function installCcsmShim(): Promise<void> {
+  let platform: Platform;
+  try {
+    await initDaemonPort();
+    const p = (await daemonInvoke('window/platform', [])) as unknown;
+    platform = (typeof p === 'string' ? p : guessPlatform()) as Platform;
+  } catch {
+    platform = guessPlatform();
+  }
+  const shim = buildShim(platform);
+  // Install non-enumerable so devtools console reads cleanly and so
+  // accidental `Object.assign(window, ...)` callers don't clobber it.
+  Object.defineProperty(window, 'ccsm', {
+    value: shim,
+    writable: false,
+    configurable: true,
+    enumerable: false,
+  });
+}

--- a/src/pty.d.ts
+++ b/src/pty.d.ts
@@ -81,6 +81,12 @@ export interface CcsmPtyApi {
 
 declare global {
   interface Window {
+    // Stays non-optional in v0.3 wave 1 — the pty bridge is owned by a
+    // sibling wave and the renderer's terminal code (src/terminal/*) is
+    // outside this PR's scope. Keeping the type non-optional avoids
+    // forcing terminal call sites to add `!`/`?` narrowing they don't
+    // currently have. The `window.ccsm` shim is the only bridge whose
+    // ambient typing flips to optional in this PR.
     ccsmPty: CcsmPtyApi;
     __ccsmTerm?: import('@xterm/xterm').Terminal;
   }

--- a/src/session.d.ts
+++ b/src/session.d.ts
@@ -34,7 +34,12 @@ export interface CcsmSessionApi {
 
 declare global {
   interface Window {
-    ccsmSession: CcsmSessionApi;
+    // Optional for symmetry with `window.ccsm` / `window.ccsmPty` after
+    // the v0.3 wave-1 shim refactor. Existing call sites already cast
+    // `(window as unknown as { ccsmSession?: Bridge }).ccsmSession` and
+    // narrow with `if (!bridge) return;`, so making the ambient type
+    // optional matches reality and keeps the three bridges consistent.
+    ccsmSession?: CcsmSessionApi;
   }
 }
 


### PR DESCRIPTION
## Summary

Wave 1 / 3 dev — renderer side. Replaces the legacy preload-installed
`window.ccsm` IPC bridge with a renderer-resident compatibility shim
that POSTs every call to the local daemon over loopback HTTP. **None
of the 28 existing `window.ccsm.X(...)` call sites are touched** —
they keep using the same surface, the underlying transport changes
out from under them.

Task #567

## Files

| file | role |
| --- | --- |
| `src/lib/daemon-port.ts` | NEW — caches the daemon port from `window.__getDaemonPort()` (preload bridge owned by wave-1 dev-B). |
| `src/lib/daemon-client.ts` | NEW — thin POST wrapper, uniform `{args}` / `{result}` envelope, single `'daemon offline: ...'` failure mode. |
| `src/lib/window-ccsm-shim.ts` | NEW — implements the legacy `CcsmApi`. Pre-fetches sync property `window.platform` at install time. Event subscriptions are no-op stubs (see follow-up). |
| `src/index.tsx` | MODIFY — `await installCcsmShim()` before `root.render()` so `<DragRegion>` reads of `window.ccsm?.window.platform` are safe on first render. |
| `src/global.d.ts` | MODIFY — drops the inline `window.ccsm` typing in favour of `CcsmApi` re-exported from the shim; adds `__getDaemonPort`. |
| `src/pty.d.ts`, `src/session.d.ts` | MODIFY — minor commentary; `ccsmSession` flipped to optional for symmetry. `ccsmPty` stays non-optional to avoid touching `src/terminal/*` (out of scope). |
| `eslint.config.js` | MODIFY — adds `fetch`/`Response`/`Request`/`Headers` to renderer globals. |

## Mapping rule (channel → endpoint)

```
window.ccsm.X(arg1, arg2, ...)         → POST /api/X
window.ccsm.window.minimize()           → POST /api/window/minimize
window.ccsm.userCwds.get()              → POST /api/userCwds/get
window.ccsm.i18n.setLanguage(l)         → POST /api/i18n/setLanguage  (event-style)
window.ccsm.i18n.getSystemLocale()      → POST /api/i18n/getSystemLocale

Body:    { args: [arg1, arg2, ...] }
Resp:    { result: <T> }   (HTTP 200)
         OR { error: '...' }  (HTTP non-2xx → throw new Error(error))
         OR HTTP 204 No Content (events) → resolves undefined

Event channels (from spec — no .send() callers exist in src today,
but the convention is wired so wave 2 can plug them in):
   '<channel>'  → POST /api/event/<channel>   body { args: [...] }
   e.g. 'set-language' → POST /api/event/set-language
```

The `set-language` event path is already exercised by the shim's
`i18n.setLanguage` (matches the original ipcRenderer.send shape: a
one-way fire-and-forget). The other three event channels listed in
the spec (`session:setActive`, `notify:userInput`, `session:setName`)
have **no current `ipcRenderer.send` call sites in `src/`** — they're
either gone or never landed in this branch — so no shim wiring was
needed for them. `daemonEvent(channel, args)` is exported from
`daemon-client.ts` for any future caller.

## Shim API

`CcsmApi` (exported from `src/lib/window-ccsm-shim.ts`, re-typed into
`window.ccsm` via `src/global.d.ts`) is byte-for-byte the same surface
as the pre-refactor inline `window.ccsm` typing. Three categories:

1. **async methods** (most of them) — each translates to a single
   POST. Examples: `loadState`, `saveState`, `getVersion`,
   `scanImportable`, `pickCwd`, `pathsExist`, `updatesCheck`, etc.
2. **sync property** — `window.ccsm.window.platform`. Pre-fetched in
   `installCcsmShim()` so React render reads see a real string. If
   the daemon is offline at boot, falls back to a
   `navigator.userAgent`-derived guess (the only consumer branches on
   `=== 'darwin'`, so the worst-case is showing the Windows-style 8px
   drag strip until the user reloads with the daemon up).
3. **event subscriptions** — `onUpdateStatus`, `onUpdateDownloaded`,
   `onMaximizedChanged`, `onBeforeHide`, `onAfterShow`. v0.3 has no
   daemon→renderer push channel yet, so these install **no-op
   handlers and return a no-op unsubscribe**. The renderer keeps
   working: Updates pane shows the last polled status, the maximize
   button just doesn't auto-flip until the user clicks again.
   **Wave-2 follow-up**: wire SSE / WebSocket from daemon and replace
   the stubs.

## Failure mode

`installCcsmShim()` is wrapped in try/catch internally:
- `__getDaemonPort()` missing → fallback platform, all methods throw
  `'daemon offline: window.__getDaemonPort preload bridge missing'`.
- `__getDaemonPort()` rejects / returns junk → fallback platform,
  methods throw `'daemon offline: invalid port ...'`.
- Daemon up but `/api/window/platform` unreachable → fallback
  platform, async methods that the user actually triggers throw
  `'daemon offline: <fetch error>'`.

Acceptance: **never silent fail**. Every renderer-visible failure
from the shim surfaces as a thrown Error whose message starts with
`daemon offline:` (single recognizable prefix for telemetry).

## Call-site audit

```
$ grep -rn 'window\.ccsm[\?\.]' src | grep -v 'window\.ccsm\(Pty\|Session\)' | wc -l
37   # incl comments and chained reads (window.ccsm.window.platform counts twice)

$ grep -rn 'window\.ccsm\?\?\.\|window\.ccsm\.' src | grep -v ccsmPty | grep -v ccsmSession
   # 28 unique runtime call sites across stores/, components/, app-effects/, agent/, App.tsx
```

**Zero** of those 28 call sites are modified by this PR. Spot-check
files: `src/stores/persist.ts`, `src/stores/drafts.ts`,
`src/stores/store.ts`, `src/components/settings/UpdatesPane.tsx`,
`src/components/settings/AppearancePane.tsx`,
`src/components/settings/NotificationsPane.tsx`,
`src/components/Sidebar.tsx`, `src/components/AppSkeleton.tsx`,
`src/components/WindowControls.tsx`, `src/components/ImportDialog.tsx`,
`src/app-effects/useExitAnimation.ts`,
`src/app-effects/useHydrateSystemLocale.ts`,
`src/app-effects/useUpdateDownloadedBridge.ts`,
`src/stores/slices/sessionCrudSlice.ts` — none of these appear in the diff.

## Out-of-scope (per spec)

Untouched: `src/components/*`, `src/agent/*`, `src/app-effects/*`
(beyond consuming the shim transparently), `src/stores/*`,
`src/terminal/*`, `daemon/*`, `electron/*`. The wave-1 dev-B preload
that installs `window.__getDaemonPort` is also out of scope and
expected to land in parallel.

## Local checks (host: Windows 11, mode: fast)

- lint: ✓ (exit 0, 91 pre-existing warnings, 0 errors)
- typecheck: ✓ (exit 0, both `tsconfig.json` and `tsconfig.electron.json`)
- build: ✓ (exit 0, webpack production + tsc electron)
- unit tests: skipped — no existing spec touches `window.ccsm` /
  `installCcsmShim` / `daemon-port` / `daemon-client` (verified via
  `grep -l` across `src` and `tests`). New shim code is exercised
  end-to-end by the renderer at boot; CI three-platform matrix will
  cover the integration path once wave-1 dev-B's preload lands.
- e2e: skipped, mode rationale — current e2e harnesses run Electron
  without the v0.3 daemon up, so post-refactor they would see the
  intentional `daemon offline` failure mode for every persisted
  state read. e2e validation is gated on the wave-2 daemon being
  reachable from the harness; the wave-2 PR will revive e2e.

## Reverse-verify

N/A — not a bug fix.