### PR TITLE
v0.3(wave2-prep): auto-registry daemon/api + 5-bridge preload skeleton

### DIFF
--- a/daemon/api/index.ts
+++ b/daemon/api/index.ts
@@ -1,20 +1,50 @@
 /**
  * Endpoint registry for the daemon HTTP API.
  *
- * Wave-1 (this PR): only the always-on endpoints `/api/health` and
- * `/api/version` registered from `daemon/main.ts`. This module is the
- * extension point — wave-2 deciders/sinks will register their endpoints by
- * calling `registerApi(router)` from here.
+ * Wave-2-prep: auto-registry. Scans sibling files in `daemon/api/*.js`,
+ * skips `index.js`, requires each, and invokes the default export as a
+ * registrar `(router: Router) => void`. Wave-2 sub-PRs (B/C) drop new
+ * files like `pty.ts` / `system.ts` here without touching this index —
+ * which lets W2-A/B/C run in parallel (no shared edits to this file).
+ *
+ * A registrar that throws is logged to stderr and skipped; one bad
+ * module must not take down the whole API surface.
  */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
 
 import type { Router } from "../router";
 
-/**
- * Register all wave-2+ API endpoints on the given router.
- *
- * Wave-1: intentionally empty. Wave-2 PRs will add route registrations here
- * (e.g. `router.addRoute("POST", "/api/sessions", createSession)`).
- */
-export function registerApi(_router: Router): void {
-  // Intentionally empty. Wave-2 dev fills in.
+type Registrar = (router: Router) => void;
+
+export function registerApi(router: Router): void {
+  const dir = __dirname;
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch (err) {
+    process.stderr.write(`registerApi: readdir(${dir}) failed: ${String(err)}\n`);
+    return;
+  }
+  const candidates = entries
+    .filter((name) => name.endsWith(".js") && name !== "index.js")
+    .sort();
+  for (const name of candidates) {
+    const full = path.join(dir, name);
+    let mod: { default?: Registrar };
+    try {
+      mod = require(full) as { default?: Registrar };
+    } catch (err) {
+      process.stderr.write(`registerApi: require(${full}) failed: ${String(err)}\n`);
+      continue;
+    }
+    const reg = mod.default;
+    if (typeof reg !== "function") continue;
+    try {
+      reg(router);
+    } catch (err) {
+      process.stderr.write(`registerApi: register(${name}) threw: ${String(err)}\n`);
+    }
+  }
 }

--- a/electron/preload/bridges/ccsmNotify.ts
+++ b/electron/preload/bridges/ccsmNotify.ts
@@ -1,0 +1,44 @@
+/**
+ * `window.ccsmNotify` — preload bridge stub for the v0.3 daemon transition.
+ *
+ * Wave-2-C replaces this file with a real SSE shim against `/api/events/notify`.
+ * Until then, subscriptions return noop unsubscribe (renderer cleanup paths run).
+ */
+
+import { contextBridge } from "electron";
+
+function noopUnsubscribe(): () => void {
+  return () => {
+    /* noop */
+  };
+}
+
+async function fireUserInput(sid: string): Promise<void> {
+  const getPort = (window as unknown as { ccsm?: { getDaemonPort?: () => Promise<number | null> } }).ccsm
+    ?.getDaemonPort;
+  if (!getPort) return;
+  const port = await getPort();
+  if (port == null) return;
+  try {
+    await fetch(`http://127.0.0.1:${port}/api/event/notify/userInput`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ args: [sid] }),
+    });
+  } catch {
+    /* fire-and-forget */
+  }
+}
+
+const ccsmNotify = {
+  userInput: (sid: string): Promise<void> => fireUserInput(sid),
+  onNotified: (_cb: (e: unknown) => void): (() => void) => noopUnsubscribe(),
+  onUnwatched: (_cb: (e: unknown) => void): (() => void) => noopUnsubscribe(),
+  onBadgeChanged: (_cb: (e: unknown) => void): (() => void) => noopUnsubscribe(),
+} as const;
+
+export type CcsmNotifyApi = typeof ccsmNotify;
+
+export function installCcsmNotifyBridge(): void {
+  contextBridge.exposeInMainWorld("ccsmNotify", ccsmNotify);
+}

--- a/electron/preload/bridges/ccsmPty.ts
+++ b/electron/preload/bridges/ccsmPty.ts
@@ -1,0 +1,59 @@
+/**
+ * `window.ccsmPty` — preload bridge stub for the v0.3 daemon transition.
+ *
+ * Wave-1 deleted the original electron/preload bridges. Wave-2-prep
+ * restores them as STUBS so the renderer can mount without crashing on
+ * `window.ccsmPty.X is undefined`. Every method throws a uniform
+ * `'pty: not yet wired (W2-B)'` error, which the existing renderer
+ * try/catch + zustand error state already handle gracefully (terminal
+ * pane shows error message, not white screen).
+ *
+ * Wave-2-B replaces this file with a real fetch+EventSource shim against
+ * `/api/pty/*` and `/api/events/pty?sid=...`. Other wave-2 sub-PRs MUST NOT
+ * touch this file (only W2-B does).
+ */
+
+import { contextBridge } from "electron";
+
+const NOT_WIRED = new Error("pty: not yet wired (W2-B)");
+
+function rejectAsync<T>(): Promise<T> {
+  return Promise.reject(NOT_WIRED);
+}
+
+function noopUnsubscribe(): () => void {
+  return () => {
+    /* noop */
+  };
+}
+
+const ccsmPty = {
+  spawn: (_opts: unknown): Promise<unknown> => rejectAsync(),
+  attach: (_sid: string): Promise<unknown> => rejectAsync(),
+  detach: (_sid: string): Promise<void> => rejectAsync(),
+  get: (_sid: string): Promise<unknown> => rejectAsync(),
+  list: (): Promise<unknown[]> => Promise.resolve([]),
+  input: (_sid: string, _data: string): Promise<void> => rejectAsync(),
+  resize: (_sid: string, _cols: number, _rows: number): Promise<void> => rejectAsync(),
+  kill: (_sid: string): Promise<void> => rejectAsync(),
+  checkClaudeAvailable: (): Promise<{ available: boolean; reason?: string }> =>
+    Promise.resolve({ available: false, reason: "pty: not yet wired (W2-B)" }),
+  getBufferSnapshot: (_sid: string): Promise<string> => Promise.resolve(""),
+  // Event subscriptions: return noop unsubscribe so renderer cleanup paths
+  // run without throwing. Real W2-B wires these to EventSource.
+  onData: (_sid: string, _cb: (data: string) => void): (() => void) => noopUnsubscribe(),
+  onExit: (_sid: string, _cb: (code: number | null) => void): (() => void) => noopUnsubscribe(),
+  onAck: (_sid: string, _cb: (seq: number) => void): (() => void) => noopUnsubscribe(),
+  // Clipboard helper used by xterm.ts. Delegate to navigator.clipboard in
+  // renderer rather than IPC — this method works even without daemon.
+  clipboard: {
+    writeText: (text: string): Promise<void> =>
+      navigator.clipboard?.writeText(text) ?? Promise.resolve(),
+  },
+} as const;
+
+export type CcsmPtyApi = typeof ccsmPty;
+
+export function installCcsmPtyBridge(): void {
+  contextBridge.exposeInMainWorld("ccsmPty", ccsmPty);
+}

--- a/electron/preload/bridges/ccsmSession.ts
+++ b/electron/preload/bridges/ccsmSession.ts
@@ -1,0 +1,56 @@
+/**
+ * `window.ccsmSession` — preload bridge stub for the v0.3 daemon transition.
+ *
+ * Stub for wave-2-prep. setActive/setName fire-and-forget against the daemon
+ * via `daemonEvent('session/setActive', ...)`-style routes (W2-A registers
+ * `/api/event/session/setActive` and `/api/event/session/setName`). Event
+ * subscriptions return noop unsubscribe — W2-C wires them to SSE.
+ *
+ * Renderer's `app-effects/use*Bridge.ts` files do `if (!window.ccsmSession)
+ * return` already; with this stub installed, callsites also tolerate
+ * "subscribed but never fires" (the noop unsubscribe is fine).
+ */
+
+import { contextBridge } from "electron";
+
+function noopUnsubscribe(): () => void {
+  return () => {
+    /* noop */
+  };
+}
+
+// Fire-and-forget POST against the daemon. Looks up the daemon port via
+// the same channel ccsmCore uses (window.ccsm.getDaemonPort) — but this
+// preload runs before window.ccsm is exposed, so we read it lazily.
+async function fireEvent(method: string, args: unknown[]): Promise<void> {
+  const getPort = (window as unknown as { ccsm?: { getDaemonPort?: () => Promise<number | null> } }).ccsm
+    ?.getDaemonPort;
+  if (!getPort) return;
+  const port = await getPort();
+  if (port == null) return;
+  try {
+    await fetch(`http://127.0.0.1:${port}/api/event/${method}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ args }),
+    });
+  } catch {
+    /* fire-and-forget — daemon offline is not fatal here */
+  }
+}
+
+const ccsmSession = {
+  setActive: (sid: string | null): Promise<void> => fireEvent("session/setActive", [sid]),
+  setName: (sid: string, name: string): Promise<void> => fireEvent("session/setName", [sid, name]),
+  // Event subscriptions: noop until W2-C wires SSE.
+  onState: (_cb: (state: unknown) => void): (() => void) => noopUnsubscribe(),
+  onTitle: (_cb: (e: unknown) => void): (() => void) => noopUnsubscribe(),
+  onActivate: (_cb: (e: unknown) => void): (() => void) => noopUnsubscribe(),
+  onCwdRedirected: (_cb: (e: unknown) => void): (() => void) => noopUnsubscribe(),
+} as const;
+
+export type CcsmSessionApi = typeof ccsmSession;
+
+export function installCcsmSessionBridge(): void {
+  contextBridge.exposeInMainWorld("ccsmSession", ccsmSession);
+}

--- a/electron/preload/bridges/ccsmSessionTitles.ts
+++ b/electron/preload/bridges/ccsmSessionTitles.ts
@@ -1,0 +1,21 @@
+/**
+ * `window.ccsmSessionTitles` — preload bridge stub for the v0.3 daemon transition.
+ *
+ * Wave-2-C replaces with real fetch shim against `/api/sessionTitles/*`.
+ * Until then, get returns null, listForProject returns [], flushPending noops.
+ * This matches the "title not yet known" state the renderer already handles.
+ */
+
+import { contextBridge } from "electron";
+
+const ccsmSessionTitles = {
+  get: (_sid: string): Promise<string | null> => Promise.resolve(null),
+  listForProject: (_projectId: string): Promise<unknown[]> => Promise.resolve([]),
+  flushPending: (): Promise<void> => Promise.resolve(),
+} as const;
+
+export type CcsmSessionTitlesApi = typeof ccsmSessionTitles;
+
+export function installCcsmSessionTitlesBridge(): void {
+  contextBridge.exposeInMainWorld("ccsmSessionTitles", ccsmSessionTitles);
+}

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -1,15 +1,29 @@
 // Preload entry point. Loaded by `electron/window/createWindow.ts` via
-// `path.join(__dirname, '..', 'preload', 'index.js')`. v0.3 wave-1 B:
-// the 5-bridge fan-out from #769 collapsed to one — the four business
-// bridges (ccsmPty / ccsmSession / ccsmNotify / ccsmSessionTitles) moved
-// to electron/__legacy_to_delete__/preload-bridges/ pending wave-2
-// deletion. Renderer reaches those domains over the daemon's loopback
-// HTTP API now (port discovered via `window.ccsm.getDaemonPort()`).
+// `path.join(__dirname, '..', 'preload', 'index.js')`.
+//
+// Wave-2-prep restores the 5-bridge skeleton from v0.2 so the renderer
+// mounts without crashing on `window.ccsmPty.X is undefined`. The four
+// business bridges (Pty/Session/Notify/SessionTitles) are STUBS — wave 2
+// sub-PRs B/C replace them one-by-one with real fetch+SSE shims against
+// the daemon's loopback API. Splitting the install into 5 separate files
+// lets W2-A/B/C touch disjoint files and run in parallel.
 
 import '@sentry/electron/preload';
 
 import { installCcsmCoreBridge } from './bridges/ccsmCore';
+import { installCcsmPtyBridge } from './bridges/ccsmPty';
+import { installCcsmSessionBridge } from './bridges/ccsmSession';
+import { installCcsmNotifyBridge } from './bridges/ccsmNotify';
+import { installCcsmSessionTitlesBridge } from './bridges/ccsmSessionTitles';
 
 installCcsmCoreBridge();
+installCcsmPtyBridge();
+installCcsmSessionBridge();
+installCcsmNotifyBridge();
+installCcsmSessionTitlesBridge();
 
 export type { CCSMAPI } from './bridges/ccsmCore';
+export type { CcsmPtyApi } from './bridges/ccsmPty';
+export type { CcsmSessionApi } from './bridges/ccsmSession';
+export type { CcsmNotifyApi } from './bridges/ccsmNotify';
+export type { CcsmSessionTitlesApi } from './bridges/ccsmSessionTitles';


### PR DESCRIPTION
## Summary
- Decouples wave 2's three sub-PRs (W2-A/B/C) from sharing edits to `daemon/api/index.ts` + `electron/preload/index.ts`.
- After this lands, W2-A/B/C touch disjoint files and run truly in parallel (saves ~1.5h vs serial).
- Renderer-safe: stubs reject sync calls with clear error, return [] / null / noop unsubscribe for list/get/event paths — matches states the renderer already handles.

## What's in
- `daemon/api/index.ts`: empty stub → auto-registry. Scans `daemon/api/*.js` (ex `index.js`), requires each, invokes default export `Registrar(router)`. W2-B drops `pty.ts`, W2-C drops `system.ts` — neither needs to edit this file.
- `electron/preload/index.ts`: install all 5 bridges (`ccsmCore` real + 4 stubs).
- `electron/preload/bridges/ccsmPty.ts` NEW stub: rejects with `'pty: not yet wired (W2-B)'`.
- `electron/preload/bridges/ccsmSession.ts` NEW stub: `setActive`/`setName` fire-and-forget POST `/api/event/session/X`.
- `electron/preload/bridges/ccsmNotify.ts` NEW stub: `userInput` fire-and-forget POST.
- `electron/preload/bridges/ccsmSessionTitles.ts` NEW stub: returns null/[].

## Why now
Without this prep, W2-A/B/C all edit `daemon/api/index.ts` (register call) and `electron/preload/index.ts` (install bridge) — guaranteed merge conflict, forcing serial. Lesson codified in `manager.md` §2.5.1 + `feedback_serial_chain_reorg_for_parallel.md`.

## Test plan
- [x] `npm run build:daemon` green
- [x] `npm run build` green (3 pre-existing bundle-size warnings)
- [ ] Smoke test `electron .` opens window without white screen (manager verifies post-merge in #576)

🤖 Generated with [Claude Code](https://claude.com/claude-code)