### PR TITLE
v0.3(wave2-prep-v2): startup auto-registry for daemon/main.ts

### DIFF
--- a/daemon/main.ts
+++ b/daemon/main.ts
@@ -18,6 +18,7 @@ import { join } from "node:path";
 import { registerApi } from "./api/index";
 import { startServer, type ServerHandle } from "./server";
 import { Router, type HandlerResult } from "./router";
+import { runStartup } from "./startup/index";
 
 interface PackageJsonLike {
   version?: string;
@@ -54,12 +55,13 @@ function buildRouter(version: string): Router {
   return router;
 }
 
-function installShutdown(handle: ServerHandle): void {
+function installShutdown(handle: ServerHandle, abortController: AbortController): void {
   let shuttingDown = false;
   const shutdown = (signal: string): void => {
     if (shuttingDown) return;
     shuttingDown = true;
     process.stderr.write(`[daemon] received ${signal}, shutting down\n`);
+    abortController.abort();
     // Stop accepting new connections; existing keep-alive conns will be torn
     // down by Node when there is no in-flight request.
     handle.close().then(
@@ -88,13 +90,17 @@ function installShutdown(handle: ServerHandle): void {
 async function main(): Promise<void> {
   const version = readPackageVersion();
   const router = buildRouter(version);
+  const abortController = new AbortController();
+
+  await runStartup({ router, version, abort: abortController.signal });
+
   const handle = await startServer({ router });
 
   // PROTOCOL: first line on stdout MUST be `PORT=<n>\n`. Don't add prefix,
   // don't buffer, don't conflate with logs.
   process.stdout.write(`PORT=${handle.port}\n`);
 
-  installShutdown(handle);
+  installShutdown(handle, abortController);
 
   process.stderr.write(
     `[daemon] listening on 127.0.0.1:${handle.port} (version=${version})\n`,

--- a/daemon/startup/index.ts
+++ b/daemon/startup/index.ts
@@ -1,0 +1,54 @@
+/**
+ * Startup auto-registry — mirror of `daemon/api/index.ts` for boot-time
+ * wiring. Scans `daemon/startup/*.js`, skipping `index.js` + `types.js`,
+ * requires each, awaits the default export as a `Startup` function.
+ *
+ * Modules execute in alphabetical filename order — if A depends on B
+ * being initialized first, name them so B sorts ahead (e.g. `00-db.ts`
+ * before `pty.ts`). One module throwing is logged + skipped; the daemon
+ * keeps booting so a single bad module doesn't crash the host.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import type { StartupContext, Startup } from "./types";
+
+export async function runStartup(ctx: StartupContext): Promise<void> {
+  const dir = __dirname;
+  let entries: string[];
+  try {
+    entries = fs.readdirSync(dir);
+  } catch (err) {
+    process.stderr.write(`runStartup: readdir(${dir}) failed: ${String(err)}\n`);
+    return;
+  }
+  const candidates = entries
+    .filter(
+      (name) =>
+        name.endsWith(".js") && name !== "index.js" && name !== "types.js",
+    )
+    .sort();
+  let okCount = 0;
+  for (const name of candidates) {
+    const full = path.join(dir, name);
+    let mod: { default?: Startup };
+    try {
+      mod = require(full) as { default?: Startup };
+    } catch (err) {
+      process.stderr.write(`runStartup: require(${full}) failed: ${String(err)}\n`);
+      continue;
+    }
+    const fn = mod.default;
+    if (typeof fn !== "function") continue;
+    try {
+      await fn(ctx);
+      okCount += 1;
+    } catch (err) {
+      process.stderr.write(
+        `runStartup: ${name} threw: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`,
+      );
+    }
+  }
+  process.stderr.write(`[daemon] startup phase complete (${okCount} modules)\n`);
+}

--- a/daemon/startup/types.ts
+++ b/daemon/startup/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Startup module contracts.
+ *
+ * Wave 2 sub-PRs (W2-A/B/C) each need to wire something at daemon boot:
+ * sentry init, sqlite open, ptyHost spawn, sessionWatcher start, notify
+ * producer, etc. Without this registry they'd all edit `daemon/main.ts`
+ * which makes them serial. Instead each drops a single file under
+ * `daemon/startup/` exporting `default` as a `Startup` function.
+ *
+ * Modules run sequentially in alphabetical filename order. If one throws,
+ * the daemon logs and continues — startup must be best-effort so a broken
+ * sub-module can't take the whole daemon down.
+ *
+ * Modules that need to register HTTP routes use `ctx.router`. Modules
+ * that need to clean up on shutdown should listen for `ctx.abort` (fired
+ * when SIGTERM/SIGINT arrives, before the HTTP server closes).
+ */
+
+import type { Router } from "../router";
+
+export interface StartupContext {
+  router: Router;
+  version: string;
+  abort: AbortSignal;
+}
+
+export type Startup = (ctx: StartupContext) => Promise<void> | void;


### PR DESCRIPTION
## Summary
- Companion to #1100 — that one decoupled `daemon/api/index.ts` and `electron/preload/index.ts`. This one decouples `daemon/main.ts` (the third hot file blocking parallel W2 dispatch).
- After this lands, W2-A/B/C drop a single \`daemon/startup/<name>.ts\` instead of editing main.ts.

## Mechanism
Mirror of \`daemon/api\` auto-registry: \`runStartup({router, version, abort})\` scans \`daemon/startup/*.js\` (excluding \`index.js\` + \`types.js\`), awaits default export. Sequential execution in alphabetical filename order. One module throwing logs + skips so a bad sub-module can't crash the whole daemon.

\`AbortSignal\` flows from main's AbortController, fired on SIGTERM/SIGINT — startup modules with long-lived consumers (sessionWatcher, ptyHost, notify producer) listen on it for shutdown.

## Test plan
- [x] \`npm run build:daemon\` green
- [x] \`node dist/daemon/main.js\` boots: prints \`[daemon] startup phase complete (0 modules)\` then \`PORT=<n>\` then listening line
- [ ] Wave 2 PRs verify their startup modules are picked up (acceptance for W2-A/B/C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)