### PR TITLE
fix(test): repair dead import in titleChanged.test.ts after W2-A mv

### DIFF
--- a/daemon/sessionWatcher/__tests__/titleChanged.test.ts
+++ b/daemon/sessionWatcher/__tests__/titleChanged.test.ts
@@ -27,18 +27,13 @@ const getSessionInfoMock = vi.fn(async () => {
 });
 
 import { __createForTest, type TitleChangedEvent } from '../index';
-// Wave-2-C: sessionTitles still lives under electron/ (W2-A's mv target).
-// This watcher test wires through sessionTitles via the watcher's
-// configurable `fetchTitle` / `flushRename` hooks, so the cross-tree
-// import below is a test-fixture-only edge — it disappears once W2-A
-// mv's electron/sessionTitles → daemon/sessionTitles.
 import {
   __resetForTests as __resetTitleBridge,
   __setSdkForTests as __setTitleBridgeSdk,
   enqueuePendingRename,
   getSessionTitle,
   flushPendingRename,
-} from '../../../electron/sessionTitles';
+} from '../../sessionTitles';
 
 let tmpRoot: string;
 


### PR DESCRIPTION
## Summary

Task #591 — PR #1104 (W2-A) moved `electron/sessionTitles` to `daemon/sessionTitles` but missed updating the import path in `daemon/sessionWatcher/__tests__/titleChanged.test.ts`. The stale comment block in the spec literally predicted this edge case ("disappears once W2-A mv's electron/sessionTitles -> daemon/sessionTitles"). dev-574 baseline picked up the resulting unit-test file failure.

This PR:
- Updates the import path from `../../../electron/sessionTitles` to `../../sessionTitles`.
- Removes the now-obsolete W2-C-era comment.

No production code changes; no `mv`s; only this one spec file touched.

## Local checks (host: Windows 11, mode: fast)
- lint: PASS (exit 0, 0 errors / 54 pre-existing warnings)
- typecheck: PASS (exit 0)
- build: PASS (webpack + tsc -p tsconfig.electron.json, exit 0)
- unit tests: PASS — `npx vitest run daemon/sessionWatcher/__tests__/titleChanged.test.ts` -> Test Files 1 passed (1), Tests 5 passed (5), Duration 34.54s
- e2e: skipped, change is import-path-only in a unit spec; no e2e harness exercises this file

## Test plan
- [x] Run `npx vitest run daemon/sessionWatcher/__tests__/titleChanged.test.ts` -> 5/5 pass
- [ ] CI three-platform matrix green