### PR TITLE
feat(daemon): enforce loopback-only bind invariant (Task #600)

### DIFF
--- a/daemon/__tests__/server.test.ts
+++ b/daemon/__tests__/server.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Loopback bind invariant tests for daemon HTTP server.
+ *
+ * Spec: docs/superpowers/specs/2026-05-06-v0.3-e2e-cutover-design.md §3
+ * Task: #600 (T-G1)
+ *
+ * The daemon has no auth layer; loopback is the trust boundary. These tests
+ * lock in the SECURITY INVARIANT documented in daemon/server.ts:
+ *  - happy path: default bind succeeds and reports a loopback address.
+ *  - explicit `127.0.0.1` / `::1` are accepted.
+ *  - any non-loopback host string (`0.0.0.0`, public IP, hostname literal,
+ *    even `localhost`) is rejected before listen.
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { isIP } from "node:net";
+
+import {
+  startServer,
+  assertLoopbackHost,
+  type ServerHandle,
+} from "../server";
+import { Router } from "../router";
+
+const handles: ServerHandle[] = [];
+
+afterEach(async () => {
+  while (handles.length > 0) {
+    const h = handles.pop()!;
+    try {
+      await h.close();
+    } catch {
+      /* socket already gone */
+    }
+  }
+});
+
+function newRouter(): Router {
+  const r = new Router();
+  r.addRoute("GET", "/ping", async () => ({ status: 200, body: { ok: true } }));
+  return r;
+}
+
+async function start(opts: { host?: string; port?: number } = {}): Promise<ServerHandle> {
+  const h = await startServer({ router: newRouter(), ...opts });
+  handles.push(h);
+  return h;
+}
+
+describe("daemon/server loopback invariant", () => {
+  describe("assertLoopbackHost", () => {
+    it("accepts 127.0.0.1", () => {
+      expect(() => assertLoopbackHost("127.0.0.1")).not.toThrow();
+    });
+
+    it("accepts ::1", () => {
+      expect(() => assertLoopbackHost("::1")).not.toThrow();
+    });
+
+    it("rejects 0.0.0.0 (wildcard)", () => {
+      expect(() => assertLoopbackHost("0.0.0.0")).toThrow(/non-loopback/);
+    });
+
+    it("rejects empty string (Node treats as wildcard)", () => {
+      expect(() => assertLoopbackHost("")).toThrow(/non-loopback/);
+    });
+
+    it("rejects public IPv4 literal", () => {
+      expect(() => assertLoopbackHost("8.8.8.8")).toThrow(/non-loopback/);
+    });
+
+    it("rejects RFC1918 private IPv4 (still routable on LAN)", () => {
+      expect(() => assertLoopbackHost("192.168.1.10")).toThrow(/non-loopback/);
+      expect(() => assertLoopbackHost("10.0.0.1")).toThrow(/non-loopback/);
+    });
+
+    it("rejects IPv6 wildcard ::", () => {
+      expect(() => assertLoopbackHost("::")).toThrow(/non-loopback/);
+    });
+
+    it("rejects 'localhost' hostname (DNS may resolve off-loopback)", () => {
+      // Intentional: spec narrows to literal IPs only. See LOOPBACK_HOSTS
+      // comment in daemon/server.ts.
+      expect(() => assertLoopbackHost("localhost")).toThrow(/non-loopback/);
+    });
+
+    it("rejects hostname literals", () => {
+      expect(() => assertLoopbackHost("daemon.example.com")).toThrow(
+        /non-loopback/,
+      );
+    });
+
+    it("error message names the offending host", () => {
+      expect(() => assertLoopbackHost("0.0.0.0")).toThrow(/"0\.0\.0\.0"/);
+    });
+  });
+
+  describe("startServer", () => {
+    it("happy path: default bind succeeds on a loopback address", async () => {
+      const h = await start();
+      expect(h.port).toBeGreaterThan(0);
+      const addr = (h.server.address() as { address: string; port: number }).address;
+      // Whatever Node reported, it must be a loopback literal.
+      expect(isIP(addr)).toBeGreaterThan(0);
+      expect(
+        addr.startsWith("127.") || addr === "::1" || addr.startsWith("::ffff:127."),
+      ).toBe(true);
+    });
+
+    it("explicit 127.0.0.1 works", async () => {
+      const h = await start({ host: "127.0.0.1" });
+      const addr = (h.server.address() as { address: string }).address;
+      expect(addr.startsWith("127.") || addr.startsWith("::ffff:127.")).toBe(true);
+    });
+
+    it("rejects 0.0.0.0 before opening any socket", async () => {
+      await expect(start({ host: "0.0.0.0" })).rejects.toThrow(/non-loopback/);
+    });
+
+    it("rejects public IP", async () => {
+      await expect(start({ host: "8.8.8.8" })).rejects.toThrow(/non-loopback/);
+    });
+
+    it("rejects 'localhost' (string-level guard, not DNS-dependent)", async () => {
+      await expect(start({ host: "localhost" })).rejects.toThrow(/non-loopback/);
+    });
+  });
+});

--- a/daemon/server.ts
+++ b/daemon/server.ts
@@ -8,6 +8,27 @@
  *  - All responses are `application/json`.
  *  - 200 OK / 400 bad_request / 404 not_found / 500 internal_error.
  *  - Request bodies, when present, are `application/json`.
+ *
+ * --------------------------------------------------------------------------
+ * SECURITY INVARIANT — LOOPBACK ONLY (spec: 2026-05-06 v0.3 e2e cutover §3)
+ * --------------------------------------------------------------------------
+ * The daemon HTTP server MUST bind to a loopback interface (127.0.0.1 or
+ * ::1). Binding to 0.0.0.0, a public IP, or a hostname that resolves to a
+ * non-loopback interface would expose the daemon's command/control surface
+ * to the local network — every endpoint here can read/spawn arbitrary user
+ * sessions, mutate prefs, and stream pty traffic. There is no auth layer
+ * (the daemon trusts the loopback boundary). DO NOT relax this without a
+ * spec change AND an auth story.
+ *
+ * Enforcement is two-layered, both fail-closed:
+ *   1. `assertLoopbackHost(host)` rejects non-loopback string inputs before
+ *      `server.listen()` is called.
+ *   2. After listen, we re-check `server.address().address` to catch the
+ *      case where DNS resolved a "loopback-looking" hostname to an
+ *      external interface (or a future Node release changes semantics).
+ *
+ * If either check fails, we close the socket and throw — the daemon will
+ * not start. This is deliberately louder than logging a warning.
  */
 
 import {
@@ -16,11 +37,64 @@ import {
   type Server,
   type ServerResponse,
 } from "node:http";
-import type { AddressInfo } from "node:net";
+import { isIP, type AddressInfo } from "node:net";
 
 import { Router, writeJson, type HandlerResult } from "./router";
 
 const MAX_BODY_BYTES = 1 * 1024 * 1024; // 1 MiB; wave-1 endpoints are tiny.
+
+/**
+ * Allow-list of loopback host strings accepted by `startServer`.
+ *
+ * Intentionally narrow: only the canonical IPv4 / IPv6 loopback literals.
+ * "localhost" is NOT included — on misconfigured hosts it can resolve to
+ * a non-loopback address (corp DNS, /etc/hosts overrides, search domains).
+ * Callers that need a hostname should resolve it themselves and pass the
+ * literal IP, so the loopback check is unambiguous.
+ */
+const LOOPBACK_HOSTS: ReadonlySet<string> = new Set(["127.0.0.1", "::1"]);
+
+/**
+ * Returns true if `addr` is a loopback IP literal.
+ *
+ * Accepts:
+ *  - any 127.0.0.0/8 IPv4 address (Node's `server.address()` may report
+ *    `127.0.0.1` or, on some platforms, the equivalent dotted form).
+ *  - `::1` and its full form `0:0:0:0:0:0:0:1`.
+ *  - IPv4-mapped IPv6 loopback `::ffff:127.0.0.1` (Node sometimes reports
+ *    this when the OS dual-stacks an IPv4 listen).
+ */
+function isLoopbackAddress(addr: string): boolean {
+  const family = isIP(addr);
+  if (family === 4) {
+    return addr.startsWith("127.");
+  }
+  if (family === 6) {
+    if (addr === "::1" || addr === "0:0:0:0:0:0:0:1") return true;
+    // IPv4-mapped IPv6: ::ffff:127.x.x.x
+    const mapped = /^::ffff:(\d+\.\d+\.\d+\.\d+)$/i.exec(addr);
+    if (mapped && mapped[1].startsWith("127.")) return true;
+    return false;
+  }
+  return false;
+}
+
+/**
+ * Throws if `host` is not in the loopback allow-list. Fails closed.
+ *
+ * See SECURITY INVARIANT note above. The error message is intentionally
+ * explicit — if this fires in production, an operator needs to know
+ * exactly what was rejected and why.
+ */
+export function assertLoopbackHost(host: string): void {
+  if (!LOOPBACK_HOSTS.has(host)) {
+    throw new Error(
+      `daemon: refusing to bind non-loopback host "${host}" — daemon HTTP ` +
+        `server must bind 127.0.0.1 or ::1 (no auth layer; loopback is the ` +
+        `trust boundary). Allowed: ${[...LOOPBACK_HOSTS].join(", ")}.`,
+    );
+  }
+}
 
 export interface ServerHandle {
   server: Server;
@@ -41,6 +115,10 @@ export async function startServer(
   const { router } = opts;
   const host = opts.host ?? "127.0.0.1";
   const port = opts.port ?? 0;
+
+  // Pre-listen guard: reject non-loopback host strings before opening
+  // any socket. See SECURITY INVARIANT in the file header.
+  assertLoopbackHost(host);
 
   const server = createServer((req, res) => {
     void handleRequest(router, req, res);
@@ -63,6 +141,18 @@ export async function startServer(
   const addr = server.address() as AddressInfo | null;
   if (!addr || typeof addr === "string") {
     throw new Error("daemon: failed to bind server (no AddressInfo)");
+  }
+
+  // Post-listen guard: belt-and-braces re-check that the kernel actually
+  // bound a loopback interface. Catches the case where DNS / OS quirks
+  // resolved a "loopback-looking" host to something external. If this
+  // fires, close the socket so we don't leak a public listener.
+  if (!isLoopbackAddress(addr.address)) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    throw new Error(
+      `daemon: server bound non-loopback address "${addr.address}" — ` +
+        `aborting (loopback invariant).`,
+    );
   }
 
   const close = (): Promise<void> =>


### PR DESCRIPTION
Task #600 — spec #592 T-G1 (P0 security gate).

## Summary
Daemon HTTP server has no auth layer; loopback (127.0.0.1 / ::1) is the trust boundary. This PR adds a fail-closed runtime guard so that no future caller, env override, or accidental refactor can bind 0.0.0.0 / a public IP and expose the daemon command/control surface to the local network.

Two-layer enforcement in daemon/server.ts:
- Pre-listen: assertLoopbackHost(host) rejects anything outside { 127.0.0.1, ::1 } before opening a socket. localhost is intentionally rejected (corp DNS / /etc/hosts can resolve it off-loopback).
- Post-listen: re-check server.address().address is a loopback IP literal; if not, close socket and throw.

Both reasons are documented as a SECURITY INVARIANT block in the file header so future readers know not to relax this without a spec change AND an auth story.

## Files
- daemon/server.ts (edit) — invariant comment + assertLoopbackHost() + post-listen re-check
- daemon/__tests__/server.test.ts (new) — 15 cases covering the helper + integration paths

Disjoint from PR #597 (electron/daemonHost) and PR #598 (daemon/api/*) per hotfile-bypass note.

## Local checks (host: Windows, mode: fast)
- lint: PASS (exit 0; 0 errors, 54 pre-existing warnings)
- typecheck: PASS (exit 0)
- build: PASS (webpack + tsc -p tsconfig.electron.json, exit 0)
- unit tests: \`npx vitest run daemon/__tests__/server.test.ts\` -> Test Files 1 passed (1), Tests 15 passed (15), Duration 31.35s
- e2e: skipped — pure daemon internal helper (assertLoopbackHost) + bind-time guard, no e2e harness exercises non-loopback host

## Test plan
- [x] happy path: default bind succeeds and reports loopback address
- [x] explicit 127.0.0.1 / ::1 accepted
- [x] 0.0.0.0, public IP, RFC1918 private IP, ::, hostname, localhost, empty string all rejected with /non-loopback/
- [x] error message names the offending host