### PR TITLE
feat(daemon-spawner): await ready-signal + 10s timeout + typed err + UT (Task #597, spec PR-3)

### DIFF
--- a/electron/__tests__/daemon-spawner.test.ts
+++ b/electron/__tests__/daemon-spawner.test.ts
@@ -1,0 +1,181 @@
+// Unit tests for electron/daemon-spawner.ts (Task #597 / spec PR-3).
+//
+// Coverage targets (4 cases per spec):
+//   1. success — daemon prints `PORT=<n>\n`, spawnDaemon resolves with n.
+//   2. timeout — daemon never prints; READY_TIMEOUT_MS elapses; reject
+//      with DaemonSpawnError(kind: 'timeout') and child SIGKILL'd.
+//   3. typed-err (bad-port-line) — daemon prints garbage on stdout;
+//      reject with DaemonSpawnError(kind: 'bad-port-line').
+//   4. kill-cleanup — killDaemon() sends SIGTERM, clears module state so
+//      a follow-up spawnDaemon() returns a fresh promise.
+//
+// We mock `child_process.spawn` with an in-memory ChildProcess stub
+// driven by EventEmitter + Readable streams (PassThrough). Real spawn
+// would shell out to `node` / the daemon binary — too slow + flaky for
+// UT; the contract we own is the parsing/timeout/typed-error logic.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { EventEmitter } from 'events';
+
+// --- spawn() mock ----------------------------------------------------------
+//
+// Each test pushes a fake ChildProcess onto `nextChild` before calling
+// spawnDaemon(). The mock pops it, returns it, records the spawn call
+// args. If nextChild is empty the mock throws — surfaces test wiring
+// bugs rather than silently spawning a real process.
+
+type FakeChild = EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+};
+
+const spawnCalls: Array<{
+  cmd: string;
+  args: ReadonlyArray<string>;
+  opts: Record<string, unknown>;
+}> = [];
+const nextChild: FakeChild[] = [];
+
+vi.mock('child_process', () => {
+  const fakeSpawn = (
+    cmd: string,
+    args: ReadonlyArray<string>,
+    opts: Record<string, unknown>,
+  ) => {
+    spawnCalls.push({ cmd, args, opts });
+    const fc = nextChild.shift();
+    if (!fc) {
+      throw new Error('test bug: no fake child queued');
+    }
+    return fc;
+  };
+  return {
+    spawn: fakeSpawn,
+    default: { spawn: fakeSpawn },
+  };
+});
+
+function makeFakeChild(): FakeChild {
+  const ee = new EventEmitter() as FakeChild;
+  // Use raw EventEmitters (not Readable streams) so test code can drive
+  // `data` events synchronously via .emit() without depending on
+  // setImmediate / process.nextTick — both of which behave differently
+  // under vi.useFakeTimers().
+  ee.stdout = new EventEmitter();
+  ee.stderr = new EventEmitter();
+  // The production code calls stdout.removeListener('data', onStdout) and
+  // re-attaches a passthrough; EventEmitter supports both.
+  ee.kill = vi.fn(() => true);
+  return ee;
+}
+
+// Defer require to AFTER the vi.mock call so the spawn mock is in place.
+// We use dynamic import inside beforeEach to also reset module state via
+// vi.resetModules() between cases — daemon-spawner has module-level
+// `child / port / readyPromise` singletons.
+let mod: typeof import('../daemon-spawner');
+
+beforeEach(async () => {
+  vi.useFakeTimers();
+  spawnCalls.length = 0;
+  nextChild.length = 0;
+  vi.resetModules();
+  mod = await import('../daemon-spawner');
+  mod.__resetForTests();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('spawnDaemon', () => {
+  it('case 1: resolves with port when daemon emits PORT=<n>', async () => {
+    const fc = makeFakeChild();
+    nextChild.push(fc);
+
+    const p = mod.spawnDaemon();
+    // Daemon prints PORT line on the next microtask, after spawnDaemon
+    // has wired up the .on('data') listener.
+    await Promise.resolve();
+    fc.stdout.emit('data', Buffer.from('PORT=54321\n', 'utf8'));
+
+    const port = await p;
+    expect(port).toBe(54321);
+    expect(mod.getDaemonPort()).toBe(54321);
+    // Verify spawn was called with our env contract.
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].opts).toMatchObject({
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  });
+
+  it('case 2: rejects with kind=timeout + SIGKILLs child after READY_TIMEOUT_MS', async () => {
+    const fc = makeFakeChild();
+    nextChild.push(fc);
+
+    const p = mod.spawnDaemon();
+    // Don't emit anything on stdout. Advance fake timers past 10s.
+    let caught: unknown = null;
+    p.catch((e) => {
+      caught = e;
+    });
+
+    await vi.advanceTimersByTimeAsync(mod.READY_TIMEOUT_MS + 50);
+    // Microtask flush so the .catch above latches.
+    await Promise.resolve();
+
+    expect(caught).toBeInstanceOf(mod.DaemonSpawnError);
+    const err = caught as InstanceType<typeof mod.DaemonSpawnError>;
+    expect(err.kind).toBe('timeout');
+    expect(err.detail.timeoutMs).toBe(mod.READY_TIMEOUT_MS);
+    // Child must have been SIGKILL'd (not SIGTERM — wedged daemons may
+    // not honor SIGTERM during startup).
+    expect(fc.kill).toHaveBeenCalledWith('SIGKILL');
+    expect(mod.getDaemonPort()).toBeNull();
+  });
+
+  it('case 3: rejects with typed DaemonSpawnError(kind=bad-port-line) on garbage stdout', async () => {
+    const fc = makeFakeChild();
+    nextChild.push(fc);
+
+    const p = mod.spawnDaemon();
+    // Capture rejection but don't await yet — we'll inspect after.
+    const recorded = p.catch((e) => e);
+    await Promise.resolve();
+    fc.stdout.emit('data', Buffer.from('hello world\n', 'utf8'));
+
+    const err = (await recorded) as InstanceType<typeof mod.DaemonSpawnError>;
+    expect(err).toBeInstanceOf(mod.DaemonSpawnError);
+    expect(err.kind).toBe('bad-port-line');
+    expect(err.detail.line).toBe('hello world');
+  });
+
+  it('case 4: killDaemon() SIGTERMs child + resets module state so next spawn is fresh', async () => {
+    // First spawn → success.
+    const fc1 = makeFakeChild();
+    nextChild.push(fc1);
+
+    const p1 = mod.spawnDaemon();
+    await Promise.resolve();
+    fc1.stdout.emit('data', Buffer.from('PORT=12345\n', 'utf8'));
+    await p1;
+    expect(mod.getDaemonPort()).toBe(12345);
+
+    // Kill — should SIGTERM and reset module state.
+    mod.killDaemon();
+    expect(fc1.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(mod.getDaemonPort()).toBeNull();
+
+    // Second spawn must NOT return the cached promise — it must spawn
+    // a new child. We queue a new fake child and verify spawnCalls grew.
+    const fc2 = makeFakeChild();
+    nextChild.push(fc2);
+    const p2 = mod.spawnDaemon();
+    await Promise.resolve();
+    fc2.stdout.emit('data', Buffer.from('PORT=23456\n', 'utf8'));
+    const port2 = await p2;
+    expect(port2).toBe(23456);
+    expect(spawnCalls).toHaveLength(2);
+  });
+});

--- a/electron/daemon-spawner.ts
+++ b/electron/daemon-spawner.ts
@@ -20,12 +20,51 @@
 //
 // Failure modes (best-effort, no fancy retry — the renderer surfaces a
 // "daemon failed to start" toast in the UI later):
-//   * spawn ENOENT → reject the ready promise.
-//   * exit before PORT line → reject the ready promise.
-//   * stdout PORT line malformed → reject the ready promise.
+//   * spawn ENOENT → reject the ready promise (kind: 'spawn-failed').
+//   * exit before PORT line → reject the ready promise (kind: 'early-exit').
+//   * stdout PORT line malformed → reject the ready promise (kind: 'bad-port-line').
+//   * READY_TIMEOUT_MS elapsed without PORT line → reject + SIGKILL child
+//     (kind: 'timeout'). Cold-launch budget is 500ms p95; 10s is the hard
+//     ceiling above which we declare the spawn dead and let the renderer
+//     surface a toast (PR #597 / spec §5.3.3 PR-3 Option C).
 
 import { spawn, type ChildProcess } from 'child_process';
 import * as path from 'path';
+
+/** Hard ceiling for the daemon's cold-launch ready signal. Cold-launch
+ *  budget under Option C is 500ms p95; 10s is the abort threshold above
+ *  which we kill the child and surface a typed error to the caller. */
+export const READY_TIMEOUT_MS = 10_000;
+
+/** Discriminated union of spawn-time failure reasons. Callers (main.ts,
+ *  preload bridge, future renderer toast) switch on `kind` instead of
+ *  string-matching the message. */
+export type DaemonSpawnFailureKind =
+  | 'spawn-failed' // spawn() itself failed (ENOENT, EACCES, etc.)
+  | 'early-exit' // child exited before printing PORT=<n>
+  | 'bad-port-line' // first stdout line wasn't `PORT=<valid integer>`
+  | 'timeout' // READY_TIMEOUT_MS elapsed with no PORT line
+  | 'no-pipes'; // spawn returned without stdout/stderr pipes
+
+/** Typed error thrown / rejected from spawnDaemon. Use `instanceof
+ *  DaemonSpawnError` + switch on `.kind` for handling. */
+export class DaemonSpawnError extends Error {
+  public readonly kind: DaemonSpawnFailureKind;
+  /** Original cause where applicable (spawn errno, exit code/signal, raw
+   *  stdout line). Stored loosely for log forwarding. */
+  public readonly detail: Record<string, unknown>;
+
+  constructor(
+    kind: DaemonSpawnFailureKind,
+    message: string,
+    detail: Record<string, unknown> = {},
+  ) {
+    super(`[daemon-spawner] ${message}`);
+    this.name = 'DaemonSpawnError';
+    this.kind = kind;
+    this.detail = detail;
+  }
+}
 
 let child: ChildProcess | null = null;
 let port: number | null = null;
@@ -80,13 +119,61 @@ export function spawnDaemon(): Promise<number> {
   const stderr = proc.stderr;
   if (!stdout || !stderr) {
     return Promise.reject(
-      new Error('[daemon-spawner] spawn returned no stdout/stderr pipes'),
+      new DaemonSpawnError(
+        'no-pipes',
+        'spawn returned no stdout/stderr pipes',
+      ),
     );
   }
 
   readyPromise = new Promise<number>((resolve, reject) => {
     let resolved = false;
     let stdoutBuf = '';
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+    const finishReject = (err: DaemonSpawnError) => {
+      if (resolved) return;
+      resolved = true;
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = null;
+      }
+      reject(err);
+    };
+    const finishResolve = (n: number) => {
+      if (resolved) return;
+      resolved = true;
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+        timeoutHandle = null;
+      }
+      resolve(n);
+    };
+
+    // 10s ready-signal timeout (Option C). On fire we SIGKILL the child
+    // (SIGTERM may not be honored if the daemon is wedged in startup),
+    // null out module state, and reject with kind: 'timeout'.
+    timeoutHandle = setTimeout(() => {
+      try {
+        proc.kill('SIGKILL');
+      } catch {
+        /* best-effort */
+      }
+      child = null;
+      port = null;
+      finishReject(
+        new DaemonSpawnError(
+          'timeout',
+          `daemon did not emit PORT=<n> within ${READY_TIMEOUT_MS}ms`,
+          { timeoutMs: READY_TIMEOUT_MS },
+        ),
+      );
+    }, READY_TIMEOUT_MS);
+    // Don't keep the event loop alive for this timer — main process has
+    // its own lifecycle holders. unref() is a no-op if not supported.
+    if (typeof timeoutHandle.unref === 'function') {
+      timeoutHandle.unref();
+    }
 
     const onStdout = (chunk: Buffer) => {
       stdoutBuf += chunk.toString('utf8');
@@ -99,24 +186,27 @@ export function spawnDaemon(): Promise<number> {
       stdoutBuf = '';
       const m = /^PORT=(\d+)$/.exec(firstLine);
       if (!m) {
-        reject(
-          new Error(
-            `[daemon-spawner] expected first stdout line "PORT=<n>", got ${JSON.stringify(firstLine)}`,
+        finishReject(
+          new DaemonSpawnError(
+            'bad-port-line',
+            `expected first stdout line "PORT=<n>", got ${JSON.stringify(firstLine)}`,
+            { line: firstLine },
           ),
         );
         return;
       }
       const parsed = Number(m[1]);
       if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) {
-        reject(
-          new Error(
-            `[daemon-spawner] invalid port from daemon: ${JSON.stringify(firstLine)}`,
+        finishReject(
+          new DaemonSpawnError(
+            'bad-port-line',
+            `invalid port from daemon: ${JSON.stringify(firstLine)}`,
+            { line: firstLine, parsed },
           ),
         );
         return;
       }
       port = parsed;
-      resolved = true;
       // Swap to a passthrough handler for any further stdout (logs).
       stdout.removeListener('data', onStdout);
       stdout.on('data', (b: Buffer) => {
@@ -126,7 +216,7 @@ export function spawnDaemon(): Promise<number> {
         process.stderr.write('[daemon stdout] ' + rest);
       }
       console.log(`[daemon-spawner] daemon ready on port ${parsed}`);
-      resolve(parsed);
+      finishResolve(parsed);
     };
     stdout.on('data', onStdout);
 
@@ -135,7 +225,11 @@ export function spawnDaemon(): Promise<number> {
     });
 
     proc.on('error', (err) => {
-      if (!resolved) reject(err);
+      finishReject(
+        new DaemonSpawnError('spawn-failed', err.message, {
+          cause: String(err),
+        }),
+      );
     });
 
     proc.on('exit', (code, signal) => {
@@ -145,13 +239,13 @@ export function spawnDaemon(): Promise<number> {
       child = null;
       port = null;
       // If we hadn't resolved yet, surface the early exit.
-      if (!resolved) {
-        reject(
-          new Error(
-            `[daemon-spawner] daemon exited before PORT line (code=${code} signal=${signal})`,
-          ),
-        );
-      }
+      finishReject(
+        new DaemonSpawnError(
+          'early-exit',
+          `daemon exited before PORT line (code=${code} signal=${signal})`,
+          { code, signal },
+        ),
+      );
     });
   });
 
@@ -177,4 +271,14 @@ export function killDaemon(): void {
   } catch {
     /* best-effort */
   }
+}
+
+/** Test-only: reset module-level state so unit tests can spawn fresh
+ *  daemons across cases without process re-import. Not exported through
+ *  any production import path — only `electron/__tests__/*.test.ts` uses
+ *  this. Idempotent. */
+export function __resetForTests(): void {
+  child = null;
+  port = null;
+  readyPromise = null;
 }


### PR DESCRIPTION
## Task

Task #597 — spec docs/superpowers/specs/2026-05-06-v0.3-e2e-cutover-design.md §5.3.3 PR-3, Option C cold-launch budget.

## Path drift note

Task spec wrote files as ``electron/daemonHost/spawnDaemon.ts`` + ``electron/daemonHost/spawnDaemon.test.ts``. The actual on-disk implementation has lived at ``electron/daemon-spawner.ts`` since Wave-1 (see commit history); ``electron/daemonHost/`` does not exist on ``working``. I edited the existing file rather than introduce a parallel hierarchy. The hotfile-bypass comment in the dispatch prompt assumed the new path; the disjoint-write argument still holds against #598 (``daemon/api/*``) and #600 (``daemon/server.ts``) — neither touches ``electron/daemon-spawner.ts``.

If a separate task wants the rename to ``electron/daemonHost/spawnDaemon.ts``, that's a follow-up mv with import-rewrite (4 callers: ``electron/main.ts``, ``window/createWindow.ts``, ``tray/createTray.ts``, ``notify/sinkConsumer.ts``).

## Summary

- Add ``READY_TIMEOUT_MS = 10_000`` hard ceiling on the ``PORT=<n>`` ready-signal wait. On expiry: ``SIGKILL`` the child, null out module state, reject with ``DaemonSpawnError(kind: 'timeout')``.
- Introduce ``DaemonSpawnError`` class with discriminated ``kind`` union (``spawn-failed | early-exit | bad-port-line | timeout | no-pipes``). Callers switch on ``.kind`` instead of string-matching.
- Replace bare ``Error`` throws with typed errors so the future renderer toast / telemetry can render specific failure copy without parsing.
- Add ``__resetForTests()`` to clear module singletons between UT cases.
- Add ``electron/__tests__/daemon-spawner.test.ts`` covering 4 cases per spec:
  1. **success** — ``PORT=<n>`` resolves with the parsed port.
  2. **timeout** — fake-timer 10s advance, child gets SIGKILL, reject with ``kind: 'timeout'``.
  3. **bad-port-line** — garbage stdout rejects with ``kind: 'bad-port-line'`` + ``detail.line``.
  4. **kill-cleanup** — ``killDaemon()`` SIGTERMs and resets state so a follow-up ``spawnDaemon()`` spawns a fresh child (verified via ``spawnCalls.length``).

## Cold-launch measurement (Option C)

Measured 20 sequential cold spawns of ``dist/daemon/main.js`` on Windows 11 (host: ``win32``, Node v22.18.0, AV active). Script: ``/tmp/measure-cold-launch.mjs`` (not committed).

| metric | ms |
|---|---|
| min  | 1130 |
| **p50**  | **1147** |
| **p95**  | **6566** |
| max  | 6566 |
| samples ok | 19 / 20 (run 1 timed out — first-touch AV scan) |

Sample distribution (sorted, ms): 1130, 1132, 1137, 1139, 1141, 1141, 1142, 1143, 1145, 1147, 1149, 1151, 1159, 1168, 1175, 1192, 1193, 1293, 6566.

### Verdict

**Option C does not meet the 500ms p95 budget on this host.** Even ignoring the AV-induced 6.5s outlier (run 1), warm steady-state is ~1.14s p50 — 2.3x over budget.

Per spec PR-3 (""不达标启 Option B fallback""): I am **flagging this for manager / spec authors** rather than unilaterally flipping the option. The implementation in this PR is option-agnostic — the await + timeout + typed-err scaffolding is needed for both Option B (lazy-spawn-on-first-RPC) and Option C (eager-spawn-at-app-ready). Option B switching is a main.ts wiring change (move ``spawnDaemon()`` call out of ``app.on('ready')`` into the first RPC handler) and belongs in a follow-up task.

Possible explanations for the gap:
- Electron's bundled Node has tsx/dist warm-cache vs cold disk read on first spawn.
- The daemon imports ~30 files including db init + migrations runner; trim opportunity.
- Windows AV scan on first daemon binary touch (run 1).
- Test was via raw ``process.execPath``, not Electron's ``app.getPath('exe')``; production path may differ.

Recommend: (a) re-measure on macOS/Linux runners to confirm cross-platform gap, (b) profile daemon startup if cross-platform gap holds, (c) decide Option B vs Option C in a follow-up.

## Local checks (host: win32, mode: fast)
- lint: ✓ (exit 0, 0 errors / 54 pre-existing warnings)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0, webpack + ``tsc -p tsconfig.electron.json``)
- unit tests: ✓ ``npx vitest run electron/__tests__/daemon-spawner.test.ts`` → 4 passed in 60ms (3.78s wall incl. transform/setup)
- e2e: skipped — pure ``electron/daemon-spawner.ts`` change, no e2e harness/probe imports it; full e2e matrix runs on CI.
- require-load smoke: ✓ ``node -e "require('./dist/electron/daemon-spawner.js')"`` printed exports without ``ERR_REQUIRE_ESM``.

## Files
- ``electron/daemon-spawner.ts`` — typed err + 10s timeout + ``__resetForTests``.
- ``electron/__tests__/daemon-spawner.test.ts`` — 4 UT cases (new).