### PR TITLE
fix(shim): point window.ccsm at actual daemon HTTP routes (Task #602, PR-1)

### DIFF
--- a/src/lib/window-ccsm-shim.ts
+++ b/src/lib/window-ccsm-shim.ts
@@ -105,9 +105,32 @@ function buildShim(platform: Platform): CcsmApi {
   const m = <T>(path: string) => (...args: unknown[]): Promise<T> =>
     daemonInvoke(path, args) as Promise<T>;
 
+  // saveState daemon route returns `{ ok: true } | { ok: false; error: string }`
+  // verbatim (see daemon/api/data.ts safeSaveState). The v0.2 preload
+  // bridge guaranteed `Promise<void>` that throws on `{ ok: false }`, and
+  // call sites in src/stores/persist.ts rely on `await saveState()` to
+  // propagate persist failures via thrown errors. The generic `m<void>`
+  // helper would resolve to the `{ ok }` discriminant and silently lose
+  // failures (data-loss regression). Unwrap-and-throw here keeps the
+  // outward contract identical to the v0.2 bridge.
+  const saveStateInvoke = async (key: string, value: string): Promise<void> => {
+    const res = (await daemonInvoke('db/save', [key, value])) as
+      | { ok: true }
+      | { ok: false; error: string }
+      | undefined
+      | null;
+    if (!res || (res as { ok: boolean }).ok !== true) {
+      const errMsg =
+        res && (res as { ok: false; error?: string }).error
+          ? (res as { ok: false; error: string }).error
+          : 'saveState failed';
+      throw new Error(errMsg);
+    }
+  };
+
   return {
-    loadState: m<string | null>('loadState'),
-    saveState: m<void>('saveState'),
+    loadState: m<string | null>('db/load'),
+    saveState: saveStateInvoke,
     i18n: {
       getSystemLocale: m<string | undefined>('i18n/getSystemLocale'),
       setLanguage: (l: 'en' | 'zh') => {
@@ -123,8 +146,11 @@ function buildShim(platform: Platform): CcsmApi {
     recentCwds: m<string[]>('recentCwds'),
     userHome: m<string>('userHome'),
     userCwds: {
-      get: m<string[]>('userCwds/get'),
-      push: m<string[]>('userCwds/push'),
+      // Daemon registers these under /api/app/userCwds/* (see
+      // daemon/api/data.ts). The shim previously called /api/userCwds/*
+      // which 404s — same drift class as loadState/saveState.
+      get: m<string[]>('app/userCwds/get'),
+      push: m<string[]>('app/userCwds/push'),
     },
     pickCwd: m<string | null>('pickCwd'),
     defaultModel: m<string | null>('defaultModel'),

--- a/tests/window-ccsm-shim.test.ts
+++ b/tests/window-ccsm-shim.test.ts
@@ -1,0 +1,118 @@
+// Regression test for Task #602 (PR-1, spec #592 T-1) — the wave-1-C
+// shim's daemon path names had drifted from the wave-2-A daemon router
+// registrations (audit doc: docs/audit/2026-05-06-ccsm-loadstate-removal.md).
+//
+// What we lock in here:
+//   1. loadState  → POST /api/db/load            (was /api/loadState, 404)
+//   2. saveState  → POST /api/db/save            (was /api/saveState, 404)
+//   3. userCwds.* → POST /api/app/userCwds/{op}  (was /api/userCwds/*,  404)
+//   4. saveState's daemon response is `{ ok: true } | { ok: false; error }`;
+//      the shim must unwrap-and-throw on `ok: false` so persist failures
+//      surface to the caller (v0.2 contract). The previous `m<void>`
+//      generic dropped the discriminant on the floor → silent data loss.
+//
+// We mock daemon-client so the test never touches a real socket — purely
+// asserts the static path map + the saveState error branch.
+
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
+
+vi.mock('../src/lib/daemon-client', () => ({
+  daemonInvoke: vi.fn(),
+  daemonEvent: vi.fn(),
+}));
+
+vi.mock('../src/lib/daemon-port', () => ({
+  init: vi.fn(async () => undefined),
+  getDaemonPort: vi.fn(async () => 12345),
+}));
+
+import { daemonInvoke } from '../src/lib/daemon-client';
+import { installCcsmShim } from '../src/lib/window-ccsm-shim';
+
+const mockedInvoke = daemonInvoke as unknown as Mock;
+
+beforeEach(() => {
+  mockedInvoke.mockReset();
+  // installCcsmShim pre-fetches `window/platform` during boot; default
+  // every call to a benign value, individual tests override per case.
+  mockedInvoke.mockResolvedValue(null);
+  // Clear any previously installed shim so installCcsmShim can redefine
+  // window.ccsm (it's installed non-enumerable + non-writable; we have to
+  // explicitly delete the property to overwrite cleanly between tests).
+  // configurable: true on the property descriptor makes this safe.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (window as any).ccsm;
+});
+
+async function install(): Promise<void> {
+  await installCcsmShim();
+  // Drop the boot-time `window/platform` call so per-test assertions only
+  // see the calls the test itself triggers.
+  mockedInvoke.mockClear();
+}
+
+describe('window-ccsm-shim daemon path map', () => {
+  it('loadState calls /api/db/load with the key arg', async () => {
+    await install();
+    mockedInvoke.mockResolvedValueOnce('cached-value');
+    const result = await window.ccsm.loadState('appearance');
+    expect(mockedInvoke).toHaveBeenCalledTimes(1);
+    expect(mockedInvoke).toHaveBeenCalledWith('db/load', ['appearance']);
+    expect(result).toBe('cached-value');
+  });
+
+  it('saveState calls /api/db/save with key + value args', async () => {
+    await install();
+    mockedInvoke.mockResolvedValueOnce({ ok: true });
+    await window.ccsm.saveState('appearance', '{"theme":"dark"}');
+    expect(mockedInvoke).toHaveBeenCalledTimes(1);
+    expect(mockedInvoke).toHaveBeenCalledWith('db/save', [
+      'appearance',
+      '{"theme":"dark"}',
+    ]);
+  });
+
+  it('userCwds.get calls /api/app/userCwds/get', async () => {
+    await install();
+    mockedInvoke.mockResolvedValueOnce(['/tmp/a', '/tmp/b']);
+    const result = await window.ccsm.userCwds.get();
+    expect(mockedInvoke).toHaveBeenCalledWith('app/userCwds/get', []);
+    expect(result).toEqual(['/tmp/a', '/tmp/b']);
+  });
+
+  it('userCwds.push calls /api/app/userCwds/push with the path arg', async () => {
+    await install();
+    mockedInvoke.mockResolvedValueOnce(['/tmp/new']);
+    const result = await window.ccsm.userCwds.push('/tmp/new');
+    expect(mockedInvoke).toHaveBeenCalledWith('app/userCwds/push', ['/tmp/new']);
+    expect(result).toEqual(['/tmp/new']);
+  });
+});
+
+describe('window-ccsm-shim saveState unwrap-throw', () => {
+  it('throws with the daemon error message when response is { ok: false, error }', async () => {
+    await install();
+    mockedInvoke.mockResolvedValueOnce({ ok: false, error: 'value_too_large' });
+    await expect(
+      window.ccsm.saveState('appearance', 'x'.repeat(10_000_000)),
+    ).rejects.toThrow('value_too_large');
+  });
+
+  it('throws a generic message when response is { ok: false } with no error string', async () => {
+    await install();
+    mockedInvoke.mockResolvedValueOnce({ ok: false });
+    await expect(window.ccsm.saveState('k', 'v')).rejects.toThrow('saveState failed');
+  });
+
+  it('throws when response is missing / null (defensive: bad daemon envelope)', async () => {
+    await install();
+    mockedInvoke.mockResolvedValueOnce(null);
+    await expect(window.ccsm.saveState('k', 'v')).rejects.toThrow('saveState failed');
+  });
+
+  it('resolves silently on { ok: true }', async () => {
+    await install();
+    mockedInvoke.mockResolvedValueOnce({ ok: true });
+    await expect(window.ccsm.saveState('k', 'v')).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
Spec: docs/superpowers/specs/2026-05-06-v0.3-e2e-cutover-design.md §2.4, §5.3.1 PR-1
Audit: docs/audit/2026-05-06-ccsm-loadstate-removal.md (Option A)
Task: #602 (depends on audit #596 / PR #1108, already merged)
Downstream: PR-7 (#606) needs `loadState` to read user override theme.

## Why

The renderer-side `window.ccsm` shim (`src/lib/window-ccsm-shim.ts`,
PR #1098, wave-1-C) was wired to flat path names (`loadState`,
`saveState`, `userCwds/get`, `userCwds/push`), while the wave-2-A
daemon router (`daemon/api/data.ts`, PR #1104) registers under
semantic groups (`db/load`, `db/save`, `app/userCwds/get`,
`app/userCwds/push`). Every renderer call was 404-ing — manifesting
as silent persist failures across appearance / notifications / drafts
(see audit doc §"Affected calls").

## What changed

`src/lib/window-ccsm-shim.ts`:
- 4-line URL fix following audit Option A (smallest diff, no daemon
  change, no breakage of other callers using the same `db/`, `app/`,
  `sessionTitles/`, `import/`, `settings/` grouping):
  - `loadState`     → `db/load`
  - `saveState`     → `db/save`
  - `userCwds.get`  → `app/userCwds/get`
  - `userCwds.push` → `app/userCwds/push`
- New `saveStateInvoke` wrapper that unwraps the daemon's
  `{ ok: true } | { ok: false; error }` response and throws on
  `ok: false`. The previous `m<void>('saveState')` resolved to the
  raw discriminant and silently dropped persist failures (the same
  data-loss regression that the v0.2 `electron/preload/bridges/ccsmCore.ts`
  guarded against).

`tests/window-ccsm-shim.test.ts` (new, 8 tests):
- 4 path-map assertions (loadState, saveState, userCwds.get,
  userCwds.push) using `vi.mock('../src/lib/daemon-client')` to
  intercept calls — locks the contract so future shim/daemon drift
  fails CI rather than silently 404-ing in production.
- 4 saveState response branches: `{ok:true}` resolves silently;
  `{ok:false,error:'value_too_large'}` throws with the daemon
  message; `{ok:false}` (no error string) throws generic
  "saveState failed"; `null` (defensive: malformed envelope) also
  throws.

Note on test path: spec asked for `src/lib/__tests__/window-ccsm-shim.test.ts`
but vitest's `include` glob in `vitest.config.ts` only picks up
`tests/**/*.test.ts` (plus electron/daemon `__tests__/**`); a
file under `src/**/__tests__/**` would not be discovered. Placed
under `tests/` to match the project convention rather than expand
the vitest include glob (which would affect every other PR).

## Out of scope (per audit doc)

Other shim methods also have potential drift versus the daemon
(`scanImportable` vs `import/scan`, `recentCwds` vs
`import/recentCwds`, `defaultModel` vs `settings/defaultModel`,
`pathsExist` vs `event/paths/exist`, etc.). Audit explicitly scopes
PR-1 to loadState/saveState/userCwds + the saveState unwrap. Other
drift will be picked up by downstream wave-2 PRs as their respective
features get smoked end-to-end. Keeping this PR minimal so PR-7
(#606) can rebase onto a small, surgical fix.

Preload + daemon untouched (Option A intent).

## Local checks (host: Windows 11, mode: fast)
- lint: ✓ (exit 0; 0 errors, baseline 54 warnings unchanged in shim/test files)
- typecheck: ✓ (exit 0; both `tsc --noEmit` and `tsc -p tsconfig.electron.json`)
- build: ✓ (exit 0; webpack 5.106.2, 36s, only pre-existing bundle-size warnings)
- unit tests: tests/window-ccsm-shim.test.ts + tests/drafts.test.ts (closest indirect consumer of saveState)
  ```
   Test Files  2 passed (2)
        Tests  17 passed (17)
     Duration  24.17s
  ```
- e2e: skipped — diff only changes shim path strings + adds a UT; the only e2e
  spec (`e2e/daemon-rpc-roundtrip.spec.ts`) drives the daemon directly and
  doesn't go through the renderer shim. Full CI matrix will catch any indirect
  regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)