### PR TITLE
feat(store): pin __ccsmStore at module eval + ccsm:app-shell-ready (Task #601, PR-2, spec #592 T-2)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,15 +38,16 @@ import { useExitAnimation } from './app-effects/useExitAnimation';
 // setter in src/store/preferences.ts).
 initI18n(usePreferences.getState().resolvedLanguage);
 
-// Expose the zustand store on `window` so E2E probes can introspect /
-// drive state directly. We set this UNCONDITIONALLY (not gated on
-// NODE_ENV) because webpack production builds dead-strip the gated
-// branch — leaving probes that exercise a production-built renderer with
-// no way to seed state. The exposure is a debug affordance, not a
-// security boundary; same trade-off as `window.__ccsmI18n`.
-if (typeof window !== 'undefined') {
-  (window as unknown as { __ccsmStore?: typeof useStore }).__ccsmStore = useStore;
-}
+// `window.__ccsmStore` is now pinned at module-eval time inside
+// src/stores/store.ts (Task #601, audit Variant A). The previous in-line
+// assignment that lived here has been moved so the pin co-locates with
+// the symbol it exposes and survives a future code-split that might
+// lazy-load this App module. See docs/audit/2026-05-06-ccsmstore-eval-order.md.
+
+// Module-scope guard for the `ccsm:app-shell-ready` window event so a
+// re-mount (HMR, future StrictMode double-effect) only emits once per
+// renderer process. PR-8 probe-utils treats the event as edge-triggered.
+let appShellReadyDispatched = false;
 
 /**
  * Inner zero-render component that lives inside `<ToastProvider>` so it
@@ -166,6 +167,22 @@ export default function App() {
   // Window hide-to-tray exit animation: fade <html> opacity in/out on
   // `window:beforeHide` / `window:afterShow`.
   useExitAnimation();
+
+  // PR-2 / Task #601: signal that the app shell has mounted and the
+  // `window.__ccsmStore` pin + `window.ccsm` bridges (installed by
+  // `installCcsmShim()` before `root.render()`) are both observable.
+  // PR-8 (#605) probe-utils consumes this in place of the current
+  // polling `waitForFunction(window.__ccsmStore && document.querySelector('aside'))`
+  // sequence. We dispatch on the first effect tick (which only runs
+  // after React has committed the initial DOM), idempotently — a
+  // module-level `dispatched` flag keeps a re-mount during HMR or a
+  // future StrictMode double-effect from emitting twice.
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    if (appShellReadyDispatched) return;
+    appShellReadyDispatched = true;
+    window.dispatchEvent(new Event('ccsm:app-shell-ready'));
+  }, []);
 
   // -----------------------------------------------------------------------
   // Remaining inline effects (intentionally NOT extracted — couple to

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -28,6 +28,24 @@ export const useStore = create<RootStore>((set, get) => ({
   hydrated: false,
 }));
 
+// Expose the zustand store on `window` so E2E probes can introspect /
+// drive state directly. We set this UNCONDITIONALLY (not gated on
+// NODE_ENV) because webpack production builds dead-strip the gated
+// branch — leaving probes that exercise a production-built renderer with
+// no way to seed state. The exposure is a debug affordance, not a
+// security boundary; same trade-off as `window.__ccsmI18n`.
+//
+// Spec §5.3.2 PR-2 (audit Variant A, docs/audit/2026-05-06-ccsmstore-eval-order.md):
+// the pin lives in this module — not in App.tsx — so that
+// `await import('src/stores/store')` is sufficient to make
+// `window.__ccsmStore` observable in the UT environment, and so the pin
+// survives any future code-split that lazy-loads App.tsx. The store
+// module is the symbol's owner, so the pin co-locates with the symbol
+// it exposes (same convention as `__ccsmI18n` / `src/i18n/index.ts`).
+if (typeof window !== 'undefined') {
+  (window as unknown as { __ccsmStore?: typeof useStore }).__ccsmStore = useStore;
+}
+
 let hydrated = false;
 
 /**

--- a/tests/store-eval-order.test.ts
+++ b/tests/store-eval-order.test.ts
@@ -1,0 +1,40 @@
+// Task #601 / spec §5.3.2 PR-2 acceptance UT (audit Variant A,
+// docs/audit/2026-05-06-ccsmstore-eval-order.md).
+//
+// Verifies that `window.__ccsmStore` is pinned synchronously at the
+// moment `src/stores/store.ts` is evaluated — i.e. before any awaited
+// hydrate / shim work, and without any consumer of the store needing
+// to import App.tsx first. Regression armor against root cause A
+// from spec §1.2.1 / §2.2 (pin trapped behind an awaited block that
+// can throw, leaving `__ccsmStore` undefined → `seedStore` HP-1
+// timeout).
+//
+// The contract: `await import('../src/stores/store')` is sufficient
+// to make `globalThis.__ccsmStore === useStore` observable. No React
+// tree, no installCcsmShim, no hydrateStore needed.
+import { describe, it, expect, beforeEach } from 'vitest';
+
+describe('store: window.__ccsmStore is pinned at module eval', () => {
+  beforeEach(() => {
+    // Sanity: clear any previous pin so the import below is the only
+    // thing that could legally restore it.
+    delete (globalThis as unknown as { __ccsmStore?: unknown }).__ccsmStore;
+  });
+
+  it('pins `useStore` on `window` synchronously when the store module is imported', async () => {
+    expect(
+      (globalThis as unknown as { __ccsmStore?: unknown }).__ccsmStore
+    ).toBeUndefined();
+
+    // Importing the store module is the only thing the test does.
+    // No App.tsx, no installCcsmShim, no hydrateStore. If the pin
+    // ever moves back to a deferred / awaited code path, this assertion
+    // flips and the spec §5.3.2 contract is violated.
+    const mod = await import('../src/stores/store');
+
+    const pinned = (globalThis as unknown as { __ccsmStore?: unknown })
+      .__ccsmStore;
+    expect(pinned).toBeDefined();
+    expect(pinned).toBe(mod.useStore);
+  });
+});

--- a/tests/store-initial-state.test.ts
+++ b/tests/store-initial-state.test.ts
@@ -1,0 +1,58 @@
+// Task #601 / spec §5.3.2 PR-2 acceptance UT (audit Variant A row,
+// `tests/stores/initialState.test.ts` line in the audit table).
+//
+// Verifies that the fields App.tsx reads on its first paint exist on
+// the store's initial (pre-hydrate) state. If a slice is ever
+// refactored such that an App.tsx selector reads `undefined` before
+// `hydrateStore()` resolves, React would render with garbage and the
+// pre-hydrate skeleton branch would silently break — this UT pins the
+// contract.
+//
+// Field list mirrors the `useStore((s) => s.X)` selectors in
+// `src/App.tsx` body (lines 67-89 today). Add new selectors here when
+// App.tsx grows new pre-hydrate reads.
+import { describe, it, expect } from 'vitest';
+import { useStore } from '../src/stores/store';
+
+describe('store: initial state covers all App.tsx first-paint reads', () => {
+  it('exposes the fields App.tsx selects from before hydrate resolves', () => {
+    const s = useStore.getState();
+
+    // Collections — must be arrays, not undefined, so .find / .map in
+    // App.tsx don't NPE on the first render tick.
+    expect(Array.isArray(s.sessions)).toBe(true);
+    expect(Array.isArray(s.groups)).toBe(true);
+
+    // Scalar selectors — defined (string / null / etc.), not undefined,
+    // so React's "Rendered fewer hooks" / "received NaN" warnings can't
+    // surface from a missing key.
+    expect(s).toHaveProperty('activeId');
+    expect(s).toHaveProperty('focusedGroupId');
+    expect(s).toHaveProperty('flashStates');
+    expect(s).toHaveProperty('theme');
+    expect(s).toHaveProperty('fontSizePx');
+
+    // `flashStates` is read by App.tsx's effect that projects to
+    // `window.__ccsmFlashStates` — must be an object even pre-hydrate
+    // so `Object.keys(flashStates)` doesn't throw.
+    expect(typeof s.flashStates).toBe('object');
+    expect(s.flashStates).not.toBeNull();
+
+    // Action selectors — App.tsx pulls callbacks from the store; if any
+    // of these are undefined at first paint, React errors with
+    // "is not a function" the moment the user touches the UI.
+    expect(typeof s.selectSession).toBe('function');
+    expect(typeof s.focusGroup).toBe('function');
+    expect(typeof s._applyExternalTitle).toBe('function');
+    expect(typeof s._applyCwdRedirect).toBe('function');
+    expect(typeof s._applyPtyExit).toBe('function');
+    expect(typeof s.moveSession).toBe('function');
+    expect(typeof s.createSession).toBe('function');
+
+    // Hydration lifecycle: must start false so the AppSkeleton branch
+    // takes effect (otherwise users with persisted sessions see a flash
+    // of the empty CTA before the snapshot lands — see App.tsx:73-81
+    // long-form comment).
+    expect(s.hydrated).toBe(false);
+  });
+});

--- a/tests/store-single-instance.test.ts
+++ b/tests/store-single-instance.test.ts
@@ -1,0 +1,66 @@
+// Task #601 / spec §5.3.2 PR-2 acceptance UT (audit Variant A,
+// docs/audit/2026-05-06-ccsmstore-eval-order.md §4).
+//
+// Regression armor against spec §2.2 root cause B (duplicate-store
+// regression: a sibling re-export creates two `useStore` instances;
+// harness writes to one, renderer reads the other → seedStore appears
+// to succeed but the rendered tree subscribes to the wrong store).
+//
+// Audit verified the count is 1 today (`src/stores/store.ts:18`). This
+// test pins that to CI: any future refactor that introduces a second
+// `create<...>(...)` call under `src/stores/**` must explicitly delete
+// or relax this assertion (and write up why a second store instance is
+// safe in the PR body).
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+
+function listTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue;
+      out.push(...listTsFiles(full));
+    } else if (st.isFile()) {
+      if (!entry.endsWith('.ts')) continue;
+      if (entry.endsWith('.test.ts') || entry.endsWith('.d.ts')) continue;
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('store: single zustand instance under src/stores', () => {
+  it('contains exactly one `create<...>(...)` call', () => {
+    const files = listTsFiles(resolve(repoRoot, 'src/stores'));
+    expect(files.length).toBeGreaterThan(0);
+
+    // Match `create<RootStore>(` or `create<…>(` etc. — zustand v4's
+    // typed factory call. Whitespace tolerant. We deliberately do NOT
+    // match the bare `create(` form (no generic) because the codebase
+    // standardised on the typed form; if someone introduces an untyped
+    // sibling it should still be caught — extend the pattern then.
+    const re = /\bcreate\s*<[^>]*>\s*\(/g;
+
+    const hits: { file: string; count: number }[] = [];
+    let total = 0;
+    for (const f of files) {
+      const src = readFileSync(f, 'utf8');
+      const matches = src.match(re);
+      const count = matches ? matches.length : 0;
+      if (count > 0) hits.push({ file: f, count });
+      total += count;
+    }
+
+    expect(
+      total,
+      `expected exactly one zustand create<...>() call across src/stores/**, got ${total}: ${JSON.stringify(hits, null, 2)}`
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
Implements spec #592 PR-2 per audit Variant A (`docs/audit/2026-05-06-ccsmstore-eval-order.md`).

## Summary
- Move the `window.__ccsmStore = useStore` pin from `src/App.tsx:48` to module top-level of `src/stores/store.ts` so the pin co-locates with the symbol it exposes (and survives any future code-split that lazy-loads `App.tsx`).
- Emit `ccsm:app-shell-ready` window event from App's first `useEffect`, idempotent via a module-scope `appShellReadyDispatched` guard. PR-8 (#605) probe-utils will consume this in place of the current `waitForFunction(window.__ccsmStore && document.querySelector('aside'))` polling.
- Add three new UTs under `tests/` (vitest include glob is `tests/**/*.test.ts`, not `src/**/__tests__/**` — same path offset PR #1114 used):
  - `tests/store-eval-order.test.ts` — `await import('../src/stores/store')` then assert `globalThis.__ccsmStore === useStore`.
  - `tests/store-single-instance.test.ts` — regex-count `create<...>(` matches across `src/stores/**` equals 1 (regression armor for spec §2.2 root cause B).
  - `tests/store-initial-state.test.ts` — every selector App.tsx reads on first paint (`sessions`, `flashStates`, `activeId`, action callbacks, `hydrated === false`) is defined on the pre-hydrate initial state.

## Why this PR alone doesn't flip the 5 s `seedStore` acceptance
Per audit §6, the `seedStore waitForFunction` 20 s timeout in scripts/probe-utils.mjs is gated by **two** conditions joined by `&&`: `!!window.__ccsmStore && document.querySelector('aside') !== null`. The store-pin half is what this PR fixes; the `aside` half is gated by `installCcsmShim()` resolving, which is gated by daemon-port readiness — that's HP-3, closed by #597 (PR-3, merged in PR #1112). With both PRs landed the cascade clears; PR-2's own correctness gate is the three new UTs.

## Local checks (host: Windows 11, mode: fast)
- lint: ✓ (exit 0, 0 errors / 54 pre-existing warnings)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0, webpack + tsc -p tsconfig.electron.json)
- unit tests:
  - new specs (`tests/store-eval-order.test.ts`, `tests/store-single-instance.test.ts`, `tests/store-initial-state.test.ts`): `Test Files 3 passed (3) | Tests 3 passed (3) | Duration 25.95s`
  - related store-touching specs (`tests/App.hooks.test.tsx`, `tests/persist-shape.test.ts`, `tests/claude-probe-race-900.test.tsx`, `tests/first-run-empty-state.test.tsx`): `Test Files 4 passed (4) | Tests 17 passed (17) | Duration 9.57s`
- e2e: skipped — pure renderer-init wiring change, no daemon/api/pty surface modified; the e2e signal that this fix unblocks (`seedStore` <5 s) is owned by PR-8 (#605) probe-utils rewrite, which depends on this PR's `ccsm:app-shell-ready` event.

## Files changed
- `src/stores/store.ts` — added the pin (with rationale comment block) immediately after `useStore = create<RootStore>(...)`.
- `src/App.tsx` — removed the old top-level pin block; added the `ccsm:app-shell-ready` `useEffect` + module-scope guard.
- `tests/store-eval-order.test.ts` (NEW)
- `tests/store-single-instance.test.ts` (NEW)
- `tests/store-initial-state.test.ts` (NEW)