### PR TITLE
[PR-7] feat(theme): tri-state resolveEffectiveTheme lib + 6 combos UT (Task #606, spec #592 T-7)

### DIFF
--- a/src/app-effects/useThemeEffect.ts
+++ b/src/app-effects/useThemeEffect.ts
@@ -1,5 +1,25 @@
 import { useEffect } from 'react';
-import { resolveEffectiveTheme } from '../stores/slices/appearanceSlice';
+import {
+  resolveEffectiveTheme,
+  type SystemPref,
+} from '../lib/resolveEffectiveTheme';
+
+/**
+ * Read the current OS-level color-scheme signal as a tri-state value.
+ * Browsers expose three states via media queries: `light`, `dark`, and
+ * `no-preference` (the user has expressed neither). The latter matches
+ * the spec's tri-state `SystemPref` and lets us draw a clean line
+ * between "user wants light" and "user has no preference, fall back to
+ * light".
+ */
+function readSystemPref(): SystemPref {
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return 'no-preference';
+  }
+  if (window.matchMedia('(prefers-color-scheme: dark)').matches) return 'dark';
+  if (window.matchMedia('(prefers-color-scheme: light)').matches) return 'light';
+  return 'no-preference';
+}
 
 /**
  * Sync the user's theme preference (and, when set to `system`, the OS
@@ -7,15 +27,18 @@ import { resolveEffectiveTheme } from '../stores/slices/appearanceSlice';
  * (legacy Tailwind variants) and `.theme-light` (new light-palette
  * overrides) so the two never coexist. Mirrors the original effect that
  * lived inline in App.tsx — extracted for SRP under Task #724.
+ *
+ * Projection logic lives in `src/lib/resolveEffectiveTheme.ts` (spec
+ * §5.3.7 PR-7), which models the OS signal as the tri-state
+ * `light | dark | no-preference` and returns the effective rendered
+ * theme.
  */
 export function useThemeEffect(theme: 'light' | 'dark' | 'system'): void {
   useEffect(() => {
     const root = document.documentElement;
     const apply = () => {
-      const osPrefersDark =
-        typeof window !== 'undefined' &&
-        window.matchMedia('(prefers-color-scheme: dark)').matches;
-      const effective = resolveEffectiveTheme(theme, osPrefersDark);
+      const systemPref = readSystemPref();
+      const effective = resolveEffectiveTheme(systemPref, theme);
       root.classList.toggle('dark', effective === 'dark');
       root.classList.toggle('theme-light', effective === 'light');
       root.dataset.theme = effective;

--- a/src/lib/resolveEffectiveTheme.ts
+++ b/src/lib/resolveEffectiveTheme.ts
@@ -1,0 +1,44 @@
+// Pure projection: (systemPref, userOverride) -> effective theme.
+//
+// Spec: docs/superpowers/specs/2026-05-06-v0.3-e2e-cutover-design.md §2 (theme),
+// §5.3.7 PR-7. Spec requires a tri-state `systemPref` ('light' | 'dark' |
+// 'no-preference') so that the renderer can faithfully project the OS
+// preferred-color-scheme media query (`light`, `dark`, or
+// `not all` / `no-preference`) through the user's own override
+// ('light' | 'dark' | 'system'). 6 combos total; default for the
+// `no-preference` + `system` cell is `light` to match the existing
+// `resolveEffectiveTheme(theme, osPrefersDark: false)` behaviour in
+// `src/stores/slices/appearanceSlice.ts`.
+//
+// Kept distinct from the existing boolean-arg helper in
+// `appearanceSlice.ts` (which `useThemeEffect` previously called) because
+// changing that signature would ripple through `CommandPalette` and other
+// call sites. The boolean helper remains; this lib is the new, tri-state
+// projection that the theme effect now consumes.
+
+export type SystemPref = 'light' | 'dark' | 'no-preference';
+export type UserOverride = 'light' | 'dark' | 'system';
+export type EffectiveTheme = 'light' | 'dark';
+
+/**
+ * Project the OS-level color-scheme signal through the user's override
+ * setting.
+ *
+ * - Explicit override (`'light'` / `'dark'`) always wins, regardless of
+ *   the OS signal — this is what "user override" means.
+ * - When the user picks `'system'` we follow the OS:
+ *   - `'dark'`          -> `'dark'`
+ *   - `'light'`         -> `'light'`
+ *   - `'no-preference'` -> `'light'` (sensible default; matches the
+ *     legacy `osPrefersDark=false` behaviour and Apple/GNOME defaults).
+ */
+export function resolveEffectiveTheme(
+  systemPref: SystemPref,
+  userOverride: UserOverride
+): EffectiveTheme {
+  if (userOverride === 'light') return 'light';
+  if (userOverride === 'dark') return 'dark';
+  // userOverride === 'system' — follow OS
+  if (systemPref === 'dark') return 'dark';
+  return 'light';
+}

--- a/tests/app-effects/useThemeEffect.test.tsx
+++ b/tests/app-effects/useThemeEffect.test.tsx
@@ -1,28 +1,48 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import { useThemeEffect } from '../../src/app-effects/useThemeEffect';
+import {
+  resolveEffectiveTheme,
+  type SystemPref,
+  type UserOverride,
+} from '../../src/lib/resolveEffectiveTheme';
 
-describe('useThemeEffect', () => {
-  let mqlListeners: Array<(ev: MediaQueryListEvent) => void>;
-  let mql: MediaQueryList;
-  let matchesValue: boolean;
+/**
+ * Tri-state OS signal scaffold: jsdom doesn't natively answer
+ * `prefers-color-scheme` queries, so we install a `matchMedia` shim that
+ * reflects an explicit `systemPref` ('light' | 'dark' | 'no-preference').
+ */
+type MqlEntry = {
+  list: MediaQueryList;
+  listeners: Array<(ev: MediaQueryListEvent) => void>;
+  setMatches: (v: boolean) => void;
+};
 
-  beforeEach(() => {
-    mqlListeners = [];
-    matchesValue = false;
-    mql = {
+function installMatchMedia(systemPref: SystemPref): {
+  darkMql: MqlEntry;
+  lightMql: MqlEntry;
+  setSystemPref: (next: SystemPref) => void;
+} {
+  const make = (
+    media: string,
+    initialMatches: boolean
+  ): MqlEntry => {
+    let matches = initialMatches;
+    const listeners: Array<(ev: MediaQueryListEvent) => void> = [];
+    const list = {
       get matches() {
-        return matchesValue;
+        return matches;
       },
-      media: '(prefers-color-scheme: dark)',
+      media,
       addEventListener: vi.fn(
         (_evt: string, cb: (ev: MediaQueryListEvent) => void) => {
-          mqlListeners.push(cb);
+          listeners.push(cb);
         }
       ),
       removeEventListener: vi.fn(
         (_evt: string, cb: (ev: MediaQueryListEvent) => void) => {
-          mqlListeners = mqlListeners.filter((x) => x !== cb);
+          const idx = listeners.indexOf(cb);
+          if (idx >= 0) listeners.splice(idx, 1);
         }
       ),
       onchange: null,
@@ -30,16 +50,83 @@ describe('useThemeEffect', () => {
       removeListener: vi.fn(),
       dispatchEvent: vi.fn(),
     } as unknown as MediaQueryList;
-    vi.stubGlobal(
-      'matchMedia',
-      vi.fn(() => mql)
-    );
-    // jsdom on Window
-    Object.defineProperty(window, 'matchMedia', {
-      configurable: true,
-      writable: true,
-      value: () => mql,
+    return {
+      list,
+      listeners,
+      setMatches: (v: boolean) => {
+        matches = v;
+      },
+    };
+  };
+
+  const darkMql = make(
+    '(prefers-color-scheme: dark)',
+    systemPref === 'dark'
+  );
+  const lightMql = make(
+    '(prefers-color-scheme: light)',
+    systemPref === 'light'
+  );
+
+  const matchMedia = vi.fn((q: string) => {
+    if (q.includes('dark')) return darkMql.list;
+    if (q.includes('light')) return lightMql.list;
+    return darkMql.list;
+  });
+  vi.stubGlobal('matchMedia', matchMedia);
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: matchMedia,
+  });
+
+  const setSystemPref = (next: SystemPref) => {
+    darkMql.setMatches(next === 'dark');
+    lightMql.setMatches(next === 'light');
+    // Notify subscribers (the hook only attaches to the dark MQL).
+    const ev = { matches: next === 'dark' } as MediaQueryListEvent;
+    for (const cb of darkMql.listeners) cb(ev);
+  };
+
+  return { darkMql, lightMql, setSystemPref };
+}
+
+describe('resolveEffectiveTheme (lib) — 6 combos (systemPref x userOverride)', () => {
+  // Spec §5.3.7 PR-7: system{light, dark, no-preference} x override{light,
+  // dark, system} = 9 cells, but the explicit override branches collapse
+  // by systemPref so the spec calls them "6 combos" once you fold the
+  // override-wins cells. We assert all 9 cells explicitly to lock the
+  // truth table.
+  const cases: Array<{
+    systemPref: SystemPref;
+    userOverride: UserOverride;
+    expected: 'light' | 'dark';
+  }> = [
+    // userOverride === 'light' -> always light (3 cells, override wins)
+    { systemPref: 'light', userOverride: 'light', expected: 'light' },
+    { systemPref: 'dark', userOverride: 'light', expected: 'light' },
+    { systemPref: 'no-preference', userOverride: 'light', expected: 'light' },
+    // userOverride === 'dark' -> always dark (3 cells, override wins)
+    { systemPref: 'light', userOverride: 'dark', expected: 'dark' },
+    { systemPref: 'dark', userOverride: 'dark', expected: 'dark' },
+    { systemPref: 'no-preference', userOverride: 'dark', expected: 'dark' },
+    // userOverride === 'system' -> follow OS, no-preference defaults to light
+    { systemPref: 'light', userOverride: 'system', expected: 'light' },
+    { systemPref: 'dark', userOverride: 'system', expected: 'dark' },
+    { systemPref: 'no-preference', userOverride: 'system', expected: 'light' },
+  ];
+
+  for (const c of cases) {
+    it(`systemPref=${c.systemPref} x userOverride=${c.userOverride} -> ${c.expected}`, () => {
+      expect(resolveEffectiveTheme(c.systemPref, c.userOverride)).toBe(
+        c.expected
+      );
     });
+  }
+});
+
+describe('useThemeEffect', () => {
+  beforeEach(() => {
     document.documentElement.className = '';
     delete document.documentElement.dataset.theme;
   });
@@ -49,29 +136,116 @@ describe('useThemeEffect', () => {
   });
 
   it('applies dark class for dark theme', () => {
+    installMatchMedia('no-preference');
     renderHook(() => useThemeEffect('dark'));
     expect(document.documentElement.classList.contains('dark')).toBe(true);
-    expect(document.documentElement.classList.contains('theme-light')).toBe(false);
+    expect(document.documentElement.classList.contains('theme-light')).toBe(
+      false
+    );
     expect(document.documentElement.dataset.theme).toBe('dark');
   });
 
   it('applies theme-light class for light theme', () => {
+    installMatchMedia('no-preference');
     renderHook(() => useThemeEffect('light'));
-    expect(document.documentElement.classList.contains('theme-light')).toBe(true);
+    expect(document.documentElement.classList.contains('theme-light')).toBe(
+      true
+    );
     expect(document.documentElement.classList.contains('dark')).toBe(false);
   });
 
   it('subscribes to matchMedia change events when theme is system, and unsubscribes on unmount', () => {
-    matchesValue = true;
+    const { darkMql } = installMatchMedia('dark');
     const { unmount } = renderHook(() => useThemeEffect('system'));
-    expect(mql.addEventListener).toHaveBeenCalledTimes(1);
+    expect(darkMql.list.addEventListener).toHaveBeenCalledTimes(1);
     expect(document.documentElement.classList.contains('dark')).toBe(true);
     unmount();
-    expect(mql.removeEventListener).toHaveBeenCalledTimes(1);
+    expect(darkMql.list.removeEventListener).toHaveBeenCalledTimes(1);
   });
 
   it('does NOT subscribe to matchMedia for explicit (non-system) themes', () => {
+    const { darkMql } = installMatchMedia('no-preference');
     renderHook(() => useThemeEffect('light'));
-    expect(mql.addEventListener).not.toHaveBeenCalled();
+    expect(darkMql.list.addEventListener).not.toHaveBeenCalled();
+  });
+
+  // 6-combo end-to-end coverage through the hook (DOM side-effects).
+  // Mirrors the pure-fn truth table above to make sure the hook actually
+  // reads the tri-state OS signal correctly via matchMedia.
+  const hookCases: Array<{
+    systemPref: SystemPref;
+    userOverride: 'light' | 'dark' | 'system';
+    expectDark: boolean;
+    expectLight: boolean;
+    expectDataTheme: 'light' | 'dark';
+  }> = [
+    {
+      systemPref: 'light',
+      userOverride: 'system',
+      expectDark: false,
+      expectLight: true,
+      expectDataTheme: 'light',
+    },
+    {
+      systemPref: 'dark',
+      userOverride: 'system',
+      expectDark: true,
+      expectLight: false,
+      expectDataTheme: 'dark',
+    },
+    {
+      systemPref: 'no-preference',
+      userOverride: 'system',
+      expectDark: false,
+      expectLight: true,
+      expectDataTheme: 'light',
+    },
+    {
+      systemPref: 'dark',
+      userOverride: 'light',
+      expectDark: false,
+      expectLight: true,
+      expectDataTheme: 'light',
+    },
+    {
+      systemPref: 'light',
+      userOverride: 'dark',
+      expectDark: true,
+      expectLight: false,
+      expectDataTheme: 'dark',
+    },
+    {
+      systemPref: 'no-preference',
+      userOverride: 'dark',
+      expectDark: true,
+      expectLight: false,
+      expectDataTheme: 'dark',
+    },
+  ];
+
+  for (const c of hookCases) {
+    it(`hook: systemPref=${c.systemPref} x userOverride=${c.userOverride} -> data-theme=${c.expectDataTheme}`, () => {
+      installMatchMedia(c.systemPref);
+      renderHook(() => useThemeEffect(c.userOverride));
+      expect(document.documentElement.classList.contains('dark')).toBe(
+        c.expectDark
+      );
+      expect(document.documentElement.classList.contains('theme-light')).toBe(
+        c.expectLight
+      );
+      expect(document.documentElement.dataset.theme).toBe(c.expectDataTheme);
+    });
+  }
+
+  it('reacts to OS preference flip while in system mode', () => {
+    const { setSystemPref } = installMatchMedia('light');
+    renderHook(() => useThemeEffect('system'));
+    expect(document.documentElement.dataset.theme).toBe('light');
+    setSystemPref('dark');
+    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
+    expect(document.documentElement.classList.contains('theme-light')).toBe(
+      false
+    );
   });
 });


### PR DESCRIPTION
## Summary

Spec: `docs/superpowers/specs/2026-05-06-v0.3-e2e-cutover-design.md` §2 (theme), §5.3.7 PR-7 (Task #606 / spec #592 T-7).

- New `src/lib/resolveEffectiveTheme.ts`: pure tri-state projection `(systemPref, userOverride) -> 'light' | 'dark'` with `systemPref: 'light' | 'dark' | 'no-preference'`. The spec calls for "6 combos" — the 9-cell truth table collapses to 6 once the override-wins cells are folded (we assert all 9 explicitly to lock the table).
- `src/app-effects/useThemeEffect.ts` now reads the OS signal via two `matchMedia` probes (`dark` + `light`) so it can disambiguate `no-preference`, then delegates to the new lib. The legacy boolean-arg `resolveEffectiveTheme` in `src/stores/slices/appearanceSlice.ts` is left untouched to avoid rippling through `CommandPalette` and other call sites.
- `tests/app-effects/useThemeEffect.test.tsx` extended with: (a) 9-cell pure-fn truth table, (b) 6-combo end-to-end DOM assertions through the hook, (c) OS-pref flip while in system mode.

Depends on (already merged):
- #602 (PR #1114) loadState shim fix
- #601 (PR #1116) `__ccsmStore` pin + `ccsm:app-shell-ready`

## Spec deviations

- Spec mentioned `src/hooks/useThemeEffect.ts` — actual path is `src/app-effects/useThemeEffect.ts`. Edited the existing file in place; no relocation.
- Spec mentioned `src/lib/resolveEffectiveTheme.ts` did not exist — created it as a new lib (per task description recommendation). Kept the existing boolean-arg `resolveEffectiveTheme` in `src/stores/slices/appearanceSlice.ts` to avoid scope creep into `CommandPalette` and the rest of the appearance pipeline; the new lib is the spec-shaped tri-state API consumed by `useThemeEffect`.
- Test file already existed (`.tsx`); extended in place rather than creating a new file.

## Layer 1 / 5-tier

- Layer 1 OK — task is real, scope matches the spec, no smell.
- 5-tier: tier 5 (self-write) for the new lib. Tier 1-3 don't apply: the existing helper in `appearanceSlice.ts` only takes a boolean and cannot represent the `no-preference` system state the spec requires; standard library has no equivalent; no existing dep covers project-domain theme projection. Tier 4 (copy from open source): no upstream maps neatly onto the spec's tri-state x override truth table — this is project-specific UX policy. Implementation is 6 lines of pure logic, fully covered by 9 + 6 unit assertions.

## Local checks (host: Windows, mode: fast)

- lint: ok (exit 0; 45 pre-existing warnings, 0 errors)
- typecheck: ok (exit 0)
- build: ok (exit 0; 3 pre-existing webpack size warnings)
- unit tests:
  - `npx vitest run tests/app-effects/useThemeEffect.test.tsx` — Test Files 1 passed (1), Tests 20 passed (20), 30.08s
  - `npx vitest run tests/appearance.test.ts tests/stores/slices/appearanceSlice.test.ts` — Test Files 2 passed (2), Tests 29 passed (29), 2.61s (regression check on the legacy helper that I left untouched)
- e2e: skipped — theme-projection probe is the follow-up PR per spec (#605 PR-8); no existing e2e hits the new tri-state path.