### PR TITLE
feat(TerminalPane): host unconditional + xterm pin order (Task #603, PR-4, spec #592 T-4)

### DIFF
--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -17,9 +17,28 @@ import { usePtyAttach, type PtyAttachState } from '../terminal/usePtyAttach';
 //
 // The host div carries [data-terminal-host] and [data-active-sid={sessionId}]
 // so the e2e probes (PR-7) can locate the active terminal deterministically.
+//
+// Spec #592 T-4 / Task #603 (PR-4) — host-unconditional + xterm pin order:
+//   - The host div is rendered ALWAYS, even when no session is active.
+//     `sessionId` is nullable; the data-active-sid attribute is set only
+//     when a sid is provided. This lets the upstream `terminal-host-mounted`
+//     e2e probe (#605 PR-8) latch on the host before the active session
+//     resolves, avoiding the previous "blank pane → conditional mount"
+//     race that #888 / #852 fallout exposed.
+//   - xterm is pinned strictly AFTER the pty-host wire is in place:
+//     `useXtermSingleton(hostRef, enabled)` only constructs the Terminal
+//     when a sid exists AND `window.ccsmPty` is wired. The renderer never
+//     boots an xterm against a half-initialised preload — this is the
+//     wire-then-instantiate ordering documented in §3.1.5.
 
 type Props = {
-  sessionId: string;
+  /**
+   * The active session id, or `null` while no session is selected.
+   * Spec #592 T-4 PR-4: kept nullable so the host element can mount
+   * before the session lifecycle resolves.
+   */
+  sessionId: string | null;
+  /** Working directory for spawn-on-attach-null. Ignored when sessionId is null. */
   cwd: string;
 };
 
@@ -27,15 +46,27 @@ export function TerminalPane({ sessionId, cwd }: Props) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const { t } = useTranslation();
 
-  useXtermSingleton(hostRef);
+  // xterm pin order: enable bring-up only once we have a sid. The
+  // singleton hook also re-checks `window.ccsmPty` internally (the
+  // pty-host wire) so the constructor never runs before the bridge.
+  const xtermEnabled = sessionId != null;
+  useXtermSingleton(hostRef, xtermEnabled);
   useTerminalResize(hostRef);
   const { state, onRetry } = usePtyAttach(sessionId, cwd);
+
+  // `data-active-sid` is set only when a sid is present. e2e probes that
+  // need to wait for "active terminal" should look for both attributes;
+  // probes that only need the host (e.g. terminal-host-mounted, #605
+  // PR-8) should match `[data-terminal-host]` alone.
+  const hostProps: Record<string, string> = { 'data-terminal-host': '' };
+  if (sessionId != null) {
+    hostProps['data-active-sid'] = sessionId;
+  }
 
   return (
     <div
       className="relative flex-1 w-full h-full bg-black ring-1 ring-inset ring-white/5"
-      data-terminal-host
-      data-active-sid={sessionId}
+      {...hostProps}
     >
       <div ref={hostRef} className="absolute inset-0" />
       <Overlay state={state} onRetry={onRetry} t={t} />
@@ -52,6 +83,14 @@ function Overlay({
   onRetry: () => void;
   t: (key: string, opts?: Record<string, unknown>) => string;
 }) {
+  if (state.kind === 'idle') {
+    // Host-mounted-without-sid window (spec #592 T-4 PR-4): no overlay
+    // text — the empty-state copy lives in App.tsx's no-active-session
+    // chrome. Returning null here keeps the host visually identical to
+    // a freshly-attached pane (black background) so the transition into
+    // 'attaching' is a single overlay flip rather than a layout shift.
+    return null;
+  }
   if (state.kind === 'attaching') {
     return (
       <div className="absolute inset-0 z-10 flex items-center justify-center text-neutral-400 text-sm pointer-events-none">

--- a/src/terminal/usePtyAttach.ts
+++ b/src/terminal/usePtyAttach.ts
@@ -15,6 +15,12 @@ import {
 } from './xtermSingleton';
 
 export type PtyAttachState =
+  // `idle` covers the host-mounted-without-sid window introduced by
+  // spec #592 T-4 / Task #603 (PR-4): TerminalPane's host div now mounts
+  // unconditionally so e2e probes (terminal-host-mounted, follow-up
+  // #605 PR-8) can find it before the active session resolves. While
+  // sessionId is null the hook does not attach and renders no overlay.
+  | { kind: 'idle' }
   | { kind: 'attaching' }
   | { kind: 'ready' }
   // `exit` distinguishes user-intentional clean exit (no signal, code 0)
@@ -46,8 +52,10 @@ export type UsePtyAttachResult = {
  * Returns `{ state, onRetry }` for the host component to render the
  * appropriate overlay (attaching / error / exit) and Retry button.
  */
-export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult {
-  const [state, setState] = useState<PtyAttachState>({ kind: 'attaching' });
+export function usePtyAttach(sessionId: string | null, cwd: string): UsePtyAttachResult {
+  const [state, setState] = useState<PtyAttachState>(
+    sessionId == null ? { kind: 'idle' } : { kind: 'attaching' },
+  );
   // Store action — clear the disconnect entry on respawn success so the
   // sidebar red dot disappears the moment the pty is back. Routed through
   // a ref so the attach effect doesn't depend on it (and re-run unnecessarily).
@@ -57,7 +65,7 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
   // Tracks the sessionId we're currently attaching for so a stale resolve
   // from a previous session can't clobber the current one when the user
   // switches quickly.
-  const requestedSidRef = useRef<string>(sessionId);
+  const requestedSidRef = useRef<string | null>(sessionId);
   // Bumped by Retry to force the attach effect to re-run for the same sid.
   const [attachNonce, setAttachNonce] = useState(0);
 
@@ -65,6 +73,47 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
   // session, reset the terminal, attach the new one, and wire data flow.
   useEffect(() => {
     requestedSidRef.current = sessionId;
+    // Spec #592 T-4 PR-4: when the host mounts without a sid (initial
+    // boot, no active session yet), stay idle. No attach IPC, no xterm
+    // touch — the host div is in DOM purely so the e2e probe can find
+    // it. We still tear down any prior attach (sid → null transition)
+    // to release the previous session's pty subscriber.
+    if (sessionId == null) {
+      const prevSid = getActiveSid();
+      if (prevSid) {
+        setSnapshotReplay(null);
+        const unsubPrev = getUnsubscribeData();
+        if (unsubPrev) {
+          try {
+            unsubPrev();
+          } catch {
+            // already torn down — safe to ignore.
+          }
+          setUnsubscribeData(null);
+        }
+        const inDispPrev = getInputDisposable();
+        if (inDispPrev) {
+          try {
+            inDispPrev.dispose();
+          } catch {
+            // already disposed — safe to ignore.
+          }
+          setInputDisposable(null);
+        }
+        const ptyApiPrev = window.ccsmPty;
+        if (ptyApiPrev) {
+          try {
+            void ptyApiPrev.detach(prevSid);
+          } catch {
+            // best-effort.
+          }
+        }
+        setActiveSid(null);
+      }
+      setState({ kind: 'idle' });
+      return;
+    }
+
     let cancelled = false;
     setState({ kind: 'attaching' });
 
@@ -424,6 +473,33 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
       // headless mirror unconditionally, and a subsequent re-attach
       // (initial mount, sid switch back, or Retry) replays via
       // `getBufferSnapshot` + drain (PR-B contract).
+      //
+      // Spec #592 T-4 PR-4 (#603): also dispose the per-attach input
+      // listener and pty data subscriber on unmount so the host →
+      // unmount path doesn't leak the Disposable / unsubscribe.
+      // Previously these only torn down on sid change (the active-sid
+      // detach branch); on a clean unmount they survived as dangling
+      // references on the singleton until a later attach overwrote
+      // them.
+      if (sessionId == null) return;
+      const inDispCleanup = getInputDisposable();
+      if (inDispCleanup) {
+        try {
+          inDispCleanup.dispose();
+        } catch {
+          // already disposed — safe to ignore.
+        }
+        setInputDisposable(null);
+      }
+      const unsubCleanup = getUnsubscribeData();
+      if (unsubCleanup) {
+        try {
+          unsubCleanup();
+        } catch {
+          // already torn down — safe to ignore.
+        }
+        setUnsubscribeData(null);
+      }
       const ptyApi = window.ccsmPty;
       if (ptyApi) {
         try {

--- a/src/terminal/useXtermSingleton.ts
+++ b/src/terminal/useXtermSingleton.ts
@@ -10,12 +10,36 @@ import { ensureTerminal } from './xtermSingleton';
  * `window.__ccsmTerm` probe handle) is created lazily inside the effect so
  * we never run xterm constructors at import time (would explode in non-DOM
  * test environments).
+ *
+ * Spec #592 T-4 / Task #603 (PR-4): xterm pin order — instantiation MUST
+ * wait for the pty-host wire (`window.ccsmPty`) so the constructor never
+ * runs against a half-initialised renderer. The host div mounts
+ * unconditionally (TerminalPane), but xterm itself is gated on
+ * `enabled` (caller passes `true` only after sid + pty bridge are ready).
+ * When `enabled` is false the hook is a no-op and re-runs on the next
+ * dependency flip, so the singleton is created exactly once at the
+ * first moment both gates are open.
  */
-export function useXtermSingleton(hostRef: RefObject<HTMLDivElement | null>): void {
+export function useXtermSingleton(
+  hostRef: RefObject<HTMLDivElement | null>,
+  enabled: boolean = true,
+): void {
+  // No deps: we run after every render and rely on ensureTerminal's
+  // module-singleton cache for idempotence. Pin order needs both gates
+  // (`enabled` and `window.ccsmPty`) to be open at the same render, but
+  // those flips don't always show up in the dep array — e.g. the pty
+  // bridge is installed by `installCcsmShim` before React mounts in
+  // production but, in tests / late-wire scenarios, can land between
+  // renders without the `enabled` flag changing. A no-dep effect makes
+  // the bring-up moment the first render where both gates are open,
+  // independent of which gate flipped last.
   useEffect(() => {
+    if (!enabled) return;
     if (!hostRef.current) return;
+    // Pty-host wire gate: never instantiate xterm before the preload
+    // bridge is in place. The pin order is documented in spec #592 T-4
+    // PR-4 — wire-then-instantiate, never the other way around.
+    if (typeof window === 'undefined' || !window.ccsmPty) return;
     ensureTerminal(hostRef.current);
-    // hostRef is a stable ref — no deps needed.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  });
 }

--- a/tests/terminal-pane-mount.test.tsx
+++ b/tests/terminal-pane-mount.test.tsx
@@ -1,0 +1,189 @@
+// Spec #592 T-4 / Task #603 (PR-4) — TerminalPane host unconditional +
+// xterm pin order.
+//
+// Three contract assertions:
+//   1. mount-without-sid: the host element [data-terminal-host] is in the
+//      DOM even when sessionId is null. xterm is NOT instantiated. This is
+//      the e2e probe (`terminal-host-mounted`, follow-up #605 PR-8) latch
+//      surface that lets the harness wait for the pane before any session
+//      resolves.
+//   2. wire-then-instantiate: xterm constructor runs only after BOTH
+//      gates open — sessionId is a string AND `window.ccsmPty` is wired.
+//      Flipping sid first while the bridge is missing is a no-op; xterm
+//      lands on the next render where both gates are satisfied.
+//   3. unmount-cleanup: on unmount the pty subscriber and input listener
+//      are torn down (the disposables installed by usePtyAttach), and
+//      `pty.detach(sid)` is called. Without these the singleton would
+//      leak references to the previous attach across full pane unmounts.
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+// Hoisted xterm spies — imported by xtermSingleton at module load. The
+// constructor call count is the canonical "did xterm instantiate?" signal
+// for the wire-then-instantiate pin order.
+const { terminalCtor, openSpy, loadAddonSpy } = vi.hoisted(() => {
+  const openSpy = vi.fn();
+  const loadAddonSpy = vi.fn();
+  // vitest v3 requires `function`/`class` (not arrow) for `new`-invoked mocks.
+  const terminalCtor = vi.fn(function () {
+    return {
+      open: openSpy,
+      loadAddon: loadAddonSpy,
+      onSelectionChange: vi.fn(),
+      attachCustomKeyEventHandler: vi.fn(),
+      unicode: { activeVersion: '6' },
+      _core: { _parent: null },
+      // Surfaces touched by usePtyAttach when a sid is present:
+      write: vi.fn(),
+      reset: vi.fn(),
+      resize: vi.fn(),
+      focus: vi.fn(),
+      onData: vi.fn(() => ({ dispose: vi.fn() })),
+      cols: 80,
+      rows: 24,
+    };
+  });
+  return { terminalCtor, openSpy, loadAddonSpy };
+});
+
+vi.mock('@xterm/xterm', () => ({ Terminal: terminalCtor }));
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn(function () {
+    return { fit: vi.fn(), proposeDimensions: vi.fn(() => ({ cols: 80, rows: 24 })) };
+  }),
+}));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-canvas', () => ({ CanvasAddon: vi.fn(function () { return {}; }) }));
+
+// xterm.css is fine to import in jsdom; the dummy keeps the load graph
+// hermetic and avoids touching the real stylesheet from node_modules.
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
+
+// Minimal store + i18n stubs so the component can render in isolation.
+vi.mock('../src/stores/store', () => ({
+  useStore: (selector: (s: unknown) => unknown) =>
+    selector({ _clearPtyExit: vi.fn() }),
+}));
+vi.mock('../src/i18n/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+// ResizeObserver stub — jsdom doesn't ship one and useTerminalResize
+// instantiates one unconditionally on mount.
+class ROStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+(globalThis as unknown as { ResizeObserver: typeof ROStub }).ResizeObserver = ROStub;
+
+import { TerminalPane } from '../src/components/TerminalPane';
+import { __resetSingletonForTests } from '../src/terminal/xtermSingleton';
+
+type PtyBridge = {
+  attach: ReturnType<typeof vi.fn>;
+  detach: ReturnType<typeof vi.fn>;
+  spawn: ReturnType<typeof vi.fn>;
+  input: ReturnType<typeof vi.fn>;
+  resize: ReturnType<typeof vi.fn>;
+  onData: ReturnType<typeof vi.fn>;
+  onExit: ReturnType<typeof vi.fn>;
+  getBufferSnapshot: ReturnType<typeof vi.fn>;
+};
+
+function installPtyBridge(): { bridge: PtyBridge; onDataUnsub: ReturnType<typeof vi.fn> } {
+  const onDataUnsub = vi.fn();
+  const bridge: PtyBridge = {
+    attach: vi.fn(async () => ({ snapshot: 'snap', cols: 80, rows: 24, pid: 1 })),
+    detach: vi.fn(async () => undefined),
+    spawn: vi.fn(async () => ({ ok: true as const, sid: 'x', pid: 1, cols: 80, rows: 24 })),
+    input: vi.fn(),
+    resize: vi.fn(async () => undefined),
+    onData: vi.fn(() => onDataUnsub),
+    onExit: vi.fn(() => vi.fn()),
+    getBufferSnapshot: vi.fn(async () => ({ snapshot: 'snap', seq: 0 })),
+  };
+  (window as unknown as { ccsmPty: PtyBridge }).ccsmPty = bridge;
+  return { bridge, onDataUnsub };
+}
+
+function clearPtyBridge(): void {
+  delete (window as unknown as { ccsmPty?: PtyBridge }).ccsmPty;
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+const flushAll = async () => {
+  await flush();
+  await flush();
+  await flush();
+};
+
+describe('TerminalPane host mount (spec #592 T-4 / Task #603 PR-4)', () => {
+  beforeEach(() => {
+    __resetSingletonForTests();
+    terminalCtor.mockClear();
+    openSpy.mockClear();
+    loadAddonSpy.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    clearPtyBridge();
+    __resetSingletonForTests();
+  });
+
+  it('mount-without-sid: host element is in DOM and xterm is NOT instantiated', async () => {
+    // Pty bridge wired but no session selected — the host must still mount.
+    installPtyBridge();
+    const { container } = render(<TerminalPane sessionId={null} cwd="" />);
+    await flushAll();
+
+    const host = container.querySelector('[data-terminal-host]');
+    expect(host).not.toBeNull();
+    // No active sid → no `data-active-sid` attribute (probes that need
+    // an active session can require both attributes).
+    expect(host?.getAttribute('data-active-sid')).toBeNull();
+    // xterm pin order: nothing instantiated until a sid is provided.
+    expect(terminalCtor).not.toHaveBeenCalled();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('wire-then-instantiate: xterm constructor only runs after both sid AND window.ccsmPty are present', async () => {
+    // Step 1: bridge missing, sid present. Pin order says no xterm yet.
+    clearPtyBridge();
+    const { rerender } = render(<TerminalPane sessionId="sid-A" cwd="/tmp" />);
+    await flushAll();
+    expect(terminalCtor).not.toHaveBeenCalled();
+
+    // Step 2: bridge lands → re-render with the same sid. The hook's
+    // `enabled` dep is unchanged across this render, but the pty-host
+    // wire gate is now open. Re-render with a sid change forces the
+    // singleton hook to re-run, confirming the pin order: wire FIRST,
+    // then xterm instantiation.
+    installPtyBridge();
+    rerender(<TerminalPane sessionId="sid-B" cwd="/tmp" />);
+    await flushAll();
+
+    expect(terminalCtor).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalled();
+  });
+
+  it('unmount-cleanup: pty.detach is called and the data subscriber unsubscribes', async () => {
+    const { onDataUnsub, bridge } = installPtyBridge();
+    const { unmount } = render(<TerminalPane sessionId="sid-C" cwd="/tmp" />);
+    await flushAll();
+
+    expect(bridge.attach).toHaveBeenCalledWith('sid-C');
+    expect(bridge.onData).toHaveBeenCalled();
+
+    unmount();
+    // Cleanup is synchronous from React's perspective; the detach call
+    // is fire-and-forget so we only assert it was invoked.
+    expect(bridge.detach).toHaveBeenCalledWith('sid-C');
+    expect(onDataUnsub).toHaveBeenCalled();
+  });
+});

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -44,10 +44,17 @@ describe('useXtermSingleton', () => {
     terminalCtor.mockClear();
     openSpy.mockClear();
     loadAddonSpy.mockClear();
+    // Spec #592 T-4 / Task #603 (PR-4): xterm pin order requires the
+    // pty-host wire (`window.ccsmPty`) to be in place BEFORE the hook
+    // instantiates xterm. The original tests asserted bring-up against
+    // a bare jsdom window, so install a no-op bridge here to satisfy
+    // the new wire gate.
+    (window as unknown as { ccsmPty: object }).ccsmPty = {};
   });
 
   afterEach(() => {
     __resetSingletonForTests();
+    delete (window as unknown as { ccsmPty?: object }).ccsmPty;
   });
 
   it('creates the Terminal singleton on first mount', () => {


### PR DESCRIPTION
## Summary

Spec #592 T-4 / Task #603 PR-4 — prepares `TerminalPane` so the upstream `terminal-host-mounted` e2e probe (#605 PR-8) can latch on the host before the active session resolves, and pins xterm instantiation strictly after the pty-host wire.

- `TerminalPane.sessionId` is now `string | null`. The `[data-terminal-host]` div renders unconditionally; `data-active-sid` is set only when a sid is provided. App.tsx still passes `active.id` (string), so the existing call site is unaffected — the nullable variant unblocks #605/#606.
- `useXtermSingleton(hostRef, enabled)` runs as a no-dep effect that internally gates on both `enabled` and `window.ccsmPty`. Pin order: wire-then-instantiate, never the other way around. The constructor never runs against a half-initialised preload.
- `usePtyAttach` accepts `string | null` (new `idle` state), and the cleanup path now disposes the per-attach input listener + pty data subscriber on unmount (previously only torn down on sid change, leaking across full pane unmounts).

3 UT cases per spec §5.3.4 in `tests/terminal-pane-mount.test.tsx`:
- `mount-without-sid` — host in DOM, xterm NOT instantiated
- `wire-then-instantiate` — ctor only after sid AND ccsmPty
- `unmount-cleanup` — `pty.detach` + onData unsub fire on unmount

The existing `useXtermSingleton` tests gain a no-op `ccsmPty` stub to satisfy the new wire gate.

Depends on (already merged): #1116 (Task #601, ccsm:app-shell-ready event + __ccsmStore pin), #1112 (Task #597, daemon ready signal), #1114 (Task #602, ccsmPty wire entry).

Followups: #605 PR-8 wires the e2e probe; #606 PR-7 will switch App.tsx to the host-unconditional render path.

## Local checks (host: Windows 11, mode: fast)

- lint: ok (exit 0, only pre-existing warnings)
- typecheck: ok (exit 0)
- build: ok (webpack + tsc -p tsconfig.electron.json)
- unit tests: 7 files / 43 passed —
  - tests/terminal-pane-mount.test.tsx (new, 3 cases)
  - tests/terminal/{useXtermSingleton,usePtyAttach,useTerminalResize}.test.tsx
  - tests/usePtyAttach-snapshot-replay.test.tsx
  - tests/pty-exit-classifier.test.ts
  - tests/store-pty-exit.test.ts
- e2e: skipped, scope is the `TerminalPane` host element + xterm pin order. The e2e probe `terminal-host-mounted` lands in #605 PR-8; the App.tsx render switch lands in #606 PR-7. No existing e2e harness exercises the host-without-sid window today.

## Test plan
- [x] new UT covers mount-without-sid + wire-then-instantiate + unmount-cleanup
- [x] existing terminal-hook UTs still green (with no-op ccsmPty stub)
- [x] App.tsx call site unaffected (nullable widening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)