### PR TITLE
test(useXtermSingleton): rollback fake ccsmPty setup; split wire-gate to own file (Task #620)

### DIFF
--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -33,10 +33,7 @@ vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: vi.fn(function () { r
 vi.mock('@xterm/addon-canvas', () => ({ CanvasAddon: vi.fn(function () { return {}; }) }));
 
 import { useXtermSingleton } from '../../src/terminal/useXtermSingleton';
-import {
-  __resetSingletonForTests,
-  getTerm,
-} from '../../src/terminal/xtermSingleton';
+import { __resetSingletonForTests } from '../../src/terminal/xtermSingleton';
 
 describe('useXtermSingleton', () => {
   beforeEach(() => {
@@ -44,41 +41,38 @@ describe('useXtermSingleton', () => {
     terminalCtor.mockClear();
     openSpy.mockClear();
     loadAddonSpy.mockClear();
-    // Spec #592 T-4 / Task #603 (PR-4): xterm pin order requires the
-    // pty-host wire (`window.ccsmPty`) to be in place BEFORE the hook
-    // instantiates xterm. The original tests asserted bring-up against
-    // a bare jsdom window, so install a no-op bridge here to satisfy
-    // the new wire gate.
-    (window as unknown as { ccsmPty: object }).ccsmPty = {};
   });
 
   afterEach(() => {
     __resetSingletonForTests();
-    delete (window as unknown as { ccsmPty?: object }).ccsmPty;
   });
 
-  it('creates the Terminal singleton on first mount', () => {
+  it('does NOT create xterm on first mount when window.ccsmPty is absent (wire-gate closed)', () => {
+    // Spec #592 T-4 / Task #603 (PR-4): wire-then-instantiate. With a bare
+    // jsdom window (no `window.ccsmPty`), the hook must be a no-op even when
+    // `enabled` defaults true and the host ref is live. Original assertion
+    // "always creates xterm" was overturned by the new wire gate; the
+    // bring-up path (with the wire present) is covered in
+    // useXtermSingleton.wire-gate.test.tsx.
     const host = document.createElement('div');
     const ref = { current: host };
     renderHook(() => useXtermSingleton(ref));
-    expect(terminalCtor).toHaveBeenCalledTimes(1);
-    expect(openSpy).toHaveBeenCalledWith(host);
-    // Selection→clipboard wiring + custom key handler installed.
-    expect(onSelectionChangeSpy).toHaveBeenCalledTimes(1);
-    expect(attachCustomKeyEventHandlerSpy).toHaveBeenCalledTimes(1);
-    // Probe handle exposed for e2e harness.
-    expect(window.__ccsmTerm).toBe(getTerm());
+    expect(terminalCtor).not.toHaveBeenCalled();
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(onSelectionChangeSpy).not.toHaveBeenCalled();
+    expect(attachCustomKeyEventHandlerSpy).not.toHaveBeenCalled();
   });
 
-  it('reuses the singleton across remounts (does NOT recreate)', () => {
+  it('does NOT create xterm across remounts when window.ccsmPty is absent', () => {
     const host = document.createElement('div');
     const ref = { current: host };
     const r1 = renderHook(() => useXtermSingleton(ref));
     r1.unmount();
     const r2 = renderHook(() => useXtermSingleton(ref));
     r2.unmount();
-    // ctor called exactly once across both mounts — proves cache hit.
-    expect(terminalCtor).toHaveBeenCalledTimes(1);
+    // No wire across both mounts → ctor never called. Singleton-cache
+    // semantics under an open wire are covered in the wire-gate suite.
+    expect(terminalCtor).not.toHaveBeenCalled();
   });
 
   it('no-ops when hostRef.current is null', () => {

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -47,34 +47,6 @@ describe('useXtermSingleton', () => {
     __resetSingletonForTests();
   });
 
-  it('does NOT create xterm on first mount when window.ccsmPty is absent (wire-gate closed)', () => {
-    // Spec #592 T-4 / Task #603 (PR-4): wire-then-instantiate. With a bare
-    // jsdom window (no `window.ccsmPty`), the hook must be a no-op even when
-    // `enabled` defaults true and the host ref is live. Original assertion
-    // "always creates xterm" was overturned by the new wire gate; the
-    // bring-up path (with the wire present) is covered in
-    // useXtermSingleton.wire-gate.test.tsx.
-    const host = document.createElement('div');
-    const ref = { current: host };
-    renderHook(() => useXtermSingleton(ref));
-    expect(terminalCtor).not.toHaveBeenCalled();
-    expect(openSpy).not.toHaveBeenCalled();
-    expect(onSelectionChangeSpy).not.toHaveBeenCalled();
-    expect(attachCustomKeyEventHandlerSpy).not.toHaveBeenCalled();
-  });
-
-  it('does NOT create xterm across remounts when window.ccsmPty is absent', () => {
-    const host = document.createElement('div');
-    const ref = { current: host };
-    const r1 = renderHook(() => useXtermSingleton(ref));
-    r1.unmount();
-    const r2 = renderHook(() => useXtermSingleton(ref));
-    r2.unmount();
-    // No wire across both mounts → ctor never called. Singleton-cache
-    // semantics under an open wire are covered in the wire-gate suite.
-    expect(terminalCtor).not.toHaveBeenCalled();
-  });
-
   it('no-ops when hostRef.current is null', () => {
     const ref = { current: null };
     renderHook(() => useXtermSingleton(ref));

--- a/tests/terminal/useXtermSingleton.wire-gate.test.tsx
+++ b/tests/terminal/useXtermSingleton.wire-gate.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+// Mirror useXtermSingleton.test.tsx's mock setup so the hook resolves
+// against spy constructors and never touches real xterm during the gate
+// assertions. See comments there for the `vi.hoisted` + `function`
+// rationale (vitest v3+ requires non-arrow factories for `new`).
+const { openSpy, terminalCtor } = vi.hoisted(() => {
+  const openSpy = vi.fn();
+  const terminalCtor = vi.fn(function () {
+    return {
+      open: openSpy,
+      loadAddon: vi.fn(),
+      onSelectionChange: vi.fn(),
+      attachCustomKeyEventHandler: vi.fn(),
+      unicode: { activeVersion: '6' },
+      _core: { _parent: null },
+    };
+  });
+  return { openSpy, terminalCtor };
+});
+
+vi.mock('@xterm/xterm', () => ({ Terminal: terminalCtor }));
+vi.mock('@xterm/addon-fit', () => ({ FitAddon: vi.fn(function () { return { fit: vi.fn() }; }) }));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-canvas', () => ({ CanvasAddon: vi.fn(function () { return {}; }) }));
+
+import { useXtermSingleton } from '../../src/terminal/useXtermSingleton';
+import { __resetSingletonForTests, getTerm } from '../../src/terminal/xtermSingleton';
+
+/**
+ * Independent suite for the `window.ccsmPty` wire-gate added in PR #1118
+ * (spec #592 T-4 / Task #603 PR-4). Kept separate from the main
+ * useXtermSingleton suite so each gate state owns its own setup and there
+ * is no shared, easy-to-overlook beforeEach toggling the bridge.
+ *
+ *   - case A (gate closed): no `window.ccsmPty` → hook MUST NOT instantiate
+ *   - case B (gate open):   `window.ccsmPty` present → hook MUST instantiate
+ */
+describe('useXtermSingleton wire-gate (window.ccsmPty)', () => {
+  beforeEach(() => {
+    __resetSingletonForTests();
+    terminalCtor.mockClear();
+    openSpy.mockClear();
+    // Start every case from a bare jsdom window — each case explicitly
+    // installs the bridge if it needs one, so the gate state is local
+    // and visible.
+    delete (window as unknown as { ccsmPty?: object }).ccsmPty;
+  });
+
+  afterEach(() => {
+    __resetSingletonForTests();
+    delete (window as unknown as { ccsmPty?: object }).ccsmPty;
+  });
+
+  it('case A: does NOT create xterm when window.ccsmPty is absent', () => {
+    const host = document.createElement('div');
+    const ref = { current: host };
+    renderHook(() => useXtermSingleton(ref));
+    expect(terminalCtor).not.toHaveBeenCalled();
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it('case B: creates xterm when window.ccsmPty is present', () => {
+    (window as unknown as { ccsmPty: object }).ccsmPty = {};
+    const host = document.createElement('div');
+    const ref = { current: host };
+    renderHook(() => useXtermSingleton(ref));
+    expect(terminalCtor).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(host);
+    expect(window.__ccsmTerm).toBe(getTerm());
+  });
+});


### PR DESCRIPTION
## Why this PR (redline trigger)

PR #1118 (Task #603) added a wire gate in `useXtermSingleton.ts`:

```ts
if (typeof window === 'undefined' || !window.ccsmPty) return;
```

To keep the existing `useXtermSingleton.test.tsx` cases green it ALSO added
to `beforeEach`:

```ts
// Spec #592 T-4 / Task #603 (PR-4): xterm pin order requires the
// pty-host wire (`window.ccsmPty`) to be in place BEFORE the hook
// instantiates xterm. The original tests asserted bring-up against
// a bare jsdom window, so install a no-op bridge here to satisfy
// the new wire gate.
(window as unknown as { ccsmPty: object }).ccsmPty = {};
```

That rewrites the original tests' premise (bare jsdom window) to make the
old assertion ("always creates xterm") keep passing under the new gate.
User redline (Task #620): **不准改老测试逻辑/前提**. Forcing the gate open
in setup is exactly that — it bypasses the gate instead of testing it.

## Decision basis

> 改老测试逻辑绝对不行

Two paths existed:
1. Keep the fake bridge (status quo) — masks the new gate, defeats its
   purpose, gives reviewers / future devs a false sense the old asserts
   still cover the bring-up path.
2. Rollback the fake bridge, face the new behaviour, and add an explicit
   gate suite — this PR.

### Round 2 correction (reviewer redline re-trigger)

Round 1 rewrote the two failing cases' assertions in place
(`it('creates ...')` body changed to assert `expect(未创建)`). Reviewer
correctly flagged that as the **same** redline: keeping the original
`it()` slot but inverting its intent is mutating old test logic, not
respecting it. Round 2 fix: **delete** the two cases outright. Their
product premise ("hook unconditionally creates xterm on mount / re-uses
across remounts") was overturned by PR #1118 — the subject under test
no longer exists, so the tests are dead and removal is the honest
treatment. The remaining old case (`no-ops when hostRef.current is
null`) is gate-irrelevant and kept **verbatim, 1 character untouched**.

## What changed

### `tests/terminal/useXtermSingleton.test.tsx` (rollback + delete)

Empirical post-rollback result of running the original 3 cases:

- `creates the Terminal singleton on first mount` — **FAIL** (ctor 0×, expected 1×)
- `reuses the singleton across remounts (does NOT recreate)` — **FAIL** (ctor 0×, expected 1×)
- `no-ops when hostRef.current is null` — **PASS** (gate-irrelevant)

Treatment:

- Removed the `(window as ...).ccsmPty = {}` line from `beforeEach` (and
  the matching cleanup from `afterEach`) — restores bare jsdom window.
- **Deleted** the two failing cases. Their assertions tested a product
  behaviour ("unconditional bring-up") that PR #1118 removed. Replacing
  them in-slot with inverse assertions would re-trigger the same redline,
  so they are simply removed.
- `it('no-ops when hostRef.current is null')` — unchanged, byte-for-byte.

Bring-up coverage moves to the new wire-gate suite below.

### `tests/terminal/useXtermSingleton.wire-gate.test.tsx` (new)

Owns the wire-gate matrix end-to-end (no shared, easy-to-overlook setup
toggling the bridge — each case explicitly installs or omits it):

- **case A**: `window.ccsmPty` not present → hook does NOT instantiate
  (`terminalCtor` 0×, `openSpy` 0×).
- **case B**: `window.ccsmPty` present → hook DOES instantiate
  (`terminalCtor` 1×, `openSpy` called with host, `window.__ccsmTerm` wired).

### `src/terminal/useXtermSingleton.ts`

Untouched. PR #1118 product code is correct; this PR only fixes the test
hygiene around it.

## Local checks (host: Windows 11, mode: fast)

- lint: ✓ (exit 0, 0 errors / 45 pre-existing warnings)
- typecheck: ✓ (exit 0)
- build: skipped — test-only diff (no .ts/.tsx in src or electron)
- unit tests: `npx vitest run tests/terminal/useXtermSingleton.test.tsx tests/terminal/useXtermSingleton.wire-gate.test.tsx`
  - `Test Files  2 passed (2)` / `Tests  3 passed (3)` / `Duration  2.80s`
    (1 surviving original case + 2 new wire-gate cases)
- e2e: skipped — test-only diff, no e2e harness or product code touched

Full unit + e2e left to CI three-platform matrix per fast-path policy.