### PR TITLE
feat(preload): A1 lazy daemon-port cache + daemonFetch helper (Task #629)

### DIFF
--- a/electron/preload/bridges/_daemon.ts
+++ b/electron/preload/bridges/_daemon.ts
@@ -26,6 +26,127 @@ async function resolvePort(): Promise<number | null> {
   }
 }
 
+// Task #629 — A1 lazy port cache + fetch helper.
+//
+// Why a separate cache (not folded into resolvePort): the existing SSE
+// reconnect loop in `openSse` re-resolves the port on every reconnect to
+// recover from daemon restarts (daemon binds 127.0.0.1:0, picks a fresh
+// port each spawn). Caching there would defeat that recovery. The cache
+// here is for one-shot RPC-style calls (`daemonFetch`) where the renderer
+// just wants the port once per session and any daemon-restart fallout
+// shows up as a fetch failure that the caller already handles.
+//
+// `null` resolutions are NOT cached — first invocation can land before
+// `daemon:getPort` is wired (preload runs before main-process IPC handlers
+// finish registering on cold boot). Caching null would freeze that race
+// permanently. Successful (numeric) resolutions are cached for the
+// lifetime of the renderer; call `__resetDaemonPortCacheForTest` from
+// tests to drop it.
+let cachedPortPromise: Promise<number | null> | null = null;
+
+/**
+ * Resolve the daemon HTTP port, caching the first successful lookup.
+ *
+ * Concurrent first calls share the same in-flight invoke promise (so we
+ * never issue two `daemon:getPort` IPC calls in parallel during the
+ * preload-startup race window). If the resolve yields `null` (handler
+ * not yet registered) we drop the cache so the next caller retries.
+ */
+export async function getCachedDaemonPort(): Promise<number | null> {
+  if (cachedPortPromise) {
+    const cached = await cachedPortPromise;
+    if (cached != null) return cached;
+    // Previous attempt resolved to null — fall through to retry.
+    cachedPortPromise = null;
+  }
+  const inflight = resolvePort();
+  cachedPortPromise = inflight;
+  const port = await inflight;
+  if (port == null) {
+    // Don't lock in a null result; next caller should re-invoke.
+    cachedPortPromise = null;
+  }
+  return port;
+}
+
+/**
+ * Test seam — drop the cached port so a fresh `getCachedDaemonPort`
+ * call re-invokes `daemon:getPort`. Not exported via the bridge surface;
+ * intended only for unit tests that swap out the `electron` module mock
+ * between assertions.
+ */
+export function __resetDaemonPortCacheForTest(): void {
+  cachedPortPromise = null;
+}
+
+export interface DaemonFetchOptions {
+  method?: string;
+  /** JSON-serializable body. Sets `Content-Type: application/json`
+   *  automatically; omit for GET / no-body requests. */
+  json?: unknown;
+  /** Extra headers merged on top of the JSON content-type (when applicable). */
+  headers?: Record<string, string>;
+  /** AbortSignal forwarded to `fetch`. */
+  signal?: AbortSignal;
+}
+
+export class DaemonUnavailableError extends Error {
+  constructor() {
+    super('daemon port unavailable');
+    this.name = 'DaemonUnavailableError';
+  }
+}
+
+export class DaemonHttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly statusText: string,
+  ) {
+    super(`daemon HTTP ${status} ${statusText}`);
+    this.name = 'DaemonHttpError';
+  }
+}
+
+/**
+ * Generic loopback fetch against the daemon. Resolves the port via the
+ * lazy cache, builds `http://127.0.0.1:${port}${path}`, and parses the
+ * response as JSON.
+ *
+ * Errors are surfaced (unlike `fireDaemonEvent` / `getDaemon` which
+ * swallow), so callers can decide retry / surface UX. Throws:
+ *   - `DaemonUnavailableError` when the port lookup fails (handler not
+ *     registered or main-process refused — caller can retry later)
+ *   - `DaemonHttpError` on non-2xx response
+ *   - the underlying `fetch` rejection (network / abort) otherwise
+ */
+export async function daemonFetch<T = unknown>(
+  path: string,
+  opts: DaemonFetchOptions = {},
+): Promise<T> {
+  const port = await getCachedDaemonPort();
+  if (port == null) throw new DaemonUnavailableError();
+  const headers: Record<string, string> = { ...(opts.headers ?? {}) };
+  let body: string | undefined;
+  if (opts.json !== undefined) {
+    headers['Content-Type'] = headers['Content-Type'] ?? 'application/json';
+    body = JSON.stringify(opts.json);
+  }
+  const res = await fetch(`http://127.0.0.1:${port}${path}`, {
+    method: opts.method ?? (body ? 'POST' : 'GET'),
+    headers,
+    body,
+    signal: opts.signal,
+  });
+  if (!res.ok) throw new DaemonHttpError(res.status, res.statusText);
+  // Empty body (204 / 205) → return undefined as T. JSON.parse of '' throws.
+  if (res.status === 204 || res.status === 205) {
+    return undefined as T;
+  }
+  const text = await res.text();
+  if (text.length === 0) return undefined as T;
+  return JSON.parse(text) as T;
+}
+
 export interface SseStream {
   /** Cancel any active source + stop reconnect loop. */
   close(): void;

--- a/tests/preload-daemon-helper.test.ts
+++ b/tests/preload-daemon-helper.test.ts
@@ -1,0 +1,182 @@
+// Task #629 — A1 unit tests for the lazy daemon-port cache + daemonFetch
+// helper added to electron/preload/bridges/_daemon.ts.
+//
+// The bridge module imports `ipcRenderer` from `electron`; under jsdom we
+// stub it with a vi.fn() invoke so the tests can drive port resolution
+// deterministically. fetch is stubbed per-case via vi.spyOn(globalThis).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const invoke = vi.fn<(channel: string) => Promise<number | null>>();
+
+vi.mock('electron', () => ({
+  ipcRenderer: {
+    invoke: (channel: string) => invoke(channel),
+  },
+}));
+
+// Import after vi.mock so the bridge picks up the stubbed electron.
+import {
+  __resetDaemonPortCacheForTest,
+  daemonFetch,
+  DaemonHttpError,
+  DaemonUnavailableError,
+  getCachedDaemonPort,
+} from '../electron/preload/bridges/_daemon';
+
+beforeEach(() => {
+  invoke.mockReset();
+  __resetDaemonPortCacheForTest();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('getCachedDaemonPort', () => {
+  it('caches the resolved port across calls (single IPC invoke)', async () => {
+    invoke.mockResolvedValue(54321);
+
+    const a = await getCachedDaemonPort();
+    const b = await getCachedDaemonPort();
+    const c = await getCachedDaemonPort();
+
+    expect(a).toBe(54321);
+    expect(b).toBe(54321);
+    expect(c).toBe(54321);
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke).toHaveBeenCalledWith('daemon:getPort');
+  });
+
+  it('coalesces concurrent first calls into a single IPC invoke', async () => {
+    let resolveInvoke!: (value: number | null) => void;
+    invoke.mockReturnValueOnce(
+      new Promise<number | null>((resolve) => {
+        resolveInvoke = resolve;
+      }),
+    );
+
+    const p1 = getCachedDaemonPort();
+    const p2 = getCachedDaemonPort();
+    const p3 = getCachedDaemonPort();
+
+    resolveInvoke(7777);
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+
+    expect([r1, r2, r3]).toEqual([7777, 7777, 7777]);
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache null resolutions (retries next call)', async () => {
+    invoke.mockResolvedValueOnce(null).mockResolvedValueOnce(8888);
+
+    const first = await getCachedDaemonPort();
+    const second = await getCachedDaemonPort();
+
+    expect(first).toBeNull();
+    expect(second).toBe(8888);
+    expect(invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns null when the IPC invoke rejects', async () => {
+    invoke.mockRejectedValueOnce(new Error('handler missing'));
+
+    const result = await getCachedDaemonPort();
+
+    expect(result).toBeNull();
+    // Cache cleared on null — next call retries.
+    invoke.mockResolvedValueOnce(1234);
+    expect(await getCachedDaemonPort()).toBe(1234);
+    expect(invoke).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('daemonFetch', () => {
+  it('GETs the cached port and parses JSON', async () => {
+    invoke.mockResolvedValue(40000);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify({ ok: true, n: 3 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+    const result = await daemonFetch<{ ok: boolean; n: number }>('/api/state');
+
+    expect(result).toEqual({ ok: true, n: 3 });
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('http://127.0.0.1:40000/api/state');
+    expect(init?.method).toBe('GET');
+    expect(init?.body).toBeUndefined();
+  });
+
+  it('POSTs JSON body with content-type when opts.json supplied', async () => {
+    invoke.mockResolvedValue(40001);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await daemonFetch('/api/event', { json: { args: [1, 'two'] } });
+
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe('http://127.0.0.1:40001/api/event');
+    expect(init?.method).toBe('POST');
+    expect(init?.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    expect(init?.body).toBe(JSON.stringify({ args: [1, 'two'] }));
+  });
+
+  it('throws DaemonUnavailableError when port lookup yields null', async () => {
+    invoke.mockResolvedValue(null);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    await expect(daemonFetch('/api/state')).rejects.toBeInstanceOf(
+      DaemonUnavailableError,
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('throws DaemonHttpError on non-2xx response', async () => {
+    invoke.mockResolvedValue(40002);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('nope', { status: 500, statusText: 'Internal Error' }),
+    );
+
+    await expect(daemonFetch('/api/state')).rejects.toMatchObject({
+      name: 'DaemonHttpError',
+      status: 500,
+    });
+  });
+
+  it('returns undefined for 204 No Content responses', async () => {
+    invoke.mockResolvedValue(40003);
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(null, { status: 204 }),
+    );
+
+    const result = await daemonFetch('/api/event', { json: { args: [] } });
+    expect(result).toBeUndefined();
+  });
+
+  it('propagates fetch rejections (e.g. abort / network)', async () => {
+    invoke.mockResolvedValue(40004);
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      new Error('network down'),
+    );
+
+    await expect(daemonFetch('/api/state')).rejects.toThrow('network down');
+  });
+
+  it('round-trips honoring an explicit method override', async () => {
+    invoke.mockResolvedValue(40005);
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await daemonFetch('/api/state', { method: 'DELETE' });
+
+    expect(fetchSpy.mock.calls[0][1]?.method).toBe('DELETE');
+  });
+});


### PR DESCRIPTION
Task #629 — A1 of the preload-single-source PR chain. Pure infrastructure addition; no existing caller is rewired in this PR, so behavior is unchanged.

## Summary
- `getCachedDaemonPort()`: module-scoped lazy cache around the existing `ipcRenderer.invoke('daemon:getPort')`. Coalesces concurrent first callers into one IPC; never caches `null` results so the preload-startup race window stays retryable instead of being frozen.
- `daemonFetch<T>(path, opts)`: generic loopback fetch wrapper that builds `http://127.0.0.1:${port}${path}`, JSON-serializes the body when `opts.json` is supplied, and parses the response. Surfaces `DaemonUnavailableError` / `DaemonHttpError` so callers can react instead of silently swallowing (unlike `fireDaemonEvent` / `getDaemon` which intentionally swallow for fire-and-forget paths).
- `__resetDaemonPortCacheForTest()`: test seam.
- Existing `resolvePort()` / `openSse()` / `fireDaemonEvent()` / `getDaemon()` are deliberately untouched — the SSE reconnect loop must keep re-resolving on every retry to recover from daemon restarts (daemon binds `127.0.0.1:0`, so each spawn picks a fresh port). Caching there would defeat that recovery.

## Not in this PR
- `ccsmCore.ts` API surface — untouched.
- `src/lib/window-ccsm-shim.ts` — B1 deletes it.
- `electron/main.ts` — `daemon:getPort` handler already exists.

## Local checks (host: Windows 11, mode: fast)
- lint: passing (exit 0; only pre-existing warnings, none introduced by this diff)
- typecheck: passing (exit 0; both `tsc --noEmit` and `tsc --noEmit -p tsconfig.electron.json`)
- build: passing (exit 0; webpack + tsc -p tsconfig.electron.json)
- unit tests: `npx vitest run tests/preload-daemon-helper.test.ts tests/electron-load-smoke.test.ts` — Test Files 2 passed (2), Tests 20 passed (20), Duration 2.57s. The new helper has no production callers so e2e is not exercised; full suite is left to CI matrix per fast-path.
- e2e: skipped — pure infrastructure addition with zero production callers, cannot affect any existing e2e behavior. B1+ PRs that wire callers through will run e2e.
- electron require-load smoke: `node -e "require('./dist/electron/preload/bridges/_daemon.js')"` → OK (no `ERR_REQUIRE_ESM`).

## Test plan
- [x] Cache returns identical port across N calls with single IPC invoke
- [x] Concurrent first callers share one in-flight IPC promise
- [x] `null` resolutions are not cached (next call retries)
- [x] IPC reject returns `null` and is also not cached
- [x] JSON GET parses response, hits correct loopback URL
- [x] JSON POST sets `Content-Type` + serialized body
- [x] `DaemonUnavailableError` thrown when port is `null`
- [x] `DaemonHttpError` thrown on non-2xx response (status preserved)
- [x] 204 No Content returns `undefined` without JSON.parse crash
- [x] Native fetch rejections (network / abort) propagate
- [x] Explicit method override (e.g. DELETE) honored