### PR TITLE
feat(preload): wire onMaximizedChanged/onBeforeHide/onAfterShow (Task #624)

### DIFF
--- a/electron/preload/bridges/ccsmCore.ts
+++ b/electron/preload/bridges/ccsmCore.ts
@@ -49,8 +49,6 @@ type Platform =
   | 'aix' | 'android' | 'darwin' | 'freebsd' | 'haiku'
   | 'linux' | 'openbsd' | 'sunos' | 'win32' | 'cygwin' | 'netbsd';
 
-const NOOP_UNSUBSCRIBE = (): void => {};
-
 // Helper: POST `/api/<path>` with `{args:[...]}` envelope, return the
 // `result` field. Same wire format as the (now-deleted) renderer shim's
 // daemonInvoke helper — kept identical so the daemon router doesn't need
@@ -218,12 +216,37 @@ function buildDaemonMethods(): {
       toggleMaximize: makeMethod<boolean>('window/toggleMaximize'),
       close: makeMethod<void>('window/close'),
       isMaximized: makeMethod<boolean>('window/isMaximized'),
-      // Push channels are stubs — daemon has no SSE→renderer channel for
-      // these in v0.3. Wave 2 will wire them; until then return a no-op
-      // unsubscribe so call sites stay alive.
-      onMaximizedChanged: () => NOOP_UNSUBSCRIBE,
-      onBeforeHide: () => NOOP_UNSUBSCRIBE,
-      onAfterShow: () => NOOP_UNSUBSCRIBE,
+      // Task #624 (C2) — main-process IPC push channels. Main emits these
+      // via `win.webContents.send(...)` from `electron/window/createWindow.ts`:
+      //   * 'window:maximizedChanged' (boolean) — on win.maximize/unmaximize
+      //   * 'window:beforeHide' ({ durationMs }) — before fade-out + hide
+      //   * 'window:afterShow' (no payload) — after the show animation
+      // The bridge wraps each handler so we hide the IpcRendererEvent from
+      // the renderer-side callback contract (matches `onUpdateStatus` /
+      // `onUpdateDownloaded` above), and returns a strict-removeListener
+      // unsubscribe so the renderer can detach without leaking.
+      onMaximizedChanged: (handler: (max: boolean) => void): (() => void) => {
+        const wrap = (_e: IpcRendererEvent, max: boolean): void => handler(max);
+        ipcRenderer.on('window:maximizedChanged', wrap);
+        return (): void => {
+          ipcRenderer.removeListener('window:maximizedChanged', wrap);
+        };
+      },
+      onBeforeHide: (handler: (info: { durationMs: number }) => void): (() => void) => {
+        const wrap = (_e: IpcRendererEvent, info: { durationMs: number }): void =>
+          handler(info);
+        ipcRenderer.on('window:beforeHide', wrap);
+        return (): void => {
+          ipcRenderer.removeListener('window:beforeHide', wrap);
+        };
+      },
+      onAfterShow: (handler: () => void): (() => void) => {
+        const wrap = (_e: IpcRendererEvent): void => handler();
+        ipcRenderer.on('window:afterShow', wrap);
+        return (): void => {
+          ipcRenderer.removeListener('window:afterShow', wrap);
+        };
+      },
       platform: syncPlatform,
     },
   };

--- a/tests/preload-ccsmcore-methods.test.ts
+++ b/tests/preload-ccsmcore-methods.test.ts
@@ -256,4 +256,103 @@ describe('buildCcsmCoreApi — flag ON', () => {
       u3();
     }).not.toThrow();
   });
+
+  // Task #624 (C2) — main-process push channels are now wired up. The
+  // bridge previously returned NOOP_UNSUBSCRIBE for these three event
+  // handlers (preserved by the test above for non-throw shape), but the
+  // production behavior must now register an `ipcRenderer.on` listener,
+  // forward the payload (skipping IpcRendererEvent), and return an
+  // unsubscribe that calls `ipcRenderer.removeListener` against the same
+  // (channel, wrap) pair. Main emits these from electron/window/createWindow.ts
+  // (`win.webContents.send('window:maximizedChanged', ...)` etc.).
+  //
+  // Strategy: replace the per-test `ipcOn` mock with a router that
+  // captures the (channel, wrap) tuple, then synthesize a main-process
+  // emit by invoking the captured wrap directly. The unsubscribe path
+  // is verified by removing the captured wrap from the router and then
+  // re-emitting — the renderer-side callback must NOT fire.
+  describe('window event channels — Task #624 (C2)', () => {
+    type Wrap = (...args: unknown[]) => void;
+    let listeners: Map<string, Set<Wrap>>;
+
+    beforeEach(() => {
+      listeners = new Map();
+      ipcOn.mockImplementation((channel: string, wrap: Wrap) => {
+        if (!listeners.has(channel)) listeners.set(channel, new Set());
+        listeners.get(channel)!.add(wrap);
+      });
+      ipcOff.mockImplementation((channel: string, wrap: Wrap) => {
+        listeners.get(channel)?.delete(wrap);
+      });
+    });
+
+    function emit(channel: string, ...args: unknown[]): void {
+      // Mirror Electron's IpcRenderer event signature: first arg is the
+      // IpcRendererEvent (we just pass an empty object — the bridge
+      // discards it via `_e`), then the payload.
+      const fakeEvent = {} as unknown;
+      for (const wrap of listeners.get(channel) ?? []) {
+        wrap(fakeEvent, ...args);
+      }
+    }
+
+    it('onMaximizedChanged forwards the boolean payload and unsubscribe stops delivery', async () => {
+      const mod = await loadModule();
+      const api = mod.buildCcsmCoreApi() as {
+        window: {
+          onMaximizedChanged: (h: (m: boolean) => void) => () => void;
+        };
+      };
+      const cb = vi.fn<(m: boolean) => void>();
+      const unsub = api.window.onMaximizedChanged(cb);
+
+      emit('window:maximizedChanged', true);
+      emit('window:maximizedChanged', false);
+      expect(cb).toHaveBeenCalledTimes(2);
+      expect(cb).toHaveBeenNthCalledWith(1, true);
+      expect(cb).toHaveBeenNthCalledWith(2, false);
+
+      unsub();
+      emit('window:maximizedChanged', true);
+      expect(cb).toHaveBeenCalledTimes(2); // no further deliveries
+    });
+
+    it('onBeforeHide forwards the {durationMs} payload and unsubscribe stops delivery', async () => {
+      const mod = await loadModule();
+      const api = mod.buildCcsmCoreApi() as {
+        window: {
+          onBeforeHide: (h: (info: { durationMs: number }) => void) => () => void;
+        };
+      };
+      const cb = vi.fn<(info: { durationMs: number }) => void>();
+      const unsub = api.window.onBeforeHide(cb);
+
+      emit('window:beforeHide', { durationMs: 220 });
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenCalledWith({ durationMs: 220 });
+
+      unsub();
+      emit('window:beforeHide', { durationMs: 220 });
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+
+    it('onAfterShow fires with no payload and unsubscribe stops delivery', async () => {
+      const mod = await loadModule();
+      const api = mod.buildCcsmCoreApi() as {
+        window: {
+          onAfterShow: (h: () => void) => () => void;
+        };
+      };
+      const cb = vi.fn<() => void>();
+      const unsub = api.window.onAfterShow(cb);
+
+      emit('window:afterShow');
+      emit('window:afterShow');
+      expect(cb).toHaveBeenCalledTimes(2);
+
+      unsub();
+      emit('window:afterShow');
+      expect(cb).toHaveBeenCalledTimes(2);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Task #624 (C2) — event-channel revive. Main process at
`electron/window/createWindow.ts` already emits three IPC push channels
(`window:maximizedChanged`, `window:beforeHide`, `window:afterShow`) but
the preload bridge in `electron/preload/bridges/ccsmCore.ts` returned
`NOOP_UNSUBSCRIBE` for the three corresponding `window.onXxx` methods —
a placeholder left over from wave B1 (Task #627). Renderer consumers
(`WindowControls.tsx` chrome icon, `useExitAnimation.ts` fade
choreography) were silently degraded.

Wired up the bridge to register `ipcRenderer.on(channel, wrap)`, forward
the typed payload (skipping `IpcRendererEvent`), and return a real
`ipcRenderer.removeListener` unsubscribe. Mirrors the existing
`onUpdateStatus` / `onUpdateDownloaded` pattern.

No `createWindow.ts` change — main side was already correct.

## Tests

Three new cases in `tests/preload-ccsmcore-methods.test.ts` under a
`window event channels — Task #624 (C2)` describe block:
- onMaximizedChanged: forwards boolean payload, unsubscribe stops delivery
- onBeforeHide: forwards `{ durationMs }` payload, unsubscribe stops delivery
- onAfterShow: fires with no payload, unsubscribe stops delivery

Each case replaces the per-test `ipcOn` mock with a router that captures
the `(channel, wrap)` tuple, then synthesizes a main-process emit by
invoking the captured wrap. Existing assertions (including the legacy
"event-channel stubs return a no-op unsubscribe" shape test) are left
untouched — they continue to pass against the new impl since it still
returns a function that does not throw.

## Local checks (host: Windows 11, mode: fast)

- lint: ✓ (exit 0, 0 errors / 45 pre-existing warnings, none from changed files)
- typecheck: ✓ (exit 0, both `tsc --noEmit` and `tsc --noEmit -p tsconfig.electron.json`)
- build: ✓ (exit 0, webpack + tsc electron emit)
- unit tests: ✓ `npx vitest run tests/preload-ccsmcore-methods.test.ts` →
  `Test Files 1 passed (1) | Tests 11 passed | 3 skipped (14) | Duration 28.87s`
- electron require-load smoke: ✓ `node -e "require('./dist/electron/preload/bridges/ccsmCore.js')"` →
  `keys: buildCcsmCoreApi,installCcsmCoreBridge` (no ERR_REQUIRE_ESM)
- e2e: skipped, change is preload-side only with no e2e case directly
  consuming these three channels (`grep -rn 'onMaximizedChanged|onBeforeHide|onAfterShow|window:maximizedChanged|window:beforeHide|window:afterShow' scripts/` → no matches). Renderer consumers (WindowControls / useExitAnimation) were already coded against the live channels; no change in observable e2e behavior beyond removing the silent degradation. CI three-platform matrix runs full e2e.

## 红线分类
- (a) 删测试 wholesale only: N/A — only added new test cases.
- (b) 残留测试断言 / setup 不动: respected. The pre-existing
  `event-channel stubs ... return a no-op unsubscribe` block at lines
  238-258 is untouched; it asserts the returned value is a function and
  calling it does not throw, both of which the new live impl still
  satisfies under the existing mock setup.
- (c) 业务代码改动有测试覆盖: yes — three new cases (one per channel)
  cover both the forward path and unsubscribe path.

## Files
- `electron/preload/bridges/ccsmCore.ts` — replace 3 NOOP stubs with
  real `ipcRenderer.on` registrations + `removeListener` unsubscribes.
  Drop unused `NOOP_UNSUBSCRIBE` constant.
- `tests/preload-ccsmcore-methods.test.ts` — add 3 cases + unsubscribe
  verification under a new describe block.