### PR TITLE
fix(daemon): prevent + self-heal better-sqlite3 ABI mismatch (Task #641)

### DIFF
--- a/electron/abi-self-heal.ts
+++ b/electron/abi-self-heal.ts
@@ -1,0 +1,246 @@
+// ABI self-heal — Task #641 Layer 3.
+//
+// Background: better-sqlite3 ships a native `.node` binding compiled
+// against a specific Node ABI (NODE_MODULE_VERSION). When a developer
+// runs plain `npm install`, npm picks up better-sqlite3's prebuilt
+// binding for the host Node ABI (e.g. v127 on Node 22), NOT the
+// Electron ABI (e.g. v145 on Electron 41). The postinstall hook
+// (scripts/postinstall.mjs) tries to rebuild via @electron/rebuild
+// — but if that fails (toolchain missing, .node locked, etc.) we
+// can ship a broken environment.
+//
+// At runtime the daemon (which lives in the Electron process tree
+// post wave-1) tries to `require('better-sqlite3')` and gets a
+// classic:
+//
+//     Error: The module '...\better_sqlite3.node' was compiled
+//     against a different Node.js version using NODE_MODULE_VERSION
+//     127. This version of Node.js requires NODE_MODULE_VERSION 145.
+//
+// daemon initDb fails, and pre-Task #641/#639 the user only saw a
+// silent storage failure. Layer 1 (#639) surfaces a banner; this
+// Layer 3 module makes the failure self-correct: detect the ABI
+// mismatch at main entry, run @electron/rebuild as a child process,
+// and restart the app once.
+//
+// Reference: https://www.electronjs.org/docs/latest/tutorial/using-native-node-modules
+//
+// Design constraints:
+//   - Pure / testable: I/O is injected via a `deps` parameter so unit
+//     tests can drive every branch without spawning subprocesses.
+//   - One-shot: a marker file under userData prevents an infinite
+//     rebuild→restart loop if the rebuild itself doesn't fix things
+//     (e.g. native toolchain truly missing).
+//   - Dev-only opt-in: in packaged builds the postinstall + ship-time
+//     pipeline is supposed to leave correct ABI on disk; the self-heal
+//     is primarily a dev-machine safety net. Packaged builds still run
+//     it because a user upgrading Electron via auto-update can also
+//     hit ABI skew (rare; still worth covering).
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+/** Result of a single self-heal attempt; consumed by the caller in main.ts. */
+export type SelfHealResult =
+  | { kind: 'ok' }                              // native loads cleanly, nothing to do
+  | { kind: 'healed'; restartHint: 'app.relaunch' } // rebuilt successfully, caller should relaunch
+  | { kind: 'already-tried'; lastError: string }   // marker present, don't loop
+  | { kind: 'rebuild-failed'; error: string };  // tried rebuild, still broken
+
+/** Injected dependencies — keeps the function pure-testable. */
+export interface SelfHealDeps {
+  /** Path to a directory we can write a one-shot marker into (typically `app.getPath('userData')`). */
+  userDataDir: string;
+  /** Repo or app root containing `node_modules/.bin/electron-rebuild`. */
+  appRoot: string;
+  /** True on packaged builds — used only for logging context. */
+  isPackaged: boolean;
+  /** `process.platform`-style; injected for testability. */
+  platform: NodeJS.Platform;
+  /**
+   * Try `require('better-sqlite3')` and exercise it with a `:memory:`
+   * open + close. Returns null on success, the Error on failure. The
+   * caller wires this to the real `require` in main.ts; tests pass a
+   * stub.
+   */
+  probeBetterSqlite3: () => Error | null;
+  /**
+   * Run `@electron/rebuild` for better-sqlite3. Returns exit code +
+   * stderr tail for diagnostics. Tests stub this.
+   */
+  runRebuild: (rebuildBin: string, cwd: string) => { status: number; stderrTail: string };
+  /** fs override (keeps tests hermetic — defaults to `node:fs`). */
+  fs?: Pick<typeof fs, 'existsSync' | 'mkdirSync' | 'readFileSync' | 'writeFileSync' | 'unlinkSync'>;
+  /** Logger. Defaults to console. */
+  log?: (msg: string) => void;
+}
+
+const MARKER_FILENAME = 'abi-self-heal-attempted.json';
+
+/**
+ * Build the marker path. Public so main.ts can clear it on a
+ * successful daemon initDb (proving the rebuild worked).
+ */
+export function selfHealMarkerPath(userDataDir: string): string {
+  return path.join(userDataDir, MARKER_FILENAME);
+}
+
+/**
+ * Detect the classic `NODE_MODULE_VERSION ... mismatch` error string. We
+ * deliberately match on the Node-emitted phrase rather than the error
+ * `code` because better-sqlite3 wraps the original error with no `code`
+ * preserved.
+ */
+export function isAbiMismatchError(err: Error | null | undefined): boolean {
+  if (!err) return false;
+  const msg = `${err.message ?? ''}\n${err.stack ?? ''}`;
+  return /NODE_MODULE_VERSION/i.test(msg) && /different.*version|requires NODE_MODULE_VERSION/i.test(msg);
+}
+
+/**
+ * Run the self-heal protocol. See SelfHealResult for the four outcomes
+ * the caller has to handle.
+ *
+ * IMPORTANT: this function is synchronous — main.ts calls it before
+ * `app.whenReady()` so the rebuild + restart can complete before any
+ * BrowserWindow / daemon-spawner code runs. The rebuild subprocess is
+ * spawned via `spawnSync` for the same reason.
+ */
+export function runAbiSelfHeal(deps: SelfHealDeps): SelfHealResult {
+  const fsMod = deps.fs ?? fs;
+  const log = deps.log ?? ((msg) => console.log(`[abi-self-heal] ${msg}`));
+  const isWindows = deps.platform === 'win32';
+
+  // Step 1: probe.
+  const probeError = deps.probeBetterSqlite3();
+  if (!probeError) {
+    // Healthy — also clear any stale marker so a future skew can self-heal again.
+    try {
+      const marker = selfHealMarkerPath(deps.userDataDir);
+      if (fsMod.existsSync(marker)) fsMod.unlinkSync(marker);
+    } catch {
+      /* swallow — best-effort cleanup */
+    }
+    return { kind: 'ok' };
+  }
+
+  // Step 2: classify. Non-ABI errors are NOT our problem (e.g. native
+  // module physically missing → after-pack hook should have caught it
+  // at build time). Bubble out so the daemon-init banner from #639
+  // surfaces the real story.
+  if (!isAbiMismatchError(probeError)) {
+    log(`probe failed but not an ABI mismatch — leaving for #639 banner: ${probeError.message}`);
+    return { kind: 'rebuild-failed', error: probeError.message };
+  }
+
+  log(`detected ABI mismatch: ${probeError.message}`);
+
+  // Step 3: one-shot guard. If we already tried last launch, don't loop;
+  // surface the marker so the L1/L2 banners (#639) can tell the user.
+  const marker = selfHealMarkerPath(deps.userDataDir);
+  if (fsMod.existsSync(marker)) {
+    let lastError = '<unknown>';
+    try {
+      const raw = fsMod.readFileSync(marker, 'utf8');
+      const parsed = JSON.parse(raw) as { error?: string };
+      if (typeof parsed.error === 'string') lastError = parsed.error;
+    } catch {
+      /* ignore parse errors — marker presence alone is the signal */
+    }
+    log(`marker present at ${marker}; refusing to loop. Last error: ${lastError}`);
+    return { kind: 'already-tried', lastError };
+  }
+
+  // Step 4: locate electron-rebuild bin. Dev install ships it under
+  // node_modules/.bin; packaged install does NOT (devDeps stripped),
+  // so self-heal degrades to "report only" in production.
+  const rebuildBinName = isWindows ? 'electron-rebuild.cmd' : 'electron-rebuild';
+  const rebuildBin = path.join(deps.appRoot, 'node_modules', '.bin', rebuildBinName);
+  if (!fsMod.existsSync(rebuildBin)) {
+    const reason = `@electron/rebuild not available at ${rebuildBin} (likely a packaged build with devDeps stripped); cannot self-heal`;
+    log(reason);
+    // Write the marker so we don't try-and-fail on every launch.
+    try {
+      fsMod.mkdirSync(deps.userDataDir, { recursive: true });
+      fsMod.writeFileSync(marker, JSON.stringify({ error: reason, ts: Date.now() }, null, 2));
+    } catch {
+      /* swallow */
+    }
+    return { kind: 'rebuild-failed', error: reason };
+  }
+
+  // Step 5: rebuild. Write the marker BEFORE the rebuild so that even a
+  // crash mid-rebuild doesn't put us into a rebuild loop on next launch.
+  try {
+    fsMod.mkdirSync(deps.userDataDir, { recursive: true });
+    fsMod.writeFileSync(
+      marker,
+      JSON.stringify({ error: probeError.message, ts: Date.now(), phase: 'started' }, null, 2),
+    );
+  } catch (err) {
+    log(`failed to write marker — proceeding anyway: ${(err as Error).message}`);
+  }
+
+  log(`running @electron/rebuild for better-sqlite3 (this may take ~30s)...`);
+  const result = deps.runRebuild(rebuildBin, deps.appRoot);
+  if (result.status !== 0) {
+    const errMsg = `@electron/rebuild exited with code ${result.status}. stderr tail: ${result.stderrTail}`;
+    log(errMsg);
+    try {
+      fsMod.writeFileSync(
+        marker,
+        JSON.stringify({ error: errMsg, ts: Date.now(), phase: 'rebuild-failed' }, null, 2),
+      );
+    } catch { /* swallow */ }
+    return { kind: 'rebuild-failed', error: errMsg };
+  }
+
+  log(`rebuild OK — caller should relaunch the app to load the new binding`);
+  return { kind: 'healed', restartHint: 'app.relaunch' };
+}
+
+/**
+ * Default `runRebuild` implementation. Pulled out for `runAbiSelfHeal`
+ * default-deps in main.ts. Kept here so tests covering the full deps
+ * shape compile against the same function signature.
+ */
+export function defaultRunRebuild(
+  rebuildBin: string,
+  cwd: string,
+): { status: number; stderrTail: string } {
+  const isWindows = process.platform === 'win32';
+  const result = spawnSync(
+    rebuildBin,
+    ['-f', '-o', 'better-sqlite3', '--build-from-source'],
+    { stdio: ['ignore', 'inherit', 'pipe'], shell: isWindows, cwd },
+  );
+  const stderr = (result.stderr ? result.stderr.toString('utf8') : '').trim();
+  // Cap to last ~2 KB so logs don't explode.
+  const stderrTail = stderr.length > 2048 ? stderr.slice(-2048) : stderr;
+  if (result.error) {
+    return { status: -1, stderrTail: `${result.error.message}\n${stderrTail}` };
+  }
+  return { status: typeof result.status === 'number' ? result.status : -1, stderrTail };
+}
+
+/**
+ * Default `probeBetterSqlite3` implementation: open an in-memory DB and
+ * close it. `:memory:` opens are cheap (no fs touch) but exercise the
+ * full bindings load + sqlite VFS init path, which is exactly where the
+ * ABI mismatch surfaces.
+ */
+export function defaultProbeBetterSqlite3(): Error | null {
+  try {
+    /* eslint-disable @typescript-eslint/no-require-imports */
+    const Database = require('better-sqlite3') as new (path: string, opts?: { readonly?: boolean }) => {
+      close: () => void;
+    };
+    /* eslint-enable @typescript-eslint/no-require-imports */
+    const db = new Database(':memory:');
+    db.close();
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err : new Error(String(err));
+  }
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -19,6 +19,12 @@
 
 import { app, BrowserWindow, ipcMain, dialog, type Tray } from 'electron';
 import * as os from 'os';
+import * as path from 'path';
+import {
+  runAbiSelfHeal,
+  defaultProbeBetterSqlite3,
+  defaultRunRebuild,
+} from './abi-self-heal';
 import { buildTrayIcon } from './branding/icon';
 import { createWindow as createMainWindowFactory } from './window/createWindow';
 import { notifyCloseActionFromRenderer } from './window/createWindow';
@@ -56,6 +62,61 @@ const isDev = !app.isPackaged && process.env.CCSM_PROD_BUNDLE !== '1';
 // Acquire the single-instance lock + register the second-instance focus
 // handler. See electron/lifecycle/singleInstance for the rationale.
 acquireSingleInstanceLock();
+
+// ─────────────────── ABI self-heal (Task #641 Layer 3) ────────────────────
+// Run BEFORE app.whenReady so that if better-sqlite3 was compiled against
+// the host Node ABI instead of Electron's (the dogfood #575 root cause), we
+// rebuild + relaunch BEFORE spawning the daemon (which would crash on its
+// first `require('better-sqlite3')`). One-shot guard inside runAbiSelfHeal
+// prevents an infinite loop if the rebuild itself can't fix things.
+//
+// In packaged builds with devDeps stripped we degrade to a no-op (rebuild
+// bin missing); the L1+L2 storage banner from #639 then surfaces the real
+// state to the user.
+function selfHealOrRelaunch(): void {
+  // Use a stable, well-known sub-dir under the OS userData root. We can't
+  // call app.getPath('userData') here yet (app may not be ready on first
+  // entry on some platforms — relying on app.name is fine because Electron
+  // initializes the path resolver at process start). Wrap in try so a
+  // probe/rebuild failure never blocks the app from at least attempting to
+  // boot — the daemon banner will tell the user something is wrong.
+  try {
+    let userDataDir: string;
+    try {
+      userDataDir = app.getPath('userData');
+    } catch {
+      // Fallback for the rare case Electron's path resolver isn't ready yet:
+      // use os.tmpdir() so the marker still works (it's only a one-shot loop
+      // guard, not user data).
+      userDataDir = path.join(os.tmpdir(), 'ccsm-abi-self-heal');
+    }
+    const result = runAbiSelfHeal({
+      userDataDir,
+      appRoot: app.getAppPath(),
+      isPackaged: app.isPackaged,
+      platform: process.platform,
+      probeBetterSqlite3: defaultProbeBetterSqlite3,
+      runRebuild: defaultRunRebuild,
+    });
+    if (result.kind === 'healed') {
+      console.log('[main] ABI self-heal succeeded — relaunching to load fresh native binding');
+      app.relaunch();
+      app.exit(0);
+      return;
+    }
+    if (result.kind === 'rebuild-failed' || result.kind === 'already-tried') {
+      // Don't kill the app — let it try to boot. The daemon-init banner
+      // (#639 L1) will surface the storage failure to the user with a
+      // precise reason.
+      console.warn(`[main] ABI self-heal could not auto-fix (${result.kind}) — continuing boot; daemon banner will surface the failure`);
+    }
+  } catch (err) {
+    // Self-heal must never throw past this boundary — a bug in the heal
+    // path can't be allowed to brick the app.
+    console.error('[main] ABI self-heal threw unexpectedly (ignoring, continuing boot):', err);
+  }
+}
+selfHealOrRelaunch();
 
 // Install the hidden Edit-role accelerator menu at module load so
 // copy/paste etc. work before app.whenReady. Re-run on locale change.

--- a/scripts/after-pack.cjs
+++ b/scripts/after-pack.cjs
@@ -88,4 +88,46 @@ exports.default = async function afterPack(context) {
   console.log(
     `[after-pack] OK ${platformKey}: node-pty ${flavor} binding present (${sizeKB} KB) at ${which}`,
   );
+
+  // ───────── better-sqlite3 native binding (Task #641 Layer 2) ──────────
+  // Same contract as node-pty above, but for better-sqlite3. The dogfood
+  // #575 root cause was a postinstall electron-rebuild failure that left
+  // better-sqlite3 compiled against the host Node ABI; the runtime daemon
+  // then crashed on first DB open with `NODE_MODULE_VERSION mismatch`.
+  // Failing the build here turns "user gets a silent storage failure on
+  // first launch" into "the install isn't published in the first place".
+  //
+  // better-sqlite3 does NOT ship cross-platform prebuilds the same way
+  // node-pty does — its npm tarball includes a single rebuilt binding for
+  // the install host, which the postinstall step (scripts/postinstall.mjs)
+  // re-targets to the Electron ABI. So we only check the rebuilt path.
+  const sqliteRoot = path.join(
+    resourcesDir,
+    'app.asar.unpacked',
+    'node_modules',
+    'better-sqlite3',
+  );
+  const sqliteBinding = path.join(sqliteRoot, 'build', 'Release', 'better_sqlite3.node');
+  if (!fs.existsSync(sqliteBinding)) {
+    let listing = '<missing>';
+    try {
+      listing = fs.readdirSync(sqliteRoot).join(', ') || '<empty>';
+    } catch {
+      // sqliteRoot may not exist at all (asarUnpack typo etc.)
+    }
+    throw new Error(
+      `[after-pack] better-sqlite3 native binding missing for ${platformKey}.\n` +
+        `  Looked for: ${sqliteBinding}\n` +
+        `  better-sqlite3 contents: ${listing}\n` +
+        `Hint: confirm \`npm install\` ran the postinstall hook (scripts/postinstall.mjs) ` +
+        `which invokes @electron/rebuild for better-sqlite3. Without this binding the ` +
+        `daemon fails to open the SQLite DB and the app shows a silent storage failure ` +
+        `on first launch (Task #575 / #641). Check build.asarUnpack in package.json ` +
+        `includes **/node_modules/better-sqlite3/**.`,
+    );
+  }
+  const sqliteSizeKB = (fs.statSync(sqliteBinding).size / 1024).toFixed(0);
+  console.log(
+    `[after-pack] OK ${platformKey}: better-sqlite3 binding present (${sqliteSizeKB} KB) at ${sqliteBinding}`,
+  );
 };

--- a/scripts/harness-abi-selfheal.mjs
+++ b/scripts/harness-abi-selfheal.mjs
@@ -1,0 +1,263 @@
+// Themed harness — ABI self-heal cluster (Task #641).
+//
+// All cases use `skipLaunch: true` (no electron boot needed): the
+// pipeline this harness defends is the BUILD pipeline (postinstall +
+// after-pack + main-entry self-heal wiring), so we assert against the
+// emitted `dist/` artifacts and source files directly. This keeps the
+// case wall-time at ~tens of milliseconds each — way cheaper than a
+// real cold-launch + ABI-mismatch reproduction (which would require a
+// destructive native-module manipulation we don't want in CI).
+//
+// Why a NEW harness file (not absorbed into harness-ui.mjs)?
+// dev-639 owns harness-ui.mjs for the storage banner case (L1+L2);
+// this Task #641 owns L3 (build + self-heal pipeline). File ownership
+// split by design — see the task spec hotfile-bypass note. The two
+// harnesses run in parallel slots in run-all-e2e.mjs's discovery glob.
+//
+// Run: `node scripts/harness-abi-selfheal.mjs`
+// Run one case: `node scripts/harness-abi-selfheal.mjs --only=after-pack-checks-sqlite`
+
+import { runHarness } from './probe-helpers/harness-runner.mjs';
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+// Bare `require` is undefined in ESM modules; createRequire builds a
+// CJS-flavored require bound to this file's URL so we can pull in the
+// post-tsc CJS emit under dist/.
+const require = createRequire(import.meta.url);
+
+// ---------- main-entry-invokes-self-heal ----------
+// Pin the contract that electron/main.ts wires the self-heal at startup.
+// We assert against the BUILT dist/electron/main.js (post-tsc), not the
+// source — we want to catch a tsconfig regression that would silently
+// drop the new module from the emit.
+async function caseMainEntryInvokesSelfHeal({ harnessRoot, log }) {
+  const distMain = path.join(harnessRoot, 'dist', 'electron', 'main.js');
+  if (!fs.existsSync(distMain)) {
+    throw new Error(
+      `dist/electron/main.js missing — run \`npm run build\` first ` +
+      `(harness expects post-tsc emit to assert main-entry wiring).`,
+    );
+  }
+  const src = fs.readFileSync(distMain, 'utf8');
+  // tsc emits both `runAbiSelfHeal` (function call) and the
+  // `./abi-self-heal` import path. We assert both are present so that
+  // a refactor that renames the module also refreshes this contract.
+  if (!src.includes('runAbiSelfHeal')) {
+    throw new Error('dist/electron/main.js does not call runAbiSelfHeal — Task #641 wiring lost');
+  }
+  if (!/abi-self-heal/.test(src)) {
+    throw new Error('dist/electron/main.js does not import ./abi-self-heal — module rename slipped through');
+  }
+  // Defensive: the call must happen BEFORE app.whenReady (or at least
+  // before the call site). We don't parse JS here; cheap heuristic:
+  // index of the runAbiSelfHeal callsite < index of the actual
+  // `whenReady().then` call. We pin the runAbiSelfHeal lookup to the
+  // tsc-emitted CommonJS shape — `(0, abi_self_heal_N.runAbiSelfHeal)(`
+  // — instead of the bare identifier so a doc comment that mentions
+  // the function doesn't false-match. Same for `whenReady().then` vs.
+  // bare `whenReady` (which appears in import bookkeeping).
+  const selfHealIdx = src.search(/abi_self_heal[_\d]*\.runAbiSelfHeal\)\(/);
+  const whenReadyIdx = src.search(/whenReady\(\)\s*\.\s*then/);
+  if (selfHealIdx === -1 || whenReadyIdx === -1) {
+    throw new Error(
+      `main.js missing one of runAbiSelfHeal call / whenReady().then ` +
+      `(selfHealIdx=${selfHealIdx}, whenReadyIdx=${whenReadyIdx}) — wiring contract broken`,
+    );
+  }
+  if (selfHealIdx > whenReadyIdx) {
+    throw new Error(
+      `runAbiSelfHeal must be invoked BEFORE app.whenReady (index ${selfHealIdx} > whenReady ${whenReadyIdx}); ` +
+      `otherwise the daemon-spawner runs first and crashes on better-sqlite3 load before we can rebuild.`,
+    );
+  }
+  log(`main.js wires runAbiSelfHeal pre-whenReady (selfHeal idx=${selfHealIdx}, whenReady idx=${whenReadyIdx})`);
+}
+
+// ---------- abi-self-heal-module-loads ----------
+// The compiled CJS module must require-load cleanly under plain Node
+// (no electron, no native deps required at module-eval time). This is
+// the same load-smoke pattern as tests/electron-load-smoke.test.ts but
+// scoped to the new module so a regression here surfaces as an e2e
+// failure even if the load-smoke test was somehow disabled.
+async function caseAbiSelfHealModuleLoads({ harnessRoot, log }) {
+  const distModule = path.join(harnessRoot, 'dist', 'electron', 'abi-self-heal.js');
+  if (!fs.existsSync(distModule)) {
+    throw new Error(
+      `dist/electron/abi-self-heal.js missing — run \`npm run build\` first.`,
+    );
+  }
+  // require() in this Node-only context: the module must avoid pulling
+  // electron at top level. Our source does `import { spawnSync } from
+  // 'node:child_process'` only, so this should just work.
+  const required = require(distModule);
+  if (typeof required.runAbiSelfHeal !== 'function') {
+    throw new Error('abi-self-heal.js: runAbiSelfHeal export missing or not a function');
+  }
+  if (typeof required.isAbiMismatchError !== 'function') {
+    throw new Error('abi-self-heal.js: isAbiMismatchError export missing');
+  }
+  if (typeof required.defaultProbeBetterSqlite3 !== 'function') {
+    throw new Error('abi-self-heal.js: defaultProbeBetterSqlite3 export missing');
+  }
+  if (typeof required.defaultRunRebuild !== 'function') {
+    throw new Error('abi-self-heal.js: defaultRunRebuild export missing');
+  }
+  log('abi-self-heal.js: all four expected exports present and callable');
+}
+
+// ---------- abi-self-heal-detects-mismatch ----------
+// End-to-end through the compiled module: feed it a fake probe that
+// throws the canonical NODE_MODULE_VERSION error, a fake rebuild that
+// returns success, an in-memory fs, and assert the result.kind chain.
+// Catches the case where a refactor drops the marker-write or the
+// is-mismatch detection regex.
+async function caseAbiSelfHealDetectsMismatch({ harnessRoot, log }) {
+  const distModule = path.join(harnessRoot, 'dist', 'electron', 'abi-self-heal.js');
+  const { runAbiSelfHeal, selfHealMarkerPath } = require(distModule);
+
+  const userDataDir = '/tmp/abi-self-heal-harness';
+  const appRoot = harnessRoot;
+  const store = new Map();
+  // Prepopulate fake bin so the rebuild step is reachable.
+  store.set(path.join(appRoot, 'node_modules', '.bin', 'electron-rebuild'), 'x');
+  store.set(path.join(appRoot, 'node_modules', '.bin', 'electron-rebuild.cmd'), 'x');
+  const fsMock = {
+    existsSync: (p) => store.has(p),
+    mkdirSync: () => {},
+    readFileSync: (p) => {
+      const v = store.get(p);
+      if (v === undefined) throw new Error(`ENOENT: ${p}`);
+      return v;
+    },
+    writeFileSync: (p, data) => store.set(p, String(data)),
+    unlinkSync: (p) => store.delete(p),
+  };
+
+  // Scenario A: ABI mismatch + successful rebuild → 'healed'.
+  let rebuildCalls = 0;
+  const probeErr = new Error(
+    'NODE_MODULE_VERSION 127 ... requires NODE_MODULE_VERSION 145',
+  );
+  const result = runAbiSelfHeal({
+    userDataDir,
+    appRoot,
+    isPackaged: false,
+    platform: 'linux',
+    probeBetterSqlite3: () => probeErr,
+    runRebuild: () => {
+      rebuildCalls += 1;
+      return { status: 0, stderrTail: '' };
+    },
+    fs: fsMock,
+    log: () => {},
+  });
+  if (result.kind !== 'healed') {
+    throw new Error(`expected result.kind='healed' for ABI-mismatch + good rebuild, got ${JSON.stringify(result)}`);
+  }
+  if (rebuildCalls !== 1) {
+    throw new Error(`expected exactly 1 rebuild call, got ${rebuildCalls}`);
+  }
+  if (!store.has(selfHealMarkerPath(userDataDir))) {
+    throw new Error('expected marker file to be written after a healed rebuild (loop guard)');
+  }
+
+  // Scenario B: marker already present → 'already-tried' (no infinite loop).
+  let secondRebuildCalls = 0;
+  const result2 = runAbiSelfHeal({
+    userDataDir,
+    appRoot,
+    isPackaged: false,
+    platform: 'linux',
+    probeBetterSqlite3: () => probeErr,
+    runRebuild: () => {
+      secondRebuildCalls += 1;
+      return { status: 0, stderrTail: '' };
+    },
+    fs: fsMock,
+    log: () => {},
+  });
+  if (result2.kind !== 'already-tried') {
+    throw new Error(`expected result.kind='already-tried' on second run, got ${JSON.stringify(result2)}`);
+  }
+  if (secondRebuildCalls !== 0) {
+    throw new Error(`marker guard broken: rebuild ran ${secondRebuildCalls} time(s) on second pass`);
+  }
+  log('healed (1 rebuild + marker) → already-tried (0 rebuilds, loop prevented)');
+}
+
+// ---------- after-pack-checks-sqlite ----------
+// Static check that scripts/after-pack.cjs verifies BOTH native bindings.
+// A regression that drops the better-sqlite3 check would let a broken
+// installer ship to users; this case catches that without packing a
+// real installer (electron-builder pack is multi-minute).
+async function caseAfterPackChecksSqlite({ harnessRoot, log }) {
+  const afterPack = path.join(harnessRoot, 'scripts', 'after-pack.cjs');
+  const src = fs.readFileSync(afterPack, 'utf8');
+  if (!/node-pty/.test(src)) {
+    throw new Error('scripts/after-pack.cjs lost the node-pty check — pre-existing contract broken');
+  }
+  if (!/better-sqlite3/.test(src)) {
+    throw new Error('scripts/after-pack.cjs missing better-sqlite3 check — Task #641 Layer 2 dropped');
+  }
+  if (!/better_sqlite3\.node/.test(src)) {
+    throw new Error('scripts/after-pack.cjs missing the actual `better_sqlite3.node` filename assertion');
+  }
+  log('after-pack.cjs verifies both node-pty AND better-sqlite3 bindings ship in the bundle');
+}
+
+// ---------- postinstall-helpers-retry ----------
+// Direct integration test of the rebuildWithRetry helper from
+// scripts/postinstall-helpers.mjs. UT covers the same surface; this
+// e2e case exists as a belt-and-suspenders check that the helper file
+// loads under plain ESM and exports the expected shape (a regression
+// that broke the import chain would slip past UT-only coverage).
+async function casePostinstallHelpersRetry({ harnessRoot, log }) {
+  const helpersUrl = new URL(
+    'file:///' +
+      path.join(harnessRoot, 'scripts', 'postinstall-helpers.mjs').replace(/\\/g, '/'),
+  );
+  const mod = await import(helpersUrl.href);
+  if (typeof mod.rebuildWithRetry !== 'function') {
+    throw new Error('postinstall-helpers.mjs: rebuildWithRetry export missing');
+  }
+  if (typeof mod.blockingSleep !== 'function') {
+    throw new Error('postinstall-helpers.mjs: blockingSleep export missing');
+  }
+  // End-to-end retry behavior: first call fails, second succeeds, on Windows.
+  let attempts = 0;
+  let sleepCalls = 0;
+  const result = mod.rebuildWithRetry({
+    rebuildBin: '/x/electron-rebuild.cmd',
+    moduleName: 'better-sqlite3',
+    cwd: '/repo',
+    isWindows: true,
+    allowFailure: false,
+    retryDelayMs: 1, // make the test fast even if sleep was real
+    spawn: () => {
+      attempts += 1;
+      return attempts === 1 ? { status: 1 } : { status: 0 };
+    },
+    sleep: () => { sleepCalls += 1; },
+  });
+  if (result.status !== 0 || result.attempts !== 2 || sleepCalls !== 1) {
+    throw new Error(
+      `retry contract broken: status=${result.status} attempts=${result.attempts} sleepCalls=${sleepCalls}`,
+    );
+  }
+  log('rebuildWithRetry: failed→sleep→succeeded loop intact (Windows EPERM recovery)');
+}
+
+// ---------- harness spec ----------
+// All cases skipLaunch — see file header for the rationale.
+await runHarness({
+  name: 'abi-selfheal',
+  cases: [
+    { id: 'main-entry-invokes-self-heal', skipLaunch: true, run: caseMainEntryInvokesSelfHeal },
+    { id: 'abi-self-heal-module-loads', skipLaunch: true, run: caseAbiSelfHealModuleLoads },
+    { id: 'abi-self-heal-detects-mismatch', skipLaunch: true, run: caseAbiSelfHealDetectsMismatch },
+    { id: 'after-pack-checks-sqlite', skipLaunch: true, run: caseAfterPackChecksSqlite },
+    { id: 'postinstall-helpers-retry', skipLaunch: true, run: casePostinstallHelpersRetry },
+  ],
+});

--- a/scripts/postinstall-helpers.mjs
+++ b/scripts/postinstall-helpers.mjs
@@ -1,0 +1,83 @@
+// Pure helpers for scripts/postinstall.mjs (Task #641 Layer 1).
+// Extracted so the EPERM/EBUSY retry-once policy is unit-testable
+// without spawning a real child process or touching node_modules.
+//
+// Usage from postinstall.mjs:
+//   import { rebuildWithRetry } from './postinstall-helpers.mjs';
+//   const ok = rebuildWithRetry({ ...config, spawn: spawnSync, sleep: blockingSleep });
+
+/**
+ * Block the calling thread for `ms` milliseconds. Used by postinstall
+ * (which runs to completion in a child process — no event loop concerns).
+ *
+ * Atomics.wait on a fresh SharedArrayBuffer is a portable, dependency-free
+ * way to sleep without busy-spinning the CPU.
+ *
+ * @param {number} ms
+ */
+export function blockingSleep(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, Math.max(0, ms | 0));
+}
+
+/**
+ * Run `@electron/rebuild` for one module, with a Windows-only retry-once
+ * policy on non-zero exit (covers EPERM/EBUSY when a stale electron.exe /
+ * vsbuild process from a previous run holds an open handle on the .node
+ * file — see Task #641 / dogfood #575).
+ *
+ * Pure: takes injected spawn + sleep, returns a result the caller consumes.
+ * NEVER calls process.exit — the caller (postinstall.mjs) decides how to
+ * react to a final non-zero status.
+ *
+ * @param {object} cfg
+ * @param {string} cfg.rebuildBin           Absolute path to electron-rebuild bin.
+ * @param {string} cfg.moduleName           e.g. 'better-sqlite3'.
+ * @param {string} cfg.cwd                  Repo root.
+ * @param {boolean} cfg.isWindows           From `process.platform === 'win32'`.
+ * @param {boolean} cfg.allowFailure        node-pty path: prebuild fallback exists, don't retry.
+ * @param {number} [cfg.retryDelayMs=5000]  Sleep before retry. Tests pass 0.
+ * @param {(bin: string, args: string[], opts: object) => { status: number | null, error?: Error, signal?: NodeJS.Signals | null }} cfg.spawn
+ *   spawnSync-shaped callable.
+ * @param {(ms: number) => void} cfg.sleep  blocking sleep, see blockingSleep.
+ * @returns {{ status: number | null, error?: Error, signal?: NodeJS.Signals | null, attempts: number }}
+ */
+export function rebuildWithRetry(cfg) {
+  const {
+    rebuildBin,
+    moduleName,
+    cwd,
+    isWindows,
+    allowFailure,
+    retryDelayMs = 5000,
+    spawn,
+    sleep,
+  } = cfg;
+  const args = ['-f', '-o', moduleName, '--build-from-source'];
+  const opts = { stdio: 'inherit', shell: isWindows, cwd };
+
+  let attempts = 1;
+  const first = spawn(rebuildBin, args, opts);
+  // Hard failures (spawn errored or killed by signal) are not retry-able —
+  // they indicate something fundamentally wrong (missing bin, OOM-killer,
+  // user pressed ^C). Surface them as-is.
+  if (first.error || first.signal) {
+    return { ...first, attempts };
+  }
+  // Success on first try, or non-Windows (no EPERM to retry around), or the
+  // caller marked this module as failure-tolerant (node-pty has a prebuild
+  // fallback) — return whatever we got.
+  if (
+    first.status === 0 ||
+    !isWindows ||
+    allowFailure ||
+    typeof first.status !== 'number'
+  ) {
+    return { ...first, attempts };
+  }
+
+  // Windows + non-zero + must-succeed → wait, retry once.
+  sleep(retryDelayMs);
+  attempts = 2;
+  const retry = spawn(rebuildBin, args, opts);
+  return { ...retry, attempts };
+}

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -28,6 +28,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import process from 'node:process';
+import { rebuildWithRetry, blockingSleep } from './postinstall-helpers.mjs';
 
 // Preflight: warn (don't block) when running on a Node major other than 20.
 // better-sqlite3 builds cleanly on Node 20.x; newer node-gyp + Node may need
@@ -73,11 +74,20 @@ if (!existsSync(rebuildBin)) {
 
 function runRebuild(moduleName, { allowFailure } = { allowFailure: false }) {
   console.log(`[postinstall] Rebuilding ${moduleName} for Electron ABI...`);
-  const result = spawnSync(
+  const result = rebuildWithRetry({
     rebuildBin,
-    ['-f', '-o', moduleName, '--build-from-source'],
-    { stdio: 'inherit', shell: isWindows, cwd: repoRoot },
-  );
+    moduleName,
+    cwd: repoRoot,
+    isWindows,
+    allowFailure,
+    spawn: spawnSync,
+    sleep: blockingSleep,
+  });
+  if (result.attempts > 1) {
+    console.warn(
+      `[postinstall] ${moduleName} rebuild required ${result.attempts} attempts (Windows EPERM/EBUSY on .node lock from a stale electron.exe / vsbuild process is the typical cause; see Task #641).`,
+    );
+  }
   if (result.error) {
     if (allowFailure) {
       console.warn(`[postinstall] ${moduleName} rebuild failed to spawn: ${result.error.message} (continuing — prebuild fallback)`);

--- a/tests/abi-self-heal.test.ts
+++ b/tests/abi-self-heal.test.ts
@@ -1,0 +1,226 @@
+// Unit tests for electron/abi-self-heal.ts (Task #641 Layer 3).
+//
+// Strategy: drive every branch of `runAbiSelfHeal` via injected `deps`
+// — no real child processes, no real require, no real fs touch.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  runAbiSelfHeal,
+  isAbiMismatchError,
+  selfHealMarkerPath,
+  type SelfHealDeps,
+} from '../electron/abi-self-heal';
+
+/** In-memory fs mock shaped to the subset runAbiSelfHeal touches. */
+function makeFsMock(initial: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    store,
+    existsSync: (p: string) => store.has(p),
+    mkdirSync: (_p: string, _opts?: unknown) => {
+      /* no-op — we only care about the eventual writeFileSync */
+    },
+    readFileSync: (p: string, _enc: string) => {
+      const v = store.get(p);
+      if (v === undefined) throw new Error(`ENOENT: ${p}`);
+      return v;
+    },
+    writeFileSync: (p: string, data: string) => {
+      store.set(p, String(data));
+    },
+    unlinkSync: (p: string) => {
+      store.delete(p);
+    },
+  };
+}
+
+/** Build a baseline deps object; tests override fields per scenario. */
+function makeDeps(overrides: Partial<SelfHealDeps> = {}): SelfHealDeps {
+  const userDataDir = path.join(os.tmpdir(), 'abi-self-heal-test');
+  const appRoot = path.join(os.tmpdir(), 'abi-self-heal-test-app');
+  const fsMock = makeFsMock({
+    // By default: pretend electron-rebuild bin EXISTS so the rebuild step
+    // is reachable. Tests can override this.
+    [path.join(appRoot, 'node_modules', '.bin', 'electron-rebuild')]: 'fake-bin',
+    [path.join(appRoot, 'node_modules', '.bin', 'electron-rebuild.cmd')]: 'fake-bin',
+  });
+  return {
+    userDataDir,
+    appRoot,
+    isPackaged: false,
+    platform: 'linux',
+    probeBetterSqlite3: () => null,
+    runRebuild: () => ({ status: 0, stderrTail: '' }),
+    fs: fsMock,
+    log: () => { /* silent */ },
+    ...overrides,
+  };
+}
+
+describe('isAbiMismatchError', () => {
+  it('matches the canonical NODE_MODULE_VERSION string', () => {
+    const err = new Error(
+      `The module 'better_sqlite3.node' was compiled against a different Node.js version using NODE_MODULE_VERSION 127. This version of Node.js requires NODE_MODULE_VERSION 145.`,
+    );
+    expect(isAbiMismatchError(err)).toBe(true);
+  });
+
+  it('matches the alternate phrasing in stack traces', () => {
+    const err = new Error('boom');
+    err.stack = 'Error: boom\n  at ... requires NODE_MODULE_VERSION 145';
+    expect(isAbiMismatchError(err)).toBe(true);
+  });
+
+  it('does NOT match unrelated errors', () => {
+    expect(isAbiMismatchError(new Error('SQLITE_CANTOPEN: unable to open db'))).toBe(false);
+    expect(isAbiMismatchError(new Error('Cannot find module better-sqlite3'))).toBe(false);
+    expect(isAbiMismatchError(null)).toBe(false);
+  });
+});
+
+describe('runAbiSelfHeal', () => {
+  let deps: SelfHealDeps;
+  beforeEach(() => {
+    deps = makeDeps();
+  });
+
+  it('returns ok when probe succeeds', () => {
+    const result = runAbiSelfHeal(deps);
+    expect(result.kind).toBe('ok');
+  });
+
+  it('clears a stale marker when probe succeeds', () => {
+    const fsMock = makeFsMock({
+      [path.join(deps.appRoot, 'node_modules', '.bin', 'electron-rebuild')]: 'x',
+      [selfHealMarkerPath(deps.userDataDir)]: '{"error":"stale"}',
+    });
+    deps = makeDeps({ fs: fsMock });
+    const result = runAbiSelfHeal(deps);
+    expect(result.kind).toBe('ok');
+    expect(fsMock.store.has(selfHealMarkerPath(deps.userDataDir))).toBe(false);
+  });
+
+  it('passes through non-ABI probe failures (leaves to #639 banner)', () => {
+    const probeErr = new Error('SQLITE_CANTOPEN: unable to open database file');
+    deps = makeDeps({ probeBetterSqlite3: () => probeErr });
+    const result = runAbiSelfHeal(deps);
+    expect(result.kind).toBe('rebuild-failed');
+    if (result.kind === 'rebuild-failed') {
+      expect(result.error).toContain('SQLITE_CANTOPEN');
+    }
+  });
+
+  it('runs the rebuild on ABI mismatch and returns healed', () => {
+    const probeErr = new Error(
+      'NODE_MODULE_VERSION 127 ... requires NODE_MODULE_VERSION 145',
+    );
+    let rebuildCalls = 0;
+    deps = makeDeps({
+      probeBetterSqlite3: () => probeErr,
+      runRebuild: () => {
+        rebuildCalls += 1;
+        return { status: 0, stderrTail: '' };
+      },
+    });
+    const result = runAbiSelfHeal(deps);
+    expect(rebuildCalls).toBe(1);
+    expect(result.kind).toBe('healed');
+    if (result.kind === 'healed') {
+      expect(result.restartHint).toBe('app.relaunch');
+    }
+  });
+
+  it('writes the one-shot marker BEFORE running rebuild (crash-safe)', () => {
+    const probeErr = new Error('NODE_MODULE_VERSION 127 requires NODE_MODULE_VERSION 145');
+    const fsMock = makeFsMock({
+      [path.join(deps.appRoot, 'node_modules', '.bin', 'electron-rebuild')]: 'x',
+    });
+    let markerAtRebuildTime = false;
+    deps = makeDeps({
+      fs: fsMock,
+      probeBetterSqlite3: () => probeErr,
+      runRebuild: () => {
+        markerAtRebuildTime = fsMock.store.has(selfHealMarkerPath(deps.userDataDir));
+        return { status: 0, stderrTail: '' };
+      },
+    });
+    runAbiSelfHeal(deps);
+    expect(markerAtRebuildTime).toBe(true);
+  });
+
+  it('refuses to loop when the marker is already present', () => {
+    const probeErr = new Error('NODE_MODULE_VERSION 127 requires NODE_MODULE_VERSION 145');
+    const fsMock = makeFsMock({
+      [path.join(deps.appRoot, 'node_modules', '.bin', 'electron-rebuild')]: 'x',
+      [selfHealMarkerPath(deps.userDataDir)]: JSON.stringify({ error: 'last attempt failed', ts: 0 }),
+    });
+    let rebuildCalls = 0;
+    deps = makeDeps({
+      fs: fsMock,
+      probeBetterSqlite3: () => probeErr,
+      runRebuild: () => {
+        rebuildCalls += 1;
+        return { status: 0, stderrTail: '' };
+      },
+    });
+    const result = runAbiSelfHeal(deps);
+    expect(rebuildCalls).toBe(0); // critical: did NOT loop into another rebuild
+    expect(result.kind).toBe('already-tried');
+    if (result.kind === 'already-tried') {
+      expect(result.lastError).toContain('last attempt failed');
+    }
+  });
+
+  it('reports rebuild-failed when the rebuild subprocess returns non-zero', () => {
+    const probeErr = new Error('NODE_MODULE_VERSION 127 requires NODE_MODULE_VERSION 145');
+    deps = makeDeps({
+      probeBetterSqlite3: () => probeErr,
+      runRebuild: () => ({ status: 1, stderrTail: 'gyp ERR! permission denied' }),
+    });
+    const result = runAbiSelfHeal(deps);
+    expect(result.kind).toBe('rebuild-failed');
+    if (result.kind === 'rebuild-failed') {
+      expect(result.error).toContain('exited with code 1');
+      expect(result.error).toContain('gyp ERR');
+    }
+  });
+
+  it('degrades gracefully in packaged builds when electron-rebuild is missing', () => {
+    const probeErr = new Error('NODE_MODULE_VERSION 127 requires NODE_MODULE_VERSION 145');
+    // Empty fs — rebuild bin does NOT exist (mimics packaged install).
+    const fsMock = makeFsMock({});
+    deps = makeDeps({
+      isPackaged: true,
+      probeBetterSqlite3: () => probeErr,
+      fs: fsMock,
+    });
+    const result = runAbiSelfHeal(deps);
+    expect(result.kind).toBe('rebuild-failed');
+    if (result.kind === 'rebuild-failed') {
+      expect(result.error).toContain('not available');
+    }
+    // Marker written so we don't try-and-fail on every launch.
+    expect(fsMock.store.has(selfHealMarkerPath(deps.userDataDir))).toBe(true);
+  });
+
+  it('uses the .cmd bin name on Windows', () => {
+    const probeErr = new Error('NODE_MODULE_VERSION 127 requires NODE_MODULE_VERSION 145');
+    const cmdPath = path.join(deps.appRoot, 'node_modules', '.bin', 'electron-rebuild.cmd');
+    const fsMock = makeFsMock({ [cmdPath]: 'x' });
+    let usedBin = '';
+    deps = makeDeps({
+      platform: 'win32',
+      fs: fsMock,
+      probeBetterSqlite3: () => probeErr,
+      runRebuild: (rebuildBin) => {
+        usedBin = rebuildBin;
+        return { status: 0, stderrTail: '' };
+      },
+    });
+    const result = runAbiSelfHeal(deps);
+    expect(usedBin).toBe(cmdPath);
+    expect(result.kind).toBe('healed');
+  });
+});

--- a/tests/postinstall.test.ts
+++ b/tests/postinstall.test.ts
@@ -1,0 +1,155 @@
+// Unit tests for scripts/postinstall-helpers.mjs (Task #641 Layer 1).
+
+import { describe, it, expect } from 'vitest';
+import { rebuildWithRetry } from '../scripts/postinstall-helpers.mjs';
+
+interface FakeSpawnResult {
+  status: number | null;
+  error?: Error;
+  signal?: NodeJS.Signals | null;
+}
+
+/** Build a spawn stub that returns a predefined queue of results. */
+function queueSpawn(results: FakeSpawnResult[]) {
+  const calls: Array<{ bin: string; args: string[]; opts: object }> = [];
+  return {
+    calls,
+    spawn: (bin: string, args: string[], opts: object): FakeSpawnResult => {
+      calls.push({ bin, args, opts });
+      const next = results.shift();
+      if (!next) throw new Error('spawn called more times than queued results');
+      return next;
+    },
+  };
+}
+
+const noopSleep = () => { /* tests don't need to actually sleep */ };
+
+describe('rebuildWithRetry', () => {
+  it('returns immediately on first-try success', () => {
+    const { spawn, calls } = queueSpawn([{ status: 0 }]);
+    const r = rebuildWithRetry({
+      rebuildBin: '/x/electron-rebuild',
+      moduleName: 'better-sqlite3',
+      cwd: '/repo',
+      isWindows: true,
+      allowFailure: false,
+      spawn,
+      sleep: noopSleep,
+    });
+    expect(r.status).toBe(0);
+    expect(r.attempts).toBe(1);
+    expect(calls).toHaveLength(1);
+    // Shape sanity:
+    expect(calls[0]?.args).toEqual([
+      '-f',
+      '-o',
+      'better-sqlite3',
+      '--build-from-source',
+    ]);
+  });
+
+  it('retries once on Windows when first attempt exits non-zero (EPERM scenario)', () => {
+    const { spawn, calls } = queueSpawn([
+      { status: 1 }, // EPERM-ish first try
+      { status: 0 }, // retry succeeds
+    ]);
+    let sleepCalls = 0;
+    const r = rebuildWithRetry({
+      rebuildBin: '/x/electron-rebuild.cmd',
+      moduleName: 'better-sqlite3',
+      cwd: '/repo',
+      isWindows: true,
+      allowFailure: false,
+      retryDelayMs: 250,
+      spawn,
+      sleep: (_ms) => { sleepCalls += 1; },
+    });
+    expect(r.status).toBe(0);
+    expect(r.attempts).toBe(2);
+    expect(calls).toHaveLength(2);
+    expect(sleepCalls).toBe(1);
+  });
+
+  it('does NOT retry on non-Windows even if first attempt fails', () => {
+    const { spawn, calls } = queueSpawn([{ status: 1 }]);
+    const r = rebuildWithRetry({
+      rebuildBin: '/x/electron-rebuild',
+      moduleName: 'better-sqlite3',
+      cwd: '/repo',
+      isWindows: false,
+      allowFailure: false,
+      spawn,
+      sleep: noopSleep,
+    });
+    expect(r.status).toBe(1);
+    expect(r.attempts).toBe(1);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('does NOT retry when allowFailure=true (node-pty path with prebuild fallback)', () => {
+    const { spawn, calls } = queueSpawn([{ status: 1 }]);
+    const r = rebuildWithRetry({
+      rebuildBin: '/x/electron-rebuild.cmd',
+      moduleName: 'node-pty',
+      cwd: '/repo',
+      isWindows: true,
+      allowFailure: true,
+      spawn,
+      sleep: noopSleep,
+    });
+    expect(r.attempts).toBe(1);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('returns the second-attempt failure when both attempts fail', () => {
+    const { spawn } = queueSpawn([
+      { status: 1 },
+      { status: 2 }, // distinct code so we can verify we report the LATEST result
+    ]);
+    const r = rebuildWithRetry({
+      rebuildBin: '/x/electron-rebuild.cmd',
+      moduleName: 'better-sqlite3',
+      cwd: '/repo',
+      isWindows: true,
+      allowFailure: false,
+      spawn,
+      sleep: noopSleep,
+    });
+    expect(r.status).toBe(2);
+    expect(r.attempts).toBe(2);
+  });
+
+  it('does NOT retry on spawn error (missing bin / OOM kill / ENOENT)', () => {
+    const { spawn, calls } = queueSpawn([
+      { status: null, error: new Error('ENOENT') },
+    ]);
+    const r = rebuildWithRetry({
+      rebuildBin: '/missing',
+      moduleName: 'better-sqlite3',
+      cwd: '/repo',
+      isWindows: true,
+      allowFailure: false,
+      spawn,
+      sleep: noopSleep,
+    });
+    expect(r.error?.message).toBe('ENOENT');
+    expect(r.attempts).toBe(1);
+    expect(calls).toHaveLength(1);
+  });
+
+  it('does NOT retry when killed by signal (user ^C)', () => {
+    const { spawn } = queueSpawn([{ status: null, signal: 'SIGINT' }]);
+    const r = rebuildWithRetry({
+      rebuildBin: '/x/electron-rebuild.cmd',
+      moduleName: 'better-sqlite3',
+      cwd: '/repo',
+      isWindows: true,
+      allowFailure: false,
+      spawn,
+      sleep: noopSleep,
+    });
+    expect(r.signal).toBe('SIGINT');
+    expect(r.attempts).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Task #641 — v0.3 ship-blocker. Dogfood #575 root cause: postinstall \`@electron/rebuild\` for better-sqlite3 silently fails (Windows .node lock, missing toolchain, etc.), leaving the binding compiled against host Node ABI (e.g. 127) instead of Electron's (e.g. 145). On first DB open the daemon crashes with \`NODE_MODULE_VERSION mismatch\` and the user sees a silent storage failure. #639 surfaces it as a banner; this PR makes the failure not happen (L3) and adds a self-heal fallback.

Three layers, all shipped:

- **Layer 1** (postinstall hardening): extracted \`rebuildWithRetry\` helper → Windows EPERM/EBUSY on a locked \`.node\` waits 5s and retries once.
- **Layer 2** (ship-time): \`scripts/after-pack.cjs\` now asserts \`better_sqlite3.node\` is present in \`app.asar.unpacked\` alongside the existing node-pty check. A failed rebuild can no longer slip past pack into a published installer.
- **Layer 3** (runtime self-heal): new \`electron/abi-self-heal.ts\` probes better-sqlite3 (\`:memory:\` open) before \`app.whenReady\`. On NODE_MODULE_VERSION mismatch it spawns \`@electron/rebuild\` and \`app.relaunch()\`. One-shot marker in userData prevents loops.

File ownership respected: \`scripts/harness-ui.mjs\` untouched (owned by dev #639). New e2e cases live in sibling \`scripts/harness-abi-selfheal.mjs\`, auto-discovered by run-all-e2e.

## Local checks (host: win32, mode: fast)

- lint: ✓ (exit 0, only pre-existing warnings)
- typecheck: ✓ (exit 0 — all three tsconfig projects)
- build: ✓ (exit 0, dist/electron/abi-self-heal.js + dist/electron/main.js present)
- unit tests: \`npx vitest run tests/abi-self-heal.test.ts tests/postinstall.test.ts tests/electron-load-smoke.test.ts\`  
  → 28 passed (19 new + 9 load-smoke unchanged), 28.5s total
- e2e: \`node scripts/harness-abi-selfheal.mjs\` → 5 passed, 0 failed (8ms wall, all skipLaunch)
- e2e baseline: \`node scripts/harness-ui.mjs --only=sidebar-align\` → 1 passed (verifies main.ts boot still works after self-heal wiring)

## Test plan

- [ ] CI three-platform matrix green on harness-abi-selfheal (5 cases)
- [ ] CI green on harness-ui (14 cases unchanged)
- [ ] Verify \`electron-builder\` pack on CI artifacts — better-sqlite3 binding listed by after-pack hook
- [ ] On a clean install where the Electron major bumped (ABI skew), confirm self-heal triggers exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)