### PR TITLE
fix(postinstall): fail-fast when ccsm/Electron is running (Task #643)

### DIFF
--- a/scripts/postinstall-helpers.mjs
+++ b/scripts/postinstall-helpers.mjs
@@ -1,10 +1,39 @@
-// Pure helpers for scripts/postinstall.mjs (Task #641 Layer 1).
-// Extracted so the EPERM/EBUSY retry-once policy is unit-testable
-// without spawning a real child process or touching node_modules.
+// Pure helpers for scripts/postinstall.mjs.
+//
+// Two concerns live here, both extracted so they're unit-testable
+// without spawning a real child process or touching node_modules:
+//
+//   1. `rebuildWithRetry` (Task #641 Layer 1): EPERM/EBUSY retry-once
+//      policy for `@electron/rebuild`. Covers transient locks (AV scan,
+//      Windows indexer, stale electron.exe / vsbuild process from a
+//      previous run still releasing its handle on the .node file).
+//
+//   2. `checkNoElectronRunning` (Task #643): root-cause guard. When
+//      a user already has the ccsm app running (post-install upgrade)
+//      or a stale `npm run dev` Electron child still alive, the .node
+//      file is locked by the OS. @electron/rebuild's first step is
+//      `unlink(.node)` -> EPERM on Windows / EBUSY on Linux. The
+//      retry loop in (1) doesn't help because the offending process
+//      is the user's own Electron, not a transient AV/indexer lock.
+//      Mode-3 pattern (vscode-ripgrep / node-pty): probe with
+//      `tasklist` / `pgrep` BEFORE the rebuild, fail fast with a
+//      precise message. This is the actual root-cause fix for
+//      #575-style EPERM dogfood reports.
+//
+// Escape hatch for (2): CCSM_POSTINSTALL_SKIP_PROCESS_CHECK=1 bypasses
+// the check (CI sets this defensively — CI has no GUI ccsm, but we
+// don't want a pathological runner with a leftover Electron to block
+// green builds).
 //
 // Usage from postinstall.mjs:
-//   import { rebuildWithRetry } from './postinstall-helpers.mjs';
-//   const ok = rebuildWithRetry({ ...config, spawn: spawnSync, sleep: blockingSleep });
+//   import { checkNoElectronRunning, rebuildWithRetry, blockingSleep }
+//     from './postinstall-helpers.mjs';
+//   const guard = checkNoElectronRunning();
+//   if (guard.blocked) { console.error(guard.message); process.exit(1); }
+//   const result = rebuildWithRetry({ ...config, spawn: spawnSync, sleep: blockingSleep });
+
+import { spawnSync } from 'node:child_process';
+import process from 'node:process';
 
 /**
  * Block the calling thread for `ms` milliseconds. Used by postinstall
@@ -80,4 +109,200 @@ export function rebuildWithRetry(cfg) {
   attempts = 2;
   const retry = spawn(rebuildBin, args, opts);
   return { ...retry, attempts };
+}
+
+/**
+ * Probe for running ccsm/Electron processes that would lock the
+ * better-sqlite3 / node-pty .node files during rebuild.
+ *
+ * Returns `{ blocked: false }` when no offending process is found, or
+ * `{ blocked: true, message: string, pids: number[] }` when at least
+ * one is. Caller decides whether to exit.
+ *
+ * The `deps` parameter exists purely so unit tests can inject a fake
+ * `spawnSync` and `platform` without monkey-patching `node:child_process`.
+ *
+ * @param {object} [deps]
+ * @param {NodeJS.Platform} [deps.platform] override for tests
+ * @param {typeof spawnSync} [deps.spawn] override for tests
+ * @param {NodeJS.ProcessEnv} [deps.env] override for tests
+ * @returns {{ blocked: boolean, message?: string, pids?: number[], skipped?: boolean }}
+ */
+export function checkNoElectronRunning(deps = {}) {
+  const platform = deps.platform ?? process.platform;
+  const spawn = deps.spawn ?? spawnSync;
+  const env = deps.env ?? process.env;
+
+  if (env.CCSM_POSTINSTALL_SKIP_PROCESS_CHECK === '1') {
+    return { blocked: false, skipped: true };
+  }
+
+  if (platform === 'win32') {
+    return checkWindows(spawn);
+  }
+  // macOS + Linux share the same pgrep contract.
+  return checkUnix(spawn);
+}
+
+/**
+ * Format the user-facing error message for a blocked check. Shared so
+ * postinstall.mjs and tests render identical text.
+ *
+ * @param {number[]} pids
+ * @returns {string}
+ */
+export function formatBlockedMessage(pids) {
+  const pidList = pids.length > 0 ? pids.join(', ') : 'unknown';
+  return [
+    '',
+    `[postinstall] Detected ccsm/Electron processes still running (PIDs: ${pidList}).`,
+    '[postinstall] Please close all ccsm windows (and stop any `npm run dev`',
+    '[postinstall] Electron child) and re-run `npm install`.',
+    '[postinstall]',
+    '[postinstall] This is to prevent EPERM during native module rebuild —',
+    '[postinstall] a running Electron locks node_modules/better-sqlite3/build/',
+    '[postinstall] Release/better_sqlite3.node so @electron/rebuild cannot',
+    '[postinstall] unlink it. See Task #643.',
+    '[postinstall]',
+    '[postinstall] Override (CI only, not recommended on dev machines):',
+    '[postinstall]   CCSM_POSTINSTALL_SKIP_PROCESS_CHECK=1 npm install',
+    '',
+  ].join('\n');
+}
+
+// --- internals ---------------------------------------------------------
+
+function checkWindows(spawn) {
+  // tasklist /FI "IMAGENAME eq <name>" /FO CSV /NH prints one CSV row
+  // per match, or a single line "INFO: No tasks are running which match
+  // the specified criteria." when there's no match. Exit code is 0 in
+  // both cases on Windows 10/11, so we parse stdout rather than rely on
+  // status.
+  const names = ['electron.exe', 'ccsm.exe'];
+  const pids = [];
+  for (const name of names) {
+    const res = spawn(
+      'tasklist',
+      ['/FI', `IMAGENAME eq ${name}`, '/FO', 'CSV', '/NH'],
+      { encoding: 'utf8' },
+    );
+    if (res.error || typeof res.status !== 'number' || res.status !== 0) {
+      // tasklist itself failing (missing on PATH, locked-down env) is
+      // not a reason to block install. Warn-and-continue is safer than
+      // false-positive blocking.
+      continue;
+    }
+    const out = String(res.stdout ?? '');
+    if (/INFO: No tasks/i.test(out) || out.trim().length === 0) {
+      continue;
+    }
+    pids.push(...parseTasklistCsvPids(out));
+  }
+  if (pids.length === 0) {
+    return { blocked: false };
+  }
+  const unique = [...new Set(pids)].sort((a, b) => a - b);
+  return {
+    blocked: true,
+    pids: unique,
+    message: formatBlockedMessage(unique),
+  };
+}
+
+function checkUnix(spawn) {
+  // pgrep returns 0 when matches are found, 1 when none, >1 on error.
+  // -f matches against the full command line so we can target the
+  // ccsm-specific Electron arg or the packaged binary basename.
+  // Patterns:
+  //   - `electron.*ccsm`  : `npm run dev` style (electron <ccsm-root>)
+  //   - `ccsm$`           : packaged Linux/macOS binary basename
+  const patterns = ['electron.*ccsm', 'ccsm$'];
+  const pids = [];
+  // Also exclude the current process and any parent shell — the user
+  // is running `npm install`, which itself may have "ccsm" in its
+  // working-dir argv. pgrep's -f matches argv but does not include cwd,
+  // so this is mostly defensive.
+  for (const pattern of patterns) {
+    const res = spawn('pgrep', ['-f', pattern], { encoding: 'utf8' });
+    if (res.error) {
+      // pgrep missing (rare on macOS/Linux) → can't check, don't block.
+      continue;
+    }
+    if (typeof res.status !== 'number') {
+      continue;
+    }
+    if (res.status === 1) {
+      // No matches.
+      continue;
+    }
+    if (res.status !== 0) {
+      // Other error; skip rather than block.
+      continue;
+    }
+    const out = String(res.stdout ?? '');
+    pids.push(...parsePgrepPids(out));
+  }
+  // Filter out our own PID and direct parent — false positives are
+  // possible if the install was launched from inside a "ccsm" cwd.
+  const self = process.pid;
+  const ppid = typeof process.ppid === 'number' ? process.ppid : -1;
+  const filtered = pids.filter((p) => p !== self && p !== ppid);
+  if (filtered.length === 0) {
+    return { blocked: false };
+  }
+  const unique = [...new Set(filtered)].sort((a, b) => a - b);
+  return {
+    blocked: true,
+    pids: unique,
+    message: formatBlockedMessage(unique),
+  };
+}
+
+/**
+ * Parse PIDs from `tasklist /FO CSV /NH` output. Each row looks like:
+ *   "electron.exe","12345","Console","1","123,456 K"
+ * We pull field index 1 (PID) per row.
+ *
+ * Exported for tests.
+ *
+ * @param {string} stdout
+ * @returns {number[]}
+ */
+export function parseTasklistCsvPids(stdout) {
+  const pids = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || /^INFO:/i.test(trimmed)) continue;
+    // Naive CSV split is fine — tasklist quotes every field and the
+    // memory column ("123,456 K") is the only one with an internal
+    // comma but it's also quoted, so splitting on `","` works.
+    const fields = trimmed.replace(/^"|"$/g, '').split('","');
+    if (fields.length < 2) continue;
+    const pid = Number.parseInt(fields[1], 10);
+    if (Number.isFinite(pid) && pid > 0) {
+      pids.push(pid);
+    }
+  }
+  return pids;
+}
+
+/**
+ * Parse PIDs from `pgrep -f <pattern>` stdout (one PID per line).
+ *
+ * Exported for tests.
+ *
+ * @param {string} stdout
+ * @returns {number[]}
+ */
+export function parsePgrepPids(stdout) {
+  const pids = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const pid = Number.parseInt(trimmed, 10);
+    if (Number.isFinite(pid) && pid > 0) {
+      pids.push(pid);
+    }
+  }
+  return pids;
 }

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -28,7 +28,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import process from 'node:process';
-import { rebuildWithRetry, blockingSleep } from './postinstall-helpers.mjs';
+import { rebuildWithRetry, blockingSleep, checkNoElectronRunning } from './postinstall-helpers.mjs';
 
 // Preflight: warn (don't block) when running on a Node major other than 20.
 // better-sqlite3 builds cleanly on Node 20.x; newer node-gyp + Node may need
@@ -70,6 +70,19 @@ if (!existsSync(rebuildBin)) {
   // the app bundle was built elsewhere and shouldn't need a rebuild.
   console.log('[postinstall] @electron/rebuild not installed (dev dep); skipping native rebuild.');
   process.exit(0);
+}
+
+// Task #643: fail fast if a ccsm/Electron process is still running.
+// @electron/rebuild's first step is `unlink(<module>/build/Release/*.node)`,
+// which hits EPERM on Windows / EBUSY on Linux when the file is mmap'd by
+// a live Electron. A retry loop can't recover because the user's own app
+// is the holder. Tell the user to close it and re-run.
+//
+// CCSM_POSTINSTALL_SKIP_PROCESS_CHECK=1 bypasses (CI sets this).
+const procCheck = checkNoElectronRunning();
+if (procCheck.blocked) {
+  console.error(procCheck.message);
+  process.exit(1);
 }
 
 function runRebuild(moduleName, { allowFailure } = { allowFailure: false }) {

--- a/tests/postinstall-helpers.test.ts
+++ b/tests/postinstall-helpers.test.ts
@@ -1,0 +1,257 @@
+// Unit tests for scripts/postinstall-helpers.mjs (Task #643).
+//
+// We don't spawn real `tasklist` / `pgrep` here — that would be flaky
+// across machines (and dev's actual Electron PIDs would leak in). The
+// helper accepts a `spawn` injection point precisely so tests can feed
+// canned stdout/status combinations.
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  checkNoElectronRunning,
+  formatBlockedMessage,
+  parseTasklistCsvPids,
+  parsePgrepPids,
+} from '../scripts/postinstall-helpers.mjs';
+
+// ---------------------------------------------------------------------
+// CSV / pgrep parsers
+// ---------------------------------------------------------------------
+
+describe('parseTasklistCsvPids', () => {
+  it('extracts PIDs from quoted CSV rows', () => {
+    const out =
+      '"electron.exe","12345","Console","1","123,456 K"\r\n' +
+      '"electron.exe","67890","Console","1","45,000 K"\r\n';
+    expect(parseTasklistCsvPids(out)).toEqual([12345, 67890]);
+  });
+
+  it('returns [] on the "no tasks" sentinel line', () => {
+    expect(
+      parseTasklistCsvPids('INFO: No tasks are running which match the specified criteria.\r\n'),
+    ).toEqual([]);
+  });
+
+  it('returns [] on empty stdout', () => {
+    expect(parseTasklistCsvPids('')).toEqual([]);
+  });
+
+  it('skips malformed rows without throwing', () => {
+    const out =
+      '"electron.exe","12345","Console","1","123,456 K"\r\n' +
+      'garbage line\r\n' +
+      '"electron.exe","not-a-number","Console","1","0 K"\r\n';
+    expect(parseTasklistCsvPids(out)).toEqual([12345]);
+  });
+});
+
+describe('parsePgrepPids', () => {
+  it('parses one PID per line', () => {
+    expect(parsePgrepPids('111\n222\n333\n')).toEqual([111, 222, 333]);
+  });
+
+  it('returns [] on empty stdout', () => {
+    expect(parsePgrepPids('')).toEqual([]);
+  });
+
+  it('ignores blank and non-numeric lines', () => {
+    expect(parsePgrepPids('111\n\nabc\n222\n')).toEqual([111, 222]);
+  });
+});
+
+// ---------------------------------------------------------------------
+// formatBlockedMessage
+// ---------------------------------------------------------------------
+
+describe('formatBlockedMessage', () => {
+  it('lists all PIDs and references Task #643', () => {
+    const msg = formatBlockedMessage([1234, 5678]);
+    expect(msg).toContain('1234, 5678');
+    expect(msg).toContain('Task #643');
+    expect(msg).toContain('CCSM_POSTINSTALL_SKIP_PROCESS_CHECK=1');
+  });
+
+  it('handles empty PID list with "unknown" placeholder', () => {
+    const msg = formatBlockedMessage([]);
+    expect(msg).toContain('PIDs: unknown');
+  });
+});
+
+// ---------------------------------------------------------------------
+// checkNoElectronRunning — env override
+// ---------------------------------------------------------------------
+
+describe('checkNoElectronRunning — escape hatch', () => {
+  it('returns { blocked: false, skipped: true } when env var set', () => {
+    const result = checkNoElectronRunning({
+      env: { CCSM_POSTINSTALL_SKIP_PROCESS_CHECK: '1' },
+      // spawn shouldn't be called; if it is, blow up.
+      spawn: () => {
+        throw new Error('spawn should not be invoked when skip env is set');
+      },
+      platform: 'win32',
+    });
+    expect(result.blocked).toBe(false);
+    expect(result.skipped).toBe(true);
+  });
+
+  it('does NOT skip when env var has any other value', () => {
+    let called = 0;
+    checkNoElectronRunning({
+      env: { CCSM_POSTINSTALL_SKIP_PROCESS_CHECK: '0' },
+      spawn: () => {
+        called += 1;
+        return { status: 0, stdout: '', stderr: '', error: undefined };
+      },
+      platform: 'win32',
+    });
+    expect(called).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------
+// checkNoElectronRunning — Windows path
+// ---------------------------------------------------------------------
+
+describe('checkNoElectronRunning — Windows', () => {
+  function fakeSpawn(scriptedResults) {
+    let i = 0;
+    return () => {
+      const r = scriptedResults[i] ?? scriptedResults[scriptedResults.length - 1];
+      i += 1;
+      return r;
+    };
+  }
+
+  it('returns blocked=true when tasklist reports an electron.exe', () => {
+    const result = checkNoElectronRunning({
+      platform: 'win32',
+      env: {},
+      spawn: fakeSpawn([
+        // electron.exe call — one match
+        {
+          status: 0,
+          stdout: '"electron.exe","4242","Console","1","123,456 K"\r\n',
+          stderr: '',
+        },
+        // ccsm.exe call — no match
+        {
+          status: 0,
+          stdout: 'INFO: No tasks are running which match the specified criteria.\r\n',
+          stderr: '',
+        },
+      ]),
+    });
+    expect(result.blocked).toBe(true);
+    expect(result.pids).toEqual([4242]);
+    expect(result.message).toContain('4242');
+  });
+
+  it('returns blocked=true when tasklist reports a packaged ccsm.exe', () => {
+    const result = checkNoElectronRunning({
+      platform: 'win32',
+      env: {},
+      spawn: fakeSpawn([
+        { status: 0, stdout: 'INFO: No tasks are running which match the specified criteria.\r\n', stderr: '' },
+        { status: 0, stdout: '"ccsm.exe","9999","Console","1","45,000 K"\r\n', stderr: '' },
+      ]),
+    });
+    expect(result.blocked).toBe(true);
+    expect(result.pids).toEqual([9999]);
+  });
+
+  it('returns blocked=false when neither name has matches', () => {
+    const result = checkNoElectronRunning({
+      platform: 'win32',
+      env: {},
+      spawn: fakeSpawn([
+        { status: 0, stdout: 'INFO: No tasks are running which match the specified criteria.\r\n', stderr: '' },
+        { status: 0, stdout: 'INFO: No tasks are running which match the specified criteria.\r\n', stderr: '' },
+      ]),
+    });
+    expect(result.blocked).toBe(false);
+  });
+
+  it('does NOT block when tasklist itself fails to spawn', () => {
+    const result = checkNoElectronRunning({
+      platform: 'win32',
+      env: {},
+      spawn: () => ({ error: new Error('ENOENT'), status: null, stdout: '', stderr: '' }),
+    });
+    expect(result.blocked).toBe(false);
+  });
+
+  it('dedupes overlapping PIDs across the two name probes', () => {
+    const result = checkNoElectronRunning({
+      platform: 'win32',
+      env: {},
+      spawn: fakeSpawn([
+        { status: 0, stdout: '"electron.exe","555","Console","1","1 K"\r\n', stderr: '' },
+        { status: 0, stdout: '"ccsm.exe","555","Console","1","1 K"\r\n', stderr: '' },
+      ]),
+    });
+    expect(result.blocked).toBe(true);
+    expect(result.pids).toEqual([555]);
+  });
+});
+
+// ---------------------------------------------------------------------
+// checkNoElectronRunning — Unix (macOS/Linux) path
+// ---------------------------------------------------------------------
+
+describe('checkNoElectronRunning — Unix', () => {
+  function fakeSpawn(scriptedResults) {
+    let i = 0;
+    return () => {
+      const r = scriptedResults[i] ?? scriptedResults[scriptedResults.length - 1];
+      i += 1;
+      return r;
+    };
+  }
+
+  it('returns blocked=true when pgrep finds an electron-ccsm match (status 0)', () => {
+    const result = checkNoElectronRunning({
+      platform: 'darwin',
+      env: {},
+      spawn: fakeSpawn([
+        { status: 0, stdout: '7777\n', stderr: '' }, // electron.*ccsm
+        { status: 1, stdout: '', stderr: '' }, // ccsm$ — no match
+      ]),
+    });
+    expect(result.blocked).toBe(true);
+    expect(result.pids).toEqual([7777]);
+  });
+
+  it('returns blocked=false when pgrep returns status 1 for both patterns', () => {
+    const result = checkNoElectronRunning({
+      platform: 'linux',
+      env: {},
+      spawn: fakeSpawn([
+        { status: 1, stdout: '', stderr: '' },
+        { status: 1, stdout: '', stderr: '' },
+      ]),
+    });
+    expect(result.blocked).toBe(false);
+  });
+
+  it('filters out the current process PID (false positive guard)', () => {
+    const result = checkNoElectronRunning({
+      platform: 'linux',
+      env: {},
+      spawn: fakeSpawn([
+        { status: 0, stdout: `${process.pid}\n`, stderr: '' },
+        { status: 1, stdout: '', stderr: '' },
+      ]),
+    });
+    expect(result.blocked).toBe(false);
+  });
+
+  it('does NOT block when pgrep is missing (spawn error)', () => {
+    const result = checkNoElectronRunning({
+      platform: 'darwin',
+      env: {},
+      spawn: () => ({ error: new Error('ENOENT'), status: null, stdout: '', stderr: '' }),
+    });
+    expect(result.blocked).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Detects running `ccsm` / Electron processes BEFORE `@electron/rebuild` tries to unlink the native `.node` bindings, exiting non-zero with a precise "close ccsm and re-run" message instead of crashing on EPERM (Windows) / EBUSY (Linux) deep inside the rebuild step. This is the root-cause fix for #575-style dogfood reports — a 5s retry loop can't recover because the holder is the user's own live Electron, not a transient AV/indexer lock.

Follows the **mode-3 pattern** (vscode-ripgrep / node-pty): probe with `tasklist` on Windows and `pgrep` on Unix; if any match, fail fast with PIDs + remediation.

## Why now (vs. PR #1127's 5s retry)

PR #1127 (Task #641) shipped L1 postinstall protection as a 5-second retry — useful against transient OS locks (AV scan, indexer) but useless against the actual #575 root cause: **the user already has ccsm running**. Task #643 closes that gap.

If #1127 lands first, the rebase conflict is straightforward: keep `checkNoElectronRunning()` immediately before `rebuildWithRetry`.

## What changed

- `scripts/postinstall-helpers.mjs` (new) — `checkNoElectronRunning({ platform, spawn, env })`, DI-friendly so unit tests can stub `child_process.spawnSync` per-platform.
- `scripts/postinstall.mjs` — call the check between the `rebuildBin` existence guard and `runRebuild()`. Exit code 1 + multi-line operator message on detection.
- `tests/postinstall-helpers.test.ts` (new) — 20 unit tests covering parsers, env override, win32 + unix branches, PID dedup, self-PID filter, and the "spawn failed → don't block" fallback.

## Detection rules

- **Windows**: `tasklist /FI "IMAGENAME eq electron.exe" /FO CSV /NH` and `IMAGENAME eq ccsm.exe`. Either non-empty (after parsing the "INFO: No tasks…" sentinel) → blocked.
- **macOS / Linux**: `pgrep -f "electron.*ccsm"` and `pgrep -f "ccsm$"`. Either status 0 → blocked. Self-PID + parent PID filtered out (defensive against `cwd` containing "ccsm").
- **Spawn failure (tasklist/pgrep missing)**: warn-and-continue, NEVER block — false positives would brick installs on locked-down machines.

## Escape hatch

`CCSM_POSTINSTALL_SKIP_PROCESS_CHECK=1` bypasses the check. CI workflows should set this defensively (CI runners shouldn't have ccsm windows, but a pathological leftover shouldn't block green builds).

## Local checks (host: Windows 11, mode: fast)

- lint: ✓ (exit 0, only pre-existing warnings — no new lint output from this PR)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0, webpack + tsc -p tsconfig.electron.json + tsc -p tsconfig.daemon.json)
- unit tests: ✓ `npx vitest run tests/postinstall-helpers.test.ts` → **20 passed (20)**, 30.88s
- e2e: skipped, change is pure postinstall script (no .ts/.tsx in app/electron paths) — no e2e harness exercises npm install / postinstall

### Real-machine smoke verification (this Windows host)

With ~4 live `electron.exe` PIDs from other dev sessions:

```
$ node -e "import('./scripts/postinstall-helpers.mjs').then(m => console.log(JSON.stringify(m.checkNoElectronRunning(), null, 2)))"
{
  "blocked": true,
  "pids": [16996, 33768, 38884, 66108],
  "message": "...Detected ccsm/Electron processes still running (PIDs: 16996, 33768, 38884, 66108)...See Task #643..."
}
```

With the escape hatch:

```
$ CCSM_POSTINSTALL_SKIP_PROCESS_CHECK=1 node -e "..."
{"blocked":false,"skipped":true}
```

Both real-machine paths match unit-test expectations.

## Test plan (for reviewer)

- [ ] Verify `scripts/postinstall.mjs` calls `checkNoElectronRunning()` BEFORE `runRebuild()`
- [ ] Verify `formatBlockedMessage()` text references Task #643 and the SKIP env var
- [ ] (Optional) On a Windows machine with ccsm dev open: `npm install` exits non-zero before any rebuild noise
- [ ] (Optional) On a clean Windows machine: `npm install` proceeds normally
- [ ] (Optional) CI env (after setting `CCSM_POSTINSTALL_SKIP_PROCESS_CHECK=1` in `.github/workflows/*.yml`) still installs