### PR TITLE
[S2-T1] daemon: cc-sm.pages.dev origin allow-list + PNA preflight

### DIFF
--- a/packages/daemon/src/auth.mts
+++ b/packages/daemon/src/auth.mts
@@ -8,12 +8,24 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 // Origin allow-list:
 //   - http(s)://127.0.0.1 / localhost  (web SPA, dev vite proxy)
 //   - tauri://localhost                 (T2 #675 — Tauri 2 webview origin)
+//   - https://cc-sm.pages.dev           (S2 #702 — Cloudflare Pages prod host)
 // The Tauri webview always sends `Origin: tauri://localhost` for in-app fetch
 // and ws upgrade; we whitelist it explicitly rather than open up arbitrary
 // cross-origin. See plan doc `logical-swinging-brook.md` §A / T2.
+//
+// S2 #702: the production web SPA is served from `https://cc-sm.pages.dev`
+// (Cloudflare Pages). It issues cross-origin loopback fetches to the local
+// daemon (which still binds 127.0.0.1) so we must allow the exact origin
+// `https://cc-sm.pages.dev` and ONLY that — no PR-preview subdomains
+// (`https://abc123.cc-sm.pages.dev` is reject-by-default; T8 #?? will gate
+// preview origins behind an explicit opt-in flag), no spoof variants
+// (`https://cc-sm-evil.pages.dev`, `https://cc-sm.pages.dev.attacker.com`),
+// and no http (Chrome's PNA + mixed-content rules require https for the
+// loopback initiator).
 const ALLOWED_ORIGIN_HOSTS = new Set(['127.0.0.1', 'localhost']);
 const ALLOWED_ORIGIN_PROTOCOLS = new Set(['http:', 'https:']);
 const TAURI_ORIGIN = 'tauri://localhost';
+const PAGES_PROD_ORIGIN = 'https://cc-sm.pages.dev';
 
 function writeJson(res: ServerResponse, status: number, body: unknown): void {
   res.statusCode = status;
@@ -48,6 +60,15 @@ function constantTimeEquals(a: string, b: string): boolean {
 export function classifyOrigin(rawOrigin: string | undefined): 'absent' | 'allowed' | 'rejected' {
   if (rawOrigin === undefined || rawOrigin.length === 0) return 'absent';
   if (rawOrigin === TAURI_ORIGIN) return 'allowed';
+  // S2 #702 — exact-string match for the Cloudflare Pages prod origin BEFORE
+  // we hand off to URL parsing. Doing this as an exact string compare (rather
+  // than parsing then checking host) makes spoof variants impossible:
+  //   - `https://cc-sm-evil.pages.dev`              → !== PAGES_PROD_ORIGIN
+  //   - `https://cc-sm.pages.dev.attacker.com`      → !== PAGES_PROD_ORIGIN
+  //   - `http://cc-sm.pages.dev`                    → !== PAGES_PROD_ORIGIN
+  //   - `https://abc123.cc-sm.pages.dev` (PR preview) → !== PAGES_PROD_ORIGIN
+  // All fall through to the loopback host check below and are rejected.
+  if (rawOrigin === PAGES_PROD_ORIGIN) return 'allowed';
   let url: URL;
   try {
     url = new URL(rawOrigin);

--- a/packages/daemon/src/http.mts
+++ b/packages/daemon/src/http.mts
@@ -135,6 +135,17 @@ function handleCorsPreflight(req: IncomingMessage, res: ServerResponse): void {
   // Cache preflight for 10 min — keeps Tauri webview from re-issuing OPTIONS
   // on every fetch. Spec lets browsers cap at their discretion (Chromium 2h).
   res.setHeader('Access-Control-Max-Age', '600');
+  // S2 #702 — Chrome 120+ Private Network Access (PNA): when a public-network
+  // page (https://cc-sm.pages.dev) initiates a fetch to a private/loopback
+  // address (127.0.0.1), the browser sends `Access-Control-Request-Private-
+  // Network: true` on the preflight and REQUIRES the response to echo back
+  // `Access-Control-Allow-Private-Network: true`, otherwise the actual
+  // request never fires. We only echo on demand (don't advertise the header
+  // to peers that didn't ask).
+  // Spec: https://wicg.github.io/private-network-access/#cors-preflight
+  if (req.headers['access-control-request-private-network'] === 'true') {
+    res.setHeader('Access-Control-Allow-Private-Network', 'true');
+  }
   // Spec allows 200 or 204; manager validation script greps for 200 explicitly.
   res.statusCode = 200;
   res.end();

--- a/packages/daemon/test/auth.test.ts
+++ b/packages/daemon/test/auth.test.ts
@@ -11,6 +11,7 @@ import type {
 } from '@ccsm/shared';
 
 import { createDaemonHttp, type DaemonHttp } from '../src/http.mjs';
+import { classifyOrigin } from '../src/auth.mjs';
 
 const TOKEN = 'test-token-do-not-use-in-prod-0123456789abcdef';
 const GOOD_ORIGIN = 'http://localhost:1234';
@@ -260,5 +261,109 @@ describe('sessions CRUD (in-memory stub)', () => {
       },
     });
     expect(r.status).toBe(200);
+  });
+});
+
+// S2 #702 — Cloudflare Pages prod origin allow-list + Chrome PNA preflight.
+// The web SPA is hosted at `https://cc-sm.pages.dev`. From the user's browser
+// it issues cross-origin loopback fetches into the daemon. Only the exact
+// production origin is allowed; spoof variants and PR-preview subdomains are
+// rejected. Chrome 120+ PNA further requires the daemon to opt-in to private
+// network access via a preflight echo header.
+describe('S2 #702 — Cloudflare Pages origin allow-list (classifyOrigin)', () => {
+  it('classifyOrigin("https://cc-sm.pages.dev") === "allowed" (prod host)', () => {
+    expect(classifyOrigin('https://cc-sm.pages.dev')).toBe('allowed');
+  });
+
+  it('classifyOrigin("https://cc-sm-evil.pages.dev") === "rejected" (sibling spoof)', () => {
+    expect(classifyOrigin('https://cc-sm-evil.pages.dev')).toBe('rejected');
+  });
+
+  it('classifyOrigin("https://cc-sm.pages.dev.attacker.com") === "rejected" (suffix spoof)', () => {
+    expect(classifyOrigin('https://cc-sm.pages.dev.attacker.com')).toBe('rejected');
+  });
+
+  it('classifyOrigin("http://cc-sm.pages.dev") === "rejected" (http stripped, must be https)', () => {
+    expect(classifyOrigin('http://cc-sm.pages.dev')).toBe('rejected');
+  });
+
+  it('classifyOrigin("https://abc123.cc-sm.pages.dev") === "rejected" (PR-preview default off)', () => {
+    // T8 will introduce an opt-in flag for preview deploys; until then,
+    // every preview subdomain MUST be rejected to keep the prod attack
+    // surface tight.
+    expect(classifyOrigin('https://abc123.cc-sm.pages.dev')).toBe('rejected');
+  });
+
+  it('classifyOrigin(undefined) === "absent" (regression for #672 same-origin)', () => {
+    // Browsers omit Origin on same-origin GET/HEAD; daemon treats absent
+    // as same-origin. This must keep working alongside the new pages.dev
+    // allow-list entry.
+    expect(classifyOrigin(undefined)).toBe('absent');
+  });
+
+  it('keeps tauri://localhost === "allowed" (T2 #675 regression)', () => {
+    expect(classifyOrigin('tauri://localhost')).toBe('allowed');
+  });
+});
+
+describe('S2 #702 — pages.dev integration through the HTTP server', () => {
+  it('accepts POST /api/sessions with Origin: https://cc-sm.pages.dev (200)', async () => {
+    const r = await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        Origin: 'https://cc-sm.pages.dev',
+        'Content-Type': 'application/json',
+      },
+      body: '{}',
+    });
+    expect(r.status).toBe(200);
+    expect(r.headers.get('access-control-allow-origin')).toBe('https://cc-sm.pages.dev');
+  });
+
+  it('rejects POST /api/sessions with Origin: https://cc-sm-evil.pages.dev (403)', async () => {
+    const r = await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        Origin: 'https://cc-sm-evil.pages.dev',
+        'Content-Type': 'application/json',
+      },
+      body: '{}',
+    });
+    expect(r.status).toBe(403);
+  });
+});
+
+describe('S2 #702 — Chrome PNA preflight echo', () => {
+  it('OPTIONS with Access-Control-Request-Private-Network: true echoes Allow-Private-Network: true', async () => {
+    const r = await fetch(`${baseUrl}/api/sessions`, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://cc-sm.pages.dev',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'authorization, content-type',
+        'Access-Control-Request-Private-Network': 'true',
+      },
+    });
+    expect(r.status).toBe(200);
+    expect(r.headers.get('access-control-allow-private-network')).toBe('true');
+    expect(r.headers.get('access-control-allow-origin')).toBe('https://cc-sm.pages.dev');
+  });
+
+  it('OPTIONS WITHOUT the PNA request header does NOT advertise Allow-Private-Network', async () => {
+    // Don't volunteer PNA capability to peers that didn't ask for it.
+    const r = await fetch(`${baseUrl}/api/sessions`, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://cc-sm.pages.dev',
+        'Access-Control-Request-Method': 'POST',
+      },
+    });
+    expect(r.status).toBe(200);
+    expect(r.headers.get('access-control-allow-private-network')).toBeNull();
+    // Other preflight headers still intact.
+    expect(r.headers.get('access-control-allow-origin')).toBe('https://cc-sm.pages.dev');
+    expect(r.headers.get('access-control-allow-methods')).toMatch(/POST/);
   });
 });


### PR DESCRIPTION
Closes Task #729.

## Summary
Add cc-sm.pages.dev as an allowed origin alongside tauri://localhost, with strict exact-match rejection of spoof variants. Add Chrome 120+ Private Network Access (PNA) preflight echo.

## Changes
- `auth.mts` `classifyOrigin()`: exact-match allow `https://cc-sm.pages.dev` alongside `tauri://localhost`. Spoof variants (`cc-sm-evil`, suffix `attacker.com`), `http://` scheme, and PR-preview subdomains all reject.
- `http.mts` `handleCorsPreflight()`: when request carries `Access-Control-Request-Private-Network: true` (Chrome 120+ PNA), echo `Access-Control-Allow-Private-Network: true`. Don't volunteer the header otherwise.
- `auth.test.ts`: 7 `classifyOrigin` unit cases + 2 integration cases for pages.dev accept/reject + 2 PNA preflight cases (with/without the request header). #672 absent-Origin regression preserved.

## Migration note
This PR carries code originally developed in the now-archived ccsm-web repo. Code was force-set onto ccsm/working on 2026-05-08; this PR re-opens the work in ccsm following working-flow protocol.

## Quality gates (local Windows)
- lint: ✅
- typecheck: ✅
- test: ✅ (94 passed, 1 skipped)
- build: ✅