### PR TITLE
[S2-T3] frontend-web: resolveDaemonBase with 3-mode priority chain

### DIFF
--- a/packages/frontend-web/src/hostConfig.ts
+++ b/packages/frontend-web/src/hostConfig.ts
@@ -1,18 +1,32 @@
-// Web shell host config — same-origin daemon address + sessionStorage token.
+// Web shell host config — daemon address resolution + sessionStorage token.
 //
 // Wave-2 T6 (#686): @ccsm/ui's RuntimeProvider takes a HostConfig and uses
-// it to construct the SessionRuntime + bind the REST API. The web shell
-// always talks to the same origin (the daemon serves the bundle), so
-// httpBase comes from window.location and the token comes from
-// sessionStorage (main.tsx wrote it there during bootstrap).
+// it to construct the SessionRuntime + bind the REST API.
 //
 // Task #696: token bootstrap is a 3-step priority chain (URL ?token= →
 // fetch /token → fail). The pure resolver lives here so it can be
 // unit-tested without booting the full SPA.
+//
+// Task #712 (S2-T3): daemon base URL resolution supports 3 modes so the SPA
+// can be served from Cloudflare Pages (cross-origin) while still talking to
+// a local loopback daemon, without breaking the existing daemon-embedded
+// case (browser opens http://127.0.0.1:9876/, SPA same-origin).
+//
+//   1. URL `?daemon=` override — runtime escape hatch (e.g. user wants to
+//      point a Pages-hosted SPA at a non-default port).
+//   2. Build-time `VITE_DAEMON_BASE` — Pages build injects the canonical
+//      loopback URL.
+//   3. Fallback — if hostname is loopback (127.0.0.1 / localhost / ::1),
+//      use `window.location.origin` (preserves the daemon-embedded default,
+//      same-origin requests, no CORS); otherwise use VITE_DAEMON_BASE or
+//      the hard default `http://127.0.0.1:9876`.
 
 import type { HostConfig } from '@ccsm/ui';
 
 export const TOKEN_STORAGE_KEY = 'ccsm.token';
+
+/** Hard default daemon base, used when env var is missing in cross-origin mode. */
+export const DEFAULT_DAEMON_BASE = 'http://127.0.0.1:9876';
 
 export interface ResolveTokenDeps {
   /** Search portion of the current URL, e.g. `?token=abc`. */
@@ -52,8 +66,66 @@ export async function resolveToken(deps: ResolveTokenDeps): Promise<string | nul
   }
 }
 
+export interface ResolveDaemonBaseDeps {
+  /** Search portion of the current URL, e.g. `?daemon=http://127.0.0.1:8888`. */
+  search: string;
+  /** Current page hostname, e.g. `127.0.0.1`, `localhost`, `cc-sm.pages.dev`. */
+  hostname: string;
+  /** Current page origin, used as same-origin fallback for the daemon-embedded case. */
+  origin: string;
+  /** Build-time injected default. Pass `import.meta.env.VITE_DAEMON_BASE` from the runtime. */
+  envBase: string | undefined;
+}
+
+/** Loopback hostnames that mean "the SPA is served by a local daemon". */
+const LOOPBACK_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
+
+function normalizeBase(raw: string): string {
+  // Drop trailing slash so callers can append `/api/...` without doubling up.
+  return raw.endsWith('/') ? raw.slice(0, -1) : raw;
+}
+
+/**
+ * Resolve the HTTP base URL the SPA should use to talk to the daemon.
+ *
+ * Priority (Task #712):
+ *   1. URL `?daemon=<url>` — runtime override (debugging / non-default port).
+ *   2. Loopback hostname (127.0.0.1 / localhost) → `origin`. This preserves
+ *      the daemon-embedded default: same-origin, no CORS, no env needed.
+ *   3. `VITE_DAEMON_BASE` — build-time injected (e.g. for Pages).
+ *   4. Hard default `http://127.0.0.1:9876`.
+ *
+ * Order rationale: rule 2 sits above rule 3 so that running a daemon-served
+ * SPA on a custom port (`http://127.0.0.1:18080/`) keeps working even when
+ * a stale `VITE_DAEMON_BASE` was baked into the bundle.
+ */
+export function resolveDaemonBase(deps: ResolveDaemonBaseDeps): string {
+  const fromUrl = new URLSearchParams(deps.search).get('daemon');
+  if (fromUrl && fromUrl.length > 0) return normalizeBase(fromUrl);
+
+  if (LOOPBACK_HOSTNAMES.has(deps.hostname)) {
+    return normalizeBase(deps.origin);
+  }
+
+  if (deps.envBase && deps.envBase.length > 0) {
+    return normalizeBase(deps.envBase);
+  }
+
+  return DEFAULT_DAEMON_BASE;
+}
+
+function currentDaemonBase(): string {
+  if (typeof window === 'undefined') return '';
+  return resolveDaemonBase({
+    search: window.location.search,
+    hostname: window.location.hostname,
+    origin: window.location.origin,
+    envBase: import.meta.env.VITE_DAEMON_BASE,
+  });
+}
+
 export const webHostConfig: HostConfig = {
-  httpBase: typeof window !== 'undefined' ? window.location.origin : '',
+  httpBase: currentDaemonBase(),
   getToken: () => {
     if (typeof window === 'undefined') return null;
     return sessionStorage.getItem(TOKEN_STORAGE_KEY);

--- a/packages/frontend-web/src/vite-env.d.ts
+++ b/packages/frontend-web/src/vite-env.d.ts
@@ -1,0 +1,12 @@
+/// <reference types="vite/client" />
+
+// Task #712 (S2-T3): build-time injected daemon base URL.
+// Cloudflare Pages build pipeline sets this; daemon-embedded build leaves
+// it undefined and the SPA falls back to `window.location.origin`.
+interface ImportMetaEnv {
+  readonly VITE_DAEMON_BASE?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/packages/frontend-web/test/hostConfig.test.ts
+++ b/packages/frontend-web/test/hostConfig.test.ts
@@ -1,0 +1,103 @@
+// Daemon base URL resolution priority (Task #712).
+
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_DAEMON_BASE, resolveDaemonBase } from '../src/hostConfig';
+
+describe('resolveDaemonBase', () => {
+  it('uses VITE_DAEMON_BASE when SPA is cross-origin (e.g. Pages)', () => {
+    const got = resolveDaemonBase({
+      search: '',
+      hostname: 'cc-sm.pages.dev',
+      origin: 'https://cc-sm.pages.dev',
+      envBase: 'http://127.0.0.1:9876',
+    });
+    expect(got).toBe('http://127.0.0.1:9876');
+  });
+
+  it('URL ?daemon= override beats env var', () => {
+    const got = resolveDaemonBase({
+      search: '?daemon=http://127.0.0.1:8888',
+      hostname: 'cc-sm.pages.dev',
+      origin: 'https://cc-sm.pages.dev',
+      envBase: 'http://127.0.0.1:9876',
+    });
+    expect(got).toBe('http://127.0.0.1:8888');
+  });
+
+  it('URL ?daemon= override beats loopback fallback', () => {
+    // Daemon-embedded SPA on default port, but user wants to point at a
+    // different daemon instance — override wins.
+    const got = resolveDaemonBase({
+      search: '?daemon=http://127.0.0.1:8888',
+      hostname: '127.0.0.1',
+      origin: 'http://127.0.0.1:9876',
+      envBase: undefined,
+    });
+    expect(got).toBe('http://127.0.0.1:8888');
+  });
+
+  it('falls back to origin when hostname is 127.0.0.1 (daemon-embedded default)', () => {
+    const got = resolveDaemonBase({
+      search: '',
+      hostname: '127.0.0.1',
+      origin: 'http://127.0.0.1:9876',
+      envBase: undefined,
+    });
+    expect(got).toBe('http://127.0.0.1:9876');
+  });
+
+  it('falls back to origin when hostname is localhost', () => {
+    const got = resolveDaemonBase({
+      search: '',
+      hostname: 'localhost',
+      origin: 'http://localhost:9876',
+      envBase: undefined,
+    });
+    expect(got).toBe('http://localhost:9876');
+  });
+
+  it('falls back to origin on loopback even when env var is set (don\'t cross-origin from local)', () => {
+    // Critical regress guard: existing daemon-embedded users must not
+    // suddenly start making cross-origin requests just because a build
+    // happened to inline VITE_DAEMON_BASE.
+    const got = resolveDaemonBase({
+      search: '',
+      hostname: '127.0.0.1',
+      origin: 'http://127.0.0.1:18080',
+      envBase: 'http://127.0.0.1:9876',
+    });
+    expect(got).toBe('http://127.0.0.1:18080');
+  });
+
+  it('falls back to hard default when cross-origin and env var missing', () => {
+    const got = resolveDaemonBase({
+      search: '',
+      hostname: 'cc-sm.pages.dev',
+      origin: 'https://cc-sm.pages.dev',
+      envBase: undefined,
+    });
+    expect(got).toBe(DEFAULT_DAEMON_BASE);
+    expect(got).toBe('http://127.0.0.1:9876');
+  });
+
+  it('treats empty ?daemon= as missing and falls through', () => {
+    const got = resolveDaemonBase({
+      search: '?daemon=',
+      hostname: 'cc-sm.pages.dev',
+      origin: 'https://cc-sm.pages.dev',
+      envBase: 'http://127.0.0.1:9876',
+    });
+    expect(got).toBe('http://127.0.0.1:9876');
+  });
+
+  it('strips trailing slash so callers can append paths cleanly', () => {
+    const got = resolveDaemonBase({
+      search: '',
+      hostname: 'cc-sm.pages.dev',
+      origin: 'https://cc-sm.pages.dev',
+      envBase: 'http://127.0.0.1:9876/',
+    });
+    expect(got).toBe('http://127.0.0.1:9876');
+  });
+});


### PR DESCRIPTION
Closes Task #718.

## Summary
Adds `resolveDaemonBase()` so the SPA can be served from Cloudflare Pages (cross-origin) while still talking to a local loopback daemon, without breaking the existing daemon-embedded default (browser opens http://127.0.0.1:9876/, SPA same-origin, no CORS).

## Priority chain
1. URL `?daemon=` override (runtime escape hatch)
2. Loopback hostname (`127.0.0.1` / `localhost` / `::1`) -> `origin` (preserves daemon-embedded default; rule 2 above rule 3 so a stale baked-in `VITE_DAEMON_BASE` doesn't drag local users cross-origin)
3. `VITE_DAEMON_BASE` build-time injected (Pages build)
4. Hard default `http://127.0.0.1:9876`

Also adds `packages/frontend-web/src/vite-env.d.ts` to type `import.meta.env.VITE_DAEMON_BASE`.

## Migration note
This PR carries code originally developed in the now-archived ccsm-web repo. Code was force-set onto ccsm/working on 2026-05-08; this PR re-opens the work in ccsm following working-flow protocol.

## Quality gates (local Windows)
- lint: ✅
- typecheck: ✅
- test: ✅ (frontend-web: 15 passed; daemon: 83 passed, 1 skipped)
- build: ✅