### PR TITLE
[S2-T5] frontend-web: add --mode pages vite build for Cloudflare Pages

### DIFF
--- a/packages/frontend-web/package.json
+++ b/packages/frontend-web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -p tsconfig.json --noEmit && vite build",
+    "build:pages": "tsc -p tsconfig.json --noEmit && vite build --mode pages",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "lint": "eslint src --max-warnings=0",
     "test": "vitest run",

--- a/packages/frontend-web/vite.config.ts
+++ b/packages/frontend-web/vite.config.ts
@@ -3,8 +3,22 @@ import react from '@vitejs/plugin-react';
 
 // Dev server proxies /api and /ws to the local daemon (default port 17832).
 // In production the daemon serves the built frontend itself, so no proxy is needed.
-export default defineConfig({
+//
+// Build modes:
+// - default (`vite build`, used by Tauri and the daemon-embedded build): keeps
+//   the historical behaviour. Vite's default `base` ('/') already produces
+//   absolute `/assets/...` references, which is what both the embedded daemon
+//   and the Tauri shell expect.
+// - `--mode pages` (Cloudflare Pages deployment): explicitly pins `base: '/'`
+//   so generated `index.html` references are root-absolute regardless of any
+//   future default changes. Output dir and hashed asset filenames stay at
+//   Vite defaults.
+//
+// `mode` is destructured so future per-mode tweaks have a clear seam; today
+// `pages` and the default share the same root-absolute base.
+export default defineConfig(({ mode: _mode }) => ({
   plugins: [react()],
+  base: '/',
   server: {
     port: 5173,
     strictPort: false,
@@ -24,4 +38,4 @@ export default defineConfig({
     outDir: 'dist',
     emptyOutDir: true,
   },
-});
+}));


### PR DESCRIPTION
Closes Task #728.

## Summary
Make `vite.config.ts` mode-aware via `defineConfig(({ mode }) => ...)` and add a `build:pages` script. Default `vite build` (used by Tauri and the daemon-embedded build) keeps current behaviour: `base='/'` is now explicit but matches Vite's default, so `dist/index.html` is byte-identical to main. `vite build --mode pages` shares the same root-absolute base so Cloudflare Pages can serve hashed `/assets/<hash>.<ext>` from the deploy root.

## Migration note
This PR carries code originally developed in the now-archived ccsm-web repo. Code was force-set onto ccsm/working on 2026-05-08; this PR re-opens the work in ccsm following working-flow protocol.

## Quality gates (local Windows)
- lint: ✅
- typecheck: ✅
- test: ✅ (frontend-web: 6 passed; daemon: 83 passed, 1 skipped)
- build: ✅ (default + `--mode pages` both green)