### PR TITLE
chore: drop ccsm-web naming (Task #730)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# ccsm-web changelog
+# ccsm changelog
 
 ## v0.1.0 — Phase 3 acceptance + walking-skeleton ready
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ccsm-web
+# ccsm
 
 Local Node daemon + browser tab for managing `claude` PTY sessions.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
-# ccsm-web Roadmap
+# ccsm Roadmap
 
-本文档记录 ccsm-web 当前的鉴权 / 部署演进路线图 (S0 → S5), 描述前端、Tauri 壳、Cloudflare 中间层、本地 daemon 与鉴权方式在每个阶段的形态。
+本文档记录 ccsm 当前的鉴权 / 部署演进路线图 (S0 → S5), 描述前端、Tauri 壳、Cloudflare 中间层、本地 daemon 与鉴权方式在每个阶段的形态。
 
 **当前位置**: S0 完工 (wave-1 + wave-2 主线 14/14)。S1 进行中 2/4: PR #36 wave-2.5 已落 Tauri 注入 `CCSM_TOKEN` env + 端口固定 9876; 还差 (a) token 移到 `~/.ccsm/token` (现硬编码), (b) web 前端不再依赖 URL `?token=`。
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,12 @@
 {
-  "name": "ccsm-web",
+  "name": "ccsm",
   "version": "0.0.0",
   "private": true,
-  "description": "ccsm — Claude Code web session manager (monorepo root)",
+  "description": "ccsm — Claude Code session manager (monorepo root)",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Jiahui-Gu/ccsm.git"
+  },
   "engines": {
     "node": ">=20.0.0"
   },

--- a/packages/daemon/src/db.mts
+++ b/packages/daemon/src/db.mts
@@ -7,8 +7,13 @@
 //   - `user_version = 1` is hard-coded. There is no migration framework yet —
 //     when schema changes, bump the version and add explicit handling.
 //   - Default DB path:
-//       Windows: %APPDATA%/ccsm-web/ccsm.db
-//       *nix:    ~/.ccsm-web/ccsm.db
+//       Windows: %APPDATA%/ccsm/ccsm.db
+//       *nix:    ~/.ccsm/ccsm.db
+//     Legacy fallback: if the new path has no db file but a legacy
+//     `ccsm-web/ccsm.db` exists at the corresponding old location, the legacy
+//     file is opened in place (with a stderr warning) so users keep their data
+//     after the ccsm-web → ccsm rename. No automatic migration — the legacy
+//     file is read where it is.
 //   - Corruption recovery: on open, run `PRAGMA quick_check`. If it returns
 //     anything other than 'ok', rename the db / wal / shm files to
 //     `<name>.corrupt-<timestamp>` and re-open a fresh empty db. This mirrors
@@ -44,9 +49,42 @@ const USER_VERSION = 1;
 export function defaultDbPath(): string {
   if (process.platform === 'win32') {
     const base = process.env.APPDATA ?? path.join(os.homedir(), 'AppData/Roaming');
+    return path.join(base, 'ccsm', 'ccsm.db');
+  }
+  return path.join(os.homedir(), '.ccsm', 'ccsm.db');
+}
+
+/**
+ * Legacy default db path (pre `ccsm-web` → `ccsm` repo rename, 2026-05).
+ * Kept so existing users don't lose their KV state after upgrading: if no db
+ * exists at {@link defaultDbPath} but one exists here, we open the legacy file
+ * in place. No automatic copy/migration.
+ */
+export function legacyDefaultDbPath(): string {
+  if (process.platform === 'win32') {
+    const base = process.env.APPDATA ?? path.join(os.homedir(), 'AppData/Roaming');
     return path.join(base, 'ccsm-web', 'ccsm.db');
   }
   return path.join(os.homedir(), '.ccsm-web', 'ccsm.db');
+}
+
+/**
+ * Resolve the effective default db path, preferring the new location but
+ * falling back to the legacy `ccsm-web` location when the new file is absent
+ * and the legacy file exists. Emits a single stderr warning when the legacy
+ * fallback is taken.
+ */
+export function resolveDefaultDbPath(): string {
+  const current = defaultDbPath();
+  if (fs.existsSync(current)) return current;
+  const legacy = legacyDefaultDbPath();
+  if (legacy !== current && fs.existsSync(legacy)) {
+    process.stderr.write(
+      `ccsm: using legacy db at ${legacy} (move to ${current} to silence this warning)\n`,
+    );
+    return legacy;
+  }
+  return current;
 }
 
 function ensureParentDir(filePath: string): void {
@@ -113,7 +151,7 @@ function applySchema(db: Database.Database): void {
 }
 
 export function openDb(opts?: OpenDbOptions): KvDb {
-  const dbPath = opts?.path ?? defaultDbPath();
+  const dbPath = opts?.path ?? resolveDefaultDbPath();
   const db = openWithCorruptionGuard(dbPath);
   applySchema(db);
 

--- a/packages/daemon/src/db.test.mts
+++ b/packages/daemon/src/db.test.mts
@@ -3,12 +3,18 @@
 //   2. missing key returns null
 //   3. persistence across close/reopen
 //   4. corruption detection — non-sqlite junk file is backed up and replaced
+//   5. ccsm-web → ccsm legacy default-path fallback (Task #730)
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { openDb } from './db.mjs';
+import {
+  defaultDbPath,
+  legacyDefaultDbPath,
+  openDb,
+  resolveDefaultDbPath,
+} from './db.mjs';
 
 let tmpDir: string;
 let dbPath: string;
@@ -78,5 +84,69 @@ describe('openDb', () => {
     const entries = fs.readdirSync(tmpDir);
     const backups = entries.filter((name) => /\.corrupt-\d+$/.test(name));
     expect(backups.length).toBeGreaterThan(0);
+  });
+});
+
+describe('resolveDefaultDbPath (ccsm-web → ccsm legacy fallback)', () => {
+  let homeDir: string;
+  let homedirSpy: ReturnType<typeof vi.spyOn>;
+  let savedAppData: string | undefined;
+
+  beforeEach(() => {
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-home-'));
+    homedirSpy = vi.spyOn(os, 'homedir').mockReturnValue(homeDir);
+    savedAppData = process.env.APPDATA;
+    // Redirect %APPDATA% (used by defaultDbPath on win32) into our fake home so
+    // the test is hermetic on every platform.
+    process.env.APPDATA = path.join(homeDir, 'AppData/Roaming');
+  });
+
+  afterEach(() => {
+    homedirSpy.mockRestore();
+    if (savedAppData === undefined) delete process.env.APPDATA;
+    else process.env.APPDATA = savedAppData;
+    try {
+      fs.rmSync(homeDir, { recursive: true, force: true });
+    } catch {
+      // best-effort
+    }
+  });
+
+  it('returns the new path when no db file exists at either location', () => {
+    expect(resolveDefaultDbPath()).toBe(defaultDbPath());
+  });
+
+  it('returns the new path when both files exist (legacy ignored)', () => {
+    const newPath = defaultDbPath();
+    fs.mkdirSync(path.dirname(newPath), { recursive: true });
+    fs.writeFileSync(newPath, '');
+    const legacy = legacyDefaultDbPath();
+    fs.mkdirSync(path.dirname(legacy), { recursive: true });
+    fs.writeFileSync(legacy, '');
+
+    expect(resolveDefaultDbPath()).toBe(newPath);
+  });
+
+  it('falls back to the legacy ccsm-web path when only legacy exists', () => {
+    const legacy = legacyDefaultDbPath();
+    fs.mkdirSync(path.dirname(legacy), { recursive: true });
+    fs.writeFileSync(legacy, '');
+
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    try {
+      expect(resolveDefaultDbPath()).toBe(legacy);
+      const warned = stderrSpy.mock.calls.some((c) =>
+        String(c[0]).includes('legacy db'),
+      );
+      expect(warned).toBe(true);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('legacy and current paths differ (sanity check for the rename)', () => {
+    expect(legacyDefaultDbPath()).not.toBe(defaultDbPath());
+    expect(legacyDefaultDbPath()).toMatch(/ccsm-web/);
+    expect(defaultDbPath()).not.toMatch(/ccsm-web/);
   });
 });

--- a/packages/e2e/README.md
+++ b/packages/e2e/README.md
@@ -1,13 +1,13 @@
 # @ccsm/e2e-web
 
-End-to-end test rig for **ccsm-web**. Built on Playwright (headless Chromium)
+End-to-end test rig for **ccsm**. Built on Playwright (headless Chromium)
 with a daemon child-process fixture and a custom screenshot helper that emits
 both a `.png` and a `.txt` per snap.
 
 ## Why both PNG and TXT
 
 The manager driving this repo (Claude) cannot reliably view rendered pixels.
-**All acceptance evidence for ccsm-web tasks lives here as PNG + TXT pairs.**
+**All acceptance evidence for ccsm tasks lives here as PNG + TXT pairs.**
 The TXT contains page title, URL, visible text, the inventory of
 `data-testid` attributes, and any captured console warnings/errors — enough
 for the manager to `Read` and verify a feature without a human in the loop.

--- a/packages/frontend-tauri/src-tauri/Cargo.toml
+++ b/packages/frontend-tauri/src-tauri/Cargo.toml
@@ -3,7 +3,7 @@ name = "ccsm-tauri"
 version = "0.0.0"
 edition = "2021"
 description = "ccsm Tauri 2 desktop shell"
-authors = ["ccsm-web contributors"]
+authors = ["ccsm contributors"]
 
 [lib]
 name = "ccsm_tauri_lib"


### PR DESCRIPTION
## Summary

Repo was renamed `ccsm-web` → `ccsm`. This PR scrubs the old name from docs / package metadata / Tauri crate authors / daemon default db path. `cc-sm` (Cloudflare Pages project, S2 deploy target) is intentionally left alone.

### Changes

- `package.json` — `name: ccsm-web` → `ccsm`; description trimmed; added `repository.url` pointing to the new ccsm repo.
- `README.md`, `CHANGELOG.md`, `docs/ROADMAP.md`, `packages/e2e/README.md` — scrub `ccsm-web` mentions in titles / prose. Historical `## v0.1.0` body left as-is.
- `packages/frontend-tauri/src-tauri/Cargo.toml` — `authors = ["ccsm-web contributors"]` → `["ccsm contributors"]`.
- `packages/daemon/src/db.mts` — default db path moved from `%APPDATA%/ccsm-web` (resp. `~/.ccsm-web`) to `%APPDATA%/ccsm` (resp. `~/.ccsm`).
  - New `resolveDefaultDbPath()` prefers the new location but falls back to the legacy `ccsm-web` path **in place** (no automatic copy/migration) when only the legacy file exists, with a single `stderr` warning. Production data is not lost.
  - `legacyDefaultDbPath()` exported alongside `defaultDbPath()` so tests can pin both.

### Out of scope (red-line per task spec)

- Daemon HTTP / WS / runtime business logic
- frontend-web / frontend-tauri Rust business logic
- `cc-sm` references (S2 Cloudflare Pages project name, decoupled from GitHub repo name)

## Verification

`git grep -E "ccsm-web|ccsm_web"` → 11 hits, all in:
- `packages/daemon/src/db.mts` — legacy path string literals + comments explaining the fallback
- `packages/daemon/src/db.test.mts` — tests asserting the fallback works

These are required for the data-migration safety net and acceptable per the task spec.

`git grep "cc-sm"` → 0 hits in this repo today (S2 work hasn't introduced the literal yet); no `cc-sm` strings were touched.

## Local checks (host: Windows 11, mode: fast)

- lint: ✗ pre-existing baseline failure unrelated to this PR (`packages/daemon/test/persist.test.ts:20:8 'PersistController' is defined but never used`). I did not touch `persist.test.ts`. Lint output before my changes shows the same error.
- typecheck: ✓ (`pnpm -F @ccsm/daemon typecheck` exit 0 after `pnpm -F @ccsm/shared build`)
- build: skipped — diff is docs + metadata + a pure addition of `resolveDefaultDbPath`/`legacyDefaultDbPath` exports plus a one-line swap in `openDb` (`defaultDbPath()` → `resolveDefaultDbPath()`). Daemon typecheck covers the type surface.
- unit tests: `pnpm -F @ccsm/daemon exec vitest run src/db.test.mts` → 8 passed (4 existing + 4 new fallback cases). Full daemon suite also re-run end-to-end: 88 passed | 1 skipped, 8.45s.
- e2e: skipped — change does not touch any frontend / WS / HTTP / runtime path; e2e harness boots daemon with a hermetic db so the path change is exercised by unit tests, not e2e.

### Notes for reviewer / manager

- The lint baseline-red is not from this PR. Please confirm whether to silently leave it or surface separately — I did not include a drive-by fix to keep scope clean.
- DB path change is a user-data-touching default. The fallback strategy (read-in-place + warn, no copy) is deliberate to avoid double-write or surprising rollback behaviour. If a one-shot migration is preferred, that's a follow-up, not this PR.