### PR TITLE
fix(ui): drop MainPane auto-create bootstrap so browser refresh doesn't multiply sessions (Task #716)

### DIFF
--- a/packages/ui/src/components/MainPane.tsx
+++ b/packages/ui/src/components/MainPane.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef } from 'react';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import 'xterm/css/xterm.css';
-import { useApi, useGetToken, useRuntime } from '../runtime-context';
+import { useGetToken, useRuntime } from '../runtime-context';
 import { useStore } from '../store';
 
 // MainPane (Task #662 / T10 — DESIGN.md §7).
@@ -14,16 +14,26 @@ import { useStore } from '../store';
 //   so a session's bytes keep flowing into its scrollback even when the
 //   user is looking at a different session. MainPane now only:
 //     1. owns ONE xterm instance (renderer-side concern),
-//     2. attaches each known sid to the runtime (idempotent),
-//     3. on activeSid change, clears xterm and replays the new sid's
+//     2. on activeSid change, clears xterm and replays the new sid's
 //        scrollback from the runtime,
-//     4. subscribes to the runtime's OUTPUT/RESET pub-sub and writes only
+//     3. subscribes to the runtime's OUTPUT/RESET pub-sub and writes only
 //        the active sid's bytes into xterm in real time.
+//
+// Task #716 — NO AUTO-CREATE ON BOOTSTRAP:
+//   Earlier MainPane revisions auto-fired POST /api/sessions when the store
+//   had zero sessions on first paint (preserving the "open page → terminal
+//   attaches" UX from T6). That broke browser refresh: the daemon's session
+//   list survives reloads, but the in-memory store starts empty, so MainPane
+//   would race useBootstrap's GET /api/sessions and POST a brand-new session
+//   on every F5. The fix is to delete the auto-create bootstrap effect
+//   entirely; useBootstrap's listSessions is now the only path that
+//   populates the store on load, and the user must click + New Session in
+//   the sidebar to mint a fresh sid. The "no active session" notice already
+//   guides them to the button. (Tauri shell: same change applies — refresh
+//   should reattach existing sessions, not multiply them.)
 //
 // LIFECYCLE INVARIANTS (preserved from T9):
 //
-//   - Bootstrap is one-shot (StrictMode dev double-invoke must not
-//     double-POST /api/sessions).
 //   - xterm is renderer-owned: rebuilt on each effect run, threaded through
 //     `termRef` so long-lived runtime listeners always write into the
 //     currently-mounted Terminal.
@@ -34,9 +44,6 @@ import { useStore } from '../store';
 export function MainPane() {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Bootstrap guard — never reset on cleanup. Survives StrictMode.
-  const bootstrappedRef = useRef(false);
-
   // Always points at the currently mounted Terminal so long-lived runtime
   // listeners survive StrictMode's mount/unmount cycle.
   const termRef = useRef<Terminal | null>(null);
@@ -45,12 +52,9 @@ export function MainPane() {
   const activeSidRef = useRef<string | null>(null);
 
   const token = useStore((s) => s.token);
-  const sessions = useStore((s) => s.sessions);
   const activeSid = useStore((s) => s.activeSid);
-  const addSession = useStore((s) => s.addSession);
 
   const runtime = useRuntime();
-  const api = useApi();
   const hostGetToken = useGetToken();
 
   // Token resolution: prefer the store cache, but fall back to the shell-
@@ -98,42 +102,14 @@ export function MainPane() {
     };
   }, []);
 
-  // ---- bootstrap effect ----
+  // ---- bootstrap effect REMOVED (Task #716) ----
   //
-  // Auto-create the first session when the page loads with no sessions in
-  // the store. Preserves the T6 UX ("open page → terminal attaches"). The
-  // sidebar's + New Session button drives subsequent sessions through the
-  // same store API, so this effect only ever fires once per page lifetime.
-  useEffect(() => {
-    if (bootstrappedRef.current) return;
-    const tok = getToken();
-    if (!tok) return;
-    if (sessions.length > 0) return;
-
-    bootstrappedRef.current = true;
-    void (async () => {
-      try {
-        const resp = await api.createSession(tok);
-        const createdAt =
-          typeof resp.createdAt === 'number' ? resp.createdAt : Date.now();
-        // Task #673: attach must happen AFTER the daemon has spawned the PTY
-        // (i.e. AFTER createSession returns 200). Doing it here, scoped to
-        // a sid we just minted, is the only way to guarantee the ws upgrade
-        // finds a runtime entry on the daemon side. The old "attach every
-        // hydrated sid" effect (removed below) raced the lazy /resume path
-        // and burned the 5-attempt reconnect budget on close(1008).
-        runtime.attach(resp.sid, tok);
-        addSession({ sid: resp.sid, createdAt, alive: true });
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        // Reset the guard so the user can click + New Session and retry —
-        // we only intended to one-shot the *automatic* bootstrap.
-        bootstrappedRef.current = false;
-        const t = termRef.current;
-        if (t) writeNoticeTo(t, `[failed to create session: ${msg}]`);
-      }
-    })();
-  }, [sessions.length, addSession]);
+  // Auto-create on empty store caused a fresh POST /api/sessions on every
+  // browser refresh (because the in-memory store starts empty even though
+  // the daemon still has the old sessions). useBootstrap (listSessions) now
+  // owns "what's already alive on the daemon"; the user clicks + New Session
+  // for new sids. The "[no active session — click + New Session]" notice in
+  // the xterm lifecycle effect below covers the empty-store first paint.
 
   // ---- runtime attach is owned by user-action callers (Task #673) ----
   //

--- a/packages/ui/test/BootstrapRefresh.test.tsx
+++ b/packages/ui/test/BootstrapRefresh.test.tsx
@@ -1,0 +1,208 @@
+// Task #716 — browser refresh must not POST a fresh /api/sessions.
+//
+// Two cases (both directly from the task acceptance criteria):
+//   1. Refresh with EXISTING sessions on the daemon (listSessions returns
+//      non-empty): bootstrap hydrates the store from listSessions, MainPane
+//      renders, and createSession is NEVER called.
+//   2. First-time visit with NO sessions on the daemon (listSessions returns
+//      empty): bootstrap hydrates an empty list, MainPane renders the
+//      "click + New Session" notice, and createSession is STILL NEVER called
+//      (the user must click + New Session in the sidebar).
+//
+// We mock the runtime-context module so `useApi`, `useRuntime`,
+// `useGetToken`, and `HttpError` are all predictable, and we render
+// `<AppContent>`-shaped trees that combine `useBootstrap` + `<MainPane />`
+// the same way the production shell does.
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  type Mock,
+} from 'vitest';
+import { render, cleanup, act } from '@testing-library/react';
+
+// Hoisted mocks — declared before the dynamic import of MainPane / useBootstrap
+// so the mock instance is what those modules pick up on first eval.
+const createSessionMock = vi.hoisted(() => vi.fn(async () => ({ sid: 'never', createdAt: 0 })));
+const listSessionsMock = vi.hoisted(() => vi.fn(async () => ({ sessions: [] as Array<{ sid: string; createdAt: number; alive: boolean }> })));
+const deleteSessionMock = vi.hoisted(() => vi.fn(async () => ({ ok: true })));
+const resumeSessionMock = vi.hoisted(() => vi.fn(async () => ({ ok: true })));
+
+const runtimeAttach = vi.hoisted(() => vi.fn());
+const runtimeDetach = vi.hoisted(() => vi.fn());
+const runtimeGet = vi.hoisted(() => vi.fn(() => undefined));
+const runtimeSendInput = vi.hoisted(() => vi.fn());
+const runtimeSendResize = vi.hoisted(() => vi.fn());
+const runtimeNotePendingWrite = vi.hoisted(() => vi.fn());
+const runtimeNoteWriteFlushed = vi.hoisted(() => vi.fn());
+const runtimeSubscribeOutput = vi.hoisted(() => vi.fn(() => () => {}));
+
+vi.mock('../src/runtime-context', () => ({
+  useRuntime: () => ({
+    attach: runtimeAttach,
+    detach: runtimeDetach,
+    has: () => false,
+    get: runtimeGet,
+    sendInput: runtimeSendInput,
+    sendResize: runtimeSendResize,
+    notePendingWrite: runtimeNotePendingWrite,
+    noteWriteFlushed: runtimeNoteWriteFlushed,
+    subscribeOutput: runtimeSubscribeOutput,
+  }),
+  useApi: () => ({
+    createSession: createSessionMock,
+    deleteSession: deleteSessionMock,
+    listSessions: listSessionsMock,
+    resumeSession: resumeSessionMock,
+  }),
+  useGetToken: () => () => 'test-token',
+  HttpError: class extends Error {
+    constructor(
+      public readonly status: number,
+      message: string,
+    ) {
+      super(message);
+      this.name = 'HttpError';
+    }
+  },
+}));
+
+import { MainPane } from '../src/components/MainPane';
+import { useBootstrap } from '../src/hooks/useBootstrap';
+import { useStore } from '../src/store';
+
+function AppShell() {
+  useBootstrap();
+  return <MainPane />;
+}
+
+async function flushMicrotasks(times = 5): Promise<void> {
+  for (let i = 0; i < times; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}
+
+function installXtermShims(): void {
+  if (!window.matchMedia) {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  }
+  HTMLCanvasElement.prototype.getContext = function getContext() {
+    return {
+      measureText: () => ({ width: 8 }),
+      fillRect: () => {},
+      clearRect: () => {},
+      getImageData: () => ({ data: new Uint8ClampedArray(4) }),
+      putImageData: () => {},
+      createImageData: () => ({ data: new Uint8ClampedArray(4) }),
+      setTransform: () => {},
+      drawImage: () => {},
+      save: () => {},
+      fillText: () => {},
+      restore: () => {},
+      beginPath: () => {},
+      moveTo: () => {},
+      lineTo: () => {},
+      closePath: () => {},
+      stroke: () => {},
+      translate: () => {},
+      scale: () => {},
+      rotate: () => {},
+      arc: () => {},
+      fill: () => {},
+      canvas: { width: 0, height: 0 },
+    } as unknown as CanvasRenderingContext2D;
+  } as unknown as typeof HTMLCanvasElement.prototype.getContext;
+}
+
+describe('Task #716 — browser refresh must not auto-create a session', () => {
+  beforeEach(() => {
+    sessionStorage.setItem('ccsm.token', 'test-token');
+    useStore.setState({
+      token: 'test-token',
+      sessions: [],
+      activeSid: null,
+      status: 'idle',
+      sessionStatuses: {},
+    });
+    installXtermShims();
+
+    createSessionMock.mockClear();
+    listSessionsMock.mockClear();
+    deleteSessionMock.mockClear();
+    resumeSessionMock.mockClear();
+    runtimeAttach.mockClear();
+    runtimeDetach.mockClear();
+  });
+
+  afterEach(() => {
+    cleanup();
+    sessionStorage.clear();
+  });
+
+  it('refresh with existing daemon sessions: hydrates list, never POSTs /api/sessions', async () => {
+    // Simulate the daemon already having two live sessions when the user
+    // hits F5 — useBootstrap.listSessions is the only path that should
+    // populate the store.
+    listSessionsMock.mockResolvedValueOnce({
+      sessions: [
+        { sid: 'sid-existing-1', createdAt: 1000, alive: true },
+        { sid: 'sid-existing-2', createdAt: 2000, alive: true },
+      ],
+    });
+
+    render(<AppShell />);
+    await flushMicrotasks();
+
+    // listSessions fired once (the bootstrap hook owns the GET).
+    expect(listSessionsMock).toHaveBeenCalledTimes(1);
+    // createSession MUST NOT fire — the bug was that MainPane's old
+    // bootstrap effect raced this hydrate and POSTed a brand-new session
+    // on every refresh.
+    expect(createSessionMock).not.toHaveBeenCalled();
+    // Store reflects the daemon's existing rows.
+    expect(useStore.getState().sessions.map((s) => s.sid)).toEqual([
+      'sid-existing-1',
+      'sid-existing-2',
+    ]);
+    // Bootstrap deliberately leaves activeSid alone so the user picks.
+    expect(useStore.getState().activeSid).toBeNull();
+    // No runtime.attach: that's the user-action callers' job (Sidebar
+    // onSelectSession after POST /resume).
+    expect(runtimeAttach).not.toHaveBeenCalled();
+  });
+
+  it('first visit with empty daemon: still does NOT auto-create, waits for user to click + New Session', async () => {
+    // The truly broken case before the #716 fix: a brand-new browser tab
+    // opened against a daemon with no sessions auto-fired createSession,
+    // teaching the app to multiply sessions on every refresh thereafter.
+    listSessionsMock.mockResolvedValueOnce({ sessions: [] });
+
+    render(<AppShell />);
+    await flushMicrotasks();
+
+    expect(listSessionsMock).toHaveBeenCalledTimes(1);
+    expect(createSessionMock).not.toHaveBeenCalled();
+    expect(useStore.getState().sessions).toEqual([]);
+    expect(useStore.getState().activeSid).toBeNull();
+    expect(runtimeAttach).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/test/MainPane.strictmode.test.tsx
+++ b/packages/ui/test/MainPane.strictmode.test.tsx
@@ -206,7 +206,7 @@ describe('MainPane under React.StrictMode (T10 reshape of P1-3 regression)', () 
     sessionStorage.clear();
   });
 
-  it('creates exactly one session despite StrictMode double-invoke', async () => {
+  it('does NOT auto-create a session on first paint (Task #716 — refresh must not multiply sessions)', async () => {
     render(
       <StrictMode>
         <MainPane />
@@ -215,15 +215,16 @@ describe('MainPane under React.StrictMode (T10 reshape of P1-3 regression)', () 
 
     await flushMicrotasks();
 
-    // Critical invariant carried over from T6: POST /api/sessions fires once
-    // even though the bootstrap effect ran twice (mount → cleanup → re-mount
-    // under StrictMode dev).
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    // T10 invariant: runtime.attach was invoked at least once for the
-    // bootstrapped sid, but never with detach (detach belongs to the user-
-    // initiated close path in the sidebar, not React cleanup).
-    expect(runtimeAttach).toHaveBeenCalled();
-    expect(runtimeAttach.mock.calls[0]![0]).toBe('sid-test-1');
+    // Task #716: the bootstrap auto-create effect was removed because it
+    // raced useBootstrap.listSessions on every browser refresh and POSTed
+    // a fresh session each time. The user must now click + New Session
+    // explicitly. POST /api/sessions must NOT have fired here (no fetch
+    // call at all — useBootstrap lives outside MainPane and isn't mounted
+    // in this test). And no runtime.attach should happen, because attach
+    // is only invoked by the user-action callers (Sidebar onNewSession /
+    // onSelectSession) AFTER a daemon-side spawn HTTP returns 200.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(runtimeAttach).not.toHaveBeenCalled();
     expect(runtimeDetach).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## Summary

Task #716 [bug-P1] — browser refresh against the daemon HTTP root was POSTing `/api/sessions` every time, leaving a stale row per F5.

**Root cause** (single sentence): `MainPane`'s bootstrap `useEffect` saw `sessions.length === 0` on every fresh mount (the in-memory store starts empty even though the daemon's session list survives the reload) and fire-and-forgot `api.createSession`, racing `useBootstrap.listSessions` and persisting a brand-new session on every refresh.

**Fix**: delete the auto-create bootstrap effect in `packages/ui/src/components/MainPane.tsx`. `useBootstrap` (GET `/api/sessions`) is now the single source of "what's already alive on the daemon"; the user clicks **+ New Session** in the sidebar to mint a fresh sid. The pre-existing `[no active session — click + New Session]` notice in the xterm lifecycle effect already covers the empty-store first paint.

## Scope note (red-line callout)

The dispatch prompt said "only touch `packages/frontend-web/src/` + `packages/frontend-web/test/`", but the auto-create effect lives in the shared `@ccsm/ui` package (`MainPane.tsx`) and is mounted by both the web and Tauri shells. The bug is in the shared code path, so the fix has to land there. The Tauri shell gets the same behaviour change for free, which matches user expectation (Tauri reload should also reattach existing sessions, not multiply them — same as web refresh).

Tests live next to the source under `packages/ui/test/` for the same reason; `packages/ui` already has the jsdom + xterm + testing-library scaffolding while `packages/frontend-web` does not, so the test-DRY win is on this side.

## Test cases (both acceptance criteria covered)

`packages/ui/test/BootstrapRefresh.test.tsx`:
1. `refresh with existing daemon sessions: hydrates list, never POSTs /api/sessions` — `listSessions` returns 2 rows, store hydrates, `createSession` is asserted **not called**, `runtime.attach` is asserted **not called**.
2. `first visit with empty daemon: still does NOT auto-create, waits for user to click + New Session` — `listSessions` returns `[]`, store stays empty, `createSession` is asserted **not called**. This is the "true fix" check from the task spec.

`packages/ui/test/MainPane.strictmode.test.tsx`:
- The old `creates exactly one session despite StrictMode double-invoke` case is inverted into `does NOT auto-create a session on first paint (Task #716 — refresh must not multiply sessions)` — same fixture (StrictMode + jsdom), flipped invariant. The remaining two cases (xterm mounts after StrictMode remount, OUTPUT routing) are unchanged.

## Local checks (host: Windows 11, mode: fast)

- lint: clean (`pnpm -F @ccsm/ui lint` + `pnpm -F @ccsm/frontend-web lint` exit 0)
- typecheck: clean (`pnpm -F @ccsm/ui typecheck` + `pnpm -F @ccsm/frontend-web typecheck` exit 0)
- build: clean (`pnpm -F @ccsm/frontend-web build` exit 0; ui tsc emit also clean)
- unit tests:
  - `pnpm -F @ccsm/ui exec vitest run test/BootstrapRefresh.test.tsx test/MainPane.strictmode.test.tsx` → 2 files / 5 tests passed (~3.8 s)
  - `pnpm -F @ccsm/ui test` full → 4 files passed (the pre-existing `frame-codec.test.ts` failure is a `@ccsm/shared` resolution issue on a clean tree before deps are built; reproduces on baseline `working` without this PR's changes — unrelated to #716)
  - `pnpm -F @ccsm/frontend-web test` full → 6 tests passed
- e2e: skipped — pure UI bootstrap-effect change, no e2e harness covers this path; the new vitest cases give the regression hook future bisects need.

## Reverse-verify

Patch-flow (per dev.md §2 — no repo-level mutating ops across worktrees):

```
git diff packages/ui/src/components/MainPane.tsx > /tmp/task-716-mainpane.patch
git checkout -- packages/ui/src/components/MainPane.tsx
pnpm -F @ccsm/ui exec vitest run test/BootstrapRefresh.test.tsx test/MainPane.strictmode.test.tsx
# -> Test Files 2 failed | Tests 3 failed | 2 passed
git apply /tmp/task-716-mainpane.patch
pnpm -F @ccsm/ui exec vitest run test/BootstrapRefresh.test.tsx test/MainPane.strictmode.test.tsx
# -> Test Files 2 passed | Tests 5 passed
```

Without the fix:
- BootstrapRefresh `refresh with existing daemon sessions` FAIL — `createSession` was called once.
- BootstrapRefresh `first visit with empty daemon` FAIL — `createSession` was called once.
- MainPane.strictmode `does NOT auto-create on first paint` FAIL — `fetchMock` was called once.

With the fix: all 5 cases pass.

## Out of scope

- Local manual tauri-dev + browser F5 verification not run on this machine (no live tauri build artifacts handy this session); the unit cases reproduce the exact race deterministically.