### PR TITLE
ci: add e2e-tauri windows job for tauri-driver smoke (Task #723)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,86 @@ jobs:
           path: packages/e2e/playwright-report/
           if-no-files-found: ignore
 
+  e2e-tauri:
+    # Task #723 [S1-followup]: Tauri 2 desktop smoke via tauri-driver +
+    # WebDriverIO. Windows-only (Tauri 2 webview = WebView2 = Edge, driven by
+    # msedgedriver pre-installed on `windows-latest`). Runs only on
+    # workflow_dispatch / schedule / push-to-main because the debug `tauri
+    # build` Rust compile is ~10 min cold (cached subsequent), too slow for
+    # every PR. swatinem/rust-cache hot path keeps reruns under ~3 min.
+    #
+    # Architecture:
+    #   wdio  ──HTTP──>  tauri-driver (port 4444)  ──spawns──>  msedgedriver
+    #                                              ──launches──> ccsm-tauri.exe
+    # Spec scope = react-shell-mounts smoke (no daemon API click), per
+    # packages/e2e-tauri/tests/smoke.spec.ts header doc.
+    if: github.event_name != 'pull_request'
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install Rust toolchain (stable msvc)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache Rust build
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: packages/frontend-tauri/src-tauri -> target
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache cargo bin (tauri-driver)
+        # `cargo install tauri-driver` is ~3 min cold; cache the built binary
+        # keyed on the cargo registry index so it survives until tauri-driver
+        # ships an upstream release.
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/tauri-driver.exe
+          key: cargo-bin-tauri-driver-v2-${{ runner.os }}
+
+      - name: Install tauri-driver (if not cached)
+        shell: bash
+        run: |
+          if [ ! -f "$HOME/.cargo/bin/tauri-driver.exe" ]; then
+            cargo install tauri-driver --locked
+          else
+            echo "tauri-driver cached at $HOME/.cargo/bin/tauri-driver.exe"
+          fi
+
+      - name: Build workspace (shared/core/ui/daemon required by tauri build)
+        run: pnpm -r build
+
+      - name: Tauri build (debug)
+        # Debug build is ~3 min on hot rust-cache (vs ~10 min release for
+        # the nightly `tauri-build` job). Smoke spec only needs the .exe;
+        # no .msi packaging, so debug profile suffices.
+        run: pnpm -F @ccsm/frontend-tauri tauri build --debug
+
+      - name: Run e2e-tauri smoke
+        shell: bash
+        env:
+          # wdio.conf.ts defaults TAURI_E2E_APP to target/release; we built
+          # debug, so override. msedgedriver.exe is pre-installed on
+          # `windows-latest` runners under C:/Program Files (x86)/Microsoft/Edge/Application
+          # but the simpler path is the bundled one in `C:/SeleniumWebDrivers/EdgeDriver/msedgedriver.exe`.
+          TAURI_E2E_APP: ${{ github.workspace }}/packages/frontend-tauri/src-tauri/target/debug/ccsm-tauri.exe
+          TAURI_E2E_MSEDGEDRIVER: C:/SeleniumWebDrivers/EdgeDriver/msedgedriver.exe
+        run: pnpm -F @ccsm/e2e-tauri test
+
   tauri-build:
     # T14 (#681): nightly Windows tauri build producing the .msi artifact.
     # Skipped on pull_request (Rust compile is ~10 min and blocks PR cycle);


### PR DESCRIPTION
## Summary

Adds a `windows-latest` CI job that builds `ccsm-tauri.exe` (debug profile) and runs the existing `packages/e2e-tauri` WebDriverIO smoke (tauri-driver -> msedgedriver -> WebView2 -> ccsm-tauri).

Per manager scope-down on Task #723:
- Subtask A ("recover packages/e2e-tauri") was a no-op: the package is already on `working` from #680 / commit 9bc2bdf. Real remaining work = wire it into CI.
- Subtask B ("cross-origin e2e-web via vite preview") split out to Task #731, blocked by #718 / PR #1133 (frontend-web cross-origin hostBase support).

Only file changed: `.github/workflows/ci.yml` (+80 / -0). No product code touched (red lines: `src-tauri/`, `frontend-tauri/src/`, `daemon/`, `core/` all untouched).

## Design notes

- **Gated `if: github.event_name != 'pull_request'`**: mirrors the existing `tauri-build` job. Cold Rust compile is ~10 min; running on every PR would balloon PR cycle. Schedule (nightly) + `workflow_dispatch` + push-to-main is enough for regression catch. Open question for reviewer: keep PR-skip, or run on PRs that touch `packages/frontend-tauri/**` / `packages/e2e-tauri/**`? See `paths-filter` follow-up if desired.
- **Debug build, not release**: smoke spec only needs the `.exe` (no `.msi` packaging); debug profile is ~3x faster on hot rust-cache.
- **`tauri-driver` cargo-bin cache**: `cargo install tauri-driver --locked` is ~3 min cold. Cached at `~/.cargo/bin/tauri-driver.exe` keyed on runner OS so it survives until tauri-driver ships an upstream release.
- **`TAURI_E2E_APP` env override**: `wdio.conf.ts` defaults to `target/release/`; we built debug, so override to `target/debug/`.
- **`TAURI_E2E_MSEDGEDRIVER` env**: points at `windows-latest`'s pre-installed `C:/SeleniumWebDrivers/EdgeDriver/msedgedriver.exe`.

## Local checks (host: Windows 11, mode: fast)

Per dev.md `3 yml-only PR rules: lint/typecheck only required since no `.ts/.tsx` changed. I ran the actual e2e-tauri smoke locally as well to validate the CI invocation.

- lint: skipped (yml-only); confirmed `pnpm -F @ccsm/e2e-tauri lint` exit 0
- typecheck: skipped (yml-only); confirmed `pnpm -F @ccsm/e2e-tauri typecheck` exit 0
- build: skipped (yml-only)
- unit tests: skipped, no source changed
- e2e: `pnpm -F @ccsm/e2e-tauri test` against locally-built `target/debug/ccsm-tauri.exe`:

```
"spec" Reporter:
[webview2 147.0.3912.98 windows #0-0] ccsm-tauri smoke (T13)
[webview2 147.0.3912.98 windows #0-0]    OK launches the Tauri shell and bootstraps the daemon end-to-end
[webview2 147.0.3912.98 windows #0-0] 1 passing (791ms)

Spec Files:	 1 passed, 1 total (100% completed) in 00:00:14
```

## Test plan

- [ ] CI: trigger via `workflow_dispatch` after merge to confirm job runs green on `windows-latest` (PR-skip means it won't run on this PR itself)
- [ ] Verify `swatinem/rust-cache` + cargo-bin cache hit on second run (target ~3 min wall)

## Out of scope (Task #731)

- Cross-origin e2e-web via vite preview + Playwright Chromium fetching loopback daemon. Requires `frontend-web/src/hostConfig.ts` to accept an injected daemon URL (currently hard-coded to `window.location.origin`). Tracked by Task #731, blocked by PR #1133.