### PR TITLE
feat(frontend-web): cross-origin token bootstrap matrix (Task #719)

### DIFF
--- a/packages/frontend-web/src/hostConfig.ts
+++ b/packages/frontend-web/src/hostConfig.ts
@@ -31,18 +31,27 @@ export const DEFAULT_DAEMON_BASE = 'http://127.0.0.1:9876';
 export interface ResolveTokenDeps {
   /** Search portion of the current URL, e.g. `?token=abc`. */
   search: string;
-  /** fetch implementation. Must accept a relative URL. */
+  /** fetch implementation. */
   fetch: typeof globalThis.fetch;
+  /**
+   * Daemon base URL (Task #719 / S2-T4). When the SPA is served from a
+   * different origin than the daemon (e.g. Cloudflare Pages → loopback
+   * daemon), `/token` must be requested as an absolute URL or the browser
+   * will hit the SPA host instead. Pass the result of `resolveDaemonBase()`
+   * here. When omitted or empty, falls back to the relative `/token` path
+   * (same-origin / daemon-embedded SPA).
+   */
+  daemonBase?: string;
 }
 
 /**
  * Returns the daemon bearer token, or null if neither the URL nor the
  * daemon `/token` endpoint produced one.
  *
- * Priority (Task #696):
+ * Priority (Task #696, cross-origin extension Task #719):
  *   1. URL `?token=` — back-compat with legacy `ccsm ready: ...?token=` URL.
- *   2. GET /token (same-origin) — preferred path so users can just open
- *      `http://127.0.0.1:9876/` with no query string.
+ *   2. GET <daemonBase>/token — same-origin in the daemon-embedded case;
+ *      cross-origin (with CORS, see daemon http.mts) when SPA is on Pages.
  *   3. null — caller surfaces a friendly "daemon offline / no token" UI.
  *
  * The function is pure w.r.t. its `deps` argument (no window / sessionStorage
@@ -52,8 +61,10 @@ export async function resolveToken(deps: ResolveTokenDeps): Promise<string | nul
   const fromUrl = new URLSearchParams(deps.search).get('token');
   if (fromUrl && fromUrl.length > 0) return fromUrl;
 
+  const base = deps.daemonBase && deps.daemonBase.length > 0 ? deps.daemonBase : '';
+  const tokenUrl = `${base}/token`;
   try {
-    const res = await deps.fetch('/token');
+    const res = await deps.fetch(tokenUrl);
     if (!res.ok) return null;
     const body = (await res.json()) as { token?: unknown };
     if (typeof body.token === 'string' && body.token.length > 0) {

--- a/packages/frontend-web/src/main.tsx
+++ b/packages/frontend-web/src/main.tsx
@@ -1,23 +1,36 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
-import { resolveToken, TOKEN_STORAGE_KEY } from './hostConfig';
+import { resolveDaemonBase, resolveToken, TOKEN_STORAGE_KEY } from './hostConfig';
 import '@ccsm/ui/styles.css';
 
 // Task #696: token bootstrap.
 //   1. URL `?token=` (back-compat with legacy `ccsm ready: http://...?token=`)
-//   2. fetch /token from the same-origin daemon (loopback-only, see daemon
-//      http.mts — no auth, returns `{ token }`)
+//   2. fetch <daemonBase>/token — same-origin in the daemon-embedded case,
+//      cross-origin (with CORS, see daemon http.mts) when SPA is on Pages.
 //   3. neither -> render a friendly "daemon offline" message and bail.
+//
+// Task #719 (S2-T4): the /token request must use the resolved daemon base
+// so it works in cross-origin mode (Pages → loopback daemon). Same-origin
+// loopback continues to hit `<origin>/token` because resolveDaemonBase
+// returns window.location.origin in that case.
 async function bootstrap(): Promise<void> {
   const rootEl = document.getElementById('root');
   if (!rootEl) {
     throw new Error('Root element #root not found');
   }
 
+  const daemonBase = resolveDaemonBase({
+    search: window.location.search,
+    hostname: window.location.hostname,
+    origin: window.location.origin,
+    envBase: import.meta.env.VITE_DAEMON_BASE,
+  });
+
   const token = await resolveToken({
     search: window.location.search,
     fetch: window.fetch.bind(window),
+    daemonBase,
   });
 
   if (!token) {

--- a/packages/frontend-web/test/resolveToken.test.ts
+++ b/packages/frontend-web/test/resolveToken.test.ts
@@ -1,4 +1,4 @@
-// Token bootstrap priority chain (Task #696).
+// Token bootstrap priority chain (Task #696, cross-origin matrix Task #719).
 
 import { describe, expect, it, vi } from 'vitest';
 
@@ -66,5 +66,121 @@ describe('resolveToken', () => {
     );
     const got = await resolveToken({ search: '?token=', fetch });
     expect(got).toBe('from-daemon-2');
+  });
+
+  // ---------------------------------------------------------------------
+  // Task #719 (S2-T4): cross-origin matrix.
+  // When the SPA is served from a different origin than the daemon (e.g.
+  // Cloudflare Pages → http://127.0.0.1:9876), the relative `/token` path
+  // would hit the SPA host instead of the daemon. resolveToken must use the
+  // resolved daemon base as an absolute URL prefix.
+  // ---------------------------------------------------------------------
+
+  describe('cross-origin (daemonBase set)', () => {
+    const DAEMON_BASE = 'http://127.0.0.1:9876';
+
+    it('still prefers URL ?token= without hitting fetch', async () => {
+      const fetch = mockFetch(async () => {
+        throw new Error('should not be called');
+      });
+      const got = await resolveToken({
+        search: '?token=from-url-xo',
+        fetch,
+        daemonBase: DAEMON_BASE,
+      });
+      expect(got).toBe('from-url-xo');
+    });
+
+    it('fetches absolute <daemonBase>/token URL when URL has no token', async () => {
+      const fetch = mockFetch(async (input) => {
+        expect(String(input)).toBe(`${DAEMON_BASE}/token`);
+        return new Response(JSON.stringify({ token: 'from-daemon-xo' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      });
+      const got = await resolveToken({
+        search: '',
+        fetch,
+        daemonBase: DAEMON_BASE,
+      });
+      expect(got).toBe('from-daemon-xo');
+    });
+
+    it('returns null when cross-origin daemon is offline (fetch throws)', async () => {
+      // Mirrors the browser's behaviour when the loopback daemon is down or
+      // CORS preflight fails: TypeError from window.fetch.
+      const fetch = mockFetch(async () => {
+        throw new TypeError('Failed to fetch');
+      });
+      const got = await resolveToken({
+        search: '',
+        fetch,
+        daemonBase: DAEMON_BASE,
+      });
+      expect(got).toBeNull();
+    });
+
+    it('returns null when cross-origin /token responds non-2xx', async () => {
+      const fetch = mockFetch(
+        async () => new Response('forbidden', { status: 403 }),
+      );
+      const got = await resolveToken({
+        search: '',
+        fetch,
+        daemonBase: DAEMON_BASE,
+      });
+      expect(got).toBeNull();
+    });
+
+    it('returns null when cross-origin /token body lacks token field', async () => {
+      const fetch = mockFetch(
+        async () =>
+          new Response(JSON.stringify({ other: 'x' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          }),
+      );
+      const got = await resolveToken({
+        search: '',
+        fetch,
+        daemonBase: DAEMON_BASE,
+      });
+      expect(got).toBeNull();
+    });
+
+    it('empty URL token + cross-origin → falls back to <daemonBase>/token', async () => {
+      const fetch = mockFetch(async (input) => {
+        expect(String(input)).toBe(`${DAEMON_BASE}/token`);
+        return new Response(JSON.stringify({ token: 'from-daemon-xo-2' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      });
+      const got = await resolveToken({
+        search: '?token=',
+        fetch,
+        daemonBase: DAEMON_BASE,
+      });
+      expect(got).toBe('from-daemon-xo-2');
+    });
+
+    it('empty daemonBase string is treated as same-origin (relative /token)', async () => {
+      // Defensive: callers should pass the result of resolveDaemonBase(), but
+      // an empty string must not produce a malformed URL.
+      const fetch = mockFetch(async (input) => {
+        expect(String(input)).toBe('/token');
+        return new Response(JSON.stringify({ token: 'from-same-origin' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      });
+      const got = await resolveToken({
+        search: '',
+        fetch,
+        daemonBase: '',
+      });
+      expect(got).toBe('from-same-origin');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Task #719 [S2-T4]: validate the URL → /token → null bootstrap chain in cross-origin mode (Pages SPA → loopback daemon).
- `resolveToken` now takes an optional `daemonBase`; when set it issues `<daemonBase>/token` as an absolute URL so the request actually reaches the daemon. `main.tsx` wires `resolveDaemonBase()` (Task #712) into the call.
- Same-origin / daemon-embedded behaviour is preserved: `resolveDaemonBase` returns `window.location.origin` on loopback hostnames, so the `/token` request is functionally same-origin (relative when `daemonBase` is empty).
- Daemon `/token` already serves CORS headers (`packages/daemon/src/http.mts:423-431`), so no daemon-side change required.

## Test matrix (packages/frontend-web/test/resolveToken.test.ts)
Same-origin (existing, 6 cases): URL token, fallback to /token, non-2xx, fetch throw, missing token field, empty URL token.
Cross-origin (new, 7 cases): URL token shortcut bypasses fetch, absolute `<daemonBase>/token` is requested, `TypeError('Failed to fetch')` (offline / CORS preflight) → null, non-2xx → null, missing token field → null, empty URL token falls back to absolute, empty `daemonBase` string defensively falls back to relative `/token`.

13 cases in resolveToken.test.ts + 9 in hostConfig.test.ts = 22 PASS.

## Local checks (host: Windows, mode: fast)
- lint: ok (exit 0)
- typecheck: ok (exit 0)
- build: ok (vite build 2.45s, 58 modules)
- unit tests: `pnpm -F @ccsm/frontend-web test` — 22/22 PASS, 2.48s
- e2e: skipped, change is purely web-shell bootstrap and is not covered by any electron probe-e2e harness.

## Test plan
- [x] resolveToken.test.ts cross-origin matrix green locally
- [x] resolveToken.test.ts same-origin matrix unchanged & green
- [x] frontend-web build green (no main.tsx regression)
- [ ] CI three-platform matrix