### PR TITLE
daemon: opt-in *.cc-sm.pages.dev preview origin (Task #721)

### DIFF
--- a/packages/daemon/src/auth.mts
+++ b/packages/daemon/src/auth.mts
@@ -17,15 +17,40 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 // (Cloudflare Pages). It issues cross-origin loopback fetches to the local
 // daemon (which still binds 127.0.0.1) so we must allow the exact origin
 // `https://cc-sm.pages.dev` and ONLY that — no PR-preview subdomains
-// (`https://abc123.cc-sm.pages.dev` is reject-by-default; T8 #?? will gate
-// preview origins behind an explicit opt-in flag), no spoof variants
+// (`https://abc123.cc-sm.pages.dev` is reject-by-default; see S2 #721 / T8
+// below for the opt-in env flag), no spoof variants
 // (`https://cc-sm-evil.pages.dev`, `https://cc-sm.pages.dev.attacker.com`),
 // and no http (Chrome's PNA + mixed-content rules require https for the
 // loopback initiator).
+//
+// S2 #721 / T8: when `CCSM_ALLOW_PAGES_PREVIEWS=1` is set in the daemon's
+// process env, single-label `*.cc-sm.pages.dev` preview subdomains over https
+// are additionally allow-listed. This is a developer / dogfood opt-in for
+// reviewing Cloudflare Pages PR previews against a local daemon; it is OFF
+// by default so end-user installs keep the tightest possible origin surface.
+// Constraints kept even when opt-in is on:
+//   - protocol MUST be https (no http preview)
+//   - exactly ONE label between scheme and `cc-sm.pages.dev`
+//     (`abc123.cc-sm.pages.dev` ✓, `a.b.cc-sm.pages.dev` ✗,
+//      `cc-sm.pages.dev` is the prod host handled separately)
+//   - that label MUST be a non-empty DNS label (alnum + hyphen, no dot)
+//   - suffix matched as `.cc-sm.pages.dev` (with leading dot) so
+//     `evil-cc-sm.pages.dev` cannot squeeze through
 const ALLOWED_ORIGIN_HOSTS = new Set(['127.0.0.1', 'localhost']);
 const ALLOWED_ORIGIN_PROTOCOLS = new Set(['http:', 'https:']);
 const TAURI_ORIGIN = 'tauri://localhost';
 const PAGES_PROD_ORIGIN = 'https://cc-sm.pages.dev';
+const PAGES_PREVIEW_SUFFIX = '.cc-sm.pages.dev';
+// Single DNS label: alnum, may contain internal hyphens, 1..63 chars.
+// (Conservative; Cloudflare Pages preview hosts are deploy-id hashes that
+// match this shape.)
+const PAGES_PREVIEW_LABEL_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
+
+function pagesPreviewsEnabled(): boolean {
+  // Read on every call so tests can flip the flag mid-suite without
+  // re-importing the module. The env access is cheap.
+  return process.env.CCSM_ALLOW_PAGES_PREVIEWS === '1';
+}
 
 function writeJson(res: ServerResponse, status: number, body: unknown): void {
   res.statusCode = status;
@@ -74,6 +99,19 @@ export function classifyOrigin(rawOrigin: string | undefined): 'absent' | 'allow
     url = new URL(rawOrigin);
   } catch {
     return 'rejected';
+  }
+  // S2 #721 / T8: opt-in `*.cc-sm.pages.dev` preview subdomains.
+  // Checked BEFORE the loopback host gate so a preview origin doesn't get
+  // spuriously rejected as "not 127.0.0.1/localhost". Must still be https,
+  // exactly one label deep, and that label must look like a real DNS label.
+  if (pagesPreviewsEnabled() && url.protocol === 'https:') {
+    const host = url.hostname;
+    if (host.endsWith(PAGES_PREVIEW_SUFFIX) && host !== PAGES_PREVIEW_SUFFIX.slice(1)) {
+      const label = host.slice(0, host.length - PAGES_PREVIEW_SUFFIX.length);
+      if (label.length > 0 && !label.includes('.') && PAGES_PREVIEW_LABEL_RE.test(label)) {
+        return 'allowed';
+      }
+    }
   }
   if (!ALLOWED_ORIGIN_PROTOCOLS.has(url.protocol)) return 'rejected';
   if (!ALLOWED_ORIGIN_HOSTS.has(url.hostname)) return 'rejected';

--- a/packages/daemon/test/auth.test.ts
+++ b/packages/daemon/test/auth.test.ts
@@ -3,7 +3,7 @@
 // auth path and the in-memory session CRUD stub.
 
 import type { AddressInfo } from 'node:net';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 
 import type {
   CreateSessionResponse,
@@ -365,5 +365,79 @@ describe('S2 #702 — Chrome PNA preflight echo', () => {
     // Other preflight headers still intact.
     expect(r.headers.get('access-control-allow-origin')).toBe('https://cc-sm.pages.dev');
     expect(r.headers.get('access-control-allow-methods')).toMatch(/POST/);
+  });
+});
+
+// S2 #721 / T8 — opt-in `*.cc-sm.pages.dev` preview subdomain allow-list.
+// Default OFF: PR-preview subdomains are rejected (already covered above).
+// When `CCSM_ALLOW_PAGES_PREVIEWS=1` is set, single-label https preview
+// subdomains are accepted; spoof / multi-label / http variants stay rejected.
+describe('S2 #721 / T8 — CCSM_ALLOW_PAGES_PREVIEWS opt-in', () => {
+  const ENV_KEY = 'CCSM_ALLOW_PAGES_PREVIEWS';
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedEnv;
+  });
+
+  it('default (env unset): preview subdomain rejected', () => {
+    delete process.env[ENV_KEY];
+    expect(classifyOrigin('https://abc123.cc-sm.pages.dev')).toBe('rejected');
+  });
+
+  it('CCSM_ALLOW_PAGES_PREVIEWS=0: preview subdomain still rejected', () => {
+    process.env[ENV_KEY] = '0';
+    expect(classifyOrigin('https://abc123.cc-sm.pages.dev')).toBe('rejected');
+  });
+
+  it('CCSM_ALLOW_PAGES_PREVIEWS=1: single-label https preview accepted', () => {
+    process.env[ENV_KEY] = '1';
+    expect(classifyOrigin('https://abc123.cc-sm.pages.dev')).toBe('allowed');
+    expect(classifyOrigin('https://deploy-preview-42.cc-sm.pages.dev')).toBe('allowed');
+  });
+
+  it('opt-in: prod host still allowed (regression)', () => {
+    process.env[ENV_KEY] = '1';
+    expect(classifyOrigin('https://cc-sm.pages.dev')).toBe('allowed');
+  });
+
+  it('opt-in: http preview rejected (must be https)', () => {
+    process.env[ENV_KEY] = '1';
+    expect(classifyOrigin('http://abc123.cc-sm.pages.dev')).toBe('rejected');
+  });
+
+  it('opt-in: multi-label preview rejected (only single label allowed)', () => {
+    process.env[ENV_KEY] = '1';
+    expect(classifyOrigin('https://a.b.cc-sm.pages.dev')).toBe('rejected');
+  });
+
+  it('opt-in: sibling spoof still rejected (cc-sm-evil.pages.dev)', () => {
+    process.env[ENV_KEY] = '1';
+    expect(classifyOrigin('https://cc-sm-evil.pages.dev')).toBe('rejected');
+    expect(classifyOrigin('https://x.cc-sm-evil.pages.dev')).toBe('rejected');
+  });
+
+  it('opt-in: suffix spoof still rejected (cc-sm.pages.dev.attacker.com)', () => {
+    process.env[ENV_KEY] = '1';
+    expect(classifyOrigin('https://abc.cc-sm.pages.dev.attacker.com')).toBe('rejected');
+  });
+
+  it('opt-in: empty / dotted label rejected (defensive)', () => {
+    process.env[ENV_KEY] = '1';
+    // `.cc-sm.pages.dev` parses to host `cc-sm.pages.dev` (the prod host) so
+    // is handled by the exact-match branch; the empty-label form below would
+    // only arise via crafted hostnames and must not become "allowed".
+    expect(classifyOrigin('https://_.cc-sm.pages.dev')).toBe('rejected');
+  });
+
+  it('opt-in does not loosen unrelated origins (evil.com still rejected)', () => {
+    process.env[ENV_KEY] = '1';
+    expect(classifyOrigin('https://evil.com')).toBe('rejected');
+    expect(classifyOrigin('http://evil.com')).toBe('rejected');
   });
 });


### PR DESCRIPTION
## Summary
S2 #721 / T8 — gate Cloudflare Pages PR-preview subdomains behind explicit env flag, default OFF.

- New env: \`CCSM_ALLOW_PAGES_PREVIEWS=1\`. When set, \`classifyOrigin\` accepts single-label https subdomains of \`cc-sm.pages.dev\` (e.g. \`https://abc123.cc-sm.pages.dev\`).
- Default behavior unchanged: PR-preview subdomains are rejected, only \`https://cc-sm.pages.dev\` (prod) + loopback + \`tauri://localhost\` are allow-listed.
- Hardened against spoofs even when opt-in is on: must be https; exactly one DNS label deep (no \`a.b.cc-sm.pages.dev\`); label must match conservative alnum+hyphen regex; suffix anchored on \`.cc-sm.pages.dev\` so \`cc-sm-evil.pages.dev\` and \`cc-sm.pages.dev.attacker.com\` stay rejected.
- Both \`http.mts\` (REST) and \`ws.mts\` (websocket upgrade) share the same \`classifyOrigin\` so the gate applies uniformly.

Files: \`packages/daemon/src/auth.mts\`, \`packages/daemon/test/auth.test.ts\`.

## Local checks (host: Windows 11, mode: fast)
- lint: ✓ (exit 0)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0, full \`npm run build\` after \`pnpm install --frozen-lockfile\`)
- unit tests: \`npx vitest run packages/daemon/test/auth.test.ts\` → 36/36 pass, 1.55s
- e2e: skipped, change is a daemon-internal origin classifier behind an env flag with full unit coverage; no e2e harness asserts on this code path.

## Test plan
- [ ] CI three-platform matrix green
- [ ] Default (no env): preview origin still 403
- [ ] With \`CCSM_ALLOW_PAGES_PREVIEWS=1\`: \`https://<deploy>.cc-sm.pages.dev\` reaches the daemon successfully