### PR TITLE
daemon: verify applyCorsHeaders + ws upgrade auto-inherit cc-sm.pages.dev (Task #727)

### DIFF
--- a/packages/daemon/test/auth.test.ts
+++ b/packages/daemon/test/auth.test.ts
@@ -335,6 +335,61 @@ describe('S2 #702 — pages.dev integration through the HTTP server', () => {
   });
 });
 
+// S2 T2 (Task #727) — verify applyCorsHeaders + ws upgrade auto-inherit T1's
+// classifyOrigin allow-list for `https://cc-sm.pages.dev`. T1 (PR #1141) added
+// the host to classifyOrigin; this group asserts that the HTTP CORS path
+// (applyCorsHeaders in http.mts) and the OPTIONS preflight handler echo the
+// origin (NOT `*`) and emit the standard CORS response headers — without any
+// further changes to http.mts. Companion ws.test.ts case covers ws.mts.
+describe('S2 T2 #727 — applyCorsHeaders auto-inherits cc-sm.pages.dev (no src changes)', () => {
+  it('echoes Origin (not *) on a normal POST from https://cc-sm.pages.dev', async () => {
+    // applyCorsHeaders branch: origin defined && classifyOrigin === 'allowed'
+    // → ACAO echoes `origin`. The * fallback is exercised by the
+    // "falls back to Allow-Origin: * when Origin header is absent" case.
+    const r = await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        Origin: 'https://cc-sm.pages.dev',
+        'Content-Type': 'application/json',
+      },
+      body: '{}',
+    });
+    expect(r.status).toBe(200);
+    expect(r.headers.get('access-control-allow-origin')).toBe('https://cc-sm.pages.dev');
+    expect(r.headers.get('access-control-allow-origin')).not.toBe('*');
+    expect(r.headers.get('vary')).toContain('Origin');
+  });
+
+  it('OPTIONS preflight from https://cc-sm.pages.dev → 200 + echo + standard CORS headers', async () => {
+    // Standard CORS preflight (no PNA): different from the PNA echo case
+    // above — this asserts the baseline preflight response is correct when
+    // the origin is the prod Pages host. Pre-auth: no Authorization header.
+    const r = await fetch(`${baseUrl}/api/sessions`, {
+      method: 'OPTIONS',
+      headers: {
+        Origin: 'https://cc-sm.pages.dev',
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'authorization, content-type',
+      },
+    });
+    expect(r.status).toBe(200);
+    expect(r.headers.get('access-control-allow-origin')).toBe('https://cc-sm.pages.dev');
+    expect(r.headers.get('access-control-allow-origin')).not.toBe('*');
+    const allowMethods = r.headers.get('access-control-allow-methods') ?? '';
+    expect(allowMethods).toMatch(/GET/);
+    expect(allowMethods).toMatch(/POST/);
+    expect(allowMethods).toMatch(/DELETE/);
+    expect(allowMethods).toMatch(/OPTIONS/);
+    const allowHeaders = r.headers.get('access-control-allow-headers') ?? '';
+    expect(allowHeaders).toMatch(/Authorization/i);
+    expect(allowHeaders).toMatch(/Content-Type/i);
+    expect(r.headers.get('vary')).toContain('Origin');
+    // PNA header NOT advertised when the request didn't ask for it.
+    expect(r.headers.get('access-control-allow-private-network')).toBeNull();
+  });
+});
+
 describe('S2 #702 — Chrome PNA preflight echo', () => {
   it('OPTIONS with Access-Control-Request-Private-Network: true echoes Allow-Private-Network: true', async () => {
     const r = await fetch(`${baseUrl}/api/sessions`, {

--- a/packages/daemon/test/ws.test.ts
+++ b/packages/daemon/test/ws.test.ts
@@ -272,6 +272,34 @@ describe('ws upgrade auth', () => {
     expect(d.ws.readyState).toBe(WebSocket.CLOSED);
   });
 
+  // S2 T2 (Task #727): ws upgrade must auto-inherit T1's classifyOrigin
+  // allow-list for `https://cc-sm.pages.dev`. ws.mts calls
+  // `classifyOrigin(origin)` and rejects on 'rejected'. After T1 (PR #1141)
+  // the prod Pages host classifies as 'allowed', so the upgrade should yield
+  // a 101 (ws OPEN) without any further change to ws.mts.
+  it('accepts Origin: https://cc-sm.pages.dev (S2 T2 #727)', async () => {
+    const sid = await createSid();
+    const d = dial(`${baseWs}/ws?sid=${sid}&token=${TOKEN}`, {
+      Origin: 'https://cc-sm.pages.dev',
+    });
+    await waitOpen(d.ws);
+    expect(d.ws.readyState).toBe(WebSocket.OPEN);
+    d.ws.close();
+  });
+
+  it('rejects Origin: https://cc-sm-evil.pages.dev (sibling spoof, S2 T2 #727)', async () => {
+    // Defense-in-depth: confirm the ws path also rejects the spoof variant
+    // that classifyOrigin marks 'rejected'. Without this we could regress
+    // ws.mts independently of http.mts.
+    const sid = await createSid();
+    const d = dial(`${baseWs}/ws?sid=${sid}&token=${TOKEN}`, {
+      Origin: 'https://cc-sm-evil.pages.dev',
+    });
+    const closed = await d.closed;
+    expect(closed.code).toBeGreaterThanOrEqual(1000);
+    expect(d.ws.readyState).toBe(WebSocket.CLOSED);
+  });
+
   // #672 regression: ws upgrade with NO Origin header must still succeed
   // (treated as same-origin). The `ws` Node client does NOT auto-add an
   // Origin header (unlike the browser API), so constructing a WebSocket


### PR DESCRIPTION
## Summary

S2 T2 (Task #727) — pure test-only follow-up to T1 (PR #1141). T1 added `https://cc-sm.pages.dev` to `classifyOrigin`. This PR pins that both `applyCorsHeaders` (http.mts) and the ws upgrade path (ws.mts) inherit that allow-list automatically, with **zero `packages/daemon/src/` changes**.

- `test/auth.test.ts` — new `describe('S2 T2 #727 — applyCorsHeaders auto-inherits cc-sm.pages.dev (no src changes)')` with two cases: (1) POST from `https://cc-sm.pages.dev` echoes the origin (not `*`) + `Vary: Origin`, (2) OPTIONS preflight (no PNA) returns 200 + echoed origin + standard `Access-Control-Allow-{Methods,Headers}` + no `Allow-Private-Network` since it wasn't requested.
- `test/ws.test.ts` — new ws upgrade cases inside the existing `ws upgrade auth` describe: accept `Origin: https://cc-sm.pages.dev` (101 OPEN), reject sibling spoof `https://cc-sm-evil.pages.dev`. The reject case is verified to actually hit the `classifyOrigin === 'rejected'` branch in ws.mts (stderr shows `[ccsm/ws] reject origin="https://cc-sm-evil.pages.dev"`).

Plan ref: `~/.claude/plans/s2-cloudflare-pages-plan.md` row T2.

## Local checks (host: Windows 11, mode: fast)
- lint: ✓ (exit 0) — `pnpm -F daemon lint`
- typecheck: ✓ (exit 0) — `pnpm -F daemon typecheck`
- build: skipped — pure test-only change, no src/.ts touched
- unit tests: ✓ `pnpm -F daemon test`
  ```
   Test Files  12 passed (12)
        Tests  113 passed | 1 skipped (114)
     Duration  6.83s
  ```
  Includes the new cases under `test/auth.test.ts` (S2 T2 #727 describe) and `test/ws.test.ts` (S2 T2 #727 ws upgrade cases). Stderr line `[ccsm/ws] reject origin="https://cc-sm-evil.pages.dev"` confirms the new ws case actually exercises ws.mts's classifyOrigin reject path.
- e2e: skipped — pure test-only change in daemon, does not affect any e2e harness