### PR TITLE
ci: add working branch to ci.yml triggers (Task #743)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,14 +2,14 @@ name: ci
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, working]
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
       - '.gitignore'
       - 'LICENSE'
   push:
-    branches: [main]
+    branches: [main, working]
     paths-ignore:
       - '**/*.md'
       - 'docs/**'


### PR DESCRIPTION
## Summary
Add `working` to ci.yml `pull_request` + `push` trigger branch filters. Currently only `main` is listed, so PRs into `working` and pushes to `working` produce zero checks — which forced manager to PATCH-remove `required_status_checks` from `working` branch protection (Task #743 backstory).

This PR is the fix: extend the filter list. No jobs / steps / matrix / other workflows changed.

```yaml
on:
  pull_request:
    branches: [main, working]
  push:
    branches: [main, working]
```

The PR itself targets `working`, so its own existence is the proof — the new trigger fires this run.

## Local checks (host: Windows, mode: yml-only)
- lint: ✓ (exit 0, `pnpm -r lint` all 8 packages Done)
- typecheck: ✓ (exit 0, after prebuild of shared/core/ui, `pnpm -r typecheck` all 8 Done)
- build: skipped (yml-only change, no .ts/.tsx touched — per dev.md §3 step 2 skip rule)
- unit tests: skipped (yml-only)
- e2e: skipped (yml-only)

## CI evidence — `gh pr checks 1145`
Captured ~25s after PR open, confirming trigger fires (would be empty `no checks reported` if the trigger were still misconfigured):

```
build (ubuntu-latest)   pending  0  https://github.com/Jiahui-Gu/ccsm/actions/runs/25513795546/job/74879337528
build (windows-latest)  pending  0  https://github.com/Jiahui-Gu/ccsm/actions/runs/25513795546/job/74879337473
tauri-build             skipping 0  https://github.com/Jiahui-Gu/ccsm/actions/runs/25513795546/job/74879338122
```

`e2e` matrix has `needs: build` so it registers after build completes; `tauri-build` is gated `if: github.event_name != 'pull_request'` so it correctly skips. `build` is the actual lint+typecheck+build job per workflow definition.

## Out of scope
- Branch protection re-enable (`gh api PUT /branches/working/protection`) — manager owns that after merge, per task spec.
- No new workflow files, no job edits.

Task #743.