### PR TITLE
test(e2e): S2 spoof-origin reject e2e (Task #753)

### DIFF
--- a/packages/e2e/fixtures/daemon.ts
+++ b/packages/e2e/fixtures/daemon.ts
@@ -34,7 +34,20 @@ export interface DaemonHandle {
   proc: ChildProcess;
 }
 
-export async function startDaemon(): Promise<DaemonHandle> {
+export interface StartDaemonOptions {
+  /**
+   * Extra env vars merged on top of `process.env` for the spawned daemon.
+   *
+   * Task #753 (S2 spoof-origin e2e): used to opt the daemon into the
+   * `CCSM_ALLOW_PAGES_PREVIEWS=1` flag so the e2e suite can verify the
+   * env-gated `*.cc-sm.pages.dev` allow-list at the HTTP layer, against a
+   * second independently-spawned daemon process (must NOT mutate the
+   * shared worker daemon's env mid-flight).
+   */
+  extraEnv?: Record<string, string>;
+}
+
+export async function startDaemon(opts: StartDaemonOptions = {}): Promise<DaemonHandle> {
   const useDist = existsSync(DAEMON_DIST_ENTRY);
   const useSrc = !useDist && existsSync(DAEMON_SRC_ENTRY);
 
@@ -52,7 +65,7 @@ export async function startDaemon(): Promise<DaemonHandle> {
 
   const proc = spawn(cmd, args, {
     cwd: DAEMON_PKG_DIR,
-    env: { ...process.env, NODE_ENV: 'test' },
+    env: { ...process.env, NODE_ENV: 'test', ...(opts.extraEnv ?? {}) },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 

--- a/packages/e2e/tests/s2-spoof-origin.spec.ts
+++ b/packages/e2e/tests/s2-spoof-origin.spec.ts
@@ -1,0 +1,126 @@
+// s2-spoof-origin.spec.ts — Task #753 (S2 收口 D, split from #744).
+//
+// Acceptance: prove the daemon's `classifyOrigin` rules hold at the HTTP
+// layer in chromium for three independent cases:
+//
+//   1. Spoof attacker subdomain
+//        Origin: https://cc-sm.pages.dev.attacker.com
+//        Expectation: 403 (suffix attack must NOT pass exact-match prod gate
+//        and must NOT match `.cc-sm.pages.dev` since the env flag is OFF).
+//
+//   2. PR-preview default reject
+//        Origin: https://abc123.cc-sm.pages.dev
+//        Daemon spawned with default env (no CCSM_ALLOW_PAGES_PREVIEWS).
+//        Expectation: 403.
+//
+//   3. PR-preview env opt-in
+//        Origin: https://abc123.cc-sm.pages.dev
+//        Daemon spawned with CCSM_ALLOW_PAGES_PREVIEWS=1.
+//        Expectation: 200 + ACAO echoes the preview origin.
+//
+// Implementation notes:
+//   - We deliberately use Playwright's `request` API (no Page) — these are
+//     pure HTTP assertions on the daemon. A real browser cannot natively
+//     send `Origin: https://abc123.cc-sm.pages.dev` from a chromium tab
+//     loaded on some other origin (Origin is set by the UA), but the
+//     `request.newContext({ extraHTTPHeaders })` API lets us drive the
+//     wire-level header the daemon sees, which is exactly what the auth
+//     layer is gating on.
+//   - Cases 1+2 reuse the worker-scoped daemon (default env). Case 3 spawns
+//     a SECOND daemon with the env flag set; we MUST NOT mutate the first
+//     daemon's env mid-flight (and `pagesPreviewsEnabled()` reads
+//     `process.env` from the daemon process, not ours, so even if we did
+//     it would have no effect). Two real processes = real env-flag check.
+
+import { expect } from '@playwright/test';
+import { request as pwRequest } from '@playwright/test';
+
+import { test as daemonTest } from '../fixtures/daemon.ts';
+import { startDaemon, stopDaemon, type DaemonHandle } from '../fixtures/daemon.ts';
+
+const test = daemonTest;
+
+test.describe('S2 spoof-origin reject (Task #753)', () => {
+  test('Case 1 — spoof `cc-sm.pages.dev.attacker.com` subdomain → 403', async ({
+    daemonUrl,
+    token,
+  }) => {
+    const base = new URL(daemonUrl).origin;
+    const ctx = await pwRequest.newContext();
+    try {
+      const resp = await ctx.get(`${base}/api/sessions`, {
+        headers: {
+          authorization: `Bearer ${token}`,
+          origin: 'https://cc-sm.pages.dev.attacker.com',
+        },
+      });
+      expect(
+        resp.status(),
+        'spoof suffix-attack origin must be rejected with 403',
+      ).toBe(403);
+      const body = (await resp.json()) as { error?: string };
+      expect(body.error).toBe('forbidden_origin');
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test('Case 2 — PR-preview `abc123.cc-sm.pages.dev` default reject → 403', async ({
+    daemonUrl,
+    token,
+  }) => {
+    const base = new URL(daemonUrl).origin;
+    const ctx = await pwRequest.newContext();
+    try {
+      const resp = await ctx.get(`${base}/api/sessions`, {
+        headers: {
+          authorization: `Bearer ${token}`,
+          origin: 'https://abc123.cc-sm.pages.dev',
+        },
+      });
+      expect(
+        resp.status(),
+        'PR-preview origin must be rejected when CCSM_ALLOW_PAGES_PREVIEWS is unset',
+      ).toBe(403);
+      const body = (await resp.json()) as { error?: string };
+      expect(body.error).toBe('forbidden_origin');
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test('Case 3 — PR-preview `abc123.cc-sm.pages.dev` with env opt-in → 200', async () => {
+    // Spawn a SECOND daemon with the env flag enabled. Cannot reuse the
+    // worker daemon because its process env was fixed at spawn time.
+    let optInDaemon: DaemonHandle | null = null;
+    try {
+      optInDaemon = await startDaemon({
+        extraEnv: { CCSM_ALLOW_PAGES_PREVIEWS: '1' },
+      });
+      const base = new URL(optInDaemon.url).origin;
+      const previewOrigin = 'https://abc123.cc-sm.pages.dev';
+
+      const ctx = await pwRequest.newContext();
+      try {
+        const resp = await ctx.get(`${base}/api/sessions`, {
+          headers: {
+            authorization: `Bearer ${optInDaemon.token}`,
+            origin: previewOrigin,
+          },
+        });
+        expect(
+          resp.status(),
+          'PR-preview origin must be allowed when CCSM_ALLOW_PAGES_PREVIEWS=1',
+        ).toBe(200);
+        // ACAO must echo the cross-origin caller, not '*'.
+        expect(resp.headers()['access-control-allow-origin']).toBe(previewOrigin);
+        const body = (await resp.json()) as { sessions?: unknown };
+        expect(Array.isArray(body.sessions)).toBe(true);
+      } finally {
+        await ctx.dispose();
+      }
+    } finally {
+      if (optInDaemon) await stopDaemon(optInDaemon);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds `packages/e2e/tests/s2-spoof-origin.spec.ts` covering the S2 origin allow-list at the e2e (chromium) layer against a real spawned daemon. Splits matrix D out of #744.

3 cases:

1. **Spoof attacker subdomain** — `Origin: https://cc-sm.pages.dev.attacker.com` → 403
2. **PR-preview default reject** (env unset) — `Origin: https://abc123.cc-sm.pages.dev` → 403
3. **PR-preview env opt-in** (`CCSM_ALLOW_PAGES_PREVIEWS=1`) — same origin → 200 + ACAO echoes preview origin

Cases 1+2 reuse the worker-scoped daemon fixture. Case 3 spawns a **second** daemon process with the env flag set — `classifyOrigin` reads `CCSM_ALLOW_PAGES_PREVIEWS` from the daemon's process env at request time, so two real processes are required to verify the gate (cannot mutate the worker daemon's env mid-flight).

Extends `fixtures/daemon.ts:startDaemon()` with optional `extraEnv` parameter; default behavior unchanged.

Uses `request.newContext({extraHTTPHeaders})` instead of a real Page — the daemon's auth gate is on the wire-level header, which the request API can drive directly without an SPA bootstrap. (A real chromium tab cannot natively send arbitrary `Origin` headers; UA controls them.)

Spoof case is also unit-tested in PR #1141 (`packages/daemon/src/auth.test.ts`); this task is the e2e-layer independent verification per #744 split.

## Files

- `packages/e2e/tests/s2-spoof-origin.spec.ts` (NEW)
- `packages/e2e/fixtures/daemon.ts` — added `StartDaemonOptions.extraEnv`

## Diff scope

- No daemon / core / frontend-web / frontend-tauri **production** source changes.
- Only e2e fixture + new spec.

## Local checks (host: Windows 11, mode: fast)

- lint: ✓ (exit 0) — `npm run lint` in `packages/e2e`
- typecheck: ✓ (exit 0) — `npm run typecheck` in `packages/e2e`
- build: ✓ (exit 0) — `pnpm -F @ccsm/shared build && pnpm -F @ccsm/daemon build`
- unit tests: skipped — no unit tests changed (e2e-only diff)
- e2e: ✓
  ```
  Running 3 tests using 1 worker
    ✓  1 [chromium] › tests\s2-spoof-origin.spec.ts:44:3 › Case 1 — spoof cc-sm.pages.dev.attacker.com subdomain → 403 (41ms)
    ✓  2 [chromium] › tests\s2-spoof-origin.spec.ts:68:3 › Case 2 — PR-preview abc123.cc-sm.pages.dev default reject → 403 (11ms)
    ✓  3 [chromium] › tests\s2-spoof-origin.spec.ts:92:3 › Case 3 — PR-preview abc123.cc-sm.pages.dev with env opt-in → 200 (237ms)
    3 passed (2.8s)
  ```

## Refs

- Task #753 (split from #744 matrix D)
- PR #1141 (Task #721) — `auth.mts` `classifyOrigin` opt-in `*.cc-sm.pages.dev` implementation