### PR TITLE
fix(e2e): repair groups-sidebar + scrollback baseline-red after #716 removed MainPane auto-create (Task #759)

### DIFF
--- a/packages/e2e/tests/groups-sidebar.spec.ts
+++ b/packages/e2e/tests/groups-sidebar.spec.ts
@@ -9,11 +9,12 @@
 // WHY DEV-MODE (vite + mock daemon):
 //   The xterm/ws boot path is irrelevant to the sidebar contract under
 //   test, and the real `claude` CLI is not available on CI. We mock just
-//   the two endpoints the sidebar hits — POST /api/sessions and
-//   DELETE /api/sessions/:sid — and reject ws upgrades (the disconnect
-//   notice doesn't block anything in the sidebar). MainPane's bootstrap
-//   path will create the *first* session on its own; subsequent sessions
-//   are driven by the user clicking + New Session, which is what we test.
+//   the three endpoints the sidebar hits — GET /api/sessions (useBootstrap
+//   hydration), POST /api/sessions, and DELETE /api/sessions/:sid — and
+//   reject ws upgrades (the disconnect notice doesn't block anything in
+//   the sidebar). The bootstrap GET returns an empty list and the spec
+//   drives session creation via explicit + New Session clicks (MainPane's
+//   auto-create-on-mount path was removed in Task #716).
 //
 // SCOPE:
 //   Mirrors the dispatch spec's e2e checklist: + New Session twice, click
@@ -58,6 +59,15 @@ async function startMockDaemon(): Promise<MockDaemon> {
   const deletedSids: string[] = [];
   const server = createServer((req, res) => {
     const url = req.url ?? '/';
+    // GET /api/sessions — useBootstrap (#670) calls this on App mount to
+    // hydrate the store. Return an empty list so the sidebar starts clean
+    // and the spec drives session creation via + New Session clicks.
+    if (req.method === 'GET' && url === '/api/sessions') {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ sessions: [] }));
+      return;
+    }
     if (req.method === 'POST' && url === '/api/sessions') {
       // Drain the body so the socket doesn't stall on Windows.
       req.on('data', () => {});
@@ -225,19 +235,21 @@ test('groups-sidebar — multi-session add / setActive / close', async ({
       .locator('[data-testid="sidebar-groups"]')
       .waitFor({ state: 'attached', timeout: 10_000 });
 
-    // ---- Stage 1: bootstrap session arrives ----
+    // ---- Stage 1: click + New Session → first session row appears ----
     //
-    // MainPane auto-creates the first session on mount. The sidebar should
-    // render exactly one session row, marked active. We use [data-active]
-    // (only the `<li>` wrapper carries that attribute, the inner row/close
-    // buttons don't) so the locator counts session rows, not their children.
+    // useBootstrap (#670) hydrates the store from GET /api/sessions; our
+    // mock returns an empty list, so the sidebar starts with zero rows and
+    // the user (this spec) drives creation explicitly. Earlier MainPane
+    // revisions auto-created the first session on mount — that bootstrap
+    // path was removed in Task #716, see MainPane.tsx for the rationale.
     const rows = page.locator('[data-testid^="sidebar-session-"][data-active]');
+    await page.locator('[data-testid="sidebar-new-session"]').click();
     await rows.first().waitFor({ state: 'attached', timeout: 10_000 });
     await expect(rows).toHaveCount(1, { timeout: 5_000 });
 
     await snap(page, testInfo, '01-after-bootstrap');
 
-    // ---- Stage 2: click + New Session → second row appears, active ----
+    // ---- Stage 2: click + New Session again → second row appears, active ----
     await page.locator('[data-testid="sidebar-new-session"]').click();
     await expect(rows).toHaveCount(2, { timeout: 5_000 });
 

--- a/packages/e2e/tests/scrollback.spec.ts
+++ b/packages/e2e/tests/scrollback.spec.ts
@@ -67,6 +67,15 @@ async function startMockDaemon(): Promise<MockDaemon> {
   const createdSids: string[] = [];
   const server = createServer((req, res) => {
     const url = req.url ?? '/';
+    // GET /api/sessions — useBootstrap (#670) hydrates the store on App
+    // mount. Return an empty list so the spec drives creation explicitly
+    // via + New Session clicks (MainPane auto-create was removed in #716).
+    if (req.method === 'GET' && url === '/api/sessions') {
+      res.statusCode = 200;
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify({ sessions: [] }));
+      return;
+    }
     if (req.method === 'POST' && url === '/api/sessions') {
       req.on('data', () => {});
       req.on('end', () => {
@@ -328,8 +337,12 @@ test('scrollback — per-session buffer + replay on switch + lastSeq reconnect',
       .locator('[data-testid="sidebar-groups"]')
       .waitFor({ state: 'attached', timeout: 10_000 });
 
-    // ---- Stage A: bootstrap session arrives, push OUTPUT into it ----
+    // ---- Stage A: create session A via + New Session, push OUTPUT into it ----
+    //
+    // useBootstrap hydrates from GET /api/sessions (mocked empty); MainPane
+    // auto-create was removed in #716. Drive creation explicitly.
     const rows = page.locator('[data-testid^="sidebar-session-"][data-active]');
+    await page.locator('[data-testid="sidebar-new-session"]').click();
     await expect(rows).toHaveCount(1, { timeout: 10_000 });
     const sidA = await rows.first().getAttribute('data-testid');
     expect(sidA).not.toBeNull();


### PR DESCRIPTION
## Summary

Two e2e specs (`groups-sidebar.spec.ts`, `scrollback.spec.ts`) have been baseline-red on the working branch since Task #716 (commit 3157ca02) removed MainPane's auto-create-on-mount path. Both specs were written assuming the renderer would POST /api/sessions on its own at boot, then waited for `[data-testid^=\"sidebar-session-\"][data-active]` to appear. After #716 that auto-create is gone; bootstrap is now owned by `useBootstrap` (#670), which calls GET /api/sessions and hydrates the store. The mock daemons in both specs implemented only POST + DELETE, so GET fell through to 404, the store stayed empty, and the wait timed out.

CI run 25515319310 (PR #1148, ubuntu-latest) surfaced this because #1145 added ubuntu to the working-branch trigger matrix; the failures are unrelated to #1148's diff.

Reproduces on local Windows too — not OS-specific despite the manager spec calling out the ubuntu-only signal. Fix is the same root cause on both platforms.

## Fix

1. Both mock daemons now answer `GET /api/sessions` with `{ sessions: [] }` (matches `ListSessionsResponse` contract in `packages/shared/api.ts`).
2. Spec stage 1 clicks `[data-testid=\"sidebar-new-session\"]` to create the first session before asserting the row appears, mirroring how a user actually starts a session today. No assertions were mocked away; the contracts under test (multi-session add/setActive/close; per-session scrollback + lastSeq reconnect) are unchanged.

## Local checks (host: Windows 11, mode: fast)
- lint: baseline-red on `origin/working` (`packages/daemon/test/persist.test.ts:20` + `packages/ui/test/BootstrapRefresh.test.tsx:24` unused-vars; both pre-existing, not from this PR's diff). Verified by stashing the diff via patch-file flow and re-running lint on clean origin/working — same 2 errors. Out of scope for #759.
- typecheck: PASS (exit 0)
- build: PASS (`npm run build`, exit 0, all packages built including frontend-web/frontend-tauri)
- e2e (changed specs only): PASS — `npx playwright test groups-sidebar.spec.ts scrollback.spec.ts` → `2 passed (17.4s)` on Windows
- Reverse-verified locally: pre-fix `groups-sidebar` reproduced the same 10s timeout on `[data-testid^=\"sidebar-session-\"][data-active]` Windows-locally (matches CI fail mode), confirming this is the actual ubuntu CI root cause and not an OS-specific timing artifact.

## Notes

- This is a test-fix PR per `feedback_local_windows_before_ci`: the manager prompt flagged the conflict (modify ubuntu-only test from a Windows host); local Windows reproduced the bug, so we verified the fix locally rather than trial-and-error on CI. CI will validate on the ubuntu/macos/windows matrix.