### PR TITLE
fix(daemon): DELETE awaits PTY exit so EXIT frame lands before 200 (Task #758)

### DIFF
--- a/packages/daemon/src/http.mts
+++ b/packages/daemon/src/http.mts
@@ -346,7 +346,16 @@ async function handleApi(
         return;
       }
       // T#668: also tear down any live PTY so the OS doesn't leak processes.
-      registry?.kill(parsed.sid);
+      // Task #758: AWAIT the kill so the EXIT frame (FrameType=0x07) lands on
+      // OPEN ws subscribers BEFORE we reply 200. Client SPAs detach their ws
+      // only after seeing the DELETE response, so as long as we broadcast
+      // first the client's ws is still in OPEN state when the daemon's
+      // onExit fan-out runs. registry.kill resolves once the EXIT broadcast
+      // has run (or after a 2000ms timeout for wedged PTYs — we still 200
+      // to avoid HTTP hang).
+      if (registry) {
+        await registry.kill(parsed.sid);
+      }
       sessions.delete(parsed.sid);
       persist?.scheduleFlush();
       const resp: DeleteSessionResponse = { ok: true };

--- a/packages/daemon/src/runtime.mts
+++ b/packages/daemon/src/runtime.mts
@@ -80,6 +80,15 @@ export interface RuntimeSession {
   exited: boolean;
   exitCode: number;
   ring: RingBuffer;
+  /**
+   * Task #758: resolves AFTER the EXIT frame (FrameType=0x07) has been
+   * broadcast to all OPEN subscribers and `exited` flipped to true. The
+   * DELETE handler awaits this (with timeout) so that the HTTP 200 is
+   * only returned once the wire-level EXIT has reached subscribers — the
+   * client's own ws is still OPEN at that moment because it only detaches
+   * after seeing the DELETE response. Resolves with the exit code.
+   */
+  exitPromise: Promise<number>;
 }
 
 export interface RuntimeRegistryOptions {
@@ -97,8 +106,14 @@ export interface RuntimeRegistry {
   get(sid: string): RuntimeSession | undefined;
   /** Has `sid` got a live runtime? */
   has(sid: string): boolean;
-  /** SIGTERM the PTY (and after 2s, SIGKILL if still alive). */
-  kill(sid: string): void;
+  /**
+   * SIGTERM the PTY (and after 2s, SIGKILL if still alive). Resolves once the
+   * EXIT frame has been broadcast to OPEN subscribers (i.e. the PTY truly
+   * exited and onExit ran), or after `awaitExitTimeoutMs` (default 2000ms)
+   * if the PTY hangs — whichever first. Task #758: the DELETE handler
+   * `await`s this so the HTTP 200 lands AFTER the wire-level EXIT.
+   */
+  kill(sid: string, awaitExitTimeoutMs?: number): Promise<void>;
   /** Iterate over all live runtimes (for shutdown). */
   entries(): IterableIterator<[string, RuntimeSession]>;
   /** Tear down everything (used by attached.shutdown). */
@@ -132,7 +147,18 @@ const defaultPtyFactory: PtyFactory = (opts) => {
   return {
     write: (d) => pty.write(d),
     resize: (c, r) => pty.resize(c, r),
-    kill: (s) => pty.kill(s),
+    kill: (s) => {
+      // Task #758: node-pty's WindowsTerminal.kill() THROWS if you pass any
+      // signal name ("Signals not supported on windows."). On Windows we
+      // must call kill() with no argument (which routes to TerminateJobObject
+      // — a hard, immediate kill). The shared PtyLike interface accepts an
+      // optional signal so POSIX callers can still pass SIGTERM / SIGKILL.
+      if (process.platform === 'win32') {
+        pty.kill();
+      } else {
+        pty.kill(s);
+      }
+    },
     onData: (cb) => {
       pty.onData(cb);
     },
@@ -177,7 +203,13 @@ export function createRuntimeRegistry(opts: RuntimeRegistryOptions): RuntimeRegi
       exited: false,
       exitCode: 0,
       ring: new RingBuffer(),
+      // Filled in below — onExit resolves it after the EXIT broadcast loop.
+      exitPromise: undefined as unknown as Promise<number>,
     };
+    let resolveExit!: (code: number) => void;
+    rt.exitPromise = new Promise<number>((r) => {
+      resolveExit = r;
+    });
     runtime.set(sid, rt);
 
     pty.onData((data) => {
@@ -241,29 +273,70 @@ export function createRuntimeRegistry(opts: RuntimeRegistryOptions): RuntimeRegi
       const live = sessions.get(sid);
       if (live) live.alive = false;
       runtime.delete(sid);
+      // Task #758: signal awaiters (DELETE handler) AFTER broadcast + map
+      // cleanup so anyone awaiting `kill()` sees a fully-settled runtime.
+      resolveExit(code);
     });
 
     return rt;
   }
 
-  function kill(sid: string): void {
+  function kill(sid: string, awaitExitTimeoutMs = 2000): Promise<void> {
     const rt = runtime.get(sid);
-    if (!rt || rt.exited) return;
-    try {
-      rt.pty.kill('SIGTERM');
-    } catch (err) {
-      console.warn(`[ccsm/runtime] kill SIGTERM sid=${sid}:`, (err as Error).message);
+    if (!rt) return Promise.resolve();
+    if (rt.exited) {
+      // onExit already fired — exitPromise is already settled.
+      return rt.exitPromise.then(() => undefined);
     }
-    const t = setTimeout(() => {
-      if (!rt.exited) {
-        try {
-          rt.pty.kill('SIGKILL');
-        } catch {
-          // ignore
+    // Task #758: send the strongest available signal up-front. On POSIX we
+    // start with SIGTERM (gives `claude` a chance to flush state) and
+    // escalate to SIGKILL after 200ms if it hasn't exited; on Windows
+    // node-pty's kill() ignores the signal name and always calls
+    // TerminateJobObject which is a hard kill, so SIGTERM/SIGKILL are
+    // equivalent there. The aggressive escalation matters because the
+    // DELETE handler awaits the EXIT broadcast — a slow `claude` shutdown
+    // (it can dump hundreds of OUTPUT frames as the SIGINT renders before
+    // it actually exits) would otherwise hit the 2s await timeout and the
+    // EXIT frame would land too late, after the client already detached.
+    const isWindows = process.platform === 'win32';
+    try {
+      rt.pty.kill(isWindows ? 'SIGKILL' : 'SIGTERM');
+    } catch (err) {
+      console.warn(`[ccsm/runtime] kill sid=${sid}:`, (err as Error).message);
+    }
+    if (!isWindows) {
+      const escalate = setTimeout(() => {
+        if (!rt.exited) {
+          try {
+            rt.pty.kill('SIGKILL');
+          } catch {
+            // ignore
+          }
         }
-      }
-    }, 2000);
-    t.unref();
+      }, 200);
+      escalate.unref();
+    }
+    // Race the PTY's onExit (which fires after EXIT broadcast) against a
+    // wall-clock timeout. Timeout path returns void without rejecting — the
+    // caller (DELETE handler) still wants to send 200 to avoid HTTP hang on
+    // a wedged PTY. We log a warning so wedged PTYs are visible in logs.
+    return new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        console.warn(
+          `[ccsm/runtime] kill sid=${sid}: PTY did not exit within ${awaitExitTimeoutMs}ms; ` +
+            `EXIT frame may have been delivered late.`,
+        );
+        resolve();
+      }, awaitExitTimeoutMs);
+      timer.unref();
+      rt.exitPromise.then(() => {
+        clearTimeout(timer);
+        resolve();
+      }, () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
   }
 
   function shutdownAll(): void {
@@ -275,7 +348,7 @@ export function createRuntimeRegistry(opts: RuntimeRegistryOptions): RuntimeRegi
           // ignore
         }
       }
-      kill(sid);
+      void kill(sid);
     }
     runtime.clear();
   }

--- a/packages/daemon/src/ws.mts
+++ b/packages/daemon/src/ws.mts
@@ -222,7 +222,7 @@ export function attachWebSocket(server: HttpServer, opts: AttachWsOptions): Atta
       // T#668 spec: ws on close should kill its OWN PTY if subscribers empty
       // (matches T4 behaviour — keeps daemon footprint tied to the active tab).
       if (rt.subscribers.size === 0 && !rt.exited) {
-        registry.kill(sid);
+        void registry.kill(sid);
       }
     };
     ws.on('close', cleanup);

--- a/packages/daemon/test/http.test.ts
+++ b/packages/daemon/test/http.test.ts
@@ -100,7 +100,7 @@ async function makeFixture(opts: { throwOnce?: boolean } = {}): Promise<Fixture>
 
 async function tearDown(fx: Fixture): Promise<void> {
   for (const sid of Array.from(fx.http.sessions.keys())) {
-    fx.registry.kill(sid);
+    void fx.registry.kill(sid);
     fx.http.sessions.delete(sid);
   }
   await new Promise<void>((resolve) => fx.http.server.close(() => resolve()));
@@ -112,7 +112,7 @@ describe('POST /api/sessions (T#668: spawns at HTTP layer)', () => {
   afterAll(async () => { await tearDown(fx); });
   afterEach(() => {
     for (const sid of Array.from(fx.http.sessions.keys())) {
-      fx.registry.kill(sid);
+      void fx.registry.kill(sid);
       fx.http.sessions.delete(sid);
     }
     fx.records.length = 0;
@@ -164,7 +164,7 @@ describe('POST /api/sessions/:sid/resume (T#668)', () => {
   afterAll(async () => { await tearDown(fx); });
   afterEach(() => {
     for (const sid of Array.from(fx.http.sessions.keys())) {
-      fx.registry.kill(sid);
+      void fx.registry.kill(sid);
       fx.http.sessions.delete(sid);
     }
     fx.records.length = 0;
@@ -192,7 +192,7 @@ describe('POST /api/sessions/:sid/resume (T#668)', () => {
     expect(fx.records.length).toBe(1);
     expect(fx.records[0]!.mode).toBe('create');
     // Step 2: simulate the runtime dying without removing the stub row.
-    fx.registry.kill(sid);
+    void fx.registry.kill(sid);
     // Force-remove the runtime entry too (kill is async via setTimeout in
     // real code, and our fake pty never fires onExit). We mimic the
     // post-restart state by clearing the runtime via a fresh resume call:
@@ -285,6 +285,160 @@ describe('POST /api/sessions/:sid/resume (T#668)', () => {
       await tearDown(failing);
     }
   });
+});
+
+// Task #758: DELETE /api/sessions/:sid must broadcast the EXIT frame
+// (FrameType=0x07) to OPEN ws subscribers BEFORE returning 200. The SPA
+// detaches its ws only after seeing the DELETE response, so the daemon's
+// onExit fan-out must run while the client ws is still OPEN — otherwise
+// the EXIT is silently dropped (PR #1148 race). We assert ordering by
+// recording timestamps of "EXIT frame received" vs "DELETE response done".
+describe('DELETE /api/sessions/:sid (Task #758: awaits PTY exit before 200)', () => {
+  interface ExitableFakePty extends PtyLike {
+    triggerExit(code: number): void;
+  }
+
+  function makeExitableFactory(): {
+    factory: PtyFactory;
+    instances: ExitableFakePty[];
+  } {
+    const instances: ExitableFakePty[] = [];
+    const factory: PtyFactory = () => {
+      let exitCb: ((e: { exitCode: number; signal?: number | undefined }) => void) | null = null;
+      const pty: ExitableFakePty = {
+        write: () => {},
+        resize: () => {},
+        kill: () => {
+          // Don't auto-exit — test drives onExit explicitly.
+        },
+        onData: () => {},
+        onExit: (cb) => {
+          exitCb = cb;
+        },
+        triggerExit(code) {
+          exitCb?.({ exitCode: code });
+        },
+      };
+      instances.push(pty);
+      return pty;
+    };
+    return { factory, instances };
+  }
+
+  async function makeFx(): Promise<{
+    http: DaemonHttp;
+    registry: RuntimeRegistry;
+    baseUrl: string;
+    instances: ExitableFakePty[];
+  }> {
+    const { factory, instances } = makeExitableFactory();
+    const http = createDaemonHttp({ token: TOKEN });
+    const registry = createRuntimeRegistry({
+      sessions: http.sessions,
+      ptyFactory: factory,
+    });
+    http.setRegistry(registry);
+    await new Promise<void>((resolve, reject) => {
+      http.server.once('error', reject);
+      http.server.listen(0, '127.0.0.1', () => {
+        http.server.removeListener('error', reject);
+        resolve();
+      });
+    });
+    const addr = http.server.address() as AddressInfo;
+    return { http, registry, baseUrl: `http://127.0.0.1:${addr.port}`, instances };
+  }
+
+  it('broadcasts EXIT frame to OPEN subscribers BEFORE the 200 response', async () => {
+    const fx = await makeFx();
+    try {
+      const create = await fetch(`${fx.baseUrl}/api/sessions`, {
+        method: 'POST',
+        headers: authedHeaders(),
+        body: JSON.stringify({ cwd: '/tmp' }),
+      });
+      const { sid } = (await create.json()) as { sid: string };
+      expect(fx.instances.length).toBe(1);
+
+      // Attach a fake subscriber so we can observe the EXIT broadcast
+      // without spinning up real ws plumbing. The runtime's onExit only
+      // sends to subscribers whose readyState === OPEN.
+      const received: Array<{ at: number; firstByte: number }> = [];
+      const fakeSock = {
+        readyState: 1,
+        OPEN: 1,
+        send(data: Uint8Array): void {
+          received.push({ at: Date.now(), firstByte: data[0] ?? 0 });
+        },
+        close(): void {
+          this.readyState = 3;
+        },
+      };
+      const rt = fx.registry.get(sid);
+      expect(rt).toBeDefined();
+      rt!.subscribers.set(
+        fakeSock as unknown as Parameters<typeof rt.subscribers.set>[0],
+        { paused: false, pausedQueue: [], pausedBytes: 0 },
+      );
+
+      // Fire DELETE in parallel with a short delayed exit trigger. If the
+      // DELETE handler awaits registry.kill (which awaits exitPromise), the
+      // response timestamp must be strictly later than the EXIT broadcast.
+      const deleteStart = Date.now();
+      const deleteP = fetch(`${fx.baseUrl}/api/sessions/${sid}`, {
+        method: 'DELETE',
+        headers: authedHeaders(),
+      });
+      await new Promise((r) => setTimeout(r, 30));
+      const triggerAt = Date.now();
+      fx.instances[0]!.triggerExit(0);
+
+      const resp = await deleteP;
+      const respDoneAt = Date.now();
+
+      expect(resp.status).toBe(200);
+      const exitFrames = received.filter((r) => r.firstByte === 0x07);
+      expect(exitFrames.length, 'expected exactly one EXIT frame').toBe(1);
+      expect(exitFrames[0]!.at).toBeGreaterThanOrEqual(triggerAt);
+      expect(exitFrames[0]!.at).toBeLessThanOrEqual(respDoneAt);
+      expect(respDoneAt - deleteStart).toBeGreaterThanOrEqual(20);
+    } finally {
+      for (const sid of Array.from(fx.http.sessions.keys())) {
+        void fx.registry.kill(sid);
+        fx.http.sessions.delete(sid);
+      }
+      await new Promise<void>((resolve) => fx.http.server.close(() => resolve()));
+    }
+  });
+
+  it('returns 200 even if the PTY hangs (await timeout falls through)', async () => {
+    const fx = await makeFx();
+    try {
+      const create = await fetch(`${fx.baseUrl}/api/sessions`, {
+        method: 'POST',
+        headers: authedHeaders(),
+        body: JSON.stringify({ cwd: '/tmp' }),
+      });
+      const { sid } = (await create.json()) as { sid: string };
+
+      // Never trigger exit -> handler hits the 2000ms timeout, then 200.
+      const t0 = Date.now();
+      const resp = await fetch(`${fx.baseUrl}/api/sessions/${sid}`, {
+        method: 'DELETE',
+        headers: authedHeaders(),
+      });
+      const elapsed = Date.now() - t0;
+      expect(resp.status).toBe(200);
+      expect(elapsed).toBeGreaterThanOrEqual(1500);
+      expect(elapsed).toBeLessThanOrEqual(3500);
+    } finally {
+      for (const sid of Array.from(fx.http.sessions.keys())) {
+        void fx.registry.kill(sid);
+        fx.http.sessions.delete(sid);
+      }
+      await new Promise<void>((resolve) => fx.http.server.close(() => resolve()));
+    }
+  }, 10_000);
 });
 
 // Task #700: GET / must serve the built SPA from packages/frontend-web/dist.

--- a/packages/daemon/test/ws-backpressure.test.ts
+++ b/packages/daemon/test/ws-backpressure.test.ts
@@ -132,7 +132,7 @@ beforeEach(() => {
 
 afterEach(() => {
   for (const sid of Array.from(http.sessions.keys())) {
-    registry.kill(sid);
+    void registry.kill(sid);
     http.sessions.delete(sid);
   }
 });

--- a/packages/daemon/test/ws-replay.test.ts
+++ b/packages/daemon/test/ws-replay.test.ts
@@ -126,7 +126,7 @@ beforeEach(() => {
 
 afterEach(() => {
   for (const sid of Array.from(http.sessions.keys())) {
-    registry.kill(sid);
+    void registry.kill(sid);
     http.sessions.delete(sid);
   }
 });

--- a/packages/daemon/test/ws.test.ts
+++ b/packages/daemon/test/ws.test.ts
@@ -140,7 +140,7 @@ beforeEach(() => {
 afterEach(() => {
   // Close any sessions created during the test so PTYs don't leak.
   for (const sid of Array.from(http.sessions.keys())) {
-    registry.kill(sid);
+    void registry.kill(sid);
     http.sessions.delete(sid);
   }
 });
@@ -411,7 +411,13 @@ describe('ws frame round-trip via fake PTY', () => {
     await d.closed;
     // Server cleanup runs on close event; give it a tick.
     await new Promise((r) => setTimeout(r, 20));
-    expect(fpty.killed).toContain('SIGTERM');
+    // Task #758: kill signal is platform-specific. POSIX gets SIGTERM (with
+    // a 200ms SIGKILL escalation backstop); Windows ignores signal names
+    // (node-pty throws on them) and uses TerminateJobObject directly, which
+    // we surface as a no-arg kill — the default ptyFactory adapter records
+    // that as the literal string 'SIGKILL' for parity in tests.
+    const expected = process.platform === 'win32' ? 'SIGKILL' : 'SIGTERM';
+    expect(fpty.killed).toContain(expected);
   });
 });
 

--- a/packages/e2e/tests/s2-pages-loopback.spec.ts
+++ b/packages/e2e/tests/s2-pages-loopback.spec.ts
@@ -478,38 +478,46 @@ test('S2 — HTTPS browser → loopback daemon (full lifecycle: CORS + PNA + tok
   const deleteResp = await deletePromise;
   expect(deleteResp.status(), 'DELETE /api/sessions/:sid must be 2xx').toBeLessThan(300);
 
-  // Wire-level proof the SPA tore the per-session ws down.
+  // Task #758: EXIT-only strict assertion.
   //
-  // Subtlety on EXIT vs ws close:
-  //   The daemon's runtime.mts emits an EXIT frame (FrameType=0x07) only
-  //   from the PTY's onExit broadcast loop, AND only to subscribers whose
-  //   ws is still readyState === OPEN. The SPA's onCloseSession path
-  //   (Sidebar.tsx) calls api.deleteSession() FIRST and then synchronously
-  //   `runtime.detach(sid)` (which calls ws.close() locally). The DELETE
-  //   handler in http.mts triggers `registry.kill(sid)` which sends SIGTERM
-  //   to the PTY — the PTY's onExit fires asynchronously a moment later,
-  //   by which point the local ws is already CLOSING and the daemon's
-  //   broadcast loop skips it. Net result: the EXIT frame is not reliably
-  //   observable on the close-button path.
+  // The DELETE handler now `await`s registry.kill (which awaits the PTY's
+  // onExit -> EXIT broadcast loop) BEFORE returning 200. Because the SPA's
+  // onCloseSession path detaches its ws only after seeing the DELETE
+  // response, the daemon's broadcast lands while the client ws is still
+  // OPEN. Therefore the EXIT frame (FrameType=0x07) is now reliably
+  // observable on Playwright's framereceived listener.
   //
-  //   The user-visible "session is gone" signal is therefore the ws.close
-  //   event (Playwright reports it via the 'close' listener on the ws),
-  //   plus the DELETE 200 + the row vanishing from the sidebar. We assert
-  //   all three so a regression that fakes any one of them still trips.
-  //
-  //   A stricter EXIT-frame test would need a different teardown — e.g.
-  //   typing `/exit` into the REPL so claude itself exits and the daemon
-  //   broadcasts EXIT before the SPA detaches. That's outside this task's
-  //   scope (and orthogonal to the S2 chain we're proving here); follow-up
-  //   coverage can land alongside #753+.
+  // Pre-#758 this test accepted "EXIT frame OR ws.close OR DELETE 2xx" as
+  // a three-way OR because the race made EXIT undeliverable; PR #1148
+  // documents the original race in detail. With #758 we tighten to the
+  // wire-level invariant: an EXIT frame MUST appear in wsFrames within
+  // 5s of the DELETE response.
+  await expect
+    .poll(
+      () =>
+        wsFrames
+          .slice(framesBeforeClose)
+          .filter((f) => f.dir === 'received' && f.type === 0x07).length,
+      {
+        message:
+          'expected daemon to broadcast EXIT frame (FrameType=0x07) before DELETE 200 (Task #758)',
+        timeout: 5_000,
+        intervals: [100, 200, 500],
+      },
+    )
+    .toBeGreaterThan(0);
+
+  // ws close still expected (SPA detaches after DELETE). Keep this as a
+  // secondary assertion since it's free and helps localise regressions
+  // (EXIT seen but ws never closed -> SPA detach broken; ws closed but
+  // no EXIT -> daemon broadcast regressed).
   await expect
     .poll(() => wsClosed.length - closesBeforeClose, {
       message: 'expected at least one ws close event after DELETE /api/sessions/:sid',
-      timeout: 15_000,
+      timeout: 5_000,
       intervals: [200, 500, 1_000],
     })
     .toBeGreaterThan(0);
-  void framesBeforeClose;
 
   // Sidebar row should be gone — closeSession() pruned the store.
   await expect(


### PR DESCRIPTION
## Summary
Fixes the EXIT-frame race documented in PR #1148 step 9: the SPA's `onCloseSession` (`api.deleteSession` then `runtime.detach`) closes the local ws as soon as the DELETE response arrives, but the daemon's `onExit` broadcast loop only fires AFTER `pty.kill()` settles asynchronously. Result: the client ws is already CLOSING when the EXIT frame is sent and the broadcast skips it.

This PR makes DELETE wire-level correct:
- `RuntimeSession` now exposes an `exitPromise` that resolves AFTER the EXIT broadcast loop has run.
- `registry.kill(sid)` is now async — races `exitPromise` against a 2000ms wall-clock timeout (with warning log on timeout to avoid hanging the HTTP response on a wedged PTY).
- DELETE handler `await`s `registry.kill` before responding 200. The client ws stays OPEN throughout the await so the EXIT broadcast reaches it; the SPA only detaches after seeing the 200.
- Windows kill path: node-pty's `WindowsTerminal.kill(signal)` THROWS `Signals not supported on windows.`, so we call `pty.kill()` no-arg on win32 (TerminateJobObject — hard, immediate kill). POSIX uses SIGTERM with a 200ms SIGKILL escalation (was 2000ms — too slow once DELETE awaits).
- E2E `s2-pages-loopback` step 9 tightened from the old three-way OR (EXIT or ws.close or DELETE 2xx) to **strict EXIT-only** (FrameType=0x07 must appear within 5s of the DELETE response).

New unit cases (`packages/daemon/test/http.test.ts`):
- EXIT frame broadcast happens BEFORE the 200 response (manual `triggerExit` + timestamp ordering).
- DELETE returns 200 even when the PTY never exits (timeout fall-through, ~2000ms).

Adjusted: `ws.test.ts` "kills PTY when last subscriber leaves" now asserts platform-specific signal (SIGKILL on win, SIGTERM on POSIX). Test `afterEach` hooks switched to `void registry.kill(...)` so fake-PTY teardown isn't stalled by the new 2s await.

## Local checks (host: Windows 11, mode: fast)
- lint: skipped — 2 pre-existing errors in `persist.test.ts` + `BootstrapRefresh.test.tsx` are unrelated and neither file is touched in this PR.
- typecheck: pass (exit 0, all packages Done).
- build: pass (daemon dist + frontend bundles green).
- unit tests: `@ccsm/daemon` vitest run — 12 files, **115 passed / 1 skipped** (incl. 2 new DELETE Task #758 cases). Duration 6.46s.
- e2e: `s2-pages-loopback --repeat-each=5` — **5 passed (36.7s)**, EXIT-only assertion stable.

## Test plan
- [x] daemon vitest run green incl. new EXIT-ordering + timeout cases.
- [x] s2-pages-loopback strict EXIT-only assertion green 5/5 on Windows.
- [ ] CI matrix (ubuntu/macos/windows) green.

Closes Task #758.