### PR TITLE
test(e2e): expand s2-pages-loopback to 4 browsers (Task #752)

### DIFF
--- a/packages/e2e/fixtures/screenshot.ts
+++ b/packages/e2e/fixtures/screenshot.ts
@@ -65,7 +65,23 @@ export async function snap(
 
   // Best-effort full-page screenshot. about:blank etc. may produce a tiny
   // image; that is fine — the .txt is the load-bearing artifact.
-  await page.screenshot({ path: pngPath, fullPage: true });
+  //
+  // Firefox enforces a hard 32767-pixel limit on either screenshot dimension
+  // (Task #752: surfaced when xterm's measure-row container reflows tall on
+  // firefox + the SPA layout, producing a fullPage taller than 32767 px and
+  // failing with "Cannot take screenshot larger than 32767"). Fall back to a
+  // viewport-only screenshot in that case so we still emit a non-empty .png
+  // and continue the test — the .txt sibling is the load-bearing artifact.
+  try {
+    await page.screenshot({ path: pngPath, fullPage: true });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/larger than 32767|too large/i.test(msg)) {
+      await page.screenshot({ path: pngPath, fullPage: false });
+    } else {
+      throw err;
+    }
+  }
 
   // Best-effort metadata capture. Each await is wrapped because some pages
   // (about:blank, error pages) throw on certain queries.

--- a/packages/e2e/playwright.config.ts
+++ b/packages/e2e/playwright.config.ts
@@ -22,10 +22,31 @@ export default defineConfig({
     trace: 'on-first-retry',
     video: 'off',
   },
+  // Multi-browser projects (Task #752).
+  //
+  // Local Windows runs all four (chromium / firefox / webkit / edge). The
+  // CI three-platform matrix arrives in #755 — on ubuntu/macos the
+  // `edge` channel relies on a system Microsoft Edge install which is
+  // not shipped by Playwright; #755 will gate edge to windows runners.
+  //
+  // Per-browser known-issue skips live in the spec (test.skip(browserName,
+  // ...)) with a documented reason — never silently hide a browser.
   projects: [
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+    {
+      name: 'edge',
+      use: { ...devices['Desktop Edge'], channel: 'msedge' },
     },
   ],
 });

--- a/packages/e2e/tests/s2-pages-loopback.spec.ts
+++ b/packages/e2e/tests/s2-pages-loopback.spec.ts
@@ -122,9 +122,27 @@ function decodeFramePayload(buf: Uint8Array): { type: number; seq: number; text:
 }
 
 test('S2 — HTTPS browser → loopback daemon (full lifecycle: CORS + PNA + token + create + I/O + reload + close)', async (
-  { page, daemonUrl, token, _httpsPreview },
+  { page, daemonUrl, token, _httpsPreview, browserName },
   testInfo,
 ) => {
+  // Task #752 — per-browser known-issue gating.
+  //
+  // WebKit (WebKitGTK / Safari engine on Windows): does NOT implement the
+  // Private Network Access (PNA) preflight protocol AND blocks fetches from
+  // a secure HTTPS context to a plaintext http://127.0.0.1 origin as mixed
+  // content. The S2 chain is precisely "HTTPS Pages-like origin →
+  // http://127.0.0.1:<dport> daemon", so the bootstrap GET /api/sessions
+  // never leaves the browser on webkit (apiHits stays empty). This is a
+  // browser-engine policy gap, not a daemon/SPA bug — the same chain works
+  // in chromium/firefox/edge. Followup #754 (Tauri tauri://localhost shape)
+  // and #755 (CI matrix) will revisit webkit coverage via a non-mixed
+  // transport. Until then we skip with this explicit reason.
+  test.skip(
+    browserName === 'webkit',
+    'webkit blocks HTTPS → http://127.0.0.1 mixed-content fetch and lacks PNA; ' +
+      'S2 chain is unreachable from webkit. Followup: #754 (Tauri shape) / #755 (CI).',
+  );
+
   // Generous: daemon spawn (~2s) + frontend boot (~2s) + claude PTY warmup
   // (~3-10s on cold cwd) + REPL trust prompt + reload + close.
   test.setTimeout(120_000);


### PR DESCRIPTION
## Summary

Task #752 (S2 收口 B): expand `s2-pages-loopback.spec.ts` (the full 9-step lifecycle from Task #751 / PR #1148) from chromium-only to firefox / webkit / edge on Windows local. CI three-platform matrix and edge gating to windows-only are deferred to #755.

## Changes

- `packages/e2e/playwright.config.ts`: add `firefox`, `webkit`, and `edge` (`channel: 'msedge'`) projects alongside the existing `chromium`. Header comment notes the windows-only edge channel and the per-browser-skip discipline.
- `packages/e2e/tests/s2-pages-loopback.spec.ts`: pull `browserName` from the test args and `test.skip(browserName === 'webkit', ...)` with an explicit reason — see "Skips" below.
- `packages/e2e/fixtures/screenshot.ts`: fallback from `fullPage: true` to viewport-only on firefox's 32767-pixel screenshot dimension cap. The .txt sibling (load-bearing artifact) is unaffected.

## Skips (with reasons)

- **webkit**: WebKit (Safari engine) does not implement Private Network Access (PNA) preflight AND blocks fetches from a secure HTTPS context to plaintext `http://127.0.0.1` as mixed content. The S2 deployment shape is precisely "HTTPS Pages-like origin → http://127.0.0.1:<dport> daemon", so the bootstrap `GET /api/sessions` never leaves the browser on webkit (`apiHits` stays empty, fail at line 255). This is a browser-engine policy gap, not a daemon/SPA bug — chromium/firefox/edge work. Followups: **#754** (Tauri `tauri://localhost` shape removes the mixed-content + PNA constraints) and **#755** (CI matrix may revisit).

No other per-browser skips. firefox + edge run the full 9-step business flow including PTY I/O, reload regression, EXIT-frame teardown.

## Local checks (host: Windows 11, mode: fast)

- lint: pass (exit 0, e2e package, --max-warnings=0)
- typecheck: pass (exit 0, e2e package tsc -p tsconfig.json --noEmit)
- build: pass (`pnpm -r build` — frontend-web dist regenerated for httpsPreview)
- unit tests: skipped — diff is e2e-only (config + spec + fixture)
- e2e (`npx playwright test s2-pages-loopback`, all 4 projects):
  ```
  Running 4 tests using 1 worker
    ✓  1 [chromium] › s2-pages-loopback (5.2s)
    ✓  2 [firefox] › s2-pages-loopback (6.3s)
    -  3 [webkit] › s2-pages-loopback   (skipped, see reason above)
    ✓  4 [edge] › s2-pages-loopback (5.5s)
    1 skipped
    3 passed (26.7s)
  ```

Per-browser individual runs (sanity, before consolidated run above):
- chromium: `1 passed (7.8s)`
- edge: `1 passed (8.1s)`
- firefox: `1 passed (9.6s)` (after screenshot fallback)
- webkit: `1 skipped`

## Test plan

- [x] chromium-on-windows still green (no regression of #1148)
- [x] All 4 projects (chromium / firefox / webkit / edge) configured — none silently dropped
- [x] webkit skip carries a documented reason (engine policy gap, not test fault)
- [x] firefox screenshot regression handled at the fixture layer (not by hiding the test)
- [ ] CI three-platform matrix follow-up: #755
- [ ] edge channel gated to windows runners in CI: #755

🤖 Generated with [Claude Code](https://claude.com/claude-code)