### PR TITLE
fix(e2e): allow node-pty install scripts so ubuntu has native binding (Task #764)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "better-sqlite3"
+      "better-sqlite3",
+      "node-pty"
     ]
   }
 }

--- a/packages/e2e/fixtures/daemon.ts
+++ b/packages/e2e/fixtures/daemon.ts
@@ -71,11 +71,24 @@ export async function startDaemon(opts: StartDaemonOptions = {}): Promise<Daemon
 
   let stdoutBuf = '';
   let stderrBuf = '';
+  // Task #764: also forward daemon stdout/stderr to the test runner's stderr
+  // (line-prefixed) so post-ready failures (e.g. PTY spawn failing inside
+  // POST /api/sessions, returning 500) leave a diagnostic trail in CI logs.
+  // Previously stderr was only surfaced if the daemon failed to print its
+  // ready line — meaning a 500 from `pty_spawn_failed` left no clue why.
+  const forwardLines = (chunk: Buffer, tag: string): void => {
+    const text = chunk.toString('utf8');
+    for (const line of text.split(/\r?\n/)) {
+      if (line.length > 0) process.stderr.write(`[daemon ${tag}] ${line}\n`);
+    }
+  };
   proc.stdout?.on('data', (chunk: Buffer) => {
     stdoutBuf += chunk.toString('utf8');
+    forwardLines(chunk, 'out');
   });
   proc.stderr?.on('data', (chunk: Buffer) => {
     stderrBuf += chunk.toString('utf8');
+    forwardLines(chunk, 'err');
   });
 
   const ready = await new Promise<{ url: string; token: string } | Error>(


### PR DESCRIPTION
## Summary

Fixes Task #764 — `s2-acceptance (ubuntu-latest)` failed in PR #1152's CI run with `POST /api/sessions` returning 500 (windows-latest passed). Root cause is a pnpm 10 install-script policy gap, not a daemon code bug.

## Root cause

- `node-pty@1.1.0` ships prebuilds only for `darwin-{arm64,x64}` and `win32-{arm64,x64}` — the `prebuilds/` folder contains **no** `linux-*` directory (verified locally in this worktree's `node_modules/.pnpm/node-pty@1.1.0/...`).
- On linux the package's install script (`node scripts/prebuild.js || node-gyp rebuild`) compiles the `.node` binding from source. **pnpm 10 BLOCKS all install scripts by default** unless the package is in the root `pnpm.onlyBuiltDependencies` allow-list.
- The allow-list previously contained only `better-sqlite3`. So on ubuntu CI, node-pty was installed with no native binding. Windows/macOS were unaffected because they consume the prebuilds, not the script.
- `defaultPtyFactory` in `packages/daemon/src/runtime.mts` does `requireCjs('node-pty')` lazily inside `nodePty.spawn(...)`. The require throws (missing binding), the try/catch in `runtime.spawn()` swallows it, the http handler in `packages/daemon/src/http.mts` returns 500 with `{error: 'pty_spawn_failed'}` — exactly what s2-pages-loopback step 5 hit.

Evidence trail:
- s2-acceptance ubuntu CI log: https://github.com/Jiahui-Gu/ccsm/actions/runs/25517647657/job/74893249298 — `Expected: 200 / Received: 500` at `s2-pages-loopback.spec.ts:310`
- `packages/daemon/src/http.mts:287` returns 500 with `pty_spawn_failed` when `registry.spawn(...)` returns null
- `packages/daemon/src/runtime.mts:195-198` returns null when `ptyFactory(...)` throws
- `node_modules/.pnpm/node-pty@1.1.0/.../prebuilds/` directory listing on linux/ubuntu would show no entry for `linux-x64`

## Fix

`package.json`: add `node-pty` to `pnpm.onlyBuiltDependencies`. After this, on linux pnpm runs the install script which falls through to `node-gyp rebuild` (build-essential is preinstalled on `ubuntu-latest`).

Verified locally on Windows: `pnpm install --frozen-lockfile` now executes node-pty's install hook (prebuild check passes on win32-x64).

## Diagnostic improvement (defense in depth)

`packages/e2e/fixtures/daemon.ts` now forwards the spawned daemon's stdout/stderr to the test runner's stderr line-prefixed with `[daemon out]` / `[daemon err]`. Previously stderr was buffered and only printed if the daemon failed to print its ready line — so post-ready failures (this 500) left zero trail in CI logs. With this in place, future PTY/daemon regressions will quote the daemon's `[ccsm/runtime] pty spawn failed for sid=...: <reason>` log directly in the failing CI job output. No spec logic touched.

## Local checks (host: Windows, mode: fast)

- lint: pre-existing baseline-red (2 errors in `persist.test.ts` + `BootstrapRefresh.test.tsx`, both untouched here — verified by reverting my diff and re-running). Not introduced by this PR.
- typecheck: pre-existing baseline state (`@ccsm/core` complains about missing `@ccsm/shared` until shared is built; resolved by `pnpm -r build` which runs in CI).
- build: `pnpm -r build` exit 0 (8 workspace packages all Done).
- unit tests: `pnpm -F @ccsm/daemon test` → `Test Files 12 passed (12) | Tests 115 passed | 1 skipped` in 7.61s. Other packages not impacted by changes.
- e2e: skipped locally — fast path. The fix is linux-specific (pnpm install behaviour); Windows e2e was already green and the fixture change only adds stderr forwarding (no test logic change). Verification = the `s2-acceptance (ubuntu-latest)` job on this PR's CI run.

## Test plan

- [ ] CI `s2-acceptance (ubuntu-latest)` turns green on this PR
- [ ] CI `s2-acceptance (windows-latest)` stays green (no regression)
- [ ] CI `e2e (ubuntu-latest)` — same node-pty issue would also affect this; expect to see daemon-related e2e tests improve too, though not the primary target