### PR TITLE
ci(e2e): limit ubuntu to chromium-only (Task #766)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,20 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright Chromium
-        run: pnpm e2e:install
+      - name: Install Playwright browsers (chromium everywhere; +firefox+webkit on windows)
+        # Task #766: ubuntu/macos run --project chromium only, so the default
+        # `pnpm e2e:install` (which installs only chromium) is enough there.
+        # windows-latest runs the full 4-browser matrix from
+        # playwright.config.ts, so it additionally needs firefox + webkit
+        # binaries. edge uses the system Edge install on windows runners and
+        # does not need a playwright download.
+        shell: bash
+        run: |
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            pnpm -F @ccsm/e2e-web exec playwright install chromium firefox webkit
+          else
+            pnpm e2e:install
+          fi
 
       - name: Install claude CLI (required by daemon node-pty spawn)
         # T7 p1-smoke spawns a real `claude` PTY via the daemon; the CLI must

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,10 +129,21 @@ jobs:
         # windows.
         # `shell: bash` so the `|` in the regex is parsed by bash, not by
         # PowerShell on windows-latest (where `|` would be a pipeline).
+        #
+        # Task #766: ubuntu/macos limit to --project chromium. PR #1151 added
+        # firefox/webkit/edge projects to playwright.config.ts; firefox/webkit
+        # fail on ubuntu (vendor gap: WebKit HTTPS->loopback mixed-content +
+        # no PNA, firefox lacks the same loopback exception). Windows still
+        # runs the full 4-browser matrix to keep cross-browser coverage.
         shell: bash
         env:
           CI: 'true'
-        run: pnpm -F @ccsm/e2e-web exec playwright test --grep-invert "p1-smoke|p3-stress|session-persistence|s2-pages-loopback"
+        run: |
+          if [[ "${{ matrix.os }}" == "windows-latest" ]]; then
+            pnpm -F @ccsm/e2e-web exec playwright test --grep-invert "p1-smoke|p3-stress|session-persistence|s2-pages-loopback"
+          else
+            pnpm -F @ccsm/e2e-web exec playwright test --grep-invert "p1-smoke|p3-stress|session-persistence|s2-pages-loopback" --project chromium
+          fi
 
       - name: Upload snapshots
         if: always()


### PR DESCRIPTION
## Summary

PR #1151 (Task #752) added firefox/webkit/edge projects to `playwright.config.ts`. The `e2e` job in `.github/workflows/ci.yml` did not pass `--project`, so after #1151 ubuntu started running all 4 browsers and 8 firefox/webkit specs failed (smoke / scrollback / frontend-strictmode / groups-sidebar). The WebKit HTTPS->loopback mixed-content + no PNA vendor gap is already documented in #1151 with a `test.skip()`, but the job-level project filter on the ubuntu runner was missing.

This PR limits ubuntu/macos to `--project chromium` and keeps windows on the full 4-browser run (matching where firefox/webkit/edge actually work). The `s2-acceptance` job has been chromium-only since #755 — this just brings the older `e2e` job in line with the same vendor reality.

## Change

`e2e` step rewritten as bash if/else on `matrix.os`:
- `windows-latest` -> full grep-invert, no `--project` (all 4 browsers)
- ubuntu/macos -> same grep-invert + `--project chromium`

No spec / harness / config changes. firefox/webkit/edge projects remain in `playwright.config.ts` (still used on windows + locally).

## Local checks (host: Windows 11, mode: fast — yml-only)
- lint: pre-existing red on unrelated files (`PersistController`/`Mock` unused vars in non-ci.yml code), not introduced by this PR
- typecheck: pre-existing red (`@ccsm/shared` module not found in `packages/core` — needs build artifacts; baseline state on `working`)
- build: skipped (yml-only, no .ts/.tsx touched)
- unit tests: skipped (yml-only)
- e2e: skipped (yml-only — this PR *is* the e2e config change; verification is the CI run on this PR)

Per dev.md \xc2\xa73 yml-only carve-out: workflow change with no .ts/.tsx diff means lint/typecheck only, and the baseline reds above are unrelated to this diff (`git diff --stat` shows ci.yml only).

## Verification

CI on this PR should show:
- `e2e (ubuntu-latest)` chromium-only, no firefox/webkit fails -> green
- `e2e (windows-latest)` still full 4-browser -> green (no regress vs PR #1151)
- `s2-acceptance` (ubuntu+windows) unchanged -> green

Closes Task #766.