### PR TITLE
ci(deploy-pages): add @ccsm/core build step (Task #769)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -25,6 +25,7 @@ on:
     paths:
       - 'packages/frontend-web/**'
       - 'packages/ui/**'
+      - 'packages/core/**'
       - 'packages/shared/**'
       - 'pnpm-lock.yaml'
       - 'pnpm-workspace.yaml'
@@ -57,8 +58,8 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Build workspace deps (shared + ui required by frontend-web)
-        run: pnpm -F @ccsm/shared build && pnpm -F @ccsm/ui build
+      - name: Build workspace deps (shared + core + ui required by frontend-web)
+        run: pnpm -F @ccsm/shared build && pnpm -F @ccsm/core build && pnpm -F @ccsm/ui build
 
       - name: Build frontend-web (pages mode)
         run: pnpm -F @ccsm/frontend-web build:pages


### PR DESCRIPTION
## Summary

deploy-pages run 25531539276 (manual dispatch on \`working\`) failed at the \`@ccsm/ui\` build step with 8 TS errors. Root cause: the \"Build workspace deps\" step only built \`@ccsm/shared\` + \`@ccsm/ui\`, missing \`@ccsm/core\`. Without \`packages/core/dist/\`, tsc cannot resolve \`@ccsm/core\` when type-checking \`packages/ui\`, which surfaces as:

- \`runtime-context.tsx:32\` / \`store.ts:29\` — \`Cannot find module '@ccsm/core'\` (TS2307)
- \`MainPane.tsx:85\` / \`runtime-context.tsx:80\` — implicit-any on callback params (TS7006); the params come from \`SessionRuntime.subscribeOutput\` / \`statusSink\` whose types live in \`@ccsm/core\`, so once the module fails to resolve every downstream type collapses to \`any\`
- \`Sidebar.tsx:226,258\` — \`'err' is of type 'unknown'\` (TS18046); the existing \`err instanceof HttpError\` narrowing is correct, but \`HttpError\` is re-exported from \`@ccsm/core\`, so the narrowing erases

All 8 errors are downstream of the same module-resolution failure. They disappear the moment \`packages/core/dist/\` exists. **No source-level changes needed** — the dispatch's first repair item (\"add explicit types to the implicit-any callbacks\") would be cargo-cult; the call sites are already correctly typed via the imported \`OutputListener\` / \`HttpError\` symbols.

## Changes

- \`.github/workflows/deploy-pages.yml\`:
  - Insert \`pnpm -F @ccsm/core build\` between the shared and ui build steps (correct topo order: shared → core → ui)
  - Add \`packages/core/**\` to the push \`paths\` filter so a core-only edit still triggers a redeploy

## Local checks (host: Windows 11, mode: full)

- lint: ok (\`pnpm -F @ccsm/ui lint\` exit 0)
- typecheck: ok (\`pnpm -F @ccsm/ui typecheck\` exit 0)
- build: ok — clean rebuild from empty \`dist/\`:
  - \`pnpm -F @ccsm/shared build\` ok
  - \`pnpm -F @ccsm/core build\` ok
  - \`pnpm -F @ccsm/ui build\` ok (was 8 errors before adding the core step)
- unit tests: skipped, change is yml-only (no .ts/.tsx touched)
- e2e: skipped, change is yml-only

## Repro

Before:
\`\`\`
pnpm -F @ccsm/shared build && pnpm -F @ccsm/ui build
# -> 8 TS errors (TS2307 + TS7006 + TS18046)
\`\`\`

After (matching new workflow order):
\`\`\`
pnpm -F @ccsm/shared build && pnpm -F @ccsm/core build && pnpm -F @ccsm/ui build
# -> all green
\`\`\`

## Follow-up

This PR only fixes the ui build / workflow yml. Verifying the actual ship to https://cc-sm.pages.dev (200) by manually running \`gh workflow run deploy-pages.yml --ref working\` is Task #767's scope, to be done after this merges.