### PR TITLE
ci(deploy-pages): add working branch to push trigger (Task #767)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,8 +3,12 @@ name: deploy-pages
 # Task #724 [S2-T6]: Cloudflare Pages deploy pipeline for the web frontend.
 #
 # Triggers:
-#   - push to main: every merge that touches frontend-web (or its workspace
-#     deps) ships to https://cc-sm.pages.dev.
+#   - push to main or working: every merge that touches frontend-web (or its
+#     workspace deps) ships to https://cc-sm.pages.dev. `working` is the
+#     post-v0.1.0 release main-line (PRs land on `working`, periodically
+#     rolled to `main`); without it here, `working` merges would not
+#     auto-deploy and would require a manual `gh workflow run --ref working`
+#     dispatch (see Task #767 follow-up).
 #   - workflow_dispatch: manual redeploy from the Actions tab (e.g. after
 #     rotating env vars in the Cloudflare dashboard, or rolling back).
 #
@@ -21,7 +25,7 @@ name: deploy-pages
 
 on:
   push:
-    branches: [main]
+    branches: [main, working]
     paths:
       - 'packages/frontend-web/**'
       - 'packages/ui/**'

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ token bootstrap 两条路径:
 浏览器可用; daemon 必须升级到带 PNA (Private Network Access) preflight
 支持的版本 (S2 起)。
 
+CI: 每次 push 到 `main` 或 `working` 且 diff 命中
+`packages/{frontend-web,ui,core,shared}` 时, `.github/workflows/deploy-pages.yml`
+自动构建并发布到 https://cc-sm.pages.dev (无需手动 `gh workflow run`)。
+也可在 Actions 页面 `workflow_dispatch` 手动重发 (e.g. 轮换 Cloudflare env 后)。
+
 ### 2. daemon-embedded (经典模式)
 
 单进程 `ccsm` 同时 serve frontend-web bundle + daemon API/WS, 浏览器直接


### PR DESCRIPTION
## What

Add `working` to the `push` branches trigger list in `.github/workflows/deploy-pages.yml` so merges to `working` auto-deploy to https://cc-sm.pages.dev. Update README's Cloudflare Pages section to document the trigger.

## Why

S2 [Task #724] originally wired the deploy-pages workflow to `push: branches: [main]` because at that time `main` was the merge target. Post-v0.1.0, the branch flow changed: PRs now land on `working` and `working` is periodically rolled to `main` (see `references/manager.md` "分支流"). The trigger was never updated, so every `working` merge that should ship to `cc-sm.pages.dev` required a manual `gh workflow run deploy-pages.yml --ref working` dispatch — automation was broken.

PR #1155 (Task #769) already added `@ccsm/core` to the workspace-deps build step and verified, via manual dispatch from `working`, that the build chain itself is healthy (HTTP 200 on cc-sm.pages.dev). This PR only changes the trigger so the dispatch becomes implicit.

## Changes

- `.github/workflows/deploy-pages.yml`: `branches: [main]` → `branches: [main, working]`. Header comment updated to explain the dual-branch rationale.
- `README.md`: Cloudflare Pages section gains a CI note describing the auto-deploy trigger.
- `--branch=main` in the `wrangler pages deploy` command is intentionally left untouched: it is the Cloudflare Pages "production environment" binding (not a git ref), so deploys from `working` still land in production at cc-sm.pages.dev. This matches the intent that `working` is the post-v0.1.0 release main-line.

## Effect after merge

Once this PR merges to `working`, the merge commit itself will auto-trigger a `deploy-pages` run (because `.github/workflows/deploy-pages.yml` is in the `paths` filter and the trigger now includes `working`). No manual `gh workflow run` needed thereafter.

## Local checks (host: Windows 11, mode: fast)

- lint: pre-existing baseline failures in `packages/daemon/test/persist.test.ts` (unused `PersistController` import) and `packages/ui/test/BootstrapRefresh.test.tsx` (unused `Mock` import) — both unrelated to this diff (verified by running lint on `origin/working` via patch-flow stash; identical 2 errors). This PR touches only `.github/workflows/deploy-pages.yml` and `README.md`, no `.ts/.tsx` changed.
- typecheck: pre-existing baseline failure in `packages/core` (cannot find `@ccsm/shared` declarations) — caused by missing prebuild of workspace deps in setup, not by this diff. Confirmed: `pnpm -F @ccsm/shared build && pnpm -F @ccsm/core typecheck` passes on this branch. Unrelated to yml/README changes.
- build: skipped per dev.md §3 (no `.ts/.tsx` changed; yml + markdown only).
- unit tests: skipped per dev.md §3 (no `.ts/.tsx` changed).
- e2e: skipped per dev.md §3 (no `.ts/.tsx` changed).

YAML syntax verified by inspection; `branches: [main, working]` is standard GitHub Actions trigger syntax (same shape used elsewhere in the repo's workflows).

## Refs

- Task #767 (this task)
- Task #724 (S2 — original deploy-pages workflow)
- PR #1155 / Task #769 (verified build chain via manual dispatch)