### PR TITLE
ci: Tauri red-line guard (no Cloudflare refs in frontend-tauri) (Task #778)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,3 +372,28 @@ jobs:
           path: packages/frontend-tauri/src-tauri/target/release/bundle/msi/*.msi
           if-no-files-found: error
           retention-days: 30
+
+  tauri-red-line-guard:
+    # Architecture principle (docs/ROADMAP.md): Web and Tauri are parallel
+    # surfaces; Tauri is NOT on the cloud data path. This guard greps
+    # frontend-tauri sources for Cloudflare Pages/Workers references that
+    # would violate that principle (e.g. fallback to cc-sm.pages.dev,
+    # wss:// to *.pages.dev / *.workers.dev). Single-OS job is enough —
+    # this is a static text check, not a build.
+    name: Tauri red-line guard (no cloud refs)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Grep frontend-tauri for cloud references
+        shell: bash
+        run: |
+          set +e
+          hits=$(grep -rE 'cc-sm\.pages\.dev|wss://[^"'\'' ]*\.pages\.dev|wss://[^"'\'' ]*\.workers\.dev' \
+            packages/frontend-tauri/src/ packages/frontend-tauri/src-tauri/src/ 2>/dev/null)
+          if [ -n "$hits" ]; then
+            echo "::error::frontend-tauri must NOT reference Cloudflare Pages/Workers (architecture principle, see docs/ROADMAP.md)"
+            echo "$hits"
+            exit 1
+          fi
+          echo "Tauri red-line guard: clean (0 hits)"


### PR DESCRIPTION
## Summary

Task #778 [S3-T9]: 准则自动化 — add a CI guard that prevents `frontend-tauri` from referencing Cloudflare Pages/Workers, enforcing the architecture principle (docs/ROADMAP.md "Architecture principles") that Web and Tauri are parallel surfaces and Tauri is NOT on the cloud data path.

The guard is a single ubuntu-latest job `tauri-red-line-guard` that greps:
- `packages/frontend-tauri/src/`
- `packages/frontend-tauri/src-tauri/src/`

for these patterns:
- `cc-sm.pages.dev` (literal)
- `wss://*.pages.dev`
- `wss://*.workers.dev`

Any hit fails the job with a `::error::` annotation pointing back to ROADMAP. Static text check, no build needed → no matrix, no Rust toolchain.

Current `frontend-tauri` has 0 hits, so the guard passes today and will catch any future regression (e.g. dev accidentally falling back to `cc-sm.pages.dev` from a Tauri-side WS pull).

## Out of scope (per task spec)

- Branch protection `required_status_checks` contexts: NOT updated here. Manager will wire that up separately.
- No changes to `frontend-tauri` source code, no other workflow touched, no new deps.

## Verification (local, host: Windows)

Dry-run on the live regex (the same one in the workflow):

| Scenario | Expected | Actual |
|---|---|---|
| Current tree (clean) | 0 hits, exit 0 | `clean (0 hits)` ✓ |
| Plant `wss://cc-sm.pages.dev/ws` in `main.tsx` | guard fires | hit reported, fails ✓ |
| Plant `wss://api.example.workers.dev/ws` in `main.tsx` | guard fires | hit reported, fails ✓ |

After each plant the file was restored (verified `git diff --stat` empty before commit).

YAML syntax validated via `python -c "import yaml; yaml.safe_load(...)"` → OK.

## Local checks (host: Windows, mode: fast)
- lint: ✓ (exit 0, `pnpm -r lint`)
- typecheck: ✓ (exit 0, `pnpm -r typecheck` after `pnpm -r build` to populate `@ccsm/shared` dist)
- build: skipped (yml-only change, no .ts/.tsx touched — per dev.md §3 yml-only special case)
- unit tests: skipped (yml-only)
- e2e: skipped (yml-only)

## Test plan
- [x] Workflow YAML parses
- [x] Guard regex catches `cc-sm.pages.dev` literal
- [x] Guard regex catches `wss://*.pages.dev`
- [x] Guard regex catches `wss://*.workers.dev`
- [x] Guard passes on clean tree
- [ ] CI run on this PR shows new `tauri-red-line-guard` job green