### PR TITLE
feat(frontend-web): default hostConfig to wss://cc-sm.pages.dev (Task #780, S3-T5)

### DIFF
--- a/packages/frontend-web/src/hostConfig.ts
+++ b/packages/frontend-web/src/hostConfig.ts
@@ -7,26 +7,26 @@
 // fetch /token → fail). The pure resolver lives here so it can be
 // unit-tested without booting the full SPA.
 //
-// Task #712 (S2-T3): daemon base URL resolution supports 3 modes so the SPA
-// can be served from Cloudflare Pages (cross-origin) while still talking to
-// a local loopback daemon, without breaking the existing daemon-embedded
-// case (browser opens http://127.0.0.1:9876/, SPA same-origin).
+// Task #712 (S2-T3): daemon base URL resolution supported 3 modes so the
+// SPA could be served from Cloudflare Pages (cross-origin) while still
+// talking to a local loopback daemon, without breaking the existing
+// daemon-embedded case (browser opens http://127.0.0.1:9876/, SPA
+// same-origin).
 //
-//   1. URL `?daemon=` override — runtime escape hatch (e.g. user wants to
-//      point a Pages-hosted SPA at a non-default port).
-//   2. Build-time `VITE_DAEMON_BASE` — Pages build injects the canonical
-//      loopback URL.
-//   3. Fallback — if hostname is loopback (127.0.0.1 / localhost / ::1),
-//      use `window.location.origin` (preserves the daemon-embedded default,
-//      same-origin requests, no CORS); otherwise use VITE_DAEMON_BASE or
-//      the hard default `http://127.0.0.1:9876`.
+// Task #780 (S3-T5): default base flips to the Cloudflare tunnel URL
+// (`https://cc-sm.pages.dev` / `wss://cc-sm.pages.dev`). The SPA is now
+// always served from Pages; in production it talks to the daemon through
+// the CF Worker + Durable Object tunnel (S3 architecture). The previous
+// loopback / envBase / origin fallbacks are gone — the only escape hatch
+// is the URL `?daemon=<url>` query parameter, which dev/test/Tauri shells
+// use to point at a local daemon.
 
 import type { HostConfig } from '@ccsm/ui';
 
 export const TOKEN_STORAGE_KEY = 'ccsm.token';
 
-/** Hard default daemon base, used when env var is missing in cross-origin mode. */
-export const DEFAULT_DAEMON_BASE = 'http://127.0.0.1:9876';
+/** Hard default daemon base for production (Cloudflare Pages + Worker tunnel, Task #780). */
+export const DEFAULT_DAEMON_BASE = 'https://cc-sm.pages.dev';
 
 export interface ResolveTokenDeps {
   /** Search portion of the current URL, e.g. `?token=abc`. */
@@ -80,16 +80,7 @@ export async function resolveToken(deps: ResolveTokenDeps): Promise<string | nul
 export interface ResolveDaemonBaseDeps {
   /** Search portion of the current URL, e.g. `?daemon=http://127.0.0.1:8888`. */
   search: string;
-  /** Current page hostname, e.g. `127.0.0.1`, `localhost`, `cc-sm.pages.dev`. */
-  hostname: string;
-  /** Current page origin, used as same-origin fallback for the daemon-embedded case. */
-  origin: string;
-  /** Build-time injected default. Pass `import.meta.env.VITE_DAEMON_BASE` from the runtime. */
-  envBase: string | undefined;
 }
-
-/** Loopback hostnames that mean "the SPA is served by a local daemon". */
-const LOOPBACK_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
 
 function normalizeBase(raw: string): string {
   // Drop trailing slash so callers can append `/api/...` without doubling up.
@@ -99,39 +90,49 @@ function normalizeBase(raw: string): string {
 /**
  * Resolve the HTTP base URL the SPA should use to talk to the daemon.
  *
- * Priority (Task #712):
- *   1. URL `?daemon=<url>` — runtime override (debugging / non-default port).
- *   2. Loopback hostname (127.0.0.1 / localhost) → `origin`. This preserves
- *      the daemon-embedded default: same-origin, no CORS, no env needed.
- *   3. `VITE_DAEMON_BASE` — build-time injected (e.g. for Pages).
- *   4. Hard default `http://127.0.0.1:9876`.
+ * Priority (Task #780 / S3-T5):
+ *   1. URL `?daemon=<url>` — runtime escape hatch (dev / test / Tauri
+ *      shell pointing at local loopback daemon).
+ *   2. Hard default `https://cc-sm.pages.dev` — production tunnel via
+ *      Cloudflare Worker + Durable Object.
  *
- * Order rationale: rule 2 sits above rule 3 so that running a daemon-served
- * SPA on a custom port (`http://127.0.0.1:18080/`) keeps working even when
- * a stale `VITE_DAEMON_BASE` was baked into the bundle.
+ * History: S2 (Task #712) preferred `window.location.origin` on loopback
+ * hostnames and `VITE_DAEMON_BASE` for the Pages build. S3 collapses all
+ * of that into a single default because the SPA is now always served from
+ * Pages and always talks to the daemon through the tunnel unless `?daemon=`
+ * explicitly redirects it.
  */
 export function resolveDaemonBase(deps: ResolveDaemonBaseDeps): string {
   const fromUrl = new URLSearchParams(deps.search).get('daemon');
   if (fromUrl && fromUrl.length > 0) return normalizeBase(fromUrl);
 
-  if (LOOPBACK_HOSTNAMES.has(deps.hostname)) {
-    return normalizeBase(deps.origin);
-  }
-
-  if (deps.envBase && deps.envBase.length > 0) {
-    return normalizeBase(deps.envBase);
-  }
-
   return DEFAULT_DAEMON_BASE;
+}
+
+/**
+ * Derive the matching ws/wss base URL from an http/https base.
+ *
+ * Used by the SPA to pick between `wss://cc-sm.pages.dev` (production
+ * tunnel) and `ws://127.0.0.1:9876` (loopback dev) without forcing the
+ * caller to plumb a separate `wsBase` field. The path (`/ws/<sid>?...`)
+ * is appended downstream by core's WsClient — this only sets the origin.
+ */
+export function resolveWsBase(deps: ResolveDaemonBaseDeps): string {
+  const httpBase = resolveDaemonBase(deps);
+  if (httpBase.startsWith('https://')) {
+    return `wss://${httpBase.slice('https://'.length)}`;
+  }
+  if (httpBase.startsWith('http://')) {
+    return `ws://${httpBase.slice('http://'.length)}`;
+  }
+  // Defensive: caller passed something exotic; hand it back unchanged.
+  return httpBase;
 }
 
 function currentDaemonBase(): string {
   if (typeof window === 'undefined') return '';
   return resolveDaemonBase({
     search: window.location.search,
-    hostname: window.location.hostname,
-    origin: window.location.origin,
-    envBase: import.meta.env.VITE_DAEMON_BASE,
   });
 }
 

--- a/packages/frontend-web/src/main.tsx
+++ b/packages/frontend-web/src/main.tsx
@@ -14,6 +14,10 @@ import '@ccsm/ui/styles.css';
 // so it works in cross-origin mode (Pages → loopback daemon). Same-origin
 // loopback continues to hit `<origin>/token` because resolveDaemonBase
 // returns window.location.origin in that case.
+//
+// Task #780 (S3-T5): the default daemon base flipped to the CF Pages
+// tunnel, so `/token` now goes to `https://cc-sm.pages.dev/token` unless
+// the user passes `?daemon=` to redirect at a local loopback daemon.
 async function bootstrap(): Promise<void> {
   const rootEl = document.getElementById('root');
   if (!rootEl) {
@@ -22,9 +26,6 @@ async function bootstrap(): Promise<void> {
 
   const daemonBase = resolveDaemonBase({
     search: window.location.search,
-    hostname: window.location.hostname,
-    origin: window.location.origin,
-    envBase: import.meta.env.VITE_DAEMON_BASE,
   });
 
   const token = await resolveToken({

--- a/packages/frontend-web/test/hostConfig.test.ts
+++ b/packages/frontend-web/test/hostConfig.test.ts
@@ -1,103 +1,65 @@
-// Daemon base URL resolution priority (Task #712).
+// Daemon base URL resolution priority (Task #712 → Task #780 / S3-T5).
 
 import { describe, expect, it } from 'vitest';
 
-import { DEFAULT_DAEMON_BASE, resolveDaemonBase } from '../src/hostConfig';
+import {
+  DEFAULT_DAEMON_BASE,
+  resolveDaemonBase,
+  resolveWsBase,
+} from '../src/hostConfig';
 
 describe('resolveDaemonBase', () => {
-  it('uses VITE_DAEMON_BASE when SPA is cross-origin (e.g. Pages)', () => {
-    const got = resolveDaemonBase({
-      search: '',
-      hostname: 'cc-sm.pages.dev',
-      origin: 'https://cc-sm.pages.dev',
-      envBase: 'http://127.0.0.1:9876',
-    });
-    expect(got).toBe('http://127.0.0.1:9876');
-  });
-
-  it('URL ?daemon= override beats env var', () => {
-    const got = resolveDaemonBase({
-      search: '?daemon=http://127.0.0.1:8888',
-      hostname: 'cc-sm.pages.dev',
-      origin: 'https://cc-sm.pages.dev',
-      envBase: 'http://127.0.0.1:9876',
-    });
-    expect(got).toBe('http://127.0.0.1:8888');
-  });
-
-  it('URL ?daemon= override beats loopback fallback', () => {
-    // Daemon-embedded SPA on default port, but user wants to point at a
-    // different daemon instance — override wins.
-    const got = resolveDaemonBase({
-      search: '?daemon=http://127.0.0.1:8888',
-      hostname: '127.0.0.1',
-      origin: 'http://127.0.0.1:9876',
-      envBase: undefined,
-    });
-    expect(got).toBe('http://127.0.0.1:8888');
-  });
-
-  it('falls back to origin when hostname is 127.0.0.1 (daemon-embedded default)', () => {
-    const got = resolveDaemonBase({
-      search: '',
-      hostname: '127.0.0.1',
-      origin: 'http://127.0.0.1:9876',
-      envBase: undefined,
-    });
-    expect(got).toBe('http://127.0.0.1:9876');
-  });
-
-  it('falls back to origin when hostname is localhost', () => {
-    const got = resolveDaemonBase({
-      search: '',
-      hostname: 'localhost',
-      origin: 'http://localhost:9876',
-      envBase: undefined,
-    });
-    expect(got).toBe('http://localhost:9876');
-  });
-
-  it('falls back to origin on loopback even when env var is set (don\'t cross-origin from local)', () => {
-    // Critical regress guard: existing daemon-embedded users must not
-    // suddenly start making cross-origin requests just because a build
-    // happened to inline VITE_DAEMON_BASE.
-    const got = resolveDaemonBase({
-      search: '',
-      hostname: '127.0.0.1',
-      origin: 'http://127.0.0.1:18080',
-      envBase: 'http://127.0.0.1:9876',
-    });
-    expect(got).toBe('http://127.0.0.1:18080');
-  });
-
-  it('falls back to hard default when cross-origin and env var missing', () => {
-    const got = resolveDaemonBase({
-      search: '',
-      hostname: 'cc-sm.pages.dev',
-      origin: 'https://cc-sm.pages.dev',
-      envBase: undefined,
-    });
+  it('defaults to the Cloudflare Pages tunnel URL when no ?daemon= is set', () => {
+    // Task #780 (S3-T5): production default is the CF tunnel; the SPA is
+    // always served from Pages and reaches the daemon via the Worker + DO.
+    const got = resolveDaemonBase({ search: '' });
     expect(got).toBe(DEFAULT_DAEMON_BASE);
+    expect(got).toBe('https://cc-sm.pages.dev');
+  });
+
+  it('URL ?daemon=http://127.0.0.1:9876 redirects back to local loopback', () => {
+    // Escape hatch for dev / test / Tauri shell: opt out of the tunnel.
+    const got = resolveDaemonBase({ search: '?daemon=http://127.0.0.1:9876' });
     expect(got).toBe('http://127.0.0.1:9876');
   });
 
-  it('treats empty ?daemon= as missing and falls through', () => {
-    const got = resolveDaemonBase({
-      search: '?daemon=',
-      hostname: 'cc-sm.pages.dev',
-      origin: 'https://cc-sm.pages.dev',
-      envBase: 'http://127.0.0.1:9876',
-    });
-    expect(got).toBe('http://127.0.0.1:9876');
+  it('URL ?daemon=https://example.com redirects to that host', () => {
+    const got = resolveDaemonBase({ search: '?daemon=https://example.com' });
+    expect(got).toBe('https://example.com');
+  });
+
+  it('keeps the CF default when the SPA happens to be served same-origin (e.g. Vite dev server)', () => {
+    // S2 used to fall back to window.location.origin on loopback hostnames.
+    // S3 explicitly does NOT — opening http://localhost:5173 still talks to
+    // the CF tunnel unless the user sets ?daemon=.
+    const got = resolveDaemonBase({ search: '' });
+    expect(got).toBe('https://cc-sm.pages.dev');
+  });
+
+  it('treats empty ?daemon= as missing and falls through to the default', () => {
+    const got = resolveDaemonBase({ search: '?daemon=' });
+    expect(got).toBe('https://cc-sm.pages.dev');
   });
 
   it('strips trailing slash so callers can append paths cleanly', () => {
-    const got = resolveDaemonBase({
-      search: '',
-      hostname: 'cc-sm.pages.dev',
-      origin: 'https://cc-sm.pages.dev',
-      envBase: 'http://127.0.0.1:9876/',
-    });
+    const got = resolveDaemonBase({ search: '?daemon=http://127.0.0.1:9876/' });
     expect(got).toBe('http://127.0.0.1:9876');
+  });
+});
+
+describe('resolveWsBase', () => {
+  it('defaults to wss://cc-sm.pages.dev when no ?daemon= is set', () => {
+    const got = resolveWsBase({ search: '' });
+    expect(got).toBe('wss://cc-sm.pages.dev');
+  });
+
+  it('matches https httpBase with wss:// scheme', () => {
+    const got = resolveWsBase({ search: '?daemon=https://example.com' });
+    expect(got).toBe('wss://example.com');
+  });
+
+  it('matches http httpBase with ws:// scheme (loopback override)', () => {
+    const got = resolveWsBase({ search: '?daemon=http://127.0.0.1:9876' });
+    expect(got).toBe('ws://127.0.0.1:9876');
   });
 });


### PR DESCRIPTION
Task #780 [S3-T5]. Plan: ~/.claude/plans/s3-cloud-tunnel-plan.md.

## What

S3 cloud-tunnel architecture: the SPA is served from Cloudflare Pages and reaches the daemon through the Worker + Durable Object tunnel by default. Flip `frontend-web/src/hostConfig.ts` to match:

- Default `httpBase = https://cc-sm.pages.dev`, `wsBase = wss://cc-sm.pages.dev`.
- `?daemon=http://127.0.0.1:9876` (or `?daemon=https://other.example`) is the only override — dev / test / Tauri shell escape hatch.
- Removed the S2 fallback chain: `window.location.origin` on loopback hosts, `VITE_DAEMON_BASE`, hard-default loopback. The SPA is always served from Pages now, so opening it via `localhost:5173` still talks to the CF tunnel unless the user explicitly redirects.
- Added `resolveWsBase()` helper that mirrors `resolveDaemonBase()` and converts the scheme (`https→wss`, `http→ws`). Callers don't need a second plumbed field.
- ws path semantics (`/ws/<sid>?seq=N&token=T`) untouched — base host only. T6 owns the `/ws/default` token-flow + tunnel routing change.
- `main.tsx` updated to the new `resolveDaemonBase` signature (search-only deps).
- Token bootstrap (sessionStorage) unchanged.

## Local checks (host: Windows, mode: fast)
- lint: ✓ (`pnpm -F @ccsm/frontend-web lint` exit 0; workspace-wide `pnpm -w lint` reports 2 pre-existing errors in `daemon/test/persist.test.ts` + `ui/test/BootstrapRefresh.test.tsx` unrelated to this PR)
- typecheck: ✓ (`pnpm -F @ccsm/frontend-web typecheck` exit 0)
- build: ✓ (`pnpm -F @ccsm/frontend-web build` — vite production build, 497 kB bundle)
- unit tests: `pnpm -F @ccsm/frontend-web test hostConfig` → `Test Files 1 passed (1) | Tests 9 passed (9) | Duration 1.72s`
- e2e: skipped, only `hostConfig.ts` + `main.tsx` (resolveDaemonBase signature update) touched, e2e harness not impacted

## Files
- `packages/frontend-web/src/hostConfig.ts`
- `packages/frontend-web/src/main.tsx` (signature update)
- `packages/frontend-web/test/hostConfig.test.ts` (rewritten cases)