### PR TITLE
feat(daemon): tunnel.mts ws client with backoff reconnect (Task #779)

### DIFF
--- a/packages/daemon/src/tunnel.mts
+++ b/packages/daemon/src/tunnel.mts
@@ -1,0 +1,204 @@
+// Cloud-tunnel WebSocket client (Task #779, S3-T3).
+//
+// Daemon-side outbound WS to the Cloudflare Worker tunnel endpoint. T3 only
+// implements the transport: dial, auto-reconnect with exponential backoff +
+// jitter, send frames, deliver inbound frames via onFrame callback. Wiring
+// (caller reads CCSM_TUNNEL_URL, mints token) lands in T4. Subprotocol token
+// auth lands in T6.
+//
+// Design notes:
+//   - ws package is already a daemon dep (used by ws.mts server) — no new dep.
+//   - Backoff sequence is hand-coded (1s / 2s / 4s / 8s / 16s / 30s ...) with
+//     ±20% jitter, capped at 30s. p-retry / exponential-backoff are
+//     overkill for ~10 lines of setTimeout.
+//   - State machine: idle -> connecting -> connected -> reconnecting ->
+//     connecting -> ... ; stop() forces 'stopped' (terminal).
+//   - send() while not connected drops the frame (logs once). Caller must
+//     gate sends on getState() === 'connected' if they care.
+
+import WebSocket, { type RawData } from 'ws';
+
+export type TunnelState =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'stopped';
+
+export interface TunnelClientOptions {
+  url: string;
+  /** Reserved for T6 subprotocol-based auth. T3 does not send it on the wire. */
+  token: string;
+  /** Invoked once per inbound frame from the cloud (binary or text). */
+  onFrame: (data: Buffer | string) => void;
+  /**
+   * DI seam for tests. Real code uses the default which constructs a real
+   * `ws.WebSocket`. Tests inject a fake socket that implements WsLike.
+   */
+  wsFactory?: WsFactory;
+}
+
+/** Minimal subset of `ws.WebSocket` that TunnelClient relies on. */
+export interface WsLike {
+  readyState: number;
+  on(event: 'open', cb: () => void): void;
+  on(event: 'message', cb: (data: RawData, isBinary: boolean) => void): void;
+  on(event: 'close', cb: (code: number, reason: Buffer) => void): void;
+  on(event: 'error', cb: (err: Error) => void): void;
+  send(data: Buffer | string | Uint8Array): void;
+  close(code?: number, reason?: string): void;
+}
+
+export type WsFactory = (url: string) => WsLike;
+
+// Backoff sequence (ms). Each step gets ±20% jitter. Capped at 30s.
+const BACKOFF_SEQUENCE_MS = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000];
+const BACKOFF_JITTER = 0.2;
+
+function defaultWsFactory(url: string): WsLike {
+  return new WebSocket(url) as unknown as WsLike;
+}
+
+export class TunnelClient {
+  private readonly url: string;
+  // Held for T6: subprotocol/header injection. Intentionally unused in T3.
+  readonly token: string;
+  private readonly onFrame: (data: Buffer | string) => void;
+  private readonly wsFactory: WsFactory;
+
+  private state: TunnelState = 'idle';
+  private ws: WsLike | null = null;
+  private attempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private stopped = false;
+
+  constructor(opts: TunnelClientOptions) {
+    this.url = opts.url;
+    this.token = opts.token;
+    this.onFrame = opts.onFrame;
+    this.wsFactory = opts.wsFactory ?? defaultWsFactory;
+  }
+
+  getState(): TunnelState {
+    return this.state;
+  }
+
+  start(): void {
+    if (this.stopped) return;
+    if (this.state !== 'idle') return;
+    this.dial();
+  }
+
+  send(data: Buffer | string): void {
+    if (this.state !== 'connected' || this.ws === null) {
+      // Drop. Caller can gate on getState() if they care.
+      console.warn('[ccsm/tunnel] drop send: state=' + this.state);
+      return;
+    }
+    try {
+      this.ws.send(data);
+    } catch (err) {
+      console.warn('[ccsm/tunnel] send error:', (err as Error).message);
+    }
+  }
+
+  stop(): void {
+    this.stopped = true;
+    this.state = 'stopped';
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws !== null) {
+      try {
+        this.ws.close(1000, 'stop');
+      } catch {
+        // ignore
+      }
+      this.ws = null;
+    }
+  }
+
+  // ---- internals --------------------------------------------------------
+
+  private dial(): void {
+    if (this.stopped) return;
+    this.state = 'connecting';
+    let socket: WsLike;
+    try {
+      socket = this.wsFactory(this.url);
+    } catch (err) {
+      console.warn('[ccsm/tunnel] factory threw:', (err as Error).message);
+      this.scheduleReconnect();
+      return;
+    }
+    this.ws = socket;
+
+    socket.on('open', () => {
+      if (this.stopped) {
+        try { socket.close(1000, 'stopped'); } catch { /* ignore */ }
+        return;
+      }
+      this.state = 'connected';
+      this.attempts = 0;
+    });
+
+    socket.on('message', (raw, isBinary) => {
+      if (isBinary) {
+        // RawData covers Buffer | ArrayBuffer | Buffer[]. Normalize to Buffer.
+        let buf: Buffer;
+        if (Buffer.isBuffer(raw)) {
+          buf = raw;
+        } else if (Array.isArray(raw)) {
+          buf = Buffer.concat(raw);
+        } else {
+          buf = Buffer.from(raw as ArrayBuffer);
+        }
+        this.onFrame(buf);
+      } else {
+        const buf = Buffer.isBuffer(raw)
+          ? raw
+          : Array.isArray(raw)
+            ? Buffer.concat(raw)
+            : Buffer.from(raw as ArrayBuffer);
+        this.onFrame(buf.toString('utf8'));
+      }
+    });
+
+    socket.on('error', (err) => {
+      console.warn('[ccsm/tunnel] ws error:', err.message);
+      // 'close' will fire after 'error' for ws; defer reconnect to 'close'.
+    });
+
+    socket.on('close', (code) => {
+      this.ws = null;
+      if (this.stopped) {
+        this.state = 'stopped';
+        return;
+      }
+      console.warn(`[ccsm/tunnel] closed code=${code}, will reconnect`);
+      this.scheduleReconnect();
+    });
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped) return;
+    this.state = 'reconnecting';
+    const delay = this.computeBackoffMs(this.attempts);
+    this.attempts += 1;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.stopped) return;
+      this.dial();
+    }, delay);
+  }
+
+  /** Exposed for tests. Pure function of attempt index. */
+  computeBackoffMs(attempt: number): number {
+    const idx = Math.min(attempt, BACKOFF_SEQUENCE_MS.length - 1);
+    const base = BACKOFF_SEQUENCE_MS[idx] ?? 30_000;
+    // ±20% jitter
+    const jitter = 1 + (Math.random() * 2 - 1) * BACKOFF_JITTER;
+    return Math.min(30_000, Math.round(base * jitter));
+  }
+}

--- a/packages/daemon/test/tunnel.test.ts
+++ b/packages/daemon/test/tunnel.test.ts
@@ -1,0 +1,255 @@
+// Unit tests for daemon tunnel client (Task #779, S3-T3).
+//
+// Mocks ws via DI seam (TunnelClientOptions.wsFactory). No real network.
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest';
+
+import { TunnelClient, type WsLike } from '../src/tunnel.mjs';
+
+// ---- Fake socket --------------------------------------------------------
+
+interface FakeSocket extends WsLike {
+  // Test helpers:
+  open(): void;
+  closeFromServer(code: number): void;
+  pushBinary(data: Buffer): void;
+  pushText(data: string): void;
+  errorOut(msg: string): void;
+  // Spies:
+  sent: Array<Buffer | string | Uint8Array>;
+  closedCalls: Array<{ code?: number; reason?: string }>;
+  url: string;
+}
+
+function makeFakeSocket(url: string): FakeSocket {
+  const handlers: {
+    open: Array<() => void>;
+    message: Array<(data: Buffer, isBinary: boolean) => void>;
+    close: Array<(code: number, reason: Buffer) => void>;
+    error: Array<(err: Error) => void>;
+  } = { open: [], message: [], close: [], error: [] };
+
+  const sock: FakeSocket = {
+    url,
+    readyState: 0,
+    sent: [],
+    closedCalls: [],
+    on(event: string, cb: unknown): void {
+      // Strong-typed dispatch.
+      if (event === 'open') handlers.open.push(cb as () => void);
+      else if (event === 'message')
+        handlers.message.push(cb as (d: Buffer, b: boolean) => void);
+      else if (event === 'close')
+        handlers.close.push(cb as (c: number, r: Buffer) => void);
+      else if (event === 'error') handlers.error.push(cb as (e: Error) => void);
+    },
+    send(data) {
+      sock.sent.push(data);
+    },
+    close(code, reason) {
+      sock.closedCalls.push({ code, reason });
+      // Fire close handlers (some real-ws impls do; we mirror).
+      for (const h of handlers.close) h(code ?? 1000, Buffer.from(reason ?? ''));
+    },
+    open() {
+      sock.readyState = 1;
+      for (const h of handlers.open) h();
+    },
+    closeFromServer(code: number) {
+      sock.readyState = 3;
+      for (const h of handlers.close) h(code, Buffer.alloc(0));
+    },
+    pushBinary(data: Buffer) {
+      for (const h of handlers.message) h(data, true);
+    },
+    pushText(data: string) {
+      for (const h of handlers.message) h(Buffer.from(data, 'utf8'), false);
+    },
+    errorOut(msg: string) {
+      for (const h of handlers.error) h(new Error(msg));
+    },
+  };
+  return sock;
+}
+
+// ---- Tests --------------------------------------------------------------
+
+describe('TunnelClient', () => {
+  let factory: Mock<(url: string) => WsLike>;
+  let sockets: FakeSocket[];
+
+  beforeEach(() => {
+    sockets = [];
+    factory = vi.fn((url: string) => {
+      const s = makeFakeSocket(url);
+      sockets.push(s);
+      return s;
+    });
+    // Pin Math.random so jitter factor = 1 (1 + (0.5*2-1)*0.2 = 1).
+    vi.spyOn(Math, 'random').mockReturnValue(0.5);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('connects, receives binary + text frames via onFrame', () => {
+    const frames: Array<Buffer | string> = [];
+    const client = new TunnelClient({
+      url: 'wss://example/tunnel/x',
+      token: 'tok',
+      onFrame: (d) => frames.push(d),
+      wsFactory: factory,
+    });
+
+    client.start();
+    expect(client.getState()).toBe('connecting');
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0].url).toBe('wss://example/tunnel/x');
+
+    sockets[0].open();
+    expect(client.getState()).toBe('connected');
+
+    sockets[0].pushBinary(Buffer.from([1, 2, 3]));
+    sockets[0].pushText('hello');
+
+    expect(frames).toHaveLength(2);
+    expect(Buffer.isBuffer(frames[0])).toBe(true);
+    expect((frames[0] as Buffer).equals(Buffer.from([1, 2, 3]))).toBe(true);
+    expect(frames[1]).toBe('hello');
+  });
+
+  it('send() forwards to the socket when connected; drops when not', () => {
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 't',
+      onFrame: () => {},
+      wsFactory: factory,
+    });
+    // Drop pre-start.
+    client.send('pre');
+    client.start();
+    // Drop while connecting.
+    client.send('mid');
+    sockets[0].open();
+    client.send(Buffer.from([9, 9]));
+    client.send('after');
+
+    expect(sockets[0].sent).toHaveLength(2);
+    expect((sockets[0].sent[0] as Buffer).equals(Buffer.from([9, 9]))).toBe(
+      true,
+    );
+    expect(sockets[0].sent[1]).toBe('after');
+  });
+
+  it('reconnects with backoff sequence 1s/2s/4s on close 1006', () => {
+    vi.useFakeTimers();
+    try {
+      const client = new TunnelClient({
+        url: 'wss://x',
+        token: 't',
+        onFrame: () => {},
+        wsFactory: factory,
+      });
+      client.start();
+      sockets[0].open();
+      expect(client.getState()).toBe('connected');
+
+      // First disconnect -> 1000ms backoff.
+      sockets[0].closeFromServer(1006);
+      expect(client.getState()).toBe('reconnecting');
+      expect(sockets).toHaveLength(1);
+      vi.advanceTimersByTime(999);
+      expect(sockets).toHaveLength(1);
+      vi.advanceTimersByTime(1);
+      expect(sockets).toHaveLength(2);
+      expect(client.getState()).toBe('connecting');
+
+      // Second disconnect (without successful open) -> 2000ms.
+      sockets[1].closeFromServer(1006);
+      vi.advanceTimersByTime(1999);
+      expect(sockets).toHaveLength(2);
+      vi.advanceTimersByTime(1);
+      expect(sockets).toHaveLength(3);
+
+      // Third -> 4000ms.
+      sockets[2].closeFromServer(1011);
+      vi.advanceTimersByTime(3999);
+      expect(sockets).toHaveLength(3);
+      vi.advanceTimersByTime(1);
+      expect(sockets).toHaveLength(4);
+
+      // Successful connect on socket 4 resets attempts.
+      sockets[3].open();
+      expect(client.getState()).toBe('connected');
+      sockets[3].closeFromServer(1006);
+      // Back to 1000ms.
+      vi.advanceTimersByTime(999);
+      expect(sockets).toHaveLength(4);
+      vi.advanceTimersByTime(1);
+      expect(sockets).toHaveLength(5);
+
+      client.stop();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stop() prevents reconnects even after subsequent close 1006', () => {
+    vi.useFakeTimers();
+    try {
+      const client = new TunnelClient({
+        url: 'wss://x',
+        token: 't',
+        onFrame: () => {},
+        wsFactory: factory,
+      });
+      client.start();
+      sockets[0].open();
+      expect(client.getState()).toBe('connected');
+
+      client.stop();
+      expect(client.getState()).toBe('stopped');
+      // stop() called close() which fired our fake close handler — fine.
+      // Even if the server-side then emits another 1006 somehow, no reconnect.
+      sockets[0].closeFromServer(1006);
+      vi.advanceTimersByTime(60_000);
+      expect(sockets).toHaveLength(1);
+      expect(client.getState()).toBe('stopped');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('computeBackoffMs caps at 30s and jitter range stays ±20%', () => {
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 't',
+      onFrame: () => {},
+      wsFactory: factory,
+    });
+    // With Math.random()=0.5 -> jitter factor = 1.
+    expect(client.computeBackoffMs(0)).toBe(1000);
+    expect(client.computeBackoffMs(1)).toBe(2000);
+    expect(client.computeBackoffMs(2)).toBe(4000);
+    expect(client.computeBackoffMs(3)).toBe(8000);
+    expect(client.computeBackoffMs(4)).toBe(16000);
+    expect(client.computeBackoffMs(5)).toBe(30000);
+    expect(client.computeBackoffMs(99)).toBe(30000);
+
+    // Jitter min (random=0 -> factor 0.8).
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    expect(client.computeBackoffMs(0)).toBe(800);
+    // Jitter max-ish (random≈1 -> factor 1.2), but cap honors 30s.
+    vi.spyOn(Math, 'random').mockReturnValue(0.9999);
+    expect(client.computeBackoffMs(5)).toBeLessThanOrEqual(30_000);
+  });
+});


### PR DESCRIPTION
## Summary

S3-T3: new `packages/daemon/src/tunnel.mts` — outbound cloud-tunnel WS client. Pure transport: dial, auto-reconnect with exponential backoff + jitter, send frames, deliver inbound frames via `onFrame`. Wiring (env `CCSM_TUNNEL_URL`, caller in `index.mts`) and subprotocol token auth come in T4 / T6.

- `class TunnelClient` with `start() / send() / stop() / getState()`.
- Backoff sequence `[1s, 2s, 4s, 8s, 16s, 30s, 30s, ...]` with ±20% jitter, 30s cap. Counter resets on a successful `open`.
- `1006` / `1011` / network error all trigger reconnect; `stop()` is terminal (no further reconnects, even if a stray close arrives).
- `send()` while not `connected` drops + warns (per spec — "drop + log").
- `wsFactory` DI seam used by tests; production uses real `ws.WebSocket`.
- New unit tests in `packages/daemon/test/tunnel.test.ts` (vitest, fake ws via DI, `vi.useFakeTimers` for backoff timing, `Math.random` pinned to 0.5 for jitter determinism). Covers binary + text inbound, send round-trip, 1s/2s/4s sequence + reset on success, `stop()` no-reconnect, `computeBackoffMs` cap + jitter range.

No new deps (uses existing `ws`). No changes to `index.mts`, frontend, cf-worker, Tauri.

## Local checks (host: Windows, mode: fast)
- lint: ✓ (exit 0) — `npx eslint packages/daemon/src/tunnel.mts packages/daemon/test/tunnel.test.ts --max-warnings=0` clean. Two pre-existing lint errors on `origin/working` (`packages/daemon/test/persist.test.ts:20`, `packages/ui/test/BootstrapRefresh.test.tsx:24`) are unrelated to this task; not introduced here.
- typecheck: ✓ (exit 0) — `pnpm -F @ccsm/daemon typecheck`
- build: ✓ (exit 0) — `pnpm -F @ccsm/daemon build`
- unit tests: ✓ — `pnpm -F @ccsm/daemon test tunnel` → 5 passed (14ms). Specs touched: `packages/daemon/test/tunnel.test.ts` only (new file).
- e2e: skipped — pure new daemon module, not wired into index.mts yet (T4); no e2e surface to exercise.

Not a bug fix → no reverse-verify section.