### PR TITLE
feat(daemon): dual-listen loopback + cloud tunnel (Task #777)

### DIFF
--- a/packages/daemon/src/index.mts
+++ b/packages/daemon/src/index.mts
@@ -25,11 +25,14 @@ import type { AddressInfo } from 'node:net';
 import { openDb } from './db.mjs';
 import { createDaemonHttp } from './http.mjs';
 import { createRuntimeRegistry } from './runtime.mjs';
+import { TunnelClient } from './tunnel.mjs';
 import { attachWebSocket } from './ws.mjs';
 
 const DEFAULT_PORT = 17832;
 const PORT_RETRY_MAX = 20;
 const SHUTDOWN_TIMEOUT_MS = 2000;
+const DEFAULT_TUNNEL_URL = 'wss://cc-sm.pages.dev/tunnel/default';
+const TUNNEL_CONNECT_POLL_MS = 100;
 
 const HANDSHAKE_FLAG = '--handshake-stdout';
 
@@ -118,6 +121,53 @@ async function main(): Promise<void> {
   http.setRegistry(registry);
   attachWebSocket(http.server, { token, sessions: http.sessions, registry });
 
+  // Dual-listen (Task #777, S3-T4): in addition to loopback HTTP, kick off an
+  // outbound WS tunnel to the Cloudflare Worker so cloud browsers can reach
+  // this daemon. Tunnel init is fire-and-forget — its failure must NEVER
+  // abort the loopback path. Set CCSM_TUNNEL_DISABLE=1 to skip entirely
+  // (tests + offline dev). T4 only verifies link-up; real frame routing into
+  // sessions lands in T6.
+  const tunnelDisabled = process.env.CCSM_TUNNEL_DISABLE === '1';
+  const tunnelUrl = process.env.CCSM_TUNNEL_URL || DEFAULT_TUNNEL_URL;
+  let tunnel: TunnelClient | null = null;
+  let tunnelStatePoll: ReturnType<typeof setInterval> | null = null;
+  if (tunnelDisabled) {
+    console.error('[ccsm] tunnel: disabled (CCSM_TUNNEL_DISABLE)');
+  } else {
+    console.error(`[ccsm] tunnel: connecting ${tunnelUrl}`);
+    tunnel = new TunnelClient({
+      url: tunnelUrl,
+      token,
+      onFrame: (data) => {
+        const len = typeof data === 'string'
+          ? Buffer.byteLength(data, 'utf8')
+          : data.length;
+        // T4 simplification: just observe link-up; T6 will route into sessions.
+        console.error(`[ccsm] tunnel: rx frame len=${len}`);
+      },
+    });
+    tunnel.start();
+    // TunnelClient does not emit a 'connected' event; poll state until we
+    // observe the first transition (or the client is stopped). Cheap timer,
+    // unref'd so it never holds the loop open. Logged once per connect.
+    let lastState = tunnel.getState();
+    tunnelStatePoll = setInterval(() => {
+      if (tunnel === null) return;
+      const s = tunnel.getState();
+      if (s !== lastState) {
+        if (s === 'connected') console.error('[ccsm] tunnel: connected');
+        lastState = s;
+      }
+      if (s === 'stopped') {
+        if (tunnelStatePoll !== null) {
+          clearInterval(tunnelStatePoll);
+          tunnelStatePoll = null;
+        }
+      }
+    }, TUNNEL_CONNECT_POLL_MS);
+    tunnelStatePoll.unref?.();
+  }
+
   // Handshake mode: bind port 0 (ephemeral) once, no retry — caller already
   // scopes the port via OS allocation, EADDRINUSE on port 0 is "out of ports"
   // and not recoverable by ++port.
@@ -145,6 +195,19 @@ async function main(): Promise<void> {
     if (shuttingDown) return;
     shuttingDown = true;
     console.error(`[ccsm] received ${signal}, shutting down`);
+    // Stop the outbound tunnel first so we don't reconnect while the HTTP
+    // server is closing. tunnel.stop() is synchronous + idempotent.
+    if (tunnel !== null) {
+      try {
+        tunnel.stop();
+      } catch (err) {
+        console.error('[ccsm] tunnel.stop error:', err);
+      }
+    }
+    if (tunnelStatePoll !== null) {
+      clearInterval(tunnelStatePoll);
+      tunnelStatePoll = null;
+    }
     // Synchronously flush any pending sessions write BEFORE we close the
     // db handle. flushNow() also clears the debounce timer so the event
     // loop has nothing left holding it open.

--- a/packages/daemon/test/lifecycle.test.ts
+++ b/packages/daemon/test/lifecycle.test.ts
@@ -43,6 +43,7 @@ const SIGINT_GRACE_MS = 4_000;
 // catch a "self-shutdown after N seconds" regression. 5s is the smallest
 // bound that comfortably covers that without slowing the suite materially.
 const IDLE_WAIT_MS = 5_000;
+const TUNNEL_LOG_WAIT_MS = 1_500;
 
 interface BootResult {
   proc: ChildProcess;
@@ -71,9 +72,19 @@ async function bootDaemon(extraEnv: Record<string, string> = {}): Promise<BootRe
   // it has its own EADDRINUSE retry from DEFAULT_PORT. Picking a random port
   // far from 17832 keeps parallel test runs from clashing.
   const port = 19000 + Math.floor(Math.random() * 1000);
+  // Disable the cloud tunnel by default — most lifecycle assertions run
+  // offline / on CI without network and would otherwise see ws errors on
+  // stderr. Tunnel-specific cases pass extraEnv to override.
+  const env: Record<string, string> = {
+    ...process.env,
+    NODE_ENV: 'test',
+    PORT: String(port),
+    CCSM_TUNNEL_DISABLE: '1',
+    ...extraEnv,
+  };
   const proc = spawn(cmd, args, {
     cwd: DAEMON_PKG_DIR,
-    env: { ...process.env, NODE_ENV: 'test', PORT: String(port), ...extraEnv },
+    env,
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 
@@ -187,9 +198,15 @@ describe('daemon lifecycle (T12)', () => {
           ),
         ]);
         expect(result).toBe('still-alive');
-        // No stderr should have been emitted while the daemon sat idle.
-        // (The graceful-shutdown notice is written on signal — not here.)
-        expect(boot.stderrRef.value, `unexpected stderr during idle: ${boot.stderrRef.value}`).toBe('');
+        // No unexpected stderr should have been emitted while idle. The
+        // tunnel subsystem (Task #777) prints one informational line on
+        // boot ("[ccsm] tunnel: disabled ..." in this test) which we
+        // explicitly filter out — it's expected, not a regression signal.
+        const idleStderr = boot.stderrRef.value
+          .split('\n')
+          .filter((l) => l.length > 0 && !l.startsWith('[ccsm] tunnel:'))
+          .join('\n');
+        expect(idleStderr, `unexpected stderr during idle: ${boot.stderrRef.value}`).toBe('');
         // Process still reports alive.
         expect(boot.proc.exitCode).toBeNull();
         expect(boot.proc.signalCode).toBeNull();
@@ -198,5 +215,52 @@ describe('daemon lifecycle (T12)', () => {
       }
     },
     IDLE_WAIT_MS + 15_000,
+  );
+
+  // Task #777 (S3-T4): dual-listen — loopback + tunnel run in parallel,
+  // tunnel failure must never abort the loopback path.
+  it(
+    'CCSM_TUNNEL_DISABLE=1 boots loopback only, no tunnel connect attempt',
+    async () => {
+      const boot = await bootDaemon({ CCSM_TUNNEL_DISABLE: '1' });
+      try {
+        // Give the daemon a moment to print any startup diagnostics.
+        await new Promise<void>((r) => setTimeout(r, TUNNEL_LOG_WAIT_MS));
+        // Loopback is up: ready line already matched in bootDaemon.
+        // Tunnel must NOT have attempted to connect.
+        expect(boot.stderrRef.value).not.toMatch(/tunnel: connecting/);
+        expect(boot.stderrRef.value).toMatch(/tunnel: disabled \(CCSM_TUNNEL_DISABLE\)/);
+        // Loopback HTTP still serves: /token responds 200 (no auth required).
+        const res = await fetch(`${boot.url.replace(/\/\?token=.*$/, '')}/token`);
+        expect(res.status).toBe(200);
+      } finally {
+        await killHard(boot.proc);
+      }
+    },
+    20_000,
+  );
+
+  it(
+    'tunnel default-on: unreachable URL still leaves loopback serving',
+    async () => {
+      // Pick a deliberately unreachable URL (port 1, refused everywhere).
+      // Tunnel will log "connecting", then ws/connect errors, then schedule
+      // a backoff reconnect — but the loopback HTTP server must remain up.
+      const boot = await bootDaemon({
+        CCSM_TUNNEL_DISABLE: '',
+        CCSM_TUNNEL_URL: 'ws://127.0.0.1:1/tunnel/default',
+      });
+      try {
+        await new Promise<void>((r) => setTimeout(r, TUNNEL_LOG_WAIT_MS));
+        expect(boot.stderrRef.value).toMatch(/tunnel: connecting ws:\/\/127\.0\.0\.1:1/);
+        // Loopback HTTP must still respond even though tunnel is down.
+        const res = await fetch(`${boot.url.replace(/\/\?token=.*$/, '')}/token`);
+        expect(res.status).toBe(200);
+        expect(boot.proc.exitCode).toBeNull();
+      } finally {
+        await killHard(boot.proc);
+      }
+    },
+    20_000,
   );
 });


### PR DESCRIPTION
S3-T4: wire `TunnelClient` (shipped in #1162 / Task #779) into daemon `main()` so the daemon listens loopback HTTP **and** dials the Cloudflare Worker tunnel in parallel. Tunnel init is fire-and-forget — its failure must never abort loopback.

## Changes

- `packages/daemon/src/index.mts`:
  - After `attachWebSocket()`, init `TunnelClient` with `CCSM_TUNNEL_URL` (default `wss://cc-sm.pages.dev/tunnel/default`) unless `CCSM_TUNNEL_DISABLE=1`.
  - Startup logs (stderr; stdout still reserved for handshake / `ccsm ready` line):
    - `[ccsm] tunnel: connecting <url>` or `[ccsm] tunnel: disabled (CCSM_TUNNEL_DISABLE)`
    - `[ccsm] tunnel: connected` once the WS dials in (observed via 100ms state poll since `TunnelClient` exposes `getState()` but no event).
    - `[ccsm] tunnel: rx frame len=<N>` per inbound cloud frame — T4 simplification, real session routing lands in T6.
  - Shutdown handler calls `tunnel.stop()` and clears the state-poll interval **before** `http.server.close()`, so we don't reconnect into a closing server.
- `packages/daemon/test/lifecycle.test.ts`:
  - `bootDaemon` now sets `CCSM_TUNNEL_DISABLE=1` by default so the existing idle / SIGINT cases stay offline-clean.
  - Idle-quiet assertion filters `[ccsm] tunnel:` lines (one informational `disabled` line is expected, not a regression signal).
  - **New case**: `CCSM_TUNNEL_DISABLE=1` → no `tunnel: connecting` ever printed; `/token` still 200.
  - **New case**: tunnel default-on with deliberately unreachable `ws://127.0.0.1:1/...` → `tunnel: connecting` logged, daemon still serves `/token` 200, process still alive.

## Manual dry-run

```
$ CCSM_TUNNEL_DISABLE=1 node packages/daemon/dist/index.mjs
[ccsm] tunnel: disabled (CCSM_TUNNEL_DISABLE)
ccsm ready: http://127.0.0.1:.../?token=...

$ CCSM_TUNNEL_URL=ws://127.0.0.1:1/x node packages/daemon/dist/index.mjs
[ccsm] tunnel: connecting ws://127.0.0.1:1/x
ccsm ready: http://127.0.0.1:.../?token=...
[ccsm/tunnel] ws error: connect ECONNREFUSED 127.0.0.1:1
[ccsm/tunnel] closed code=1006, will reconnect
...
```

Both modes match spec: loopback always serves; tunnel is parallel + non-fatal.

## Out of scope

- Routing inbound cloud frames into `sessions` (T6).
- Worker-side subprotocol token auth (T6).
- Frontend `hostConfig` switch (T5).
- Not touching `tunnel.mts` (shipped in #1162).

## Local checks (host: Windows 11, mode: fast)
- lint: ✓ (`pnpm -w lint` red on 2 pre-existing errors in `packages/daemon/test/persist.test.ts` and `packages/ui/test/BootstrapRefresh.test.tsx` — unrelated to this PR; verified by patch-stashing my diff and re-running lint, same 2 errors persist on `origin/working`)
- typecheck: ✓ (`pnpm -F @ccsm/daemon typecheck` exit 0)
- build: ✓ (`pnpm -F @ccsm/daemon build` exit 0)
- unit tests: ✓ — `pnpm -F @ccsm/daemon test lifecycle` → `Tests 3 passed | 1 skipped (4)` in 11.31s. The 3 passing cases are: idle-quiet (5949ms), `CCSM_TUNNEL_DISABLE=1` boots loopback only (1786ms), tunnel default-on with unreachable URL still serves loopback (1769ms). 1 skip = SIGINT POSIX-only.
- e2e: skipped — change is daemon-internal, no e2e probe exercises tunnel link-up; T8 will add the cloud-path e2e.