### PR TITLE
feat(cf-worker): TunnelDO browser <-> daemon pairing + frame forward (Task #774, S3-T2)

### DIFF
--- a/packages/cf-worker/package.json
+++ b/packages/cf-worker/package.json
@@ -8,11 +8,13 @@
     "deploy": "wrangler deploy",
     "typecheck": "tsc --noEmit",
     "build": "tsc --noEmit",
-    "lint": "eslint src --max-warnings=0"
+    "lint": "eslint src --max-warnings=0",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240909.0",
     "typescript": "^5.6.3",
+    "vitest": "^2.1.4",
     "wrangler": "^3.78.0"
   }
 }

--- a/packages/cf-worker/src/index.ts
+++ b/packages/cf-worker/src/index.ts
@@ -2,11 +2,10 @@ export interface Env {
   TUNNEL: DurableObjectNamespace;
 }
 
+export { TunnelDO } from './tunnel-do';
+
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
-    // env is reserved for T2 routing into the TUNNEL Durable Object.
-    void env;
-
     const url = new URL(req.url);
     const isUpgrade =
       req.headers.get('Upgrade')?.toLowerCase() === 'websocket';
@@ -15,24 +14,13 @@ export default {
       (url.pathname === '/ws/default' || url.pathname === '/tunnel/default') &&
       isUpgrade
     ) {
-      // T2 will route to DO. T1 placeholder: 426 Upgrade Required.
-      return new Response('Tunnel handler not yet wired (S3-T2 pending)', {
-        status: 426,
-      });
+      // Route both directions into the same DO instance keyed by 'default'
+      // so the daemon ws and browser ws end up paired in one TunnelDO.
+      // Multi-tunnel routing (per-user / per-pairing-id) is future work.
+      const id = env.TUNNEL.idFromName('default');
+      const stub = env.TUNNEL.get(id);
+      return stub.fetch(req);
     }
     return new Response('Not Found', { status: 404 });
   },
 };
-
-// TunnelDO is implemented in S3-T2 (tunnel-do.ts). Stub class so wrangler.toml
-// binding resolves and `wrangler dev` boots without a missing-class error.
-export class TunnelDO {
-  constructor(state: DurableObjectState, env: Env) {
-    void state;
-    void env;
-  }
-  async fetch(req: Request): Promise<Response> {
-    void req;
-    return new Response('TunnelDO stub (S3-T2 pending)', { status: 501 });
-  }
-}

--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -1,0 +1,98 @@
+import type { Env } from './index';
+
+interface PairedSockets {
+  browser?: WebSocket | undefined;
+  daemon?: WebSocket | undefined;
+}
+
+/**
+ * TunnelDO pairs a daemon websocket with a browser websocket and forwards
+ * frames between them in both directions.
+ *
+ * Routes (path is whatever the worker forwards; we match suffix only):
+ *   /tunnel/default — daemon dials in (long-lived).
+ *   /ws/default     — browser connects; closes 1011 if no daemon paired yet.
+ *
+ * Lifecycle:
+ *   - Frames (text + binary) are forwarded as-is via ws.send(ev.data).
+ *   - daemon close/error → browser closed with 1006/1011, both slots cleared
+ *     so a fresh daemon can re-pair.
+ *   - browser close → daemon stays alive; next browser can re-pair.
+ *
+ * S3-T2 (Task #774). e2e coverage lives in S3-T8.
+ */
+export class TunnelDO {
+  private state: DurableObjectState;
+  private env: Env;
+  private sockets: PairedSockets = {};
+
+  constructor(state: DurableObjectState, env: Env) {
+    this.state = state;
+    this.env = env;
+    void this.state;
+    void this.env;
+  }
+
+  async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    const upgrade = req.headers.get('Upgrade');
+    if (upgrade?.toLowerCase() !== 'websocket') {
+      return new Response('Expected websocket', { status: 426 });
+    }
+
+    const pair = new WebSocketPair();
+    const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
+
+    if (url.pathname.endsWith('/tunnel/default')) {
+      server.accept();
+      this.sockets.daemon = server;
+      this.wireDaemon(server);
+      return new Response(null, { status: 101, webSocket: client });
+    }
+
+    if (url.pathname.endsWith('/ws/default')) {
+      if (!this.sockets.daemon) {
+        server.accept();
+        server.close(1011, 'daemon offline');
+        return new Response(null, { status: 101, webSocket: client });
+      }
+      server.accept();
+      this.sockets.browser = server;
+      this.wireBrowser(server);
+      return new Response(null, { status: 101, webSocket: client });
+    }
+
+    return new Response('Not Found', { status: 404 });
+  }
+
+  private wireDaemon(ws: WebSocket): void {
+    ws.addEventListener('message', (ev: MessageEvent) => {
+      this.sockets.browser?.send(ev.data);
+    });
+    ws.addEventListener('close', () => {
+      try {
+        this.sockets.browser?.close(1006, 'daemon disconnected');
+      } catch {
+        /* browser may already be gone */
+      }
+      this.sockets.browser = undefined;
+      this.sockets.daemon = undefined;
+    });
+    ws.addEventListener('error', () => {
+      try {
+        this.sockets.browser?.close(1011, 'daemon error');
+      } catch {
+        /* browser may already be gone */
+      }
+    });
+  }
+
+  private wireBrowser(ws: WebSocket): void {
+    ws.addEventListener('message', (ev: MessageEvent) => {
+      this.sockets.daemon?.send(ev.data);
+    });
+    ws.addEventListener('close', () => {
+      this.sockets.browser = undefined;
+    });
+  }
+}

--- a/packages/cf-worker/test/tunnel-do.test.ts
+++ b/packages/cf-worker/test/tunnel-do.test.ts
@@ -1,0 +1,251 @@
+/**
+ * TunnelDO unit tests.
+ *
+ * We don't boot wrangler / workerd here — pairing is a pure protocol
+ * concern (wire two WebSocket-shaped objects together) and the workers
+ * runtime adds boot cost + flake without exercising the logic we own.
+ *
+ * Strategy: stub `WebSocketPair` and a minimal `WebSocket`-shaped object
+ * with addEventListener/dispatchEvent/send/close/accept on globalThis,
+ * then drive `TunnelDO.fetch(req)` directly. Real wire-level pairing
+ * over a live worker is covered by S3-T8 e2e.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type Listener = (ev: { data?: unknown; code?: number; reason?: string }) => void;
+
+interface FakeServerSocket {
+  readonly side: 'server';
+  accepted: boolean;
+  closed: boolean;
+  closeCode?: number;
+  closeReason?: string;
+  sent: Array<unknown>;
+  listeners: { message: Listener[]; close: Listener[]; error: Listener[] };
+  accept(): void;
+  send(data: unknown): void;
+  close(code?: number, reason?: string): void;
+  addEventListener(type: 'message' | 'close' | 'error', cb: Listener): void;
+  // Test helpers (drive the socket as if a peer wrote/closed):
+  emitMessage(data: unknown): void;
+  emitClose(): void;
+  emitError(): void;
+}
+
+interface FakeClientSocket {
+  readonly side: 'client';
+}
+
+function makeServerSocket(): FakeServerSocket {
+  const sock: FakeServerSocket = {
+    side: 'server',
+    accepted: false,
+    closed: false,
+    sent: [],
+    listeners: { message: [], close: [], error: [] },
+    accept() {
+      this.accepted = true;
+    },
+    send(data: unknown) {
+      if (this.closed) throw new Error('socket closed');
+      this.sent.push(data);
+    },
+    close(code?: number, reason?: string) {
+      if (this.closed) return;
+      this.closed = true;
+      this.closeCode = code;
+      this.closeReason = reason;
+    },
+    addEventListener(type, cb) {
+      this.listeners[type].push(cb);
+    },
+    emitMessage(data) {
+      for (const cb of this.listeners.message) cb({ data });
+    },
+    emitClose() {
+      for (const cb of this.listeners.close) cb({});
+      this.closed = true;
+    },
+    emitError() {
+      for (const cb of this.listeners.error) cb({});
+    },
+  };
+  return sock;
+}
+
+const created: { client: FakeClientSocket; server: FakeServerSocket }[] = [];
+
+class FakeWebSocketPair {
+  '0': FakeClientSocket;
+  '1': FakeServerSocket;
+  constructor() {
+    const client: FakeClientSocket = { side: 'client' };
+    const server = makeServerSocket();
+    this[0] = client;
+    this[1] = server;
+    created.push({ client, server });
+  }
+}
+
+// Workers runtime allows `new Response(null, { status: 101, webSocket })`
+// for ws upgrades; Node's undici Response rejects status < 200. Wrap to
+// allow 101 only in tests so we can drive TunnelDO.fetch directly.
+const NodeResponse = globalThis.Response;
+class WorkersResponse {
+  status: number;
+  body: unknown;
+  webSocket?: unknown;
+  constructor(body: unknown, init?: { status?: number; webSocket?: unknown }) {
+    if (init && typeof init.status === 'number' && init.status === 101) {
+      this.status = 101;
+      this.body = body;
+      this.webSocket = init.webSocket;
+      return;
+    }
+    // Fall through to real Response for non-upgrade paths so status/body
+    // semantics match production for those branches.
+    const real = new NodeResponse(body as BodyInit | null, init);
+    return real as unknown as WorkersResponse;
+  }
+}
+
+beforeEach(() => {
+  created.length = 0;
+  // @ts-expect-error — install workers-runtime globals for the unit test.
+  globalThis.WebSocketPair = FakeWebSocketPair;
+  // @ts-expect-error — patch Response to permit status 101 upgrades.
+  globalThis.Response = WorkersResponse;
+});
+
+afterEach(() => {
+  // @ts-expect-error — clean up to avoid leaking globals across files.
+  delete globalThis.WebSocketPair;
+  globalThis.Response = NodeResponse;
+  vi.restoreAllMocks();
+});
+
+async function loadDO() {
+  const mod = await import('../src/tunnel-do.js');
+  return mod.TunnelDO;
+}
+
+function makeReq(path: string): Request {
+  return new Request(`https://example.test${path}`, {
+    headers: { Upgrade: 'websocket' },
+  });
+}
+
+const fakeState = {} as DurableObjectState;
+const fakeEnv = {} as { TUNNEL: DurableObjectNamespace };
+
+describe('TunnelDO', () => {
+  it('rejects non-websocket requests with 426', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(fakeState, fakeEnv);
+    const res = await inst.fetch(
+      new Request('https://example.test/tunnel/default'),
+    );
+    expect(res.status).toBe(426);
+  });
+
+  it('pairs daemon then browser; daemon -> browser forwards text + binary', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(fakeState, fakeEnv);
+
+    await inst.fetch(makeReq('/tunnel/default'));
+    const daemon = created[0].server;
+    expect(daemon.accepted).toBe(true);
+
+    await inst.fetch(makeReq('/ws/default'));
+    const browser = created[1].server;
+    expect(browser.accepted).toBe(true);
+    expect(browser.closed).toBe(false);
+
+    daemon.emitMessage('hello');
+    daemon.emitMessage(new Uint8Array([1, 2, 3]));
+    expect(browser.sent).toEqual(['hello', new Uint8Array([1, 2, 3])]);
+  });
+
+  it('forwards browser -> daemon (text + binary)', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(fakeState, fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    await inst.fetch(makeReq('/ws/default'));
+    const daemon = created[0].server;
+    const browser = created[1].server;
+
+    browser.emitMessage('ping');
+    browser.emitMessage(new Uint8Array([9, 9]));
+    expect(daemon.sent).toEqual(['ping', new Uint8Array([9, 9])]);
+  });
+
+  it('closes browser ws with 1011 daemon offline when no daemon paired', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(fakeState, fakeEnv);
+
+    const res = await inst.fetch(makeReq('/ws/default'));
+    expect(res.status).toBe(101);
+    const browser = created[0].server;
+    expect(browser.accepted).toBe(true);
+    expect(browser.closed).toBe(true);
+    expect(browser.closeCode).toBe(1011);
+    expect(browser.closeReason).toBe('daemon offline');
+  });
+
+  it('daemon close triggers browser close 1006 and clears slots', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(fakeState, fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    await inst.fetch(makeReq('/ws/default'));
+    const daemon = created[0].server;
+    const browser = created[1].server;
+
+    daemon.emitClose();
+
+    expect(browser.closed).toBe(true);
+    expect(browser.closeCode).toBe(1006);
+    expect(browser.closeReason).toBe('daemon disconnected');
+
+    // After daemon drop the next browser should hit "daemon offline" path
+    // (slots cleared so a fresh /ws/default re-runs the no-daemon branch).
+    const res = await inst.fetch(makeReq('/ws/default'));
+    expect(res.status).toBe(101);
+    const browser2 = created[2].server;
+    expect(browser2.closeCode).toBe(1011);
+  });
+
+  it('browser close leaves daemon alive; new browser can re-pair', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(fakeState, fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    await inst.fetch(makeReq('/ws/default'));
+    const daemon = created[0].server;
+    const browser = created[1].server;
+
+    browser.emitClose();
+    expect(daemon.closed).toBe(false);
+
+    await inst.fetch(makeReq('/ws/default'));
+    const browser2 = created[2].server;
+    expect(browser2.accepted).toBe(true);
+    expect(browser2.closed).toBe(false);
+
+    daemon.emitMessage('after-rebind');
+    expect(browser2.sent).toEqual(['after-rebind']);
+  });
+
+  it('daemon error closes browser with 1011 daemon error', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(fakeState, fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    await inst.fetch(makeReq('/ws/default'));
+    const daemon = created[0].server;
+    const browser = created[1].server;
+
+    daemon.emitError();
+
+    expect(browser.closed).toBe(true);
+    expect(browser.closeCode).toBe(1011);
+    expect(browser.closeReason).toBe('daemon error');
+  });
+});

--- a/packages/cf-worker/vitest.config.ts
+++ b/packages/cf-worker/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.4
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
       wrangler:
         specifier: ^3.78.0
         version: 3.114.17(@cloudflare/workers-types@4.20260508.1)


### PR DESCRIPTION
## Summary

Replaces the T1 stub `TunnelDO` with the real Durable Object that pairs a daemon WebSocket with a browser WebSocket and forwards frames in both directions.

- New `packages/cf-worker/src/tunnel-do.ts` exporting `TunnelDO` with full pairing + lifecycle.
- `src/index.ts` now forwards `/ws/default` and `/tunnel/default` upgrades into the DO instance keyed by `idFromName('default')` (placeholder routing; multi-tunnel routing is future work).
- `wrangler.toml` binding from T1 (`TUNNEL` -> `TunnelDO`) is unchanged.

### Pairing semantics

- daemon dials `/tunnel/default` first, slot stored.
- browser connects on `/ws/default`; if no daemon paired -> close `1011 daemon offline`.
- once both paired, text + binary frames forward as-is via `ws.send(ev.data)`.
- daemon close -> browser closed `1006 daemon disconnected`, both slots cleared so a fresh daemon can re-pair.
- daemon error -> browser closed `1011 daemon error`.
- browser close -> daemon stays alive, next browser can re-pair.

### Tests

Unit tests (`packages/cf-worker/test/tunnel-do.test.ts`, vitest, node env) drive `TunnelDO.fetch` directly with a fake `WebSocketPair` + WebSocket-shaped objects. `Response` is patched in test setup to permit status 101 (undici rejects sub-200). 7 cases:

1. non-upgrade request -> 426.
2. daemon -> browser forwards text + binary.
3. browser -> daemon forwards text + binary.
4. no daemon -> browser closed 1011 'daemon offline'.
5. daemon close -> browser 1006 + slot clear (next browser re-runs offline branch).
6. browser close -> daemon survives, second browser re-pairs and receives frames.
7. daemon error -> browser closed 1011 'daemon error'.

Live-runtime pairing over a real worker (`wrangler.unstable_dev` + `ws` client) is intentionally **not** covered here — that is S3-T8 e2e scope. Keeping the unit dep-free (no wrangler boot, no `ws` package) means it runs in <1s and never flakes on workerd download / network.

## Local checks (host: Windows, mode: fast)

- lint: cf-worker green (workspace baseline has 2 unrelated errors in `packages/daemon/test/persist.test.ts` and `packages/ui/test/BootstrapRefresh.test.tsx` — not introduced by this PR; verifiable via `git diff origin/working...HEAD --name-only` not touching those files).
- typecheck: green (`pnpm -F @ccsm/cf-worker typecheck`).
- build: same as typecheck for this package (`tsc --noEmit`).
- unit tests: green — `pnpm -F @ccsm/cf-worker test` -> `Test Files 1 passed (1) | Tests 7 passed (7) | Duration 862ms`.
- e2e: skipped, no electron / harness changes; e2e wire test for tunnel is S3-T8.

## Out of scope

- Multi-tunnel routing (per-user / per-pairing-id `idFromName(...)`). Currently fixed `'default'`.
- Auth / pairing token validation. T6+ task.
- Live wrangler boot test (S3-T8 e2e covers the wire path).

Task #774