### PR TITLE
ci(cf-worker): add deploy-worker workflow (Task #776)

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,66 @@
+name: deploy-worker
+
+# Task #776 [S3-T7]: Cloudflare Worker deploy pipeline for cf-worker
+# (TunnelDO browser <-> daemon pairing + frame forward).
+#
+# Triggers:
+#   - push to main or working: ship cf-worker on every merge that touches
+#     packages/cf-worker (or pnpm workspace metadata that changes its
+#     resolved deps). Mirrors deploy-pages.yml branch policy: `working`
+#     is the post-v0.1.0 release main-line, `main` is the periodic roll-up.
+#   - workflow_dispatch: manual redeploy from the Actions tab (e.g. after
+#     rotating wrangler secrets or rolling back).
+#
+# NOTE: this workflow file itself is intentionally NOT in `paths` — editing
+# the yml should not retrigger a worker deploy.
+#
+# Secrets (already configured on the repo for deploy-pages.yml; reused here
+# — no new secrets required per Task #776 spec):
+#   - CLOUDFLARE_API_TOKEN: scoped token with Workers:Edit on account.
+#   - CLOUDFLARE_ACCOUNT_ID: account containing the cf-worker.
+
+on:
+  push:
+    branches: [main, working]
+    paths:
+      - 'packages/cf-worker/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+  workflow_dispatch:
+
+# Concurrency: only one Worker deploy at a time per ref; cancel stale runs.
+concurrency:
+  group: deploy-worker-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck cf-worker
+        run: pnpm -F @ccsm/cf-worker typecheck
+
+      - name: Deploy to Cloudflare Workers
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: packages/cf-worker
+          command: deploy


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy-worker.yml` to deploy `packages/cf-worker` to Cloudflare Workers via `cloudflare/wrangler-action@v3`.
- Mirrors `deploy-pages.yml` style (pnpm 10.33.2 + node 22 + cache:pnpm, frozen lockfile install, concurrency group, workflow_dispatch).
- Triggers on push to `main` / `working` when `packages/cf-worker/**`, `pnpm-lock.yaml`, or `pnpm-workspace.yaml` change. The workflow file itself is intentionally NOT in `paths` to avoid self-retriggering on yml edits.
- Reuses existing `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` secrets (no new secrets required, per spec).
- Steps: checkout -> pnpm/action-setup -> setup-node -> install -> `pnpm -F @ccsm/cf-worker typecheck` -> wrangler-action `deploy` with `workingDirectory: packages/cf-worker`.

## Local checks (host: Windows, mode: fast)
- yaml parse: PASS (python `yaml.safe_load`; jobs=`['deploy']`, branches=`['main','working']`, paths=`['packages/cf-worker/**','pnpm-lock.yaml','pnpm-workspace.yaml']`)
- lint: skipped (yml-only change, no .ts/.tsx touched — per dev.md §3 yml-only exception)
- typecheck: skipped (same reason)
- build: skipped (same reason)
- unit tests: skipped (same reason)
- e2e: skipped (same reason)

## Notes
- Does not modify `deploy-pages.yml` or any other workflow.
- Does not touch any `packages/` source.
- Concurrency group `deploy-worker-${{ github.ref }}` mirrors deploy-pages convention.