### PR TITLE
fix(cf-worker): use new_sqlite_classes (free plan DO)

### DIFF
--- a/packages/cf-worker/wrangler.toml
+++ b/packages/cf-worker/wrangler.toml
@@ -11,4 +11,4 @@ class_name = "TunnelDO"
 
 [[migrations]]
 tag = "v1"
-new_classes = ["TunnelDO"]
+new_sqlite_classes = ["TunnelDO"]


### PR DESCRIPTION
## Summary
- 1-line wrangler.toml fix: `new_classes` → `new_sqlite_classes`
- Free-plan CF requires SQLite-backed DO migration (code 10097)
- TunnelDO uses no DO storage, behavior identical

## Test plan
- [x] yml syntax OK
- [ ] merge → deploy-worker auto-trigger green