### PR TITLE
feat(frontend-web): Pages Functions reverse-proxy ws to ccsm-worker (Task #785, S3-B)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -73,8 +73,14 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          # Run wrangler from the frontend-web package so it picks up
+          # `wrangler.toml` (Task #785, S3-B). That config declares the
+          # TUNNEL_WORKER service binding consumed by `functions/[[path]].ts`,
+          # which reproxies /ws/default + /tunnel/default to the standalone
+          # ccsm-worker Worker (owner of the TunnelDO DO class).
+          workingDirectory: packages/frontend-web
           # `pages deploy` is the v3 wrangler subcommand for Pages uploads.
           # --project-name pins the target Pages project (cc-sm).
           # --branch=main mirrors the git branch so the Pages dashboard
           # surfaces deploys under the production environment.
-          command: pages deploy packages/frontend-web/dist --project-name=cc-sm --branch=main
+          command: pages deploy dist --project-name=cc-sm --branch=main

--- a/packages/frontend-web/functions/[[path]].ts
+++ b/packages/frontend-web/functions/[[path]].ts
@@ -1,0 +1,43 @@
+// Task #785 [S3-B]: Cloudflare Pages Function that fronts cc-sm.pages.dev so
+// the browser only ever talks to the Pages origin.
+//
+// Why this exists: cc-sm.pages.dev is a static SPA host. Without a Function,
+// any request to `/ws/default` or `/tunnel/default` falls through to the SPA
+// fallback (200 index.html), so the WebSocket upgrade handshake never reaches
+// the Durable Object on ccsm-worker. This Function intercepts the tunnel
+// paths and reproxies them via a service binding to the independent
+// `ccsm-worker` Worker (which owns the TunnelDO Durable Object class —
+// Pages Functions cannot define DO classes themselves, see Task #774 / S3-B
+// research note afea153b6a17c9838 and the Pages Functions wrangler docs:
+// https://developers.cloudflare.com/pages/functions/wrangler-configuration/).
+//
+// Scope (intentionally narrow for this task):
+//   - WebSocket paths (`/ws/default`, `/tunnel/default`) are proxied to the
+//     Worker so the daemon can dial wss://cc-sm.pages.dev/tunnel/default and
+//     the browser can dial wss://cc-sm.pages.dev/ws/default, both terminating
+//     in the same TunnelDO instance.
+//   - REST `/api/*` is NOT proxied here yet. The daemon sits behind NAT and
+//     the Worker cannot dial back into it, so REST has to flow over the same
+//     ws tunnel (HTTP-over-tunnel framing). That is a separate followup task.
+//     For now REST stays on the loopback `?daemon=` escape hatch used in dev.
+//   - Everything else falls through to `ctx.next()` so Pages serves the
+//     static SPA assets (`/index.html`, `/assets/*`, etc.) as before.
+
+interface Env {
+  // Service binding to the standalone ccsm-worker Worker (configured in
+  // wrangler.toml as `[[services]] binding = "TUNNEL_WORKER"`). Pages
+  // Functions invoke it as a Fetcher; the Worker's own fetch handler routes
+  // /ws/default and /tunnel/default into the TunnelDO.
+  TUNNEL_WORKER: Fetcher;
+}
+
+export const onRequest: PagesFunction<Env> = async (ctx) => {
+  const url = new URL(ctx.request.url);
+
+  if (url.pathname === '/ws/default' || url.pathname === '/tunnel/default') {
+    return ctx.env.TUNNEL_WORKER.fetch(ctx.request);
+  }
+
+  // Static SPA assets and SPA fallback are handled by Pages itself.
+  return ctx.next();
+};

--- a/packages/frontend-web/package.json
+++ b/packages/frontend-web/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -p tsconfig.json --noEmit && vite build",
-    "build:pages": "tsc -p tsconfig.json --noEmit && vite build --mode pages",
-    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "build": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.functions.json --noEmit && vite build",
+    "build:pages": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.functions.json --noEmit && vite build --mode pages",
+    "typecheck": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.functions.json --noEmit",
     "lint": "eslint src --max-warnings=0",
     "test": "vitest run",
     "preview": "vite preview"
@@ -18,6 +18,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@cloudflare/workers-types": "^4.20240909.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.3",

--- a/packages/frontend-web/tsconfig.functions.json
+++ b/packages/frontend-web/tsconfig.functions.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": true,
+    "isolatedModules": true,
+    "skipLibCheck": true
+  },
+  "include": ["functions/**/*"]
+}

--- a/packages/frontend-web/wrangler.toml
+++ b/packages/frontend-web/wrangler.toml
@@ -1,0 +1,25 @@
+# Task #785 [S3-B]: wrangler config for the Cloudflare Pages project that
+# hosts cc-sm.pages.dev. The Pages Function under `functions/[[path]].ts`
+# uses the TUNNEL_WORKER service binding declared here to reproxy
+# /ws/default and /tunnel/default into the standalone ccsm-worker Worker
+# (which owns the TunnelDO Durable Object).
+#
+# Pages-specific keys (`pages_build_output_dir`) and service bindings are
+# only respected when wrangler runs from this directory. The deploy-pages
+# workflow therefore sets `workingDirectory: packages/frontend-web` so that
+# `wrangler pages deploy dist` picks this file up.
+#
+# Refs:
+#   - https://developers.cloudflare.com/pages/functions/wrangler-configuration/
+#   - https://developers.cloudflare.com/pages/functions/bindings/#service-bindings
+
+name = "cc-sm"
+compatibility_date = "2026-01-01"
+pages_build_output_dir = "dist"
+
+# Service binding to the independent ccsm-worker Worker. The Worker is
+# deployed separately by .github/workflows/deploy-worker.yml and owns the
+# TunnelDO Durable Object class (DO classes cannot live in Pages Functions).
+[[services]]
+binding = "TUNNEL_WORKER"
+service = "ccsm-worker"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
         specifier: ^19.0.0
         version: 19.2.6(react@19.2.6)
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20240909.0
+        version: 4.20260508.1
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14


### PR DESCRIPTION
## Summary

cc-sm.pages.dev is a static SPA host. Without a Function, requests to `/ws/default` and `/tunnel/default` fall through to the SPA fallback (200 `index.html`), so the WebSocket upgrade handshake never reaches the TunnelDO that lives on ccsm-worker.

This PR adds a Pages Function that intercepts the two tunnel paths and reproxies them to the standalone ccsm-worker Worker via a `TUNNEL_WORKER` service binding declared in a new `packages/frontend-web/wrangler.toml`. Pages Functions cannot define Durable Object classes themselves (Cloudflare [docs](https://developers.cloudflare.com/pages/functions/wrangler-configuration/)), so the DO keeps living in cf-worker and the Function only acts as a transport-level proxy.

`deploy-pages.yml` now runs wrangler with `workingDirectory: packages/frontend-web` so the new `wrangler.toml` is honored and the service binding is provisioned on deploy.

## Scope notes (intentional)

- **REST `/api/*` is NOT proxied here.** The daemon sits behind NAT and the Worker cannot dial back into it, so REST has to flow over the same ws tunnel via HTTP-over-tunnel framing — that is a separate followup task. For now REST keeps the loopback `?daemon=` escape hatch used in dev.
- `hostConfig.ts` is unchanged (still defaults to `wss://cc-sm.pages.dev`).
- `cf-worker/src/index.ts` is unchanged (per task spec — `/api/*` worker-side support deferred to the HTTP-over-tunnel followup).

## Files

- `packages/frontend-web/functions/[[path]].ts` (new) — catch-all Pages Function, reproxies ws paths via service binding
- `packages/frontend-web/wrangler.toml` (new) — declares `TUNNEL_WORKER` service binding to `ccsm-worker`
- `packages/frontend-web/tsconfig.functions.json` (new) — separate tsconfig with `@cloudflare/workers-types` so `PagesFunction<Env>` resolves; not picked up by the SPA build
- `packages/frontend-web/package.json` — adds `@cloudflare/workers-types` devDep, threads new tsconfig through `typecheck` / `build` / `build:pages`
- `.github/workflows/deploy-pages.yml` — `workingDirectory: packages/frontend-web` so `wrangler.toml` and `functions/` are honored
- `pnpm-lock.yaml` — regenerated for the new devDep

## Local checks (host: Windows 11, mode: fast)

- lint: green (`pnpm -F @ccsm/frontend-web lint`)
- typecheck: green (`pnpm -F @ccsm/frontend-web typecheck` — runs both `tsconfig.json` and `tsconfig.functions.json`)
- build: green (`pnpm -F @ccsm/frontend-web build`, vite output unchanged: `dist/index.html` + `dist/assets/*`)
- unit tests: skipped — no production source touched in this package; `functions/` is Pages-runtime code with no existing test harness, and only ws paths are routed through the Function (covered post-merge by the curl probes below)
- e2e: skipped — Pages Function deploy is verified post-merge via curl, not via local e2e

## Test plan

- [ ] After merge, deploy-pages workflow goes green
- [ ] `curl -i 'https://cc-sm.pages.dev/tunnel/default' -H 'Upgrade: websocket' -H 'Connection: Upgrade'` returns 101 (no longer 200 SPA fallback)
- [ ] `curl -i 'https://cc-sm.pages.dev/ws/default' -H 'Upgrade: websocket' -H 'Connection: Upgrade' -H 'Sec-WebSocket-Protocol: ccsm.testtoken'` returns 101 or 1011 (depending on whether daemon dialed in), not 200
- [ ] Local daemon with `CCSM_TUNNEL_URL=wss://cc-sm.pages.dev/tunnel/default` connects (proves Pages Function reaches the same DO instance as the direct workers.dev URL)

## Followup

- HTTP-over-tunnel for REST `/api/*` so the browser's REST calls also flow through the Pages origin → Worker → DO → daemon path. Required for true cross-network operation; until then REST stays on loopback via `?daemon=`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)