### PR TITLE
fix(frontend-web): add wrangler devDep so deploy-pages workflow works

### DIFF
--- a/packages/frontend-web/package.json
+++ b/packages/frontend-web/package.json
@@ -24,6 +24,7 @@
     "@vitejs/plugin-react": "^4.3.3",
     "typescript": "^5.6.3",
     "vite": "^5.4.10",
-    "vitest": "^2.1.4"
+    "vitest": "^2.1.4",
+    "wrangler": "^3.114.17"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -204,6 +204,9 @@ importers:
       vitest:
         specifier: ^2.1.4
         version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
+      wrangler:
+        specifier: ^3.114.17
+        version: 3.114.17(@cloudflare/workers-types@4.20260508.1)
 
   packages/shared:
     devDependencies:


### PR DESCRIPTION
## Summary
- 1-line: add `wrangler@^3.114.17` to `packages/frontend-web/devDependencies`
- Fixes deploy-pages workflow crashing on `workspace:*` protocol when wrangler-action falls back to `npm i wrangler`

## Test plan
- [x] pnpm install succeeds
- [ ] merge → deploy-pages workflow goes green