### PR TITLE
feat(tunnel): HTTP-over-tunnel for REST /api/* + /token (Task #787, S3-C)

### DIFF
--- a/packages/cf-worker/src/index.ts
+++ b/packages/cf-worker/src/index.ts
@@ -25,6 +25,17 @@ export default {
       // the browser doesn't reject the handshake (RFC 6455 §4.2.2 step 4).
       return stub.fetch(req);
     }
+
+    // Task #787 (S3-C): REST `/api/*` and `/token` flow through the same DO
+    // instance, which serializes them as http_req control frames over the
+    // daemon-dialed ws and awaits the matching http_res. The browser only
+    // ever talks to cc-sm.pages.dev; the DO bridges to the NAT'd daemon.
+    if (url.pathname.startsWith('/api/') || url.pathname === '/token') {
+      const id = env.TUNNEL.idFromName('default');
+      const stub = env.TUNNEL.get(id);
+      return stub.fetch(req);
+    }
+
     return new Response('Not Found', { status: 404 });
   },
 };

--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -9,6 +9,13 @@ interface PairedSockets {
 const WS_SUBPROTOCOL_PREFIX = 'ccsm.';
 
 /**
+ * HTTP-over-tunnel timeout. Cloudflare Worker subrequest cap is 30s; we
+ * reject in-flight HTTP requests after that with 504 so the browser sees a
+ * deterministic upstream timeout instead of a Worker eviction.
+ */
+const HTTP_OVER_TUNNEL_TIMEOUT_MS = 30_000;
+
+/**
  * Hello control frame the DO injects ahead of any browser→daemon traffic so
  * the daemon can run the browser-presented token through its existing
  * classifyOrigin / token check path (Task #782, S3-T6).
@@ -22,9 +29,81 @@ interface HelloFrame {
   token: string;
 }
 
+/**
+ * HTTP-over-tunnel frames (Task #787, S3-C). Mux REST `/api/*` + `/token`
+ * over the same daemon-dialed ws so the browser only ever talks to
+ * cc-sm.pages.dev. Distinguished from S3-T6 raw OUTPUT/INPUT frames by the
+ * `type` field — raw frames are binary OR text without a JSON `type`.
+ */
+interface HttpReqFrame {
+  type: 'http_req';
+  id: string;
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  body_b64: string;
+}
+
+interface HttpResFrame {
+  type: 'http_res';
+  id: string;
+  status: number;
+  headers: Record<string, string>;
+  body_b64: string;
+}
+
+interface PendingHttp {
+  resolve: (res: Response) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
 function buildHelloFrame(token: string): string {
   const frame: HelloFrame = { type: 'hello', token };
   return JSON.stringify(frame);
+}
+
+function arrayBufferToBase64(buf: ArrayBuffer): string {
+  const bytes = new Uint8Array(buf);
+  let binary = '';
+  // Chunk to avoid blowing argument count limits on big payloads.
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(
+      null,
+      Array.from(bytes.subarray(i, i + CHUNK)),
+    );
+  }
+  return btoa(binary);
+}
+
+function base64ToUint8Array(b64: string): Uint8Array {
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+/**
+ * Parse a daemon-bound text frame as an http_res control frame. Returns null
+ * for raw text (S3-T6 OUTPUT passthrough) so the caller falls through to the
+ * existing browser-forward path.
+ */
+function tryParseControlFrame(text: string): HttpResFrame | null {
+  if (text.length === 0 || text.charCodeAt(0) !== 0x7b /* '{' */) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object') return null;
+  const obj = parsed as Record<string, unknown>;
+  if (obj.type !== 'http_res') return null;
+  if (typeof obj.id !== 'string') return null;
+  if (typeof obj.status !== 'number') return null;
+  if (typeof obj.body_b64 !== 'string') return null;
+  if (obj.headers === null || typeof obj.headers !== 'object') return null;
+  return parsed as HttpResFrame;
 }
 
 /**
@@ -58,6 +137,7 @@ function extractBrowserToken(req: Request): { token: string; protocol: string } 
  * Routes (path is whatever the worker forwards; we match suffix only):
  *   /tunnel/default — daemon dials in (long-lived).
  *   /ws/default     — browser connects; closes 1011 if no daemon paired yet.
+ *   /api/*, /token  — HTTP request multiplexed over the daemon ws (Task #787).
  *
  * Lifecycle:
  *   - On browser pair: DO extracts token from Sec-WebSocket-Protocol header,
@@ -66,18 +146,21 @@ function extractBrowserToken(req: Request): { token: string; protocol: string } 
  *     and emits a hello control frame `{type:"hello",token}` to the daemon
  *     before any browser->daemon raw forwarding (Task #782, S3-T6).
  *   - Frames (text + binary) after hello are forwarded as-is via ws.send.
+ *     Text frames that parse as http_res control frames are routed to the
+ *     pending HTTP request map instead of forwarded raw (Task #787, S3-C).
  *   - daemon close/error → browser closed with 1006/1011, both slots cleared
- *     so a fresh daemon can re-pair.
+ *     so a fresh daemon can re-pair. Pending HTTP requests reject → 502.
  *   - browser close → daemon stays alive; next browser can re-pair. Token
  *     state is reset so a fresh browser gets re-authed.
  *
- * S3-T2 (Task #774). Token plumbing S3-T6 (Task #782). e2e in S3-T8.
+ * S3-T2 (Task #774). Token plumbing S3-T6 (Task #782). HTTP mux S3-C (Task #787).
  */
 export class TunnelDO {
   private state: DurableObjectState;
   private env: Env;
   private sockets: PairedSockets = {};
   private browserToken: string | null = null;
+  private pendingHttp = new Map<string, PendingHttp>();
 
   constructor(state: DurableObjectState, env: Env) {
     this.state = state;
@@ -89,6 +172,16 @@ export class TunnelDO {
   async fetch(req: Request): Promise<Response> {
     const url = new URL(req.url);
     const upgrade = req.headers.get('Upgrade');
+
+    // HTTP-over-tunnel (Task #787): /api/* and /token are NOT ws upgrades —
+    // they're regular requests muxed over the daemon ws as control frames.
+    if (
+      upgrade?.toLowerCase() !== 'websocket' &&
+      (url.pathname.startsWith('/api/') || url.pathname === '/token')
+    ) {
+      return this.proxyHttp(req);
+    }
+
     if (upgrade?.toLowerCase() !== 'websocket') {
       return new Response('Expected websocket', { status: 426 });
     }
@@ -146,8 +239,90 @@ export class TunnelDO {
     return this.browserToken;
   }
 
+  /** Test-only accessor for in-flight HTTP request count. */
+  getPendingHttpCountForTest(): number {
+    return this.pendingHttp.size;
+  }
+
+  /**
+   * Serialize a regular HTTP request into an http_req control frame, send it
+   * on the daemon ws, and await the matching http_res. 30s timeout → 504.
+   * Daemon offline → 503 immediately. Daemon drop while pending → 502.
+   */
+  private async proxyHttp(req: Request): Promise<Response> {
+    if (!this.sockets.daemon) {
+      return new Response('daemon offline', { status: 503 });
+    }
+    const id = crypto.randomUUID();
+    const url = new URL(req.url);
+    const headers: Record<string, string> = {};
+    req.headers.forEach((v, k) => {
+      headers[k] = v;
+    });
+    const body = await req.arrayBuffer();
+    const body_b64 = body.byteLength === 0 ? '' : arrayBufferToBase64(body);
+    const frame: HttpReqFrame = {
+      type: 'http_req',
+      id,
+      method: req.method,
+      path: url.pathname + url.search,
+      headers,
+      body_b64,
+    };
+    return new Promise<Response>((resolve) => {
+      const timer = setTimeout(() => {
+        if (this.pendingHttp.delete(id)) {
+          resolve(new Response('upstream timeout', { status: 504 }));
+        }
+      }, HTTP_OVER_TUNNEL_TIMEOUT_MS);
+      this.pendingHttp.set(id, { resolve, timer });
+      try {
+        this.sockets.daemon!.send(JSON.stringify(frame));
+      } catch {
+        clearTimeout(timer);
+        this.pendingHttp.delete(id);
+        resolve(new Response('upstream send failed', { status: 502 }));
+      }
+    });
+  }
+
+  /** Reject every in-flight HTTP request when the daemon ws drops. */
+  private failAllPendingHttp(status: number, body: string): void {
+    for (const [, pending] of this.pendingHttp) {
+      clearTimeout(pending.timer);
+      pending.resolve(new Response(body, { status }));
+    }
+    this.pendingHttp.clear();
+  }
+
+  /** Resolve a pending HTTP request from a parsed http_res control frame. */
+  private completeHttpRes(frame: HttpResFrame): void {
+    const pending = this.pendingHttp.get(frame.id);
+    if (pending === undefined) return;
+    this.pendingHttp.delete(frame.id);
+    clearTimeout(pending.timer);
+    const bytes = frame.body_b64.length === 0
+      ? new Uint8Array(0)
+      : base64ToUint8Array(frame.body_b64);
+    pending.resolve(
+      new Response(bytes as unknown as BodyInit, {
+        status: frame.status,
+        headers: frame.headers,
+      }),
+    );
+  }
+
   private wireDaemon(ws: WebSocket): void {
     ws.addEventListener('message', (ev: MessageEvent) => {
+      // Inspect text frames for control-frame envelopes (Task #787).
+      // Binary frames + non-control text fall through to browser passthrough.
+      if (typeof ev.data === 'string') {
+        const ctrl = tryParseControlFrame(ev.data);
+        if (ctrl !== null) {
+          this.completeHttpRes(ctrl);
+          return;
+        }
+      }
       this.sockets.browser?.send(ev.data);
     });
     ws.addEventListener('close', () => {
@@ -156,6 +331,7 @@ export class TunnelDO {
       } catch {
         /* browser may already be gone */
       }
+      this.failAllPendingHttp(502, 'daemon disconnected');
       this.sockets.browser = undefined;
       this.sockets.daemon = undefined;
       this.browserToken = null;

--- a/packages/cf-worker/test/tunnel-do.test.ts
+++ b/packages/cf-worker/test/tunnel-do.test.ts
@@ -311,4 +311,127 @@ describe('TunnelDO', () => {
     expect(browser.closeCode).toBe(1011);
     expect(browser.closeReason).toBe('daemon error');
   });
+
+  // ---- HTTP-over-tunnel (Task #787, S3-C) -------------------------------
+
+  function makeHttpReq(path: string, method = 'GET', body?: string): Request {
+    return new Request(`https://example.test${path}`, {
+      method,
+      body,
+    });
+  }
+
+  it('proxyHttp returns 503 when no daemon paired', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(fakeState, fakeEnv);
+    const res = await inst.fetch(makeHttpReq('/api/sessions'));
+    expect(res.status).toBe(503);
+  });
+
+  it('proxyHttp serializes http_req frame to daemon and resolves on http_res', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(fakeState, fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    const daemon = created[0].server;
+
+    const respPromise = inst.fetch(makeHttpReq('/api/sessions'));
+    // Yield so the await req.arrayBuffer() and ws.send complete.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(daemon.sent).toHaveLength(1);
+    const frame = JSON.parse(daemon.sent[0] as string);
+    expect(frame.type).toBe('http_req');
+    expect(frame.method).toBe('GET');
+    expect(frame.path).toBe('/api/sessions');
+    expect(typeof frame.id).toBe('string');
+    expect(frame.id.length).toBeGreaterThan(0);
+    expect(inst.getPendingHttpCountForTest()).toBe(1);
+
+    // Daemon sends back a control http_res frame.
+    const bodyText = JSON.stringify({ ok: true });
+    const body_b64 = btoa(bodyText);
+    daemon.emitMessage(JSON.stringify({
+      type: 'http_res',
+      id: frame.id,
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      body_b64,
+    }));
+
+    const res = await respPromise;
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('application/json');
+    expect(await res.text()).toBe(bodyText);
+    expect(inst.getPendingHttpCountForTest()).toBe(0);
+  });
+
+  it('proxyHttp routes /token via the same path', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(fakeState, fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    const daemon = created[0].server;
+
+    const respPromise = inst.fetch(makeHttpReq('/token'));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const frame = JSON.parse(daemon.sent[0] as string);
+    expect(frame.path).toBe('/token');
+
+    daemon.emitMessage(JSON.stringify({
+      type: 'http_res',
+      id: frame.id,
+      status: 200,
+      headers: {},
+      body_b64: btoa('tok'),
+    }));
+    const res = await respPromise;
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('tok');
+  });
+
+  it('http_res control frame is NOT forwarded as raw output to browser', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(fakeState, fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
+    const daemon = created[0].server;
+    const browser = created[1].server;
+
+    // Start an http req so there's a pending entry for the http_res to land on.
+    const respPromise = inst.fetch(makeHttpReq('/api/sessions'));
+    await new Promise((r) => setTimeout(r, 0));
+    const reqFrame = JSON.parse(daemon.sent.at(-1) as string);
+
+    daemon.emitMessage(JSON.stringify({
+      type: 'http_res',
+      id: reqFrame.id,
+      status: 200,
+      headers: {},
+      body_b64: btoa('ok'),
+    }));
+    await respPromise;
+
+    // Browser should never have received the http_res control frame.
+    for (const sent of browser.sent) {
+      if (typeof sent === 'string') {
+        expect(sent.includes('"type":"http_res"')).toBe(false);
+      }
+    }
+  });
+
+  it('daemon close while http req pending rejects with 502', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(fakeState, fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    const daemon = created[0].server;
+
+    const respPromise = inst.fetch(makeHttpReq('/api/sessions'));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(inst.getPendingHttpCountForTest()).toBe(1);
+
+    daemon.emitClose();
+    const res = await respPromise;
+    expect(res.status).toBe(502);
+    expect(inst.getPendingHttpCountForTest()).toBe(0);
+  });
 });

--- a/packages/daemon/src/index.mts
+++ b/packages/daemon/src/index.mts
@@ -126,9 +126,20 @@ async function main(): Promise<void> {
   // this daemon. Tunnel init is fire-and-forget — its failure must NEVER
   // abort the loopback path. Set CCSM_TUNNEL_DISABLE=1 to skip entirely
   // (tests + offline dev). T4 only verifies link-up; real frame routing into
-  // sessions lands in T6.
+  // sessions lands in T6. Task #787 (S3-C) adds HTTP-over-tunnel mux: the
+  // tunnel client now owns a daemonLoopbackPort so it can fetch
+  // http://127.0.0.1:<port><path> on receipt of http_req control frames —
+  // hence we construct it AFTER listen so we have the bound port.
   const tunnelDisabled = process.env.CCSM_TUNNEL_DISABLE === '1';
   const tunnelUrl = process.env.CCSM_TUNNEL_URL || DEFAULT_TUNNEL_URL;
+
+  // Handshake mode: bind port 0 (ephemeral) once, no retry — caller already
+  // scopes the port via OS allocation, EADDRINUSE on port 0 is "out of ports"
+  // and not recoverable by ++port.
+  const { port } = handshakeMode
+    ? await listenOnce(http, 0)
+    : await listenWithRetry(http, startPort, PORT_RETRY_MAX);
+
   let tunnel: TunnelClient | null = null;
   let tunnelStatePoll: ReturnType<typeof setInterval> | null = null;
   if (tunnelDisabled) {
@@ -138,6 +149,7 @@ async function main(): Promise<void> {
     tunnel = new TunnelClient({
       url: tunnelUrl,
       token,
+      daemonLoopbackPort: port,
       onFrame: (data) => {
         const len = typeof data === 'string'
           ? Buffer.byteLength(data, 'utf8')
@@ -167,13 +179,6 @@ async function main(): Promise<void> {
     }, TUNNEL_CONNECT_POLL_MS);
     tunnelStatePoll.unref?.();
   }
-
-  // Handshake mode: bind port 0 (ephemeral) once, no retry — caller already
-  // scopes the port via OS allocation, EADDRINUSE on port 0 is "out of ports"
-  // and not recoverable by ++port.
-  const { port } = handshakeMode
-    ? await listenOnce(http, 0)
-    : await listenWithRetry(http, startPort, PORT_RETRY_MAX);
 
   if (handshakeMode) {
     // Single-line JSON, no other stdout writes for the rest of the process.

--- a/packages/daemon/src/tunnel.mts
+++ b/packages/daemon/src/tunnel.mts
@@ -48,10 +48,24 @@ export interface TunnelClientOptions {
   /** Invoked once per inbound frame from the cloud (binary or text). */
   onFrame: (data: Buffer | string) => void;
   /**
+   * Loopback HTTP port the daemon is listening on. Used by the HTTP-over-
+   * tunnel path (Task #787, S3-C): incoming `http_req` control frames are
+   * fetched against `http://127.0.0.1:<port><path>` and the response is
+   * serialized back as an `http_res` control frame on the same ws. Pass 0
+   * to disable HTTP mux (tests / configs that only exercise raw ws).
+   */
+  daemonLoopbackPort?: number;
+  /**
    * DI seam for tests. Real code uses the default which constructs a real
    * `ws.WebSocket`. Tests inject a fake socket that implements WsLike.
    */
   wsFactory?: WsFactory;
+  /**
+   * DI seam for tests. Defaults to `globalThis.fetch` (Node 22). Tests
+   * inject a stub so we can drive http_req → http_res without binding a
+   * real loopback server.
+   */
+  fetchImpl?: typeof fetch;
 }
 
 /** Minimal subset of `ws.WebSocket` that TunnelClient relies on. */
@@ -78,6 +92,39 @@ function defaultWsFactory(url: string): WsLike {
 interface HelloFrame {
   type: 'hello';
   token: string;
+}
+
+/**
+ * HTTP-over-tunnel control frames (Task #787, S3-C). Mux the loopback REST
+ * surface over the same daemon-dialed ws so cloud browsers can hit
+ * `cc-sm.pages.dev/api/*` without a direct path to the NAT'd daemon.
+ */
+interface HttpReqFrame {
+  type: 'http_req';
+  id: string;
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  body_b64: string;
+}
+
+interface HttpResFrame {
+  type: 'http_res';
+  id: string;
+  status: number;
+  headers: Record<string, string>;
+  body_b64: string;
+}
+
+function parseHttpReq(parsed: Record<string, unknown>): HttpReqFrame | null {
+  if (parsed.type !== 'http_req') return null;
+  if (typeof parsed.id !== 'string' || parsed.id.length === 0) return null;
+  if (typeof parsed.method !== 'string') return null;
+  if (typeof parsed.path !== 'string') return null;
+  if (typeof parsed.body_b64 !== 'string') return null;
+  if (parsed.headers === null || typeof parsed.headers !== 'object') return null;
+  // Trust the DO; we already shape-checked the surface fields.
+  return parsed as unknown as HttpReqFrame;
 }
 
 function parseHello(text: string): HelloFrame | null {
@@ -111,6 +158,8 @@ export class TunnelClient {
   readonly token: string;
   private readonly onFrame: (data: Buffer | string) => void;
   private readonly wsFactory: WsFactory;
+  private readonly daemonLoopbackPort: number;
+  private readonly fetchImpl: typeof fetch;
 
   private state: TunnelState = 'idle';
   private ws: WsLike | null = null;
@@ -125,6 +174,8 @@ export class TunnelClient {
     this.token = opts.token;
     this.onFrame = opts.onFrame;
     this.wsFactory = opts.wsFactory ?? defaultWsFactory;
+    this.daemonLoopbackPort = opts.daemonLoopbackPort ?? 0;
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
   }
 
   getState(): TunnelState {
@@ -249,7 +300,18 @@ export class TunnelClient {
           : Array.isArray(raw)
             ? Buffer.concat(raw)
             : Buffer.from(raw as ArrayBuffer);
-        this.onFrame(buf.toString('utf8'));
+        const text = buf.toString('utf8');
+        // Task #787: try to parse text frame as an http_req control frame
+        // before falling through to the raw S3-T6 OUTPUT/INPUT path. We only
+        // consider it a control frame if it parses as JSON with `type:
+        // "http_req"`; everything else (raw text output, frames lacking
+        // `type`) flows through onFrame untouched.
+        const ctrl = this.tryParseHttpReq(text);
+        if (ctrl !== null) {
+          void this.handleHttpReq(ctrl);
+          return;
+        }
+        this.onFrame(text);
       }
     });
 
@@ -269,6 +331,83 @@ export class TunnelClient {
       console.warn(`[ccsm/tunnel] closed code=${code}, will reconnect`);
       this.scheduleReconnect();
     });
+  }
+
+  private tryParseHttpReq(text: string): HttpReqFrame | null {
+    if (text.length === 0 || text.charCodeAt(0) !== 0x7b /* '{' */) return null;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      return null;
+    }
+    if (parsed === null || typeof parsed !== 'object') return null;
+    return parseHttpReq(parsed as Record<string, unknown>);
+  }
+
+  /**
+   * Handle an inbound `http_req` frame: fetch the daemon's loopback HTTP
+   * server, serialize the response as `http_res`, send back on the same ws.
+   * Errors map to status 502 with text/plain body so the browser sees a
+   * deterministic upstream error instead of a hung request.
+   */
+  private async handleHttpReq(frame: HttpReqFrame): Promise<void> {
+    if (this.daemonLoopbackPort === 0) {
+      this.send(JSON.stringify({
+        type: 'http_res',
+        id: frame.id,
+        status: 503,
+        headers: { 'content-type': 'text/plain' },
+        body_b64: Buffer.from('http-over-tunnel disabled (no loopback port)').toString('base64'),
+      } satisfies HttpResFrame));
+      return;
+    }
+    const url = `http://127.0.0.1:${this.daemonLoopbackPort}${frame.path}`;
+    const body = frame.body_b64.length > 0
+      ? Buffer.from(frame.body_b64, 'base64')
+      : undefined;
+    // Strip hop-by-hop headers + the inbound Host so loopback fetch picks the
+    // right one. `content-length` will be recomputed by undici.
+    const headers: Record<string, string> = {};
+    for (const [k, v] of Object.entries(frame.headers)) {
+      const lk = k.toLowerCase();
+      if (lk === 'host' || lk === 'connection' || lk === 'content-length') continue;
+      headers[k] = v;
+    }
+    console.error(`[ccsm] tunnel: rx http_req ${frame.method} ${frame.path}`);
+    let response: globalThis.Response;
+    try {
+      const init: RequestInit = {
+        method: frame.method,
+        headers,
+        redirect: 'manual',
+      };
+      if (body !== undefined) {
+        init.body = body;
+      }
+      response = await this.fetchImpl(url, init);
+    } catch (err) {
+      this.send(JSON.stringify({
+        type: 'http_res',
+        id: frame.id,
+        status: 502,
+        headers: { 'content-type': 'text/plain' },
+        body_b64: Buffer.from(`upstream error: ${(err as Error).message}`).toString('base64'),
+      } satisfies HttpResFrame));
+      return;
+    }
+    const resHeaders: Record<string, string> = {};
+    response.headers.forEach((v, k) => {
+      resHeaders[k] = v;
+    });
+    const resBody = Buffer.from(await response.arrayBuffer());
+    this.send(JSON.stringify({
+      type: 'http_res',
+      id: frame.id,
+      status: response.status,
+      headers: resHeaders,
+      body_b64: resBody.toString('base64'),
+    } satisfies HttpResFrame));
   }
 
   private rejectHello(reason: string): void {

--- a/packages/daemon/test/tunnel.test.ts
+++ b/packages/daemon/test/tunnel.test.ts
@@ -330,4 +330,162 @@ describe('TunnelClient', () => {
     vi.spyOn(Math, 'random').mockReturnValue(0.9999);
     expect(client.computeBackoffMs(5)).toBeLessThanOrEqual(30_000);
   });
+
+  // ---- HTTP-over-tunnel (Task #787, S3-C) -------------------------------
+
+  it('handles inbound http_req: fetches loopback and replies http_res', async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL, _init?: RequestInit) => {
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'tok',
+      onFrame: () => {},
+      wsFactory: factory,
+      daemonLoopbackPort: 12345,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    client.start();
+    sockets[0].open();
+    // Hello first.
+    sockets[0].pushText(JSON.stringify({ type: 'hello', token: 'tok' }));
+
+    sockets[0].pushText(JSON.stringify({
+      type: 'http_req',
+      id: 'req-1',
+      method: 'GET',
+      path: '/api/sessions',
+      headers: { authorization: 'Bearer tok' },
+      body_b64: '',
+    }));
+
+    // Wait for fetch + send.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [calledUrl, calledInit] = fetchImpl.mock.calls[0];
+    expect(calledUrl).toBe('http://127.0.0.1:12345/api/sessions');
+    expect((calledInit as RequestInit).method).toBe('GET');
+    expect(((calledInit as RequestInit).headers as Record<string, string>).authorization)
+      .toBe('Bearer tok');
+
+    // Should have replied with an http_res text frame.
+    const sent = sockets[0].sent.find((s) =>
+      typeof s === 'string' && s.includes('"type":"http_res"'),
+    ) as string | undefined;
+    expect(sent).toBeDefined();
+    const resFrame = JSON.parse(sent as string);
+    expect(resFrame.id).toBe('req-1');
+    expect(resFrame.status).toBe(200);
+    expect(resFrame.headers['content-type']).toBe('application/json');
+    expect(Buffer.from(resFrame.body_b64, 'base64').toString('utf8'))
+      .toBe(JSON.stringify({ ok: true }));
+  });
+
+  it('http_req with body_b64 forwards decoded bytes to loopback fetch', async () => {
+    const fetchImpl = vi.fn(async (_url: string | URL, _init?: RequestInit) => {
+      return new Response('', { status: 204 });
+    });
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'tok',
+      onFrame: () => {},
+      wsFactory: factory,
+      daemonLoopbackPort: 4242,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    client.start();
+    sockets[0].open();
+    sockets[0].pushText(JSON.stringify({ type: 'hello', token: 'tok' }));
+
+    const payload = JSON.stringify({ foo: 'bar' });
+    sockets[0].pushText(JSON.stringify({
+      type: 'http_req',
+      id: 'req-2',
+      method: 'POST',
+      path: '/api/sessions',
+      headers: { 'content-type': 'application/json' },
+      body_b64: Buffer.from(payload, 'utf8').toString('base64'),
+    }));
+
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const init = fetchImpl.mock.calls[0][1] as RequestInit;
+    expect(init.method).toBe('POST');
+    expect(Buffer.isBuffer(init.body)).toBe(true);
+    expect((init.body as Buffer).toString('utf8')).toBe(payload);
+  });
+
+  it('http_req fetch failure → http_res status 502', async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error('ECONNREFUSED');
+    });
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'tok',
+      onFrame: () => {},
+      wsFactory: factory,
+      daemonLoopbackPort: 1,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    client.start();
+    sockets[0].open();
+    sockets[0].pushText(JSON.stringify({ type: 'hello', token: 'tok' }));
+
+    sockets[0].pushText(JSON.stringify({
+      type: 'http_req',
+      id: 'req-3',
+      method: 'GET',
+      path: '/api/sessions',
+      headers: {},
+      body_b64: '',
+    }));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const sent = sockets[0].sent.find((s) =>
+      typeof s === 'string' && s.includes('"type":"http_res"'),
+    ) as string | undefined;
+    expect(sent).toBeDefined();
+    const resFrame = JSON.parse(sent as string);
+    expect(resFrame.id).toBe('req-3');
+    expect(resFrame.status).toBe(502);
+  });
+
+  it('http_req control frames are NOT forwarded to onFrame', async () => {
+    const fetchImpl = vi.fn(async () => new Response('', { status: 204 }));
+    const onFrame = vi.fn();
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'tok',
+      onFrame,
+      wsFactory: factory,
+      daemonLoopbackPort: 1234,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    client.start();
+    sockets[0].open();
+    sockets[0].pushText(JSON.stringify({ type: 'hello', token: 'tok' }));
+
+    sockets[0].pushText(JSON.stringify({
+      type: 'http_req',
+      id: 'req-4',
+      method: 'GET',
+      path: '/api/sessions',
+      headers: {},
+      body_b64: '',
+    }));
+    // Plain non-control text still flows through onFrame.
+    sockets[0].pushText('not-a-control-frame');
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(onFrame).toHaveBeenCalledTimes(1);
+    expect(onFrame.mock.calls[0][0]).toBe('not-a-control-frame');
+  });
 });

--- a/packages/frontend-web/functions/[[path]].ts
+++ b/packages/frontend-web/functions/[[path]].ts
@@ -11,15 +11,15 @@
 // research note afea153b6a17c9838 and the Pages Functions wrangler docs:
 // https://developers.cloudflare.com/pages/functions/wrangler-configuration/).
 //
-// Scope (intentionally narrow for this task):
+// Scope:
 //   - WebSocket paths (`/ws/default`, `/tunnel/default`) are proxied to the
 //     Worker so the daemon can dial wss://cc-sm.pages.dev/tunnel/default and
 //     the browser can dial wss://cc-sm.pages.dev/ws/default, both terminating
 //     in the same TunnelDO instance.
-//   - REST `/api/*` is NOT proxied here yet. The daemon sits behind NAT and
-//     the Worker cannot dial back into it, so REST has to flow over the same
-//     ws tunnel (HTTP-over-tunnel framing). That is a separate followup task.
-//     For now REST stays on the loopback `?daemon=` escape hatch used in dev.
+//   - Task #787 (S3-C): REST `/api/*` and `/token` are also proxied to the
+//     Worker, which forwards them into the same TunnelDO. The DO mux's them
+//     onto the daemon-dialed ws as `http_req` control frames so the NAT'd
+//     daemon can serve them. Browser only ever talks to cc-sm.pages.dev.
 //   - Everything else falls through to `ctx.next()` so Pages serves the
 //     static SPA assets (`/index.html`, `/assets/*`, etc.) as before.
 
@@ -27,14 +27,19 @@ interface Env {
   // Service binding to the standalone ccsm-worker Worker (configured in
   // wrangler.toml as `[[services]] binding = "TUNNEL_WORKER"`). Pages
   // Functions invoke it as a Fetcher; the Worker's own fetch handler routes
-  // /ws/default and /tunnel/default into the TunnelDO.
+  // /ws/default, /tunnel/default, /api/*, and /token into the TunnelDO.
   TUNNEL_WORKER: Fetcher;
 }
 
 export const onRequest: PagesFunction<Env> = async (ctx) => {
   const url = new URL(ctx.request.url);
 
-  if (url.pathname === '/ws/default' || url.pathname === '/tunnel/default') {
+  if (
+    url.pathname === '/ws/default' ||
+    url.pathname === '/tunnel/default' ||
+    url.pathname === '/token' ||
+    url.pathname.startsWith('/api/')
+  ) {
     return ctx.env.TUNNEL_WORKER.fetch(ctx.request);
   }
 


### PR DESCRIPTION
## Summary

Task #787 [S3-C] — REST `/api/*` + `/token` now flow over the same daemon-dialed ws so cloud browsers only ever talk to `cc-sm.pages.dev` and the NAT'd daemon never needs an inbound path.

- **cf-worker `TunnelDO`**: incoming non-upgrade `/api/*` + `/token` get serialized as `{type:\"http_req\",id,method,path,headers,body_b64}` JSON control frames on the daemon ws; pending Map keyed by id awaits the matching `{type:\"http_res\",...}`. Timeout 30s -> 504, daemon offline -> 503, daemon drop while pending -> 502, send failure -> 502. Raw S3-T6 OUTPUT/INPUT passthrough is untouched: binary frames + text frames that don't parse as a control envelope still forward to the browser unchanged.
- **cf-worker `index.ts`**: route `/api/*` + `/token` (non-upgrade) into `TUNNEL.idFromName('default')`.
- **daemon `TunnelClient`**: ctor takes `daemonLoopbackPort` + optional `fetchImpl` (DI seam). Inbound text frames are checked for `type:\"http_req\"` after hello; on hit we `fetch('http://127.0.0.1:<port><path>', ...)` and write back an `http_res` frame with status / headers / base64 body. Fetch error -> 502, missing port -> 503. Non-control text still flows through `onFrame` so S3-T6 wiring is untouched.
- **daemon `index.mts`**: reordered listen() before TunnelClient construction so the bound port can be threaded in. `--handshake-stdout` json contract unchanged.
- **frontend-web Pages Function**: fan `/api/*` + `/token` into the same `TUNNEL_WORKER` service binding alongside existing `/ws/default` + `/tunnel/default`.

Stays inside the constraint set: no new deps (Buffer / atob / btoa / native fetch already present), no Tauri changes, no streaming/SSE, no hello frame protocol changes.

## Local checks (host: Windows, mode: fast)
- lint: ✓ (cf-worker, daemon, frontend-web all exit 0)
- typecheck: ✓ (cf-worker, daemon, frontend-web all exit 0; required first building @ccsm/core + @ccsm/shared + @ccsm/ui dist for shared type resolution)
- build: ✓ (cf-worker tsc --noEmit; daemon tsc -p tsconfig.json)
- unit tests:
  - \`pnpm --filter @ccsm/cf-worker test\` -> 16 passed (1 file, 1.86s) — includes 5 new HTTP-over-tunnel cases
  - \`pnpm --filter @ccsm/daemon test\` -> 130 passed / 1 skipped (13 files, 11.48s) — includes 4 new TunnelClient http_req cases
- e2e: skipped, change is server-side ws/HTTP framing only with no electron / probe coverage; live verification listed under Test plan below.

## Test plan
- [ ] After merge + Pages deploy + worker deploy: \`curl -i 'https://cc-sm.pages.dev/api/sessions' -H 'authorization: Bearer <daemon-token>'\` (with local daemon dialing wss://cc-sm.pages.dev/tunnel/default) returns the daemon JSON, not a 200 SPA fallback.
- [ ] \`curl -i 'https://cc-sm.pages.dev/token'\` returns the daemon /token response.
- [ ] daemon stderr emits \`[ccsm] tunnel: rx http_req GET /api/sessions\` lines.