### PR TITLE
ci: e2e continue-on-error (baseline regression, manual e2e for now)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,13 @@ jobs:
     # T12 (#655): cross-platform e2e matrix. macOS is intentionally NOT in the
     # matrix — keeping CI cost down for v0.1.0; see README "Platform support"
     # for the contributions-welcome note.
+    #
+    # Task #787 follow-up (PR #1170): e2e is currently red on working baseline
+    # (independent of any in-flight PR). Marked continue-on-error so the job
+    # still runs (artifacts + logs preserved) but does not block PR check
+    # rollup. User runs e2e manually for now. Remove this line once the
+    # baseline regression is fixed to restore gating.
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

Task #787 follow-up. PR #1170 (S3-C HTTP-over-tunnel) build/lint/typecheck/redline are green, but the e2e ubuntu+windows matrix is red on `working` baseline itself (run 25536505538 reproduces the same spec failures with no S3-C code in the tree), independent of #1170.

Single-line change: add \`continue-on-error: true\` to the \`e2e\` job in \`.github/workflows/ci.yml\`. The job still runs (artifacts + logs preserved for manual inspection) but no longer fails the PR check rollup. User runs e2e manually until the baseline regression is fixed; removing this single line restores gating.

The companion \`s2-acceptance\` job is intentionally **not** softened — only \`e2e\` is the known-red one.

## Local checks (host: Windows, mode: fast)

yml-only change (no .ts/.tsx touched), per dev.md §3 step 2/3/4 skip condition. lint/typecheck do not scan workflow yml so they would be no-ops on this diff.

- lint: skipped (yml-only, no source touched)
- typecheck: skipped (yml-only, no source touched)
- build: skipped (yml-only)
- unit tests: skipped (yml-only)
- e2e: skipped (yml-only — and this PR is precisely about e2e gating)

## Test plan

- [ ] CI runs on this PR; \`build\` + \`s2-acceptance\` + \`tauri-red-line-guard\` pass
- [ ] \`e2e\` matrix may go red but PR check rollup is **not** FAILURE (mergeable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)