### PR TITLE
fix(tunnel): allow http_req control frame before hello (Task #789, S3-D)

### DIFF
--- a/packages/cf-worker/test/tunnel-do.test.ts
+++ b/packages/cf-worker/test/tunnel-do.test.ts
@@ -434,4 +434,38 @@ describe('TunnelDO', () => {
     expect(res.status).toBe(502);
     expect(inst.getPendingHttpCountForTest()).toBe(0);
   });
+
+  // Task #789, S3-D regression: the DO MUST be able to forward /api/* to a
+  // daemon that has never seen a browser pairing (i.e. no /ws/default open
+  // and therefore no hello frame emitted to the daemon yet). The pre-fix
+  // bug closed the daemon ws on the first http_req (daemon hello-gate
+  // rejected http_req as malformed hello), causing 502 reconnect-loops.
+  it('proxyHttp succeeds without any browser /ws/default pairing', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(fakeState, fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    const daemon = created[0].server;
+    // Sanity: no browser ever connected, so DO emitted NO hello frame.
+    expect(daemon.sent).toHaveLength(0);
+
+    const respPromise = inst.fetch(makeHttpReq('/api/sessions'));
+    await new Promise((r) => setTimeout(r, 0));
+
+    // First daemon-bound payload is the http_req itself, not a hello.
+    expect(daemon.sent).toHaveLength(1);
+    const frame = JSON.parse(daemon.sent[0] as string);
+    expect(frame.type).toBe('http_req');
+    expect(frame.path).toBe('/api/sessions');
+
+    daemon.emitMessage(JSON.stringify({
+      type: 'http_res',
+      id: frame.id,
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+      body_b64: btoa('[]'),
+    }));
+    const res = await respPromise;
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('[]');
+  });
 });

--- a/packages/daemon/src/tunnel.mts
+++ b/packages/daemon/src/tunnel.mts
@@ -20,8 +20,11 @@
 //   - send() while not connected drops the frame (logs once). Caller must
 //     gate sends on getState() === 'connected' if they care.
 //   - Hello state: tracked per-connection (`helloSeen` reset on every dial).
-//     Until hello arrives, all inbound text frames are inspected as hello;
-//     binary or non-hello-text before hello → close 1008.
+//     Until hello arrives, raw passthrough is gated: binary frames and
+//     non-JSON text before hello → close 1008. JSON `{type:"http_req"}`
+//     control frames (Task #787) are accepted before hello — they're
+//     injected by the DO regardless of browser pairing and carry no browser
+//     token by design (Task #789, S3-D).
 //
 // timingSafeEqual constant-time comparison is reused from auth.mts (NOT
 // reimplemented) to honor the §1 5-tier "use existing in-repo" rule.
@@ -256,10 +259,18 @@ export class TunnelClient {
     });
 
     socket.on('message', (raw, isBinary) => {
-      // Hello-gate (Task #782): the FIRST frame after a browser pairs MUST be
-      // a JSON text frame `{type:"hello",token}`. Anything else → 1008 and
-      // we drop the frame (NOT forwarded to onFrame). After hello, raw
-      // passthrough resumes.
+      // Hello-gate (Task #782): a browser-paired daemon expects the FIRST
+      // text frame to be `{type:"hello",token}` so the daemon can authorize
+      // browser-bound raw OUTPUT/INPUT passthrough. Binary or non-JSON text
+      // before hello → 1008 (frame is NOT forwarded to onFrame).
+      //
+      // Task #789, S3-D: HTTP-over-tunnel control frames (`http_req`) are
+      // injected by the DO regardless of whether a browser is paired (the
+      // browser may hit `/api/*` directly without ever opening a /ws/default
+      // session). Those frames carry no browser token by design — the DO
+      // already gates HTTP entry — so they MUST be accepted before hello.
+      // We sniff text frames for `{type:"http_req"}` first; only "neither
+      // hello nor http_req" lands on the rejectHello path.
       if (!this.helloSeen) {
         if (isBinary) {
           this.rejectHello('binary frame before hello');
@@ -270,6 +281,13 @@ export class TunnelClient {
           : Array.isArray(raw)
             ? Buffer.concat(raw)
             : Buffer.from(raw as ArrayBuffer)).toString('utf8');
+        const ctrl = this.tryParseHttpReq(text);
+        if (ctrl !== null) {
+          // http_req is browser-pairing-independent; handle without flipping
+          // helloSeen so a subsequent browser pairing still requires hello.
+          void this.handleHttpReq(ctrl);
+          return;
+        }
         const hello = parseHello(text);
         if (hello === null) {
           this.rejectHello('malformed hello frame');

--- a/packages/daemon/test/tunnel.test.ts
+++ b/packages/daemon/test/tunnel.test.ts
@@ -488,4 +488,121 @@ describe('TunnelClient', () => {
     expect(onFrame).toHaveBeenCalledTimes(1);
     expect(onFrame.mock.calls[0][0]).toBe('not-a-control-frame');
   });
+
+  // ---- Task #789, S3-D: http_req allowed before hello ------------------
+
+  it('http_req before hello is accepted (browser may not be paired)', async () => {
+    // Reproduces the Task #789 bug: the DO forwards `/api/*` requests to the
+    // daemon ws as http_req frames whether or not a browser is paired. The
+    // pre-fix daemon hello-gate rejected http_req as a malformed hello and
+    // closed 1008, causing the daemon to reconnect-loop and the browser to
+    // see 502 from the DO's pendingHttp rejection path.
+    const fetchImpl = vi.fn(async () =>
+      new Response('[]', { status: 200, headers: { 'content-type': 'application/json' } }),
+    );
+    const onFrame = vi.fn();
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'tok',
+      onFrame,
+      wsFactory: factory,
+      daemonLoopbackPort: 9999,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    client.start();
+    sockets[0].open();
+    expect(client.getBrowserToken()).toBeNull();
+
+    // No hello yet — the DO sends http_req directly.
+    sockets[0].pushText(JSON.stringify({
+      type: 'http_req',
+      id: 'pre-hello-1',
+      method: 'GET',
+      path: '/api/sessions',
+      headers: {},
+      body_b64: '',
+    }));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    // No 1008 close.
+    expect(sockets[0].closedCalls).toHaveLength(0);
+    // helloSeen stays false — a later browser pairing still requires hello.
+    expect(client.getBrowserToken()).toBeNull();
+    // http_res sent back.
+    const sent = sockets[0].sent.find((s) =>
+      typeof s === 'string' && s.includes('"type":"http_res"'),
+    ) as string | undefined;
+    expect(sent).toBeDefined();
+    const resFrame = JSON.parse(sent as string);
+    expect(resFrame.id).toBe('pre-hello-1');
+    expect(resFrame.status).toBe(200);
+    // onFrame NOT called for control frames.
+    expect(onFrame).not.toHaveBeenCalled();
+  });
+
+  it('after pre-hello http_req, a subsequent browser hello still flips helloSeen', async () => {
+    // Guard the invariant: handling http_req before hello must NOT silently
+    // mark helloSeen=true (otherwise a fake browser could skip the token
+    // check entirely by injecting an http_req as the first frame).
+    const fetchImpl = vi.fn(async () => new Response('', { status: 204 }));
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'good-token',
+      onFrame: () => {},
+      wsFactory: factory,
+      daemonLoopbackPort: 9999,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+    });
+    client.start();
+    sockets[0].open();
+
+    sockets[0].pushText(JSON.stringify({
+      type: 'http_req',
+      id: 'p',
+      method: 'GET',
+      path: '/api/x',
+      headers: {},
+      body_b64: '',
+    }));
+    expect(client.getBrowserToken()).toBeNull();
+
+    // Now a browser pairs; hello with bad token must still be rejected.
+    sockets[0].pushText(JSON.stringify({ type: 'hello', token: 'WRONG' }));
+    expect(sockets[0].closedCalls).toHaveLength(1);
+    expect(sockets[0].closedCalls[0].code).toBe(1008);
+  });
+
+  it('binary frame before hello still closes 1008 even with http mux enabled', async () => {
+    // Raw passthrough channel must remain gated by hello.
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'tok',
+      onFrame: () => {},
+      wsFactory: factory,
+      daemonLoopbackPort: 9999,
+      fetchImpl: (async () => new Response('', { status: 204 })) as unknown as typeof fetch,
+    });
+    client.start();
+    sockets[0].open();
+    sockets[0].pushBinary(Buffer.from([1, 2, 3]));
+    expect(sockets[0].closedCalls).toHaveLength(1);
+    expect(sockets[0].closedCalls[0].code).toBe(1008);
+  });
+
+  it('non-control non-hello text before hello still closes 1008', async () => {
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'tok',
+      onFrame: () => {},
+      wsFactory: factory,
+      daemonLoopbackPort: 9999,
+      fetchImpl: (async () => new Response('', { status: 204 })) as unknown as typeof fetch,
+    });
+    client.start();
+    sockets[0].open();
+    sockets[0].pushText('plain-text-not-json');
+    expect(sockets[0].closedCalls).toHaveLength(1);
+    expect(sockets[0].closedCalls[0].code).toBe(1008);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes the user-reported 502 when opening `https://cc-sm.pages.dev/?token=XXX` and the SPA fetches `/api/sessions`. The daemon's hello-gate (Task #782) was closing the tunnel ws with 1008 because the DO's HTTP-over-tunnel path (Task #787) sends `http_req` frames whether or not a browser ws is paired, but the daemon required the first text frame to parse as `{type:"hello",token}`. Result: daemon reconnect-loop, browser sees 502 "daemon disconnected" from the DO's pendingHttp rejection.

## Root cause

- Task #774/#782 (daemon `tunnel.mts`): pre-hello onMessage parses every text frame as a hello; non-hello → close 1008.
- Task #787 (DO `tunnel-do.ts` + `cf-worker/src/index.ts`): `/api/*` and `/token` are forwarded to daemon ws as `http_req` control frames immediately, no requirement for `/ws/default` browser pairing first.
- User flow: SPA loads → fetch `/api/sessions` (no `/ws/default` opened yet) → DO routes to daemon ws → first frame the daemon sees is `http_req`, NOT `hello` → 1008.

## Fix

In `tunnel.mts`'s pre-hello onMessage branch, try-parse text frames as `http_req` first. Match → handle via the existing `handleHttpReq` path; importantly do NOT flip `helloSeen` (a later browser pairing still requires hello). No match → fall through to the original hello-or-reject path. Binary frames and non-JSON text before hello still 1008.

Why this is safe:
- `http_req` frames carry no browser token by design — the DO already gates HTTP entry. The daemon just executes loopback fetches with DO-supplied auth headers. This change only relaxes the daemon's acceptance of a frame shape it was already designed to handle (the post-hello path already routed `http_req` to `handleHttpReq`).
- Browser ws OUTPUT/INPUT raw passthrough (#774) is unchanged: that channel still demands a valid hello before any raw frame flows.
- The "fake browser bypasses token check by leading with `http_req`" attack is moot: `http_req` does not flip `helloSeen`, so the next hello must still validate against the daemon's expected token.

Considered alternative: have the daemon emit a `daemon-hello` after dial and have the DO route `http_req` only to that. Rejected — adds wire-protocol complexity and a new DO state for no security gain over the above.

### Note for manager (out of scope here)

`cf-worker/src/index.ts` and `TunnelDO.proxyHttp` currently forward `/api/*` and `/token` to the daemon ws **without any token check at the worker edge**. The daemon's loopback HTTP layer enforces auth, but pushing every unauthorized `/api/*` request through the tunnel is wasteful and noisy. Worth considering a worker-edge token gate as a follow-up (likely a #787-related debt item, not #789).

## Local checks (host: Windows 11, mode: fast)
- lint: pass for changed files (`packages/daemon/src/tunnel.mts`, `packages/daemon/test/tunnel.test.ts`, `packages/cf-worker/test/tunnel-do.test.ts`) — eslint exit 0
- typecheck: pass for `@ccsm/daemon` + `@ccsm/cf-worker` (workspace `pnpm --filter` exit 0)
- build: pass for `@ccsm/daemon` + `@ccsm/cf-worker` (tsc exit 0)
- unit tests: `npx vitest run packages/daemon/test/tunnel.test.ts packages/cf-worker/test/tunnel-do.test.ts` — 34/34 pass, ~2.5s
- e2e: skipped, daemon/cf-worker only changes (no electron/UI code touched, no e2e harness covers cloud-tunnel pairing in repo today)

Pre-existing baseline lint/typecheck errors in unrelated packages (`packages/ui/src/runtime-context.tsx`, `packages/daemon/test/persist.test.ts`, etc.) are NOT introduced by this PR — `git status` shows my diff only touches the 3 files listed.

## Reverse-verify
- patched-out fix → `npx vitest run packages/daemon/test/tunnel.test.ts -t "http_req before hello"` → FAIL: `expect(sockets[0].closedCalls).toHaveLength(0)` blew at line 529 (1008 close fired)
- patch reapplied → same command → PASS (1 passed, 16 skipped)

## Test plan

- [ ] CI green on three-OS matrix
- [ ] Manual e2e: user opens `https://cc-sm.pages.dev/?token=<daemon-token>` → daemon stderr no longer prints `[ccsm/tunnel] hello rejected: malformed hello frame` reconnect-loop; `/api/sessions` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)