### PR TITLE
fix(do): use WebSocket Hibernation API for tunnel-do (Task #790, S3-E)

### DIFF
--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -182,16 +182,23 @@ export class TunnelDO extends DurableObject<Env> {
     return this.ctx;
   }
 
-  /** Recover the daemon socket post-hibernation, or undefined if none. */
+  /** Recover the daemon socket post-hibernation, or undefined if none.
+   * Filters by readyState so stale/closing sockets aren't selected. */
   private getDaemonSocket(): WebSocket | undefined {
     const arr = this.state.getWebSockets(TAG_DAEMON);
-    return arr.length > 0 ? arr[0] : undefined;
+    for (const ws of arr) {
+      if (ws.readyState === WebSocket.OPEN) return ws;
+    }
+    return undefined;
   }
 
   /** Recover the browser socket post-hibernation, or undefined if none. */
   private getBrowserSocket(): WebSocket | undefined {
     const arr = this.state.getWebSockets(TAG_BROWSER);
-    return arr.length > 0 ? arr[0] : undefined;
+    for (const ws of arr) {
+      if (ws.readyState === WebSocket.OPEN) return ws;
+    }
+    return undefined;
   }
 
   override async fetch(req: Request): Promise<Response> {
@@ -215,18 +222,15 @@ export class TunnelDO extends DurableObject<Env> {
     const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
 
     if (url.pathname.endsWith('/tunnel/default')) {
-      // If a stale daemon ws is still tracked, close it so getWebSockets(daemon)
-      // returns just the new one. CF closes the old socket on the wire when we
-      // call .close(); the daemon side will just reconnect.
-      const stale = this.getDaemonSocket();
-      console.log(`[TunnelDO] /tunnel/default: stale=${stale !== undefined}, allWs=${this.state.getWebSockets().length}`);
-      if (stale !== undefined) {
-        try { stale.close(1011, 'replaced by new daemon'); } catch { /* ignore */ }
-      }
+      // Don't proactively close any "stale" daemon ws here. CF's hibernation
+      // runtime fires webSocketClose on dead sockets and removes them from
+      // state on its own; readyState filtering in getDaemonSocket() handles
+      // the transient case. Closing here triggered a reconnect loop in prod
+      // because the still-open prior daemon ws (from a fast reconnect) got
+      // 1011'd by the next handshake, which the daemon then retried.
       const attachment: DaemonAttachment = { role: 'daemon' };
       this.state.acceptWebSocket(server, [TAG_DAEMON]);
       server.serializeAttachment(attachment);
-      console.log(`[TunnelDO] /tunnel/default: accepted, daemon count now=${this.state.getWebSockets(TAG_DAEMON).length}`);
       return new Response(null, { status: 101, webSocket: client });
     }
 
@@ -248,12 +252,8 @@ export class TunnelDO extends DurableObject<Env> {
         return new Response(null, { status: 101, webSocket: client });
       }
 
-      // Replace any stale browser ws so getWebSockets(browser) is unique.
-      const stale = this.getBrowserSocket();
-      if (stale !== undefined) {
-        try { stale.close(1000, 'replaced'); } catch { /* ignore */ }
-      }
-
+      // Don't proactively close any prior browser ws — same reasoning as the
+      // daemon path above. readyState filtering picks the live one.
       const attachment: BrowserAttachment = { role: 'browser', token: extracted.token };
       this.state.acceptWebSocket(server, [TAG_BROWSER]);
       server.serializeAttachment(attachment);
@@ -297,9 +297,8 @@ export class TunnelDO extends DurableObject<Env> {
     }
   }
 
-  override webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean): void {
+  override webSocketClose(ws: WebSocket, _code: number, _reason: string, _wasClean: boolean): void {
     const att = ws.deserializeAttachment() as SocketAttachment | null;
-    console.log(`[TunnelDO] webSocketClose role=${att?.role} code=${code} reason=${reason} wasClean=${wasClean}`);
     if (att === null) return;
     if (att.role === 'daemon') {
       this.handleDaemonClose();

--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -1,3 +1,4 @@
+import { DurableObject } from 'cloudflare:workers';
 import type { Env } from './index';
 
 /** Subprotocol prefix matching frontend-web/src/hostConfig.ts (Task #782). */
@@ -169,15 +170,16 @@ function extractBrowserToken(req: Request): { token: string; protocol: string } 
  * S3-T2 (Task #774). Token plumbing S3-T6 (Task #782). HTTP mux S3-C (Task #787).
  * Hibernation S3-E (Task #790).
  */
-export class TunnelDO {
-  private state: DurableObjectState;
-  private env: Env;
+export class TunnelDO extends DurableObject<Env> {
   private pendingHttp = new Map<string, PendingHttp>();
 
   constructor(state: DurableObjectState, env: Env) {
-    this.state = state;
-    this.env = env;
-    void this.env;
+    super(state, env);
+  }
+
+  /** Convenience for state.getWebSockets — `this.ctx` is provided by the base class. */
+  private get state(): DurableObjectState {
+    return this.ctx;
   }
 
   /** Recover the daemon socket post-hibernation, or undefined if none. */
@@ -192,7 +194,7 @@ export class TunnelDO {
     return arr.length > 0 ? arr[0] : undefined;
   }
 
-  async fetch(req: Request): Promise<Response> {
+  override async fetch(req: Request): Promise<Response> {
     const url = new URL(req.url);
     const upgrade = req.headers.get('Upgrade');
 
@@ -279,7 +281,7 @@ export class TunnelDO {
   // re-instantiated lazily on next event. Sockets are recovered via
   // state.getWebSockets(tag); per-socket state via ws.deserializeAttachment().
 
-  webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): void {
+  override webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): void {
     const att = ws.deserializeAttachment() as SocketAttachment | null;
     if (att === null) {
       // Should not happen — we always serialize on accept. Defensive close.
@@ -293,7 +295,7 @@ export class TunnelDO {
     }
   }
 
-  webSocketClose(ws: WebSocket, _code: number, _reason: string, _wasClean: boolean): void {
+  override webSocketClose(ws: WebSocket, _code: number, _reason: string, _wasClean: boolean): void {
     const att = ws.deserializeAttachment() as SocketAttachment | null;
     if (att === null) return;
     if (att.role === 'daemon') {
@@ -303,7 +305,7 @@ export class TunnelDO {
     }
   }
 
-  webSocketError(ws: WebSocket, _err: unknown): void {
+  override webSocketError(ws: WebSocket, _err: unknown): void {
     const att = ws.deserializeAttachment() as SocketAttachment | null;
     if (att === null) return;
     if (att.role === 'daemon') {

--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -1,10 +1,5 @@
 import type { Env } from './index';
 
-interface PairedSockets {
-  browser?: WebSocket | undefined;
-  daemon?: WebSocket | undefined;
-}
-
 /** Subprotocol prefix matching frontend-web/src/hostConfig.ts (Task #782). */
 const WS_SUBPROTOCOL_PREFIX = 'ccsm.';
 
@@ -14,6 +9,10 @@ const WS_SUBPROTOCOL_PREFIX = 'ccsm.';
  * deterministic upstream timeout instead of a Worker eviction.
  */
 const HTTP_OVER_TUNNEL_TIMEOUT_MS = 30_000;
+
+/** WebSocket Hibernation API tags (passed to state.acceptWebSocket). */
+const TAG_DAEMON = 'daemon';
+const TAG_BROWSER = 'browser';
 
 /**
  * Hello control frame the DO injects ahead of any browser→daemon traffic so
@@ -56,6 +55,23 @@ interface PendingHttp {
   resolve: (res: Response) => void;
   timer: ReturnType<typeof setTimeout>;
 }
+
+/**
+ * Per-socket state persisted across hibernation via ws.serializeAttachment.
+ * Browser sockets carry the bearer token extracted from Sec-WebSocket-Protocol
+ * so the daemon-side hello frame can be re-emitted if needed; daemon sockets
+ * carry no per-conn state today (helloSeen etc. live on the daemon side).
+ */
+interface BrowserAttachment {
+  role: 'browser';
+  token: string;
+}
+
+interface DaemonAttachment {
+  role: 'daemon';
+}
+
+type SocketAttachment = BrowserAttachment | DaemonAttachment;
 
 function buildHelloFrame(token: string): string {
   const frame: HelloFrame = { type: 'hello', token };
@@ -139,34 +155,41 @@ function extractBrowserToken(req: Request): { token: string; protocol: string } 
  *   /ws/default     — browser connects; closes 1011 if no daemon paired yet.
  *   /api/*, /token  — HTTP request multiplexed over the daemon ws (Task #787).
  *
- * Lifecycle:
- *   - On browser pair: DO extracts token from Sec-WebSocket-Protocol header,
- *     stores it on `browserToken`, echoes the same protocol on the 101
- *     response (RFC 6455 §4.2.2 — browser rejects the handshake otherwise),
- *     and emits a hello control frame `{type:"hello",token}` to the daemon
- *     before any browser->daemon raw forwarding (Task #782, S3-T6).
- *   - Frames (text + binary) after hello are forwarded as-is via ws.send.
- *     Text frames that parse as http_res control frames are routed to the
- *     pending HTTP request map instead of forwarded raw (Task #787, S3-C).
- *   - daemon close/error → browser closed with 1006/1011, both slots cleared
- *     so a fresh daemon can re-pair. Pending HTTP requests reject → 502.
- *   - browser close → daemon stays alive; next browser can re-pair. Token
- *     state is reset so a fresh browser gets re-authed.
+ * Hibernation (Task #790, S3-E): the DO uses Cloudflare's WebSocket
+ * Hibernation API (`state.acceptWebSocket` + `webSocketMessage` /
+ * `webSocketClose` / `webSocketError` class methods) so the runtime can
+ * evict the JS instance during idle periods without losing the daemon
+ * pairing. On wake, sockets are recovered via `state.getWebSockets(tag)`
+ * and per-socket state via `ws.deserializeAttachment()`.
+ *
+ * In-flight HTTP request promises (`pendingHttp`) are intentionally NOT
+ * persisted — hibernation invalidates the resolve closure, so any pending
+ * request at hibernate time is effectively dropped (browser retries).
  *
  * S3-T2 (Task #774). Token plumbing S3-T6 (Task #782). HTTP mux S3-C (Task #787).
+ * Hibernation S3-E (Task #790).
  */
 export class TunnelDO {
   private state: DurableObjectState;
   private env: Env;
-  private sockets: PairedSockets = {};
-  private browserToken: string | null = null;
   private pendingHttp = new Map<string, PendingHttp>();
 
   constructor(state: DurableObjectState, env: Env) {
     this.state = state;
     this.env = env;
-    void this.state;
     void this.env;
+  }
+
+  /** Recover the daemon socket post-hibernation, or undefined if none. */
+  private getDaemonSocket(): WebSocket | undefined {
+    const arr = this.state.getWebSockets(TAG_DAEMON);
+    return arr.length > 0 ? arr[0] : undefined;
+  }
+
+  /** Recover the browser socket post-hibernation, or undefined if none. */
+  private getBrowserSocket(): WebSocket | undefined {
+    const arr = this.state.getWebSockets(TAG_BROWSER);
+    return arr.length > 0 ? arr[0] : undefined;
   }
 
   async fetch(req: Request): Promise<Response> {
@@ -190,14 +213,24 @@ export class TunnelDO {
     const [client, server] = Object.values(pair) as [WebSocket, WebSocket];
 
     if (url.pathname.endsWith('/tunnel/default')) {
-      server.accept();
-      this.sockets.daemon = server;
-      this.wireDaemon(server);
+      // If a stale daemon ws is still tracked, close it so getWebSockets(daemon)
+      // returns just the new one. CF closes the old socket on the wire when we
+      // call .close(); the daemon side will just reconnect.
+      const stale = this.getDaemonSocket();
+      if (stale !== undefined) {
+        try { stale.close(1011, 'replaced by new daemon'); } catch { /* ignore */ }
+      }
+      const attachment: DaemonAttachment = { role: 'daemon' };
+      this.state.acceptWebSocket(server, [TAG_DAEMON]);
+      server.serializeAttachment(attachment);
       return new Response(null, { status: 101, webSocket: client });
     }
 
     if (url.pathname.endsWith('/ws/default')) {
-      if (!this.sockets.daemon) {
+      const daemon = this.getDaemonSocket();
+      if (daemon === undefined) {
+        // No daemon paired — accept-and-close so the browser sees a clean 1011
+        // rather than a half-open handshake. We don't hibernate this socket.
         server.accept();
         server.close(1011, 'daemon offline');
         return new Response(null, { status: 101, webSocket: client });
@@ -210,17 +243,22 @@ export class TunnelDO {
         server.close(1008, 'missing token subprotocol');
         return new Response(null, { status: 101, webSocket: client });
       }
-      this.browserToken = extracted.token;
-      server.accept();
-      this.sockets.browser = server;
-      this.wireBrowser(server);
-      // Emit hello as the first daemon-bound frame. Synchronous send is fine
-      // here — the daemon ws is already accepted and we're inside the DO's
-      // single-threaded request handler.
+
+      // Replace any stale browser ws so getWebSockets(browser) is unique.
+      const stale = this.getBrowserSocket();
+      if (stale !== undefined) {
+        try { stale.close(1000, 'replaced'); } catch { /* ignore */ }
+      }
+
+      const attachment: BrowserAttachment = { role: 'browser', token: extracted.token };
+      this.state.acceptWebSocket(server, [TAG_BROWSER]);
+      server.serializeAttachment(attachment);
+
+      // Emit hello as the first daemon-bound frame after this browser pair.
       try {
-        this.sockets.daemon?.send(buildHelloFrame(extracted.token));
+        daemon.send(buildHelloFrame(extracted.token));
       } catch {
-        /* daemon may have just dropped; close browser, slots clean up via daemon close */
+        /* daemon may have just dropped; cleanup happens via webSocketClose */
       }
       // Echo the chosen subprotocol on the 101 response so the browser
       // accepts the handshake (RFC 6455 §4.2.2 step 4).
@@ -234,9 +272,93 @@ export class TunnelDO {
     return new Response('Not Found', { status: 404 });
   }
 
+  // --- WebSocket Hibernation API event dispatch -------------------------
+  //
+  // Cloudflare runtime calls these class methods (instead of addEventListener
+  // callbacks) so the DO instance can be evicted during idle periods and
+  // re-instantiated lazily on next event. Sockets are recovered via
+  // state.getWebSockets(tag); per-socket state via ws.deserializeAttachment().
+
+  webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): void {
+    const att = ws.deserializeAttachment() as SocketAttachment | null;
+    if (att === null) {
+      // Should not happen — we always serialize on accept. Defensive close.
+      try { ws.close(1011, 'no attachment'); } catch { /* ignore */ }
+      return;
+    }
+    if (att.role === 'daemon') {
+      this.handleDaemonMessage(message);
+    } else {
+      this.handleBrowserMessage(message);
+    }
+  }
+
+  webSocketClose(ws: WebSocket, _code: number, _reason: string, _wasClean: boolean): void {
+    const att = ws.deserializeAttachment() as SocketAttachment | null;
+    if (att === null) return;
+    if (att.role === 'daemon') {
+      this.handleDaemonClose();
+    } else {
+      this.handleBrowserClose();
+    }
+  }
+
+  webSocketError(ws: WebSocket, _err: unknown): void {
+    const att = ws.deserializeAttachment() as SocketAttachment | null;
+    if (att === null) return;
+    if (att.role === 'daemon') {
+      this.handleDaemonError();
+    }
+    // browser error: nothing to do (mirrors prior behavior — wireBrowser had no error handler).
+  }
+
+  private handleDaemonMessage(data: string | ArrayBuffer): void {
+    if (typeof data === 'string') {
+      const ctrl = tryParseControlFrame(data);
+      if (ctrl !== null) {
+        this.completeHttpRes(ctrl);
+        return;
+      }
+    }
+    const browser = this.getBrowserSocket();
+    if (browser !== undefined) {
+      try { browser.send(data); } catch { /* browser may have just dropped */ }
+    }
+  }
+
+  private handleBrowserMessage(data: string | ArrayBuffer): void {
+    const daemon = this.getDaemonSocket();
+    if (daemon !== undefined) {
+      try { daemon.send(data); } catch { /* daemon may have just dropped */ }
+    }
+  }
+
+  private handleDaemonClose(): void {
+    const browser = this.getBrowserSocket();
+    if (browser !== undefined) {
+      try { browser.close(1006, 'daemon disconnected'); } catch { /* ignore */ }
+    }
+    this.failAllPendingHttp(502, 'daemon disconnected');
+  }
+
+  private handleDaemonError(): void {
+    const browser = this.getBrowserSocket();
+    if (browser !== undefined) {
+      try { browser.close(1011, 'daemon error'); } catch { /* ignore */ }
+    }
+  }
+
+  private handleBrowserClose(): void {
+    // Daemon stays alive; nothing to do beyond letting CF drop the ws ref.
+  }
+
   /** Test-only accessor for the currently-paired browser token. */
   getBrowserTokenForTest(): string | null {
-    return this.browserToken;
+    const browser = this.getBrowserSocket();
+    if (browser === undefined) return null;
+    const att = browser.deserializeAttachment() as SocketAttachment | null;
+    if (att === null || att.role !== 'browser') return null;
+    return att.token;
   }
 
   /** Test-only accessor for in-flight HTTP request count. */
@@ -250,7 +372,8 @@ export class TunnelDO {
    * Daemon offline → 503 immediately. Daemon drop while pending → 502.
    */
   private async proxyHttp(req: Request): Promise<Response> {
-    if (!this.sockets.daemon) {
+    const daemon = this.getDaemonSocket();
+    if (daemon === undefined) {
       return new Response('daemon offline', { status: 503 });
     }
     const id = crypto.randomUUID();
@@ -277,7 +400,7 @@ export class TunnelDO {
       }, HTTP_OVER_TUNNEL_TIMEOUT_MS);
       this.pendingHttp.set(id, { resolve, timer });
       try {
-        this.sockets.daemon!.send(JSON.stringify(frame));
+        daemon.send(JSON.stringify(frame));
       } catch {
         clearTimeout(timer);
         this.pendingHttp.delete(id);
@@ -310,48 +433,5 @@ export class TunnelDO {
         headers: frame.headers,
       }),
     );
-  }
-
-  private wireDaemon(ws: WebSocket): void {
-    ws.addEventListener('message', (ev: MessageEvent) => {
-      // Inspect text frames for control-frame envelopes (Task #787).
-      // Binary frames + non-control text fall through to browser passthrough.
-      if (typeof ev.data === 'string') {
-        const ctrl = tryParseControlFrame(ev.data);
-        if (ctrl !== null) {
-          this.completeHttpRes(ctrl);
-          return;
-        }
-      }
-      this.sockets.browser?.send(ev.data);
-    });
-    ws.addEventListener('close', () => {
-      try {
-        this.sockets.browser?.close(1006, 'daemon disconnected');
-      } catch {
-        /* browser may already be gone */
-      }
-      this.failAllPendingHttp(502, 'daemon disconnected');
-      this.sockets.browser = undefined;
-      this.sockets.daemon = undefined;
-      this.browserToken = null;
-    });
-    ws.addEventListener('error', () => {
-      try {
-        this.sockets.browser?.close(1011, 'daemon error');
-      } catch {
-        /* browser may already be gone */
-      }
-    });
-  }
-
-  private wireBrowser(ws: WebSocket): void {
-    ws.addEventListener('message', (ev: MessageEvent) => {
-      this.sockets.daemon?.send(ev.data);
-    });
-    ws.addEventListener('close', () => {
-      this.sockets.browser = undefined;
-      this.browserToken = null;
-    });
   }
 }

--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -219,12 +219,14 @@ export class TunnelDO extends DurableObject<Env> {
       // returns just the new one. CF closes the old socket on the wire when we
       // call .close(); the daemon side will just reconnect.
       const stale = this.getDaemonSocket();
+      console.log(`[TunnelDO] /tunnel/default: stale=${stale !== undefined}, allWs=${this.state.getWebSockets().length}`);
       if (stale !== undefined) {
         try { stale.close(1011, 'replaced by new daemon'); } catch { /* ignore */ }
       }
       const attachment: DaemonAttachment = { role: 'daemon' };
       this.state.acceptWebSocket(server, [TAG_DAEMON]);
       server.serializeAttachment(attachment);
+      console.log(`[TunnelDO] /tunnel/default: accepted, daemon count now=${this.state.getWebSockets(TAG_DAEMON).length}`);
       return new Response(null, { status: 101, webSocket: client });
     }
 
@@ -295,8 +297,9 @@ export class TunnelDO extends DurableObject<Env> {
     }
   }
 
-  override webSocketClose(ws: WebSocket, _code: number, _reason: string, _wasClean: boolean): void {
+  override webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean): void {
     const att = ws.deserializeAttachment() as SocketAttachment | null;
+    console.log(`[TunnelDO] webSocketClose role=${att?.role} code=${code} reason=${reason} wasClean=${wasClean}`);
     if (att === null) return;
     if (att.role === 'daemon') {
       this.handleDaemonClose();

--- a/packages/cf-worker/test/stubs/cloudflare-workers.ts
+++ b/packages/cf-worker/test/stubs/cloudflare-workers.ts
@@ -1,0 +1,27 @@
+/**
+ * Test-only stub for the `cloudflare:workers` virtual module. The runtime
+ * provides this module in production; vitest cannot resolve it under Node.
+ * We export a minimal `DurableObject` base class with the same shape the
+ * test mocks rely on (constructor stores ctx/env, no-op default methods).
+ */
+export class DurableObject<Env = unknown> {
+  protected ctx: DurableObjectState;
+  protected env: Env;
+  constructor(ctx: DurableObjectState, env: Env) {
+    this.ctx = ctx;
+    this.env = env;
+  }
+  // Default no-op overridable lifecycle hooks. Subclasses override these.
+  fetch(_req: Request): Response | Promise<Response> {
+    return new Response('not implemented', { status: 500 });
+  }
+  webSocketMessage(_ws: WebSocket, _message: string | ArrayBuffer): void {
+    /* no-op */
+  }
+  webSocketClose(_ws: WebSocket, _code: number, _reason: string, _wasClean: boolean): void {
+    /* no-op */
+  }
+  webSocketError(_ws: WebSocket, _err: unknown): void {
+    /* no-op */
+  }
+}

--- a/packages/cf-worker/test/tunnel-do.test.ts
+++ b/packages/cf-worker/test/tunnel-do.test.ts
@@ -5,31 +5,30 @@
  * concern (wire two WebSocket-shaped objects together) and the workers
  * runtime adds boot cost + flake without exercising the logic we own.
  *
- * Strategy: stub `WebSocketPair` and a minimal `WebSocket`-shaped object
- * with addEventListener/dispatchEvent/send/close/accept on globalThis,
- * then drive `TunnelDO.fetch(req)` directly. Real wire-level pairing
- * over a live worker is covered by S3-T8 e2e.
+ * Strategy: stub `WebSocketPair`, a `WebSocket`-shaped object that supports
+ * the Hibernation API attachment hooks, and a fake `DurableObjectState`
+ * with `acceptWebSocket` / `getWebSockets`. We drive `TunnelDO.fetch(req)`
+ * directly and dispatch socket events via the DO's class methods
+ * (`webSocketMessage` / `webSocketClose` / `webSocketError`) the same way
+ * the Cloudflare runtime does (Task #790, S3-E hibernation).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-type Listener = (ev: { data?: unknown; code?: number; reason?: string }) => void;
-
 interface FakeServerSocket {
   readonly side: 'server';
-  accepted: boolean;
+  accepted: boolean;          // legacy non-hibernating accept (ws/default 1011 path)
+  hibernating: boolean;       // accepted via state.acceptWebSocket
+  tags: string[];
+  attachment: unknown;
   closed: boolean;
   closeCode?: number;
   closeReason?: string;
   sent: Array<unknown>;
-  listeners: { message: Listener[]; close: Listener[]; error: Listener[] };
   accept(): void;
   send(data: unknown): void;
   close(code?: number, reason?: string): void;
-  addEventListener(type: 'message' | 'close' | 'error', cb: Listener): void;
-  // Test helpers (drive the socket as if a peer wrote/closed):
-  emitMessage(data: unknown): void;
-  emitClose(): void;
-  emitError(): void;
+  serializeAttachment(value: unknown): void;
+  deserializeAttachment(): unknown;
 }
 
 interface FakeClientSocket {
@@ -40,9 +39,11 @@ function makeServerSocket(): FakeServerSocket {
   const sock: FakeServerSocket = {
     side: 'server',
     accepted: false,
+    hibernating: false,
+    tags: [],
+    attachment: null,
     closed: false,
     sent: [],
-    listeners: { message: [], close: [], error: [] },
     accept() {
       this.accepted = true;
     },
@@ -56,18 +57,11 @@ function makeServerSocket(): FakeServerSocket {
       this.closeCode = code;
       this.closeReason = reason;
     },
-    addEventListener(type, cb) {
-      this.listeners[type].push(cb);
+    serializeAttachment(value: unknown) {
+      this.attachment = value;
     },
-    emitMessage(data) {
-      for (const cb of this.listeners.message) cb({ data });
-    },
-    emitClose() {
-      for (const cb of this.listeners.close) cb({});
-      this.closed = true;
-    },
-    emitError() {
-      for (const cb of this.listeners.error) cb({});
+    deserializeAttachment() {
+      return this.attachment;
     },
   };
   return sock;
@@ -141,13 +135,63 @@ function makeReq(path: string, protocol?: string): Request {
 
 const BROWSER_PROTO = 'ccsm.test-token-xyz';
 
-const fakeState = {} as DurableObjectState;
+/**
+ * Fake DurableObjectState that implements the WebSocket Hibernation surface
+ * we use (`acceptWebSocket(ws, tags)` + `getWebSockets(tag?)`). The runtime's
+ * real implementation also persists the socket across DO eviction; in the
+ * unit test we only care that `getWebSockets(tag)` returns sockets that were
+ * registered and have not been .close()d yet.
+ */
+function makeState(): DurableObjectState {
+  const tracked: Array<{ ws: FakeServerSocket; tags: string[] }> = [];
+  const state = {
+    acceptWebSocket(ws: FakeServerSocket, tags?: string[]) {
+      ws.hibernating = true;
+      ws.tags = tags ?? [];
+      tracked.push({ ws, tags: tags ?? [] });
+    },
+    getWebSockets(tag?: string): FakeServerSocket[] {
+      return tracked
+        .filter((t) => !t.ws.closed && (tag === undefined || t.tags.includes(tag)))
+        .map((t) => t.ws);
+    },
+  };
+  return state as unknown as DurableObjectState;
+}
+
 const fakeEnv = {} as { TUNNEL: DurableObjectNamespace };
+
+/**
+ * Helper to dispatch a hibernation message event through the DO.
+ * Runtime calls `instance.webSocketMessage(ws, data)`; we mirror that.
+ */
+function emitMessage(
+  inst: { webSocketMessage(ws: WebSocket, data: string | ArrayBuffer): void },
+  ws: FakeServerSocket,
+  data: string | ArrayBuffer,
+): void {
+  inst.webSocketMessage(ws as unknown as WebSocket, data);
+}
+
+function emitClose(
+  inst: { webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean): void },
+  ws: FakeServerSocket,
+): void {
+  inst.webSocketClose(ws as unknown as WebSocket, 1006, '', false);
+  ws.closed = true;
+}
+
+function emitError(
+  inst: { webSocketError(ws: WebSocket, err: unknown): void },
+  ws: FakeServerSocket,
+): void {
+  inst.webSocketError(ws as unknown as WebSocket, new Error('test'));
+}
 
 describe('TunnelDO', () => {
   it('rejects non-websocket requests with 426', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
     const res = await inst.fetch(
       new Request('https://example.test/tunnel/default'),
     );
@@ -156,25 +200,27 @@ describe('TunnelDO', () => {
 
   it('pairs daemon then browser; daemon -> browser forwards text + binary', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
 
     await inst.fetch(makeReq('/tunnel/default'));
     const daemon = created[0].server;
-    expect(daemon.accepted).toBe(true);
+    expect(daemon.hibernating).toBe(true);
+    expect(daemon.tags).toEqual(['daemon']);
 
     await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
     const browser = created[1].server;
-    expect(browser.accepted).toBe(true);
+    expect(browser.hibernating).toBe(true);
+    expect(browser.tags).toEqual(['browser']);
     expect(browser.closed).toBe(false);
 
-    daemon.emitMessage('hello');
-    daemon.emitMessage(new Uint8Array([1, 2, 3]));
+    emitMessage(inst, daemon, 'hello');
+    emitMessage(inst, daemon, new Uint8Array([1, 2, 3]) as unknown as ArrayBuffer);
     expect(browser.sent).toEqual(['hello', new Uint8Array([1, 2, 3])]);
   });
 
   it('forwards browser -> daemon (text + binary), preceded by hello frame', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
     await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
     const daemon = created[0].server;
@@ -188,14 +234,14 @@ describe('TunnelDO', () => {
       token: 'test-token-xyz',
     });
 
-    browser.emitMessage('ping');
-    browser.emitMessage(new Uint8Array([9, 9]));
+    emitMessage(inst, browser, 'ping');
+    emitMessage(inst, browser, new Uint8Array([9, 9]) as unknown as ArrayBuffer);
     expect(daemon.sent.slice(1)).toEqual(['ping', new Uint8Array([9, 9])]);
   });
 
   it('extracts browserToken from Sec-WebSocket-Protocol header', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
     await inst.fetch(makeReq('/ws/default', 'ccsm.abc-987'));
     expect(inst.getBrowserTokenForTest()).toBe('abc-987');
@@ -203,13 +249,10 @@ describe('TunnelDO', () => {
 
   it('echoes Sec-WebSocket-Protocol on the 101 response so browser accepts handshake', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
     const res = await inst.fetch(makeReq('/ws/default', 'ccsm.zzz'));
     expect(res.status).toBe(101);
-    // WorkersResponse stores headers via the real Response; for our test
-    // shim the headers init flows through the upgrade branch — verify by
-    // checking the stub captured them.
     const headers = (res as unknown as { headers?: Headers | Record<string, string> }).headers;
     if (headers !== undefined) {
       const echoed =
@@ -222,7 +265,7 @@ describe('TunnelDO', () => {
 
   it('closes browser ws with 1008 when Sec-WebSocket-Protocol is missing', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
     const res = await inst.fetch(makeReq('/ws/default'));
     expect(res.status).toBe(101);
@@ -234,7 +277,7 @@ describe('TunnelDO', () => {
 
   it('closes browser ws with 1008 when no ccsm.* subprotocol is present', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
     await inst.fetch(makeReq('/ws/default', 'other.subproto'));
     const browser = created[1].server;
@@ -244,7 +287,7 @@ describe('TunnelDO', () => {
 
   it('closes browser ws with 1011 daemon offline when no daemon paired', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
 
     const res = await inst.fetch(makeReq('/ws/default'));
     expect(res.status).toBe(101);
@@ -257,13 +300,13 @@ describe('TunnelDO', () => {
 
   it('daemon close triggers browser close 1006 and clears slots', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
     await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
     const daemon = created[0].server;
     const browser = created[1].server;
 
-    daemon.emitClose();
+    emitClose(inst, daemon);
 
     expect(browser.closed).toBe(true);
     expect(browser.closeCode).toBe(1006);
@@ -279,33 +322,33 @@ describe('TunnelDO', () => {
 
   it('browser close leaves daemon alive; new browser can re-pair', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
     await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
     const daemon = created[0].server;
     const browser = created[1].server;
 
-    browser.emitClose();
+    emitClose(inst, browser);
     expect(daemon.closed).toBe(false);
 
     await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
     const browser2 = created[2].server;
-    expect(browser2.accepted).toBe(true);
+    expect(browser2.hibernating).toBe(true);
     expect(browser2.closed).toBe(false);
 
-    daemon.emitMessage('after-rebind');
+    emitMessage(inst, daemon, 'after-rebind');
     expect(browser2.sent).toEqual(['after-rebind']);
   });
 
   it('daemon error closes browser with 1011 daemon error', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
     await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
     const daemon = created[0].server;
     const browser = created[1].server;
 
-    daemon.emitError();
+    emitError(inst, daemon);
 
     expect(browser.closed).toBe(true);
     expect(browser.closeCode).toBe(1011);
@@ -323,14 +366,14 @@ describe('TunnelDO', () => {
 
   it('proxyHttp returns 503 when no daemon paired', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
     const res = await inst.fetch(makeHttpReq('/api/sessions'));
     expect(res.status).toBe(503);
   });
 
   it('proxyHttp serializes http_req frame to daemon and resolves on http_res', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
     const daemon = created[0].server;
 
@@ -350,7 +393,7 @@ describe('TunnelDO', () => {
     // Daemon sends back a control http_res frame.
     const bodyText = JSON.stringify({ ok: true });
     const body_b64 = btoa(bodyText);
-    daemon.emitMessage(JSON.stringify({
+    emitMessage(inst, daemon, JSON.stringify({
       type: 'http_res',
       id: frame.id,
       status: 200,
@@ -367,7 +410,7 @@ describe('TunnelDO', () => {
 
   it('proxyHttp routes /token via the same path', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
     const daemon = created[0].server;
 
@@ -377,7 +420,7 @@ describe('TunnelDO', () => {
     const frame = JSON.parse(daemon.sent[0] as string);
     expect(frame.path).toBe('/token');
 
-    daemon.emitMessage(JSON.stringify({
+    emitMessage(inst, daemon, JSON.stringify({
       type: 'http_res',
       id: frame.id,
       status: 200,
@@ -391,7 +434,7 @@ describe('TunnelDO', () => {
 
   it('http_res control frame is NOT forwarded as raw output to browser', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
     await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
     const daemon = created[0].server;
@@ -402,7 +445,7 @@ describe('TunnelDO', () => {
     await new Promise((r) => setTimeout(r, 0));
     const reqFrame = JSON.parse(daemon.sent.at(-1) as string);
 
-    daemon.emitMessage(JSON.stringify({
+    emitMessage(inst, daemon, JSON.stringify({
       type: 'http_res',
       id: reqFrame.id,
       status: 200,
@@ -421,7 +464,7 @@ describe('TunnelDO', () => {
 
   it('daemon close while http req pending rejects with 502', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
     const daemon = created[0].server;
 
@@ -429,7 +472,7 @@ describe('TunnelDO', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(inst.getPendingHttpCountForTest()).toBe(1);
 
-    daemon.emitClose();
+    emitClose(inst, daemon);
     const res = await respPromise;
     expect(res.status).toBe(502);
     expect(inst.getPendingHttpCountForTest()).toBe(0);
@@ -442,7 +485,7 @@ describe('TunnelDO', () => {
   // rejected http_req as malformed hello), causing 502 reconnect-loops.
   it('proxyHttp succeeds without any browser /ws/default pairing', async () => {
     const TunnelDO = await loadDO();
-    const inst = new TunnelDO(fakeState, fakeEnv);
+    const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
     const daemon = created[0].server;
     // Sanity: no browser ever connected, so DO emitted NO hello frame.
@@ -457,7 +500,7 @@ describe('TunnelDO', () => {
     expect(frame.type).toBe('http_req');
     expect(frame.path).toBe('/api/sessions');
 
-    daemon.emitMessage(JSON.stringify({
+    emitMessage(inst, daemon, JSON.stringify({
       type: 'http_res',
       id: frame.id,
       status: 200,
@@ -467,5 +510,62 @@ describe('TunnelDO', () => {
     const res = await respPromise;
     expect(res.status).toBe(200);
     expect(await res.text()).toBe('[]');
+  });
+
+  // ---- Hibernation (Task #790, S3-E) ------------------------------------
+
+  it('hibernate -> wake: daemon socket is recovered via state.getWebSockets and proxyHttp still works', async () => {
+    // Models the production 503 bug: DO instance is evicted after idle,
+    // a fresh instance is constructed for the next request, and it must
+    // re-discover the live daemon ws via state.getWebSockets('daemon')
+    // rather than rely on in-memory `this.sockets`.
+    const TunnelDO = await loadDO();
+    const state = makeState();
+
+    // First instance: daemon dials in.
+    const inst1 = new TunnelDO(state, fakeEnv);
+    await inst1.fetch(makeReq('/tunnel/default'));
+    const daemon = created[0].server;
+    expect(daemon.hibernating).toBe(true);
+
+    // Simulate hibernation: drop the first JS instance entirely. The fake
+    // state preserves the registered ws (the runtime would do the same via
+    // the hibernation API), so a fresh instance can recover it.
+    const inst2 = new TunnelDO(state, fakeEnv);
+
+    // No in-memory daemon ref on the new instance, but proxyHttp must still
+    // succeed because the state-tracked daemon ws is reachable.
+    const respPromise = inst2.fetch(makeHttpReq('/api/sessions'));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(daemon.sent).toHaveLength(1);
+    const frame = JSON.parse(daemon.sent[0] as string);
+    expect(frame.type).toBe('http_req');
+
+    emitMessage(inst2, daemon, JSON.stringify({
+      type: 'http_res',
+      id: frame.id,
+      status: 200,
+      headers: {},
+      body_b64: btoa('ok'),
+    }));
+    const res = await respPromise;
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ok');
+  });
+
+  it('hibernate -> wake: browser token is restored from ws.deserializeAttachment', async () => {
+    const TunnelDO = await loadDO();
+    const state = makeState();
+
+    const inst1 = new TunnelDO(state, fakeEnv);
+    await inst1.fetch(makeReq('/tunnel/default'));
+    await inst1.fetch(makeReq('/ws/default', 'ccsm.persisted-tok'));
+    expect(inst1.getBrowserTokenForTest()).toBe('persisted-tok');
+
+    // Fresh instance after hibernation — token must come from the socket's
+    // serialized attachment, not from a member field.
+    const inst2 = new TunnelDO(state, fakeEnv);
+    expect(inst2.getBrowserTokenForTest()).toBe('persisted-tok');
   });
 });

--- a/packages/cf-worker/test/tunnel-do.test.ts
+++ b/packages/cf-worker/test/tunnel-do.test.ts
@@ -24,6 +24,7 @@ interface FakeServerSocket {
   closeCode?: number;
   closeReason?: string;
   sent: Array<unknown>;
+  readyState: number;
   accept(): void;
   send(data: unknown): void;
   close(code?: number, reason?: string): void;
@@ -44,6 +45,7 @@ function makeServerSocket(): FakeServerSocket {
     attachment: null,
     closed: false,
     sent: [],
+    readyState: 1, // WebSocket.OPEN
     accept() {
       this.accepted = true;
     },
@@ -56,6 +58,7 @@ function makeServerSocket(): FakeServerSocket {
       this.closed = true;
       this.closeCode = code;
       this.closeReason = reason;
+      this.readyState = 3; // CLOSED
     },
     serializeAttachment(value: unknown) {
       this.attachment = value;
@@ -177,6 +180,7 @@ function emitClose(
   inst: { webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean): void },
   ws: FakeServerSocket,
 ): void {
+  ws.readyState = 3; // CLOSED — getDaemonSocket / getBrowserSocket filter on this
   inst.webSocketClose(ws as unknown as WebSocket, 1006, '', false);
   ws.closed = true;
 }

--- a/packages/cf-worker/vitest.config.ts
+++ b/packages/cf-worker/vitest.config.ts
@@ -1,8 +1,17 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
   test: {
     environment: 'node',
     include: ['test/**/*.test.ts'],
+    alias: {
+      // The `cloudflare:workers` virtual module is only available in the
+      // workerd runtime; stub it for unit tests so importing the DO doesn't
+      // fail at module-resolve time (Task #790, S3-E hibernation).
+      'cloudflare:workers': fileURLToPath(
+        new URL('./test/stubs/cloudflare-workers.ts', import.meta.url),
+      ),
+    },
   },
 });


### PR DESCRIPTION
## Summary

Fixes intermittent `503 daemon offline` ~30s after daemon connects (Task #790, S3-E).

**Root cause**: `TunnelDO` accepted ws via `server.accept()` + `addEventListener` and cached refs on `this.sockets`. Cloudflare evicts idle DO instances; on wake, the fresh JS instance had `this.sockets.daemon === undefined` while the daemon ws on the wire was still alive. `proxyHttp` short-circuited to 503.

**Fix**: switch to the [WebSocket Hibernation API](https://developers.cloudflare.com/durable-objects/best-practices/websockets/):

- `extends DurableObject<Env>` from `cloudflare:workers` (required — plain class doesn't get hibernation dispatch wired up by the runtime).
- `state.acceptWebSocket(server, ['daemon' | 'browser'])` instead of `server.accept()`.
- Override class methods `webSocketMessage` / `webSocketClose` / `webSocketError`; the runtime dispatches via these post-wake.
- Recover sockets via `state.getWebSockets(tag)` filtered by `readyState === WebSocket.OPEN` on every access — no in-memory caching of `WebSocket` refs across the request boundary, and no proactive `close` of prior sockets (the runtime fires `webSocketClose` on dead ones itself; closing manually caused a 1011 reconnect loop in the first prod test).
- Persist per-socket state (browser token, role) via `ws.serializeAttachment` / `deserializeAttachment`.
- `pendingHttp` Map is intentionally NOT persisted: hibernation invalidates the resolve closure, so any pending HTTP at hibernate time is dropped (browser retries). Daemon close still rejects pending with 502.

The daemon side, frontend, and ws frame protocol are unchanged. wrangler.toml `compatibility_date = "2026-01-01"` already supports hibernation (added 2024-04-15).

## Local checks (host: Windows 11, mode: fast)
- lint: `packages/cf-worker` clean (exit 0). Repo-level `npm run lint` reports 2 pre-existing errors in `daemon/test/persist.test.ts` and `ui/test/BootstrapRefresh.test.tsx`, unrelated to this change (verified by re-running lint with this PR's diff stripped via patch-file).
- typecheck: `packages/cf-worker` `tsc --noEmit` exit 0. Repo-level `pnpm -r typecheck` has pre-existing failures in `ui/` (implicit-any, missing `@ccsm/core` typings) on origin/working, none touched by this PR.
- build: `packages/cf-worker` `tsc --noEmit` exit 0.
- unit tests: `npx vitest run` in `packages/cf-worker` -> **19 passed** (19/19), 151ms. Includes 2 new cases:
  - `hibernate -> wake: daemon socket is recovered via state.getWebSockets and proxyHttp still works`
  - `hibernate -> wake: browser token is restored from ws.deserializeAttachment`
- e2e: skipped, change is cf-worker DO internals; no e2e harness covers DO eviction (production-only behavior).

## Files

- `packages/cf-worker/src/tunnel-do.ts` — rewrite to hibernation API, extend DurableObject base class.
- `packages/cf-worker/test/tunnel-do.test.ts` — adapt mocks (fake `DurableObjectState` with `acceptWebSocket`/`getWebSockets`, dispatch via class methods, `readyState` on fake socket); 2 new hibernation cases.
- `packages/cf-worker/test/stubs/cloudflare-workers.ts` — minimal `DurableObject` base class stub for vitest (Node can't resolve `cloudflare:workers`).
- `packages/cf-worker/vitest.config.ts` — alias `cloudflare:workers` to the test stub.

## Production verification

Deployed via `gh workflow run deploy-worker.yml` + `deploy-pages.yml` on this branch (runs 25543617623 / pages auto). Then ran the manager-described repro on Windows host:

```
$ CCSM_TUNNEL_URL=wss://cc-sm.pages.dev/tunnel/default node packages/daemon/dist/index.mjs &
[ccsm] tunnel: connecting wss://cc-sm.pages.dev/tunnel/default
ccsm ready: http://127.0.0.1:17839/?token=ApU-IElBZMOQ3p6Qtpz6SK8o_y2nl-usQonvlWCvbek
[ccsm] tunnel: connected
# (daemon stays connected, NO `closed code=1011` reconnect — fix confirmed.)

$ sleep 60
$ curl -s -w "HTTP %{http_code}\nTotal time: %{time_total}s\n" \
    -X GET "https://cc-sm.pages.dev/api/sessions" \
    -H "authorization: Bearer ApU-IElBZMOQ3p6Qtpz6SK8o_y2nl-usQonvlWCvbek"
{"error":"unauthorized"}
HTTP 401
Total time: 0.085963s
```

**Pre-fix behavior** (per manager's repro on origin/working): same curl after 30s+ idle returns `503 daemon offline`. Post-fix: request reaches the daemon (which returns its own 401 because the loopback token isn't an over-tunnel auth token — that's outside this task's scope; the point is the request is no longer short-circuited at the DO with 503).

**Pre-deploy behavior on this branch's first push** (also captured in commit log): a transient 1011 reconnect loop in daemon caused by proactive stale-ws close on `/tunnel/default`. Removed in commit 99b2aa90; final test above shows the daemon stays connected through the full 60s idle window.