### PR TITLE
feat(tunnel): wire ws frames to PTY via hello-with-sid (Task #793, S3-G)

### DIFF
--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -20,13 +20,21 @@ const TAG_BROWSER = 'browser';
  * the daemon can run the browser-presented token through its existing
  * classifyOrigin / token check path (Task #782, S3-T6).
  *
- * Wire format: JSON text frame `{"type":"hello","token":"<t>"}`. Subsequent
- * frames are raw passthrough. The daemon side parses ONLY the first text
- * frame as hello; if it's missing or malformed the daemon closes 1008.
+ * Wire format: JSON text frame `{"type":"hello","token":"<t>","sid":"<s>","lastSeq":<n>}`.
+ * `sid` + `lastSeq` were added in Task #793 (S3-G) so the daemon can route
+ * the paired browser ws into the right per-session PTY ring buffer; older
+ * deployments without those fields fall back to "no session attached"
+ * behaviour on the daemon side. Subsequent frames are raw passthrough. The
+ * daemon side parses ONLY the first text frame as hello; if it's missing or
+ * malformed the daemon closes 1008.
  */
 interface HelloFrame {
   type: 'hello';
   token: string;
+  /** Task #793: session id the browser is attaching to (`sid` query param). */
+  sid?: string;
+  /** Task #793: ring-buffer replay cursor (`lastSeq` query param, default 0). */
+  lastSeq?: number;
 }
 
 /**
@@ -74,8 +82,8 @@ interface DaemonAttachment {
 
 type SocketAttachment = BrowserAttachment | DaemonAttachment;
 
-function buildHelloFrame(token: string): string {
-  const frame: HelloFrame = { type: 'hello', token };
+function buildHelloFrame(token: string, sid: string, lastSeq: number): string {
+  const frame: HelloFrame = { type: 'hello', token, sid, lastSeq };
   return JSON.stringify(frame);
 }
 
@@ -252,6 +260,28 @@ export class TunnelDO extends DurableObject<Env> {
         return new Response(null, { status: 101, webSocket: client });
       }
 
+      // Task #793 (S3-G): the browser ws URL carries the session id + ring
+      // replay cursor as query params (`?sid=<s>&lastSeq=<n>`). Both are
+      // forwarded to the daemon inside the hello frame so the daemon can
+      // route the paired ws into the right per-session PTY. Missing sid →
+      // close 1008 (browser bug; falling through with no sid would dump
+      // every PTY's bytes into a wrong-tab terminal).
+      const sid = url.searchParams.get('sid') ?? '';
+      if (sid.length === 0) {
+        server.accept();
+        server.close(1008, 'missing sid');
+        return new Response(null, { status: 101, webSocket: client });
+      }
+      const lastSeqRaw = url.searchParams.get('lastSeq');
+      let lastSeq = 0;
+      if (lastSeqRaw !== null) {
+        const n = Number(lastSeqRaw);
+        if (Number.isFinite(n) && Number.isInteger(n) && n >= 0 && n <= 0xffffffff) {
+          lastSeq = n;
+        }
+        // Bad lastSeq → fall through with 0 (matches daemon "missing == 0").
+      }
+
       // Don't proactively close any prior browser ws — same reasoning as the
       // daemon path above. readyState filtering picks the live one.
       const attachment: BrowserAttachment = { role: 'browser', token: extracted.token };
@@ -260,7 +290,7 @@ export class TunnelDO extends DurableObject<Env> {
 
       // Emit hello as the first daemon-bound frame after this browser pair.
       try {
-        daemon.send(buildHelloFrame(extracted.token));
+        daemon.send(buildHelloFrame(extracted.token, sid, lastSeq));
       } catch {
         /* daemon may have just dropped; cleanup happens via webSocketClose */
       }

--- a/packages/cf-worker/test/tunnel-do.test.ts
+++ b/packages/cf-worker/test/tunnel-do.test.ts
@@ -136,6 +136,15 @@ function makeReq(path: string, protocol?: string): Request {
   });
 }
 
+/** Browser /ws/default request with sid + lastSeq query params (Task #793). */
+function makeBrowserWsReq(opts: { sid?: string; lastSeq?: number; protocol?: string }): Request {
+  const params: string[] = [];
+  if (opts.sid !== undefined) params.push(`sid=${encodeURIComponent(opts.sid)}`);
+  if (opts.lastSeq !== undefined) params.push(`lastSeq=${opts.lastSeq}`);
+  const qs = params.length > 0 ? `?${params.join('&')}` : '';
+  return makeReq(`/ws/default${qs}`, opts.protocol);
+}
+
 const BROWSER_PROTO = 'ccsm.test-token-xyz';
 
 /**
@@ -211,7 +220,7 @@ describe('TunnelDO', () => {
     expect(daemon.hibernating).toBe(true);
     expect(daemon.tags).toEqual(['daemon']);
 
-    await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
+    await inst.fetch(makeReq('/ws/default?sid=s', BROWSER_PROTO));
     const browser = created[1].server;
     expect(browser.hibernating).toBe(true);
     expect(browser.tags).toEqual(['browser']);
@@ -226,16 +235,19 @@ describe('TunnelDO', () => {
     const TunnelDO = await loadDO();
     const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
-    await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
+    await inst.fetch(makeReq('/ws/default?sid=s', BROWSER_PROTO));
     const daemon = created[0].server;
     const browser = created[1].server;
 
     // Task #782: DO injects a hello control frame as the first daemon-bound
-    // payload before any browser->daemon raw forwarding.
+    // payload before any browser->daemon raw forwarding. Task #793 adds sid +
+    // lastSeq so the daemon can route into the right per-session PTY.
     expect(daemon.sent).toHaveLength(1);
     expect(JSON.parse(daemon.sent[0] as string)).toEqual({
       type: 'hello',
       token: 'test-token-xyz',
+      sid: 's',
+      lastSeq: 0,
     });
 
     emitMessage(inst, browser, 'ping');
@@ -247,7 +259,7 @@ describe('TunnelDO', () => {
     const TunnelDO = await loadDO();
     const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
-    await inst.fetch(makeReq('/ws/default', 'ccsm.abc-987'));
+    await inst.fetch(makeReq('/ws/default?sid=s', 'ccsm.abc-987'));
     expect(inst.getBrowserTokenForTest()).toBe('abc-987');
   });
 
@@ -255,7 +267,7 @@ describe('TunnelDO', () => {
     const TunnelDO = await loadDO();
     const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
-    const res = await inst.fetch(makeReq('/ws/default', 'ccsm.zzz'));
+    const res = await inst.fetch(makeReq('/ws/default?sid=s', 'ccsm.zzz'));
     expect(res.status).toBe(101);
     const headers = (res as unknown as { headers?: Headers | Record<string, string> }).headers;
     if (headers !== undefined) {
@@ -283,7 +295,7 @@ describe('TunnelDO', () => {
     const TunnelDO = await loadDO();
     const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
-    await inst.fetch(makeReq('/ws/default', 'other.subproto'));
+    await inst.fetch(makeReq('/ws/default?sid=s', 'other.subproto'));
     const browser = created[1].server;
     expect(browser.closed).toBe(true);
     expect(browser.closeCode).toBe(1008);
@@ -306,7 +318,7 @@ describe('TunnelDO', () => {
     const TunnelDO = await loadDO();
     const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
-    await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
+    await inst.fetch(makeReq('/ws/default?sid=s', BROWSER_PROTO));
     const daemon = created[0].server;
     const browser = created[1].server;
 
@@ -318,7 +330,7 @@ describe('TunnelDO', () => {
 
     // After daemon drop the next browser should hit "daemon offline" path
     // (slots cleared so a fresh /ws/default re-runs the no-daemon branch).
-    const res = await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
+    const res = await inst.fetch(makeReq('/ws/default?sid=s', BROWSER_PROTO));
     expect(res.status).toBe(101);
     const browser2 = created[2].server;
     expect(browser2.closeCode).toBe(1011);
@@ -328,14 +340,14 @@ describe('TunnelDO', () => {
     const TunnelDO = await loadDO();
     const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
-    await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
+    await inst.fetch(makeReq('/ws/default?sid=s', BROWSER_PROTO));
     const daemon = created[0].server;
     const browser = created[1].server;
 
     emitClose(inst, browser);
     expect(daemon.closed).toBe(false);
 
-    await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
+    await inst.fetch(makeReq('/ws/default?sid=s', BROWSER_PROTO));
     const browser2 = created[2].server;
     expect(browser2.hibernating).toBe(true);
     expect(browser2.closed).toBe(false);
@@ -348,7 +360,7 @@ describe('TunnelDO', () => {
     const TunnelDO = await loadDO();
     const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
-    await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
+    await inst.fetch(makeReq('/ws/default?sid=s', BROWSER_PROTO));
     const daemon = created[0].server;
     const browser = created[1].server;
 
@@ -359,10 +371,77 @@ describe('TunnelDO', () => {
     expect(browser.closeReason).toBe('daemon error');
   });
 
+  // ---- Task #793 (S3-G): hello frame carries sid + lastSeq --------------
+
+  it('hello frame includes sid + lastSeq from the ws upgrade query', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(makeState(), fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    await inst.fetch(
+      makeBrowserWsReq({ sid: 'sess-abc', lastSeq: 42, protocol: BROWSER_PROTO }),
+    );
+    const daemon = created[0].server;
+    expect(daemon.sent).toHaveLength(1);
+    expect(JSON.parse(daemon.sent[0] as string)).toEqual({
+      type: 'hello',
+      token: 'test-token-xyz',
+      sid: 'sess-abc',
+      lastSeq: 42,
+    });
+  });
+
+  it('hello defaults lastSeq=0 when query param is omitted', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(makeState(), fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    await inst.fetch(makeBrowserWsReq({ sid: 'sess-1', protocol: BROWSER_PROTO }));
+    const daemon = created[0].server;
+    const hello = JSON.parse(daemon.sent[0] as string);
+    expect(hello.sid).toBe('sess-1');
+    expect(hello.lastSeq).toBe(0);
+  });
+
+  it('closes browser ws with 1008 when sid query param is missing', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(makeState(), fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    // Has token subprotocol, has paired daemon, but no sid → 1008.
+    await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
+    const browser = created[1].server;
+    expect(browser.closed).toBe(true);
+    expect(browser.closeCode).toBe(1008);
+    expect(browser.closeReason).toBe('missing sid');
+    // Daemon must NOT have received a hello (no successful pairing).
+    const daemon = created[0].server;
+    expect(daemon.sent).toHaveLength(0);
+  });
+
+  it('closes browser ws with 1008 when sid query param is empty string', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(makeState(), fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    await inst.fetch(makeReq('/ws/default?sid=', BROWSER_PROTO));
+    const browser = created[1].server;
+    expect(browser.closed).toBe(true);
+    expect(browser.closeCode).toBe(1008);
+  });
+
+  it('ignores invalid lastSeq and falls back to 0', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(makeState(), fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    await inst.fetch(makeReq('/ws/default?sid=s&lastSeq=NaN', BROWSER_PROTO));
+    const daemon = created[0].server;
+    const hello = JSON.parse(daemon.sent[0] as string);
+    expect(hello.lastSeq).toBe(0);
+    // Browser pairing succeeded.
+    const browser = created[1].server;
+    expect(browser.closed).toBe(false);
+  });
+
   // ---- HTTP-over-tunnel (Task #787, S3-C) -------------------------------
 
-  function makeHttpReq(path: string, method = 'GET', body?: string): Request {
-    return new Request(`https://example.test${path}`, {
+  function makeHttpReq(path: string, method = 'GET', body?: string): Request {    return new Request(`https://example.test${path}`, {
       method,
       body,
     });
@@ -440,7 +519,7 @@ describe('TunnelDO', () => {
     const TunnelDO = await loadDO();
     const inst = new TunnelDO(makeState(), fakeEnv);
     await inst.fetch(makeReq('/tunnel/default'));
-    await inst.fetch(makeReq('/ws/default', BROWSER_PROTO));
+    await inst.fetch(makeReq('/ws/default?sid=s', BROWSER_PROTO));
     const daemon = created[0].server;
     const browser = created[1].server;
 
@@ -564,7 +643,7 @@ describe('TunnelDO', () => {
 
     const inst1 = new TunnelDO(state, fakeEnv);
     await inst1.fetch(makeReq('/tunnel/default'));
-    await inst1.fetch(makeReq('/ws/default', 'ccsm.persisted-tok'));
+    await inst1.fetch(makeReq('/ws/default?sid=s', 'ccsm.persisted-tok'));
     expect(inst1.getBrowserTokenForTest()).toBe('persisted-tok');
 
     // Fresh instance after hibernation — token must come from the socket's

--- a/packages/core/src/ws/client.ts
+++ b/packages/core/src/ws/client.ts
@@ -52,6 +52,14 @@ export type WsStatus =
 export interface HostBase {
   httpBase: string;
   wsBase?: string;
+  /**
+   * Optional path override for the ws upgrade URL (Task #793, S3-G). Defaults
+   * to `API_PATHS.ws` (`/ws`) — used when the daemon is reachable directly
+   * (loopback / Tauri shell). The cloud-tunnel deployment must point at
+   * `/ws/default` so the Cloudflare Pages Function + Worker route the
+   * request into the TunnelDO instead of falling through to the SPA.
+   */
+  wsPath?: string;
 }
 
 export interface WsClientOptions {
@@ -110,7 +118,8 @@ export function buildWsUrl(
   if (lastSeq > 0) params.set('lastSeq', String(lastSeq));
   // Trim trailing slash to avoid `//ws` when caller passes `http://h/`.
   const origin = wsOrigin.replace(/\/+$/, '');
-  return `${origin}${API_PATHS.ws}?${params.toString()}`;
+  const path = hostBase.wsPath ?? API_PATHS.ws;
+  return `${origin}${path}?${params.toString()}`;
 }
 
 function deriveWsOrigin(httpBase: string): string {

--- a/packages/core/test/ws-client.test.ts
+++ b/packages/core/test/ws-client.test.ts
@@ -92,6 +92,22 @@ describe('buildWsUrl (hostBase injection)', () => {
     const url = buildWsUrl('s', 't', 0, { httpBase: 'http://127.0.0.1:17832/' });
     expect(url).toBe('ws://127.0.0.1:17832/ws?sid=s&token=t');
   });
+
+  // Task #793 (S3-G): cloud-tunnel deployment must hit `/ws/default` so the
+  // Pages Function + Worker route into the TunnelDO; literal `/ws` falls
+  // through to the SPA index.html.
+  it('honours an explicit wsPath override', () => {
+    const url = buildWsUrl('s', 't', 0, {
+      httpBase: 'https://cc-sm.pages.dev',
+      wsPath: '/ws/default',
+    });
+    expect(url).toBe('wss://cc-sm.pages.dev/ws/default?sid=s&token=t');
+  });
+
+  it('falls back to API_PATHS.ws when wsPath is omitted', () => {
+    const url = buildWsUrl('s', 't', 0, { httpBase: 'http://127.0.0.1:9876' });
+    expect(url).toBe('ws://127.0.0.1:9876/ws?sid=s&token=t');
+  });
 });
 
 describe('WsClient', () => {

--- a/packages/daemon/src/index.mts
+++ b/packages/daemon/src/index.mts
@@ -26,7 +26,7 @@ import { openDb } from './db.mjs';
 import { createDaemonHttp } from './http.mjs';
 import { createRuntimeRegistry } from './runtime.mjs';
 import { TunnelClient } from './tunnel.mjs';
-import { attachWebSocket } from './ws.mjs';
+import { attachFrameRouter, attachWebSocket } from './ws.mjs';
 
 const DEFAULT_PORT = 17832;
 const PORT_RETRY_MAX = 20;
@@ -154,8 +154,31 @@ async function main(): Promise<void> {
         const len = typeof data === 'string'
           ? Buffer.byteLength(data, 'utf8')
           : data.length;
-        // T4 simplification: just observe link-up; T6 will route into sessions.
+        // Frames that arrive before any browser pairing (no hello+sid yet)
+        // land here. Once the browser sends hello with sid, onBrowserAttach
+        // takes over and routes binary frames into the per-session PTY.
         console.error(`[ccsm] tunnel: rx frame len=${len}`);
+      },
+      // Task #793 (S3-G): wire the paired browser ws into the runtime
+      // registry's per-session fan-out. The router owns replay + subscribe
+      // + INPUT/RESIZE forwarding for the rest of this connection; we tear
+      // it down via the returned handle when the tunnel ws drops.
+      onBrowserAttach: ({ sid, lastSeq, send }) => {
+        const router = attachFrameRouter({
+          sid,
+          lastSeq,
+          registry,
+          send: (data) => send(data),
+        });
+        if (!router.attached) {
+          console.warn(`[ccsm] tunnel: attach failed sid=${JSON.stringify(sid)} (not_spawned or exited)`);
+          return null;
+        }
+        console.error(`[ccsm] tunnel: attached sid=${sid} lastSeq=${lastSeq}`);
+        return {
+          onFrame: (data) => router.onFrame(data),
+          onClose: () => router.close(),
+        };
       },
     });
     tunnel.start();

--- a/packages/daemon/src/tunnel.mts
+++ b/packages/daemon/src/tunnel.mts
@@ -69,6 +69,45 @@ export interface TunnelClientOptions {
    * real loopback server.
    */
   fetchImpl?: typeof fetch;
+  /**
+   * Task #793 (S3-G): invoked when a paired browser ws sends its hello
+   * frame containing a session id. The caller (daemon main / ws.mts) wires
+   * the supplied `send` channel into the runtime registry's per-session PTY
+   * fan-out so OUTPUT frames flow browser-ward and INPUT/RESIZE frames flow
+   * PTY-ward. Receives the parsed sid + replay cursor.
+   *
+   * If absent, hello frames are still token-checked and forwarded raw via
+   * onFrame (legacy passthrough behaviour).
+   */
+  onBrowserAttach?: (info: BrowserAttachInfo) => BrowserAttachHandle | null;
+}
+
+/**
+ * Information passed to `onBrowserAttach` so the daemon main can resolve the
+ * sid → runtime + start fan-out.
+ *
+ * `send` is a thin wrapper around the underlying ws.send so the caller
+ * doesn't have to know whether the bytes are travelling over a real loopback
+ * ws or a tunnel (Task #793, S3-G). It is only valid for the duration of
+ * the current connection — once `webSocketClose` fires, the handle's
+ * `onClose` is invoked so the caller can drop the runtime subscription.
+ */
+export interface BrowserAttachInfo {
+  sid: string;
+  lastSeq: number;
+  /** Send a binary frame back to the browser via the tunnel. */
+  send: (data: Uint8Array | Buffer) => void;
+}
+
+/**
+ * Caller-returned hooks the tunnel uses to feed browser-bound frames into
+ * the daemon's per-session router (Task #793, S3-G).
+ */
+export interface BrowserAttachHandle {
+  /** Daemon-bound binary frame from the browser (INPUT / RESIZE / PAUSE / RESUME). */
+  onFrame: (data: Buffer) => void;
+  /** Tunnel ws closed — caller must drop subscription, kill if last subscriber. */
+  onClose: () => void;
 }
 
 /** Minimal subset of `ws.WebSocket` that TunnelClient relies on. */
@@ -95,6 +134,10 @@ function defaultWsFactory(url: string): WsLike {
 interface HelloFrame {
   type: 'hello';
   token: string;
+  /** Task #793 (S3-G): session id from the browser ws `?sid=` query. */
+  sid?: string;
+  /** Task #793 (S3-G): replay cursor from the browser ws `?lastSeq=` query. */
+  lastSeq?: number;
 }
 
 /**
@@ -141,7 +184,14 @@ function parseHello(text: string): HelloFrame | null {
   const obj = parsed as Record<string, unknown>;
   if (obj.type !== 'hello') return null;
   if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
-  return { type: 'hello', token: obj.token };
+  const out: HelloFrame = { type: 'hello', token: obj.token };
+  if (typeof obj.sid === 'string' && obj.sid.length > 0) {
+    out.sid = obj.sid;
+  }
+  if (typeof obj.lastSeq === 'number' && Number.isFinite(obj.lastSeq) && obj.lastSeq >= 0) {
+    out.lastSeq = obj.lastSeq;
+  }
+  return out;
 }
 
 function constantTimeTokenEquals(presented: string, expected: string): boolean {
@@ -171,6 +221,9 @@ export class TunnelClient {
   private stopped = false;
   private helloSeen = false;
   private browserToken: string | null = null;
+  // Task #793 (S3-G): per-connection browser session attachment.
+  private readonly onBrowserAttach: ((info: BrowserAttachInfo) => BrowserAttachHandle | null) | null;
+  private browserAttachHandle: BrowserAttachHandle | null = null;
 
   constructor(opts: TunnelClientOptions) {
     this.url = opts.url;
@@ -179,6 +232,7 @@ export class TunnelClient {
     this.wsFactory = opts.wsFactory ?? defaultWsFactory;
     this.daemonLoopbackPort = opts.daemonLoopbackPort ?? 0;
     this.fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
+    this.onBrowserAttach = opts.onBrowserAttach ?? null;
   }
 
   getState(): TunnelState {
@@ -239,6 +293,7 @@ export class TunnelClient {
     this.state = 'connecting';
     this.helloSeen = false;
     this.browserToken = null;
+    this.browserAttachHandle = null;
     let socket: WsLike;
     try {
       socket = this.wsFactory(this.url);
@@ -299,6 +354,29 @@ export class TunnelClient {
         }
         this.helloSeen = true;
         this.browserToken = hello.token;
+        // Task #793 (S3-G): if the browser supplied a sid in hello, hand the
+        // pairing off to the daemon main so it can wire this tunnel into the
+        // matching per-session PTY ring. The handle owns frame routing for
+        // the rest of this connection.
+        if (this.onBrowserAttach !== null && typeof hello.sid === 'string' && hello.sid.length > 0) {
+          const send = (payload: Uint8Array | Buffer): void => {
+            // Bridge to the underlying ws. Always binary frame back to browser.
+            const buf = Buffer.isBuffer(payload)
+              ? payload
+              : Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength);
+            this.send(buf);
+          };
+          try {
+            this.browserAttachHandle = this.onBrowserAttach({
+              sid: hello.sid,
+              lastSeq: hello.lastSeq ?? 0,
+              send,
+            });
+          } catch (err) {
+            console.warn('[ccsm/tunnel] onBrowserAttach threw:', (err as Error).message);
+            this.browserAttachHandle = null;
+          }
+        }
         return;
       }
       if (isBinary) {
@@ -310,6 +388,14 @@ export class TunnelClient {
           buf = Buffer.concat(raw);
         } else {
           buf = Buffer.from(raw as ArrayBuffer);
+        }
+        // Task #793 (S3-G): when an attach handle is bound, the binary
+        // frame is a browser→daemon PTY frame (INPUT/RESIZE/PAUSE/RESUME)
+        // that belongs to the paired session. Routing into the runtime
+        // subsumes the legacy onFrame passthrough.
+        if (this.browserAttachHandle !== null) {
+          this.browserAttachHandle.onFrame(buf);
+          return;
         }
         this.onFrame(buf);
       } else {
@@ -342,6 +428,15 @@ export class TunnelClient {
       this.ws = null;
       this.helloSeen = false;
       this.browserToken = null;
+      // Task #793 (S3-G): tear down per-session attachment.
+      if (this.browserAttachHandle !== null) {
+        try {
+          this.browserAttachHandle.onClose();
+        } catch (err) {
+          console.warn('[ccsm/tunnel] attach onClose threw:', (err as Error).message);
+        }
+        this.browserAttachHandle = null;
+      }
       if (this.stopped) {
         this.state = 'stopped';
         return;

--- a/packages/daemon/src/ws.mts
+++ b/packages/daemon/src/ws.mts
@@ -54,6 +54,283 @@ export interface AttachedWs {
 // Re-export for backwards-compat with tests/imports.
 export type { PtyFactory, PtyLike, SessionLike } from './runtime.mjs';
 
+// ---- attachFrameRouter -------------------------------------------------
+//
+// Task #793 (S3-G): the per-session frame routing that used to live inline in
+// attachWebSocket's onConnection is now an exported helper so the cloud-tunnel
+// path (TunnelClient.onBrowserAttach in tunnel.mts) can reuse the EXACT same
+// fan-out logic — replay → subscribe → forward client frames into the PTY —
+// without the loopback ws server. The only differences vs the loopback path:
+//
+//   - the wire is a `send(Uint8Array)` callback supplied by the caller
+//     (tunnel.mts wraps its own `tunnel.send`; ws.mts wraps `ws.send`);
+//   - cleanup is not driven by ws lifecycle events — the caller invokes
+//     `close()` when its own connection drops.
+//
+// Both paths land on the same RuntimeRegistry (so a tunnel-attached browser
+// and a same-origin loopback browser see identical subscriber-list semantics:
+// same ring replay, same OUTPUT fan-out, same kill-on-last-subscriber).
+
+/** Bytes-out channel the router uses to push frames to the client. */
+export type FrameSendFn = (data: Uint8Array) => void;
+
+export interface AttachFrameRouterOptions {
+  sid: string;
+  lastSeq: number;
+  registry: RuntimeRegistry;
+  /** Send a single (already-encoded) frame back to the client. */
+  send: FrameSendFn;
+  /**
+   * Close the underlying transport with a code + reason. Invoked by the
+   * registry on PTY exit (`1000 'exited'`) or pause-queue overflow
+   * (`1009 'pause_queue_overflow'`). For the loopback ws path this maps to
+   * `ws.close(code, reason)`; for the cloud-tunnel path the daemon main
+   * does NOT close the tunnel ws (it stays up for the next browser pairing)
+   * — the tunnel adapter passes a no-op so subscriber-level closes don't
+   * tear the entire tunnel down.
+   */
+  closeTransport?: (code?: number, reason?: string) => void;
+}
+
+export interface FrameRouter {
+  /** Feed an inbound binary frame from the client (INPUT/RESIZE/PAUSE/RESUME). */
+  onFrame: (data: Uint8Array | Buffer) => void;
+  /**
+   * Drop this attachment from the runtime's subscriber set. If we were the
+   * last subscriber, kicks off PTY kill (matches the loopback ws behaviour).
+   * Idempotent.
+   */
+  close: () => void;
+  /**
+   * True iff the runtime accepted the attachment (i.e. sid was found and the
+   * session was not already exited). When false the caller should close the
+   * underlying transport with a reasonable code (1008 / 1000 'exited').
+   */
+  attached: boolean;
+}
+
+/**
+ * Wire a single subscriber (loopback ws OR cloud-tunnel browser) into the
+ * runtime registry's per-session fan-out.
+ *
+ * Returns a `FrameRouter` whose `onFrame` should be called for every inbound
+ * binary frame on the underlying transport, and whose `close` should be
+ * called when that transport drops. `attached` reports whether the
+ * registry accepted the subscription so the caller can short-circuit on
+ * not-found / already-exited.
+ */
+export function attachFrameRouter(opts: AttachFrameRouterOptions): FrameRouter {
+  const { sid, lastSeq, registry, send } = opts;
+  const closeTransport = opts.closeTransport;
+
+  const rt = registry.get(sid);
+  if (!rt) {
+    return {
+      onFrame: () => {
+        /* noop — caller should have closed already */
+      },
+      close: () => {
+        /* noop */
+      },
+      attached: false,
+    };
+  }
+
+  if (rt.exited) {
+    try {
+      send(
+        encodeFrame({ type: FrameType.EXIT, seq: rt.outputSeq, payload: encodeExit(rt.exitCode) }),
+      );
+    } catch {
+      // ignore — caller is about to close the transport
+    }
+    return {
+      onFrame: () => {
+        /* noop */
+      },
+      close: () => {
+        /* noop */
+      },
+      attached: false,
+    };
+  }
+
+  // Replay BEFORE adding to subscribers so we don't interleave replayed
+  // bytes with a fresh live OUTPUT (Task #661 invariant).
+  if (lastSeq < rt.outputSeq) {
+    const replay = rt.ring.range(lastSeq + 1, rt.outputSeq);
+    if (replay === null) {
+      try {
+        send(
+          encodeFrame({
+            type: FrameType.RESET,
+            seq: rt.outputSeq,
+            payload: new Uint8Array(0),
+          }),
+        );
+      } catch (err) {
+        console.warn('[ccsm/ws] RESET send failed:', (err as Error).message);
+      }
+    } else if (replay.byteLength > 0) {
+      const total = replay.byteLength;
+      for (let off = 0; off < total; off += REPLAY_CHUNK_BYTES) {
+        const end = Math.min(off + REPLAY_CHUNK_BYTES, total);
+        const chunk = replay.subarray(off, end);
+        try {
+          send(
+            encodeFrame({
+              type: FrameType.OUTPUT,
+              seq: rt.outputSeq,
+              payload: chunk,
+            }),
+          );
+        } catch (err) {
+          console.warn('[ccsm/ws] replay send failed:', (err as Error).message);
+          break;
+        }
+      }
+    }
+  }
+
+  // Synthesize a SubscriberSocket-shaped object so the registry's fan-out
+  // loop can call `.send()` / `.close()` / read `.readyState` against it
+  // exactly the way it does for a real `ws.WebSocket`. We keep readyState
+  // wired to OPEN until close() flips it; the registry checks
+  // `sock.readyState === sock.OPEN` before each frame.
+  let readyState = 1; // OPEN
+  const sock: SubscriberSocket = {
+    get readyState() {
+      return readyState;
+    },
+    OPEN: 1,
+    send: (data: Uint8Array) => {
+      try {
+        send(data);
+      } catch (err) {
+        console.warn('[ccsm/ws] router send failed:', (err as Error).message);
+      }
+    },
+    close: (code?: number, reason?: string) => {
+      readyState = 3; // CLOSED
+      if (closeTransport !== undefined) {
+        try {
+          closeTransport(code, reason);
+        } catch {
+          // ignore — best-effort
+        }
+      }
+    },
+  };
+
+  rt.subscribers.set(sock, {
+    paused: false,
+    pausedQueue: [],
+    pausedBytes: 0,
+  });
+
+  // Capture the narrowed runtime ref so the closures below don't re-fetch
+  // (also satisfies TS, which loses the narrow across closure boundaries).
+  const runtimeRef: RuntimeSession = rt;
+
+  let closed = false;
+  function close(): void {
+    if (closed) return;
+    closed = true;
+    readyState = 3;
+    runtimeRef.subscribers.delete(sock);
+    if (runtimeRef.subscribers.size === 0 && !runtimeRef.exited) {
+      void registry.kill(sid);
+    }
+  }
+
+  function onFrame(raw: Uint8Array | Buffer): void {
+    if (closed) return;
+    let buf: Uint8Array;
+    if (raw instanceof Buffer) {
+      buf = new Uint8Array(raw.buffer, raw.byteOffset, raw.byteLength);
+    } else {
+      buf = raw;
+    }
+    let frame;
+    try {
+      frame = decodeFrame(buf);
+    } catch (err) {
+      console.warn('[ccsm/ws] bad frame from client:', (err as Error).message);
+      return;
+    }
+    handleClientFrame(runtimeRef, sock, frame.type, frame.payload);
+  }
+
+  return { onFrame, close, attached: true };
+}
+
+/**
+ * Per-frame dispatch shared by both the loopback ws server and the cloud-
+ * tunnel attachment (Task #793). Pulled out so we don't duplicate the
+ * INPUT/RESIZE/PAUSE/RESUME handling — both transports drive the same PTY
+ * via the same code path.
+ */
+function handleClientFrame(
+  rt: RuntimeSession,
+  sock: SubscriberSocket,
+  type: FrameType,
+  payload: Uint8Array,
+): void {
+  switch (type) {
+    case FrameType.INPUT: {
+      const s = Buffer.from(payload).toString('utf8');
+      try {
+        rt.pty.write(s);
+      } catch (err) {
+        console.warn('[ccsm/ws] pty.write error:', (err as Error).message);
+      }
+      break;
+    }
+    case FrameType.RESIZE: {
+      let dims;
+      try {
+        dims = decodeResize(payload);
+      } catch (err) {
+        console.warn('[ccsm/ws] bad resize payload:', (err as Error).message);
+        return;
+      }
+      try {
+        rt.pty.resize(dims.cols, dims.rows);
+      } catch (err) {
+        console.warn('[ccsm/ws] pty.resize error:', (err as Error).message);
+      }
+      break;
+    }
+    case FrameType.PAUSE: {
+      const state = rt.subscribers.get(sock);
+      if (state) state.paused = true;
+      break;
+    }
+    case FrameType.RESUME: {
+      const state = rt.subscribers.get(sock);
+      if (!state) break;
+      state.paused = false;
+      if (state.pausedQueue.length > 0) {
+        const queued = state.pausedQueue;
+        state.pausedQueue = [];
+        state.pausedBytes = 0;
+        for (const frame of queued) {
+          if (sock.readyState !== sock.OPEN) break;
+          try {
+            sock.send(frame);
+          } catch (err) {
+            console.warn('[ccsm/ws] resume flush send failed:', (err as Error).message);
+            break;
+          }
+        }
+      }
+      break;
+    }
+    default:
+      console.warn(`[ccsm/ws] ignoring c->s frame type=0x${type.toString(16)}`);
+  }
+}
+
 // ---- Auth helpers (mirrors auth.mts logic for ws upgrade) ---------------
 // Origin policy is shared with HTTP via `classifyOrigin` (auth.mts):
 //   - 'absent'   -> same-origin per #672, allow.
@@ -133,69 +410,39 @@ export function attachWebSocket(server: HttpServer, opts: AttachWsOptions): Atta
   server.on('upgrade', onUpgrade);
 
   function onConnection(ws: WSWebSocket, sid: string, lastSeq: number): void {
-    // T#668: ws no longer spawns PTYs. The runtime must already exist (created
-    // via POST /api/sessions or POST /api/sessions/:sid/resume). If it doesn't
-    // we close with 1008 ("policy violation") and a machine-readable reason
-    // the frontend can branch on to issue a /resume call.
-    const rt: RuntimeSession | undefined = registry.get(sid);
-    if (!rt) {
-      ws.close(1008, 'session_not_spawned');
-      return;
-    }
-
-    if (rt.exited) {
-      try {
-        ws.send(encodeFrame({ type: FrameType.EXIT, seq: rt.outputSeq, payload: encodeExit(rt.exitCode) }));
-      } catch {
-        // ignore
-      }
-      ws.close(1000, 'exited');
-      return;
-    }
-
-    // T8 #661: lastSeq replay BEFORE adding ws to subscribers, so we don't
-    // interleave replayed bytes with a freshly-arriving live OUTPUT.
-    if (lastSeq < rt.outputSeq) {
-      const replay = rt.ring.range(lastSeq + 1, rt.outputSeq);
-      if (replay === null) {
+    // Delegate the per-session frame routing to the shared helper so the
+    // loopback ws path and the cloud-tunnel path (Task #793, S3-G) share the
+    // same replay → subscribe → forward semantics. ws.send accepts the
+    // encoded frame directly; on attach failure we close with a machine-
+    // readable reason the frontend branches on.
+    const router = attachFrameRouter({
+      sid,
+      lastSeq,
+      registry,
+      send: (data) => {
+        ws.send(data);
+      },
+      closeTransport: (code, reason) => {
         try {
-          ws.send(
-            encodeFrame({
-              type: FrameType.RESET,
-              seq: rt.outputSeq,
-              payload: new Uint8Array(0),
-            }),
-          );
-        } catch (err) {
-          console.warn('[ccsm/ws] RESET send failed:', (err as Error).message);
+          ws.close(code, reason);
+        } catch {
+          // already closing — ignore
         }
-      } else if (replay.byteLength > 0) {
-        const total = replay.byteLength;
-        for (let off = 0; off < total; off += REPLAY_CHUNK_BYTES) {
-          const end = Math.min(off + REPLAY_CHUNK_BYTES, total);
-          const chunk = replay.subarray(off, end);
-          try {
-            ws.send(
-              encodeFrame({
-                type: FrameType.OUTPUT,
-                seq: rt.outputSeq,
-                payload: chunk,
-              }),
-            );
-          } catch (err) {
-            console.warn('[ccsm/ws] replay send failed:', (err as Error).message);
-            break;
-          }
-        }
-      }
-    }
-
-    // Add to subscribers (registry's fan-out loop sees us via the shared Map).
-    rt.subscribers.set(ws as unknown as SubscriberSocket, {
-      paused: false,
-      pausedQueue: [],
-      pausedBytes: 0,
+      },
     });
+    if (!router.attached) {
+      // Either sid not registered or runtime already exited. The helper has
+      // already emitted EXIT for the exited case; for not-found we close
+      // 1008 with the machine-readable reason the frontend uses to issue
+      // /resume.
+      const rt = registry.get(sid);
+      if (!rt) {
+        ws.close(1008, 'session_not_spawned');
+      } else {
+        ws.close(1000, 'exited');
+      }
+      return;
+    }
 
     ws.on('message', (raw, isBinary) => {
       if (!isBinary) return;
@@ -207,89 +454,15 @@ export function attachWebSocket(server: HttpServer, opts: AttachWsOptions): Atta
       } else {
         buf = new Uint8Array(raw as ArrayBuffer);
       }
-      let frame;
-      try {
-        frame = decodeFrame(buf);
-      } catch (err) {
-        console.warn('[ccsm/ws] bad frame from client:', (err as Error).message);
-        return;
-      }
-      handleClientFrame(rt, ws, frame.type, frame.payload);
+      router.onFrame(buf);
     });
 
-    const cleanup = (): void => {
-      rt.subscribers.delete(ws as unknown as SubscriberSocket);
-      // T#668 spec: ws on close should kill its OWN PTY if subscribers empty
-      // (matches T4 behaviour — keeps daemon footprint tied to the active tab).
-      if (rt.subscribers.size === 0 && !rt.exited) {
-        void registry.kill(sid);
-      }
-    };
-    ws.on('close', cleanup);
+    ws.on('close', () => {
+      router.close();
+    });
     ws.on('error', (err) => {
       console.warn(`[ccsm/ws] socket error sid=${sid}:`, err.message);
     });
-  }
-
-  function handleClientFrame(
-    rt: RuntimeSession,
-    ws: WSWebSocket,
-    type: FrameType,
-    payload: Uint8Array,
-  ): void {
-    switch (type) {
-      case FrameType.INPUT: {
-        const s = Buffer.from(payload).toString('utf8');
-        try {
-          rt.pty.write(s);
-        } catch (err) {
-          console.warn('[ccsm/ws] pty.write error:', (err as Error).message);
-        }
-        break;
-      }
-      case FrameType.RESIZE: {
-        let dims;
-        try {
-          dims = decodeResize(payload);
-        } catch (err) {
-          console.warn('[ccsm/ws] bad resize payload:', (err as Error).message);
-          return;
-        }
-        try {
-          rt.pty.resize(dims.cols, dims.rows);
-        } catch (err) {
-          console.warn('[ccsm/ws] pty.resize error:', (err as Error).message);
-        }
-        break;
-      }
-      case FrameType.PAUSE: {
-        const state = rt.subscribers.get(ws as unknown as SubscriberSocket);
-        if (state) state.paused = true;
-        break;
-      }
-      case FrameType.RESUME: {
-        const state = rt.subscribers.get(ws as unknown as SubscriberSocket);
-        if (!state) break;
-        state.paused = false;
-        if (state.pausedQueue.length > 0) {
-          const queued = state.pausedQueue;
-          state.pausedQueue = [];
-          state.pausedBytes = 0;
-          for (const frame of queued) {
-            if (ws.readyState !== ws.OPEN) break;
-            try {
-              ws.send(frame);
-            } catch (err) {
-              console.warn('[ccsm/ws] resume flush send failed:', (err as Error).message);
-              break;
-            }
-          }
-        }
-        break;
-      }
-      default:
-        console.warn(`[ccsm/ws] ignoring c->s frame type=0x${type.toString(16)}`);
-    }
   }
 
   async function shutdown(): Promise<void> {

--- a/packages/daemon/test/tunnel.test.ts
+++ b/packages/daemon/test/tunnel.test.ts
@@ -605,4 +605,128 @@ describe('TunnelClient', () => {
     expect(sockets[0].closedCalls).toHaveLength(1);
     expect(sockets[0].closedCalls[0].code).toBe(1008);
   });
+
+  // ---- Task #793 (S3-G): hello-with-sid → onBrowserAttach --------------
+
+  it('hello with sid+lastSeq invokes onBrowserAttach with parsed values', () => {
+    const attachCalls: Array<{ sid: string; lastSeq: number }> = [];
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'tok',
+      onFrame: () => {},
+      wsFactory: factory,
+      onBrowserAttach: ({ sid, lastSeq }) => {
+        attachCalls.push({ sid, lastSeq });
+        return { onFrame: () => {}, onClose: () => {} };
+      },
+    });
+    client.start();
+    sockets[0].open();
+
+    sockets[0].pushText(JSON.stringify({
+      type: 'hello',
+      token: 'tok',
+      sid: 'sess-abc',
+      lastSeq: 17,
+    }));
+
+    expect(attachCalls).toEqual([{ sid: 'sess-abc', lastSeq: 17 }]);
+    expect(client.getBrowserToken()).toBe('tok');
+  });
+
+  it('hello without sid does NOT invoke onBrowserAttach (legacy passthrough)', () => {
+    const onBrowserAttach = vi.fn();
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'tok',
+      onFrame: () => {},
+      wsFactory: factory,
+      onBrowserAttach: onBrowserAttach as unknown as Parameters<typeof TunnelClient>[0]['onBrowserAttach'],
+    });
+    client.start();
+    sockets[0].open();
+    sockets[0].pushText(JSON.stringify({ type: 'hello', token: 'tok' }));
+    expect(onBrowserAttach).not.toHaveBeenCalled();
+  });
+
+  it('post-hello binary frames route to attach handle, not onFrame', () => {
+    const onFrame = vi.fn();
+    const handleFrames: Buffer[] = [];
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'tok',
+      onFrame,
+      wsFactory: factory,
+      onBrowserAttach: () => ({
+        onFrame: (data) => handleFrames.push(data),
+        onClose: () => {},
+      }),
+    });
+    client.start();
+    sockets[0].open();
+    sockets[0].pushText(JSON.stringify({
+      type: 'hello',
+      token: 'tok',
+      sid: 'sess',
+      lastSeq: 0,
+    }));
+
+    sockets[0].pushBinary(Buffer.from([1, 2, 3]));
+    expect(handleFrames).toHaveLength(1);
+    expect(handleFrames[0].equals(Buffer.from([1, 2, 3]))).toBe(true);
+    // onFrame NOT called when attach handle owns binary routing.
+    expect(onFrame).not.toHaveBeenCalled();
+  });
+
+  it('attach handle.send() pushes a binary frame back through the tunnel ws', () => {
+    let sendBack: ((data: Uint8Array | Buffer) => void) | null = null;
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'tok',
+      onFrame: () => {},
+      wsFactory: factory,
+      onBrowserAttach: ({ send }) => {
+        sendBack = send;
+        return { onFrame: () => {}, onClose: () => {} };
+      },
+    });
+    client.start();
+    sockets[0].open();
+    sockets[0].pushText(JSON.stringify({
+      type: 'hello',
+      token: 'tok',
+      sid: 'sess',
+      lastSeq: 0,
+    }));
+
+    expect(sendBack).not.toBeNull();
+    (sendBack as unknown as (data: Uint8Array) => void)(new Uint8Array([7, 8, 9]));
+    // Tunnel ws.send should have received the bridged buffer.
+    expect(sockets[0].sent).toHaveLength(1);
+    const sent = sockets[0].sent[0] as Buffer;
+    expect(Buffer.isBuffer(sent)).toBe(true);
+    expect(sent.equals(Buffer.from([7, 8, 9]))).toBe(true);
+  });
+
+  it('socket close after attach fires handle.onClose exactly once', () => {
+    const onClose = vi.fn();
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'tok',
+      onFrame: () => {},
+      wsFactory: factory,
+      onBrowserAttach: () => ({ onFrame: () => {}, onClose }),
+    });
+    client.start();
+    sockets[0].open();
+    sockets[0].pushText(JSON.stringify({
+      type: 'hello',
+      token: 'tok',
+      sid: 'sess',
+      lastSeq: 0,
+    }));
+
+    sockets[0].closeFromServer(1006);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/daemon/test/ws.test.ts
+++ b/packages/daemon/test/ws.test.ts
@@ -33,7 +33,7 @@ import {
   type PtyLike,
   type RuntimeRegistry,
 } from '../src/runtime.mjs';
-import { attachWebSocket, type AttachedWs } from '../src/ws.mjs';
+import { attachWebSocket, attachFrameRouter, type AttachedWs } from '../src/ws.mjs';
 
 const TOKEN = 'test-token-do-not-use-in-prod-0123456789abcdef';
 const GOOD_ORIGIN = 'http://localhost:1234';
@@ -462,5 +462,146 @@ describe('ws T#668: subscribe-only (no spawn on connect)', () => {
 
     d.ws.close();
     await d.closed;
+  });
+});
+
+// ---- attachFrameRouter (Task #793, S3-G) -------------------------------
+//
+// The cloud-tunnel path bypasses the loopback WebSocketServer and wires a
+// "browser-paired" subscriber straight into the runtime registry via the
+// shared helper. These tests exercise the helper in isolation so we don't
+// have to boot a tunnel + DO to verify routing semantics.
+
+describe('attachFrameRouter (cloud-tunnel browser attach)', () => {
+  let attachedFr: AttachedWs;
+  let httpFr: DaemonHttp;
+  let registryFr: RuntimeRegistry;
+  let ptyState: { factory: PtyFactory; instances: FakePty[] };
+
+  beforeAll(async () => {
+    ptyState = makeFakePtyFactory();
+    httpFr = createDaemonHttp({ token: TOKEN });
+    registryFr = createRuntimeRegistry({
+      sessions: httpFr.sessions,
+      ptyFactory: ptyState.factory,
+    });
+    httpFr.setRegistry(registryFr);
+    attachedFr = attachWebSocket(httpFr.server, {
+      token: TOKEN,
+      sessions: httpFr.sessions,
+      registry: registryFr,
+    });
+    await new Promise<void>((resolve, reject) => {
+      httpFr.server.once('error', reject);
+      httpFr.server.listen(0, '127.0.0.1', () => {
+        httpFr.server.removeListener('error', reject);
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await attachedFr.shutdown();
+    await new Promise<void>((resolve) => httpFr.server.close(() => resolve()));
+  });
+
+  beforeEach(() => {
+    ptyState.instances.length = 0;
+  });
+
+  afterEach(() => {
+    for (const sid of Array.from(httpFr.sessions.keys())) {
+      void registryFr.kill(sid);
+      httpFr.sessions.delete(sid);
+    }
+  });
+
+  async function createSidFr(): Promise<string> {
+    const baseUrl = `http://127.0.0.1:${(httpFr.server.address() as AddressInfo).port}`;
+    const r = await fetch(`${baseUrl}/api/sessions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        Origin: GOOD_ORIGIN,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    });
+    const j = (await r.json()) as { sid: string };
+    return j.sid;
+  }
+
+  it('routes PTY OUTPUT into the supplied send() and forwards INPUT into the PTY', async () => {
+    const sid = await createSidFr();
+    expect(ptyState.instances.length).toBe(1);
+    const fpty = ptyState.instances[0]!;
+
+    const sent: Uint8Array[] = [];
+    const router = attachFrameRouter({
+      sid,
+      lastSeq: 0,
+      registry: registryFr,
+      send: (data) => sent.push(new Uint8Array(data)),
+    });
+    expect(router.attached).toBe(true);
+
+    // Live PTY output → registry fan-out → router send.
+    fpty.emitData('hello-from-pty');
+    expect(sent.length).toBe(1);
+    const dec = decodeFrame(sent[0]!);
+    expect(dec.type).toBe(FrameType.OUTPUT);
+    expect(Buffer.from(dec.payload).toString('utf8')).toBe('hello-from-pty');
+
+    // Browser-bound INPUT frame → router.onFrame → PTY.write.
+    const inputPayload = new TextEncoder().encode('typed input\n');
+    const inputFrame = encodeFrame({
+      type: FrameType.INPUT,
+      seq: 1,
+      payload: inputPayload,
+    });
+    router.onFrame(inputFrame);
+    expect(fpty.written).toEqual(['typed input\n']);
+
+    // Browser-bound RESIZE → PTY.resize.
+    const resizeFrame = encodeFrame({
+      type: FrameType.RESIZE,
+      seq: 2,
+      payload: encodeResize(132, 50),
+    });
+    router.onFrame(resizeFrame);
+    expect(fpty.lastResize).toEqual({ cols: 132, rows: 50 });
+
+    router.close();
+  });
+
+  it('returns attached=false when sid is unknown', () => {
+    const sent: Uint8Array[] = [];
+    const router = attachFrameRouter({
+      sid: 'no-such-sid',
+      lastSeq: 0,
+      registry: registryFr,
+      send: (data) => sent.push(new Uint8Array(data)),
+    });
+    expect(router.attached).toBe(false);
+    // Sending frames to a not-attached router is a noop.
+    router.onFrame(new Uint8Array([1, 2, 3]));
+    expect(sent.length).toBe(0);
+  });
+
+  it('close() on the last subscriber kills the PTY (matches loopback ws semantics)', async () => {
+    const sid = await createSidFr();
+    const fpty = ptyState.instances[0]!;
+    const router = attachFrameRouter({
+      sid,
+      lastSeq: 0,
+      registry: registryFr,
+      send: () => {},
+    });
+    expect(router.attached).toBe(true);
+    expect(fpty.killed.length).toBe(0);
+    router.close();
+    // kill is async via registry.kill; give it a tick.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fpty.killed.length).toBeGreaterThan(0);
   });
 });

--- a/packages/frontend-web/src/hostConfig.ts
+++ b/packages/frontend-web/src/hostConfig.ts
@@ -137,6 +137,26 @@ function currentDaemonBase(): string {
 }
 
 /**
+ * Decide which ws path the SPA should hit (Task #793, S3-G).
+ *
+ * - Cloud / Pages default (no `?daemon=` override): `/ws/default`. The
+ *   Pages Function + Worker only route literal `/ws/default` into the
+ *   TunnelDO; anything else falls through to the SPA index.html.
+ * - `?daemon=` override: leave undefined so core's WsClient falls back to
+ *   `API_PATHS.ws` (`/ws`), which is what the loopback daemon serves.
+ */
+export function resolveWsPath(deps: ResolveDaemonBaseDeps): string | undefined {
+  const fromUrl = new URLSearchParams(deps.search).get('daemon');
+  if (fromUrl && fromUrl.length > 0) return undefined;
+  return '/ws/default';
+}
+
+function currentWsPath(): string | undefined {
+  if (typeof window === 'undefined') return undefined;
+  return resolveWsPath({ search: window.location.search });
+}
+
+/**
  * WebSocket subprotocol prefix (Task #782, S3-T6).
  *
  * Browsers do not allow custom headers on `new WebSocket(url)`, so we smuggle
@@ -175,4 +195,5 @@ export const webHostConfig: HostConfig = {
     if (typeof window === 'undefined') return null;
     return sessionStorage.getItem(TOKEN_STORAGE_KEY);
   },
+  ...(currentWsPath() !== undefined ? { wsPath: currentWsPath() as string } : {}),
 };

--- a/packages/frontend-web/test/hostConfig.test.ts
+++ b/packages/frontend-web/test/hostConfig.test.ts
@@ -7,6 +7,7 @@ import {
   getWsProtocol,
   resolveDaemonBase,
   resolveWsBase,
+  resolveWsPath,
   WS_SUBPROTOCOL_PREFIX,
 } from '../src/hostConfig';
 
@@ -63,6 +64,25 @@ describe('resolveWsBase', () => {
   it('matches http httpBase with ws:// scheme (loopback override)', () => {
     const got = resolveWsBase({ search: '?daemon=http://127.0.0.1:9876' });
     expect(got).toBe('ws://127.0.0.1:9876');
+  });
+});
+
+describe('resolveWsPath (Task #793, S3-G)', () => {
+  it('defaults to /ws/default for cloud-tunnel deployment', () => {
+    // Pages Function only routes literal `/ws/default` into the Worker + DO;
+    // anything else (e.g. `/ws`) falls through to the SPA index.html and the
+    // browser sees a hung handshake.
+    expect(resolveWsPath({ search: '' })).toBe('/ws/default');
+  });
+
+  it('returns undefined when ?daemon= override is set (loopback / Tauri)', () => {
+    // With a direct daemon base, the loopback daemon serves `/ws` (literal).
+    // Returning undefined lets core's WsClient fall back to API_PATHS.ws.
+    expect(resolveWsPath({ search: '?daemon=http://127.0.0.1:9876' })).toBeUndefined();
+  });
+
+  it('treats empty ?daemon= as missing and keeps the cloud default', () => {
+    expect(resolveWsPath({ search: '?daemon=' })).toBe('/ws/default');
   });
 });
 

--- a/packages/ui/src/runtime-context.tsx
+++ b/packages/ui/src/runtime-context.tsx
@@ -76,7 +76,10 @@ export function RuntimeProvider({
   // NOT throw their references away on every render.
   const value = useMemo<RuntimeContextValue>(() => {
     const runtime = new SessionRuntime({
-      hostBase: { httpBase: hostConfig.httpBase },
+      hostBase: {
+        httpBase: hostConfig.httpBase,
+        ...(hostConfig.wsPath !== undefined ? { wsPath: hostConfig.wsPath } : {}),
+      },
       statusSink: (sid, status) => {
         useStore.getState().setSessionStatus(sid, status);
       },

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -24,4 +24,10 @@ export interface HostConfig {
    * has to make the next call return the new value.
    */
   getToken: () => string | null;
+  /**
+   * Optional override for the ws upgrade path (Task #793, S3-G). Defaults to
+   * `/ws`. Cloud-tunnel deployment uses `/ws/default` so the request reaches
+   * the Worker + DO instead of falling through to the SPA.
+   */
+  wsPath?: string;
 }


### PR DESCRIPTION
## Summary

Closes the two remaining gaps that left the cloud-tunnel terminal pane blank after Task #787 plumbed REST `/api/*`:

- **Gap 1 (frontend ws URL)**: browser hit `wss://cc-sm.pages.dev/ws?...` but the Pages Function + Worker only accept literal `/ws/default`. Added optional `wsPath` to `HostBase` / `HostConfig`, piped it through `RuntimeProvider`, and have `webHostConfig` resolve `/ws/default` on cloud (and `undefined` -> fall back to `API_PATHS.ws='/ws'` when `?daemon=` overrides to a loopback daemon).
- **Gap 2 (daemon ws frame routing)**: `TunnelClient.onFrame` was a no-op log. Hello frame is now extended with `sid` + `lastSeq` (DO extracts both from the browser ws upgrade query). Daemon parses them and hands the pairing off via a new `onBrowserAttach` callback. Daemon `main` wires that into `attachFrameRouter`, a new helper extracted from `attachWebSocket.onConnection` so both transports share the same replay -> subscribe -> forward semantics. Missing sid on the browser ws -> DO closes 1008.

Refactor is internal: the loopback ws path now goes through `attachFrameRouter` too (via a synthetic `SubscriberSocket` whose `close()` forwards to `ws.close()`), so the existing 18 `ws.test.ts` cases still pass unchanged.

## Test plan
- [x] `pnpm -r run lint` (exit 0)
- [x] `pnpm -r run typecheck` (exit 0)
- [x] `pnpm -r run build` (exit 0)
- [x] cf-worker tests: 24/24 pass (5 new S3-G cases — hello carries sid+lastSeq, missing/empty sid -> 1008, bad lastSeq -> 0 fallback)
- [x] daemon tests: 142/143 pass + 1 pre-existing skip (5 new tunnel.test.ts cases for `onBrowserAttach`; 3 new ws.test.ts cases for `attachFrameRouter` direct exercise)
- [x] core tests: 45/45 pass (2 new `buildWsUrl` cases for `wsPath` override + fallback)
- [x] frontend-web tests: 30/30 pass (3 new `resolveWsPath` cases)
- [x] ui tests: 33/33 pass
- [ ] Manual cloud verification — manager will hand off to user (browser opens https://cc-sm.pages.dev with daemon paired via `wss://cc-sm.pages.dev/tunnel/default`; new session terminal should render).

## Local checks (host: Windows, mode: fast)
- lint: ✓ (exit 0)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0)
- unit tests: ran the 5 changed packages (cf-worker, core, daemon, frontend-web, ui) end-to-end; all green per counts above.
- e2e: skipped — daemon-only frame routing change with full unit coverage at the seam (`attachFrameRouter` is exercised directly + via the existing 18 loopback ws cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)