### PR TITLE
fix(smoke): R-1 — pages-dev fixture uses built dist, not wrangler --proxy (Task #6)

### DIFF
--- a/packages/smoke/fixtures/orchestrator.ts
+++ b/packages/smoke/fixtures/orchestrator.ts
@@ -42,8 +42,8 @@
 // fails fast at the first missing piece. Phase 2 (turning red → green) is
 // scoped as a series of followup tasks (see PR body) so the changes do not
 // land in this single TDD-spec PR.
-import { spawn, type ChildProcess } from 'node:child_process';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -149,29 +149,66 @@ export default async function globalSetup(): Promise<void> {
 
   // 2. frontend-web Pages dev. Reverse-proxies /api/*, /token, /ws/*, /tunnel/*
   //    via functions/[[path]].ts to the worker above. Bound on PAGES_PORT.
+  //
+  //    R-1 fix (Task #6): we serve the *built* `dist/` instead of running
+  //    `wrangler pages dev -- pnpm dev` (proxy mode). Reasons:
+  //      - `wrangler pages dev <directory> -- <cmd>` is mutually exclusive
+  //        in current wrangler (`-- <proxy-cmd>` requires NO directory arg,
+  //        and we can't pass a directory + `--port` + `-- pnpm dev` at the
+  //        same time without wrangler erroring out at startup), which is
+  //        why R-1 wedged the fixture before Task #6.
+  //      - Serving `dist/` matches prod Pages deploy semantics: same static
+  //        bundle + same `functions/[[path]].ts` reverse-proxy. No vite-dev
+  //        middleware divergence.
+  //    We build first (cheap incremental on warm tsc/vite caches) before
+  //    spawning wrangler. If build is slow on a cold machine, doc'd in
+  //    README; cache-mtime gate is intentionally not added here to avoid
+  //    drift between smoke and CI.
+  const frontendWebCwd = join(REPO_ROOT, 'packages/frontend-web');
+  process.stderr.write('[pages-dev] building frontend-web dist/ (one-shot)…\n');
+  const buildStart = Date.now();
+  const buildResult = spawnSync(
+    'pnpm',
+    ['--filter', '@ccsm/frontend-web...', 'build'],
+    {
+      cwd: REPO_ROOT,
+      stdio: 'inherit',
+      shell: process.platform === 'win32',
+    },
+  );
+  if (buildResult.status !== 0) {
+    throw new Error(
+      `[pages-dev] frontend-web build failed (exit=${buildResult.status})`,
+    );
+  }
+  const distDir = join(frontendWebCwd, 'dist');
+  try { statSync(distDir); } catch {
+    throw new Error(`[pages-dev] expected build output at ${distDir} but it does not exist`);
+  }
+  process.stderr.write(`[pages-dev] build done in ${Date.now() - buildStart}ms; serving ${distDir}\n`);
+
   const pages = spawnProc({
     name: 'pages-dev',
-    cwd: join(REPO_ROOT, 'packages/frontend-web'),
+    cwd: frontendWebCwd,
     cmd: 'pnpm',
     args: [
       'exec',
       'wrangler',
       'pages',
       'dev',
+      distDir,
       '--port',
       String(PAGES_PORT),
-      // FOLLOWUP: pages Function needs a way to be told the local worker
-      // origin. Currently wired to wss://cc-sm.pages.dev only.
-      '--',
-      'pnpm',
-      'dev',
+      '--ip',
+      '127.0.0.1',
     ],
     env: {
-      // FOLLOWUP: this env hand-off is currently a no-op — the Pages Function
-      // [[path]].ts does not read SMOKE_WORKER_ORIGIN. Smoke goes red here.
+      // FOLLOWUP (R-2): this env hand-off is currently a no-op — the Pages
+      // Function [[path]].ts hard-codes the prod worker origin. Smoke will
+      // go red on the next layer once R-1 unwedges.
       SMOKE_WORKER_ORIGIN: `http://127.0.0.1:${WORKER_PORT}`,
     },
-    readyMatch: /Compiled successfully|listening on/i,
+    readyMatch: /Ready on http|listening on http/i,
     readyTimeoutMs: 60_000,
   });
   handles.push(pages);


### PR DESCRIPTION
## Change
Picked **option (i)** (recommended in PR #1176): pages-dev fixture now runs `pnpm --filter @ccsm/frontend-web... build` to produce a real `dist/`, then `wrangler pages dev <dist-dir> --port 8788 --ip 127.0.0.1`. The previous `wrangler pages dev --port N -- pnpm dev` form is invalid — wrangler refuses the `<directory>` + `--port` + `--` proxy combo and exited 1 before binding. Serving the built `dist/` also matches prod Pages deploy semantics (same static bundle + same `functions/[[path]].ts` reverse-proxy), so we don't drift between smoke and prod. The filter uses `@ccsm/frontend-web...` (with `...`) so workspace deps like `@ccsm/ui` get built first; without that, tsc fails with `Cannot find module '@ccsm/ui'`.

Smoke startup now pays a one-shot frontend-web build cost (~30-50s warm tsc/vite, longer cold). Acceptable — cache-mtime gating intentionally skipped to avoid drift between smoke and CI semantics.

## Phase 1: red (before)
PR #1176 (Task #2, the smoke scaffold merged at aa29b6e8) shipped the orchestrator in deliberate red state. The pages-dev fixture was the very first wedge: `wrangler pages dev --port 8788 -- pnpm dev` exited code 1 immediately, so smoke could never reach R-2..R-5.

## Phase 2: smoke now reaches tauri-dev (next red)
Real tail from `pnpm --filter @ccsm/smoke smoke` on Windows host:

```
[cf-worker] [wrangler:inf] Ready on http://127.0.0.1:8787
[pages-dev] building frontend-web dist/ (one-shot)…
[pages-dev] ✨ Compiled Worker successfully
[pages-dev] Your worker has access to the following bindings:
- Services:
  - TUNNEL_WORKER: ccsm-worker [connected]
[pages-dev] [wrangler:inf] Ready on http://127.0.0.1:8788
[tauri-dev]      Running BeforeDevCommand (`pnpm dev`)
[tauri-dev] error when starting dev server:
Error: Port 1420 is already in use
[tauri-dev]  ELIFECYCLE  Command failed with exit code 1.
[tauri-dev]        Error The "beforeDevCommand" terminated with a non-zero status code.
Error: [tauri-dev] exited before ready (code=1, signal=null)
```

Both cf-worker (8787) and pages-dev (8788) now come up green, and the cf-worker service binding from pages-dev shows `[connected]`. The next wedge is in the tauri-dev fixture, **not** in pages-dev — R-1 is fully unwedged.

## Next red — for manager
**R-?** = `tauri dev`'s `beforeDevCommand: pnpm dev` collides with vite's default port 1420 because the orchestrator is already running pages-dev (or because a stale 1420 listener from a prior smoke run lingered). Scope: either (a) make `frontend-tauri/vite.config.ts` accept `VITE_DEV_PORT` env + orchestrator passes a free port, or (b) drop the tauri `beforeDevCommand` for smoke and let tauri load the pages-dev URL directly. Either way ~5-15 lines + 1 env wire-up. Pick one and open the next task; this PR intentionally does not touch frontend-tauri / src-tauri.

R-2..R-5 (daemon CCSM_TUNNEL_URL passthrough, Pages Function prod-origin hardcode, `?worker=` override, `?daemon=` token injection) are still red but masked by the tauri-dev wedge above; they'll surface once the tauri-dev fixture comes up.

## Local checks (host: Windows 11, mode: fast)
- lint: ✓ (exit 0) — `pnpm --filter @ccsm/smoke lint`
- typecheck: ✓ (exit 0) — `pnpm -r typecheck` all 8 packages Done
- build: n/a (orchestrator change is .ts only; `pnpm -r typecheck` covers the tsc surface, and the orchestrator build is exercised by running smoke itself)
- unit tests: ✓ — `pnpm -r test` green: ui 33/33, frontend-web 30/30, frontend-tauri (no tests, passWithNoTests), shared/cf-worker/core/daemon all Done
- e2e (smoke): partial — orchestrator now reaches tauri-dev (next red, see Phase 2). pages-dev fixture itself is fully green; this is exactly the Done criterion for R-1.

Note: chromium playwright binary already installed locally; not part of this PR (R-6 owns chromium install).