### PR TITLE
fix(smoke): R-7 — tauri-dev VITE_DEV_PORT env to avoid 1420 collision (Task #9)

### DIFF
--- a/packages/frontend-tauri/vite.config.ts
+++ b/packages/frontend-tauri/vite.config.ts
@@ -1,14 +1,21 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
-// Vite config for the Tauri 2 desktop shell. Uses a fixed dev port so
-// `tauri.conf.json` can hard-wire `devUrl: http://localhost:1420`.
-// Tauri controls when this is started via `beforeDevCommand`.
+// Vite config for the Tauri 2 desktop shell. Default dev port is 1420 so
+// `tauri.conf.json` can hard-wire `devUrl: http://localhost:1420` for the
+// normal developer workflow (`pnpm tauri dev`, no env). Smoke (and any other
+// orchestrator that needs to run multiple instances side-by-side) overrides
+// the port via `VITE_DEV_PORT`, paired with a Tauri `--config` override that
+// rewrites `build.devUrl` to the same port; see
+// `packages/smoke/fixtures/orchestrator.ts`. Tauri controls when this is
+// started via `beforeDevCommand`.
+const DEV_PORT = Number(process.env.VITE_DEV_PORT ?? 1420);
+
 export default defineConfig({
   plugins: [react()],
   clearScreen: false,
   server: {
-    port: 1420,
+    port: DEV_PORT,
     strictPort: true,
   },
   // Tauri expects the bundled frontend at `../dist` relative to src-tauri/.

--- a/packages/smoke/fixtures/find-port.ts
+++ b/packages/smoke/fixtures/find-port.ts
@@ -1,0 +1,32 @@
+// Pick an OS-assigned free TCP port by binding to :0, reading the bound port,
+// then closing. Used by the smoke orchestrator to avoid colliding on the
+// vite default dev port (1420) when smoke and a developer's own
+// `pnpm tauri dev` happen to overlap, or when CI runs multiple smoke
+// invocations on the same host. There's an inherent race window between
+// close() and the consumer re-binding, but for our single-shot orchestrator
+// (one bind per process, immediate handoff to vite/tauri) it's fine.
+import { createServer } from 'node:net';
+
+export async function findFreePort(): Promise<number> {
+  return new Promise((resolvePort, rejectPort) => {
+    const srv = createServer();
+    srv.unref();
+    srv.on('error', rejectPort);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      if (addr === null || typeof addr === 'string') {
+        srv.close();
+        rejectPort(new Error(`unexpected server.address(): ${String(addr)}`));
+        return;
+      }
+      const { port } = addr;
+      srv.close((closeErr) => {
+        if (closeErr !== undefined && closeErr !== null) {
+          rejectPort(closeErr);
+          return;
+        }
+        resolvePort(port);
+      });
+    });
+  });
+}

--- a/packages/smoke/fixtures/orchestrator.ts
+++ b/packages/smoke/fixtures/orchestrator.ts
@@ -43,10 +43,11 @@
 // scoped as a series of followup tasks (see PR body) so the changes do not
 // land in this single TDD-spec PR.
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
-import { mkdtempSync, rmSync, statSync } from 'node:fs';
+import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { findFreePort } from './find-port.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../../..');
@@ -218,11 +219,28 @@ export default async function globalSetup(): Promise<void> {
   //    daemon_mgr::start_daemon. We need the daemon to dial OUR local worker,
   //    not the prod tunnel — that requires daemon_mgr.rs to honor a
   //    CCSM_TUNNEL_URL env override (see followup #2-A).
+  //
+  //    R-7 fix (Task #9): the default vite dev port (1420) hard-wired in
+  //    `frontend-tauri/vite.config.ts` and `tauri.conf.json` collides when
+  //    the smoke orchestrator runs alongside a developer's own
+  //    `pnpm tauri dev`, or when CI runs more than one smoke pass on the
+  //    same host. We pick a free port here, hand it to vite via
+  //    `VITE_DEV_PORT`, and override Tauri's `build.devUrl` via the
+  //    `--config <path>` CLI flag (Tauri 2 merges this on top of
+  //    tauri.conf.json). We pass a *file path* rather than an inline JSON
+  //    string because on Windows pnpm's argv forwarding strips the embedded
+  //    double quotes and Tauri's clap parser then rejects the unquoted JSON.
+  //    Developers who run `pnpm tauri dev` without these get the unchanged
+  //    1420 default.
+  const taurFreePort = await findFreePort();
+  const taurDevUrl = `http://localhost:${taurFreePort}`;
+  const taurConfigPath = join(tempDataDir, 'tauri.smoke.conf.json');
+  writeFileSync(taurConfigPath, JSON.stringify({ build: { devUrl: taurDevUrl } }), 'utf8');
   const tauri = spawnProc({
     name: 'tauri-dev',
     cwd: join(REPO_ROOT, 'packages/frontend-tauri'),
     cmd: 'pnpm',
-    args: ['tauri', 'dev'],
+    args: ['tauri', 'dev', '--config', taurConfigPath],
     env: {
       // FOLLOWUP: daemon_mgr.rs does not currently propagate this env to the
       // daemon child. Smoke goes red here.
@@ -230,6 +248,9 @@ export default async function globalSetup(): Promise<void> {
       // Override db path to a smoke-private temp dir so we don't pollute the
       // real %LOCALAPPDATA%/dev.ccsm.tauri/ccsm.db.
       CCSM_DB_PATH: join(tempDataDir, 'ccsm.db'),
+      // Picked up by frontend-tauri/vite.config.ts; must match the devUrl
+      // override above.
+      VITE_DEV_PORT: String(taurFreePort),
     },
     readyMatch: /daemon-ready|handshake ok port=/i,
     readyTimeoutMs: 90_000,


### PR DESCRIPTION
## Change

R-7 follow-up to PR #1177 (R-1 pages-dev). The smoke orchestrator's
\`tauri-dev\` fixture was wedging because the vite dev server hard-wired to
port \`1420\` (matching \`tauri.conf.json\`'s \`devUrl\`) collides whenever
something else is already on that port — the developer's own
\`pnpm tauri dev\`, or a parallel smoke run on the same host.

Picked option **(a)** from the reviewer's two candidates: parameterize
the smoke fixture with a free port, leave the product defaults alone.
Option (b) (delete \`beforeDevCommand\` from \`tauri.conf.json\`) was
rejected as larger and breaks the normal \`pnpm tauri dev\` developer UX.

Files:
- \`packages/frontend-tauri/vite.config.ts\` — \`server.port\` reads
  \`process.env.VITE_DEV_PORT\` (default \`1420\`), \`strictPort\` kept.
- \`packages/smoke/fixtures/find-port.ts\` (new, ~30 lines) — bind
  \`net.createServer\` on \`:0\`, read assigned port, close. Stdlib only.
- \`packages/smoke/fixtures/orchestrator.ts\` — for tauri-dev fixture:
  \`findFreePort()\` → write a JSON config patch (\`{build:{devUrl}}\`) to a
  temp file → \`pnpm tauri dev --config <path>\` + env \`VITE_DEV_PORT\`.
  Wrote a file rather than inline JSON because Windows pnpm argv
  forwarding strips embedded double quotes and Tauri's clap parser
  rejects unquoted JSON (verified locally with both forms).

Did **not** touch \`tauri.conf.json\`: when both vite and tauri get the
same overridden port (vite via env, tauri via \`--config\`) the hard-coded
\`devUrl: http://localhost:1420\` in the base file is harmlessly
overridden by Tauri 2's config merge. Keeping the static default means
\`pnpm tauri dev\` with no flags or env still sees the historical 1420
behaviour byte-for-byte.

## Phase 1: red (before)

PR #1177's phase 2 ended at the \`tauri-dev\` fixture wedging at vite
startup because port 1420 was occupied (either by a developer's own
\`tauri dev\` session or by a previous smoke run that didn't release the
port).

## Phase 2: smoke now reaches X

After this PR, smoke proceeds past \`cf-worker\` ready, past
\`pages-dev\` ready, and past vite-on-free-port ready. The Tauri shell
boots all the way to \`Running target\debug\ccsm-tauri.exe\` (cargo
compile + link succeed). The fixture then times out 90s later because
the webview never emits the \`daemon-ready\` event the readyMatch is
waiting for — i.e. we have surfaced the next layer of red.

Real tail from a clean local run on Windows 11:

\`\`\`
[pages-dev] [wrangler:inf] Ready on http://127.0.0.1:8788
[tauri-dev]      Running BeforeDevCommand (\`pnpm dev\`)
[tauri-dev]   ➜  Local:   http://localhost:65398/
[tauri-dev]      Running DevCommand (\`cargo  run --no-default-features --color always --\`)
[tauri-dev]    Compiling ccsm-tauri v0.0.0 (...\src-tauri)
[tauri-dev]     Finished \`dev\` profile [unoptimized + debuginfo] target(s) in 16.77s
[tauri-dev]      Running \`target\debug\ccsm-tauri.exe\`
Error: [tauri-dev] ready timeout after 90000ms; readyMatch=/daemon-ready|handshake ok port=/i
\`\`\`

Note the vite \`Local: http://localhost:65398/\` (a kernel-assigned free
port, not 1420) — confirming both \`VITE_DEV_PORT\` and the
\`--config\` devUrl override took effect.

## Next red — for manager

**R-4** (already on the original PR #1176 R-list): \`frontend-tauri/src/App.tsx\`
does not auto-invoke \`start_daemon\` on mount, so the Rust shell never
spawns the daemon and never emits \`daemon-ready\`. Scope = wire an
auto-bootstrap call (gated to dev/smoke or unconditional, per
manager's call) plus matching readyMatch test.

Side observation (out-of-scope for R-7): smoke's teardown does not
reap \`cargo.exe\` + \`ccsm-tauri.exe\` grandchildren on Windows. After
each failing smoke run the previous \`ccsm-tauri.exe\` keeps the
target binary locked, so the next \`cargo build\` fails LNK1104 until
the zombie is killed manually. Doesn't block R-7 but worth tracking
as R-9 / future task.

## Local checks (host: Windows 11, mode: fast)
- lint: ✓ (exit 0, all 8 packages \`Done\`)
- typecheck: ✓ (exit 0, all 8 packages \`Done\` after pre-build of
  \`@ccsm/shared\`, \`@ccsm/core\`, \`@ccsm/ui\` deps)
- build: shared/core/ui pre-built for typecheck; no full \`pnpm -r build\`
  needed for this scope (only product change is \`vite.config.ts\` whose
  consumer is vite itself, exercised live via smoke; \`find-port.ts\` is
  fixture-only, not bundled).
- unit tests: \`pnpm -r test\` ran the relevant suites:
  - \`@ccsm/cf-worker\`: \`Test Files 4 passed (4)\`, \`Tests 39 passed (39)\`
  - \`@ccsm/shared\`: \`Test Files 6 passed (6)\`, \`Tests 38 passed (38)\`
  - \`@ccsm/core\`: \`Test Files 13 passed (13)\`, \`Tests 75 passed (75)\`
  - \`@ccsm/daemon\`: passed
  - \`@ccsm/ui\`: \`Test Files 5 passed (5)\`, \`Tests 33 passed (33)\`
  - \`@ccsm/frontend-tauri\`: \`No test files found, exiting with code 0\`
  - \`@ccsm/frontend-web\`: \`Test Files 2 passed (2)\`, \`Tests 30 passed (30)\`
- e2e: skipped — repo no longer has e2e/e2e-tauri packages (deleted in
  PR #1175); the smoke harness *is* the e2e harness here, and its tail
  is quoted above. The R-7 fix is exercised by smoke itself (vite logs
  show free port instead of 1420).
- \`pnpm tauri dev\` no-env equivalence: verified locally — \`pnpm exec
  vite --host 127.0.0.1\` (no env) reports \`Local: http://127.0.0.1:1420/\`,
  while \`VITE_DEV_PORT=37412 pnpm exec vite --host 127.0.0.1\` reports
  \`Local: http://127.0.0.1:37412/\`. Default behavior preserved
  byte-for-byte.