### PR TITLE
fix(smoke): R-4 — start daemon from Tauri lib.rs setup hook (Task #11)

### DIFF
--- a/packages/frontend-tauri/src-tauri/src/daemon_mgr.rs
+++ b/packages/frontend-tauri/src-tauri/src/daemon_mgr.rs
@@ -88,7 +88,26 @@ pub async fn start_daemon(app: AppHandle, state: State<'_, DaemonState>) -> Resu
     {
         let guard = state.killer.lock().unwrap();
         if guard.is_some() {
-            return Err("daemon already started".into());
+            // Idempotent: if setup hook already started the daemon, the webview
+            // re-invoking start_daemon is a no-op rather than an error. Lets
+            // option-(b) lib.rs setup hook coexist with any existing webview
+            // gesture path without breaking either.
+            return Ok(());
+        }
+    }
+    spawn_daemon_inner(app).await
+}
+
+/// Internal spawn fn shared by the `start_daemon` command (webview gesture)
+/// and the lib.rs `setup` hook (Tauri-level auto-start). Caller is responsible
+/// for the "already running" idempotency check; this fn assumes the slot is
+/// empty and will overwrite the killer if invoked twice concurrently.
+pub async fn spawn_daemon_inner(app: AppHandle) -> Result<(), String> {
+    let state: State<DaemonState> = app.state();
+    {
+        let guard = state.killer.lock().unwrap();
+        if guard.is_some() {
+            return Ok(());
         }
     }
 

--- a/packages/frontend-tauri/src-tauri/src/lib.rs
+++ b/packages/frontend-tauri/src-tauri/src/lib.rs
@@ -9,7 +9,7 @@
 mod daemon_mgr;
 mod job_object;
 
-use daemon_mgr::{start_daemon, DaemonState};
+use daemon_mgr::{spawn_daemon_inner, start_daemon, DaemonState};
 use job_object::JobObject;
 use tauri::Manager;
 
@@ -25,6 +25,21 @@ pub fn run() {
             // child — including via TerminateProcess paths that bypass Drop.
             let job = JobObject::new().map_err(|e| format!("JobObject::new: {e}"))?;
             app.manage(job);
+
+            // R-4 (Task #11): auto-start the daemon from the Tauri setup hook
+            // rather than relying on a webview gesture. Tauri spawning the
+            // daemon is the product design (see project memory
+            // `project_tauri_spawns_daemon.md`); webview-invoke would couple
+            // daemon liveness to React render which the architecture rejects.
+            // The `start_daemon` command is kept as an idempotent no-op for
+            // any callers that still invoke it.
+            let app_handle = app.handle().clone();
+            tauri::async_runtime::spawn(async move {
+                if let Err(e) = spawn_daemon_inner(app_handle).await {
+                    eprintln!("[lib.rs setup] spawn_daemon_inner failed: {e}");
+                }
+            });
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![start_daemon])


### PR DESCRIPTION
## Change
- `frontend-tauri/src-tauri/src/lib.rs`: setup hook 里 `tauri::async_runtime::spawn` 异步调 `spawn_daemon_inner(app_handle)`; 失败 eprintln, 不 panic 阻断 setup
- `frontend-tauri/src-tauri/src/daemon_mgr.rs`: 抽出 `pub async fn spawn_daemon_inner(app: AppHandle)`; `start_daemon` webview command 改幂等 (`if guard.is_some() { return Ok(()) }`)
- 不动 `frontend-tauri/src/*` (option (a) App.tsx useEffect 不选)

## 选 option (b) lib.rs setup hook 而非 (a) App.tsx useEffect
Tauri 起 daemon 是产品设计 (auto-memory `project_tauri_spawns_daemon.md`)。option (a) 把 daemon liveness 绑在 React 渲染上 — webview crash / hot-reload / SPA 路由跳转都可能触发重复 spawn 或漏 spawn, 跟架构反向。setup hook 在 Tauri 主进程启动期一次性发起, 是单一所有权点。

## Phase 1: red (before)
PR #1178 (R-7) merged 后 smoke 跑过 vite + cargo + Tauri 真启 ccsm-tauri.exe, 但 90s 等不到 `daemon-ready` event — webview App.tsx 不 auto-invoke `start_daemon`, daemon 永不起。

## Phase 2: smoke now reaches X
**未在本 PR 跑 smoke** — auto-memory `project_smoke_windows_zombie_lock_2026_05_08.md` 记录: 本地 Windows 跑 smoke 触发 zombie ccsm-tauri.exe 持文件锁 LNK1104, taskkill //F 自己 timeout, 双 dev 并发跑必死锁。R-9 (tree-kill teardown) 还没修完。当前 dev 只跑 `cargo build` + `pnpm -r typecheck` + `pnpm -r test` 证明编译 + 类型 + 单测过, smoke 端到端验证留给 R-9 修完后统一一次跑。

## Next red — for manager
R-4 解开后下一红预计在: R-2 (Pages Function 硬编码 prod worker URL) / R-3 (Tauri `CCSM_TUNNEL_URL` env 不传到 daemon, daemon 也无 `DEFAULT_TUNNEL_URL` fallback) / R-5 (frontend-web token 注入在 `wrangler pages dev` 下不工作)。具体哪条先红等 R-9 修完后跑 smoke 看 phase 2 输出确定。