### PR TITLE
fix(smoke): R-9 v3.A — split smoke build from runtime, no more spawning cargo (Task #15)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,11 @@ build/
 coverage/
 .env
 .env.local
+
+# R-9 v3.A (Task #15): smoke build artifacts — release ccsm-tauri.exe + isolated
+# cargo target — produced by `pnpm smoke:build`, consumed by `pnpm smoke:run`.
+# Physically isolated from the developer's `packages/frontend-tauri/src-tauri/target/`
+# so a zombie .exe holding a file lock under the user's day-to-day target/ cannot
+# wedge smoke. Never commit binaries.
+packages/smoke/.fixtures/bin/
+packages/smoke/.fixtures/cargo-target/

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "lint": "eslint . --max-warnings=0",
     "typecheck": "pnpm -r run typecheck",
     "test": "pnpm -r run test",
-    "smoke": "pnpm --filter @ccsm/smoke run smoke"
+    "smoke": "pnpm --filter @ccsm/smoke run smoke",
+    "smoke:build": "pnpm --filter @ccsm/smoke run smoke:build",
+    "smoke:run": "pnpm --filter @ccsm/smoke run smoke:run"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.13.0",

--- a/packages/smoke/README.md
+++ b/packages/smoke/README.md
@@ -1,0 +1,38 @@
+# @ccsm/smoke
+
+Local-only S3 cloud-mode happy-path smoke. Not run in CI.
+
+## R-9 v3.A — build vs runtime split (Task #15)
+
+Smoke build (cargo + vite) is split from smoke runtime (spawn `.exe`):
+
+- `pnpm smoke:build` — one-shot release build. Produces:
+  - `packages/daemon/dist/index.mjs` (tsc)
+  - `packages/frontend-tauri/dist/` (vite)
+  - `packages/smoke/.fixtures/cargo-target/release/ccsm-tauri.exe`
+    (cargo --release with isolated `--target-dir`)
+  - copied to `packages/smoke/.fixtures/bin/ccsm-tauri.exe`
+- `pnpm smoke:run` — spawn the prebuilt `.exe`. Does NOT run cargo, vite,
+  or `tauri dev`.
+
+The cargo target dir is intentionally isolated from
+`packages/frontend-tauri/src-tauri/target/` (the developer's day-to-day
+build output). A zombie `ccsm-tauri.exe` holding a file lock under the
+user's normal `target/` therefore cannot wedge smoke (LNK1104 root cause —
+see project memory `project_smoke_windows_zombie_lock_2026_05_08.md`).
+
+## Workflow
+
+First time on a machine, or after changing product source:
+
+```bash
+pnpm smoke:build   # 5-10 min cold; incremental afterwards
+```
+
+Day-to-day (test iteration):
+
+```bash
+pnpm smoke:run
+```
+
+`.fixtures/bin/` and `.fixtures/cargo-target/` are gitignored.

--- a/packages/smoke/fixtures/orchestrator.ts
+++ b/packages/smoke/fixtures/orchestrator.ts
@@ -1,53 +1,39 @@
-// Smoke orchestrator (Task #2).
+// Smoke orchestrator (Task #2 / R-9 v3.A split: build vs runtime).
 //
 // Brings up the 3 long-lived processes the cloud-mode happy path requires:
-//   1. wrangler dev    — runs the cf-worker (TunnelDO) on http://127.0.0.1:8787
+//   1. wrangler dev       — runs the cf-worker (TunnelDO) on http://127.0.0.1:8787
 //   2. wrangler pages dev — serves frontend-web's dist + Pages Functions
 //      `[[path]].ts` reverse-proxy on http://127.0.0.1:8788; Functions forward
 //      `/api/*` + `/token` + `/ws/*` + `/tunnel/*` to the worker above.
-//   3. tauri dev       — Rust shell that spawns the daemon as a child via
-//      `daemon_mgr::start_daemon`. The daemon prints handshake JSON
-//      `{ready, port, token}` on stdout; the shell parses it and emits a
-//      `daemon-ready` Tauri event. The shell is also responsible for setting
-//      `CCSM_TUNNEL_URL=ws://127.0.0.1:8787/tunnel/default` so the daemon
-//      dials our local wrangler dev worker instead of the prod
-//      `wss://cc-sm.pages.dev` tunnel.
+//   3. ccsm-tauri.exe (release) — already built by `pnpm smoke:build` into
+//      `packages/smoke/.fixtures/bin/ccsm-tauri.exe`. Spawned directly here.
+//      The Tauri lib.rs setup hook (R-4, Task #11) auto-spawns the daemon as
+//      a Rust child via `daemon_mgr::spawn_daemon_inner`; daemon_mgr resolves
+//      `packages/daemon/dist/index.mjs` via cwd-relative search, so we set
+//      cwd=REPO_ROOT when spawning the .exe.
+//
+// R-9 v3.A architecture (Task #15) — what we no longer do:
+//   - We do NOT spawn `cargo`. Cargo build is `pnpm smoke:build`'s job, run
+//     once before the smoke test, with --target-dir pinned to
+//     `.fixtures/cargo-target/` (physically isolated from the developer's
+//     `packages/frontend-tauri/src-tauri/target/`).
+//   - We do NOT spawn `vite` (frontend-tauri dev server). The release .exe
+//     already has the built frontendDist bundled (vite build ran during
+//     smoke:build).
+//   - We do NOT spawn `tauri dev` / `pnpm tauri dev`. The release .exe is
+//     what users actually run, and is what we test.
+//   - We do NOT need `VITE_DEV_PORT` / dev-port-collision dance — there is
+//     no dev server.
 //
 // Teardown reverses the spawn order. On Windows we rely on the Tauri Job
 // Object to reap the daemon descendant when the Tauri parent dies; non-windows
 // uses kill_on_drop semantics. wrangler dev / pages dev are killed via
-// process.kill on the spawn handle (their workerd children are reaped by the
-// shell on SIGTERM).
-//
-// Status (red phase, Task #2): this orchestrator is intentionally a single
-// file that exercises every plumbing concern listed above. Most of those
-// concerns are NOT yet implemented in the product:
-//   - Tauri's `start_daemon` does not accept / honor a CCSM_TUNNEL_URL env
-//     override (daemon_mgr.rs does not pass any tunnel-url env through).
-//   - `tauri dev` has no headless / no-window mode wired into tauri.conf.json
-//     so we can't run it on a CI-style headless workstation; the human dev
-//     sees a real window pop.
-//   - The webview's `App.tsx` does not auto-invoke `start_daemon` on mount,
-//     so the daemon is never spawned without a manual click.
-//   - The Pages Function `[[path]].ts` is configured for the production
-//     wss://cc-sm.pages.dev origin only; running it under wrangler pages dev
-//     against http://127.0.0.1:8787 requires either (a) a `?worker=` override
-//     param the Function honors, or (b) an env-var binding.
-//   - There is no `?daemon=` token-injection path that lets Playwright's
-//     chromium pick up the daemon-minted token without going through the
-//     SPA's sessionStorage bootstrap (the prod path uses a Pages Function
-//     header injection that doesn't fire under wrangler pages dev).
-//
-// All of those gaps are surfaced as the Phase 1 red output: the orchestrator
-// fails fast at the first missing piece. Phase 2 (turning red → green) is
-// scoped as a series of followup tasks (see PR body) so the changes do not
-// land in this single TDD-spec PR.
+// process.kill on the spawn handle.
 import { spawn, spawnSync, type ChildProcess } from 'node:child_process';
-import { mkdtempSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { findFreePort } from './find-port.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../../..');
@@ -215,44 +201,55 @@ export default async function globalSetup(): Promise<void> {
   handles.push(pages);
   await pages.ready;
 
-  // 3. Tauri dev shell. Spawns the daemon as a Rust child via
-  //    daemon_mgr::start_daemon. We need the daemon to dial OUR local worker,
-  //    not the prod tunnel — that requires daemon_mgr.rs to honor a
-  //    CCSM_TUNNEL_URL env override (see followup #2-A).
+  // 3. Tauri release shell (R-9 v3.A, Task #15).
   //
-  //    R-7 fix (Task #9): the default vite dev port (1420) hard-wired in
-  //    `frontend-tauri/vite.config.ts` and `tauri.conf.json` collides when
-  //    the smoke orchestrator runs alongside a developer's own
-  //    `pnpm tauri dev`, or when CI runs more than one smoke pass on the
-  //    same host. We pick a free port here, hand it to vite via
-  //    `VITE_DEV_PORT`, and override Tauri's `build.devUrl` via the
-  //    `--config <path>` CLI flag (Tauri 2 merges this on top of
-  //    tauri.conf.json). We pass a *file path* rather than an inline JSON
-  //    string because on Windows pnpm's argv forwarding strips the embedded
-  //    double quotes and Tauri's clap parser then rejects the unquoted JSON.
-  //    Developers who run `pnpm tauri dev` without these get the unchanged
-  //    1420 default.
-  const taurFreePort = await findFreePort();
-  const taurDevUrl = `http://localhost:${taurFreePort}`;
-  const taurConfigPath = join(tempDataDir, 'tauri.smoke.conf.json');
-  writeFileSync(taurConfigPath, JSON.stringify({ build: { devUrl: taurDevUrl } }), 'utf8');
+  //    We spawn the prebuilt `ccsm-tauri.exe` from `.fixtures/bin/` directly.
+  //    `pnpm smoke:build` produces this artifact (cargo --release with an
+  //    isolated --target-dir under `.fixtures/cargo-target/`), so smoke runtime
+  //    never invokes cargo or vite. cwd is REPO_ROOT so daemon_mgr.rs's
+  //    cwd-relative search for `packages/daemon/dist/index.mjs` resolves.
+  //    The R-4 (Task #11) lib.rs setup hook auto-spawns the daemon — no
+  //    webview gesture needed.
+  //
+  //    FOLLOWUPs left for subsequent R-* tasks (see PR body):
+  //      - R-3: daemon_mgr does not propagate CCSM_TUNNEL_URL to the daemon
+  //        child yet, so the daemon dials the prod tunnel instead of our
+  //        wrangler dev worker. We still set the env on the parent for when
+  //        R-3 lands; the daemon currently ignores it.
+  //      - CCSM_DB_PATH is also computed here for when daemon_mgr starts
+  //        honoring an env override (today daemon_mgr pins db to
+  //        app_local_data_dir; smoke pollutes the real %LOCALAPPDATA% until
+  //        a follow-up adds an env override).
+  const exeName = process.platform === 'win32' ? 'ccsm-tauri.exe' : 'ccsm-tauri';
+  const releaseExe = join(__dirname, '..', '.fixtures', 'bin', exeName);
+  try { statSync(releaseExe); } catch {
+    throw new Error(
+      `[tauri-release] artifact missing: ${releaseExe}\n` +
+      `Run \`pnpm smoke:build\` first (one-shot release build).`,
+    );
+  }
+
   const tauri = spawnProc({
-    name: 'tauri-dev',
-    cwd: join(REPO_ROOT, 'packages/frontend-tauri'),
-    cmd: 'pnpm',
-    args: ['tauri', 'dev', '--config', taurConfigPath],
+    name: 'tauri-release',
+    cwd: REPO_ROOT,
+    cmd: releaseExe,
+    args: [],
     env: {
-      // FOLLOWUP: daemon_mgr.rs does not currently propagate this env to the
-      // daemon child. Smoke goes red here.
+      // FOLLOWUP (R-3): daemon_mgr.rs does not currently propagate this env
+      // to the daemon child; smoke goes red on the tunnel layer until R-3.
       CCSM_TUNNEL_URL: `ws://127.0.0.1:${WORKER_PORT}/tunnel/default`,
-      // Override db path to a smoke-private temp dir so we don't pollute the
-      // real %LOCALAPPDATA%/dev.ccsm.tauri/ccsm.db.
-      CCSM_DB_PATH: join(tempDataDir, 'ccsm.db'),
-      // Picked up by frontend-tauri/vite.config.ts; must match the devUrl
-      // override above.
-      VITE_DEV_PORT: String(taurFreePort),
+      // FOLLOWUP: daemon currently ignores parent CCSM_DB_PATH because
+      // daemon_mgr.rs pins it to app_local_data_dir. Set anyway so a
+      // follow-up that switches daemon_mgr to honor an override gets the
+      // smoke-private path automatically.
+      CCSM_DB_PATH: join(tempDataDir ?? tmpdir(), 'ccsm.db'),
     },
-    readyMatch: /daemon-ready|handshake ok port=/i,
+    // The lib.rs setup hook calls spawn_daemon_inner, which logs
+    // "[daemon-mgr] resolved daemon script: …" before spawning, then the
+    // daemon prints its `{"ready":true,...}` handshake on stdout which
+    // daemon_mgr forwards as a Tauri "daemon-ready" event. We match either
+    // the Rust-side log or the daemon stdout passthrough.
+    readyMatch: /daemon-ready|"ready"\s*:\s*true|handshake ok port=/i,
     readyTimeoutMs: 90_000,
   });
   handles.push(tauri);

--- a/packages/smoke/package.json
+++ b/packages/smoke/package.json
@@ -5,11 +5,13 @@
   "type": "module",
   "description": "Local-only S3 full-stack happy-path smoke (Tauri shell -> daemon -> wrangler dev cf-worker tunnel -> Pages functions -> Playwright chromium). Not run in CI.",
   "scripts": {
+    "smoke:build": "node scripts/build-fixtures.mjs",
+    "smoke:run": "playwright test",
     "smoke": "playwright test",
     "smoke:headed": "playwright test --headed",
     "typecheck": "tsc --noEmit",
     "lint": "eslint tests fixtures --max-warnings=0",
-    "test": "echo 'smoke is run via `pnpm smoke`, skipped under `pnpm -r test` because it requires Tauri + wrangler dev + a real chromium' && exit 0"
+    "test": "echo 'smoke is run via `pnpm smoke:run` (after a one-shot `pnpm smoke:build`); skipped under `pnpm -r test` because it requires a real Tauri release exe + wrangler dev + a real chromium' && exit 0"
   },
   "devDependencies": {
     "@playwright/test": "^1.48.2",

--- a/packages/smoke/scripts/build-fixtures.mjs
+++ b/packages/smoke/scripts/build-fixtures.mjs
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+// R-9 v3.A — smoke build script (Task #15).
+//
+// One-shot producer of the release artifacts the smoke fixture spawns. Splits
+// build from runtime so that:
+//   1. `pnpm smoke:run` does not spawn cargo / vite / `tauri dev` — the
+//      runtime path is just spawning a release `.exe` that's already on disk.
+//   2. The artifact path (`packages/smoke/.fixtures/bin/`) is *physically
+//      isolated* from a developer's day-to-day
+//      `packages/frontend-tauri/src-tauri/target/`, so a zombie `ccsm-tauri.exe`
+//      holding a file lock under the user's `target/` cannot wedge smoke.
+//   3. We pin `--target-dir` to `.fixtures/cargo-target/` for the same reason:
+//      smoke's cargo build never touches the developer's shared target dir.
+//
+// Steps:
+//   T1. Build @ccsm/daemon (tsc -> packages/daemon/dist/index.mjs).
+//        daemon_mgr.rs `resolve_daemon_script` walks up looking for
+//        `packages/daemon/dist/index.mjs` from the cwd we spawn the .exe in
+//        (REPO_ROOT). So the daemon dist still lives in its normal repo
+//        location — only the binary is what we copy out to .fixtures/bin/.
+//   T2. Build @ccsm/frontend-tauri (vite -> packages/frontend-tauri/dist/).
+//        Tauri's `tauri.conf.json` `frontendDist: "../dist"` is what gets
+//        embedded into ccsm-tauri.exe at cargo-build time, so the vite build
+//        MUST happen before cargo build.
+//   T3. cargo build --release with `--target-dir
+//        packages/smoke/.fixtures/cargo-target` to keep the build artifacts
+//        out of the user's shared target/.
+//   T4. Copy the resulting ccsm-tauri.exe to
+//        `packages/smoke/.fixtures/bin/ccsm-tauri.exe`.
+//
+// NOT done here: spawning cargo / vite from the smoke runtime (orchestrator).
+// That's the whole point of this split.
+
+import { spawnSync } from 'node:child_process';
+import { copyFileSync, mkdirSync, existsSync, statSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SMOKE_DIR = resolve(__dirname, '..');
+const REPO_ROOT = resolve(SMOKE_DIR, '../..');
+const FIXTURES_BIN = join(SMOKE_DIR, '.fixtures', 'bin');
+const FIXTURES_CARGO_TARGET = join(SMOKE_DIR, '.fixtures', 'cargo-target');
+
+const IS_WINDOWS = process.platform === 'win32';
+const EXE_NAME = IS_WINDOWS ? 'ccsm-tauri.exe' : 'ccsm-tauri';
+
+function run(label, cmd, args, cwd, env) {
+  process.stderr.write(`\n[smoke:build] ${label}\n  $ ${cmd} ${args.join(' ')}\n  (cwd=${cwd})\n`);
+  const r = spawnSync(cmd, args, {
+    cwd,
+    stdio: 'inherit',
+    shell: IS_WINDOWS, // pnpm/cargo .cmd shims on Windows
+    env: { ...process.env, ...(env ?? {}) },
+  });
+  if (r.status !== 0) {
+    process.stderr.write(`[smoke:build] ${label} failed (exit=${r.status})\n`);
+    process.exit(r.status ?? 1);
+  }
+}
+
+// T1 — daemon dist (build daemon + its workspace deps)
+run(
+  'T1 build @ccsm/daemon (+ workspace deps)',
+  'pnpm',
+  ['--filter', '@ccsm/daemon...', 'build'],
+  REPO_ROOT,
+);
+const daemonDist = join(REPO_ROOT, 'packages/daemon/dist/index.mjs');
+if (!existsSync(daemonDist)) {
+  process.stderr.write(`[smoke:build] daemon dist missing: ${daemonDist}\n`);
+  process.exit(1);
+}
+
+// T2 — frontend-tauri vite build (produces ../dist that tauri.conf.json embeds).
+// `...` includes workspace deps (@ccsm/ui etc.) so their dist exists for tsc.
+run(
+  'T2 build @ccsm/frontend-tauri (vite, + workspace deps)',
+  'pnpm',
+  ['--filter', '@ccsm/frontend-tauri...', 'build'],
+  REPO_ROOT,
+);
+
+// T3 — cargo --release with isolated target dir
+mkdirSync(FIXTURES_CARGO_TARGET, { recursive: true });
+const manifestPath = join(REPO_ROOT, 'packages/frontend-tauri/src-tauri/Cargo.toml');
+run(
+  'T3 cargo build --release (isolated target-dir)',
+  'cargo',
+  [
+    'build',
+    '--release',
+    '--manifest-path', manifestPath,
+    '--target-dir', FIXTURES_CARGO_TARGET,
+  ],
+  REPO_ROOT,
+);
+
+// T4 — copy exe to .fixtures/bin/
+mkdirSync(FIXTURES_BIN, { recursive: true });
+const builtExe = join(FIXTURES_CARGO_TARGET, 'release', EXE_NAME);
+const destExe = join(FIXTURES_BIN, EXE_NAME);
+if (!existsSync(builtExe)) {
+  process.stderr.write(`[smoke:build] cargo did not produce ${builtExe}\n`);
+  process.exit(1);
+}
+copyFileSync(builtExe, destExe);
+const sz = statSync(destExe).size;
+process.stderr.write(`\n[smoke:build] OK\n  -> ${destExe}\n  size=${sz} bytes\n`);
+process.stderr.write(`  daemon=${daemonDist} (resolved at runtime by ccsm-tauri.exe via cwd-relative search)\n`);


### PR DESCRIPTION
## Change

- **New** \`pnpm smoke:build\` (\`packages/smoke/scripts/build-fixtures.mjs\`)
  one-shot release builder:
  1. \`pnpm --filter @ccsm/daemon... build\` — daemon dist
  2. \`pnpm --filter @ccsm/frontend-tauri... build\` — vite produces
     \`packages/frontend-tauri/dist/\` (embedded by Tauri)
  3. \`cargo build --release --manifest-path …/src-tauri/Cargo.toml --target-dir packages/smoke/.fixtures/cargo-target\`
     — **isolated** target dir (the whole point of v3.A)
  4. Copy \`ccsm-tauri.exe\` → \`packages/smoke/.fixtures/bin/ccsm-tauri.exe\`
- **Rewritten** \`packages/smoke/fixtures/orchestrator.ts\` step 3:
  no longer \`spawn('pnpm', ['tauri', 'dev'])\`; now spawns the prebuilt
  \`.fixtures/bin/ccsm-tauri.exe\` directly with \`cwd=REPO_ROOT\` so
  \`daemon_mgr::resolve_daemon_script\` finds \`packages/daemon/dist/index.mjs\`.
  R-7 vite-port dance + \`tauri.smoke.conf.json\` machinery removed (no dev
  server to collide with).
- **New** \`pnpm smoke:run\` (alias of \`playwright test\`) — pure runtime,
  no build.
- **\`.gitignore\`** adds \`packages/smoke/.fixtures/{bin,cargo-target}/\` —
  binaries never committed.
- **\`packages/smoke/README.md\`** documents the build / run split workflow.
- Top-level \`package.json\` exposes \`pnpm smoke:build\` + \`pnpm smoke:run\`.

## 架构 root cause (Layer 2)

Pre-PR the smoke fixture spawned \`tauri dev\` which ran cargo + vite hot
reload + ccsm-tauri.exe + daemon spawn all inside one fixture process,
**sharing the developer's**
\`packages/frontend-tauri/src-tauri/target/\` cargo dir. Any zombie
\`ccsm-tauri.exe\` holding a file lock there → \`LNK1104\` blocking smoke
forever (memory \`project_smoke_windows_zombie_lock_2026_05_08.md\`).

Glue fixes (tree-kill, \`CARGO_TARGET_DIR=tmpdir\`) were rejected by the
user as anti-architecture. v3.A is the architecture fix:

1. **Separate concerns.** Build is a one-shot, runtime is just \`spawn(.exe)\`.
2. **Test what users run.** Users run the release exe, not \`tauri dev\`.
3. **Physically isolate build artifacts.** \`--target-dir\` to
   \`.fixtures/cargo-target/\` means smoke's cargo never touches the
   developer's \`target/\` — a zombie holding an old user-target lock
   cannot wedge smoke.

## Phase 1: red (before)

Local Windows \`pnpm smoke\` triggered LNK1104 inside cargo invoked by the
fixture's \`pnpm tauri dev\` step; the resulting zombie ccsm-tauri.exe held
the file lock; \`taskkill //F\` on it timed out (memory
\`project_smoke_windows_zombie_lock_2026_05_08.md\`). Smoke was unrunnable.

## Phase 2: smoke now reaches the SPA-load step

After this PR, \`pnpm smoke:build\` produces the release exe to
\`.fixtures/bin/\` (isolated from user \`target/\`); \`pnpm smoke:run\` spawns
that exe. **Local Windows real run output:**

\`pnpm smoke:build\` → 3m 09s cargo, OK:
\`\`\`
[smoke:build] T1 build @ccsm/daemon (+ workspace deps)  → Done
[smoke:build] T2 build @ccsm/frontend-tauri (vite, + workspace deps)  → Done
[smoke:build] T3 cargo build --release (isolated target-dir)
   Compiling ccsm-tauri v0.0.0 (…/packages/frontend-tauri/src-tauri)
    Finished \`release\` profile [optimized] target(s) in 3m 09s
[smoke:build] OK
  -> …\.fixtures\bin\ccsm-tauri.exe  size=11478528 bytes
\`\`\`

Verify isolation: \`packages/frontend-tauri/src-tauri/target/\` does **not**
exist — every cargo artifact lives under \`.fixtures/cargo-target/\`.

\`pnpm smoke:run\` (head 50 + tail 100):

**Head 50 (orchestrator boot, NO cargo / NO vite-dev / NO tauri dev):**
\`\`\`
> @ccsm/smoke@0.0.0 smoke:run …
> playwright test
[cf-worker] [wrangler:inf] Ready on http://127.0.0.1:8787
[pages-dev] building frontend-web dist/ (one-shot)…
packages/frontend-web build: ✓ built in 2.17s
[pages-dev] build done in 9752ms; serving …\packages\frontend-web\dist
\`\`\`

**Tail 100 (Tauri release exe spawned, daemon comes up via R-4 hook,
then smoke red'd at SPA-load — the next layer down):**
\`\`\`
[pages-dev] [wrangler:inf] Ready on http://127.0.0.1:8788
[tauri-release] [daemon-mgr] resolved daemon script: …\packages\daemon\dist\index.mjs
[tauri-release] [daemon-mgr] CCSM_DB_PATH=…\AppData\Local\dev.ccsm.tauri\ccsm.db
[tauri-release] [daemon-mgr] spawned daemon pid=77160
[tauri-release] [daemon-mgr] assigned pid=77160 to Job Object
[tauri-release] [daemon stderr] [ccsm] tunnel: connecting ws://127.0.0.1:8787/tunnel/default
[tauri-release] [daemon-mgr] handshake ok port=52530 token=9a7773…

  1) tests\s3-happy-path.spec.ts:16:1 › cloud-mode happy path …
    Error: page.goto: net::ERR_CONNECTION_RESET at http://127.0.0.1:8788/
        at …\tests\s3-happy-path.spec.ts:18:14
  1 failed
\`\`\`

**Result**: LNK1104 absent (no cargo spawned in the runtime path);
release exe boots; R-4 setup hook auto-spawns daemon; daemon completes
its handshake; Job Object adopts the child. Smoke advances past the
build-coupling block and now red's at the SPA-load layer — the next
real product issue.

## Local checks (host: Windows 11, mode: fast)

- lint: ✓ (\`pnpm --filter @ccsm/smoke lint\` exit 0)
- typecheck: ✓ (\`pnpm --filter @ccsm/smoke typecheck\` exit 0)
- build: ✓ (\`pnpm smoke:build\` produced 11.4 MB release exe in 3m 09s)
- unit tests: ran affected packages —
  \`@ccsm/smoke\` test (skip stub), \`@ccsm/daemon\` 142/142 pass,
  \`@ccsm/shared\` 33/33 pass, \`@ccsm/frontend-web\` 30/30 pass,
  \`@ccsm/cf-worker\` 24/24 pass. No code paths touched in
  \`@ccsm/ui\` / \`@ccsm/core\` / \`@ccsm/electron\` / etc.
- e2e (smoke real run): \`pnpm smoke:run\` reaches Tauri-release-spawn +
  daemon handshake (output above); fails at next layer (page.goto
  ERR_CONNECTION_RESET on Pages dev) — that's the next red.

## Next red — for manager

\`page.goto('http://127.0.0.1:8788/')\` returns \`net::ERR_CONNECTION_RESET\`
even though \`[wrangler:inf] Ready on http://127.0.0.1:8788\` printed and
the Pages worker compiled. Likely **R-2** (\`functions/[[path]].ts\` hard
codes the prod \`https://cc-sm.pages.dev\` worker origin → reverse-proxy
to a non-existent prod target → reset on first request). Scope: thread
\`SMOKE_WORKER_ORIGIN\` env (already set by orchestrator) into the Pages
Function so it routes to \`http://127.0.0.1:8787\`. Pages-dev side-warning
\`Could not resolve …middleware-loader.entry.ts\` is a known wrangler 3.114
quirk and most likely unrelated.