### PR TITLE
fix(smoke): R-9 v3.D — Job Object spawn + fail-fast zombie detect (Task #19)

### DIFF
--- a/packages/smoke/fixtures/job-object.ts
+++ b/packages/smoke/fixtures/job-object.ts
@@ -1,0 +1,215 @@
+// R-9 v3.D — Win32 Job Object wrapper for smoke fixtures.
+//
+// Why we need this on top of `child.kill()` in orchestrator's killHandle():
+// - Tauri's release .exe spawns multiple child processes (webview helper,
+//   wry sandbox, the embedded daemon Node process) that are NOT killed when
+//   the parent ccsm-tauri.exe receives a `child.kill()` from Node — Windows
+//   has no SIGTERM, and `child.kill()` defaults to TerminateProcess on the
+//   ccsm-tauri.exe pid only. The descendants survive as zombies, holding a
+//   filesystem lock on `.fixtures/bin/ccsm-tauri.exe` (because the .exe text
+//   image is mapped into them via shared sections), which then makes the
+//   next `pnpm smoke:build` T4 copyfile fail with EBUSY.
+// - The Tauri Rust side has its own Job Object (T9, see
+//   packages/frontend-tauri/src-tauri/src/job_object.rs) but that one only
+//   reaps the *daemon* child of Tauri, not the Tauri exe itself or its
+//   webview helpers. From the smoke orchestrator's POV, we are the *parent*
+//   of ccsm-tauri.exe, so we are the layer responsible for binding the whole
+//   Tauri process tree to a Job that kernel-kills on Job-handle close.
+//
+// Mechanism: create one Win32 Job Object per smoke run with
+// JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. Assign the spawned child pid via
+// AssignProcessToJobObject. When the smoke process exits (graceful or
+// crash) the kernel closes our handle, which atomically terminates every
+// process in the Job — including descendants started after assignment, per
+// MSDN ("processes assigned to a job inherit the job association unless
+// JOB_OBJECT_LIMIT_BREAKAWAY_OK is set, which we do not set").
+//
+// FFI choice: we use `koffi` (MIT, 0 deps, actively maintained — last
+// publish 2026-05) to call kernel32 + kernel32 JobObjects entry points. We
+// considered:
+//   - native node-gyp addon: heavy build chain (msvc), failure mode worse
+//     than the bug we're fixing
+//   - PowerShell + Add-Type: per-spawn process overhead, brittle
+//   - `windows-job-object` npm: does not exist on the registry (verified
+//     2026-05-08)
+//   - `win32-api` npm: depends on koffi anyway and has a much wider surface
+//     than we need; using koffi directly is leaner
+//
+// On non-Windows this module is a no-op stub: smoke is Windows-first per
+// project_smoke_windows_zombie_lock_2026_05_08.md, and POSIX kill semantics
+// already cascade via process groups.
+import koffi from 'koffi';
+
+const IS_WINDOWS = process.platform === 'win32';
+
+export interface SmokeJobObject {
+  /** Assign a child pid (after spawn) to the Job. */
+  assign(pid: number): void;
+  /** Close the Job handle, which (under KILL_ON_JOB_CLOSE) kernel-kills every assigned descendant. */
+  close(): void;
+}
+
+interface Kernel32Bindings {
+  CreateJobObjectW: (lpJobAttributes: unknown, lpName: unknown) => unknown;
+  SetInformationJobObject: (
+    hJob: unknown,
+    JobObjectInformationClass: number,
+    lpJobObjectInformation: unknown,
+    cbJobObjectInformationLength: number,
+  ) => number;
+  AssignProcessToJobObject: (hJob: unknown, hProcess: unknown) => number;
+  OpenProcess: (dwDesiredAccess: number, bInheritHandle: number, dwProcessId: number) => unknown;
+  CloseHandle: (hObject: unknown) => number;
+  GetLastError: () => number;
+}
+
+// Lazily bind so non-Windows never tries to load kernel32.
+let bindings: Kernel32Bindings | null = null;
+
+function getBindings(): Kernel32Bindings {
+  if (bindings !== null) return bindings;
+  const lib = koffi.load('kernel32.dll');
+
+  // Win32 type aliases. koffi understands native widths.
+  // HANDLE / BOOL / DWORD all map to platform-native ints; we use uintptr_t /
+  // int / uint32 explicitly so cross-arch (x64) is correct.
+  bindings = {
+    // HANDLE CreateJobObjectW(LPSECURITY_ATTRIBUTES lpJobAttributes, LPCWSTR lpName)
+    CreateJobObjectW: lib.func('void* __stdcall CreateJobObjectW(void*, void*)'),
+    // BOOL SetInformationJobObject(HANDLE, JOBOBJECTINFOCLASS, LPVOID, DWORD)
+    SetInformationJobObject: lib.func(
+      'int __stdcall SetInformationJobObject(void*, int, void*, uint32)',
+    ),
+    // BOOL AssignProcessToJobObject(HANDLE hJob, HANDLE hProcess)
+    AssignProcessToJobObject: lib.func(
+      'int __stdcall AssignProcessToJobObject(void*, void*)',
+    ),
+    // HANDLE OpenProcess(DWORD dwDesiredAccess, BOOL bInheritHandle, DWORD dwProcessId)
+    OpenProcess: lib.func('void* __stdcall OpenProcess(uint32, int, uint32)'),
+    // BOOL CloseHandle(HANDLE)
+    CloseHandle: lib.func('int __stdcall CloseHandle(void*)'),
+    // DWORD GetLastError(void)
+    GetLastError: lib.func('uint32 __stdcall GetLastError()'),
+  };
+  return bindings;
+}
+
+// JOBOBJECT_EXTENDED_LIMIT_INFORMATION layout. We only need to set
+// LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE. Rest is zero-initialized.
+//
+// struct JOBOBJECT_BASIC_LIMIT_INFORMATION { // 48 bytes on x64
+//   LARGE_INTEGER PerProcessUserTimeLimit;   //  8
+//   LARGE_INTEGER PerJobUserTimeLimit;       //  8
+//   DWORD         LimitFlags;                //  4
+//   SIZE_T        MinimumWorkingSetSize;     //  8 (x64)
+//   SIZE_T        MaximumWorkingSetSize;     //  8
+//   DWORD         ActiveProcessLimit;        //  4
+//   ULONG_PTR     Affinity;                  //  8
+//   DWORD         PriorityClass;             //  4
+//   DWORD         SchedulingClass;           //  4
+// };  // total = 8+8+4+8+8+4+8+4+4 = 56, but with alignment LimitFlags is at offset 16
+//
+// struct IO_COUNTERS { ULONGLONG x6; }       // 48
+// struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION {
+//   JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation; // 56 (with align)
+//   IO_COUNTERS                       IoInfo;                // 48
+//   SIZE_T                            ProcessMemoryLimit;    //  8
+//   SIZE_T                            JobMemoryLimit;        //  8
+//   SIZE_T                            PeakProcessMemoryUsed; //  8
+//   SIZE_T                            PeakJobMemoryUsed;     //  8
+// };
+//
+// On x64 with 8-byte alignment: BasicLimitInformation occupies 64 bytes
+// (LimitFlags at offset 16, MinimumWorkingSetSize aligned to 24, ...
+// SchedulingClass at 60, padding to 64). Then IO_COUNTERS at 64..112,
+// then 4 SIZE_T at 112..144. Total 144.
+//
+// We pre-allocate a zero buffer and write LimitFlags at offset 16.
+const JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE = 0x00002000;
+const JobObjectExtendedLimitInformation = 9;
+const PROCESS_SET_QUOTA = 0x0100;
+const PROCESS_TERMINATE = 0x0001;
+const EXTENDED_LIMIT_INFO_SIZE = 144; // x64
+
+function setKillOnJobCloseInfo(buf: Buffer): void {
+  buf.fill(0);
+  // LimitFlags is a DWORD (4 bytes) inside JOBOBJECT_BASIC_LIMIT_INFORMATION.
+  // Offset breakdown on x64 (LLP64): two LARGE_INTEGER (8+8) before LimitFlags.
+  buf.writeUInt32LE(JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE, 16);
+}
+
+class WindowsJobObject implements SmokeJobObject {
+  private handle: unknown;
+  private closed = false;
+
+  constructor() {
+    const k = getBindings();
+    const handle = k.CreateJobObjectW(null, null);
+    if (!handle || koffi.address(handle) === 0n) {
+      throw new Error(`CreateJobObjectW failed (GetLastError=${k.GetLastError()})`);
+    }
+    this.handle = handle;
+
+    const info = Buffer.alloc(EXTENDED_LIMIT_INFO_SIZE);
+    setKillOnJobCloseInfo(info);
+    const ok = k.SetInformationJobObject(
+      this.handle,
+      JobObjectExtendedLimitInformation,
+      info,
+      EXTENDED_LIMIT_INFO_SIZE,
+    );
+    if (ok === 0) {
+      const err = k.GetLastError();
+      // Best-effort cleanup
+      k.CloseHandle(this.handle);
+      this.handle = null;
+      throw new Error(`SetInformationJobObject failed (GetLastError=${err})`);
+    }
+  }
+
+  assign(pid: number): void {
+    if (this.closed) throw new Error('JobObject already closed');
+    const k = getBindings();
+    const proc = k.OpenProcess(PROCESS_SET_QUOTA | PROCESS_TERMINATE, 0, pid);
+    if (!proc || koffi.address(proc) === 0n) {
+      throw new Error(`OpenProcess(pid=${pid}) failed (GetLastError=${k.GetLastError()})`);
+    }
+    try {
+      const ok = k.AssignProcessToJobObject(this.handle, proc);
+      if (ok === 0) {
+        throw new Error(
+          `AssignProcessToJobObject(pid=${pid}) failed (GetLastError=${k.GetLastError()})`,
+        );
+      }
+    } finally {
+      k.CloseHandle(proc);
+    }
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    const k = getBindings();
+    if (this.handle) {
+      // Closing the last Job handle is what triggers KILL_ON_JOB_CLOSE.
+      k.CloseHandle(this.handle);
+      this.handle = null;
+    }
+  }
+}
+
+class NoopJobObject implements SmokeJobObject {
+  assign(_pid: number): void { /* no-op on non-Windows */ }
+  close(): void { /* no-op */ }
+}
+
+/**
+ * Create a Job Object configured with KILL_ON_JOB_CLOSE.
+ *
+ * On Windows, returns a real Win32 Job-Object-backed instance.
+ * On non-Windows, returns a no-op stub (smoke is Windows-first).
+ */
+export function createSmokeJobObject(): SmokeJobObject {
+  if (!IS_WINDOWS) return new NoopJobObject();
+  return new WindowsJobObject();
+}

--- a/packages/smoke/fixtures/orchestrator.ts
+++ b/packages/smoke/fixtures/orchestrator.ts
@@ -34,6 +34,7 @@ import { mkdtempSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createSmokeJobObject, type SmokeJobObject } from './job-object.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../../..');
@@ -50,6 +51,10 @@ interface ProcHandle {
 
 const handles: ProcHandle[] = [];
 let tempDataDir: string | null = null;
+// R-9 v3.D: Job Object that wraps the Tauri release exe (and its descendants —
+// webview helper, daemon Node child) so that any death of the smoke process
+// kernel-reaps the whole tree. Non-Windows = no-op.
+let tauriJob: SmokeJobObject | null = null;
 
 function spawnProc(opts: {
   name: string;
@@ -120,6 +125,23 @@ async function killHandle(h: ProcHandle): Promise<void> {
 }
 
 export default async function globalSetup(): Promise<void> {
+  try {
+    await globalSetupInner();
+  } catch (err) {
+    // R-9 v3.D — if setup fails midway (e.g. tauri readyMatch timeout),
+    // run teardown to release the Job Object + kill any spawned processes,
+    // otherwise we leak zombies that lock .fixtures/bin/ccsm-tauri.exe.
+    process.stderr.write(`[smoke setup] failed: ${(err as Error).message} — running teardown\n`);
+    try { await globalTeardown(); } catch (teardownErr) {
+      process.stderr.write(
+        `[smoke setup] teardown after failure also failed: ${(teardownErr as Error).message}\n`,
+      );
+    }
+    throw err;
+  }
+}
+
+async function globalSetupInner(): Promise<void> {
   tempDataDir = mkdtempSync(join(tmpdir(), 'ccsm-smoke-'));
 
   // 1. cf-worker (wrangler dev). Listens on WORKER_PORT.
@@ -253,14 +275,61 @@ export default async function globalSetup(): Promise<void> {
     readyTimeoutMs: 90_000,
   });
   handles.push(tauri);
+
+  // R-9 v3.D — bind the Tauri process tree to a Job Object with
+  // KILL_ON_JOB_CLOSE *immediately after spawn, before awaiting ready*. This
+  // way:
+  //   - any descendant the Tauri exe spawns later (webview helper, wry
+  //     sandbox, the daemon Node child) inherits the Job association
+  //     automatically (we do NOT set JOB_OBJECT_LIMIT_BREAKAWAY_OK), so the
+  //     whole tree dies when our Job handle closes;
+  //   - if globalSetup throws between spawn and `await tauri.ready` (e.g.
+  //     readyMatch timeout), globalTeardown's `tauriJob.close()` still
+  //     reaps everything, instead of leaving zombies that lock
+  //     .fixtures/bin/ccsm-tauri.exe and wedge the next smoke:build T4.
+  //
+  // The Tauri Rust side has its own Job Object for the daemon (T9, see
+  // packages/frontend-tauri/src-tauri/src/job_object.rs); that handles the
+  // case where a *user* hard-kills ccsm-tauri.exe in production. This Job
+  // is the smoke-side equivalent for the case where smoke (the parent of
+  // ccsm-tauri.exe) crashes.
+  if (tauri.child.pid !== undefined) {
+    tauriJob = createSmokeJobObject();
+    try {
+      tauriJob.assign(tauri.child.pid);
+      process.stderr.write(`[smoke] assigned tauri pid=${tauri.child.pid} to Job Object\n`);
+    } catch (err) {
+      process.stderr.write(
+        `[smoke] WARN: failed to assign tauri pid=${tauri.child.pid} to Job Object: ${(err as Error).message}\n` +
+        `[smoke] WARN: descendants may zombie; smoke:build T4 fail-fast will catch on next run\n`,
+      );
+      try { tauriJob.close(); } catch { /* ignore */ }
+      tauriJob = null;
+    }
+  }
+
   await tauri.ready;
 
   process.env.SMOKE_BASE_URL = `http://127.0.0.1:${PAGES_PORT}`;
 }
 
 export async function globalTeardown(): Promise<void> {
-  // Reverse spawn order so the Tauri Job Object reaps daemon first, then
-  // pages dev (which owns its workerd), then cf-worker.
+  // R-9 v3.D — close the Job Object FIRST. Under
+  // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE this kernel-terminates ccsm-tauri.exe
+  // and every descendant it spawned (webview helper, wry sandbox, daemon
+  // Node child) atomically — releasing the file lock on
+  // .fixtures/bin/ccsm-tauri.exe so the next `pnpm smoke:build` T4 copy
+  // does not hit EBUSY. Doing this before per-handle kill ensures a graceful
+  // teardown path doesn't race with an exited-but-still-mapped child.
+  if (tauriJob !== null) {
+    try { tauriJob.close(); } catch (err) {
+      process.stderr.write(`[smoke teardown] tauriJob.close failed: ${(err as Error).message}\n`);
+    }
+    tauriJob = null;
+  }
+
+  // Reverse spawn order so any process not bound to the Job (cf-worker,
+  // pages-dev) still gets a chance at clean SIGTERM.
   for (const h of [...handles].reverse()) {
     try {
       await killHandle(h);

--- a/packages/smoke/package.json
+++ b/packages/smoke/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@playwright/test": "^1.48.2",
     "@types/node": "^22.9.0",
+    "koffi": "^2.16.2",
     "typescript": "^5.6.3"
   }
 }

--- a/packages/smoke/scripts/build-fixtures.mjs
+++ b/packages/smoke/scripts/build-fixtures.mjs
@@ -32,7 +32,7 @@
 // That's the whole point of this split.
 
 import { spawnSync } from 'node:child_process';
-import { copyFileSync, mkdirSync, existsSync, statSync } from 'node:fs';
+import { copyFileSync, mkdirSync, existsSync, statSync, openSync, closeSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -104,6 +104,57 @@ if (!existsSync(builtExe)) {
   process.stderr.write(`[smoke:build] cargo did not produce ${builtExe}\n`);
   process.exit(1);
 }
+
+// R-9 v3.D — fail-fast lock detection BEFORE copyFileSync.
+//
+// If a previous smoke run left a zombie ccsm-tauri.exe (or a webview/wry
+// helper that mapped the .exe image) holding a file lock on destExe,
+// copyFileSync will fail with EBUSY mid-copy. We detect this up-front by
+// trying to open the file for read+write; on Windows that returns EBUSY /
+// EPERM if any process holds an exclusive map / write share.
+//
+// We deliberately do NOT retry-with-sleep here (that's glue, masks the
+// real bug) and do NOT spawn taskkill (also glue + can wedge in kernel
+// syscalls when there are many zombies). The orchestrator's R-9 v3.D Job
+// Object change ensures *new* runs reap their tree on exit; this fail-fast
+// is the safety net for any pre-existing zombies (e.g. from before this
+// fix landed, or from a TerminateProcess of the smoke runner) so the user
+// gets a clear actionable error instead of a confusing copyfile failure
+// in the middle of T4.
+if (existsSync(destExe)) {
+  let fd = -1;
+  try {
+    fd = openSync(destExe, 'r+');
+  } catch (err) {
+    const code = (err && typeof err === 'object' && 'code' in err) ? err.code : 'UNKNOWN';
+    process.stderr.write(
+      `\n[smoke:build] T4 ABORT — destination .exe is locked\n` +
+      `  path:  ${destExe}\n` +
+      `  errno: ${code} (${err && err.message ? err.message : err})\n` +
+      `\n` +
+      `Likely cause: a zombie ccsm-tauri.exe / webview helper / wry sandbox\n` +
+      `from a previous smoke run is still mapping this .exe image, holding\n` +
+      `a Windows file lock. We refuse to retry-with-sleep (it would mask\n` +
+      `the real bug) or to taskkill (it deadlocks under high zombie counts).\n` +
+      `\n` +
+      `What to do:\n` +
+      `  1. Identify the locker:\n` +
+      `       Get-Process ccsm-tauri | Format-List Id,Path,StartTime\n` +
+      `       handle.exe "${destExe}"   # SysInternals handle.exe if installed\n` +
+      `  2. Kill it gracefully (close the app), or as a last resort reboot —\n` +
+      `     under heavy zombie load 'taskkill /F' itself can wedge.\n` +
+      `  3. Re-run \`pnpm smoke:build\`. Subsequent runs will not zombie\n` +
+      `     because the orchestrator now binds the Tauri tree to a Win32\n` +
+      `     Job Object with KILL_ON_JOB_CLOSE (R-9 v3.D, Task #19).\n`,
+    );
+    process.exit(2);
+  } finally {
+    if (fd !== -1) {
+      try { closeSync(fd); } catch { /* ignore */ }
+    }
+  }
+}
+
 copyFileSync(builtExe, destExe);
 const sz = statSync(destExe).size;
 process.stderr.write(`\n[smoke:build] OK\n  -> ${destExe}\n  size=${sz} bytes\n`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@types/node':
         specifier: ^22.9.0
         version: 22.19.17
+      koffi:
+        specifier: ^2.16.2
+        version: 2.16.2
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -1974,6 +1977,9 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  koffi@2.16.2:
+    resolution: {integrity: sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -4089,6 +4095,8 @@ snapshots:
       json-buffer: 3.0.1
 
   kleur@4.1.5: {}
+
+  koffi@2.16.2: {}
 
   levn@0.4.1:
     dependencies:


### PR DESCRIPTION
## Change

- `packages/smoke/fixtures/job-object.ts` (NEW) — Win32 Job Object wrapper using `koffi` FFI. `createSmokeJobObject()` returns an object with `assign(pid)` + `close()`. Windows: real `CreateJobObjectW` + `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` + `AssignProcessToJobObject`. Non-Windows: no-op stub.
- `packages/smoke/fixtures/orchestrator.ts` — after spawning the Tauri release `.exe`, immediately `tauriJob.assign(child.pid)` BEFORE awaiting `ready`. Descendants (webview helper, wry sandbox, daemon Node child) inherit the Job association automatically (no `JOB_OBJECT_LIMIT_BREAKAWAY_OK` set). `globalSetup` wrapped in try/catch that runs `globalTeardown` on failure (so a `readyMatch` timeout still releases the Job). `globalTeardown` closes the Job FIRST, which kernel-reaps the whole tree atomically.
- `packages/smoke/scripts/build-fixtures.mjs` — T4 fail-fast: before `copyFileSync`, try `openSync(destExe, 'r+')`. EBUSY/EPERM → exit 2 with an actionable error block (no retry-with-sleep, no taskkill — both rejected as glue per Task #19 spec).
- `packages/smoke/package.json` — add `koffi@^2.16.2` (devDependency). MIT, 0 deps, prebuilt N-API addon (no node-gyp required).

## 4 层 root cause (Layer 2)

smoke 自 spawn Tauri exe 没用 Job Object, 父死后 Tauri 变 zombie 持文件锁。memory `project_tauri2_spike_2026_05_07.md` 已 spike Job Object 是 Windows 唯一可靠 reap 机制。daemon 内部已用 (R-4, see `packages/frontend-tauri/src-tauri/src/job_object.rs`), smoke 这层漏 — 因为从 smoke 角度 Tauri exe 自己**就是**那个 child, 需要再上一层 Job 包它和它的全部 descendants。

## Phase 1: red (before)

PR #1180 / #1181 merged 后 smoke 跑通过几关, 但每跑完 ccsm-tauri.exe 不 graceful exit, 留 zombie。10 个 zombie 累积后, smoke:build T4 copyfile EBUSY (target 被锁), 整个 smoke loop 阻断。

可观测红信号 (Task #21 R-3 dev 报告):
- `Get-Process ccsm-tauri` 显示 ~10 个累积 zombie
- `pnpm smoke:build` T4 在 `copyFileSync(builtExe, destExe)` 抛 EBUSY
- `taskkill /F /IM ccsm-tauri.exe` 自身 timeout (kernel syscall blocked under high zombie load)

## Phase 2: smoke now reaches X

**本 PR 不本机端到端跑 smoke** — 现存 zombie 阻断 smoke:build T4 (copyfile EBUSY), `taskkill /F` 自己 timeout 也清不掉 (kernel syscall 阻塞)。架构修复后, **新启动**的 Tauri spawn 用 Job Object 包父死自动 reap, 不再积 zombie; **现存** zombie 留 user 重启系统 clean state 一次, 之后再积概率为零。Verify 留给下个 PR 在 clean state 下跑一次完整 smoke。

代码层验证 (本 PR 已做):
- typecheck: `pnpm --filter @ccsm/smoke typecheck` exit 0
- lint: `pnpm --filter @ccsm/smoke lint` exit 0
- koffi load smoke: `node -e "const k=require('koffi'); k.load('kernel32.dll').func('void* __stdcall CreateJobObjectW(void*, void*)')(null,null)"` returns valid handle
- Job Object semantic verify: standalone test compiled `job-object.ts`, assigned own pid, called `close()` → kernel terminated the Node process before `console.log('closed')` ran. Confirms `KILL_ON_JOB_CLOSE` works end-to-end. (Test was throwaway — production code does NOT assign self pid.)
- cargo build skipped: this PR touches no Rust source and no `Cargo.toml`. R-9 v3.A's prebuilt `.fixtures/bin/ccsm-tauri.exe` produced by previous merged PRs is the artifact orchestrator spawns; nothing about cargo's behavior changes.
- npm dep: `koffi` is MIT, 0 runtime deps, prebuilt binary (`koffi.node`) ships in the package — pnpm "ignored build scripts" warning is benign because koffi's install script is for source builds, not used here. lockfile diff = 8 lines (single new entry + integrity hash).

## Local checks (host: Windows 11, mode: fast)

- lint: PASS (eslint tests fixtures --max-warnings=0, exit 0)
- typecheck: PASS (tsc --noEmit, exit 0)
- build: N/A (smoke has no build step; `smoke:build` is the artifact pipeline tested separately and skipped — see "Phase 2" above)
- unit tests: N/A (smoke has no unit tests; `pnpm test` in smoke is a no-op echo per package.json)
- e2e: SKIPPED — smoke E2E (Playwright) requires `pnpm smoke:build` to succeed, which is currently EBUSY-blocked by pre-existing zombies. This is the exact bug this PR fixes; see manager memory `project_smoke_windows_zombie_lock_2026_05_08.md`. After user reboots / clears zombies, a follow-up PR/task should re-run end-to-end.

## Next red — for manager

等 user 重启清 zombie 后跑一次 smoke 验证 R-9 v3.D 实效, 然后看暴露下一红 (R-5 / R-6 或新红)。