### PR TITLE
fix(ui): R-12 — add data-testid session-list + terminal-pane for smoke (Task #28)

### DIFF
--- a/packages/ui/src/components/MainPane.tsx
+++ b/packages/ui/src/components/MainPane.tsx
@@ -239,7 +239,7 @@ export function MainPane() {
   }, [activeSid, token]);
 
   return (
-    <div className="main-pane">
+    <div className="main-pane" data-testid="terminal-pane">
       <div
         id="terminal"
         ref={containerRef}

--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -313,7 +313,7 @@ export function Sidebar() {
               No sessions yet — click + New Session above
             </div>
           ) : (
-            <ul className="sidebar__session-list">
+            <ul className="sidebar__session-list" data-testid="session-list">
               {sessions.map((s) => {
                 const isActive = s.sid === activeSid;
                 return (

--- a/packages/ui/test/MainPane.strictmode.test.tsx
+++ b/packages/ui/test/MainPane.strictmode.test.tsx
@@ -228,6 +228,24 @@ describe('MainPane under React.StrictMode (T10 reshape of P1-3 regression)', () 
     expect(runtimeDetach).not.toHaveBeenCalled();
   });
 
+  it('exposes data-testid="terminal-pane" on the MainPane root (Task #28 smoke contract)', async () => {
+    // s3-happy-path.spec.ts probes getByTestId('terminal-pane') to click +
+    // assert the xterm scrollback. The host MUST be attached to a node that
+    // (a) is visible and (b) reflects the rendered terminal text. Anchor it
+    // on the .main-pane root so the testid stays stable regardless of which
+    // child contains the live xterm.
+    const { container } = render(
+      <StrictMode>
+        <MainPane />
+      </StrictMode>,
+    );
+
+    await flushMicrotasks();
+
+    const pane = container.querySelector('[data-testid="terminal-pane"]');
+    expect(pane).not.toBeNull();
+  });
+
   it('mounts a live xterm into the container after the StrictMode remount', async () => {
     const { container } = render(
       <StrictMode>

--- a/packages/ui/test/Sidebar.test.tsx
+++ b/packages/ui/test/Sidebar.test.tsx
@@ -173,6 +173,23 @@ describe('Sidebar', () => {
     }
   });
 
+  // Task #28 / R-12: smoke spec (s3-happy-path) probes data-testid="session-list"
+  // on the sessions <ul>. Missing this testid is what made dev-27's smoke run
+  // time out at getByTestId('session-list') even though the sidebar rendered
+  // correctly. Lock the contract so this can't regress silently.
+  it('exposes data-testid="session-list" on the sessions <ul> (smoke contract)', () => {
+    useStore.setState({
+      sessions: [
+        { sid: 'aaaa1111', createdAt: 0, alive: true },
+      ],
+      activeSid: 'aaaa1111',
+    });
+    render(<Sidebar />);
+    const list = screen.getByTestId('session-list');
+    expect(list).toBeDefined();
+    expect(list.tagName).toBe('UL');
+  });
+
   it('shows the empty-state hint inside the GROUPS zone when sessions is empty', () => {
     render(<Sidebar />);
     expect(


### PR DESCRIPTION
## Summary

R-5 (#1183) merged so cloud-mode `/token` boot is healthy and dev-27 reproduced the smoke run reaching the post-token-boot UI. The remaining red was at `getByTestId('session-list')` 30s timeout — the page snapshot dev-27 captured shows the sidebar renders normally ("No sessions yet — click + New Session above"), so this is a pure Layer-4 (test contract) gap: smoke probes testids the product never exposed.

`packages/smoke/tests/s3-happy-path.spec.ts` expects:
- L23: `session-list` (sessions `<ul>` in Sidebar)
- L28/32/36/42: `terminal-pane` (MainPane root)

Fix: attach `data-testid="session-list"` to the existing `<ul className="sidebar__session-list">` and `data-testid="terminal-pane"` to the existing `<div className="main-pane">`. **className is unchanged** — no CSS regression risk. The existing `data-testid="main-terminal"` on the inner xterm host is left intact.

## 4-layer root cause (per memory: feedback_fix_arch_not_glue)

- L1 protocol: OK (R-5 merged, /token returns 200)
- L2 architecture: OK (Sidebar / MainPane render the right DOM)
- L3 ordering: OK (orchestrator brings up all 3 child processes)
- **L4 test contract**: FAIL — testids the test contract requires were absent. Fix is at the right layer (give the product the testids), not glue (rewriting the smoke selectors).

## TDD

Both targeted testids had **0 grep hits** repo-wide before this PR. New unit assertions go red without the source change (verified with reverse run, see Phase 1 below).

### Phase 1 (red, before source change)

```
FAIL test/Sidebar.test.tsx > Sidebar > exposes data-testid="session-list" on the sessions <ul> (smoke contract)
  → screen.getByTestId('session-list') threw — testid absent in DOM
FAIL test/MainPane.strictmode.test.tsx > MainPane … > exposes data-testid="terminal-pane" on the MainPane root (Task #28 smoke contract)
  → container.querySelector('[data-testid="terminal-pane"]') === null

 Test Files  2 failed (2)
      Tests  2 failed | 18 passed (20)
```

### Phase 2 (green, after source change)

```
 ✓ test/Sidebar.test.tsx (16 tests) 151ms
 ✓ test/MainPane.strictmode.test.tsx (4 tests) 196ms

 Test Files  2 passed (2)
      Tests  20 passed (20)
   Duration  3.34s
```

## Local checks (host: Windows 11, mode: fast)

- lint: pre-existing failures in `packages/daemon/test/persist.test.ts:20` and `packages/ui/test/BootstrapRefresh.test.tsx:24` are NOT in this PR's diff (verified `git diff origin/working -- <files>` empty); `pnpm --filter @ccsm/ui lint` on the files I touched: clean.
- typecheck: `pnpm -w typecheck` after `shared`+`core`+`ui` builds: all 8 packages green.
- build: `pnpm --filter @ccsm/ui build` exit 0.
- unit tests (fast — only changed specs): `npx vitest run test/Sidebar.test.tsx test/MainPane.strictmode.test.tsx` → 20 passed in 3.34s.
- smoke / e2e: **not run locally** — per memory `project_smoke_windows_zombie_lock_2026_05_08`, smoke is reserved for a manager verify-only task. Manager will dispatch a follow-up R-task to run smoke against this PR.

## Out of scope

- Not touching className (CSS regression risk).
- Not modifying smoke spec.
- Not touching unrelated files.