### PR TITLE
feat(smoke): R-13 — stage markers + SPA console forwarding (Task #31)

### DIFF
--- a/packages/frontend-web/src/main.tsx
+++ b/packages/frontend-web/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
-import { resolveDaemonBase, resolveToken, TOKEN_STORAGE_KEY } from './hostConfig';
+import { resolveDaemonBase, resolveToken, resolveWsBase, resolveWsPath, TOKEN_STORAGE_KEY } from './hostConfig';
 import '@ccsm/ui/styles.css';
 
 // Task #696: token bootstrap.
@@ -18,6 +18,12 @@ import '@ccsm/ui/styles.css';
 // Task #780 (S3-T5): the default daemon base flipped to the CF Pages
 // tunnel, so `/token` now goes to `https://cc-sm.pages.dev/token` unless
 // the user passes `?daemon=` to redirect at a local loopback daemon.
+//
+// Task #31 (R-13): the boot path emits `[ccsm spa] …` console.log markers
+// so the smoke spec's beforeEach console-forwarder can fingerprint where
+// the SPA broke (token fetch failed / token resolved / ws url computed)
+// without opening the headed browser. console.log only — no new try/catch,
+// no control-flow change.
 async function bootstrap(): Promise<void> {
   const rootEl = document.getElementById('root');
   if (!rootEl) {
@@ -28,13 +34,30 @@ async function bootstrap(): Promise<void> {
     search: window.location.search,
   });
 
+  console.log('[ccsm spa] fetching /token from', daemonBase || window.location.origin);
+
+  // R-13: instrument the fetch passed into resolveToken so we log the actual
+  // /token request URL + response status without changing resolveToken's
+  // pure signature. Other fetches (REST API after boot) are not wrapped.
+  const tracingFetch: typeof window.fetch = async (input, init) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.endsWith('/token') || url.includes('/token?')) {
+      const t0 = Date.now();
+      const res = await window.fetch(input, init);
+      console.log('[ccsm spa] /token response status=', res.status, 'in', Date.now() - t0, 'ms');
+      return res;
+    }
+    return window.fetch(input, init);
+  };
+
   const token = await resolveToken({
     search: window.location.search,
-    fetch: window.fetch.bind(window),
+    fetch: tracingFetch,
     daemonBase,
   });
 
   if (!token) {
+    console.error('[ccsm spa] token resolved null — rendering daemon-offline fallback');
     rootEl.innerHTML =
       '<div style="font-family:system-ui;padding:24px;color:#888;">' +
       'Daemon offline or no token available. Start the daemon, then reload this page.' +
@@ -42,7 +65,17 @@ async function bootstrap(): Promise<void> {
     return;
   }
 
+  console.log('[ccsm spa] token resolved tokenLen=', token.length);
+
   sessionStorage.setItem(TOKEN_STORAGE_KEY, token);
+
+  // R-13: log the ws url the SessionRuntime / WsClient is about to dial.
+  // Computed identically to webHostConfig (resolveWsBase + resolveWsPath)
+  // so a mismatch between this log and the actual ws upgrade in worker logs
+  // pinpoints a hostConfig drift.
+  const wsBase = resolveWsBase({ search: window.location.search });
+  const wsPath = resolveWsPath({ search: window.location.search }) ?? '/ws';
+  console.log('[ccsm spa] ws connecting', `${wsBase}${wsPath}`);
 
   createRoot(rootEl).render(
     <StrictMode>

--- a/packages/smoke/fixtures/orchestrator.ts
+++ b/packages/smoke/fixtures/orchestrator.ts
@@ -100,6 +100,60 @@ function spawnProc(opts: {
   return { name: opts.name, child, ready };
 }
 
+// R-13 (Task #31) — stage marker helper. Wraps each setup phase in a
+// monotonically-numbered `[smoke stage N/10: <name>]` start/ok/FAILED log line
+// so a red smoke run no longer needs the reader to guess which jump (cf-worker
+// spawn / pages-dev build / tauri spawn / daemon handshake / tunnel ws) of the
+// boot pipeline broke. Failures rethrow so globalSetup's catch arm runs the
+// existing teardown (line ~134); we do not change control flow.
+const STAGE_TOTAL = 10;
+async function runStage<T>(n: number, name: string, fn: () => Promise<T> | T): Promise<T> {
+  const start = Date.now();
+  process.stderr.write(`[smoke stage ${n}/${STAGE_TOTAL}: ${name}] start\n`);
+  try {
+    const result = await fn();
+    process.stderr.write(`[smoke stage ${n}/${STAGE_TOTAL}: ${name}] ok in ${Date.now() - start}ms\n`);
+    return result;
+  } catch (err) {
+    const msg = (err as Error).message;
+    process.stderr.write(
+      `[smoke stage ${n}/${STAGE_TOTAL}: ${name}] FAILED in ${Date.now() - start}ms: ${msg}\n`,
+    );
+    throw err;
+  }
+}
+
+// R-13 — attach a tail-watcher to the tauri child stdout/stderr that prints
+// stage markers 7-10 as their substrings flow by. These stages are logically
+// inside `await tauri.ready` (the lib.rs setup hook auto-spawns the daemon
+// child, the daemon handshake fires daemon-mgr's "daemon-ready" Tauri event,
+// and the daemon then dials the tunnel ws). Orchestrator does not drive them
+// directly, so we cannot wrap them in runStage; we observe them instead.
+// Observed-only marker: prints `[smoke stage N/10: <name>] observed at +Xms`
+// on first match, no FAILED variant (a missing stage manifests as the next
+// stage's runStage timing out, which still fingerprints which jump broke).
+function attachTauriStageWatcher(child: ChildProcess, t0: number): void {
+  const stages: Array<{ n: number; name: string; pattern: RegExp; seen: boolean }> = [
+    { n: 7, name: 'daemon spawn',          pattern: /daemon-mgr.*resolved daemon script|spawn_daemon_inner/i, seen: false },
+    { n: 8, name: 'daemonJob assign pid',  pattern: /job_object.*assign|daemon.*pid=\d+.*assigned/i,           seen: false },
+    { n: 9, name: 'daemon handshake ok',   pattern: /"ready"\s*:\s*true|handshake ok port=|daemon-ready/i,     seen: false },
+    { n: 10, name: 'tunnel ws connected',  pattern: /tunnel.*ws.*(connected|open)|tunnel-do.*upgrade/i,        seen: false },
+  ];
+  const watch = (chunk: Buffer): void => {
+    const text = chunk.toString('utf8');
+    for (const s of stages) {
+      if (!s.seen && s.pattern.test(text)) {
+        s.seen = true;
+        process.stderr.write(
+          `[smoke stage ${s.n}/${STAGE_TOTAL}: ${s.name}] observed at +${Date.now() - t0}ms\n`,
+        );
+      }
+    }
+  };
+  child.stdout?.on('data', watch);
+  child.stderr?.on('data', watch);
+}
+
 async function killHandle(h: ProcHandle): Promise<void> {
   return new Promise((resolveKill) => {
     if (h.child.exitCode !== null || h.child.signalCode !== null) {
@@ -154,7 +208,7 @@ async function globalSetupInner(): Promise<void> {
     readyTimeoutMs: 60_000,
   });
   handles.push(worker);
-  await worker.ready;
+  await runStage(1, 'cf-worker spawn ready', () => worker.ready);
 
   // 2. frontend-web Pages dev. Reverse-proxies /api/*, /token, /ws/*, /tunnel/*
   //    via functions/[[path]].ts to the worker above. Bound on PAGES_PORT.
@@ -174,27 +228,29 @@ async function globalSetupInner(): Promise<void> {
   //    README; cache-mtime gate is intentionally not added here to avoid
   //    drift between smoke and CI.
   const frontendWebCwd = join(REPO_ROOT, 'packages/frontend-web');
-  process.stderr.write('[pages-dev] building frontend-web dist/ (one-shot)…\n');
-  const buildStart = Date.now();
-  const buildResult = spawnSync(
-    'pnpm',
-    ['--filter', '@ccsm/frontend-web...', 'build'],
-    {
-      cwd: REPO_ROOT,
-      stdio: 'inherit',
-      shell: process.platform === 'win32',
-    },
-  );
-  if (buildResult.status !== 0) {
-    throw new Error(
-      `[pages-dev] frontend-web build failed (exit=${buildResult.status})`,
-    );
-  }
   const distDir = join(frontendWebCwd, 'dist');
-  try { statSync(distDir); } catch {
-    throw new Error(`[pages-dev] expected build output at ${distDir} but it does not exist`);
-  }
-  process.stderr.write(`[pages-dev] build done in ${Date.now() - buildStart}ms; serving ${distDir}\n`);
+  await runStage(2, 'pages-dev build done', () => {
+    process.stderr.write('[pages-dev] building frontend-web dist/ (one-shot)…\n');
+    const buildStart = Date.now();
+    const buildResult = spawnSync(
+      'pnpm',
+      ['--filter', '@ccsm/frontend-web...', 'build'],
+      {
+        cwd: REPO_ROOT,
+        stdio: 'inherit',
+        shell: process.platform === 'win32',
+      },
+    );
+    if (buildResult.status !== 0) {
+      throw new Error(
+        `[pages-dev] frontend-web build failed (exit=${buildResult.status})`,
+      );
+    }
+    try { statSync(distDir); } catch {
+      throw new Error(`[pages-dev] expected build output at ${distDir} but it does not exist`);
+    }
+    process.stderr.write(`[pages-dev] build done in ${Date.now() - buildStart}ms; serving ${distDir}\n`);
+  });
 
   const pages = spawnProc({
     name: 'pages-dev',
@@ -221,7 +277,7 @@ async function globalSetupInner(): Promise<void> {
     readyTimeoutMs: 60_000,
   });
   handles.push(pages);
-  await pages.ready;
+  await runStage(3, 'pages-dev spawn ready', () => pages.ready);
 
   // 3. Tauri release shell (R-9 v3.A, Task #15).
   //
@@ -251,7 +307,7 @@ async function globalSetupInner(): Promise<void> {
     );
   }
 
-  const tauri = spawnProc({
+  const tauri = await runStage(4, 'tauri spawn', () => spawnProc({
     name: 'tauri-release',
     cwd: REPO_ROOT,
     cmd: releaseExe,
@@ -273,8 +329,14 @@ async function globalSetupInner(): Promise<void> {
     // the Rust-side log or the daemon stdout passthrough.
     readyMatch: /daemon-ready|"ready"\s*:\s*true|handshake ok port=/i,
     readyTimeoutMs: 90_000,
-  });
+  }));
   handles.push(tauri);
+
+  // R-13 — start observing tauri child output for stage 7-10 substrings as
+  // soon as the child is alive, BEFORE the readyMatch await, so the markers
+  // print in real time rather than getting buffered behind stage 6.
+  const tauriT0 = Date.now();
+  attachTauriStageWatcher(tauri.child, tauriT0);
 
   // R-9 v3.D — bind the Tauri process tree to a Job Object with
   // KILL_ON_JOB_CLOSE *immediately after spawn, before awaiting ready*. This
@@ -294,21 +356,23 @@ async function globalSetupInner(): Promise<void> {
   // is the smoke-side equivalent for the case where smoke (the parent of
   // ccsm-tauri.exe) crashes.
   if (tauri.child.pid !== undefined) {
-    tauriJob = createSmokeJobObject();
-    try {
-      tauriJob.assign(tauri.child.pid);
-      process.stderr.write(`[smoke] assigned tauri pid=${tauri.child.pid} to Job Object\n`);
-    } catch (err) {
-      process.stderr.write(
-        `[smoke] WARN: failed to assign tauri pid=${tauri.child.pid} to Job Object: ${(err as Error).message}\n` +
-        `[smoke] WARN: descendants may zombie; smoke:build T4 fail-fast will catch on next run\n`,
-      );
-      try { tauriJob.close(); } catch { /* ignore */ }
-      tauriJob = null;
-    }
+    await runStage(5, 'tauriJob assign pid', () => {
+      tauriJob = createSmokeJobObject();
+      try {
+        tauriJob.assign(tauri.child.pid as number);
+        process.stderr.write(`[smoke] assigned tauri pid=${tauri.child.pid} to Job Object\n`);
+      } catch (err) {
+        process.stderr.write(
+          `[smoke] WARN: failed to assign tauri pid=${tauri.child.pid} to Job Object: ${(err as Error).message}\n` +
+          `[smoke] WARN: descendants may zombie; smoke:build T4 fail-fast will catch on next run\n`,
+        );
+        try { tauriJob.close(); } catch { /* ignore */ }
+        tauriJob = null;
+      }
+    });
   }
 
-  await tauri.ready;
+  await runStage(6, 'tauri ready', () => tauri.ready);
 
   process.env.SMOKE_BASE_URL = `http://127.0.0.1:${PAGES_PORT}`;
 }

--- a/packages/smoke/tests/s3-happy-path.spec.ts
+++ b/packages/smoke/tests/s3-happy-path.spec.ts
@@ -13,6 +13,18 @@
 // processes — that itself is part of Phase 1's red signal.
 import { test, expect } from '@playwright/test';
 
+// R-13 (Task #31) — pipe SPA-side console / pageerror / requestfailed events
+// to the orchestrator's stderr so a red smoke run no longer needs the reader
+// to open the headed browser to find out *why* the SPA never reached the
+// post-token-boot UI. With these handlers in place a missing /token, a
+// failed CORS preflight, or an SPA throw all surface as a `[smoke spa …]`
+// line in the same stream as the stage markers.
+test.beforeEach(async ({ page }) => {
+  page.on('console', m => process.stderr.write(`[smoke spa console.${m.type()}] ${m.text()}\n`));
+  page.on('pageerror', e => process.stderr.write(`[smoke spa pageerror] ${e.message}\n${e.stack ?? ''}\n`));
+  page.on('requestfailed', r => process.stderr.write(`[smoke spa requestfailed] ${r.url()} -> ${r.failure()?.errorText}\n`));
+});
+
 test('cloud-mode happy path: open SPA, create session, run echo, see output', async ({ page }) => {
   // The Pages dev origin; SMOKE_BASE_URL is wired by the orchestrator.
   await page.goto('/');


### PR DESCRIPTION
## Summary
- Wraps each smoke globalSetup phase in `[smoke stage N/10: <name>]` start/ok/FAILED markers (helper `runStage` + listener-based observer for tauri-internal stages 7-10).
- Forwards Playwright `console` / `pageerror` / `requestfailed` events to orchestrator stderr via `test.beforeEach`, so SPA-side failures surface in the same red signal.
- Adds `[ccsm spa]` console.log breadcrumbs around `/token` fetch + token resolution + ws URL in `main.tsx`. console.log only, no control-flow change.

Layer 4 (test observability) fix per the 4-layer root-cause discipline. Layers 1-3 unchanged.

## Local checks (host: Windows, mode: fast)
- lint: ✓ smoke + frontend-web (pre-existing unused-var errors in daemon/persist + ui/BootstrapRefresh are unrelated to this PR)
- typecheck: ✓ smoke + frontend-web + workspace incremental
- build: skipped — `@ccsm/smoke` has no `build` script (`pnpm smoke:build` is the cargo+vite fixture builder, out of scope)
- unit tests: frontend-web vitest → 31 passed (hostConfig 18, resolveToken 13), 1.83s
- e2e (smoke runtime): SKIPPED per task spec. pool-4 is running smoke concurrently; running smoke in pool-5 would deadlock on the shared cargo target dir (Windows LNK1104, memory `project_smoke_windows_zombie_lock_2026_05_08`). Static evidence below.

## Static evidence

Six `runStage(n, name, fn)` call sites in `packages/smoke/fixtures/orchestrator.ts`:
1. cf-worker spawn ready
2. pages-dev build done
3. pages-dev spawn ready
4. tauri spawn
5. tauriJob assign pid
6. tauri ready

Four substring matchers in `attachTauriStageWatcher` (observed-only because daemon is a tauri child, orchestrator does not drive these awaits):
- 7  daemon spawn — `/daemon-mgr.*resolved daemon script|spawn_daemon_inner/i`
- 8  daemonJob assign pid — `/job_object.*assign|daemon.*pid=\d+.*assigned/i`
- 9  daemon handshake ok — `/\"ready\"\s*:\s*true|handshake ok port=|daemon-ready/i`
- 10 tunnel ws connected — `/tunnel.*ws.*(connected|open)|tunnel-do.*upgrade/i`

Five `[ccsm spa]` console.log sites in `packages/frontend-web/src/main.tsx`:
- pre-fetch `/token` (logs daemonBase or window.location.origin)
- `/token` response status + duration (via tracingFetch wrapper)
- token resolved tokenLen= (or `console.error` fallback when null)
- ws connecting `<wsBase><wsPath>` after token persisted

SPA console forwarder in `packages/smoke/tests/s3-happy-path.spec.ts`:
```ts
test.beforeEach(async ({ page }) => {
  page.on('console', m => process.stderr.write(`[smoke spa console.${m.type()}] ${m.text()}\n`));
  page.on('pageerror', e => process.stderr.write(`[smoke spa pageerror] ${e.message}\n${e.stack ?? ''}\n`));
  page.on('requestfailed', r => process.stderr.write(`[smoke spa requestfailed] ${r.url()} -> ${r.failure()?.errorText}\n`));
});
```

Verifying the live stage-marker stream against an actual smoke run is left to a manager-driven verify-only follow-up task per the task spec (no parallel smoke allowed in this pool today).

## Test plan
- [ ] Manager dispatches a verify-only task in a free pool to capture real stage marker output and confirm ordering.
- [ ] Optional: confirm a deliberate red (e.g. kill cf-worker pre-stage-3) produces a `FAILED in Xms` line at the right stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)