### PR TITLE
feat(smoke): R-15 — waitForHttpStable per-attempt log + cf-worker /health (Task #37)

### DIFF
--- a/packages/cf-worker/src/index.ts
+++ b/packages/cf-worker/src/index.ts
@@ -10,6 +10,18 @@ export default {
     const isUpgrade =
       req.headers.get('Upgrade')?.toLowerCase() === 'websocket';
 
+    // R-15 (Task #37) — liveness probe for smoke orchestrator stage 1.
+    // wrangler dev's bare `GET /` is routed into TunnelDO via the catch-all
+    // below (well, used to be — now 404), and during cold-start workerd may
+    // hold the connection open without flushing headers (UND_ERR_HEADERS_TIMEOUT).
+    // `/health` is a static synchronous Response that touches no DO / KV /
+    // binding, so it returns headers as soon as the worker module is parsed.
+    // The smoke probe targets this path so a stuck DO does not masquerade as
+    // a stuck listener.
+    if (url.pathname === '/health') {
+      return new Response('ok\n', { status: 200 });
+    }
+
     if (
       (url.pathname === '/ws/default' || url.pathname === '/tunnel/default') &&
       isUpgrade

--- a/packages/cf-worker/test/health.test.ts
+++ b/packages/cf-worker/test/health.test.ts
@@ -1,0 +1,44 @@
+// R-15 (Task #37) — `/health` is a binding-free liveness probe used by the
+// smoke orchestrator's stage 1 stable-readiness check. dev-36 verify saw
+// `UND_ERR_HEADERS_TIMEOUT` on bare `GET /` because `/` was routed into
+// TunnelDO and workerd did not flush headers during cold-start. `/health`
+// must short-circuit before any DO touch and return a static 200 / 'ok\n'.
+//
+// We import the worker's default export and call `.fetch(req, env)` directly
+// with a stub `env` whose TUNNEL access throws — that proves /health does
+// not look at the binding (regression guard against someone reordering the
+// branches).
+import { describe, it, expect } from 'vitest';
+import worker from '../src/index';
+
+function envThatExplodesOnTunnelAccess(): { TUNNEL: DurableObjectNamespace } {
+  return new Proxy({} as { TUNNEL: DurableObjectNamespace }, {
+    get(_t, prop) {
+      if (prop === 'TUNNEL') {
+        throw new Error('regression: /health must not touch env.TUNNEL');
+      }
+      return undefined;
+    },
+  });
+}
+
+describe('cf-worker /health', () => {
+  it('returns 200 ok without touching any binding', async () => {
+    const res = await worker.fetch(
+      new Request('http://127.0.0.1:8787/health'),
+      envThatExplodesOnTunnelAccess(),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ok\n');
+  });
+
+  it('still 404s for unknown paths (does not become a permissive proxy)', async () => {
+    // Intentionally pass a real-ish env where TUNNEL access does NOT throw,
+    // so we hit the existing 404 branch without false positives.
+    const res = await worker.fetch(
+      new Request('http://127.0.0.1:8787/totally-unknown'),
+      { TUNNEL: undefined as unknown as DurableObjectNamespace },
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/smoke/fixtures/orchestrator.ts
+++ b/packages/smoke/fixtures/orchestrator.ts
@@ -229,9 +229,12 @@ async function globalSetupInner(): Promise<void> {
   await runStage(1, 'cf-worker spawn ready', async () => {
     await worker.ready;
     // R-14 — stdout "Ready on http" only means the listener bound; wrangler
-    // may still reparse + reload. Probe `/` (workerd default returns 404 for
-    // unrouted root) until 3000ms of consecutive 200..499.
-    await waitForHttpStable(`http://127.0.0.1:${WORKER_PORT}/`, {
+    // may still reparse + reload. Probe `/health` (static 200, no DO touch —
+    // R-15 / Task #37) until 3000ms of consecutive 200..499. Targeting
+    // `/health` not `/` because dev-36 verify saw UND_ERR_HEADERS_TIMEOUT on
+    // bare GET / when workerd cold-started — TunnelDO routing held the
+    // connection without flushing headers.
+    await waitForHttpStable(`http://127.0.0.1:${WORKER_PORT}/health`, {
       stableForMs: 3000,
       timeout: 60_000,
     });

--- a/packages/smoke/fixtures/wait-http-stable.ts
+++ b/packages/smoke/fixtures/wait-http-stable.ts
@@ -19,6 +19,16 @@
 // poll cadence is a tradeoff: short enough that a 3000ms stable window means
 // at least 15 consecutive successful probes (a 1-2 reload bounce is not
 // silently absorbed); long enough that wrangler does not get hammered.
+//
+// R-15 (Task #37) — observability layer. dev-36 verify exposed a stage 1
+// 60s timeout with `lastStatus=null lastErrno=UND_ERR_HEADERS_TIMEOUT`: TCP
+// accept passed, but GET / never returned headers. The previous helper only
+// logged on timeout, so we could not tell whether (a) wrangler cold-started
+// and the first probe never got headers, (b) every probe stuck the same
+// way, or (c) headers arrived and stalled mid-body. We now emit a one-shot
+// `start` line and a per-attempt line **only when (status, errno) changes**
+// — naive per-poll logging would emit ~300 lines per 60s stage and bury
+// signal. Timeout summary still prints the final state for grep-ability.
 
 export interface WaitForHttpStableOptions {
   /** Total budget before the helper rejects, ms. */
@@ -38,6 +48,13 @@ export interface WaitForHttpStableOptions {
    */
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
+  /**
+   * R-15 (Task #37) — sink for per-attempt observability. Defaults to
+   * process.stderr.write so smoke logs fingerprint a stuck wrangler probe
+   * (UND_ERR_HEADERS_TIMEOUT, ECONNREFUSED, …) without flipping behavior.
+   * Tests inject a spy to assert the change-only log cadence.
+   */
+  log?: (line: string) => void;
 }
 
 const DEFAULT_POLL_MS = 200;
@@ -79,6 +96,7 @@ export async function waitForHttpStable(
   const now = opts.now ?? Date.now;
   const sleep = opts.sleep ?? ((ms) => new Promise<void>((r) => setTimeout(r, ms)));
   const pollIntervalMs = opts.pollIntervalMs ?? DEFAULT_POLL_MS;
+  const log = opts.log ?? ((line) => process.stderr.write(line));
 
   if (typeof fetchImpl !== 'function') {
     throw new Error('waitForHttpStable: no fetch implementation available');
@@ -89,11 +107,29 @@ export async function waitForHttpStable(
   let stableSince: number | null = null;
   let lastStatus: number | null = null;
   let lastErrno: string | null = null;
+  // R-15 (Task #37) — change-only attempt logging. With pollIntervalMs=200
+  // and timeout=60_000, naive per-attempt logging would emit 300 lines per
+  // stage; we only emit when (status, errno) transitions, plus the first
+  // attempt and the timeout summary. This is enough to fingerprint
+  // UND_ERR_HEADERS_TIMEOUT vs ECONNREFUSED vs partial-headers-then-stuck
+  // without burying real signal under poll noise.
+  let attempt = 0;
+  let prevKey: string | null = null;
+  log(`[wait-http-stable ${url}] start poll=${pollIntervalMs}ms stableForMs=${opts.stableForMs} timeout=${opts.timeout}\n`);
 
   while (now() < deadline) {
     const outcome = await probeOnce(url, fetchImpl);
     lastStatus = outcome.status;
     lastErrno = outcome.errno;
+    attempt += 1;
+    const key = `${outcome.status ?? 'null'}|${outcome.errno ?? 'null'}`;
+    if (prevKey === null || prevKey !== key) {
+      log(
+        `[wait-http-stable ${url}] attempt=${attempt} elapsed=${now() - start}ms ` +
+        `status=${outcome.status ?? 'null'} errno=${outcome.errno ?? 'null'}\n`,
+      );
+      prevKey = key;
+    }
 
     if (outcome.ok) {
       const t = now();
@@ -106,8 +142,9 @@ export async function waitForHttpStable(
     await sleep(pollIntervalMs);
   }
 
-  throw new Error(
+  const summary =
     `waitForHttpStable(${url}) timed out after ${opts.timeout}ms ` +
-    `(stableForMs=${opts.stableForMs}, lastStatus=${lastStatus ?? 'null'}, lastErrno=${lastErrno ?? 'null'})`,
-  );
+    `(stableForMs=${opts.stableForMs}, lastStatus=${lastStatus ?? 'null'}, lastErrno=${lastErrno ?? 'null'})`;
+  log(`[wait-http-stable ${url}] timeout attempts=${attempt} ${summary}\n`);
+  throw new Error(summary);
 }

--- a/packages/smoke/test/wait-http-stable.test.ts
+++ b/packages/smoke/test/wait-http-stable.test.ts
@@ -193,4 +193,66 @@ describe('waitForHttpStable', () => {
     await tickUntilSettled(promise, clock);
     // Resolves after the run of 200s past the 502 reset.
   });
+
+  // R-15 (Task #37) — change-only attempt logging. dev-36 verify exposed a
+  // 60s stage 1 timeout with `lastErrno=UND_ERR_HEADERS_TIMEOUT`; the only
+  // way to tell whether all 300 probes stuck the same way vs intermittent
+  // recovery is per-attempt observability. But naive per-poll logging would
+  // bury signal under 300 noise lines per stage. Verify the helper logs
+  // start + first attempt + each (status, errno) transition only.
+  it('logs start + only on (status, errno) transition', async () => {
+    // 7 fake outcomes: null, null, 200, 200, 200, 500, 500.
+    // Expect log calls: start + null(first) + 200(transition) + 500(transition) = 4.
+    const clock = makeClock();
+    const seq: ProbeResult[] = [
+      { kind: 'reset' },             // null/ECONNRESET, attempt=1 (first → log)
+      { kind: 'reset' },             // null/ECONNRESET, attempt=2 (no change)
+      { kind: 'ok', status: 200 },   // 200/null,        attempt=3 (transition → log)
+      { kind: 'ok', status: 200 },   // attempt=4
+      { kind: 'ok', status: 200 },   // attempt=5
+      { kind: 'ok', status: 500 },   // 500/null,        attempt=6 (transition → log)
+      { kind: 'ok', status: 500 },   // attempt=7
+    ];
+    const { fetchImpl } = makeFetch(seq);
+    const lines: string[] = [];
+    const log = (line: string): void => { lines.push(line); };
+
+    const promise = waitForHttpStable('http://127.0.0.1:1/health', {
+      timeout: 2_000,
+      stableForMs: 5_000, // never resolves; we want the timeout summary path
+      pollIntervalMs: 200,
+      fetchImpl,
+      now: clock.now,
+      sleep: clock.sleep,
+      log,
+    });
+
+    let err: unknown;
+    promise.catch((e) => { err = e; });
+    // Drive 7 probes (t=0..1400ms) — well under the 2000ms timeout.
+    for (let i = 0; i < 7; i++) {
+      await Promise.resolve(); await Promise.resolve();
+      clock.advance(200);
+    }
+    // Then drive past timeout to flush summary.
+    for (let i = 0; i < 10 && err === undefined; i++) {
+      await Promise.resolve(); await Promise.resolve();
+      clock.advance(200);
+    }
+    expect(err).toBeDefined();
+
+    // Filter out the timeout summary so we can count the body lines exactly.
+    const startLines = lines.filter((l) => l.includes('start poll='));
+    const attemptLines = lines.filter((l) => l.includes('] attempt='));
+    const timeoutLines = lines.filter((l) => l.includes('] timeout '));
+
+    expect(startLines).toHaveLength(1);
+    // 3 attempt transitions: null(first), 200(transition), 500(transition).
+    // NOT 7 — the 4 repeats of identical (status,errno) must not log.
+    expect(attemptLines).toHaveLength(3);
+    expect(attemptLines[0]).toMatch(/attempt=1 .*status=null errno=ECONNRESET/);
+    expect(attemptLines[1]).toMatch(/attempt=3 .*status=200 errno=null/);
+    expect(attemptLines[2]).toMatch(/attempt=6 .*status=500 errno=null/);
+    expect(timeoutLines).toHaveLength(1);
+  });
 });


### PR DESCRIPTION
## Background

dev-36 R-14 verify exposed a new red: stage 1 cf-worker
`waitForHttpStable(http://127.0.0.1:8787/)` 60s timeout, `lastStatus=null
lastErrno=UND_ERR_HEADERS_TIMEOUT`. TCP accept landed but `GET /` never
returned headers. Three indistinguishable candidates from existing logs:
(a) TUNNEL DO not responding to bare `GET /`, (b) wrangler cold-start, (c)
undici keep-alive half-dead socket / IPv6.

R-15 = observability + binding-free probe URL, **no behavior fix, no
retry/sleep glue** (memory `feedback_log_until_certain.md`,
`feedback_fix_arch_not_glue.md`).

## Changes

1. **`waitForHttpStable` per-attempt logging**
   (`packages/smoke/fixtures/wait-http-stable.ts`)
   - One-shot `[wait-http-stable <url>] start poll=200ms stableForMs=3000 timeout=60000` line
   - Per-attempt line `attempt=N elapsed=Xms status=<n|null> errno=<str|null>`
     **only when (status, errno) transitions**, plus first attempt and
     timeout summary. Naive per-poll logging would emit ~300 lines per 60s
     stage.
   - New `log` option for test injection; defaults to `process.stderr.write`.
   - API otherwise unchanged.

2. **cf-worker `/health` route** (`packages/cf-worker/src/index.ts`)
   - Returns static `new Response('ok\n', { status: 200 })`.
   - Branch sits **before** any DO/KV/binding access — proven by a Proxy
     env that throws on `TUNNEL` access.

3. **orchestrator stage 1 URL** (`packages/smoke/fixtures/orchestrator.ts`)
   - `http://127.0.0.1:8787/` → `http://127.0.0.1:8787/health`.
   - Stage 3 (pages-dev) untouched — still hits SPA `index.html` at `/`.

4. **stderr/stdout forward audit**
   - `spawnProc` (orchestrator.ts:86-95) already attaches the same `watch`
     closure to both `child.stdout` and `child.stderr`. Confirmed — no
     change needed.

## URL grep

```
$ git grep -n 'waitForHttpStable.*8787' packages/smoke
packages/smoke/fixtures/orchestrator.ts:    await waitForHttpStable(`http://127.0.0.1:${WORKER_PORT}/health`, {
```

## Local checks (host: Windows 11, mode: fast)

- lint: smoke OK / cf-worker OK
- typecheck: smoke OK / cf-worker OK (`pnpm -w typecheck` other pre-existing
  red in `@ccsm/ui` unrelated to this PR)
- unit tests:
  - `packages/smoke` `npx vitest run test/wait-http-stable.test.ts` →
    **6 passed** (incl. new R-15 logging test)
  - `packages/cf-worker` `npx vitest run` → **26 passed** (incl. 2 new
    `health.test.ts` cases)
- e2e: skipped (smoke not run locally per memory
  `project_smoke_windows_zombie_lock_2026_05_08.md`)

## Reverse-verify (R-15 logging test)

Stash the fix in `wait-http-stable.ts` → run new R-15 test → FAIL:
```
AssertionError: expected [] to have a length of 1 but got +0
  ❯ test/wait-http-stable.test.ts:249:24
   247|     const timeoutLines = lines.filter((l) => l.includes('] timeout '));
   249|     expect(startLines).toHaveLength(1);
Test Files  1 failed (1)
     Tests  1 failed | 5 passed (6)
```

Re-apply patch → run test → PASS:
```
✓ test/wait-http-stable.test.ts (6 tests) 8ms
Test Files  1 passed (1)
     Tests  6 passed (6)
```

## Reverse-verify (/health route)

cf-worker `/health` test exists alongside the route in the same PR; with
the route absent the new `health.test.ts` would 404 the GET (`Not Found`
fallback) and fail `expect(res.status).toBe(200)`. Audit-only equivalent
since adding/removing a route is a single-line atomic change.

## Out of scope (not done, by design)

- Not "fixing" `UND_ERR_HEADERS_TIMEOUT` — root cause unknown, observability
  first per memory `feedback_log_until_certain.md`.
- No retry / sleep / keep-alive disable (Layer 4 glue).
- No local `pnpm smoke` run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)