### PR TITLE
fix(ui): R-16 — move session-list testid to stable wrapper (Task #41)

### DIFF
--- a/packages/ui/src/components/Sidebar.tsx
+++ b/packages/ui/src/components/Sidebar.tsx
@@ -308,12 +308,22 @@ export function Sidebar() {
 
         <div className="sidebar__group" data-testid="sidebar-group-default">
           <div className="sidebar__group-header">{'▾'} default</div>
+          {/*
+            Task #41 / R-16: data-testid="session-list" must live on a stable
+            wrapper that exists in BOTH empty and populated states. R-12
+            originally put it on the <ul>, but that <ul> is only rendered when
+            sessions.length > 0, so the smoke spec (s3-happy-path) — which
+            asserts session-list visible BEFORE creating a session — timed out
+            on a perfectly healthy SPA. Moving the testid onto this wrapper
+            <div> decouples the test contract from the empty/populated branch.
+          */}
+          <div className="sidebar__group-body" data-testid="session-list">
           {sessions.length === 0 ? (
             <div className="sidebar__groups-empty">
               No sessions yet — click + New Session above
             </div>
           ) : (
-            <ul className="sidebar__session-list" data-testid="session-list">
+            <ul className="sidebar__session-list">
               {sessions.map((s) => {
                 const isActive = s.sid === activeSid;
                 return (
@@ -364,6 +374,7 @@ export function Sidebar() {
               })}
             </ul>
           )}
+          </div>
         </div>
       </div>
 

--- a/packages/ui/test/Sidebar.test.tsx
+++ b/packages/ui/test/Sidebar.test.tsx
@@ -173,11 +173,13 @@ describe('Sidebar', () => {
     }
   });
 
-  // Task #28 / R-12: smoke spec (s3-happy-path) probes data-testid="session-list"
-  // on the sessions <ul>. Missing this testid is what made dev-27's smoke run
-  // time out at getByTestId('session-list') even though the sidebar rendered
-  // correctly. Lock the contract so this can't regress silently.
-  it('exposes data-testid="session-list" on the sessions <ul> (smoke contract)', () => {
+  // Task #28 / R-12 / R-16: smoke spec (s3-happy-path) probes
+  // data-testid="session-list" BEFORE creating any session, so the testid
+  // must live on a stable wrapper that exists in BOTH empty and populated
+  // states. R-12 originally put the testid on the <ul>, which only renders
+  // when sessions.length > 0 — that broke smoke (Task #41 root cause).
+  // Lock the contract so this can't regress silently.
+  it('exposes data-testid="session-list" on a stable wrapper when sessions are populated', () => {
     useStore.setState({
       sessions: [
         { sid: 'aaaa1111', createdAt: 0, alive: true },
@@ -185,9 +187,19 @@ describe('Sidebar', () => {
       activeSid: 'aaaa1111',
     });
     render(<Sidebar />);
-    const list = screen.getByTestId('session-list');
-    expect(list).toBeDefined();
-    expect(list.tagName).toBe('UL');
+    const wrapper = screen.getByTestId('session-list');
+    expect(wrapper).toBeDefined();
+    // The <ul> with the actual session rows must be inside the wrapper.
+    expect(wrapper.querySelector('ul.sidebar__session-list')).not.toBeNull();
+  });
+
+  it('exposes data-testid="session-list" even when sessions is empty (R-16 contract)', () => {
+    // Default store state has sessions=[] — must still find the testid.
+    render(<Sidebar />);
+    const wrapper = screen.getByTestId('session-list');
+    expect(wrapper).toBeDefined();
+    // Empty-state hint lives inside the wrapper.
+    expect(wrapper.textContent).toMatch(/No sessions yet/);
   });
 
   it('shows the empty-state hint inside the GROUPS zone when sessions is empty', () => {


### PR DESCRIPTION
## Background (research-40 lock)

Smoke run at R-15 timed out on `s3-happy-path.spec.ts:35`: `getByTestId('session-list')` waited 30s. research-40 confirmed:

- SPA + token + ws + daemon all healthy.
- Page snapshot shows the sidebar rendering `No sessions yet — click + New Session above` empty-state.
- Root cause: R-12 put `data-testid=\"session-list\"` on the `<ul>` at `Sidebar.tsx:316`, but that `<ul>` only renders inside the `sessions.length > 0` branch. Empty-state takes the other branch (just a `<div class=\"sidebar__groups-empty\">`), so the testid never exists pre-session-creation.
- Smoke spec is correct to assert visibility BEFORE creating any session — that is the intended contract for a stable container.

## What changed

**Layer 4 (test contract) fix at the architectural layer, not glue:**

`packages/ui/src/components/Sidebar.tsx` — wrap both branches of the empty/populated render in a new stable container `<div class=\"sidebar__group-body\" data-testid=\"session-list\">`. The testid now identifies the container that holds either the empty hint or the `<ul>`, so it exists in both states.

```tsx
<div className=\"sidebar__group-body\" data-testid=\"session-list\">
  {sessions.length === 0 ? (
    <div className=\"sidebar__groups-empty\">No sessions yet — ...</div>
  ) : (
    <ul className=\"sidebar__session-list\">...</ul>
  )}
</div>
```

`packages/ui/test/Sidebar.test.tsx` — split R-12's single lock test into two:
1. Populated state: wrapper exists and contains a `<ul.sidebar__session-list>`.
2. **Empty state (new R-16 lock)**: wrapper exists and contains the empty-state hint text. This is the regression guard for Task #41.

## Why testid must be decoupled from the conditional branch

A test contract `getByTestId('session-list')` should mean \"the session list container is present\", not \"there is at least one session\". Coupling testid to a state-conditional `<ul>` gives a false signal: \"sidebar is broken\" when really \"sidebar is healthy and just empty\". The fix makes the testid a true container contract — same intent, but now state-independent.

## Reverse-verify

- Revert `Sidebar.tsx` back to the testid on `<ul>` while keeping the new empty-state unit test → empty-state assertion FAILS (wrapper not found).
- Apply the wrapper fix → both populated and empty tests PASS.

(Verified by inspecting that the new empty-state test specifically queries for the wrapper, which only exists in the patched code.)

## Local checks (host: Windows 11, mode: fast)

- lint: not run (test/source-only change, no lint-rule-affecting code)
- typecheck: ok (`pnpm --filter @ccsm/ui typecheck` exit 0 after `pnpm --filter @ccsm/core build`)
- unit tests: ok (`pnpm --filter @ccsm/ui test` — 5 files / 36 tests passed; Sidebar.test.tsx 17 tests including the two new lock tests)
- e2e: skipped, change is UI-test-contract only; smoke (the relevant e2e) is intentionally NOT run locally per Task #41 spec (host smoke-zombie deadlock policy). CI three-platform matrix will exercise it.

## Out of scope

- Did not touch smoke selector (smoke contract is the authority).
- No retry / sleep / timeout workarounds.
- No daemon / ws / token / cf-worker changes.