### PR TITLE
feat(observability): R-17 — 12 ws diagnostic logs to lock candidate G (Task #45)

### DIFF
--- a/packages/cf-worker/src/index.ts
+++ b/packages/cf-worker/src/index.ts
@@ -31,6 +31,8 @@ export default {
       // Multi-tunnel routing (per-user / per-pairing-id) is future work.
       const id = env.TUNNEL.idFromName('default');
       const stub = env.TUNNEL.get(id);
+      // R-17 log #12 (Task #45): record ws-route entry into the DO stub.
+      console.log('[worker] route ' + url.pathname + ' upgrade=' + isUpgrade);
       // Task #782 (S3-T6): forward the full request (incl.
       // `Sec-WebSocket-Protocol` if the browser sent one) to the DO. The DO
       // is responsible for echoing the protocol back on the 101 response so
@@ -45,6 +47,8 @@ export default {
     if (url.pathname.startsWith('/api/') || url.pathname === '/token') {
       const id = env.TUNNEL.idFromName('default');
       const stub = env.TUNNEL.get(id);
+      // R-17 log #12 (Task #45): record HTTP-mux route entry into the DO stub.
+      console.log('[worker] route ' + url.pathname + ' upgrade=' + isUpgrade);
       return stub.fetch(req);
     }
 

--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -239,6 +239,8 @@ export class TunnelDO extends DurableObject<Env> {
       const attachment: DaemonAttachment = { role: 'daemon' };
       this.state.acceptWebSocket(server, [TAG_DAEMON]);
       server.serializeAttachment(attachment);
+      // R-17 log #1 (Task #45): daemon ws accepted into hibernation pool.
+      console.log('[do] daemon ws accepted');
       return new Response(null, { status: 101, webSocket: client });
     }
 
@@ -287,11 +289,17 @@ export class TunnelDO extends DurableObject<Env> {
       const attachment: BrowserAttachment = { role: 'browser', token: extracted.token };
       this.state.acceptWebSocket(server, [TAG_BROWSER]);
       server.serializeAttachment(attachment);
+      // R-17 log #2 (Task #45): browser ws accepted, about to emit hello.
+      console.log('[do] browser ws accepted sid=' + sid + ' token=' + extracted.token.slice(0, 6));
 
       // Emit hello as the first daemon-bound frame after this browser pair.
       try {
         daemon.send(buildHelloFrame(extracted.token, sid, lastSeq));
-      } catch {
+        // R-17 log #3 (Task #45): hello successfully sent to daemon.
+        console.log('[do] hello sent to daemon');
+      } catch (err) {
+        // R-17 log #3 (Task #45): hello send threw — daemon ws likely just dropped.
+        console.log('[do] hello send failed: ' + String(err));
         /* daemon may have just dropped; cleanup happens via webSocketClose */
       }
       // Echo the chosen subprotocol on the 101 response so the browser
@@ -329,6 +337,8 @@ export class TunnelDO extends DurableObject<Env> {
 
   override webSocketClose(ws: WebSocket, _code: number, _reason: string, _wasClean: boolean): void {
     const att = ws.deserializeAttachment() as SocketAttachment | null;
+    // R-17 log #4 (Task #45): record close code/reason/wasClean for both roles.
+    console.log('[do] ws close role=' + att?.role + ' code=' + _code + ' reason=' + _reason + ' wasClean=' + _wasClean);
     if (att === null) return;
     if (att.role === 'daemon') {
       this.handleDaemonClose();
@@ -339,6 +349,8 @@ export class TunnelDO extends DurableObject<Env> {
 
   override webSocketError(ws: WebSocket, _err: unknown): void {
     const att = ws.deserializeAttachment() as SocketAttachment | null;
+    // R-17 log #5 (Task #45): record ws-level error for both roles.
+    console.error('[do] ws error role=' + att?.role + ' err=' + String(_err));
     if (att === null) return;
     if (att.role === 'daemon') {
       this.handleDaemonError();
@@ -347,6 +359,9 @@ export class TunnelDO extends DurableObject<Env> {
   }
 
   private handleDaemonMessage(data: string | ArrayBuffer): void {
+    // R-17 log #6 (Task #45): direction + length for every daemon→browser frame.
+    const len = typeof data === 'string' ? data.length : data.byteLength;
+    console.log('[do] msg dir=daemon->browser len=' + len);
     if (typeof data === 'string') {
       const ctrl = tryParseControlFrame(data);
       if (ctrl !== null) {
@@ -361,6 +376,9 @@ export class TunnelDO extends DurableObject<Env> {
   }
 
   private handleBrowserMessage(data: string | ArrayBuffer): void {
+    // R-17 log #6 (Task #45): direction + length for every browser→daemon frame.
+    const len = typeof data === 'string' ? data.length : data.byteLength;
+    console.log('[do] msg dir=browser->daemon len=' + len);
     const daemon = this.getDaemonSocket();
     if (daemon !== undefined) {
       try { daemon.send(data); } catch { /* daemon may have just dropped */ }

--- a/packages/core/src/ws/client.ts
+++ b/packages/core/src/ws/client.ts
@@ -160,6 +160,8 @@ export class WsClient {
     this.setStatus('connecting');
 
     ws.onopen = () => {
+      // R-17 log #11 (Task #45): SPA-side ws open marker.
+      console.log('[ccsm spa] ws open code=- reason=-');
       this.setStatus('attached');
       if (this.pendingResize) {
         const { cols, rows } = this.pendingResize;
@@ -171,12 +173,19 @@ export class WsClient {
       this.handleMessage(ev.data);
     };
     ws.onerror = () => {
+      // R-17 log #11 (Task #45): SPA-side ws error marker. Browsers don't
+      // expose detail on ws.onerror, so the fields are placeholders to keep
+      // the grep shape stable across open/close/error.
+      console.log('[ccsm spa] ws error code=- reason=-');
       // Browser ws errors don't expose detail; surface a generic reason.
       if (!this.exitSeen) {
         this.opts.onDisconnect?.('ws error');
       }
     };
-    ws.onclose = () => {
+    ws.onclose = (ev: CloseEvent) => {
+      // R-17 log #11 (Task #45): SPA-side ws close — code + reason are the
+      // smoking gun for "Network connection lost" (research-44 candidate G).
+      console.log('[ccsm spa] ws close code=' + ev.code + ' reason=' + ev.reason);
       // EXIT path already transitioned status; don't clobber it.
       if (!this.exitSeen) {
         this.setStatus('disconnected');

--- a/packages/daemon/src/index.mts
+++ b/packages/daemon/src/index.mts
@@ -164,6 +164,10 @@ async function main(): Promise<void> {
       // + INPUT/RESIZE forwarding for the rest of this connection; we tear
       // it down via the returned handle when the tunnel ws drops.
       onBrowserAttach: ({ sid, lastSeq, send }) => {
+        // R-17 log #10 (Task #45): record browser-attach entry pre-routing so
+        // we can diff against tunnel.mts log #8 (hello received) and the DO
+        // log #2 (browser ws accepted) on the cloud side.
+        console.error('[ccsm] tunnel: browser attach sid=' + sid + ' lastSeq=' + lastSeq);
         const router = attachFrameRouter({
           sid,
           lastSeq,

--- a/packages/daemon/src/tunnel.mts
+++ b/packages/daemon/src/tunnel.mts
@@ -304,6 +304,10 @@ export class TunnelClient {
     }
     this.ws = socket;
 
+    // R-17 log #9 (Task #45): per-connection inbound frame counter. Reset on
+    // every dial() so the close log reports frames-since-open for THIS link.
+    let frameCount = 0;
+
     socket.on('open', () => {
       if (this.stopped) {
         try { socket.close(1000, 'stopped'); } catch { /* ignore */ }
@@ -314,6 +318,8 @@ export class TunnelClient {
     });
 
     socket.on('message', (raw, isBinary) => {
+      // R-17 log #9 (Task #45): tally every inbound frame for the close log.
+      frameCount += 1;
       // Hello-gate (Task #782): a browser-paired daemon expects the FIRST
       // text frame to be `{type:"hello",token}` so the daemon can authorize
       // browser-bound raw OUTPUT/INPUT passthrough. Binary or non-JSON text
@@ -354,6 +360,8 @@ export class TunnelClient {
         }
         this.helloSeen = true;
         this.browserToken = hello.token;
+        // R-17 log #8 (Task #45): hello received, record sid + lastSeq.
+        console.error('[ccsm] tunnel: hello received sid=' + (hello.sid ?? '-') + ' lastSeq=' + (hello.lastSeq ?? 0));
         // Task #793 (S3-G): if the browser supplied a sid in hello, hand the
         // pairing off to the daemon main so it can wire this tunnel into the
         // matching per-session PTY ring. The handle owns frame routing for
@@ -442,6 +450,9 @@ export class TunnelClient {
         return;
       }
       console.warn(`[ccsm/tunnel] closed code=${code}, will reconnect`);
+      // R-17 log #9 (Task #45): emit frames-since-open so we can tell whether
+      // the link drained any traffic before closing (research-44 candidate G).
+      console.error('[ccsm] tunnel: ws close frameCount=' + frameCount + ' code=' + code);
       this.scheduleReconnect();
     });
   }

--- a/packages/frontend-web/functions/[[path]].ts
+++ b/packages/frontend-web/functions/[[path]].ts
@@ -55,7 +55,14 @@ export const onRequest: PagesFunction<Env> = async (ctx) => {
     url.pathname === '/token' ||
     url.pathname.startsWith('/api/')
   ) {
-    return ctx.env.TUNNEL_WORKER.fetch(ctx.request);
+    // R-17 log #7 (Task #45): proxy entry — pathname + upgrade hint.
+    const upgrade = ctx.request.headers.get('Upgrade') ?? '';
+    console.log('[pages-fn] proxy ' + url.pathname + ' upgrade=' + upgrade);
+    const resp = await ctx.env.TUNNEL_WORKER.fetch(ctx.request);
+    // R-17 log #7 (Task #45): proxy response — status (and upgrade resp header
+    // if the worker promoted to ws so we can spot 101 vs 426/404 quickly).
+    console.log('[pages-fn] proxy resp status=' + resp.status + ' upgrade=' + (resp.headers.get('Upgrade') ?? ''));
+    return resp;
   }
 
   // R-14 — SPA history-mode fallback. If the request is a GET for a route


### PR DESCRIPTION
## Summary

Pure observability PR. Adds 12 log statements across the cloud-tunnel ws path so we can lock research-44's **candidate G**: \"wrangler pages dev's two workerd processes service-binding ws pipe drops immediately after the 101 with 'Network connection lost' (string not in our code, Grep 0 hits).\"

No control flow / routing / reconnect / timeout / retry change.

## Why log not fix

Research-44 disprove'd A/B/C/D/E/F and landed on G as \"closest of A, reframed\" — not 100% locked. The real fix for G touches the wrangler pages-dev two-workerd service-binding topology (R-18 candidate, large architecture change). Per the \"log until certain, don't guess-fix\" rule (memory: feedback_log_until_certain.md), we diagnose first, then fix at the right architecture layer. Adding logs is observability, not glue (memory: feedback_fix_arch_not_glue.md — retry / sleep / skip / tmpdir is glue; logs are not).

## 12 logs (per research-44)

1. `cf-worker/src/tunnel-do.ts` — daemon ws accepted
2. `cf-worker/src/tunnel-do.ts` — browser ws accepted (sid + token prefix)
3. `cf-worker/src/tunnel-do.ts` — hello sent / send-failed (try + catch branches)
4. `cf-worker/src/tunnel-do.ts` — `webSocketClose` role / code / reason / wasClean
5. `cf-worker/src/tunnel-do.ts` — `webSocketError` role / err
6. `cf-worker/src/tunnel-do.ts` — `handleDaemonMessage` / `handleBrowserMessage` dir + len
7. `frontend-web/functions/[[path]].ts` — pages-fn proxy entry (pathname + upgrade) + exit (status + upgrade resp)
8. `daemon/src/tunnel.mts` — hello received sid + lastSeq
9. `daemon/src/tunnel.mts` — per-connection `frameCount` (incremented on every inbound message, dumped in close handler) — answers \"did the link drain ANY traffic before dying?\"
10. `daemon/src/index.mts` — `onBrowserAttach` sid + lastSeq pre-routing
11. `core/src/ws/client.ts` — spa ws open / close / error with code + reason (`ev.code` / `ev.reason` from `CloseEvent`)
12. `cf-worker/src/index.ts` — worker route entry pathname + upgrade

## Local checks (host: Windows, mode: fast)

- lint: skipped (no .ts logic change beyond log statements; typecheck covers shape)
- typecheck:
  - `pnpm --filter @ccsm/cf-worker typecheck`: ✓ (exit 0)
  - `pnpm --filter @ccsm/daemon typecheck`: ✓ (exit 0)
  - `pnpm --filter @ccsm/frontend-web typecheck`: ✓ (exit 0)
  - `pnpm --filter @ccsm/core typecheck`: ✓ (exit 0)
- unit tests: `pnpm --filter @ccsm/cf-worker test` → 26 passed (2 files), 2.05s
- e2e: skipped (per task spec — no local smoke; CI / next R-18 will exercise)

## Forbidden actions taken: none

- No control flow / routing / reconnect / timeout change
- No retry / sleep / keep-alive
- No wrangler config / pages-dev topology change (deferred to R-18)
- No local smoke run (per spec)

🤖 Generated with [Claude Code](https://claude.com/claude-code)