### PR TITLE
fix(spa-ws): R-18 — pass token via Sec-WebSocket-Protocol subprotocol (Task #48)

### DIFF
--- a/packages/core/src/ws/client.ts
+++ b/packages/core/src/ws/client.ts
@@ -19,6 +19,16 @@
 //   - PAUSE / RESUME backpressure (T11).
 //
 // We intentionally use the browser-native WebSocket; no third-party ws lib.
+//
+// Task #48 (R-18): browsers cannot set custom headers on `new WebSocket(...)`.
+// The cf-worker TunnelDO authenticates the upgrade by reading the bearer token
+// out of the `Sec-WebSocket-Protocol` request header (RFC 6455 §1.9). Without
+// it the DO closes the socket with code=1008 reason="missing token subprotocol"
+// — exactly the symptom observed across all 16 reconnect attempts in the R-17
+// /tmp/smoke-r17-verify.log capture. The contract (encoding `ccsm.<token>` in
+// the subprotocol list, server taking the first `ccsm.*` entry and echoing it
+// on the 101) is mirrored in `packages/cf-worker/src/tunnel-do.ts` and
+// `packages/frontend-web/src/hostConfig.ts` (WS_SUBPROTOCOL_PREFIX).
 
 import {
   FrameType,
@@ -28,6 +38,26 @@ import {
   encodeResize,
 } from '@ccsm/shared';
 import { API_PATHS } from '@ccsm/shared';
+
+/**
+ * Subprotocol prefix used to smuggle the daemon bearer token through the
+ * browser ws upgrade. Must stay in sync with cf-worker tunnel-do.ts and
+ * frontend-web hostConfig.ts (Task #782 / Task #48).
+ */
+export const WS_SUBPROTOCOL_PREFIX = 'ccsm.';
+
+/**
+ * Build the subprotocol array passed to `new WebSocket(url, protocols)`.
+ *
+ * Encoding: `['ccsm.<token>']`. Token charset is the daemon's hex/base64
+ * randombytes which is already RFC 6455 subprotocol-token safe (RFC 7230
+ * `tchar`), so no encoding step is needed. Returns `[]` for an empty token
+ * — the upstream DO will then close 1008 and the caller can surface that.
+ */
+export function buildWsSubprotocols(token: string): string[] {
+  if (token.length === 0) return [];
+  return [`${WS_SUBPROTOCOL_PREFIX}${token}`];
+}
 
 export type WsStatus =
   | 'idle'
@@ -154,7 +184,15 @@ export class WsClient {
       this.opts.lastSeq ?? 0,
       this.opts.hostBase,
     );
-    const ws = new Ctor(url);
+    // Task #48 (R-18): pass token in BOTH the URL query AND the
+    // Sec-WebSocket-Protocol subprotocol list. The loopback daemon
+    // (`packages/daemon/src/ws.mts`) reads the query param; the cf-worker
+    // TunnelDO reads the subprotocol header (browsers can't set arbitrary
+    // headers on `new WebSocket(...)`). Without the subprotocol the DO
+    // closes 1008 reason="missing token subprotocol" — see R-17 verify log
+    // /tmp/smoke-r17-verify.log (16x identical close).
+    const protocols = buildWsSubprotocols(this.opts.token);
+    const ws = protocols.length > 0 ? new Ctor(url, protocols) : new Ctor(url);
     ws.binaryType = 'arraybuffer';
     this.ws = ws;
     this.setStatus('connecting');

--- a/packages/core/test/session-runtime.test.ts
+++ b/packages/core/test/session-runtime.test.ts
@@ -51,7 +51,7 @@ class FakeWs {
   onopen: (() => void) | null = null;
   onmessage: ((ev: { data: unknown }) => void) | null = null;
   onerror: (() => void) | null = null;
-  onclose: (() => void) | null = null;
+  onclose: ((ev?: CloseEvent) => void) | null = null;
 
   constructor(public readonly url: string) {
     FakeWs.instances.push(this);
@@ -75,7 +75,7 @@ class FakeWs {
     if (this.readyState === FakeWs.CLOSED) return;
     this.closedByClient = true;
     this.readyState = FakeWs.CLOSED;
-    this.onclose?.();
+    this.onclose?.({ code: 1000, reason: '' } as CloseEvent);
   }
 
   // Test helpers
@@ -92,7 +92,9 @@ class FakeWs {
   serverClose(): void {
     if (this.readyState === FakeWs.CLOSED) return;
     this.readyState = FakeWs.CLOSED;
-    this.onclose?.();
+    // Pass a CloseEvent-shaped object so the R-17 close log (Task #45) can
+    // read `ev.code`/`ev.reason` without throwing.
+    this.onclose?.({ code: 1006, reason: '' } as CloseEvent);
   }
 }
 

--- a/packages/core/test/ws-client.test.ts
+++ b/packages/core/test/ws-client.test.ts
@@ -6,7 +6,7 @@ import {
   encodeExit,
   encodeFrame,
 } from '@ccsm/shared';
-import { WsClient, buildWsUrl, type HostBase } from '../src/ws/client.js';
+import { WsClient, buildWsUrl, buildWsSubprotocols, WS_SUBPROTOCOL_PREFIX, type HostBase } from '../src/ws/client.js';
 
 const HOST: HostBase = { httpBase: 'http://127.0.0.1:17832' };
 
@@ -24,9 +24,9 @@ class MockWs {
   onopen: (() => void) | null = null;
   onmessage: ((ev: { data: unknown }) => void) | null = null;
   onerror: (() => void) | null = null;
-  onclose: (() => void) | null = null;
+  onclose: ((ev?: CloseEvent) => void) | null = null;
 
-  constructor(public readonly url: string) {
+  constructor(public readonly url: string, public readonly protocols?: string | string[]) {
     MockWs.lastInstance = this;
   }
   static lastInstance: MockWs | null = null;
@@ -49,7 +49,7 @@ class MockWs {
   close(): void {
     this.closed = true;
     this.readyState = MockWs.CLOSED;
-    this.onclose?.();
+    this.onclose?.({ code: 1000, reason: '' } as CloseEvent);
   }
 
   // Test helpers
@@ -215,7 +215,7 @@ describe('WsClient', () => {
     client.connect();
     const ws = MockWs.lastInstance!;
     ws.open();
-    ws.onclose?.();
+    ws.onclose?.({ code: 1006, reason: '' } as CloseEvent);
     expect(onDisconnect).toHaveBeenCalledWith('ws closed');
     expect(client.getStatus()).toBe('disconnected');
   });
@@ -333,5 +333,74 @@ describe('WsClient', () => {
     const [data, seq] = onOutput.mock.calls[0]!;
     expect(new TextDecoder().decode(data as Uint8Array)).toBe('chunk');
     expect(seq).toBe(99);
+  });
+});
+
+// Task #48 (R-18): protocol contract — SPA must encode the bearer token in
+// the Sec-WebSocket-Protocol subprotocol list so the cf-worker TunnelDO can
+// authenticate the upgrade. Browsers can't set arbitrary headers on
+// `new WebSocket(...)`, so the second-argument `protocols` array is the only
+// transport. Server-side parser lives in
+// `packages/cf-worker/src/tunnel-do.ts` (extractBrowserToken). R-17 verify
+// log /tmp/smoke-r17-verify.log captured 16x close 1008 "missing token
+// subprotocol" because this contract was unimplemented on the SPA side.
+describe('buildWsSubprotocols (Task #48 protocol contract)', () => {
+  it('encodes the token as `ccsm.<token>` matching cf-worker tunnel-do', () => {
+    expect(buildWsSubprotocols('abc123')).toEqual(['ccsm.abc123']);
+  });
+
+  it('exports the prefix constant in sync with cf-worker / hostConfig', () => {
+    expect(WS_SUBPROTOCOL_PREFIX).toBe('ccsm.');
+  });
+
+  it('returns [] for an empty token (DO will close 1008 — caller surfaces it)', () => {
+    expect(buildWsSubprotocols('')).toEqual([]);
+  });
+});
+
+describe('WsClient subprotocol passthrough (Task #48)', () => {
+  beforeEach(() => {
+    MockWs.lastInstance = null;
+  });
+
+  it('passes [`ccsm.<token>`] as the second arg to `new WebSocket(url, protocols)`', () => {
+    const client = new WsClient({
+      sid: 'sid-x',
+      token: 'tok-xyz',
+      hostBase: HOST,
+      WebSocketImpl: MockWs as unknown as typeof WebSocket,
+    });
+    client.connect();
+    const ws = MockWs.lastInstance!;
+    expect(ws.protocols).toEqual(['ccsm.tok-xyz']);
+  });
+
+  it('still puts the token in the URL query (loopback daemon reads ?token=)', () => {
+    // Reverse-verify: dropping the URL token would break the loopback /
+    // Tauri shell daemon (packages/daemon/src/ws.mts:380), which authenticates
+    // off the query. Both transports must work; subprotocol is additive.
+    const client = new WsClient({
+      sid: 'sid-x',
+      token: 'tok-xyz',
+      hostBase: HOST,
+      WebSocketImpl: MockWs as unknown as typeof WebSocket,
+    });
+    client.connect();
+    const ws = MockWs.lastInstance!;
+    expect(ws.url).toContain('token=tok-xyz');
+  });
+
+  it('omits the protocols arg entirely when token is empty (avoids passing [])', () => {
+    // `new WebSocket(url, [])` is legal but some implementations behave
+    // oddly; pass the single-arg form to keep the existing contract.
+    const client = new WsClient({
+      sid: 'sid-x',
+      token: '',
+      hostBase: HOST,
+      WebSocketImpl: MockWs as unknown as typeof WebSocket,
+    });
+    client.connect();
+    const ws = MockWs.lastInstance!;
+    expect(ws.protocols).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

R-17 verify (dev-47, log `/tmp/smoke-r17-verify.log`, 455 lines) locked candidate H: SPA `new WebSocket(url)` was single-arg, so the cf-worker TunnelDO closed every upgrade with `code=1008 reason=\"missing token subprotocol\"`. 16 identical reconnect attempts, 0 hello/attach/frame, daemon tunnel itself stayed connected — making this an SPA-side protocol omission, not network / DO / daemon.

The DO authenticates by reading the bearer token from `Sec-WebSocket-Protocol` (encoded `ccsm.<token>`, see `packages/cf-worker/src/tunnel-do.ts:145` `extractBrowserToken`). Browsers cannot set arbitrary headers on `new WebSocket(url)`; the second-arg `protocols` array IS the header.

Fix is layer-1 (protocol contract), not glue:
- `buildWsSubprotocols(token)` returns `['ccsm.<token>']` matching the prefix already shared with cf-worker tunnel-do.ts and frontend-web hostConfig.ts (the latter was exported but never wired into `WsClient`).
- `WsClient.connect` now calls `new Ctor(url, protocols)` when token is non-empty. Empty token keeps the single-arg form.
- URL `?token=` query is preserved so the loopback / Tauri daemon (`packages/daemon/src/ws.mts:380`) keeps authenticating off the query. Both transports must work; subprotocol is additive.

## Reverse-verify

The new test `'WsClient subprotocol passthrough > passes [ccsm.<token>] as the second arg'` reads the mock's recorded `protocols` argument. Without the fix in `client.ts`, the constructor is single-arg → `protocols` is `undefined` → assertion `expect(ws.protocols).toEqual(['ccsm.tok-xyz'])` fails. With the fix, it passes. The companion test `'still puts the token in the URL query'` ensures the loopback transport is not regressed.

A second test guards the empty-token guard (`expect(ws.protocols).toBeUndefined()`), preventing a future refactor from accidentally passing `new WebSocket(url, [])` and provoking quirky impl behaviour.

## Drive-by

R-17 (PR #1189) added `ev.code` / `ev.reason` reads to `ws.onclose` for the `[ccsm spa] ws close code=...` log line, but the existing `FakeWs` (session-runtime test) and `MockWs` (ws-client test) harnesses still called `onclose?.()` with no argument — 4 unit tests had been failing on `working` as a result. Mocks now pass a CloseEvent-shaped `{code, reason}` so the log line evaluates without `TypeError`. No production-side change.

## Out of scope (per manager spec)

- no cf-worker / daemon / token-gen edits
- no smoke run (Windows / pool concurrency hazard, see memory)
- no retry / sleep / 1008 close-handling workaround
- no wrangler / pages-dev topology changes

## Local checks (host: Windows, mode: fast)

- lint: skipped (no .ts changes outside tested packages)
- typecheck: ✓ `@ccsm/core`, `@ccsm/cf-worker`, `@ccsm/frontend-web` (all exit 0)
- build: ✓ `@ccsm/shared`, `@ccsm/core`, `@ccsm/ui` (prerequisite for typecheck of consumers)
- unit tests:
  - `@ccsm/core`: 51/51 pass (3 files: ws-client, session-runtime, api-sessions) — duration 1.09s
  - `@ccsm/cf-worker`: 26/26 pass (tunnel-do, health) — duration 0.96s
- e2e: skipped, fix is in a single SPA-side line + protocol contract test; cloud smoke is the integration check (manager will run R-19 verify on a separate pool per spec).