### PR TITLE
chore(spa): R-20 — add 2 logs to localize keystroke drop (Task #57)

### DIFF
--- a/packages/core/src/ws/client.ts
+++ b/packages/core/src/ws/client.ts
@@ -235,6 +235,7 @@ export class WsClient {
 
   /** Send raw user input as one INPUT frame. No-op if not yet attached. */
   sendInput(data: string): void {
+    console.log('[ccsm spa] sendInput len=' + data.length);
     const ws = this.ws;
     if (!ws || ws.readyState !== ws.OPEN) return;
     const payload = new TextEncoder().encode(data);

--- a/packages/ui/src/components/MainPane.tsx
+++ b/packages/ui/src/components/MainPane.tsx
@@ -202,6 +202,7 @@ export function MainPane() {
 
     // ---- xterm input/resize wiring ----
     const inputDisp = term.onData((data) => {
+      console.log('[ccsm spa] xterm onData len=' + data.length);
       const sid = activeSidRef.current;
       if (sid) runtime.sendInput(sid, data);
     });


### PR DESCRIPTION
## Context — research-56 locked in

R-19 verify-only smoke evidence:
- payload bytes: 9-5 + 8-5 = 7 bytes total (RESIZE frames only)
- INPUT frames sent = 0 (expected ~22 for typed keystrokes)
- DOM shows 0 echo characters despite cmd.exe conpty default echo on
- Conclusion: keystrokes never reached xterm; daemon/PTY are not the suspect

Strongest hypothesis: the spec's `terminal-pane` outer `<div>` click does
not transfer focus into xterm's hidden `<textarea>`, so xterm never fires
`onData`.

## Change

Pure observability — 2 console logs, no behavior change:

- `packages/core/src/ws/client.ts:237` — `sendInput`: `console.log('[ccsm spa] sendInput len=' + data.length)`
- `packages/ui/src/components/MainPane.tsx:204` — xterm `onData`: `console.log('[ccsm spa] xterm onData len=' + data.length)`

## Verdict matrix (next verify-only smoke)

| log A (sendInput) | log B (xterm onData) | Verdict |
|---|---|---|
| 0 | 0 | click never focused hidden textarea -> R-21 fix spec to click inner textarea |
| 0 | >0 | SPA send path broken between xterm and ws.client |
| >0 | >0 | daemon -> PTY bridge dropping bytes |

## Non-goals (explicit)
- No spec / click target / focus changes
- No xterm options change
- No ws send behavior change
- No retry / sleep added

## Local checks (host: Windows, mode: fast)
- lint: skipped (logs-only, no lint rules touched)
- typecheck: core ✓, ui ✓ (exit 0)
- build: ✓ (shared + core tsc emit clean)
- unit tests: `@ccsm/core` 51 passed (3 files), `@ccsm/ui` 36 passed (5 files)
- e2e: skipped — diagnostic logs only, behavior unchanged; final verdict comes from next verify-only smoke