### PR TITLE
fix(core+spa): R-21 — sendInput buffer-until-open + data-ws-state (Task #61)

### DIFF
--- a/packages/core/src/runtime/session-runtime.ts
+++ b/packages/core/src/runtime/session-runtime.ts
@@ -145,6 +145,7 @@ export class SessionRuntime {
       hasEverAttached: false,
       pendingWrites: 0,
       paused: false,
+      pendingInput: [],
     };
     this.entries.set(sid, entry);
     this.openWs(entry, token);
@@ -177,9 +178,31 @@ export class SessionRuntime {
     this.entries.delete(sid);
   }
 
-  /** Send INPUT to the session's ws (no-op if not attached / not OPEN). */
+  /**
+   * Send INPUT to the session's ws.
+   *
+   * Task #61 (R-21) — buffer-until-open: keystrokes that arrive while the
+   * ws is `connecting` (or its `client` slot is briefly null between
+   * close and reconnect) are queued on `entry.pendingInput`, in arrival
+   * order, and flushed verbatim on the `attached` status edge. Without
+   * this buffer, the ~340ms createSession→ws-OPEN window in cloud-mode
+   * smoke silently drops every keystroke the user typed before xterm's
+   * onData saw an open socket — research-60 confirmed 22 dropped chars on
+   * a single happy-path run.
+   *
+   * If `sid` is unknown (no runtime entry) we drop on the floor — there's
+   * nothing to attach the queue to and the caller (xterm onData) already
+   * gates on `activeSidRef`. The OPEN-but-no-entry case is impossible.
+   */
   sendInput(sid: string, data: string): void {
-    this.entries.get(sid)?.client?.sendInput(data);
+    const entry = this.entries.get(sid);
+    if (!entry) return;
+    const client = entry.client;
+    if (client && client.getStatus() === 'attached') {
+      client.sendInput(data);
+      return;
+    }
+    entry.pendingInput.push(data);
   }
 
   /** Send RESIZE to the session's ws. */
@@ -294,6 +317,16 @@ export class SessionRuntime {
       entry.reconnectAttempts = 0;
       // #673 invariant: once true, never reset. See types.ts JSDoc.
       entry.hasEverAttached = true;
+      // Task #61 (R-21): flush keystrokes that arrived while the ws was
+      // still `connecting`. Order-preserving, no coalescing — each entry
+      // is one user-visible INPUT frame.
+      if (entry.pendingInput.length > 0 && entry.client) {
+        const queued = entry.pendingInput;
+        entry.pendingInput = [];
+        for (const data of queued) {
+          entry.client.sendInput(data);
+        }
+      }
     }
     this.publishStatus(entry);
   }

--- a/packages/core/src/runtime/types.ts
+++ b/packages/core/src/runtime/types.ts
@@ -89,6 +89,19 @@ export interface SessionRuntimeEntry {
    * frame when this changes; otherwise a chatty PTY would spam frames.
    */
   paused: boolean;
+  /**
+   * Task #61 (R-21) — INPUT frames received via `sendInput` before the ws
+   * has reached OPEN. Without this queue, keystrokes typed during the
+   * createSession→ws-attached window (~340ms in cloud-mode smoke) hit
+   * `WsClient.sendInput`, see `readyState !== OPEN`, and are silently
+   * dropped. We push them here in arrival order and flush them on the
+   * `attached` status edge in `session-runtime.ts`.
+   *
+   * No coalescing — each user keystroke is a distinct INPUT chunk. The
+   * queue is unbounded by design (token boot only ever buffers a handful
+   * of keystrokes; an attached ws drains it instantly).
+   */
+  pendingInput: string[];
 }
 
 /**

--- a/packages/core/test/session-runtime.test.ts
+++ b/packages/core/test/session-runtime.test.ts
@@ -450,4 +450,63 @@ describe('SessionRuntime — per-session scrollback + reconnect (T10/#662, T5/#6
     ).not.toThrow();
     expect(runtime.get('s1')!.scrollbackBytes).toBe(2);
   });
+
+  // ---- Task #61 (R-21): sendInput buffer-until-open ---------------------
+  it('sendInput buffers keystrokes typed before ws OPEN, flushes in order on attached', () => {
+    const { runtime } = makeRuntime();
+    runtime.attach('s1', 'tok');
+    const ws = FakeWs.instances[0]!;
+    // ws is `connecting` — no OPEN yet. INPUT must NOT hit the wire.
+    runtime.sendInput('s1', 'a');
+    runtime.sendInput('s1', 'b');
+    runtime.sendInput('s1', 'cd');
+    expect(ws.sent).toHaveLength(0);
+    expect(runtime.get('s1')!.pendingInput).toEqual(['a', 'b', 'cd']);
+
+    // Transition to attached → queue flushes verbatim, in order, one
+    // INPUT frame per queued chunk (no coalescing).
+    ws.open();
+    expect(runtime.get('s1')!.pendingInput).toEqual([]);
+    expect(ws.sent).toHaveLength(3);
+    const decoded = ws.sent.map((b) => decodeFrame(b));
+    for (const f of decoded) expect(f.type).toBe(FrameType.INPUT);
+    expect(new TextDecoder().decode(decoded[0]!.payload)).toBe('a');
+    expect(new TextDecoder().decode(decoded[1]!.payload)).toBe('b');
+    expect(new TextDecoder().decode(decoded[2]!.payload)).toBe('cd');
+
+    // Subsequent sendInput while attached goes straight through.
+    runtime.sendInput('s1', 'e');
+    expect(ws.sent).toHaveLength(4);
+    expect(new TextDecoder().decode(decodeFrame(ws.sent[3]!).payload)).toBe(
+      'e',
+    );
+    expect(runtime.get('s1')!.pendingInput).toEqual([]);
+  });
+
+  it('sendInput preserves order across pre-open + post-open mix', () => {
+    const { runtime } = makeRuntime();
+    runtime.attach('s1', 'tok');
+    const ws = FakeWs.instances[0]!;
+
+    // N=3 pre-open
+    runtime.sendInput('s1', '1');
+    runtime.sendInput('s1', '2');
+    runtime.sendInput('s1', '3');
+    ws.open();
+    // M=2 post-open
+    runtime.sendInput('s1', '4');
+    runtime.sendInput('s1', '5');
+
+    expect(ws.sent).toHaveLength(5);
+    const payloads = ws.sent.map((b) =>
+      new TextDecoder().decode(decodeFrame(b).payload),
+    );
+    expect(payloads).toEqual(['1', '2', '3', '4', '5']);
+  });
+
+  it('sendInput on unknown sid is a no-op (no entry, no throw)', () => {
+    const { runtime } = makeRuntime();
+    expect(() => runtime.sendInput('ghost', 'x')).not.toThrow();
+    expect(FakeWs.instances).toHaveLength(0);
+  });
 });

--- a/packages/smoke/tests/s3-happy-path.spec.ts
+++ b/packages/smoke/tests/s3-happy-path.spec.ts
@@ -42,6 +42,18 @@ test('cloud-mode happy path: open SPA, create session, run echo, see output', as
   // Send one command and assert PTY echo. The terminal is xterm.js; we read
   // its rendered DOM rather than poking the terminal API directly.
   await page.getByTestId('terminal-pane').click();
+  // Task #61 (R-21) — wait until the ws actually reaches OPEN before
+  // typing. Without this gate, keystrokes raced the createSession→ws-open
+  // window (~340ms) and were silently dropped (research-60 confirmed 22
+  // chars lost on a single happy-path run). The Layer 1 production fix is
+  // the buffer-until-open queue in @ccsm/core SessionRuntime.sendInput;
+  // this assertion is the Layer 4 test contract that locks the contract
+  // visible to the smoke without depending on the buffer's timing.
+  await expect(page.getByTestId('terminal-pane')).toHaveAttribute(
+    'data-ws-state',
+    'open',
+    { timeout: 10_000 },
+  );
   await page.keyboard.type('echo hello-from-smoke');
   await page.keyboard.press('Enter');
 

--- a/packages/ui/src/components/MainPane.tsx
+++ b/packages/ui/src/components/MainPane.tsx
@@ -53,6 +53,9 @@ export function MainPane() {
 
   const token = useStore((s) => s.token);
   const activeSid = useStore((s) => s.activeSid);
+  const activeStatus = useStore((s) =>
+    s.activeSid ? (s.sessionStatuses[s.activeSid] ?? 'idle') : 'idle',
+  );
 
   const runtime = useRuntime();
   const hostGetToken = useGetToken();
@@ -240,7 +243,11 @@ export function MainPane() {
   }, [activeSid, token]);
 
   return (
-    <div className="main-pane" data-testid="terminal-pane">
+    <div
+      className="main-pane"
+      data-testid="terminal-pane"
+      data-ws-state={wsStateAttr(activeSid, activeStatus)}
+    >
       <div
         id="terminal"
         ref={containerRef}
@@ -249,6 +256,23 @@ export function MainPane() {
       />
     </div>
   );
+}
+
+// Task #61 (R-21) — smoke test contract: terminal-pane carries
+// `data-ws-state` so a Playwright test can deterministically wait for the
+// ws to be live before typing. Mapping collapses the 5 WsStatus variants
+// to the 3 states the test needs:
+//   - 'open'       : ws established at least once (`attached`).
+//   - 'connecting' : entry exists, ws still negotiating (idle/connecting).
+//   - 'closed'     : no active session, OR ws closed/exited.
+function wsStateAttr(
+  activeSid: string | null,
+  status: string,
+): 'connecting' | 'open' | 'closed' {
+  if (!activeSid) return 'closed';
+  if (status === 'attached') return 'open';
+  if (status === 'disconnected' || status === 'exited') return 'closed';
+  return 'connecting';
 }
 
 // Module-scope helper so the closures above don't each capture a fresh copy.

--- a/packages/ui/test/MainPane.strictmode.test.tsx
+++ b/packages/ui/test/MainPane.strictmode.test.tsx
@@ -290,4 +290,86 @@ describe('MainPane under React.StrictMode (T10 reshape of P1-3 regression)', () 
     // A foreign sid is silently dropped.
     expect(() => outputListenerHolder.current!('other-sid', payload)).not.toThrow();
   });
+
+  // ---- Task #61 (R-21): data-ws-state attribute -----------------------
+  it('renders data-ws-state="closed" when no active session', async () => {
+    useStore.setState({
+      token: 'test-token',
+      sessions: [],
+      activeSid: null,
+      status: 'idle',
+      sessionStatuses: {},
+    });
+    const { container } = render(
+      <StrictMode>
+        <MainPane />
+      </StrictMode>,
+    );
+    await flushMicrotasks();
+    const pane = container.querySelector(
+      '[data-testid="terminal-pane"]',
+    ) as HTMLElement | null;
+    expect(pane).not.toBeNull();
+    expect(pane!.getAttribute('data-ws-state')).toBe('closed');
+  });
+
+  it('renders data-ws-state="connecting" when active sid status is connecting', async () => {
+    useStore.setState({
+      token: 'test-token',
+      sessions: [{ sid: 'sid-A', createdAt: 0, alive: true }],
+      activeSid: 'sid-A',
+      status: 'connecting',
+      sessionStatuses: { 'sid-A': 'connecting' },
+    });
+    const { container } = render(
+      <StrictMode>
+        <MainPane />
+      </StrictMode>,
+    );
+    await flushMicrotasks();
+    const pane = container.querySelector(
+      '[data-testid="terminal-pane"]',
+    ) as HTMLElement | null;
+    expect(pane!.getAttribute('data-ws-state')).toBe('connecting');
+  });
+
+  it('renders data-ws-state="open" when active sid status is attached', async () => {
+    useStore.setState({
+      token: 'test-token',
+      sessions: [{ sid: 'sid-A', createdAt: 0, alive: true }],
+      activeSid: 'sid-A',
+      status: 'attached',
+      sessionStatuses: { 'sid-A': 'attached' },
+    });
+    const { container } = render(
+      <StrictMode>
+        <MainPane />
+      </StrictMode>,
+    );
+    await flushMicrotasks();
+    const pane = container.querySelector(
+      '[data-testid="terminal-pane"]',
+    ) as HTMLElement | null;
+    expect(pane!.getAttribute('data-ws-state')).toBe('open');
+  });
+
+  it('renders data-ws-state="closed" when active sid status is disconnected/exited', async () => {
+    useStore.setState({
+      token: 'test-token',
+      sessions: [{ sid: 'sid-A', createdAt: 0, alive: true }],
+      activeSid: 'sid-A',
+      status: 'exited',
+      sessionStatuses: { 'sid-A': 'exited' },
+    });
+    const { container } = render(
+      <StrictMode>
+        <MainPane />
+      </StrictMode>,
+    );
+    await flushMicrotasks();
+    const pane = container.querySelector(
+      '[data-testid="terminal-pane"]',
+    ) as HTMLElement | null;
+    expect(pane!.getAttribute('data-ws-state')).toBe('closed');
+  });
 });


### PR DESCRIPTION
## Summary (Task #61, smoke R-21)

research-60 locked the keystroke-drop root cause: in cloud-mode happy-path, xterm `onData` calls `runtime.sendInput(sid, data)` synchronously after the user types. During the ~340ms window between `await api.createSession(tok)` returning and the per-session ws reaching OPEN, `WsClient.sendInput` sees `readyState !== OPEN` and silently drops the frame. 22 chars were lost on a single smoke run. **Real users typing fast at session start hit the same bug** — this is a production drop, not just a test artefact.

### Layer 1 — protocol layer fix (production bug)

`packages/core/src/runtime/session-runtime.ts` `sendInput` no longer forwards blindly to `WsClient.sendInput`. It now:

- Looks up the entry. Unknown sid → no-op (caller already gates on `activeSidRef`).
- If `client.getStatus() === 'attached'` → forward straight to ws.
- Otherwise → push the data string onto `entry.pendingInput` (new field on `SessionRuntimeEntry`).

`handleStatusChange` flushes the queue verbatim, in arrival order, on the `attached` edge. **No coalescing** — every user keystroke remains a distinct INPUT frame, so the daemon's PTY sees the same byte stream the user typed.

### Layer 4 — test contract (`data-ws-state`)

`packages/ui/src/components/MainPane.tsx` reads `state.sessionStatuses[activeSid]` and renders a new `data-ws-state` attribute on the `terminal-pane` root:

| WsStatus       | data-ws-state |
|----------------|---------------|
| (no activeSid) | `closed`      |
| `attached`     | `open`        |
| `disconnected` / `exited` | `closed` |
| `idle` / `connecting` | `connecting` |

Smoke spec (`packages/smoke/tests/s3-happy-path.spec.ts`) gains a wait between click and `keyboard.type`:

```ts
await expect(page.getByTestId('terminal-pane')).toHaveAttribute(
  'data-ws-state', 'open', { timeout: 10_000 },
);
```

Click target unchanged. The buffer fix already protects against the race, but the explicit gate makes the smoke deterministic instead of relying on PTY echo masking out-of-order timing.

## Reverse-verify (sendInput buffer)

The new unit test `sendInput buffers keystrokes typed before ws OPEN, flushes in order on attached`:

- pre-open `sendInput('a' / 'b' / 'cd')` → asserts `ws.sent.length === 0` and `entry.pendingInput === ['a','b','cd']`.
- `ws.open()` → asserts `ws.sent.length === 3` with payloads `'a','b','cd'` in order.
- post-attached `sendInput('e')` bypasses the queue → asserts `ws.sent[3].payload === 'e'` and queue empty.

Without the fix, all four sendInputs that pre-date `ws.open()` would call into `WsClient.sendInput` directly and the assertion `ws.sent.length === 0` already fails (drop is silent in `WsClient` so the state would just stay empty — but `pendingInput` would never accumulate either, so the queue assertion fails). Mix test (`N=3 pre-open + M=2 post-open`) similarly locks order.

## Local checks (host: Windows 11, mode: fast)

- lint: skipped (no global lint script in this repo; ts files are typechecked below)
- typecheck: ✓ `@ccsm/core` + `@ccsm/ui` + `@ccsm/smoke` all exit 0
- build: ✓ `@ccsm/shared` + `@ccsm/core` exit 0
- unit tests:
  - `pnpm --filter @ccsm/core test` → 3 files, 54 tests passed (16 in session-runtime.test.ts including 3 new buffer tests)
  - `pnpm --filter @ccsm/ui test` → 5 files, 40 tests passed (8 in MainPane.strictmode.test.tsx including 4 new data-ws-state tests)
- e2e/smoke: skipped per Task spec (do NOT run smoke locally — single-pool isolation; CI matrix will run smoke).

## Files

- `packages/core/src/runtime/types.ts` — add `pendingInput: string[]` to `SessionRuntimeEntry`.
- `packages/core/src/runtime/session-runtime.ts` — buffer-until-open in `sendInput`; flush in `handleStatusChange` on attached edge; init `pendingInput: []` in `attach`.
- `packages/core/test/session-runtime.test.ts` — 3 new buffer tests.
- `packages/ui/src/components/MainPane.tsx` — read activeStatus from store, render `data-ws-state` via `wsStateAttr` helper.
- `packages/ui/test/MainPane.strictmode.test.tsx` — 4 new tests covering closed/connecting/open/exited mappings.
- `packages/smoke/tests/s3-happy-path.spec.ts` — wait `data-ws-state="open"` before typing.

## Out of scope

- cf-worker / daemon / `ws/client.ts` untouched.
- Click target unchanged (the buffer fix is the production fix; the smoke gate is belt-and-braces).
- No retry/sleep, no `keyboard.type` delay change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)