### PR TITLE
fix(smoke): R-22 — click inner xterm textarea to fix keystroke focus drop (Task #64)

### DIFF
--- a/packages/smoke/tests/s3-happy-path.spec.ts
+++ b/packages/smoke/tests/s3-happy-path.spec.ts
@@ -41,7 +41,18 @@ test('cloud-mode happy path: open SPA, create session, run echo, see output', as
 
   // Send one command and assert PTY echo. The terminal is xterm.js; we read
   // its rendered DOM rather than poking the terminal API directly.
-  await page.getByTestId('terminal-pane').click();
+  //
+  // Task #64 (R-22) — click the inner xterm hidden `<textarea
+  // aria-label="Terminal input">` rather than the outer `terminal-pane` div.
+  // dev-63 verify (R-21) locked the cause: clicking the outer div did not
+  // forward focus to xterm's hidden textarea, so `keyboard.type(...)` keystrokes
+  // landed on `document.body` and most chars were dropped before reaching
+  // xterm's onData (the R-19 verify error-context.md showed only 1 onData
+  // event with len=3 for a 21-char type, and the active element was body).
+  // R-21's buffer-until-open queue already fixed the WS race; this is a
+  // Layer 4 test-contract fix only — production focus behavior is unchanged
+  // (a real user clicking the terminal naturally focuses the textarea).
+  await page.getByLabel('Terminal input').click();
   // Task #61 (R-21) — wait until the ws actually reaches OPEN before
   // typing. Without this gate, keystrokes raced the createSession→ws-open
   // window (~340ms) and were silently dropped (research-60 confirmed 22


### PR DESCRIPTION
## Summary

dev-63 verify of R-21 locked the residual keystroke-drop cause: with R-21's `buffer-until-open` queue and `data-ws-state=\"open\"` gate both in place, typing 21 chars at the smoke still produced only **one** xterm `onData` event with `len=3`. The R-19 verify `error-context.md` showed why — an accessible `textbox \"Terminal input\"` (xterm's hidden `<textarea aria-label=\"Terminal input\">`) sibling to a focused `<body>`. Clicking the outer `terminal-pane` div in Playwright did not forward focus to xterm's hidden textarea, so most keystrokes landed on `document.body` and were dropped **before** reaching xterm — i.e. before `sendInput`, before the WS, before the daemon.

This PR is a **Layer 4 test-contract fix only**. The spec now clicks the inner xterm textarea via its accessible label:

```ts
await page.getByLabel('Terminal input').click();
```

R-21's WS-race fix is still correct and still necessary; it just wasn't the only loss path.

## Why no production change

- A real user clicking the visible terminal naturally focuses xterm's hidden textarea (xterm's own pointer handler). The focus-forwarding gap only manifests under Playwright's synthetic click on the wrapper div.
- Forwarding focus from `terminal-pane` → xterm textarea in MainPane would be glue for a Playwright-only quirk, not a real user-facing bug.
- R-12..R-21 already addressed the real prod loss paths (`sendInput` buffer-until-open, `data-ws-state` attribute for the smoke gate, `CCSM_PTY_ENTRY` routing). This PR aligns the smoke's click target with the path a real click takes.

## Why no keyboard.type delay (yet)

Once focus is on xterm's textarea, Playwright's default per-keystroke pacing has been adequate in every prior smoke run that did manage to focus the textarea. Adding a delay before evidence of need would be preemptive glue. Revisit only if R-22 verify still shows partial loss.

## Files

- `packages/smoke/tests/s3-happy-path.spec.ts` — change click target from `getByTestId('terminal-pane')` to `getByLabel('Terminal input')`; expand the comment to record the dev-63 finding.

## Local checks (host: Windows 11, mode: fast)

- lint: skipped (pure spec change in @ccsm/smoke; no other package touched)
- typecheck (@ccsm/smoke): pass — `pnpm --filter @ccsm/smoke typecheck` exit 0 (`tsc --noEmit`)
- build: skipped (no production .ts/.tsx changed)
- unit tests: skipped (pure smoke spec change)
- e2e / smoke: **not run locally** per manager directive (Windows smoke zombie-lock risk per memory `project_smoke_windows_zombie_lock_2026_05_08`); CI smoke job will exercise R-22.

## Out of scope / explicitly NOT touched

- cf-worker / daemon / `ws/client.ts` / SessionRuntime
- R-12..R-21 production fixes
- MainPane or any production focus behavior
- `keyboard.type` delay / retry / sleep