### PR TITLE
fix(smoke): R-24 — close session via testid + hover (Task #71)

### DIFF
--- a/packages/smoke/tests/s3-happy-path.spec.ts
+++ b/packages/smoke/tests/s3-happy-path.spec.ts
@@ -84,6 +84,10 @@ test('cloud-mode happy path: open SPA, create session, run echo, see output', as
   });
 
   // Close the session (UI close button — daemon will tear down the PTY).
-  await page.getByRole('button', { name: /close session/i }).click();
+  // The close button uses CSS hover-only visibility (sidebar__session-close),
+  // so the a11y tree hides it until hover. Target by testid + hover first.
+  const closeBtn = page.getByTestId(/^sidebar-session-close-/).first();
+  await closeBtn.hover();
+  await closeBtn.click();
   await expect(page.getByTestId('terminal-pane')).not.toBeVisible({ timeout: 10_000 });
 });


### PR DESCRIPTION
## Summary

R-24: spec close-session selector fix per research-70 lock-in.

The s3 happy-path spec timed out on `getByRole('button', { name: /close session/i })` because the close button (`Sidebar.tsx:358-371`) uses CSS hover-only visibility (`sidebar__session-close` opacity 0 until row hover). The a11y tree hides it until hover, so Playwright's role/name query never resolves within timeout.

**Layer 4 spec-only fix**:
```ts
const closeBtn = page.getByTestId(/^sidebar-session-close-/).first();
await closeBtn.hover();
await closeBtn.click();
```

- Stable testid (`sidebar-session-close-<sid>`) replaces brittle role/name match.
- `hover()` first to make the button visible/interactable.
- No retry/sleep, no production change.

**Why no production fix**: hover-only is intentional UX (GitHub-style row-hover affordance), not a bug. research-70 explicitly scoped this as Layer 4 (spec-only).

## Files
- `packages/smoke/tests/s3-happy-path.spec.ts` — replace role/name selector with testid + hover.

## Local checks (host: Windows, mode: fast)
- lint: pre-existing baseline errors in `packages/daemon/test/persist.test.ts` and `packages/ui/test/BootstrapRefresh.test.tsx` (unrelated to this diff)
- typecheck (smoke package): clean (`tsc --noEmit` exit 0)
- typecheck (full repo): pre-existing baseline errors in `packages/ui/src/components/Sidebar.tsx` + missing `@ccsm/core` dist (unrelated to this diff)
- unit tests: skipped — diff is a single Playwright spec, no unit coverage applies
- e2e: skipped — smoke run deferred to CI per task spec ("不本地跑 smoke")

## Test plan
- [ ] CI smoke matrix turns the s3 happy-path close-session step green