### PR TITLE
fix(smoke): R-25 — hover session row to reveal close button (Task #74)

### DIFF
--- a/packages/smoke/tests/s3-happy-path.spec.ts
+++ b/packages/smoke/tests/s3-happy-path.spec.ts
@@ -84,10 +84,17 @@ test('cloud-mode happy path: open SPA, create session, run echo, see output', as
   });
 
   // Close the session (UI close button — daemon will tear down the PTY).
-  // The close button uses CSS hover-only visibility (sidebar__session-close),
-  // so the a11y tree hides it until hover. Target by testid + hover first.
+  // The close button is hidden until the parent <li>.sidebar__session is
+  // hovered (CSS rule `.sidebar__session:hover .sidebar__session-close`).
+  // Hovering the close button directly is a catch-22 — Playwright requires
+  // the target to be visible before hover, but hover is what makes it
+  // visible. Hover the parent row first to reveal the close button, then
+  // click it. We avoid `{ force: true }` because force bypasses
+  // actionability checks and would not exercise the real CSS reveal users
+  // experience.
+  const sessionRow = page.getByTestId(/^sidebar-session-[0-9a-f]/).first();
+  await sessionRow.hover();
   const closeBtn = page.getByTestId(/^sidebar-session-close-/).first();
-  await closeBtn.hover();
   await closeBtn.click();
   await expect(page.getByTestId('terminal-pane')).not.toBeVisible({ timeout: 10_000 });
 });


### PR DESCRIPTION
## Summary

dev-73 verify (R-24) showed `closeBtn.hover()` timing out after 120s on
spec line 90. Root cause is a catch-22 in the CSS hover-reveal pattern:

```css
.sidebar__session-close { opacity: 0 }
.sidebar__session:hover .sidebar__session-close { opacity: 1 }
```

The close button is hidden until its parent `<li>.sidebar__session` is
hovered. Playwright's `hover()` waits for the target to be visible before
dispatching pointer events — but here visibility *requires* hover, so the
hover never resolves.

## Fix (Layer 4 — spec only)

Hover the parent session row first (testid `sidebar-session-<sid>`, the
`<li>`) to trigger the CSS reveal, then click the close button:

```ts
const sessionRow = page.getByTestId(/^sidebar-session-[0-9a-f]/).first();
await sessionRow.hover();
const closeBtn = page.getByTestId(/^sidebar-session-close-/).first();
await closeBtn.click();
```

The regex `[0-9a-f]` excludes the sibling testids `sidebar-session-row-`
and `sidebar-session-close-` (sids are UUIDs, always hex-prefixed).

## Why not `{ force: true }`

`force: true` bypasses Playwright's actionability checks (visible /
stable / enabled / receives events). It would make the click land
regardless of whether the button is actually rendered for users, turning
a real UX regression into a silent green test. The parent-hover approach
exercises the exact CSS pathway a human user takes.

## Files

- `packages/smoke/tests/s3-happy-path.spec.ts` — close step now hovers
  row, then clicks close.

No production / Sidebar.tsx / CSS changes.

## Local checks (host: Windows, mode: fast)
- typecheck (smoke): exit 0
- lint: pre-existing errors in unrelated packages (daemon/persist.test, ui/BootstrapRefresh.test); smoke spec clean
- smoke run: skipped per task instructions (Windows zombie / target lock — CI runs it)
- e2e: skipped — change is smoke-only spec edit

## Test plan
- [ ] CI smoke job on this PR turns green (was red on R-24 with the 120s hover timeout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)