### PR TITLE
fix(smoke): R-26 — assert ws-state=closed instead of pane invisibility (Task #77)

### DIFF
--- a/packages/smoke/tests/s3-happy-path.spec.ts
+++ b/packages/smoke/tests/s3-happy-path.spec.ts
@@ -96,5 +96,5 @@ test('cloud-mode happy path: open SPA, create session, run echo, see output', as
   await sessionRow.hover();
   const closeBtn = page.getByTestId(/^sidebar-session-close-/).first();
   await closeBtn.click();
-  await expect(page.getByTestId('terminal-pane')).not.toBeVisible({ timeout: 10_000 });
+  await expect(page.getByTestId('terminal-pane')).toHaveAttribute('data-ws-state', 'closed', { timeout: 10_000 });
 });


### PR DESCRIPTION
## Context (Task #77, smoke R-26)

dev-76 verify of R-25 confirmed the close path actually works in the running app:
- sidebar shows empty-state
- main shows empty placeholder
- websocket closes (1005 / 1006)

But the spec assertion at line 99 was wrong:

```ts
await expect(page.getByTestId('terminal-pane')).not.toBeVisible({ timeout: 10_000 });
```

`terminal-pane` is `MainPane`'s permanent container — it does not unmount on session close, so it is always visible and `.not.toBeVisible()` could never pass.

## Fix (Layer 4, 1 line)

Switch the assertion to:

```ts
await expect(page.getByTestId('terminal-pane')).toHaveAttribute('data-ws-state', 'closed', { timeout: 10_000 });
```

This is symmetric with the earlier wait at line ~64 (`toHaveAttribute('data-ws-state', 'open', ...)` added in R-21) and exercises the real `data-ws-state` attribute semantics rather than DOM visibility.

## Files
- `packages/smoke/tests/s3-happy-path.spec.ts` — line 99 assertion swap

## Local checks (host: Windows, mode: fast)
- lint: skipped (one-line spec change, no production / lint config touched)
- typecheck: ✓ (exit 0, `tsc --noEmit -p packages/smoke/tsconfig.json`)
- build: skipped (no production code changed)
- unit tests: skipped (no unit specs touched / impacted)
- e2e: not run locally per task spec ("不本地跑 smoke"); CI smoke matrix will exercise.