### PR TITLE
feat(cloud-e2e): Playwright harness for cc-sm.pages.dev (Task #82)

### DIFF
--- a/tools/cloud-e2e/.gitignore
+++ b/tools/cloud-e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+test-results/
+playwright-report/
+package-lock.json
+pnpm-lock.yaml

--- a/tools/cloud-e2e/README.md
+++ b/tools/cloud-e2e/README.md
@@ -1,0 +1,66 @@
+# cloud-e2e
+
+Standalone Playwright harness that exercises the **deployed** cloud SPA at
+`https://cc-sm.pages.dev` end-to-end. Built for Task #82 so manager (or any
+maintainer) can verify "real users on two machines" scenarios without
+hand-clicking a browser.
+
+## Why standalone (not under `packages/`)
+
+`pnpm-workspace.yaml` only globs `packages/*`. Keeping this tool outside
+the workspace means:
+
+- Installing `@playwright/test` and downloading the Chromium binary does
+  not touch the monorepo lockfile (avoids hot-file mutex contention when
+  manager runs it ad-hoc).
+- `pnpm install` at the repo root never recurses here, so the heavy browser
+  download only happens when a maintainer explicitly opts in.
+
+## Setup
+
+```bash
+cd tools/cloud-e2e
+pnpm install        # or: npm install
+pnpm install:browsers   # downloads Chromium (~150 MB, one-time)
+```
+
+## Run
+
+```bash
+cd tools/cloud-e2e
+pnpm test                       # headless, default base = https://cc-sm.pages.dev
+pnpm test:headed                # eyeballs mode for debugging
+CCSM_CLOUD_BASE_URL=https://my-preview.pages.dev pnpm test  # custom origin
+```
+
+Failure artifacts:
+
+- `test-results/` — per-test trace.zip + screenshot + video on failure.
+- `playwright-report/` — HTML report (`npx playwright show-report` to view).
+
+Both are gitignored.
+
+## Specs
+
+### `specs/two-tab-pairing.spec.ts`
+
+Opens **two browser contexts** (each context = isolated cookies + storage,
+so it simulates two physically distinct machines), navigates each to `/`,
+clicks New Session, asserts the WS reaches `data-ws-state="open"`, types a
+unique `echo cloud-e2e-<uuid>`, and asserts that:
+
+1. Both tabs get **distinct** sids.
+2. Each tab's `terminal-pane` contains its own uuid.
+3. Neither tab contains the other tab's uuid (no cross-contamination).
+
+This is the acceptance test for **R-27** (multi-client cloud pairing).
+Before R-27 lands, the second tab is expected to fail (one tab will time
+out waiting for `data-ws-state="open"` or the wrong uuid will appear in
+the wrong terminal). After R-27, both tabs go green.
+
+## Maintenance
+
+Selectors mirror `packages/smoke/tests/s3-happy-path.spec.ts`. If that
+spec changes selectors, update this one too — they target the same
+`@ccsm/ui` `data-testid`s (`session-list`, `sidebar-new-session`,
+`terminal-pane`, `Terminal input`).

--- a/tools/cloud-e2e/package.json
+++ b/tools/cloud-e2e/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ccsm-cloud-e2e",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Standalone Playwright harness that exercises the deployed cc-sm.pages.dev cloud SPA end-to-end (Task #82). Lives outside the pnpm workspace on purpose so installing browsers / @playwright/test does not perturb the monorepo lockfile.",
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "install:browsers": "playwright install chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.2",
+    "@types/node": "^22.9.0",
+    "typescript": "^5.6.3"
+  }
+}

--- a/tools/cloud-e2e/playwright.config.ts
+++ b/tools/cloud-e2e/playwright.config.ts
@@ -1,0 +1,38 @@
+// Playwright config for the standalone cloud-e2e harness (Task #82).
+//
+// Why standalone (not in packages/ or in the pnpm workspace):
+//   - The monorepo's `pnpm-workspace.yaml` only globs `packages/*`, so this
+//     tool stays out of the workspace install graph and avoids hot-file
+//     mutex contention on the root lockfile when manager runs it ad-hoc.
+//   - Target is the *deployed* cc-sm.pages.dev cloud SPA; no local fixtures,
+//     no orchestrator, no daemon spawn — manager just runs `pnpm test`.
+//
+// Failure artifacts (trace.zip, screenshots, video) land in
+// `test-results/` so the manager can inspect them after a red run.
+import { defineConfig, devices } from '@playwright/test';
+
+const BASE_URL = process.env.CCSM_CLOUD_BASE_URL ?? 'https://cc-sm.pages.dev';
+
+export default defineConfig({
+  testDir: './specs',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: BASE_URL,
+    headless: true,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/tools/cloud-e2e/specs/two-tab-pairing.spec.ts
+++ b/tools/cloud-e2e/specs/two-tab-pairing.spec.ts
@@ -1,0 +1,150 @@
+// Two-tab pairing spec (Task #82).
+//
+// Simulates two independent machines hitting the deployed cc-sm.pages.dev
+// SPA simultaneously. Each "machine" gets its own browser context (fresh
+// storage / cookies — equivalent to a separate browser profile), opens the
+// SPA, creates a new session, types a unique echo, and asserts that the
+// terminal pane contains *its own* uuid (not the other tab's).
+//
+// Selectors / wait gates are taken from packages/smoke/tests/s3-happy-path.spec.ts:
+//   - data-testid="session-list"   — post-token-boot UI is mounted
+//   - sidebar-new-session button   — create a session
+//   - data-testid="terminal-pane"  — xterm container; carries data-ws-state
+//   - aria-label="Terminal input"  — xterm's hidden textarea (focus target)
+//
+// Token bootstrap: the SPA's hostConfig.ts already does the 3-step priority
+// chain (URL ?token= → fetch /token → fail). cc-sm.pages.dev serves /token
+// via the Pages Function + Worker tunnel, so we just navigate to '/' and
+// let the SPA do its thing.
+//
+// Pre-R-27 expectation: with the single-token / single-tunnel cloud model,
+// the second context is expected to fail (PTY output never appears or both
+// tabs share one session). After R-27 lands, both tabs should each see
+// their own sid and their own echoed uuid. This spec is the acceptance
+// gate for R-27.
+import { test, expect, type BrowserContext, type Page } from '@playwright/test';
+import { randomUUID } from 'node:crypto';
+
+interface TabHandle {
+  context: BrowserContext;
+  page: Page;
+  label: string;
+  uuid: string;
+}
+
+async function openFreshTab(
+  browser: import('@playwright/test').Browser,
+  label: string,
+): Promise<TabHandle> {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  // Mirror smoke's diagnostics: pipe SPA console / pageerror / requestfailed
+  // into the test process stderr so a red run is debuggable from the trace
+  // alone without re-running headed.
+  page.on('console', m =>
+    process.stderr.write(`[${label} console.${m.type()}] ${m.text()}\n`),
+  );
+  page.on('pageerror', e =>
+    process.stderr.write(`[${label} pageerror] ${e.message}\n${e.stack ?? ''}\n`),
+  );
+  page.on('requestfailed', r =>
+    process.stderr.write(
+      `[${label} requestfailed] ${r.url()} -> ${r.failure()?.errorText}\n`,
+    ),
+  );
+
+  await page.goto('/');
+  return { context, page, label, uuid: randomUUID() };
+}
+
+async function bootSession(tab: TabHandle): Promise<string> {
+  // Wait for the post-token-boot UI; if /token failed (no tunnel / bad
+  // worker / cf outage) this never resolves and the test fails fast.
+  await expect(tab.page.getByTestId('session-list')).toBeVisible({
+    timeout: 30_000,
+  });
+
+  await tab.page.getByTestId('sidebar-new-session').click();
+  await expect(tab.page.getByTestId('terminal-pane')).toBeVisible({
+    timeout: 30_000,
+  });
+
+  // Read the sid off the just-rendered session row. The sidebar tags each
+  // row with `data-testid="sidebar-session-<sid>"` (Sidebar.tsx:337). We
+  // need the sid for the cross-tab uniqueness assertion below.
+  const row = tab.page.getByTestId(/^sidebar-session-[0-9a-f]/).first();
+  await expect(row).toBeVisible({ timeout: 30_000 });
+  const testId = await row.getAttribute('data-testid');
+  if (!testId) throw new Error(`[${tab.label}] sidebar session row has no data-testid`);
+  const sid = testId.replace(/^sidebar-session-/, '');
+
+  // Wait for the ws to actually reach OPEN before we type — same gate the
+  // smoke spec uses. Without this, keystrokes race the createSession →
+  // ws-open window (~340ms) and chars get dropped.
+  await expect(tab.page.getByTestId('terminal-pane')).toHaveAttribute(
+    'data-ws-state',
+    'open',
+    { timeout: 30_000 },
+  );
+
+  return sid;
+}
+
+async function echoUuid(tab: TabHandle): Promise<void> {
+  const cmd = `echo cloud-e2e-${tab.uuid}`;
+  // Click xterm's hidden textarea, not the outer pane (smoke R-22 fix —
+  // clicking the pane div doesn't forward focus to xterm so chars get
+  // dropped onto document.body).
+  await tab.page.getByLabel('Terminal input').click();
+  // pressSequentially + 30ms delay paces input closer to a real user so
+  // xterm emits each keystroke as its own onData (smoke R-23 fix —
+  // page.keyboard.type batches into len=3 onData events).
+  await tab.page.getByLabel('Terminal input').pressSequentially(cmd, { delay: 30 });
+  await tab.page.keyboard.press('Enter');
+}
+
+test('two tabs, two sessions, each tab sees only its own PTY echo', async ({
+  browser,
+}) => {
+  const tabA = await openFreshTab(browser, 'tabA');
+  const tabB = await openFreshTab(browser, 'tabB');
+
+  try {
+    // Boot both sessions in parallel — this is the whole point: two
+    // "machines" hitting the cloud SPA at the same time. R-27 is what makes
+    // this work; before R-27 the second tab is expected to be red.
+    const [sidA, sidB] = await Promise.all([bootSession(tabA), bootSession(tabB)]);
+
+    expect(sidA, 'tabA sid must be non-empty').toBeTruthy();
+    expect(sidB, 'tabB sid must be non-empty').toBeTruthy();
+    expect(
+      sidA,
+      'tabA and tabB must get distinct sids (each tab is a separate session)',
+    ).not.toEqual(sidB);
+
+    // Type each tab's unique echo command in parallel.
+    await Promise.all([echoUuid(tabA), echoUuid(tabB)]);
+
+    // Each tab's terminal must contain ITS OWN uuid.
+    await expect(tabA.page.getByTestId('terminal-pane')).toContainText(
+      `cloud-e2e-${tabA.uuid}`,
+      { timeout: 30_000 },
+    );
+    await expect(tabB.page.getByTestId('terminal-pane')).toContainText(
+      `cloud-e2e-${tabB.uuid}`,
+      { timeout: 30_000 },
+    );
+
+    // Cross-contamination check: tabA's terminal must NOT contain tabB's
+    // uuid (and vice versa). If the cloud routes both tabs to the same
+    // PTY, this assertion catches it.
+    const aText = await tabA.page.getByTestId('terminal-pane').innerText();
+    const bText = await tabB.page.getByTestId('terminal-pane').innerText();
+    expect(aText, 'tabA must not see tabB uuid').not.toContain(tabB.uuid);
+    expect(bText, 'tabB must not see tabA uuid').not.toContain(tabA.uuid);
+  } finally {
+    await tabA.context.close();
+    await tabB.context.close();
+  }
+});

--- a/tools/cloud-e2e/tsconfig.json
+++ b/tools/cloud-e2e/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["specs/**/*.ts", "playwright.config.ts"]
+}


### PR DESCRIPTION
## Summary
- New standalone Playwright tool under `tools/cloud-e2e/` that exercises the deployed `https://cc-sm.pages.dev` SPA end-to-end. Lives outside the pnpm workspace on purpose so installing `@playwright/test` + the chromium binary does not touch the monorepo lockfile (avoids hot-file mutex).
- Spec `two-tab-pairing.spec.ts` opens two isolated browser contexts (= two simulated machines), clicks `sidebar-new-session` in each, waits for `data-ws-state="open"`, types a unique `echo cloud-e2e-<uuid>`, and asserts each tab sees only its own uuid + sids are distinct.
- Acts as the acceptance gate for **R-27** (multi-client cloud pairing). Pre-R-27 the second tab is expected to fail; post-R-27 both tabs go green.

## Files
- `tools/cloud-e2e/package.json` (NEW, single-file, not in workspace)
- `tools/cloud-e2e/playwright.config.ts` (NEW)
- `tools/cloud-e2e/specs/two-tab-pairing.spec.ts` (NEW)
- `tools/cloud-e2e/tsconfig.json` (NEW)
- `tools/cloud-e2e/README.md` (NEW)
- `tools/cloud-e2e/.gitignore` (NEW)
- `pnpm-workspace.yaml` unchanged (still globs only `packages/*`)
- `packages/**` unchanged (zero source touched)

Selectors copied verbatim from `packages/smoke/tests/s3-happy-path.spec.ts` (`session-list`, `sidebar-new-session`, `terminal-pane`, `Terminal input`, `data-ws-state`) so the two harnesses stay in lock-step. Token bootstrap is delegated to the SPA's existing 3-step priority chain in `packages/frontend-web/src/hostConfig.ts` — no token plumbing in the spec.

## How to run

```bash
cd tools/cloud-e2e
pnpm install         # or npm install
pnpm install:browsers
pnpm test            # headless against https://cc-sm.pages.dev
```

Override origin via `CCSM_CLOUD_BASE_URL=...`. Failure artifacts land in `tools/cloud-e2e/test-results/` (trace.zip, screenshot, video).

## Local checks (host: Windows 11, mode: fast)
- lint: skipped (new tool, no eslint config in scope; not wired into root scripts)
- typecheck: ✓ `npx tsc --noEmit` clean (using local `tsconfig.json`)
- build: skipped (no build step — Playwright runs `.ts` directly via its loader)
- unit tests: skipped (no unit specs under `tools/cloud-e2e/`)
- e2e: `npx playwright test --list` discovers `[chromium] two-tab-pairing.spec.ts:107:1 › two tabs, two sessions, each tab sees only its own PTY echo`. Not executed against the live cloud here per spec — the harness is itself the acceptance test for R-27 and will be run by manager once R-27 merges. Running it now (R-27 not yet merged) is expected to red on the second tab, which matches Task #82's "this is R-27's acceptance test" framing.
- monorepo lint/typecheck: not run — zero `packages/**` files touched, only new `tools/cloud-e2e/**` files added.

## Why no `packages/`-level changes
Task spec is explicit: "不动 packages/ 任何文件。不动 root 的 package.json / lockfile". This PR is purely additive under `tools/cloud-e2e/`, so the existing CI matrix is unaffected.