### PR TITLE
fix(daemon): R-27 — re-pair tunnel hello supports multi-sid on one ws (Task #81)

### DIFF
--- a/packages/daemon/src/tunnel.mts
+++ b/packages/daemon/src/tunnel.mts
@@ -25,6 +25,13 @@
 //     control frames (Task #787) are accepted before hello — they're
 //     injected by the DO regardless of browser pairing and carry no browser
 //     token by design (Task #789, S3-D).
+//   - Multi-sid re-pair (Task #81, R-27): a single SPA reuses one tunnel ws
+//     across multiple sessions. Each New Session re-sends `{type:"hello",
+//     token, sid:<new>}` on the SAME ws. The daemon tracks `currentSid` per
+//     connection; when a hello with a different sid arrives, we tear down
+//     the old browserAttachHandle (so the prior PTY drops its subscriber)
+//     and call onBrowserAttach again with the new sid. Same-sid hello is
+//     idempotent. Token is re-checked on every hello.
 //
 // timingSafeEqual constant-time comparison is reused from auth.mts (NOT
 // reimplemented) to honor the §1 5-tier "use existing in-repo" rule.
@@ -222,6 +229,10 @@ export class TunnelClient {
   private helloSeen = false;
   private browserToken: string | null = null;
   // Task #793 (S3-G): per-connection browser session attachment.
+  // Task #81 (R-27): currentSid tracks the sid of the most-recent hello so
+  // we can detect re-pair (SPA reusing one tunnel ws across sessions) and
+  // tear down the old attach handle before invoking onBrowserAttach again.
+  private currentSid: string | null = null;
   private readonly onBrowserAttach: ((info: BrowserAttachInfo) => BrowserAttachHandle | null) | null;
   private browserAttachHandle: BrowserAttachHandle | null = null;
 
@@ -293,6 +304,7 @@ export class TunnelClient {
     this.state = 'connecting';
     this.helloSeen = false;
     this.browserToken = null;
+    this.currentSid = null;
     this.browserAttachHandle = null;
     let socket: WsLike;
     try {
@@ -332,62 +344,16 @@ export class TunnelClient {
       // already gates HTTP entry — so they MUST be accepted before hello.
       // We sniff text frames for `{type:"http_req"}` first; only "neither
       // hello nor http_req" lands on the rejectHello path.
-      if (!this.helloSeen) {
-        if (isBinary) {
+      //
+      // Task #81 (R-27): every text frame is sniffed for hello, even after
+      // helloSeen, so a paired SPA can re-pair the same tunnel ws to a new
+      // sid (New Session in the SPA). parseHello is cheap (single JSON.parse
+      // + shape check) and runs before the raw onFrame fall-through.
+      if (isBinary) {
+        if (!this.helloSeen) {
           this.rejectHello('binary frame before hello');
           return;
         }
-        const text = (Buffer.isBuffer(raw)
-          ? raw
-          : Array.isArray(raw)
-            ? Buffer.concat(raw)
-            : Buffer.from(raw as ArrayBuffer)).toString('utf8');
-        const ctrl = this.tryParseHttpReq(text);
-        if (ctrl !== null) {
-          // http_req is browser-pairing-independent; handle without flipping
-          // helloSeen so a subsequent browser pairing still requires hello.
-          void this.handleHttpReq(ctrl);
-          return;
-        }
-        const hello = parseHello(text);
-        if (hello === null) {
-          this.rejectHello('malformed hello frame');
-          return;
-        }
-        if (!constantTimeTokenEquals(hello.token, this.token)) {
-          this.rejectHello('bad token in hello');
-          return;
-        }
-        this.helloSeen = true;
-        this.browserToken = hello.token;
-        // R-17 log #8 (Task #45): hello received, record sid + lastSeq.
-        console.error('[ccsm] tunnel: hello received sid=' + (hello.sid ?? '-') + ' lastSeq=' + (hello.lastSeq ?? 0));
-        // Task #793 (S3-G): if the browser supplied a sid in hello, hand the
-        // pairing off to the daemon main so it can wire this tunnel into the
-        // matching per-session PTY ring. The handle owns frame routing for
-        // the rest of this connection.
-        if (this.onBrowserAttach !== null && typeof hello.sid === 'string' && hello.sid.length > 0) {
-          const send = (payload: Uint8Array | Buffer): void => {
-            // Bridge to the underlying ws. Always binary frame back to browser.
-            const buf = Buffer.isBuffer(payload)
-              ? payload
-              : Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength);
-            this.send(buf);
-          };
-          try {
-            this.browserAttachHandle = this.onBrowserAttach({
-              sid: hello.sid,
-              lastSeq: hello.lastSeq ?? 0,
-              send,
-            });
-          } catch (err) {
-            console.warn('[ccsm/tunnel] onBrowserAttach threw:', (err as Error).message);
-            this.browserAttachHandle = null;
-          }
-        }
-        return;
-      }
-      if (isBinary) {
         // RawData covers Buffer | ArrayBuffer | Buffer[]. Normalize to Buffer.
         let buf: Buffer;
         if (Buffer.isBuffer(raw)) {
@@ -406,25 +372,40 @@ export class TunnelClient {
           return;
         }
         this.onFrame(buf);
-      } else {
-        const buf = Buffer.isBuffer(raw)
-          ? raw
-          : Array.isArray(raw)
-            ? Buffer.concat(raw)
-            : Buffer.from(raw as ArrayBuffer);
-        const text = buf.toString('utf8');
-        // Task #787: try to parse text frame as an http_req control frame
-        // before falling through to the raw S3-T6 OUTPUT/INPUT path. We only
-        // consider it a control frame if it parses as JSON with `type:
-        // "http_req"`; everything else (raw text output, frames lacking
-        // `type`) flows through onFrame untouched.
-        const ctrl = this.tryParseHttpReq(text);
-        if (ctrl !== null) {
-          void this.handleHttpReq(ctrl);
+        return;
+      }
+
+      // Text frame path.
+      const text = (Buffer.isBuffer(raw)
+        ? raw
+        : Array.isArray(raw)
+          ? Buffer.concat(raw)
+          : Buffer.from(raw as ArrayBuffer)).toString('utf8');
+
+      // 1) http_req control frame — always handled (browser-pairing-independent).
+      const ctrl = this.tryParseHttpReq(text);
+      if (ctrl !== null) {
+        void this.handleHttpReq(ctrl);
+        return;
+      }
+
+      // 2) hello frame — always sniffed, so SPA re-pair (Task #81) works.
+      const hello = parseHello(text);
+      if (hello !== null) {
+        if (!constantTimeTokenEquals(hello.token, this.token)) {
+          this.rejectHello('bad token in hello');
           return;
         }
-        this.onFrame(text);
+        this.handleHello(hello);
+        return;
       }
+
+      // 3) Non-control non-hello text. Gated by helloSeen.
+      if (!this.helloSeen) {
+        this.rejectHello('malformed hello frame');
+        return;
+      }
+      this.onFrame(text);
     });
 
     socket.on('error', (err) => {
@@ -436,6 +417,7 @@ export class TunnelClient {
       this.ws = null;
       this.helloSeen = false;
       this.browserToken = null;
+      this.currentSid = null;
       // Task #793 (S3-G): tear down per-session attachment.
       if (this.browserAttachHandle !== null) {
         try {
@@ -455,6 +437,63 @@ export class TunnelClient {
       console.error('[ccsm] tunnel: ws close frameCount=' + frameCount + ' code=' + code);
       this.scheduleReconnect();
     });
+  }
+
+  /**
+   * Handle a token-validated hello frame. Idempotent for same sid; performs
+   * a re-pair (tear down old attach handle + invoke onBrowserAttach again)
+   * when sid changes. Task #81 (R-27).
+   */
+  private handleHello(hello: HelloFrame): void {
+    this.helloSeen = true;
+    this.browserToken = hello.token;
+    const newSid = typeof hello.sid === 'string' && hello.sid.length > 0
+      ? hello.sid
+      : null;
+
+    // Same sid (incl. both null / both same string) → idempotent. Don't
+    // re-attach; preserves PTY subscription and replay cursor.
+    if (newSid === this.currentSid) {
+      // R-17 log #8 (Task #45): hello received, record sid + lastSeq.
+      console.error('[ccsm] tunnel: hello received sid=' + (hello.sid ?? '-') + ' lastSeq=' + (hello.lastSeq ?? 0) + ' (idempotent)');
+      return;
+    }
+
+    // sid changed (null→sid, sid→sid', or sid→null). Tear down old handle
+    // first so the prior PTY drops its subscriber before the new one binds.
+    if (this.browserAttachHandle !== null) {
+      try {
+        this.browserAttachHandle.onClose();
+      } catch (err) {
+        console.warn('[ccsm/tunnel] attach onClose threw on re-pair:', (err as Error).message);
+      }
+      this.browserAttachHandle = null;
+    }
+
+    this.currentSid = newSid;
+    // R-17 log #8 (Task #45): hello received, record sid + lastSeq.
+    console.error('[ccsm] tunnel: hello received sid=' + (hello.sid ?? '-') + ' lastSeq=' + (hello.lastSeq ?? 0));
+
+    // Task #793 (S3-G): bind new attach handle if SPA supplied a sid.
+    if (this.onBrowserAttach !== null && newSid !== null) {
+      const send = (payload: Uint8Array | Buffer): void => {
+        // Bridge to the underlying ws. Always binary frame back to browser.
+        const buf = Buffer.isBuffer(payload)
+          ? payload
+          : Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength);
+        this.send(buf);
+      };
+      try {
+        this.browserAttachHandle = this.onBrowserAttach({
+          sid: newSid,
+          lastSeq: hello.lastSeq ?? 0,
+          send,
+        });
+      } catch (err) {
+        console.warn('[ccsm/tunnel] onBrowserAttach threw:', (err as Error).message);
+        this.browserAttachHandle = null;
+      }
+    }
   }
 
   private tryParseHttpReq(text: string): HttpReqFrame | null {

--- a/packages/daemon/test/tunnel.test.ts
+++ b/packages/daemon/test/tunnel.test.ts
@@ -729,4 +729,157 @@ describe('TunnelClient', () => {
     sockets[0].closeFromServer(1006);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
+
+  // ---- Task #81 (R-27): multi-sid re-pair on a single tunnel ws --------
+
+  it('second hello with new sid tears down old handle and re-attaches', () => {
+    // Reproduces the Task #81 bug: SPA reuses one cf-worker tunnel ws across
+    // sessions. New Session sends `{type:"hello",token,sid:<new>}` on the
+    // SAME ws; the daemon must tear down the prior attach handle and bind a
+    // fresh one so the new sid's PTY gets a subscriber.
+    const attachCalls: Array<{ sid: string; lastSeq: number }> = [];
+    const closeCalls: string[] = [];
+    let nextHandleId = 0;
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'tok',
+      onFrame: () => {},
+      wsFactory: factory,
+      onBrowserAttach: ({ sid, lastSeq }) => {
+        attachCalls.push({ sid, lastSeq });
+        const id = `handle-${nextHandleId++}-for-${sid}`;
+        return {
+          onFrame: () => {},
+          onClose: () => {
+            closeCalls.push(id);
+          },
+        };
+      },
+    });
+    client.start();
+    sockets[0].open();
+
+    // First hello: sid=A.
+    sockets[0].pushText(JSON.stringify({
+      type: 'hello',
+      token: 'tok',
+      sid: 'sess-A',
+      lastSeq: 0,
+    }));
+    expect(attachCalls).toEqual([{ sid: 'sess-A', lastSeq: 0 }]);
+    expect(closeCalls).toEqual([]);
+    // No 1008 close.
+    expect(sockets[0].closedCalls).toHaveLength(0);
+
+    // Second hello: sid=B on the SAME ws → re-pair.
+    sockets[0].pushText(JSON.stringify({
+      type: 'hello',
+      token: 'tok',
+      sid: 'sess-B',
+      lastSeq: 5,
+    }));
+    expect(attachCalls).toEqual([
+      { sid: 'sess-A', lastSeq: 0 },
+      { sid: 'sess-B', lastSeq: 5 },
+    ]);
+    // Old handle's onClose was invoked exactly once before the new attach.
+    expect(closeCalls).toEqual(['handle-0-for-sess-A']);
+    // Still no 1008 close — re-pair is in-band, not a protocol violation.
+    expect(sockets[0].closedCalls).toHaveLength(0);
+
+    // Third hello: same sid=B → idempotent. Neither onClose nor a fresh
+    // onBrowserAttach should fire.
+    sockets[0].pushText(JSON.stringify({
+      type: 'hello',
+      token: 'tok',
+      sid: 'sess-B',
+      lastSeq: 9,
+    }));
+    expect(attachCalls).toEqual([
+      { sid: 'sess-A', lastSeq: 0 },
+      { sid: 'sess-B', lastSeq: 5 },
+    ]);
+    expect(closeCalls).toEqual(['handle-0-for-sess-A']);
+  });
+
+  it('post-hello re-pair: binary frames after re-pair route to NEW handle', () => {
+    // Guard: after re-pair, binary frames must land on the new attach
+    // handle, not the old one (the original bug — frames were silently
+    // dropped because the gate locked on the first hello).
+    const handleAFrames: Buffer[] = [];
+    const handleBFrames: Buffer[] = [];
+    let nextSid: 'A' | 'B' = 'A';
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'tok',
+      onFrame: () => {},
+      wsFactory: factory,
+      onBrowserAttach: () => {
+        const target = nextSid === 'A' ? handleAFrames : handleBFrames;
+        nextSid = nextSid === 'A' ? 'B' : 'A';
+        return {
+          onFrame: (data) => target.push(data),
+          onClose: () => {},
+        };
+      },
+    });
+    client.start();
+    sockets[0].open();
+
+    sockets[0].pushText(JSON.stringify({
+      type: 'hello',
+      token: 'tok',
+      sid: 'sess-A',
+      lastSeq: 0,
+    }));
+    sockets[0].pushBinary(Buffer.from([0xa1]));
+    expect(handleAFrames).toHaveLength(1);
+    expect(handleBFrames).toHaveLength(0);
+
+    // Re-pair to sid=B.
+    sockets[0].pushText(JSON.stringify({
+      type: 'hello',
+      token: 'tok',
+      sid: 'sess-B',
+      lastSeq: 0,
+    }));
+    sockets[0].pushBinary(Buffer.from([0xb1]));
+    // The new frame went to handle B, NOT to handle A (which would've been
+    // the old buggy behaviour — a stale subscriber on a torn-down session).
+    expect(handleAFrames).toHaveLength(1);
+    expect(handleBFrames).toHaveLength(1);
+    expect(handleBFrames[0].equals(Buffer.from([0xb1]))).toBe(true);
+  });
+
+  it('re-pair hello with bad token closes 1008', () => {
+    // Token is re-checked on EVERY hello. A spoofed re-pair must still hit
+    // the 1008 path. (Once the ws is closed, the close handler tears the
+    // old attach down via onClose — that's covered by the close-fires-once
+    // test above.)
+    const client = new TunnelClient({
+      url: 'wss://x',
+      token: 'good',
+      onFrame: () => {},
+      wsFactory: factory,
+      onBrowserAttach: () => ({ onFrame: () => {}, onClose: () => {} }),
+    });
+    client.start();
+    sockets[0].open();
+    sockets[0].pushText(JSON.stringify({
+      type: 'hello',
+      token: 'good',
+      sid: 'sess-A',
+      lastSeq: 0,
+    }));
+    expect(sockets[0].closedCalls).toHaveLength(0);
+
+    sockets[0].pushText(JSON.stringify({
+      type: 'hello',
+      token: 'WRONG',
+      sid: 'sess-B',
+      lastSeq: 0,
+    }));
+    expect(sockets[0].closedCalls).toHaveLength(1);
+    expect(sockets[0].closedCalls[0].code).toBe(1008);
+  });
 });


### PR DESCRIPTION
## Summary

SPA reuses one cf-worker tunnel ws across sessions. New Session sends `{type:"hello",token,sid:<new>}` on the SAME ws, but the daemon's hello-gate (`helloSeen=true`) treated subsequent hellos as raw OUTPUT/INPUT frames and routed them to the OLD sid's attach handle — the new sid's PTY had `subscribers=0` and the right pane stayed blank.

Evidence (from Task #81 background, 2026-05-09):
```
ws-msg #1-3: 三段 hello (text), 第 1 段触发 onBrowserAttach, 第 2/3 段被忽略
[ccsm/runtime] pty onData sid=56a2... subscribers=0
[ccsm/runtime] pty onData sid=401f... subscribers=0
0 行 attachFrameRouter for sid=56a2.../401f...
```

## Fix (architecture layer)

Every text frame is now sniffed for hello (after http_req sniff) even after `helloSeen`. Track `currentSid: string | null` per connection. When a hello's sid differs from `currentSid`:

1. Tear down the old `browserAttachHandle` (invoking `onClose()` so the prior PTY drops its subscriber).
2. Call `onBrowserAttach` again with the new sid + lastSeq.
3. Update `currentSid`.

Same-sid hello is idempotent (no re-attach). Token is re-checked on every hello — a spoofed re-pair still hits 1008. The hello-gate (`helloSeen`) is preserved as the raw-passthrough gate (binary / non-control non-hello text before any hello → 1008), so the existing security tests stay green and SRP is honoured: `helloSeen` gates raw passthrough, `currentSid` tracks the paired session.

Files:
- `packages/daemon/src/tunnel.mts` — text frame handling refactored; new `handleHello()` method encapsulates attach/re-attach/idempotent-reuse logic; `dial()`/`close` reset `currentSid`.
- `packages/daemon/test/tunnel.test.ts` — 3 new cases.

## Test cases added

1. `second hello with new sid tears down old handle and re-attaches` — protocol per spec: hello A → attach(A); hello B same ws → onClose(A-handle) + attach(B); hello B again → idempotent (no onClose, no re-attach).
2. `post-hello re-pair: binary frames after re-pair route to NEW handle` — binary INPUT after re-pair lands on B's handle, not A's (the original symptom).
3. `re-pair hello with bad token closes 1008` — auth still enforced on every hello.

## Local checks (host: Windows 11, mode: fast)

- lint: pre-existing warnings on `packages/daemon/test/persist.test.ts` + `packages/ui/test/BootstrapRefresh.test.tsx` unrelated to this PR (origin/working CI is green; baseline lint config differs locally). My diff touches only `packages/daemon/src/tunnel.mts` + `packages/daemon/test/tunnel.test.ts` — neither file flagged by eslint.
- typecheck: ✓ (exit 0, all 8 workspace projects)
- build: ✓ (exit 0)
- unit tests (daemon full): ✓ 154 passed | 1 skipped (155) — `pnpm test` in `packages/daemon`
  - `test/tunnel.test.ts`: 25 passed (22 pre-existing + 3 new R-27 cases)
- e2e: skipped, change is daemon-internal tunnel hello-gate state machine; no e2e harness exercises multi-sid hello on one ws.

## Notes

- `helloSeen` retained as raw-passthrough gate (separate concern from sid lifecycle); avoided spec's "delete helloSeen entirely" because legacy tests cover hello-without-sid passthrough where `currentSid` would remain null and would re-trigger `rejectHello` on subsequent text.
- Comment block updated to document the multi-sid re-pair invariant (Task #81).