### PR TITLE
log(tunnel): R-28 — log /token + http_req path for 502 forensics (Task #85)

### DIFF
--- a/packages/cf-worker/src/index.ts
+++ b/packages/cf-worker/src/index.ts
@@ -49,7 +49,17 @@ export default {
       const stub = env.TUNNEL.get(id);
       // R-17 log #12 (Task #45): record HTTP-mux route entry into the DO stub.
       console.log('[worker] route ' + url.pathname + ' upgrade=' + isUpgrade);
-      return stub.fetch(req);
+      // R-28 (Task #85): /token 502 取证 — log each /token request entry +
+      // upstream response status, including method + the cf-ray + the
+      // request id from cf headers so we can correlate with the DO log.
+      const r28Method = req.method;
+      const r28Cf = req.headers.get('cf-ray') ?? '-';
+      const r28Ua = (req.headers.get('user-agent') ?? '-').slice(0, 32);
+      console.log('[r28][worker] enter path=' + url.pathname + ' method=' + r28Method + ' cf-ray=' + r28Cf + ' ua=' + r28Ua);
+      const r28Started = Date.now();
+      const r28Res = await stub.fetch(req);
+      console.log('[r28][worker] exit path=' + url.pathname + ' status=' + r28Res.status + ' dur_ms=' + (Date.now() - r28Started) + ' cf-ray=' + r28Cf);
+      return r28Res;
     }
 
     return new Response('Not Found', { status: 404 });

--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -424,8 +424,22 @@ export class TunnelDO extends DurableObject<Env> {
    * Daemon offline → 503 immediately. Daemon drop while pending → 502.
    */
   private async proxyHttp(req: Request): Promise<Response> {
+    const r28Url = new URL(req.url);
+    const r28Path = r28Url.pathname;
+    const r28DaemonAll = this.state.getWebSockets(TAG_DAEMON);
+    const r28DaemonStates = r28DaemonAll.map((ws) => ws.readyState).join(',');
+    const r28BrowserAll = this.state.getWebSockets(TAG_BROWSER);
+    console.log(
+      '[r28][do] proxyHttp enter path=' + r28Path +
+      ' method=' + req.method +
+      ' daemon_count=' + r28DaemonAll.length +
+      ' daemon_states=[' + r28DaemonStates + ']' +
+      ' browser_count=' + r28BrowserAll.length +
+      ' pending_http=' + this.pendingHttp.size,
+    );
     const daemon = this.getDaemonSocket();
     if (daemon === undefined) {
+      console.log('[r28][do] proxyHttp path=' + r28Path + ' decision=503-no-daemon');
       return new Response('daemon offline', { status: 503 });
     }
     const id = crypto.randomUUID();
@@ -444,18 +458,21 @@ export class TunnelDO extends DurableObject<Env> {
       headers,
       body_b64,
     };
+    console.log('[r28][do] proxyHttp send-frame path=' + r28Path + ' id=' + id + ' body_len=' + body.byteLength);
     return new Promise<Response>((resolve) => {
       const timer = setTimeout(() => {
         if (this.pendingHttp.delete(id)) {
+          console.log('[r28][do] proxyHttp path=' + r28Path + ' id=' + id + ' decision=504-timeout');
           resolve(new Response('upstream timeout', { status: 504 }));
         }
       }, HTTP_OVER_TUNNEL_TIMEOUT_MS);
       this.pendingHttp.set(id, { resolve, timer });
       try {
         daemon.send(JSON.stringify(frame));
-      } catch {
+      } catch (err) {
         clearTimeout(timer);
         this.pendingHttp.delete(id);
+        console.log('[r28][do] proxyHttp path=' + r28Path + ' id=' + id + ' decision=502-send-failed err=' + String(err));
         resolve(new Response('upstream send failed', { status: 502 }));
       }
     });
@@ -463,6 +480,7 @@ export class TunnelDO extends DurableObject<Env> {
 
   /** Reject every in-flight HTTP request when the daemon ws drops. */
   private failAllPendingHttp(status: number, body: string): void {
+    console.log('[r28][do] failAllPendingHttp status=' + status + ' body=' + body + ' count=' + this.pendingHttp.size);
     for (const [, pending] of this.pendingHttp) {
       clearTimeout(pending.timer);
       pending.resolve(new Response(body, { status }));
@@ -473,7 +491,11 @@ export class TunnelDO extends DurableObject<Env> {
   /** Resolve a pending HTTP request from a parsed http_res control frame. */
   private completeHttpRes(frame: HttpResFrame): void {
     const pending = this.pendingHttp.get(frame.id);
-    if (pending === undefined) return;
+    if (pending === undefined) {
+      console.log('[r28][do] completeHttpRes id=' + frame.id + ' status=' + frame.status + ' decision=no-pending (maybe timed-out)');
+      return;
+    }
+    console.log('[r28][do] completeHttpRes id=' + frame.id + ' status=' + frame.status + ' body_len=' + frame.body_b64.length);
     this.pendingHttp.delete(frame.id);
     clearTimeout(pending.timer);
     const bytes = frame.body_b64.length === 0

--- a/packages/daemon/src/tunnel.mts
+++ b/packages/daemon/src/tunnel.mts
@@ -516,6 +516,7 @@ export class TunnelClient {
    */
   private async handleHttpReq(frame: HttpReqFrame): Promise<void> {
     if (this.daemonLoopbackPort === 0) {
+      console.error('[r28][daemon] http_req id=' + frame.id + ' ' + frame.method + ' ' + frame.path + ' decision=503-no-loopback-port');
       this.send(JSON.stringify({
         type: 'http_res',
         id: frame.id,
@@ -538,6 +539,8 @@ export class TunnelClient {
       headers[k] = v;
     }
     console.error(`[ccsm] tunnel: rx http_req ${frame.method} ${frame.path}`);
+    console.error('[r28][daemon] http_req enter id=' + frame.id + ' ' + frame.method + ' ' + frame.path + ' loopback_port=' + this.daemonLoopbackPort + ' body_len=' + (body?.length ?? 0));
+    const r28Started = Date.now();
     let response: globalThis.Response;
     try {
       const init: RequestInit = {
@@ -550,6 +553,7 @@ export class TunnelClient {
       }
       response = await this.fetchImpl(url, init);
     } catch (err) {
+      console.error('[r28][daemon] http_req id=' + frame.id + ' fetch-threw err=' + (err as Error).message + ' dur_ms=' + (Date.now() - r28Started));
       this.send(JSON.stringify({
         type: 'http_res',
         id: frame.id,
@@ -564,6 +568,7 @@ export class TunnelClient {
       resHeaders[k] = v;
     });
     const resBody = Buffer.from(await response.arrayBuffer());
+    console.error('[r28][daemon] http_req exit id=' + frame.id + ' status=' + response.status + ' body_len=' + resBody.length + ' dur_ms=' + (Date.now() - r28Started));
     this.send(JSON.stringify({
       type: 'http_res',
       id: frame.id,


### PR DESCRIPTION
## Background

R-27 (PR #1200) fixed daemon tunnel hello re-pair across multi-sid on one ws. Running `tools/cloud-e2e` harness (PR #1199) on top reveals a SEPARATE end-to-end blocker:

```
[tabA] /token 200 OK in 65ms — ws connects
[tabB] /token 502 in 107ms — falls through to daemon-offline UI
```

This is NOT an R-27 regression — R-27 was about ws frames; R-28 is about the `/token` HTTP-over-tunnel mux. Repro evidence + traces are in `tools/cloud-e2e/test-results/two-tab-pairing-*-chromium/`.

## Phase 1 — forensics only (this PR)

Per memory `feedback_log_until_certain` (2026-05-08): when evidence does not uniquely pin a root cause, add observability first, repro, then fix. Candidates:

- (a) cf-worker `/token` handler (e.g. single-use token)
- (b) TunnelDO state on second `/token` (daemon ws missing / pending map / hibernation race)
- (c) Pages Function `functions/[[path]].ts` fallthrough — **eliminated by absence** (no such file in repo)
- (d) daemon-side `handleHttpReq` mux not routing the second `http_req`

This PR only adds `[r28]`-tagged `console.log` on the four hops the request traverses. No control-flow changes:

- `packages/cf-worker/src/index.ts` — `/token` enter/exit (path, method, cf-ray, status, dur_ms)
- `packages/cf-worker/src/tunnel-do.ts` `proxyHttp` — daemon ws count + readyStates, browser ws count, `pendingHttp` size; tag 503 / 504 / 502 decision paths; `failAllPendingHttp` count; `completeHttpRes` no-pending branch
- `packages/daemon/src/tunnel.mts` `handleHttpReq` — enter, fetch-threw, exit with status / dur_ms

## Next step (manager)

1. Merge → `deploy-pages.yml` deploys cf-worker.
2. Restart local Tauri daemon.
3. Run `cd tools/cloud-e2e && npx playwright test`, collect `wrangler tail` + browser console + daemon stderr, then attribute 502 to (a) / (b) / (d) in a PR comment.

Phase 2 fix is a separate task once the root cause is nailed.

## Local checks (host: Windows, mode: fast)
- lint (cf-worker + daemon, packages I touched): exit 0
- typecheck (cf-worker + daemon): exit 0
- build: skipped — log-only diff, no .ts/.tsx structural change beyond `console.log` calls
- unit tests: skipped — no behavioral change to test (controlled by task spec: "不改任何控制流, 只加观测 log")
- e2e: skipped — task is forensics; manager will run `tools/cloud-e2e` harness against deployed worker + restarted daemon (deploy + restart out of band of this branch)

Note: repo-wide `pnpm -r run typecheck` has pre-existing failures in `@ccsm/core` and `@ccsm/ui` due to missing `@ccsm/shared` build artifacts in a fresh worktree — unrelated to this diff (reproduces on `origin/working` HEAD before this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)