### PR TITLE
log(daemon): R-29 — pty spawn forensics for conpty AttachConsole crash (Task #86)

### DIFF
--- a/packages/daemon/src/runtime.mts
+++ b/packages/daemon/src/runtime.mts
@@ -171,6 +171,42 @@ const defaultPtyFactory: PtyFactory = (opts) => {
     opts.sid,
     isWindows,
   );
+  // Task #86 (R-29) — log-only forensics for conpty `AttachConsole failed`
+  // crash observed under `tauri dev` cloud-e2e harness. node-pty 1.1.0's
+  // conpty agent (lib/conpty_console_list_agent.js) calls Win32
+  // GetConsoleProcessList, which requires AttachConsole(pid) to succeed
+  // first. If the daemon process has no inheritable console (e.g. spawned
+  // by Tauri Rust with CREATE_NO_WINDOW=0x0800_0000, see
+  // packages/frontend-tauri/src-tauri/src/daemon_mgr.rs:176), AttachConsole
+  // fails and node-pty's helper subprocess throws + exits, killing the
+  // daemon. This block dumps the daemon's own stdio/console state before
+  // each spawn so we can correlate a crash to the daemon's console
+  // ancestry. NOT a fix — see Phase 2 task proposal in the PR body.
+  /* eslint-disable no-console */
+  console.error('[ccsm-pty-forensics] spawn=' + JSON.stringify({
+    sid: opts.sid,
+    mode: opts.mode,
+    cmd,
+    args,
+    isWindows,
+    platform: process.platform,
+    nodeVersion: process.version,
+    pid: process.pid,
+    ppid: typeof process.ppid === 'number' ? process.ppid : null,
+    stdinIsTTY: Boolean((process.stdin as { isTTY?: boolean }).isTTY),
+    stdoutIsTTY: Boolean((process.stdout as { isTTY?: boolean }).isTTY),
+    stderrIsTTY: Boolean((process.stderr as { isTTY?: boolean }).isTTY),
+    connected: typeof process.connected === 'boolean' ? process.connected : null,
+    hasParentIPC: Boolean(process.send),
+    cwd: opts.cwd,
+    useConpty: true,
+    // Surrogate for "do we have a console" — on Windows the only userspace
+    // signal short of FFI is whether stdout is a TTY (false under
+    // CREATE_NO_WINDOW + Stdio::piped) and whether process.stdin was wired.
+    // The conpty agent itself is what would call GetConsoleWindow; we can't
+    // call it from JS without FFI, so we proxy via TTY flags.
+  }));
+  /* eslint-enable no-console */
   const pty = nodePty.spawn(cmd, args, {
     name: 'xterm-256color',
     cols: opts.cols,


### PR DESCRIPTION
## Summary

Phase 1 forensics-only for the `Error: AttachConsole failed` crash that kills the daemon every time the `tauri dev` cloud-e2e harness creates a session (R-27 unblocked the tunnel pairing → this is the next visible failure on the path to terminal-render).

**No PTY behavior changed.** Adds a single `console.error('[ccsm-pty-forensics] spawn=...')` line in `defaultPtyFactory` that dumps the daemon's TTY / console ancestry / pid / ppid / cmd+args before each `nodePty.spawn`. Goal: the next user-driven cloud-e2e run produces a diagnostic line that correlates the helper-agent `AttachConsole` failure to the daemon's missing console.

## Background — what crashed

User-supplied stderr from a `tauri dev` cloud-e2e run (Task #86 spec):

```
node_modules\.pnpm\node-pty@1.1.0\node_modules\node-pty\lib\conpty_console_list_agent.js:13
var consoleProcessList = getConsoleProcessList(shellPid);
                         ^
Error: AttachConsole failed
Node.js v22.18.0
```

Per node-pty source, every conpty spawn forks a helper Node subprocess (`conpty_console_list_agent.js`) that calls Win32 `GetConsoleProcessList(shellPid)`. That API requires a successful `AttachConsole(pid)` first. If the daemon process has no inheritable console, AttachConsole fails, the helper throws, and the daemon dies.

## Code-review evidence — smoke vs cloud-e2e daemon spawn path

I read both spawn paths and they are **the same Rust code**:

| | smoke (`packages/smoke/fixtures/orchestrator.ts:361`) | cloud-e2e (`tauri dev`, Task #86 user run) |
|---|---|---|
| Tauri shell | release `ccsm-tauri.exe` from `.fixtures/bin/` | `tauri dev` (vite + cargo dev) |
| Daemon spawn fn | `daemon_mgr::spawn_daemon_inner` (lib.rs setup hook) | same |
| Stdio | `Stdio::piped()` stdout+stderr, `Stdio::null()` stdin | same |
| Windows creation flag | `CREATE_NO_WINDOW (0x0800_0000)` — `daemon_mgr.rs:176` | same |
| `CCSM_PTY_ENTRY` | **`cmd.exe`** (smoke override, `orchestrator.ts:385`) | **unset → default `claude.cmd`** |

Key file: `packages/frontend-tauri/src-tauri/src/daemon_mgr.rs:173-177`:
```rust
#[cfg(windows)]
{
    cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW — avoid console flash
}
```

So: the daemon child explicitly has no console (`CREATE_NO_WINDOW`) on **both** smoke and cloud-e2e. The only behavioral difference between the two is what node-pty subsequently spawns inside the daemon: `cmd.exe` (smoke) vs `claude.cmd` → `node …` (cloud-e2e default).

## Root-cause candidates (not yet narrowed)

(a) **Tauri-side**: `CREATE_NO_WINDOW` strips the daemon's console, so node-pty's helper-agent `AttachConsole(shellPid)` has no parent console to attach to. Fix would live in `daemon_mgr.rs` (allocate a hidden console with `CREATE_NEW_CONSOLE` or `AllocConsole`, or drop `CREATE_NO_WINDOW`).

(b) **node-pty 1.1.0 .cmd-shim conpty path**: `claude.cmd` is a batch-file shim that re-spawns `node` with extra args. The conpty agent's process-list scan over a `.cmd → node.exe` chain is a known fragile area in node-pty issue tracker. Fix would be upstream or version-pin (out of our scope).

(c) **conpty unsupported here**: dropping `useConpty: true` would fall back to winpty. Not desirable on modern Windows; explicitly out of scope per task spec.

I did **not** lock the answer because the open question is whether smoke under the same `CREATE_NO_WINDOW` daemon would also crash if smoke routed through `claude.cmd`. That experiment requires `pnpm smoke:build` (~5 min cargo release rebuild) which I avoided per memory `feedback_smoke_windows_zombie_lock_2026_05_08` (no concurrent local smoke from dev pool). The forensic log lands now so the user's existing `tauri dev` session immediately produces evidence on the next cloud-e2e run — cheaper signal than rebuilding smoke.

## What the new log looks like

Each PTY spawn (cloud-e2e flow: 2 sids → 2 spawns) now prints to daemon stderr:

```
[ccsm-pty-forensics] spawn={"sid":"…","mode":"create","cmd":"claude.cmd","args":["--session-id","…"],"isWindows":true,"platform":"win32","nodeVersion":"v22.18.0","pid":12345,"ppid":67890,"stdinIsTTY":false,"stdoutIsTTY":false,"stderrIsTTY":false,"connected":null,"hasParentIPC":false,"cwd":"…","useConpty":true}
```

If `stdoutIsTTY/stderrIsTTY` are both false **and** AttachConsole crashes immediately after, root cause locks on (a). If they happen to be true, locks on (b).

## Phase 2 proposal

Open follow-up task: **R-30 — fix conpty AttachConsole crash on Tauri-spawned daemon**. Given the forensic log, two repairs to evaluate:

1. **Drop `CREATE_NO_WINDOW`, use `CREATE_NEW_CONSOLE` + `SW_HIDE`** in `daemon_mgr.rs` so the daemon owns a hidden console its node-pty children can AttachConsole to. Tradeoff: a (hidden) console host process per daemon.
2. **Pre-attach a console inside the daemon JS** before any pty spawn (e.g. `windowsHide: true` child_process noop spawn or FFI `AllocConsole`). Lower platform-shell impact but requires a native call.

Decision belongs to manager + Phase 2 dev, not this task.

## Local checks (host: Windows 11, mode: fast)
- lint: skipped (2 pre-existing errors in `persist.test.ts` and `BootstrapRefresh.test.tsx` unrelated to this diff; verified by reverting my change and re-running — same 2 errors)
- typecheck: ✓ (`pnpm --filter @ccsm/daemon` `tsc --noEmit` exit 0 after `@ccsm/shared` build)
- build: ✓ (`pnpm --filter @ccsm/daemon run build` exit 0)
- unit tests: ✓ `daemon/test/runtime.test.ts` 9 passed (1 file, 5ms tests / 2.02s total)
- e2e: skipped — log-only diff, does not change PTY behavior; smoke not rebuilt locally per `feedback_smoke_windows_zombie_lock_2026_05_08`. CI matrix will pick it up.

## Out of scope (deliberately not touched)

- `useConpty: true` setting — task spec forbids
- node-pty version pin / patch — task spec forbids
- skip / xfail tests — task spec forbids
- any `try/catch` around the `nodePty.spawn` call — would mask the diagnostic
- `daemon_mgr.rs` changes — Phase 2 R-30