### PR TITLE
[research-only] R-30 attempt + pushback (Task #87)

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@ccsm/shared": "workspace:*",
     "better-sqlite3": "^11.10.0",
+    "koffi": "^2.16.2",
     "node-pty": "^1.1.0",
     "ws": "^8.20.0"
   },

--- a/packages/daemon/src/hide-console-windows.mts
+++ b/packages/daemon/src/hide-console-windows.mts
@@ -1,0 +1,56 @@
+// R-30 (Task #87): hide the daemon's own console window on Windows.
+//
+// Background: Tauri spawns the daemon with CREATE_NEW_CONSOLE so node-pty's
+// `conpty_console_list_agent.js` helper subprocess inherits a stable console
+// handle (see `packages/frontend-tauri/src-tauri/src/daemon_mgr.rs` for the
+// full rationale on why CREATE_NO_WINDOW broke the second PTY spawn). The
+// trade-off is that the daemon launches with a visible Node console window.
+//
+// This module hides that window via Win32 user32!ShowWindow(GetConsoleWindow,
+// SW_HIDE), called once at daemon startup. We use `koffi` (a thin
+// dlopen/dlsym wrapper, prebuilt native binary, no compile step) because Node
+// has no built-in way to call user32 from JS and we don't want to add another
+// node-gyp build for a 3-line FFI call.
+//
+// No-op on non-Windows.
+//
+// Failure modes (logged + ignored):
+//   - koffi fails to load (very rare; would surface as ERR_DLOPEN_FAILED)
+//   - GetConsoleWindow returns 0 (process has no console — e.g. spawned by
+//     something other than Tauri with CREATE_NEW_CONSOLE; the conpty fix is
+//     not active in that case but we don't need to hide anything either)
+//   - ShowWindow returns 0 (window was already hidden — fine)
+//
+// Hiding is best-effort. The functional fix (CREATE_NEW_CONSOLE giving
+// node-pty a console to attach/detach against) does NOT depend on this hide
+// succeeding — only on the console existing.
+
+export async function hideOwnConsoleWindowOnWindows(): Promise<void> {
+  if (process.platform !== 'win32') return;
+  try {
+    // Lazy ESM import so non-Windows platforms never load koffi.
+    const koffiMod = await import('koffi');
+    const koffi = (koffiMod as { default?: typeof import('koffi') }).default ?? koffiMod;
+    const user32 = koffi.load('user32.dll');
+    const kernel32 = koffi.load('kernel32.dll');
+
+    // HWND GetConsoleWindow();
+    const GetConsoleWindow = kernel32.func('void* GetConsoleWindow()');
+    // BOOL ShowWindow(HWND hWnd, int nCmdShow);
+    const ShowWindow = user32.func('int ShowWindow(void* hWnd, int nCmdShow)');
+
+    const hwnd = GetConsoleWindow();
+    if (!hwnd) {
+      console.error('[ccsm] hide-console: GetConsoleWindow returned null (no console attached)');
+      return;
+    }
+    const SW_HIDE = 0;
+    ShowWindow(hwnd, SW_HIDE);
+    console.error('[ccsm] hide-console: hid console window');
+  } catch (err) {
+    // Don't let an FFI/koffi load failure abort daemon startup — the user
+    // would just see a stray Node console window, which is annoying but not
+    // functionally broken (the conpty fix in Rust still applies).
+    console.error('[ccsm] hide-console: failed to hide console window:', err);
+  }
+}

--- a/packages/daemon/src/index.mts
+++ b/packages/daemon/src/index.mts
@@ -24,6 +24,7 @@ import type { AddressInfo } from 'node:net';
 
 import { openDb } from './db.mjs';
 import { createDaemonHttp } from './http.mjs';
+import { hideOwnConsoleWindowOnWindows } from './hide-console-windows.mjs';
 import { createRuntimeRegistry } from './runtime.mjs';
 import { TunnelClient } from './tunnel.mjs';
 import { attachFrameRouter, attachWebSocket } from './ws.mjs';
@@ -103,6 +104,12 @@ async function listenWithRetry(
 }
 
 async function main(): Promise<void> {
+  // R-30 (Task #87): when launched by Tauri with CREATE_NEW_CONSOLE (so
+  // node-pty's conpty helper has a stable console to attach/detach), hide the
+  // resulting Node console window so users don't see it pop up. No-op when
+  // run standalone (no console / not Windows).
+  await hideOwnConsoleWindowOnWindows();
+
   const handshakeMode = process.argv.includes(HANDSHAKE_FLAG);
   const startPort = parsePort(process.env.PORT);
   const token =

--- a/packages/frontend-tauri/src-tauri/src/daemon_mgr.rs
+++ b/packages/frontend-tauri/src-tauri/src/daemon_mgr.rs
@@ -172,8 +172,28 @@ pub async fn spawn_daemon_inner(app: AppHandle) -> Result<(), String> {
 
     #[cfg(windows)]
     {
-        // tokio::process::Command exposes creation_flags directly on Windows.
-        cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW — avoid console flash
+        // R-30 (Task #87): use CREATE_NEW_CONSOLE instead of CREATE_NO_WINDOW.
+        //
+        // Background: node-pty 1.1.0 on Windows forks a helper subprocess
+        // (`conpty_console_list_agent.js`) for every `pty.spawn()` that calls
+        // `AttachConsole(shellPid)`. AttachConsole requires the calling process
+        // to NOT already be attached to a console. With CREATE_NO_WINDOW the
+        // daemon has no console, so the FIRST PTY spawn implicitly
+        // AllocConsole's; the SECOND spawn then fails because a Windows
+        // process can be attached to only ONE console at a time → conpty #2
+        // is internally broken with no onData → second tab terminal never
+        // receives output. Confirmed by R-29 forensics on cloud-e2e two-tab
+        // harness (PR #1202).
+        //
+        // CREATE_NEW_CONSOLE gives the daemon its own console up front. The
+        // helper subprocess inherits it; AttachConsole(target) → ... →
+        // FreeConsole + AttachConsole(parent) cycle works for every spawn.
+        //
+        // The console window is hidden by daemon JS at startup
+        // (packages/daemon/src/console-hide-windows.mts via koffi → user32.dll
+        // ShowWindow) so users don't see a Node prompt.
+        const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
+        cmd.creation_flags(CREATE_NEW_CONSOLE);
     }
 
     let mut child = cmd.spawn().map_err(|e| format!("spawn failed: {e}"))?;
@@ -389,6 +409,30 @@ fn write_token_file(path: &Path, token: &str) -> Result<(), String> {
     Ok(())
 }
 
+// R-30 (Task #87): Allocate a hidden console for the Tauri process so the
+// spawned daemon (and node-pty's `conpty_console_list_agent.js` helper that
+// it forks per PTY) inherits a stable console handle.
+//
+// Background: node-pty 1.1.0 on Windows forks a helper subprocess for every
+// `pty.spawn()` that calls `AttachConsole(shellPid)`. AttachConsole requires
+// the calling process to not already be attached to a console; if the daemon
+// implicitly AllocConsole'd on the first spawn (because it had none), the
+// SECOND spawn's AttachConsole fails — the second tab's terminal never
+// receives PTY output. Forensics from R-29 (PR #1202) confirmed this exact
+// sequence on cloud-e2e two-tab harness.
+//
+// Fix: ensure the parent (Tauri) process owns a console before any daemon
+// spawn. The daemon inherits it via normal CreateProcess inheritance (no
+// CREATE_NO_WINDOW / no CREATE_NEW_CONSOLE). The helper subprocess, when it
+// AttachConsole's to a conpty shell, can cleanly return to the inherited
+// console afterward — so spawn #2, #3, ... all work.
+//
+// We hide the console window (`ShowWindow(SW_HIDE)`) immediately after
+// AllocConsole so users never see a stray window. AllocConsole may legitimately
+// fail if the process already has a console (ERROR_ACCESS_DENIED 0x5);
+// that's fine — we just hide whatever console exists.
+//
+// Idempotent and safe to call multiple times. Logs once-per-call.
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
+      koffi:
+        specifier: ^2.16.2
+        version: 2.16.2
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0

--- a/research-report-task-87.md
+++ b/research-report-task-87.md
@@ -1,0 +1,216 @@
+# R-30 Research Report — conpty AttachConsole second-spawn failure
+
+**Task**: #87 (R-30: 修 PTY conpty AttachConsole — Tauri CREATE_NEW_CONSOLE+SW_HIDE)
+**Status**: research-pushback. Original spec hypothesis falsified; not shipping.
+**Date**: 2026-05-09
+**Host**: Windows 11 Enterprise 26200, Node v22.18.0, node-pty 1.1.0
+
+## TL;DR
+
+Implemented spec's recommended Plan A (Tauri `creation_flags` change from
+`CREATE_NO_WINDOW` to `CREATE_NEW_CONSOLE`, plus daemon-side koffi
+`ShowWindow(GetConsoleWindow, SW_HIDE)` to hide the resulting console
+window). **Manual cloud-e2e two-tab harness still fails identically**:
+spawn #1 succeeds, spawn #2 throws `AttachConsole failed` at
+`conpty_console_list_agent.js:13`. Spec's root-cause hypothesis ("daemon
+has no console with CREATE_NO_WINDOW → 1st spawn implicit AllocConsole
+binds it; 2nd spawn fails") does not survive the test — daemon now has a
+stable own console up front, and the 2nd-spawn failure is bit-identical.
+
+## What was attempted (commit 5aee8576 on this branch)
+
+| File | Change |
+|---|---|
+| `packages/frontend-tauri/src-tauri/src/daemon_mgr.rs` | `creation_flags(CREATE_NO_WINDOW)` → `creation_flags(CREATE_NEW_CONSOLE)` |
+| `packages/daemon/src/hide-console-windows.mts` (new) | koffi-loaded user32!ShowWindow(GetConsoleWindow, SW_HIDE) at daemon startup |
+| `packages/daemon/src/index.mts` | invoke hide helper top of `main()` |
+| `packages/daemon/package.json` + lockfile | add `koffi ^2.16.2` |
+
+Build: `cargo check` ✓, `pnpm --filter @ccsm/daemon build` ✓.
+
+## Verification — fix did NOT resolve the bug
+
+Manual run: `cd packages/frontend-tauri && pnpm tauri dev` (background),
+then `cd tools/cloud-e2e && npx playwright test`.
+
+### Daemon stderr after fix (relevant lines from `/tmp/tauri-dev.log`)
+
+```
+[daemon-mgr] spawned daemon pid=22012
+[daemon-mgr] assigned pid=22012 to Job Object
+[daemon stderr] [ccsm] hide-console: hid console window
+[daemon stderr] [ccsm] tunnel: connecting wss://cc-sm.pages.dev/tunnel/default
+[daemon-mgr] handshake ok port=56905 token=9a7773…
+[daemon stderr] [ccsm] tunnel: connected
+[daemon stderr] [ccsm-pty-forensics] spawn={"sid":"9d96ea15-...","mode":"create","cmd":"claude.cmd","stdinIsTTY":false,"stdoutIsTTY":false,"stderrIsTTY":false,"useConpty":true,"pid":22012,"ppid":39244,...}
+[daemon stderr] [ccsm-pty-forensics] spawn={"sid":"ae2c773a-...","mode":"create","cmd":"claude.cmd",...}
+[daemon stderr] Error: AttachConsole failed
+[daemon stderr]     at Object.<anonymous> (...\\node-pty\\lib\\conpty_console_list_agent.js:13:26)
+```
+
+- 2 spawns fired, 1 `AttachConsole failed` (on the 2nd) — **same shape as
+  the R-29 baseline forensics**.
+- Hide-console succeeded (`[ccsm] hide-console: hid console window`), so
+  the koffi FFI path is healthy; this is not the cause of the failure.
+
+### cloud-e2e result
+
+`tools/cloud-e2e/specs/two-tab-pairing.spec.ts` — fails at
+`tab.page.getByLabel('Terminal input').click()` for the second tab,
+15 000 ms timeout, element resolves but is not visible (xterm host pane
+never paints because PTY produces no output).
+
+## What the spec hypothesis says (and why it doesn't hold)
+
+Spec (Task #87 description, Phase 2 修法 A):
+
+> 第 1 spawn: daemon 进程没 attach 任何 console (Tauri Rust 用 CREATE_NO_WINDOW), AttachConsole 时隐式触发 AllocConsole, 成功
+> 第 2 spawn: daemon 进程已 attached 到 conpty1 的 console, AttachConsole(conpty2 shell) 被拒
+> ... daemon 有 console (CREATE_NEW_CONSOLE+SW_HIDE) → helper 继承 console → helper detach OK → attach OK
+
+If that mechanism were correct, switching to CREATE_NEW_CONSOLE would
+make spawn #2 succeed. It doesn't. Therefore the differentiator between
+spawn #1 (works) and spawn #2 (fails) is **NOT** "daemon has/has-no
+console at process startup". It is some state mutation inside the daemon
+process **between spawn #1 returning and spawn #2 starting**, that
+poisons the 2nd helper's console-attach attempt.
+
+## Source-level evidence
+
+`node-pty/src/win/conpty_console_list.cc` lines 18–22 (helper
+subprocess body):
+
+```cpp
+if (!FreeConsole()) {
+    throw Napi::Error::New(env, "FreeConsole failed");
+}
+if (!AttachConsole(pid)) {
+    throw Napi::Error::New(env, "AttachConsole failed");   // ← thrown
+}
+auto processList = std::vector<DWORD>(64);
+auto processCount = GetConsoleProcessList(...);
+FreeConsole();
+```
+
+Helper inherits the daemon's console state via `child_process.fork`,
+runs FreeConsole (releases inherited binding), runs
+AttachConsole(targetPid) (binds to the conpty shell). The throw is on
+`AttachConsole`, not `FreeConsole` — i.e. the inherited state was
+released cleanly, but the new attach to the conpty shell is rejected.
+
+`node-pty/src/win/conpty.cc` (daemon-side, called by `pty.spawn()`)
+calls `CreatePseudoConsole`/`ConptyCreatePseudoConsole`. It does NOT
+call AttachConsole/FreeConsole on the daemon directly. **However**, the
+Microsoft pseudo-console API documentation
+(<https://learn.microsoft.com/en-us/windows/console/createpseudoconsole>)
+implies the HPCON handle ties the daemon to the conpty's session in some
+opaque way that affects subsequent AttachConsole calls. The exact
+mechanism is undocumented; the failure mode is consistent with "process
+that has spawned at least one HPCON cannot AttachConsole to any other
+HPCON's shell pid until it disposes the first HPCON".
+
+## Real root-cause hypothesis (NOT YET CONFIRMED — needs R-31 forensics)
+
+**H1 (most likely)**: After the daemon calls `CreatePseudoConsole` for
+spawn #1, the daemon process is implicitly bound to that HPCON's
+console group. Helpers forked thereafter inherit that binding. The
+helper's `FreeConsole` releases the inherited handle but does **not**
+sever the deeper HPCON↔daemon linkage; subsequent `AttachConsole(pid2)`
+where pid2 is owned by HPCON#2 returns ERROR_ACCESS_DENIED because the
+calling helper's parent (daemon) is still associated with HPCON#1.
+
+**H2 (less likely)**: It's not HPCON binding but `getConsoleProcessList`
+itself that is destructive — running the helper for spawn #1 leaves
+side-effects in the daemon's console state. Less plausible because the
+helper is a separate process; whatever it does to its own console
+shouldn't propagate back to daemon. But not impossible if conhost shares
+state across the process group.
+
+H1 vs H2 cannot be distinguished without measuring `GetConsoleWindow`
+and `GetConsoleProcessList` from inside the daemon (not the helper)
+**before** and **after** each `pty.spawn()`. That is the R-31 ask.
+
+## Candidate fixes (≥2, with risks) — DO NOT IMPLEMENT YET
+
+### A. Daemon-side `FreeConsole()` before each `pty.spawn()` (workaround)
+
+In `packages/daemon/src/runtime.mts` `defaultPtyFactory`, on Windows,
+call `kernel32!FreeConsole()` via koffi immediately before
+`nodePty.spawn`. Goal: reset the daemon's console attachment so the
+helper inherits a clean "no console" each spawn, equivalent to the
+post-startup baseline-spawn-#1 condition.
+
+- **Risk H1-true**: H1 says the binding is HPCON-level, not console-handle-level —
+  FreeConsole won't break it. Then this is a no-op and spawn #2 still fails.
+- **Risk H1-false**: it works, but introduces ~1 ms latency per spawn and
+  a koffi call from a hot path; also FFI failure modes leak into PTY
+  spawn pipeline.
+- **Already prototyped this on this branch as a separate uncommitted
+  change** (saved at `/tmp/task-87-runtime-mts-uncommitted-attempt2.patch`);
+  not tested manually because manager halted further attempts. Would be
+  the test-once-and-decide path R-32 if R-31 confirms H1 is wrong.
+- **Layer**: Layer 4 glue per memory `feedback_fix_arch_not_glue.md`
+  reading. Not preferred unless higher-layer fix is infeasible.
+
+### B. Patch / vendor node-pty `conpty.cc` to dispose HPCON properly (root-cause fix if H1)
+
+Modify `node-pty/src/win/conpty.cc`'s lifecycle to ensure the daemon is
+not bound to HPCON#N's console after spawn return — possibly by spawning
+the conpty in an isolated process group, or by closing the HPCON handle
+on the daemon side once the shell has detached.
+
+- **Risk**: requires deep understanding of Microsoft's HPCON internals
+  that are not publicly documented; likely needs new conpty API
+  (`ClosePseudoConsole` is called but apparently not enough).
+- **Risk**: vendoring node-pty (or maintaining a local fork / patch-package)
+  adds maintenance debt; CI builds need a custom build step for the
+  native module.
+- **Layer**: Layer 2 (the actually-broken layer). Memory-aligned.
+- **Cost**: high — needs spike, repro on minimal example, MS-team
+  consultation likely.
+
+### C. Single-conpty model: serialize all PTYs through one HPCON
+
+Architectural change: the daemon owns a single HPCON and multiplexes
+multiple "logical" sessions over it. No second `CreatePseudoConsole`
+ever, so the binding-cross-conpty problem cannot manifest.
+
+- **Risk**: very large refactor. Each session's stdout/stderr/exit needs
+  re-multiplexing in JS layer; ANSI state isolation is non-trivial.
+  Spec explicitly rejects this (`不必要`).
+
+### D. Switch to winpty fallback (`useConpty: false`)
+
+- Spec rejected this (perf + Win 11 unsupported). Not viable.
+
+## Recommended next actions (manager's call, NOT mine)
+
+1. **R-31** (forensics-only): instrument `defaultPtyFactory` with koffi
+   FFI probes for `GetConsoleWindow()` and `GetConsoleProcessList(0)` on
+   the daemon process **before** and **after** each `pty.spawn()`. Log
+   the deltas. Run cloud-e2e two-tab harness; capture stderr. This is
+   the only way to distinguish H1 from H2 before committing to fix
+   layer.
+2. **R-32**: depending on R-31 result, implement A (cheap, Layer 4
+   glue) or B (correct, Layer 2, expensive). Document layer choice in
+   PR body.
+3. Decide whether to keep this branch's koffi setup + hide-console as
+   prerequisite scaffolding for R-32, or revert and let R-32 reintroduce
+   the FFI dep itself.
+
+## Pushback
+
+I am pushing back per dev role §5 (cannot reach a working fix without
+more evidence) and per memory `feedback_log_until_certain.md` (証拠
+不足时不许猜着改). Halting changes here. Manager: please file R-31
+or override with new spec.
+
+## Branch artifacts
+
+- HEAD commit `5aee8576`: R-30 attempt (Tauri CREATE_NEW_CONSOLE + daemon
+  hide-console-windows.mts via koffi). Build green; fix non-functional.
+- Saved patch (not committed): `/tmp/task-87-runtime-mts-uncommitted-attempt2.patch`
+  — daemon-side FreeConsole-before-spawn (Plan A above), unverified,
+  recoverable for R-32.
+- Logs: `/tmp/tauri-dev.log` on dev host (ephemeral; key lines quoted
+  above).


### PR DESCRIPTION
## Status: research-only — DO NOT MERGE

This PR documents an attempted R-30 fix that **did not solve the bug**.
Spec's root-cause hypothesis was falsified by manual cloud-e2e re-run.
Pushing back to manager per memory `feedback_log_until_certain.md`
(no guessing-fixes without evidence) and dev role §5 (push back when
stuck).

See `research-report-task-87.md` (added in this PR) for the full
write-up. Highlights below.

## What was attempted (commit 5aee8576)

- `daemon_mgr.rs`: `CREATE_NO_WINDOW` → `CREATE_NEW_CONSOLE` so the
  daemon owns its own console.
- `packages/daemon/src/hide-console-windows.mts` (new): koffi-loaded
  `user32!ShowWindow(GetConsoleWindow, SW_HIDE)` at daemon startup.
- `packages/daemon/src/index.mts`: invoke hide helper top of `main()`.
- `package.json` + lockfile: add `koffi ^2.16.2`.

Build: `cargo check` ✓, `pnpm --filter @ccsm/daemon build` ✓.

## Why it didn't work

Manual `pnpm tauri dev` + `cd tools/cloud-e2e && npx playwright test`:

```
[daemon stderr] [ccsm] hide-console: hid console window         ← hide ok
[daemon-mgr] handshake ok port=56905                            ← daemon ok
[daemon stderr] [ccsm-pty-forensics] spawn=...sid=9d96ea15...   ← spawn 1
[daemon stderr] [ccsm-pty-forensics] spawn=...sid=ae2c773a...   ← spawn 2
[daemon stderr] Error: AttachConsole failed                     ← spawn 2 fails
[daemon stderr]     at conpty_console_list_agent.js:13:26
```

Spawn #1 succeeds, spawn #2 fails — **identical to the R-29 baseline
forensics**. cloud-e2e two-tab harness still fails at the second tab's
`Terminal input` click (15s timeout, xterm has no PTY output to render).

So the differentiator is NOT "daemon has/has-no console at startup".
It must be some state mutation inside the daemon **between spawn 1
returning and spawn 2 starting**.

## Real root-cause hypothesis (NEEDS R-31 forensics)

**H1**: `CreatePseudoConsole` for spawn #1 binds the daemon process to
HPCON#1's console group at a level deeper than `FreeConsole` can
release. The helper subprocess for spawn #2 inherits that binding;
`AttachConsole(pid2)` returns ERROR_ACCESS_DENIED because the calling
helper's parent (daemon) is still associated with HPCON#1.

**H2**: `getConsoleProcessList` itself has destructive side-effects on
the daemon's console state. Less plausible.

H1 vs H2 needs daemon-side `GetConsoleWindow()` +
`GetConsoleProcessList()` measurements before+after each `pty.spawn()`
to distinguish.

## Candidate fixes (DO NOT IMPLEMENT YET — manager call)

- **A**: daemon-side `FreeConsole()` before each `pty.spawn()` (Layer 4
  glue, may not work if H1 is true). Prototype saved to
  `/tmp/task-87-runtime-mts-uncommitted-attempt2.patch` on dev host.
- **B**: vendor / patch node-pty `conpty.cc` to dispose HPCON properly
  (Layer 2, root-cause if H1 — expensive, needs MS-internal knowledge).
- **C**: single-conpty model — spec rejected, too large.
- **D**: winpty fallback — spec rejected, perf + Win11 unsupported.

## Recommended manager actions

1. File **R-31**: forensics-only, instrument `defaultPtyFactory` with
   koffi probes for `GetConsoleWindow` + `GetConsoleProcessList` on the
   daemon process before+after each spawn. Distinguish H1 from H2.
2. **R-32**: implement A or B based on R-31 result, document layer.
3. Decide whether to keep this branch's koffi+hide-console scaffolding
   as foundation for R-32 or revert and reintroduce.

## Local checks (host: Windows 11, mode: research-only)

- lint: pre-existing baseline red (PersistController/Mock unused
  vars in files I didn't touch — verified equally red on
  origin/working via patch-flow checkout).
- typecheck: pre-existing baseline red (core/api/sessions.ts can't
  resolve `@ccsm/shared` without prior `pnpm --filter @ccsm/shared
  build` — same on origin/working).
- daemon build: ✓ (`pnpm --filter @ccsm/daemon build`).
- cargo check (frontend-tauri/src-tauri): ✓.
- e2e (cloud-e2e two-tab-pairing): **FAILS**, identical signature to
  pre-R-30 baseline — proof the fix doesn't fire on the actual bug.

## Done criteria for THIS PR

- ✓ branch pushed
- ✓ research-report-task-87.md committed with evidence + hypotheses
- ✓ this PR body links the report and reproduces the key stderr
- ✗ NOT to be merged. Manager closes after filing R-31.