### PR TITLE
log(daemon): R-31 — koffi console-state probes around pty spawn (Task #89)

### DIFF
--- a/packages/daemon/package.json
+++ b/packages/daemon/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@ccsm/shared": "workspace:*",
     "better-sqlite3": "^11.10.0",
+    "koffi": "^2.16.2",
     "node-pty": "^1.1.0",
     "ws": "^8.20.0"
   },

--- a/packages/daemon/src/console-probe.mts
+++ b/packages/daemon/src/console-probe.mts
@@ -1,0 +1,133 @@
+// Task #89 (R-31) — koffi-based Win32 console-state probes for PTY spawn
+// forensics. R-30 (Plan A: Tauri CREATE_NEW_CONSOLE + daemon-side
+// ShowWindow(GetConsoleWindow, SW_HIDE) via koffi) failed: spawn #2 still
+// hits `AttachConsole failed` in node-pty's conpty_console_list_agent.js,
+// identical to R-29 baseline. That falsifies R-30's root-cause hypothesis
+// (daemon has no console at startup → first spawn implicitly AllocConsole-
+// binds → second spawn cannot AttachConsole).
+//
+// Two surviving hypotheses (PR #1203 body):
+//   H1 — CreatePseudoConsole for spawn #1 binds the daemon process to
+//        HPCON#1's console group at a level deeper than FreeConsole
+//        releases. Helper subprocess for spawn #2 inherits that binding;
+//        AttachConsole(pid2) returns ERROR_ACCESS_DENIED because daemon
+//        (parent) is still bound to HPCON#1.
+//   H2 — getConsoleProcessList itself has destructive side effects on
+//        daemon console state.
+//
+// To distinguish H1 vs H2 we expose two pure read probes from runtime.mts:
+//   - getConsoleHwnd(): GetConsoleWindow → integer hwnd or null
+//   - getConsoleProcessList(): GetConsoleProcessList → { count, pids }
+//
+// Both stubs no-op on non-Windows so importing this module on darwin/linux
+// is safe.
+
+import { createRequire } from 'node:module';
+
+interface KoffiLib {
+  func(signature: string): (...args: unknown[]) => unknown;
+}
+
+interface KoffiModule {
+  load(name: string): KoffiLib;
+  // koffi's typed-array / out-buffer support
+  alloc(type: string, count: number): Uint8Array;
+  // Note: we use Buffer.alloc for the DWORD array argument since koffi
+  // accepts Node Buffers as raw output buffers when the C signature is a
+  // pointer.
+}
+
+let cached: {
+  getConsoleWindow: (() => number) | null;
+  getConsoleProcessList: ((buf: Buffer, len: number) => number) | null;
+} | null = null;
+
+function getApis(): {
+  getConsoleWindow: (() => number) | null;
+  getConsoleProcessList: ((buf: Buffer, len: number) => number) | null;
+} {
+  if (cached) return cached;
+  if (process.platform !== 'win32') {
+    cached = { getConsoleWindow: null, getConsoleProcessList: null };
+    return cached;
+  }
+  try {
+    const requireCjs = createRequire(import.meta.url);
+    const koffi = requireCjs('koffi') as KoffiModule;
+    const kernel32 = koffi.load('kernel32.dll');
+    // HWND GetConsoleWindow(void)
+    const fnGetConsoleWindow = kernel32.func('void* __stdcall GetConsoleWindow()') as () => unknown;
+    // DWORD GetConsoleProcessList(LPDWORD lpdwProcessList, DWORD dwProcessCount)
+    const fnGetConsoleProcessList = kernel32.func(
+      'uint32 __stdcall GetConsoleProcessList(_Out_ uint32 *lpdwProcessList, uint32 dwProcessCount)',
+    ) as (buf: Buffer, len: number) => number;
+    cached = {
+      getConsoleWindow: () => {
+        const v = fnGetConsoleWindow() as number | bigint | null;
+        if (v === null || v === undefined) return 0;
+        if (typeof v === 'bigint') return Number(v);
+        return v as number;
+      },
+      getConsoleProcessList: fnGetConsoleProcessList,
+    };
+  } catch {
+    cached = { getConsoleWindow: null, getConsoleProcessList: null };
+  }
+  return cached;
+}
+
+/**
+ * Wraps Win32 GetConsoleWindow. Returns hwnd as integer (may be large on
+ * x64) or null when there is no attached console / call failed / non-Windows.
+ */
+export function getConsoleHwnd(): number | null {
+  const { getConsoleWindow } = getApis();
+  if (!getConsoleWindow) return null;
+  try {
+    const hwnd = getConsoleWindow();
+    if (!hwnd || hwnd === 0) return null;
+    return hwnd;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Wraps Win32 GetConsoleProcessList. Returns the count and the list of
+ * pids attached to the caller's console. Adaptive: starts with a 32-slot
+ * buffer; if the API reports it needs more, retries once with the reported
+ * size. Returns { count: 0, pids: [] } on non-Windows / failure / no
+ * attached console.
+ */
+export function getConsoleProcessList(): { count: number; pids: number[] } {
+  const { getConsoleProcessList: fn } = getApis();
+  if (!fn) return { count: 0, pids: [] };
+  try {
+    const initialLen = 32;
+    const buf = Buffer.alloc(initialLen * 4); // DWORD = 4 bytes
+    const ret = fn(buf, initialLen);
+    if (!ret || ret === 0) {
+      return { count: 0, pids: [] };
+    }
+    if (ret <= initialLen) {
+      const pids: number[] = [];
+      for (let i = 0; i < ret; i++) {
+        pids.push(buf.readUInt32LE(i * 4));
+      }
+      return { count: ret, pids };
+    }
+    // Need a bigger buffer — retry once with reported size.
+    const buf2 = Buffer.alloc(ret * 4);
+    const ret2 = fn(buf2, ret);
+    if (!ret2 || ret2 === 0 || ret2 > ret) {
+      return { count: ret, pids: [] };
+    }
+    const pids: number[] = [];
+    for (let i = 0; i < ret2; i++) {
+      pids.push(buf2.readUInt32LE(i * 4));
+    }
+    return { count: ret2, pids };
+  } catch {
+    return { count: 0, pids: [] };
+  }
+}

--- a/packages/daemon/src/runtime.mts
+++ b/packages/daemon/src/runtime.mts
@@ -17,7 +17,13 @@ import { createRequire } from 'node:module';
 
 import { encodeExit, encodeFrame, FrameType } from '@ccsm/shared';
 
+import { getConsoleHwnd, getConsoleProcessList } from './console-probe.mjs';
 import { RingBuffer } from './ring.mjs';
+
+// Task #89 (R-31): module-scoped counter; incremented per defaultPtyFactory
+// invocation so [r31-pre] / [r31-post] log lines can be correlated across
+// spawn 1, 2, 3 within a single daemon process lifetime.
+let r31SpawnIndex = 0;
 
 // ---- Public types -------------------------------------------------------
 
@@ -207,6 +213,23 @@ const defaultPtyFactory: PtyFactory = (opts) => {
     // call it from JS without FFI, so we proxy via TTY flags.
   }));
   /* eslint-enable no-console */
+  // Task #89 (R-31) — in-process Win32 probes around node-pty spawn to
+  // distinguish H1 (CreatePseudoConsole binds daemon to HPCON#1's console
+  // group) vs H2 (GetConsoleProcessList itself has destructive side effects
+  // on daemon console state). Pre-probe runs BEFORE spawn; post-probe runs
+  // AFTER (no try/catch). On non-Windows the probes return null/empty.
+  const r31Idx = ++r31SpawnIndex;
+  /* eslint-disable no-console */
+  if (isWindows) {
+    const preHwnd = getConsoleHwnd();
+    const preList = getConsoleProcessList();
+    console.error(
+      `[r31-pre] sid=${opts.sid} spawn_index=${r31Idx} ` +
+        `hwnd=${preHwnd === null ? 'null' : '0x' + preHwnd.toString(16)} ` +
+        `proc_count=${preList.count} proc_pids=[${preList.pids.join(',')}]`,
+    );
+  }
+  /* eslint-enable no-console */
   const pty = nodePty.spawn(cmd, args, {
     name: 'xterm-256color',
     cols: opts.cols,
@@ -215,6 +238,17 @@ const defaultPtyFactory: PtyFactory = (opts) => {
     env: process.env as Record<string, string>,
     useConpty: true,
   });
+  /* eslint-disable no-console */
+  if (isWindows) {
+    const postHwnd = getConsoleHwnd();
+    const postList = getConsoleProcessList();
+    console.error(
+      `[r31-post] sid=${opts.sid} spawn_index=${r31Idx} ` +
+        `hwnd=${postHwnd === null ? 'null' : '0x' + postHwnd.toString(16)} ` +
+        `proc_count=${postList.count} proc_pids=[${postList.pids.join(',')}]`,
+    );
+  }
+  /* eslint-enable no-console */
   return {
     write: (d) => pty.write(d),
     resize: (c, r) => pty.resize(c, r),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
+      koffi:
+        specifier: ^2.16.2
+        version: 2.16.2
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0


### PR DESCRIPTION
## Summary

Phase 1 forensics-only follow-up to R-29 (PR #1202, merged) and R-30 (PR #1203, research-only — Plan A failed). Adds two koffi-bound Win32 read probes (`GetConsoleWindow`, `GetConsoleProcessList`) around `defaultPtyFactory()`'s `nodePty.spawn` so that the next `tauri dev` cloud-e2e run produces enough state-deltas to distinguish H1 vs H2 (see Background).

**No PTY behavior changed.** No retries, no AttachConsole try/catch, no spawn-flag changes. Pure observability per memory `feedback_log_until_certain.md`: when evidence insufficient, add observability first, do NOT guess-fix.

## Background — what R-30 falsified

R-30 attempted Plan A (Tauri `CREATE_NEW_CONSOLE` + daemon-side `ShowWindow(GetConsoleWindow, SW_HIDE)` via koffi) and **failed**: spawn #2 still throws `AttachConsole failed` in `conpty_console_list_agent.js:13`, identical to R-29 baseline. That falsifies R-30's root-cause hypothesis (daemon has no console at startup → first spawn implicitly AllocConsole-binds → second spawn cannot AttachConsole). The differentiator is NOT daemon's startup console state.

Two surviving hypotheses:

- **H1** — `CreatePseudoConsole` for spawn #1 binds the daemon process to HPCON#1's console group at a level deeper than `FreeConsole` releases. Helper subprocess for spawn #2 inherits that binding. `AttachConsole(pid2)` returns ERROR_ACCESS_DENIED because daemon (parent) is still bound to HPCON#1.
- **H2** — `getConsoleProcessList` itself has destructive side effects on daemon console state.

H1 vs H2 cannot be told apart from R-29's existing forensics dump (it only logs TTY flags, not the actual hwnd / process list).

## What this PR adds

`packages/daemon/src/console-probe.mts` (new) — koffi wrapper exporting:
- `getConsoleHwnd(): number | null` — wraps `kernel32!GetConsoleWindow`, returns hwnd as integer or null.
- `getConsoleProcessList(): { count: number; pids: number[] }` — wraps `kernel32!GetConsoleProcessList(buf, len)` with adaptive len (start 32, retry once if larger needed).
- Stubs for non-Windows so importing on darwin/linux is safe.

`packages/daemon/src/runtime.mts` — `defaultPtyFactory()`:
- Module-scoped `r31SpawnIndex` counter, incremented per spawn.
- **Before** `nodePty.spawn`: call both probes, log `[r31-pre] sid=<sid> spawn_index=<n> hwnd=<hex|null> proc_count=<n> proc_pids=[...]`.
- **After** `nodePty.spawn` returns (no try/catch): same probe, log `[r31-post] ...`.

`packages/daemon/package.json` + `pnpm-lock.yaml` — add `koffi ^2.16.2` to daemon dependencies (same version already used by `tools/cloud-e2e` devDeps).

## Probe local sanity check

Verified the probe loads + returns plausible values on this Windows host (without any pty spawn yet):

```
$ node -e "(async () => { const m = await import('./packages/daemon/dist/console-probe.mjs'); console.log('hwnd=', m.getConsoleHwnd()); console.log('list=', JSON.stringify(m.getConsoleProcessList())); })()"
hwnd= null
list= {"count":3,"pids":[75592,80604,80696]}
```

(Detached bash → no GetConsoleWindow but GetConsoleProcessList enumerates the process group. This confirms koffi binds and the API call shape is correct.)

## What manager/reviewer should look for in the actual cloud-e2e run

When the user (or manager) next runs `cd packages/frontend-tauri && pnpm tauri dev` then `cd tools/cloud-e2e && npx playwright test`, the daemon stderr (forwarded by `daemon_mgr.rs` as `daemon-stderr` events / printed by the Tauri parent's `eprintln!`) will contain pairs of lines. Expected sequence for the failing harness:

```
[r31-pre]  sid=<sid1> spawn_index=1 hwnd=<H?>  proc_count=<P?> proc_pids=[...]
[r31-post] sid=<sid1> spawn_index=1 hwnd=<H?>  proc_count=<P?> proc_pids=[...]
[r31-pre]  sid=<sid2> spawn_index=2 hwnd=<H?>  proc_count=<P?> proc_pids=[...]
Error: AttachConsole failed             ← from conpty_console_list_agent.js:13
```

(spawn_index 3 may also appear if the harness retries.)

### Decision rules

| Pattern | Conclusion |
|---|---|
| `hwnd` flips `null → non-null` between pre1 and post1, AND `proc_count` jumps `0 → ≥2` | **H1 confirmed** — HPCON#1 binds daemon parent. Spawn #2's helper inherits binding. |
| `hwnd` is the **same** non-null value at post1 and pre2 (daemon stayed bound between spawns) | **H1 confirmed** (binding persists) |
| `hwnd` / `proc_count` mutate between probe calls *without* a spawn happening between them | **H2 confirmed** — `GetConsoleProcessList` itself has side effects |
| Both probes return identical state across pre1/post1/pre2 yet AttachConsole still fails | both hypotheses **inconclusive** — escalate to deeper trace (e.g. ETW console events) |

This PR does NOT make the call — it adds the data to make the call. R-32 (whoever picks it up) reads the daemon stderr table from a real run, fills in the table, and writes the conclusion.

## Why this is not glue per memory `feedback_fix_arch_not_glue.md`

This PR adds **observability**, not control flow. No retries, no error-swallowing, no `.skip`. Memory `feedback_log_until_certain.md` explicitly carves this out: "加 log 让事实暴露, retry 让事实掩盖。加 log 不算胶水."

## Local checks (host: Windows 11, mode: fast)
- lint: ✓ `pnpm --filter @ccsm/daemon lint` exit 0
- typecheck: ✓ `pnpm --filter @ccsm/daemon typecheck` exit 0
- build: ✓ `pnpm --filter @ccsm/daemon build` exit 0 (after `@ccsm/shared` build)
- unit tests: ✓ `pnpm --filter @ccsm/daemon test` — 14 files / 154 passed / 1 skipped, 11.28s
- e2e: skipped — log-only diff, does not change PTY behavior. The actual `[r31-pre]/[r31-post]` lines need a real `tauri dev` + cloud-e2e session (token + cf tunnel + claude CLI) which this dev pool can't provide stably; following R-29's same approach (PR #1202 also skipped e2e). PR body lists expected log shape so manager/reviewer can read the eventual run output directly.

## Out of scope (deliberately not touched)

- `daemon_mgr.rs` — R-30 attempted CREATE_NEW_CONSOLE change is reverted (base = `origin/working` = `d00c8eea`); no Rust changes here.
- `hide-console-windows.mts` from R-30 — not present in this PR (not needed for forensics).
- `index.mts` `main()` — no startup hide-console call.
- Cargo.toml — no Rust dep changes.
- node-pty version pin / patch — task spec forbids.
- skip / xfail tests — task spec forbids.
- any try/catch around `nodePty.spawn` — would mask the diagnostic.

## Files

- `packages/daemon/src/console-probe.mts` (new, 130 LOC)
- `packages/daemon/src/runtime.mts` (modified, +33/-0 around the existing R-29 forensics block)
- `packages/daemon/package.json` (added `koffi: ^2.16.2`)
- `pnpm-lock.yaml` (regen — only the daemon importer line + 2 lines for the koffi entry under `packages/daemon`)