### PR TITLE
fix(daemon): R-32 — node-pty useConptyDll: true to skip AttachConsole crash (Task #93)

### DIFF
--- a/packages/daemon/src/runtime.mts
+++ b/packages/daemon/src/runtime.mts
@@ -237,6 +237,12 @@ const defaultPtyFactory: PtyFactory = (opts) => {
     cwd: opts.cwd,
     env: process.env as Record<string, string>,
     useConpty: true,
+    // R-32 (Task #93) — node-pty 1.1.0 useConptyDll: true skips the
+    // per-spawn helper-fork (conpty_console_list_agent.js) which was
+    // crashing in AttachConsole because it inherits the daemon's empty
+    // console (see Task #91 evidence on PR #1204). Loads conpty.dll
+    // in-process instead, so kill/status paths bypass the helper entirely.
+    useConptyDll: true,
   });
   /* eslint-disable no-console */
   if (isWindows) {


### PR DESCRIPTION
## Summary

R-32 / arch-review F8 fix. One-line workaround for the conpty helper-fork crash documented in PR #1204 (R-31).

PR #1204 (R-31) evidence proved:
- spawn1+spawn2 `[r31-pre]/[r31-post]` were **identical** (hwnd=null, proc_count=1, proc_pids=[daemon]) — H1 (HPCON binds daemon) + H2 (probe side-effect) both **disproved**
- crash is in `conpty_console_list_agent.js:13` helper subprocess at `AttachConsole`, because the helper inherits daemon's empty console (daemon spawned by Tauri with CREATE_NO_WINDOW + Stdio::piped)
- arch-review F1 root cause: per-spawn helper-fork model is the broken window

node-pty 1.1.0 ships `useConptyDll: true` flag (`windowsPtyAgent.js:140-160`): kill / status / process-list paths skip the helper-fork entirely and load `conpty.dll` in-process. This is the precise fix for this bug.

## Change

`packages/daemon/src/runtime.mts` — single field added to `nodePty.spawn()` opts in `defaultPtyFactory`:

```ts
useConptyDll: true,
```

R-31 forensics probes (`[r31-pre]`, `[r31-post]`, `[ccsm-pty-forensics]`) preserved as before/after evidence.

## Local checks (host: Windows 11, mode: fast)

- lint: skipped on full repo (3925 pre-existing baseline-red, all `no-undef navigator/document/setInterval` — eslint env config issue, not introduced here). `pnpm --filter @ccsm/daemon lint`: ✓ (exit 0)
- typecheck: ✓ (full repo `pnpm typecheck` exit 0)
- build: ✓ (`pnpm --filter @ccsm/daemon build` exit 0; also @ccsm/shared, @ccsm/core, @ccsm/ui all green)
- unit tests (daemon): ✓ — 154 passed | 1 skipped, 14 test files, 10.20s
- e2e: see "Local Windows verification" below — Tauri dev + cloud-e2e two-tab harness

## Local Windows verification (the hard done condition)

**Setup**: `pnpm --filter @ccsm/frontend-tauri tauri dev` (Tauri spawned daemon as designed per `project_tauri_spawns_daemon.md`), then `cd tools/cloud-e2e && pnpm test`.

**daemon stderr (post-fix)** — full r31 probe pairs around two PTY spawns from cloud-e2e two-tab harness:

```
[daemon stderr] [ccsm-pty-forensics] spawn={"sid":"e69ddda8-3ac7-4411-a005-ea507e6fcc71","mode":"create","cmd":"claude.cmd","args":["--session-id","e69ddda8-3ac7-4411-a005-ea507e6fcc71"],"isWindows":true,"platform":"win32","nodeVersion":"v22.18.0","pid":69512,"ppid":50848,"stdinIsTTY":false,"stdoutIsTTY":false,"stderrIsTTY":false,"connected":null,"hasParentIPC":false,"cwd":"...src-tauri","useConpty":true}
[daemon stderr] [r31-pre]  sid=e69ddda8-... spawn_index=1 hwnd=null proc_count=1 proc_pids=[69512]
[daemon stderr] [r31-post] sid=e69ddda8-... spawn_index=1 hwnd=null proc_count=1 proc_pids=[69512]
[daemon stderr] [ccsm-pty-forensics] spawn={"sid":"0aeba365-05f1-4639-aeb6-5f19838c646e",...}
[daemon stderr] [r31-pre]  sid=0aeba365-... spawn_index=2 hwnd=null proc_count=1 proc_pids=[69512]
[daemon stderr] [r31-post] sid=0aeba365-... spawn_index=2 hwnd=null proc_count=1 proc_pids=[69512]
```

**Diff vs PR #1204 (R-31) baseline**:
- ✅ ZERO `AttachConsole failed` lines (R-31 baseline had these on every spawn)
- ✅ ZERO `conpty_console_list_agent` helper crashes
- ✅ Both spawns complete cleanly (Tauri stayed up, daemon stayed connected to wss tunnel)
- r31 probes preserved as forensics (no functional change to probe code)

**cloud-e2e two-tab harness result**: ❌ FAIL on `getByLabel('Terminal input').click()` — element not visible. **This is unrelated to PTY spawn** — both tabs successfully reached `data-ws-state="open"`, sidebar rows rendered, daemon spawned both PTYs cleanly (see stderr above), and `[ccsm spa] sendInput len=1` console events fired multiple times before the click timeout. The xterm helper-textarea visibility issue is a cloud SPA / xterm rendering concern, not a daemon PTY issue.

Per task spec push-back clause:

> 如果 useConptyDll: true 改完 cloud-e2e 仍红, 不要硬扩范围尝试 F2/F3 — 直接 push back, 把 fix 后 stderr 写到 PR body, manager 拍板上 R-33 (F6 race lock) / R-34 (F2 子进程模型) 哪个。

The PTY-layer fix (F8) **landed and verified clean via daemon stderr**. The remaining cloud-e2e xterm-input visibility failure is a separate layer — manager to decide whether R-33/R-34 are still needed or whether xterm-input visibility is its own R-X.

## Test plan
- [ ] CI three-platform matrix green
- [ ] Manager / reviewer to decide whether xterm-input visibility in cloud-e2e is in-scope here or a follow-up R-X