### PR TITLE
diag(daemon): R-39 — 5-line PTY/WS/tunnel log + harness 60s timeout (Task #102)

### DIFF
--- a/packages/daemon/src/runtime.mts
+++ b/packages/daemon/src/runtime.mts
@@ -323,9 +323,21 @@ export function createRuntimeRegistry(opts: RuntimeRegistryOptions): RuntimeRegi
     });
     runtime.set(sid, rt);
 
+    console.error('[r38-spawn-armed] sid=' + sid + ' armed_at=' + Date.now());
+    const r38Started = Date.now();
+    const r38NoByteTimer = setInterval(() => {
+      if (rt.outputSeq === 0) {
+        console.error('[r38-still-silent] sid=' + sid + ' elapsed_ms=' + (Date.now() - r38Started) + ' subs=' + rt.subscribers.size);
+      } else {
+        clearInterval(r38NoByteTimer);
+      }
+    }, 2000);
+    r38NoByteTimer.unref();
+
     pty.onData((data) => {
       const payload = Buffer.from(data, 'utf8');
       const payloadView = new Uint8Array(payload.buffer, payload.byteOffset, payload.byteLength);
+      console.error('[r38-pty-data] sid=' + sid + ' bytes=' + payloadView.byteLength + ' subs=' + rt.subscribers.size + ' first32hex=' + Buffer.from(payloadView.subarray(0, 32)).toString('hex'));
       rt.outputSeq = (rt.outputSeq + 1) >>> 0;
       rt.ring.append(rt.outputSeq, payloadView);
       const frame = encodeFrame({

--- a/packages/daemon/src/tunnel.mts
+++ b/packages/daemon/src/tunnel.mts
@@ -274,6 +274,8 @@ export class TunnelClient {
       return;
     }
     try {
+      const r38SendBytes = typeof data === 'string' ? data.length : data.byteLength;
+      console.error('[r38-tunnel-tx] state=' + this.state + ' bytes=' + r38SendBytes);
       this.ws.send(data);
     } catch (err) {
       console.warn('[ccsm/tunnel] send error:', (err as Error).message);

--- a/packages/daemon/src/ws.mts
+++ b/packages/daemon/src/ws.mts
@@ -205,6 +205,7 @@ export function attachFrameRouter(opts: AttachFrameRouterOptions): FrameRouter {
     OPEN: 1,
     send: (data: Uint8Array) => {
       try {
+        console.error('[r38-sub-send] sid=' + sid + ' bytes=' + data.byteLength);
         send(data);
       } catch (err) {
         console.warn('[ccsm/ws] router send failed:', (err as Error).message);
@@ -227,6 +228,7 @@ export function attachFrameRouter(opts: AttachFrameRouterOptions): FrameRouter {
     pausedQueue: [],
     pausedBytes: 0,
   });
+  console.error('[r38-subscriber-added] sid=' + sid + ' subs_now=' + rt.subscribers.size + ' lastSeq=' + lastSeq + ' rt_outputSeq=' + rt.outputSeq);
 
   // Capture the narrowed runtime ref so the closures below don't re-fetch
   // (also satisfies TS, which loses the narrow across closure boundaries).

--- a/tools/cloud-e2e/specs/two-tab-pairing.spec.ts
+++ b/tools/cloud-e2e/specs/two-tab-pairing.spec.ts
@@ -356,6 +356,7 @@ async function echoUuid(tab: TabHandle): Promise<void> {
 test('two tabs, two sessions, each tab sees only its own PTY echo', async ({
   browser,
 }) => {
+  test.setTimeout(60_000);
   const tabA = await openFreshTab(browser, 'tabA');
   const tabB = await openFreshTab(browser, 'tabB');
 


### PR DESCRIPTION
## Summary

R-38 (research-101) proposed adding 5 daemon log lines + 1 harness timeout fix to classify the post-PTY-spawn 30s silence among 4 candidates (C1/C2 claude no bytes / C3 PTY conout / C4-daemon fan-out / C4-cloud DO drop). This PR implements that proposal 1:1, runs once on Windows host against deployed cloud, and ships ground-truth evidence.

## Changes (5 daemon log lines + 1 harness fix)

**packages/daemon/src/runtime.mts** (3 sites):
- `[r38-spawn-armed]` after `runtime.set(sid, rt)`, plus 2s-interval `[r38-still-silent]` while `rt.outputSeq===0` (auto-clears once first byte lands)
- `[r38-pty-data]` at top of `pty.onData` handler: `bytes / subs / first32hex`

**packages/daemon/src/ws.mts** (2 sites):
- `[r38-subscriber-added]` after `rt.subscribers.set(sock, ...)` with `subs_now / lastSeq / rt_outputSeq`
- `[r38-sub-send]` inside `SubscriberSocket.send` wrapper, before delegating to `send(data)`

**packages/daemon/src/tunnel.mts** (1 site):
- `[r38-tunnel-tx]` inside `TunnelClient.send`, before `this.ws.send(data)`: `state / bytes`

**tools/cloud-e2e/specs/two-tab-pairing.spec.ts** (1 line):
- `test.setTimeout(60_000)` at top of test fn so the 30s `waitForPtyOutput` gate has room to fire `dumpFailure(...)` before harness wall-clock kills the test (default ~30s killed dump before snap.json could land).

No business logic changed. Logs are unconditional (one-shot diag per R-38 spec).

## Diagnostic run (host: Windows 11, Tauri-spawned daemon, real cc-sm.pages.dev cloud)

### `/tmp/r38-tauri.log` grep `r38-` (46 lines, key events):
```
[r38-tunnel-tx] state=connected bytes=494                              # tabA hello
[r38-tunnel-tx] state=connected bytes=494                              # tabB hello
[r38-spawn-armed] sid=ce51899e... armed_at=...                         # tabA spawn
[r38-pty-data] sid=ce51899e... bytes=23 subs=0 first32hex=1b5b3174...  # claude DID emit bytes
[r38-spawn-armed] sid=75915a2e... armed_at=...                         # tabB spawn
[r38-subscriber-added] sid=ce51899e... subs_now=1 lastSeq=0 rt_outputSeq=1
[r38-pty-data] sid=75915a2e... bytes=4 subs=0 first32hex=1b5b3174
[r38-pty-data] sid=75915a2e... bytes=19 subs=0 first32hex=1b5b631b...
[r38-subscriber-added] sid=75915a2e... subs_now=1 lastSeq=0 rt_outputSeq=2
[r38-pty-data] sid=75915a2e... bytes=5 subs=1 first32hex=1b5b3f376c
[r38-sub-send] sid=75915a2e... bytes=10                                # fan-out FIRES
[r38-tunnel-tx] state=connected bytes=10                               # tunnel.send FIRES
... (continues for ~20 more pty-data → sub-send → tunnel-tx triples) ...
[r38-pty-data] sid=75915a2e... bytes=3795 subs=1 first32hex=1b5b3f...  # full claude UI banner
[r38-sub-send] sid=75915a2e... bytes=3800
[r38-tunnel-tx] state=connected bytes=3800
```

### `/tmp/r38-harness.log` grep `wsStats|messages|bytes`:
```
[R-34 DIAG tabA] wsStats:{constructed:1, opened:1, messages:0, bytes:0, closed:0, errors:0, ...}
[R-34 DIAG tabB] wsStats:{constructed:1, opened:1, messages:0, bytes:0, closed:0, errors:0, ...}
```

### `tools/cloud-e2e/test-results/r34-diag/*-snap.json`:
- both tabs: `wsState:"open"`, `xtermPresent:true`, `xtermRowsText:" "` (1 char, just empty space)
- both tabs: `wsStats.messages: 0`, `wsStats.bytes: 0`, `lastErrorMsg: null`, `lastCloseCode: null`
- tabA sid: `ce51899e-4e31-4223-b2e3-708038fe935c`
- tabB sid: `75915a2e-df44-4e0a-aac5-f5914ec21ddd`

## Classification

Per R-38 decision table:

| obs | pty-data | sub-send | tunnel-tx | browser msgs | conclusion |
|-----|----------|----------|-----------|--------------|------------|
| **observed** | ✅ fires | ✅ fires | ✅ fires | ❌ 0 | **C4-cloud (Cloudflare DO drops binary frames daemon→browser)** |

Daemon side is healthy end-to-end: `claude` produces bytes → registry fan-out queues frame → SubscriberSocket.send → TunnelClient.send → ws.send writes to the wss://cc-sm.pages.dev/tunnel/default socket. But browser-side WebSocket constructed against `wss://cc-sm.pages.dev/ws/default?sid=...&token=...` opens (`opened:1`) and stays open (`closed:0`, no error) yet sees ZERO inbound messages.

The DO router is not relaying daemon-side binary OUTPUT frames to the paired browser ws.

## Side observation (out of scope; flag for follow-up research)

tabA's sid (`ce51899e`) shows `[r38-spawn-armed]` and `[r38-subscriber-added]` but ZERO `[r38-sub-send]` lines. ALL fan-out goes to tabB's sid (`75915a2e`). Suggests when tabB's hello arrives on the tunnel, it overrides tabA's attach handle (R-27 multi-sid-on-one-tunnel re-pair gap), so even if the cloud DO worked, tabA would still be silent. Recommend a separate research task to look at `TunnelClient.handleHello` re-pair semantics — but that's NOT the cause of the harness timeout; even single-tab would be red because of the C4-cloud DO drop.

## Local checks (host: Windows 11, mode: fast)

- lint: ✗ — 3 PRE-EXISTING errors NOT in files this PR touches (verified via `git diff origin/working`):
  - `packages/daemon/test/persist.test.ts:20` unused `PersistController` (untouched)
  - `packages/ui/test/BootstrapRefresh.test.tsx:24` unused `Mock` (untouched)
  - `tools/cloud-e2e/specs/two-tab-pairing.spec.ts:262` `\$` escape (untouched line — only added line 359 setTimeout)
- typecheck: ✓ (exit 0, all 8 workspace projects pass)
- build: ✓ (exit 0, all packages including frontend-tauri / frontend-web)
- unit tests: ✓ daemon `pnpm test` 14 files / 154 passed / 1 skipped (11.1s) — `[r38-still-silent]` log lines visible in test stderr but test outcomes unchanged
- e2e: ran cloud-e2e two-tab spec — failed AS DESIGNED (this is a diag PR; the harness gate is the very thing producing the evidence above)