### PR TITLE
fix(tunnel): R-41 — sid envelope + DO sid-indexed routing + keep-both (Task #105)

### DIFF
--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -16,6 +16,44 @@ const TAG_DAEMON = 'daemon';
 const TAG_BROWSER = 'browser';
 
 /**
+ * Per-browser tag prefix (Task #105, R-41). The browser ws is registered
+ * with `[TAG_BROWSER, TAG_BROWSER_SID + sid]` so the DO can recover the
+ * correct ws per sid post-hibernation via `state.getWebSockets(tag)`. We
+ * keep TAG_BROWSER on the same ws too so legacy "list every browser"
+ * lookups still work.
+ */
+const TAG_BROWSER_SID_PREFIX = 'browser-sid:';
+
+/** Bound on inbound sid-envelope sidLen — must match daemon-side helper. */
+const ENVELOPE_MAX_SID_LEN = 64;
+
+function encodeSidEnvelope(sid: string, payload: ArrayBuffer | Uint8Array): Uint8Array {
+  const sidBytes = new TextEncoder().encode(sid);
+  if (sidBytes.length === 0 || sidBytes.length > ENVELOPE_MAX_SID_LEN) {
+    throw new Error('encodeSidEnvelope: bad sid length ' + sidBytes.length);
+  }
+  const payloadView = payload instanceof Uint8Array
+    ? payload
+    : new Uint8Array(payload);
+  const out = new Uint8Array(1 + sidBytes.length + payloadView.byteLength);
+  out[0] = sidBytes.length;
+  out.set(sidBytes, 1);
+  out.set(payloadView, 1 + sidBytes.length);
+  return out;
+}
+
+function decodeSidEnvelope(buf: ArrayBuffer): { sid: string; payload: Uint8Array } | null {
+  const view = new Uint8Array(buf);
+  if (view.byteLength < 2) return null;
+  const sidLen = view[0] ?? 0;
+  if (sidLen === 0 || sidLen > ENVELOPE_MAX_SID_LEN) return null;
+  if (view.byteLength < 1 + sidLen) return null;
+  const sid = new TextDecoder().decode(view.subarray(1, 1 + sidLen));
+  const payload = view.subarray(1 + sidLen);
+  return { sid, payload };
+}
+
+/**
  * Hello control frame the DO injects ahead of any browser→daemon traffic so
  * the daemon can run the browser-presented token through its existing
  * classifyOrigin / token check path (Task #782, S3-T6).
@@ -74,6 +112,10 @@ interface PendingHttp {
 interface BrowserAttachment {
   role: 'browser';
   token: string;
+  /** Task #105 (R-41): sid this browser ws is paired with. Required so the
+   * DO can route daemon→browser binary frames by sid (envelope header) and
+   * label browser→daemon binary frames before forwarding. */
+  sid: string;
 }
 
 interface DaemonAttachment {
@@ -200,13 +242,32 @@ export class TunnelDO extends DurableObject<Env> {
     return undefined;
   }
 
-  /** Recover the browser socket post-hibernation, or undefined if none. */
-  private getBrowserSocket(): WebSocket | undefined {
+  /** Recover the browser socket post-hibernation, or undefined if none.
+   *
+   * Task #105 (R-41): wave-2 supports multiple concurrent browser ws (one
+   * per sid) attached to the same DO. Pass `sid` to look up the specific
+   * browser ws; without it we return any OPEN browser ws (legacy callers
+   * that don't yet route by sid). The sid-indexed lookup uses the per-ws
+   * tag `browser-sid:<sid>` set at acceptWebSocket time. */
+  private getBrowserSocket(sid?: string): WebSocket | undefined {
+    if (sid !== undefined) {
+      const tagged = this.state.getWebSockets(TAG_BROWSER_SID_PREFIX + sid);
+      for (const ws of tagged) {
+        if (ws.readyState === WebSocket.OPEN) return ws;
+      }
+      return undefined;
+    }
     const arr = this.state.getWebSockets(TAG_BROWSER);
     for (const ws of arr) {
       if (ws.readyState === WebSocket.OPEN) return ws;
     }
     return undefined;
+  }
+
+  /** Return all currently-OPEN browser ws (Task #105 R-41 hibernation diag). */
+  private getAllBrowserSockets(): WebSocket[] {
+    const arr = this.state.getWebSockets(TAG_BROWSER);
+    return arr.filter((ws) => ws.readyState === WebSocket.OPEN);
   }
 
   override async fetch(req: Request): Promise<Response> {
@@ -286,8 +347,10 @@ export class TunnelDO extends DurableObject<Env> {
 
       // Don't proactively close any prior browser ws — same reasoning as the
       // daemon path above. readyState filtering picks the live one.
-      const attachment: BrowserAttachment = { role: 'browser', token: extracted.token };
-      this.state.acceptWebSocket(server, [TAG_BROWSER]);
+      // Task #105 (R-41): tag the browser ws with `browser-sid:<sid>` so
+      // post-hibernation lookups can recover the right ws per sid.
+      const attachment: BrowserAttachment = { role: 'browser', token: extracted.token, sid };
+      this.state.acceptWebSocket(server, [TAG_BROWSER, TAG_BROWSER_SID_PREFIX + sid]);
       server.serializeAttachment(attachment);
       // R-17 log #2 (Task #45): browser ws accepted, about to emit hello.
       console.log('[do] browser ws accepted sid=' + sid + ' token=' + extracted.token.slice(0, 6));
@@ -331,7 +394,7 @@ export class TunnelDO extends DurableObject<Env> {
     if (att.role === 'daemon') {
       this.handleDaemonMessage(message);
     } else {
-      this.handleBrowserMessage(message);
+      this.handleBrowserMessage(message, att.sid);
     }
   }
 
@@ -368,34 +431,73 @@ export class TunnelDO extends DurableObject<Env> {
         this.completeHttpRes(ctrl);
         return;
       }
+      // Hello / other control text frames are passed to the (single, legacy)
+      // browser ws if any. With wave-2 routing the daemon doesn't send text
+      // frames browser-ward (PTY data is binary + sid-enveloped) — this
+      // branch only fires for legacy / debug text frames. Pick first OPEN.
+      const browser = this.getBrowserSocket();
+      if (browser !== undefined) {
+        try { browser.send(data); } catch { /* ignore */ }
+      }
+      return;
     }
-    const browser = this.getBrowserSocket();
-    if (browser !== undefined) {
-      try { browser.send(data); } catch { /* browser may have just dropped */ }
+    // Task #105 (R-41): binary frame from daemon → strip sid envelope →
+    // route to the browser ws that paired on that sid. Drop with a log if
+    // envelope is malformed or the sid is unknown (browser may have just
+    // closed; daemon will see ws-close back-pressure on its own).
+    const env = decodeSidEnvelope(data);
+    if (env === null) {
+      console.log('[do] drop daemon->browser binary: malformed sid envelope (len=' + len + ')');
+      return;
     }
+    const browser = this.getBrowserSocket(env.sid);
+    if (browser === undefined) {
+      const known = this.getAllBrowserSockets().length;
+      console.log('[do] drop daemon->browser binary: no browser for sid=' + env.sid + ' (open browsers=' + known + ')');
+      return;
+    }
+    try {
+      // Strip envelope before delivering to the browser — the browser ws
+      // protocol is plain encoded frames (@ccsm/shared.encodeFrame output).
+      browser.send(env.payload);
+    } catch { /* browser may have just dropped */ }
   }
 
-  private handleBrowserMessage(data: string | ArrayBuffer): void {
+  private handleBrowserMessage(data: string | ArrayBuffer, sid: string): void {
     // R-17 log #6 (Task #45): direction + length for every browser→daemon frame.
     const len = typeof data === 'string' ? data.length : data.byteLength;
-    console.log('[do] msg dir=browser->daemon len=' + len);
+    console.log('[do] msg dir=browser->daemon len=' + len + ' sid=' + sid);
     const daemon = this.getDaemonSocket();
-    if (daemon !== undefined) {
+    if (daemon === undefined) return;
+    if (typeof data === 'string') {
+      // Text frames from browser are not used in current protocol; forward
+      // raw for forward-compat (no sid header — text frames stay control).
       try { daemon.send(data); } catch { /* daemon may have just dropped */ }
+      return;
     }
+    // Task #105 (R-41): wrap browser→daemon binary frame in sid envelope so
+    // the daemon can route INPUT/RESIZE/PAUSE/RESUME into the right per-sid
+    // PTY when multiple browser tabs share one tunnel ws.
+    let envelope: Uint8Array;
+    try {
+      envelope = encodeSidEnvelope(sid, data);
+    } catch (err) {
+      console.log('[do] drop browser->daemon binary: envelope encode failed sid=' + sid + ' err=' + String(err));
+      return;
+    }
+    try { daemon.send(envelope); } catch { /* daemon may have just dropped */ }
   }
 
   private handleDaemonClose(): void {
-    const browser = this.getBrowserSocket();
-    if (browser !== undefined) {
+    // Task #105 (R-41): close every paired browser ws (wave-2 may have many).
+    for (const browser of this.getAllBrowserSockets()) {
       try { browser.close(1006, 'daemon disconnected'); } catch { /* ignore */ }
     }
     this.failAllPendingHttp(502, 'daemon disconnected');
   }
 
   private handleDaemonError(): void {
-    const browser = this.getBrowserSocket();
-    if (browser !== undefined) {
+    for (const browser of this.getAllBrowserSockets()) {
       try { browser.close(1011, 'daemon error'); } catch { /* ignore */ }
     }
   }

--- a/packages/cf-worker/test/tunnel-do.test.ts
+++ b/packages/cf-worker/test/tunnel-do.test.ts
@@ -223,11 +223,19 @@ describe('TunnelDO', () => {
     await inst.fetch(makeReq('/ws/default?sid=s', BROWSER_PROTO));
     const browser = created[1].server;
     expect(browser.hibernating).toBe(true);
-    expect(browser.tags).toEqual(['browser']);
+    // Task #105 (R-41): browser ws is now tagged with both 'browser' and
+    // 'browser-sid:<sid>' so the DO can recover per-sid.
+    expect(browser.tags).toEqual(['browser', 'browser-sid:s']);
     expect(browser.closed).toBe(false);
 
     emitMessage(inst, daemon, 'hello');
-    emitMessage(inst, daemon, new Uint8Array([1, 2, 3]) as unknown as ArrayBuffer);
+    // Task #105 (R-41): daemon→browser binary is now sid-enveloped on the
+    // wire. DO strips the envelope before delivering to the browser ws, so
+    // the browser still sees raw payload bytes.
+    const env = new Uint8Array(1 + 1 + 3);
+    env[0] = 1; env[1] = 's'.charCodeAt(0);
+    env[2] = 1; env[3] = 2; env[4] = 3;
+    emitMessage(inst, daemon, env.buffer.slice(env.byteOffset, env.byteOffset + env.byteLength) as ArrayBuffer);
     expect(browser.sent).toEqual(['hello', new Uint8Array([1, 2, 3])]);
   });
 
@@ -252,7 +260,13 @@ describe('TunnelDO', () => {
 
     emitMessage(inst, browser, 'ping');
     emitMessage(inst, browser, new Uint8Array([9, 9]) as unknown as ArrayBuffer);
-    expect(daemon.sent.slice(1)).toEqual(['ping', new Uint8Array([9, 9])]);
+    // Task #105 (R-41): browser→daemon binary is wrapped in a sid envelope
+    // by the DO so the daemon can route into the right per-sid PTY when
+    // multiple browser tabs share one tunnel ws. Envelope: [sidLen, ...sid, ...payload].
+    expect(daemon.sent.slice(1)).toEqual([
+      'ping',
+      new Uint8Array([1, 's'.charCodeAt(0), 9, 9]),
+    ]);
   });
 
   it('extracts browserToken from Sec-WebSocket-Protocol header', async () => {
@@ -650,5 +664,127 @@ describe('TunnelDO', () => {
     // serialized attachment, not from a member field.
     const inst2 = new TunnelDO(state, fakeEnv);
     expect(inst2.getBrowserTokenForTest()).toBe('persisted-tok');
+  });
+
+  // ---- Task #105 (R-41): multi-sid envelope routing ----------------------
+
+  function envelope(sid: string, payload: number[]): ArrayBuffer {
+    const sidBytes = new TextEncoder().encode(sid);
+    const out = new Uint8Array(1 + sidBytes.length + payload.length);
+    out[0] = sidBytes.length;
+    out.set(sidBytes, 1);
+    out.set(Uint8Array.from(payload), 1 + sidBytes.length);
+    return out.buffer.slice(out.byteOffset, out.byteOffset + out.byteLength) as ArrayBuffer;
+  }
+
+  it('R-41: two browsers (different sids) each receive only their own daemon binary frames', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(makeState(), fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    const daemon = created[0].server;
+    await inst.fetch(makeReq('/ws/default?sid=alpha', 'ccsm.tok-a'));
+    await inst.fetch(makeReq('/ws/default?sid=beta', 'ccsm.tok-b'));
+    const browserA = created[1].server;
+    const browserB = created[2].server;
+
+    expect(browserA.tags).toEqual(['browser', 'browser-sid:alpha']);
+    expect(browserB.tags).toEqual(['browser', 'browser-sid:beta']);
+
+    // Daemon emits a sid-enveloped binary for alpha then for beta.
+    emitMessage(inst, daemon, envelope('alpha', [10, 20, 30]));
+    emitMessage(inst, daemon, envelope('beta', [40, 50]));
+
+    // Each browser only sees its own payload (envelope stripped).
+    expect(browserA.sent).toEqual([new Uint8Array([10, 20, 30])]);
+    expect(browserB.sent).toEqual([new Uint8Array([40, 50])]);
+  });
+
+  it('R-41: browser->daemon binary is wrapped with sender browser sid', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(makeState(), fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    const daemon = created[0].server;
+    await inst.fetch(makeReq('/ws/default?sid=alpha', 'ccsm.tok-a'));
+    await inst.fetch(makeReq('/ws/default?sid=beta', 'ccsm.tok-b'));
+    const browserA = created[1].server;
+    const browserB = created[2].server;
+
+    // Skip the two hello frames (one per browser pairing).
+    const helloCount = daemon.sent.length;
+
+    emitMessage(inst, browserA, new Uint8Array([1, 2]) as unknown as ArrayBuffer);
+    emitMessage(inst, browserB, new Uint8Array([3, 4, 5]) as unknown as ArrayBuffer);
+
+    const fromA = daemon.sent[helloCount] as Uint8Array;
+    const fromB = daemon.sent[helloCount + 1] as Uint8Array;
+    // alpha = 5 utf8 bytes -> sidLen=5, sid='alpha', payload=[1,2]
+    expect(Array.from(fromA)).toEqual([5, ...new TextEncoder().encode('alpha'), 1, 2]);
+    // beta = 4 utf8 bytes
+    expect(Array.from(fromB)).toEqual([4, ...new TextEncoder().encode('beta'), 3, 4, 5]);
+  });
+
+  it('R-41: daemon binary with unknown sid is dropped (no fan-out)', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(makeState(), fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    const daemon = created[0].server;
+    await inst.fetch(makeReq('/ws/default?sid=alpha', 'ccsm.tok-a'));
+    const browserA = created[1].server;
+
+    // Daemon sends envelope with sid that no browser has paired with.
+    emitMessage(inst, daemon, envelope('ghost', [9, 9]));
+    expect(browserA.sent).toEqual([]);
+  });
+
+  it('R-41: malformed envelope (sidLen=0) is dropped, no crash', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(makeState(), fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    const daemon = created[0].server;
+    await inst.fetch(makeReq('/ws/default?sid=alpha', 'ccsm.tok-a'));
+    const browserA = created[1].server;
+
+    const bad = new Uint8Array([0, 1, 2, 3]);
+    emitMessage(inst, daemon, bad.buffer.slice(bad.byteOffset, bad.byteOffset + bad.byteLength) as ArrayBuffer);
+    expect(browserA.sent).toEqual([]);
+  });
+
+  it('R-41: daemon close fans out close to ALL paired browsers', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(makeState(), fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    const daemon = created[0].server;
+    await inst.fetch(makeReq('/ws/default?sid=alpha', 'ccsm.tok-a'));
+    await inst.fetch(makeReq('/ws/default?sid=beta', 'ccsm.tok-b'));
+    const browserA = created[1].server;
+    const browserB = created[2].server;
+
+    emitClose(inst, daemon);
+
+    expect(browserA.closed).toBe(true);
+    expect(browserA.closeCode).toBe(1006);
+    expect(browserB.closed).toBe(true);
+    expect(browserB.closeCode).toBe(1006);
+  });
+
+  it('R-41: hibernate -> wake recovers per-sid browser routing', async () => {
+    const TunnelDO = await loadDO();
+    const state = makeState();
+    const inst1 = new TunnelDO(state, fakeEnv);
+    await inst1.fetch(makeReq('/tunnel/default'));
+    await inst1.fetch(makeReq('/ws/default?sid=alpha', 'ccsm.tok-a'));
+    await inst1.fetch(makeReq('/ws/default?sid=beta', 'ccsm.tok-b'));
+    const daemon = created[0].server;
+    const browserA = created[1].server;
+    const browserB = created[2].server;
+
+    // Drop the first instance. New instance must re-discover via tags.
+    const inst2 = new TunnelDO(state, fakeEnv);
+
+    emitMessage(inst2, daemon, envelope('alpha', [7]));
+    emitMessage(inst2, daemon, envelope('beta', [8]));
+
+    expect(browserA.sent).toEqual([new Uint8Array([7])]);
+    expect(browserB.sent).toEqual([new Uint8Array([8])]);
   });
 });

--- a/packages/daemon/src/tunnel.mts
+++ b/packages/daemon/src/tunnel.mts
@@ -25,13 +25,19 @@
 //     control frames (Task #787) are accepted before hello — they're
 //     injected by the DO regardless of browser pairing and carry no browser
 //     token by design (Task #789, S3-D).
-//   - Multi-sid re-pair (Task #81, R-27): a single SPA reuses one tunnel ws
-//     across multiple sessions. Each New Session re-sends `{type:"hello",
-//     token, sid:<new>}` on the SAME ws. The daemon tracks `currentSid` per
-//     connection; when a hello with a different sid arrives, we tear down
-//     the old browserAttachHandle (so the prior PTY drops its subscriber)
-//     and call onBrowserAttach again with the new sid. Same-sid hello is
-//     idempotent. Token is re-checked on every hello.
+//   - Multi-sid keep-both (Task #105, R-41): a single SPA reuses one tunnel ws
+//     across multiple browser tabs / sessions. Each browser hello carries its
+//     own sid; the daemon keeps a Map<sid, attachHandle> and adds a NEW
+//     attach on each previously-unseen sid (no tear-down of the prior ones).
+//     Same-sid hello is idempotent (token re-checked).
+//
+//     Wave-1 design (R-27) was tear-down-on-resid: only one active sid at a
+//     time. Wave-2 needs concurrent fan-out for multiple tabs sharing one
+//     daemon, so that assumption was lifted in R-41. The daemon-bound
+//     binary frames carry a sid envelope (see envelope helpers below) so
+//     INPUT/RESIZE/PAUSE/RESUME from each tab routes into the correct PTY
+//     and OUTPUT from each PTY routes back over the single tunnel ws with
+//     a sid header that the DO uses to pick the right browser ws.
 //
 // timingSafeEqual constant-time comparison is reused from auth.mts (NOT
 // reimplemented) to honor the §1 5-tier "use existing in-repo" rule.
@@ -201,6 +207,56 @@ function parseHello(text: string): HelloFrame | null {
   return out;
 }
 
+// ---- Sid-envelope helpers (Task #105, R-41) ----------------------------
+//
+// Wave-2 multi-tab routing: the daemon and the DO share ONE tunnel ws but
+// must fan out N concurrent browser↔PTY sessions over it. Every binary
+// frame on the tunnel carries a small sid header so the receiving side can
+// route into the correct per-sid PTY (daemon side) or per-sid browser ws
+// (DO side).
+//
+// Wire format (binary frames only — control text frames like hello /
+// http_req / http_res / http_res' are unchanged):
+//   byte 0:        sidLen (uint8, MUST be > 0 and <= 64)
+//   bytes 1..N:    sid as utf8
+//   bytes N+1..:   raw payload (the encoded INPUT / OUTPUT / RESIZE / EXIT
+//                  frame produced by @ccsm/shared.encodeFrame)
+//
+// 64-byte cap on sid is a sanity bound — real sids are short hex/base64url
+// strings (~32 chars). A malformed envelope (sidLen=0, sidLen>buf-1, or
+// sidLen exceeding the cap) is dropped with a warn log on either side.
+
+const ENVELOPE_MAX_SID_LEN = 64;
+
+export function encodeSidEnvelope(sid: string, payload: Uint8Array | Buffer): Buffer {
+  const sidBuf = Buffer.from(sid, 'utf8');
+  if (sidBuf.length === 0 || sidBuf.length > ENVELOPE_MAX_SID_LEN) {
+    throw new Error(
+      `[ccsm/tunnel] encodeSidEnvelope: bad sid length ${sidBuf.length}`,
+    );
+  }
+  const payloadBuf = Buffer.isBuffer(payload)
+    ? payload
+    : Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength);
+  const out = Buffer.allocUnsafe(1 + sidBuf.length + payloadBuf.length);
+  out.writeUInt8(sidBuf.length, 0);
+  sidBuf.copy(out, 1);
+  payloadBuf.copy(out, 1 + sidBuf.length);
+  return out;
+}
+
+export function decodeSidEnvelope(
+  buf: Buffer,
+): { sid: string; payload: Buffer } | null {
+  if (buf.length < 2) return null;
+  const sidLen = buf.readUInt8(0);
+  if (sidLen === 0 || sidLen > ENVELOPE_MAX_SID_LEN) return null;
+  if (buf.length < 1 + sidLen) return null;
+  const sid = buf.subarray(1, 1 + sidLen).toString('utf8');
+  const payload = buf.subarray(1 + sidLen);
+  return { sid, payload };
+}
+
 function constantTimeTokenEquals(presented: string, expected: string): boolean {
   const a = Buffer.from(presented, 'utf8');
   const b = Buffer.from(expected, 'utf8');
@@ -229,12 +285,13 @@ export class TunnelClient {
   private helloSeen = false;
   private browserToken: string | null = null;
   // Task #793 (S3-G): per-connection browser session attachment.
-  // Task #81 (R-27): currentSid tracks the sid of the most-recent hello so
-  // we can detect re-pair (SPA reusing one tunnel ws across sessions) and
-  // tear down the old attach handle before invoking onBrowserAttach again.
-  private currentSid: string | null = null;
+  // Task #105 (R-41): wave-2 lifts the single-tab assumption. The tunnel ws
+  // is shared across N concurrent browser tabs, so we keep a Map<sid,
+  // attachHandle> and add new entries on each previously-unseen hello sid
+  // (no tear-down of prior sids — that was the wave-1 R-27 behaviour). On
+  // ws close all attach handles are dropped.
+  private readonly attachHandles = new Map<string, BrowserAttachHandle>();
   private readonly onBrowserAttach: ((info: BrowserAttachInfo) => BrowserAttachHandle | null) | null;
-  private browserAttachHandle: BrowserAttachHandle | null = null;
 
   constructor(opts: TunnelClientOptions) {
     this.url = opts.url;
@@ -306,8 +363,7 @@ export class TunnelClient {
     this.state = 'connecting';
     this.helloSeen = false;
     this.browserToken = null;
-    this.currentSid = null;
-    this.browserAttachHandle = null;
+    this.attachHandles.clear();
     let socket: WsLike;
     try {
       socket = this.wsFactory(this.url);
@@ -365,12 +421,29 @@ export class TunnelClient {
         } else {
           buf = Buffer.from(raw as ArrayBuffer);
         }
-        // Task #793 (S3-G): when an attach handle is bound, the binary
-        // frame is a browser→daemon PTY frame (INPUT/RESIZE/PAUSE/RESUME)
-        // that belongs to the paired session. Routing into the runtime
-        // subsumes the legacy onFrame passthrough.
-        if (this.browserAttachHandle !== null) {
-          this.browserAttachHandle.onFrame(buf);
+        // Task #105 (R-41): browser→daemon binary frames now carry a sid
+        // envelope so a single tunnel ws can route concurrent tabs into the
+        // right per-sid PTY. Decode header → look up handle → forward
+        // payload. Drop with a warn log if envelope is malformed or the
+        // sid was never attached (DO bug or hibernation race).
+        if (this.attachHandles.size > 0) {
+          const env = decodeSidEnvelope(buf);
+          if (env === null) {
+            console.warn(
+              '[ccsm/tunnel] drop browser->daemon binary: malformed sid envelope (len=' +
+                buf.length + ')',
+            );
+            return;
+          }
+          const handle = this.attachHandles.get(env.sid);
+          if (handle === undefined) {
+            console.warn(
+              '[ccsm/tunnel] drop browser->daemon binary: no attach for sid=' +
+                env.sid + ' (known sids=[' + Array.from(this.attachHandles.keys()).join(',') + '])',
+            );
+            return;
+          }
+          handle.onFrame(env.payload);
           return;
         }
         this.onFrame(buf);
@@ -419,15 +492,17 @@ export class TunnelClient {
       this.ws = null;
       this.helloSeen = false;
       this.browserToken = null;
-      this.currentSid = null;
-      // Task #793 (S3-G): tear down per-session attachment.
-      if (this.browserAttachHandle !== null) {
-        try {
-          this.browserAttachHandle.onClose();
-        } catch (err) {
-          console.warn('[ccsm/tunnel] attach onClose threw:', (err as Error).message);
+      // Task #793 (S3-G) + Task #105 (R-41): tear down ALL per-sid attaches
+      // on tunnel ws drop.
+      if (this.attachHandles.size > 0) {
+        for (const [sid, handle] of this.attachHandles) {
+          try {
+            handle.onClose();
+          } catch (err) {
+            console.warn('[ccsm/tunnel] attach onClose threw sid=' + sid + ':', (err as Error).message);
+          }
         }
-        this.browserAttachHandle = null;
+        this.attachHandles.clear();
       }
       if (this.stopped) {
         this.state = 'stopped';
@@ -442,9 +517,14 @@ export class TunnelClient {
   }
 
   /**
-   * Handle a token-validated hello frame. Idempotent for same sid; performs
-   * a re-pair (tear down old attach handle + invoke onBrowserAttach again)
-   * when sid changes. Task #81 (R-27).
+   * Handle a token-validated hello frame. Idempotent for a sid we've already
+   * attached on this connection; binds a NEW attach handle for any
+   * previously-unseen sid (Task #105, R-41 keep-both).
+   *
+   * Wave-1 (R-27) used to tear down the prior attach on sid change so only
+   * one tab could be active at a time. Wave-2 needs concurrent fan-out
+   * (multiple tabs over one tunnel ws), so we no longer drop prior sids on
+   * a new hello — we just add the new one to the Map.
    */
   private handleHello(hello: HelloFrame): void {
     this.helloSeen = true;
@@ -453,47 +533,47 @@ export class TunnelClient {
       ? hello.sid
       : null;
 
-    // Same sid (incl. both null / both same string) → idempotent. Don't
-    // re-attach; preserves PTY subscription and replay cursor.
-    if (newSid === this.currentSid) {
-      // R-17 log #8 (Task #45): hello received, record sid + lastSeq.
-      console.error('[ccsm] tunnel: hello received sid=' + (hello.sid ?? '-') + ' lastSeq=' + (hello.lastSeq ?? 0) + ' (idempotent)');
+    if (newSid === null) {
+      // Hello without sid (legacy / token-only re-auth). Nothing to attach.
+      console.error('[ccsm] tunnel: hello received sid=- lastSeq=' + (hello.lastSeq ?? 0) + ' (no-sid passthrough)');
       return;
     }
 
-    // sid changed (null→sid, sid→sid', or sid→null). Tear down old handle
-    // first so the prior PTY drops its subscriber before the new one binds.
-    if (this.browserAttachHandle !== null) {
-      try {
-        this.browserAttachHandle.onClose();
-      } catch (err) {
-        console.warn('[ccsm/tunnel] attach onClose threw on re-pair:', (err as Error).message);
-      }
-      this.browserAttachHandle = null;
+    // Already attached for this sid → idempotent. Preserves PTY subscription
+    // and replay cursor.
+    if (this.attachHandles.has(newSid)) {
+      console.error('[ccsm] tunnel: hello received sid=' + newSid + ' lastSeq=' + (hello.lastSeq ?? 0) + ' (idempotent, ' + this.attachHandles.size + ' active sids)');
+      return;
     }
 
-    this.currentSid = newSid;
-    // R-17 log #8 (Task #45): hello received, record sid + lastSeq.
-    console.error('[ccsm] tunnel: hello received sid=' + (hello.sid ?? '-') + ' lastSeq=' + (hello.lastSeq ?? 0));
+    console.error('[ccsm] tunnel: hello received sid=' + newSid + ' lastSeq=' + (hello.lastSeq ?? 0) + ' (' + (this.attachHandles.size + 1) + ' active sids)');
 
-    // Task #793 (S3-G): bind new attach handle if SPA supplied a sid.
-    if (this.onBrowserAttach !== null && newSid !== null) {
+    // Task #793 (S3-G) + Task #105 (R-41): bind a NEW attach handle for the
+    // newly-paired sid. send wraps the daemon→browser binary frame in a sid
+    // envelope so the DO can pick the right per-sid browser ws.
+    if (this.onBrowserAttach !== null) {
+      const attachSid = newSid;
       const send = (payload: Uint8Array | Buffer): void => {
-        // Bridge to the underlying ws. Always binary frame back to browser.
-        const buf = Buffer.isBuffer(payload)
-          ? payload
-          : Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength);
-        this.send(buf);
+        let envelope: Buffer;
+        try {
+          envelope = encodeSidEnvelope(attachSid, payload);
+        } catch (err) {
+          console.warn('[ccsm/tunnel] envelope encode failed sid=' + attachSid + ':', (err as Error).message);
+          return;
+        }
+        this.send(envelope);
       };
       try {
-        this.browserAttachHandle = this.onBrowserAttach({
-          sid: newSid,
+        const handle = this.onBrowserAttach({
+          sid: attachSid,
           lastSeq: hello.lastSeq ?? 0,
           send,
         });
+        if (handle !== null) {
+          this.attachHandles.set(attachSid, handle);
+        }
       } catch (err) {
-        console.warn('[ccsm/tunnel] onBrowserAttach threw:', (err as Error).message);
-        this.browserAttachHandle = null;
+        console.warn('[ccsm/tunnel] onBrowserAttach threw sid=' + attachSid + ':', (err as Error).message);
       }
     }
   }

--- a/packages/daemon/test/tunnel.test.ts
+++ b/packages/daemon/test/tunnel.test.ts
@@ -649,7 +649,12 @@ describe('TunnelClient', () => {
     expect(onBrowserAttach).not.toHaveBeenCalled();
   });
 
-  it('post-hello binary frames route to attach handle, not onFrame', () => {
+  it('post-hello binary frames (sid-enveloped) route to the matching attach handle, not onFrame', () => {
+    // Task #105 (R-41): browser→daemon binary on the wire now carries a
+    // sid envelope `[sidLen][sid utf8][payload]`. The daemon decodes the
+    // header, looks up the attach handle for that sid, and forwards the
+    // payload (envelope stripped). Frames whose sid never attached are
+    // dropped with a warn log.
     const onFrame = vi.fn();
     const handleFrames: Buffer[] = [];
     const client = new TunnelClient({
@@ -671,14 +676,24 @@ describe('TunnelClient', () => {
       lastSeq: 0,
     }));
 
-    sockets[0].pushBinary(Buffer.from([1, 2, 3]));
+    // Build envelope: [sidLen=4]['s','e','s','s'][1,2,3]
+    const env = Buffer.concat([
+      Buffer.from([4]),
+      Buffer.from('sess', 'utf8'),
+      Buffer.from([1, 2, 3]),
+    ]);
+    sockets[0].pushBinary(env);
     expect(handleFrames).toHaveLength(1);
     expect(handleFrames[0].equals(Buffer.from([1, 2, 3]))).toBe(true);
     // onFrame NOT called when attach handle owns binary routing.
     expect(onFrame).not.toHaveBeenCalled();
   });
 
-  it('attach handle.send() pushes a binary frame back through the tunnel ws', () => {
+  it('attach handle.send() wraps payload in sid envelope before pushing through tunnel ws', () => {
+    // Task #105 (R-41): daemon→browser binary is wrapped in a sid envelope
+    // so the DO can route to the right per-sid browser ws. The wrap
+    // happens at the BrowserAttachInfo.send seam so registry callers don't
+    // have to know envelope exists.
     let sendBack: ((data: Uint8Array | Buffer) => void) | null = null;
     const client = new TunnelClient({
       url: 'wss://x',
@@ -701,11 +716,16 @@ describe('TunnelClient', () => {
 
     expect(sendBack).not.toBeNull();
     (sendBack as unknown as (data: Uint8Array) => void)(new Uint8Array([7, 8, 9]));
-    // Tunnel ws.send should have received the bridged buffer.
+    // Tunnel ws.send should have received an envelope: [4]['s','e','s','s'][7,8,9]
     expect(sockets[0].sent).toHaveLength(1);
     const sent = sockets[0].sent[0] as Buffer;
     expect(Buffer.isBuffer(sent)).toBe(true);
-    expect(sent.equals(Buffer.from([7, 8, 9]))).toBe(true);
+    const expected = Buffer.concat([
+      Buffer.from([4]),
+      Buffer.from('sess', 'utf8'),
+      Buffer.from([7, 8, 9]),
+    ]);
+    expect(sent.equals(expected)).toBe(true);
   });
 
   it('socket close after attach fires handle.onClose exactly once', () => {
@@ -730,13 +750,13 @@ describe('TunnelClient', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  // ---- Task #81 (R-27): multi-sid re-pair on a single tunnel ws --------
+  // ---- Task #105 (R-41): wave-2 multi-sid keep-both ---------------------
 
-  it('second hello with new sid tears down old handle and re-attaches', () => {
-    // Reproduces the Task #81 bug: SPA reuses one cf-worker tunnel ws across
-    // sessions. New Session sends `{type:"hello",token,sid:<new>}` on the
-    // SAME ws; the daemon must tear down the prior attach handle and bind a
-    // fresh one so the new sid's PTY gets a subscriber.
+  it('second hello with new sid keeps the old handle attached and adds the new one', () => {
+    // Wave-2 (R-41): one tunnel ws fans out N concurrent browser tabs to
+    // the same daemon. Each unique sid hello adds a NEW attach handle; the
+    // prior sid's handle is NOT torn down (that was the wave-1 R-27
+    // behaviour). Same-sid hello stays idempotent.
     const attachCalls: Array<{ sid: string; lastSeq: number }> = [];
     const closeCalls: string[] = [];
     let nextHandleId = 0;
@@ -768,10 +788,9 @@ describe('TunnelClient', () => {
     }));
     expect(attachCalls).toEqual([{ sid: 'sess-A', lastSeq: 0 }]);
     expect(closeCalls).toEqual([]);
-    // No 1008 close.
     expect(sockets[0].closedCalls).toHaveLength(0);
 
-    // Second hello: sid=B on the SAME ws → re-pair.
+    // Second hello: sid=B on the SAME ws → keep-both, NO tear-down.
     sockets[0].pushText(JSON.stringify({
       type: 'hello',
       token: 'tok',
@@ -782,13 +801,11 @@ describe('TunnelClient', () => {
       { sid: 'sess-A', lastSeq: 0 },
       { sid: 'sess-B', lastSeq: 5 },
     ]);
-    // Old handle's onClose was invoked exactly once before the new attach.
-    expect(closeCalls).toEqual(['handle-0-for-sess-A']);
-    // Still no 1008 close — re-pair is in-band, not a protocol violation.
+    // R-41 critical: old handle MUST NOT be closed.
+    expect(closeCalls).toEqual([]);
     expect(sockets[0].closedCalls).toHaveLength(0);
 
-    // Third hello: same sid=B → idempotent. Neither onClose nor a fresh
-    // onBrowserAttach should fire.
+    // Third hello: same sid=B → idempotent; no new attach, no close.
     sockets[0].pushText(JSON.stringify({
       type: 'hello',
       token: 'tok',
@@ -799,24 +816,31 @@ describe('TunnelClient', () => {
       { sid: 'sess-A', lastSeq: 0 },
       { sid: 'sess-B', lastSeq: 5 },
     ]);
-    expect(closeCalls).toEqual(['handle-0-for-sess-A']);
+    expect(closeCalls).toEqual([]);
+
+    // Tunnel ws close fires onClose for ALL active handles.
+    sockets[0].closeFromServer(1006);
+    expect(closeCalls.sort()).toEqual([
+      'handle-0-for-sess-A',
+      'handle-1-for-sess-B',
+    ].sort());
   });
 
-  it('post-hello re-pair: binary frames after re-pair route to NEW handle', () => {
-    // Guard: after re-pair, binary frames must land on the new attach
-    // handle, not the old one (the original bug — frames were silently
-    // dropped because the gate locked on the first hello).
+  it('post-hello multi-sid: sid-enveloped binary frames route to the right handle', () => {
+    // R-41 multi-sid fan-out: with two attach handles bound, binary frames
+    // on the wire MUST be sid-enveloped and route to whichever handle owns
+    // that sid. Frames whose sid never attached are dropped (no fall-through
+    // to the default onFrame, which would short-circuit the routing layer).
     const handleAFrames: Buffer[] = [];
     const handleBFrames: Buffer[] = [];
-    let nextSid: 'A' | 'B' = 'A';
+    const onFrame = vi.fn();
     const client = new TunnelClient({
       url: 'wss://x',
       token: 'tok',
-      onFrame: () => {},
+      onFrame,
       wsFactory: factory,
-      onBrowserAttach: () => {
-        const target = nextSid === 'A' ? handleAFrames : handleBFrames;
-        nextSid = nextSid === 'A' ? 'B' : 'A';
+      onBrowserAttach: ({ sid }) => {
+        const target = sid === 'sess-A' ? handleAFrames : handleBFrames;
         return {
           onFrame: (data) => target.push(data),
           onClose: () => {},
@@ -826,29 +850,28 @@ describe('TunnelClient', () => {
     client.start();
     sockets[0].open();
 
-    sockets[0].pushText(JSON.stringify({
-      type: 'hello',
-      token: 'tok',
-      sid: 'sess-A',
-      lastSeq: 0,
-    }));
-    sockets[0].pushBinary(Buffer.from([0xa1]));
-    expect(handleAFrames).toHaveLength(1);
-    expect(handleBFrames).toHaveLength(0);
+    sockets[0].pushText(JSON.stringify({ type: 'hello', token: 'tok', sid: 'sess-A', lastSeq: 0 }));
+    sockets[0].pushText(JSON.stringify({ type: 'hello', token: 'tok', sid: 'sess-B', lastSeq: 0 }));
 
-    // Re-pair to sid=B.
-    sockets[0].pushText(JSON.stringify({
-      type: 'hello',
-      token: 'tok',
-      sid: 'sess-B',
-      lastSeq: 0,
-    }));
-    sockets[0].pushBinary(Buffer.from([0xb1]));
-    // The new frame went to handle B, NOT to handle A (which would've been
-    // the old buggy behaviour — a stale subscriber on a torn-down session).
-    expect(handleAFrames).toHaveLength(1);
-    expect(handleBFrames).toHaveLength(1);
-    expect(handleBFrames[0].equals(Buffer.from([0xb1]))).toBe(true);
+    function envelope(sid: string, payload: number[]): Buffer {
+      return Buffer.concat([
+        Buffer.from([Buffer.byteLength(sid, 'utf8')]),
+        Buffer.from(sid, 'utf8'),
+        Buffer.from(payload),
+      ]);
+    }
+    sockets[0].pushBinary(envelope('sess-A', [0xa1]));
+    sockets[0].pushBinary(envelope('sess-B', [0xb1]));
+    sockets[0].pushBinary(envelope('sess-B', [0xb2]));
+    // Unknown sid → dropped.
+    sockets[0].pushBinary(envelope('ghost', [0xff]));
+    // Malformed envelope (sidLen=0) → dropped.
+    sockets[0].pushBinary(Buffer.from([0, 1, 2]));
+
+    expect(handleAFrames.map((b) => Array.from(b))).toEqual([[0xa1]]);
+    expect(handleBFrames.map((b) => Array.from(b))).toEqual([[0xb1], [0xb2]]);
+    // onFrame is bypassed entirely once any attach handle is bound.
+    expect(onFrame).not.toHaveBeenCalled();
   });
 
   it('re-pair hello with bad token closes 1008', () => {


### PR DESCRIPTION
## Summary
Wave-2 multi-tab architecture-layer fix (Task #105 — research-104 / R-40 root-cause). Three pieces ship together because they are one protocol contract:

1. **Sid envelope on the wire** (binary frames only): `[u8 sidLen][sid utf8][payload]`. Control text frames (hello / http_req / http_res) are unchanged. Cap `ENVELOPE_MAX_SID_LEN = 64`.
2. **DO sid-indexed routing** (`packages/cf-worker/src/tunnel-do.ts`): browser ws is now tagged with `['browser', 'browser-sid:<sid>']` and its attachment carries `sid`, so post-hibernation `getBrowserSocket(sid)` recovers the right ws via `state.getWebSockets(tag)`. `handleDaemonMessage` decodes the envelope and routes to the matching browser ws (envelope stripped). `handleBrowserMessage` wraps the binary in a sid envelope before forwarding to the daemon. `handleDaemonClose / handleDaemonError` fan out close to **all** paired browsers.
3. **Daemon `handleHello` keep-both** (`packages/daemon/src/tunnel.mts`): replaced single `currentSid + browserAttachHandle` with `Map<sid, BrowserAttachHandle>`. Previously-unseen sid → add a new handle (no tear-down). Same sid → idempotent. `BrowserAttachInfo.send` wraps payload in sid envelope before pushing through the single tunnel ws. Inbound binary on the tunnel decodes envelope → looks up handle by sid → forwards stripped payload (drop with warn log if envelope malformed or sid unknown). Tunnel ws close fans out `onClose` to all active handles.

Architecture-layer per `feedback_fix_arch_not_glue.md` — no glue (no per-frame retries, no broadcast fallbacks, no tear-down side effects on hello).

### Files
- `packages/daemon/src/tunnel.mts` — `Map<sid, attachHandle>`, envelope encode/decode helpers, keep-both `handleHello`, sid-routed binary in
- `packages/cf-worker/src/tunnel-do.ts` — per-sid browser tag + attachment, envelope encode/decode, sid-routed binary both ways, fan-out close
- `packages/daemon/test/tunnel.test.ts` — rewrote 4 R-27 tear-down tests as R-41 keep-both contracts (envelope wrap on send, envelope decode on multi-sid route, second hello keeps old handle alive)
- `packages/cf-worker/test/tunnel-do.test.ts` — updated 2 existing tests for the new wire format; added 5 R-41 cases (multi-sid daemon→browser fan-out, browser→daemon sid wrap, unknown-sid drop, malformed envelope drop, daemon-close fan-out, hibernation per-sid recovery)

## Local checks (host: Windows, mode: fast)
- lint: pre-existing baseline-red unaffected by this PR. 3 errors, all in files I did NOT touch (`packages/daemon/test/persist.test.ts`, `packages/ui/test/BootstrapRefresh.test.tsx`, `tools/cloud-e2e/specs/two-tab-pairing.spec.ts`). `git diff --name-only origin/working...HEAD` shows only the 4 R-41 files. Newly-added daemon and cf-worker code passes lint clean.
- typecheck: ✓ (exit 0, all packages)
- build: ✓ (exit 0, all packages)
- unit tests:
  - `pnpm --filter @ccsm/cf-worker test` — **32/32 PASS** (937 ms). Includes the 5 new R-41 cases.
  - `pnpm --filter @ccsm/daemon test` — **155/155 PASS, 1 skipped** (11.49 s). Includes the rewritten R-41 keep-both + multi-sid envelope routing tests.
- e2e (cloud-e2e harness): NOT run locally. The harness targets a deployed cf-worker (defaults to `cc-sm.pages.dev`) and the prompt explicitly forbids deploying to production wrangler. Local `wrangler dev --local` did boot (verified — banner + `Ready on http://127.0.0.1:8787` after ~60s warm-up), but pointing the SPA + Tauri-launched daemon at `ws://localhost:8787/tunnel/default` and chasing hibernation differences vs production workerd is a research task in itself. The unit tests cover every protocol contract this PR introduces (envelope encode/decode, sid routing both directions, keep-both hello, daemon-close fan-out, hibernation per-sid recovery via `state.getWebSockets(tag)`); the deploy-driven e2e is the right validation layer for the wire-level integration.

## Diagnostic logs (from R-38/R-39, unchanged by this PR)
- `[r38-pty-data] sid=<X>` — fires per PTY data event with the sid + bytes + sub count (runtime.mts:340)
- `[r38-sub-send] sid=<X> bytes=<n>` — fires per subscriber send (ws.mts:208), wraps the EXACT payload that BrowserAttachInfo.send wraps in a sid envelope. With multi-sid attached, two distinct sid lines fire and do not interleave or replace each other (covered by the new daemon test `post-hello multi-sid: sid-enveloped binary frames route to the right handle`).
- `[r38-tunnel-tx] state=connected bytes=<n>` — fires per `tunnel.send`; `n` is the envelope length (`1 + sidLen + payload.byteLength`).