### PR TITLE
fix(frontend-tauri): R-43 — pin vite + tauri devUrl to IPv4 (Task #109)

### DIFF
--- a/packages/frontend-tauri/src-tauri/tauri.conf.json
+++ b/packages/frontend-tauri/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",
-    "devUrl": "http://localhost:1420",
+    "devUrl": "http://127.0.0.1:1420",
     "frontendDist": "../dist"
   },
   "app": {

--- a/packages/frontend-tauri/vite.config.ts
+++ b/packages/frontend-tauri/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   server: {
     port: DEV_PORT,
     strictPort: true,
+    host: '127.0.0.1',
   },
   // Tauri expects the bundled frontend at `../dist` relative to src-tauri/.
   build: {


### PR DESCRIPTION
## Summary

Fix Tauri dev blank-screen by forcing both vite and Tauri devUrl onto IPv4 loopback. Root cause from research-108: Node `Server.listen('localhost')` on Windows binds only `::1` (getaddrinfo gives IPv6 first); WebView2's `localhost` resolution prefers IPv4 → `ERR_CONNECTION_REFUSED`.

## Changes (2 lines)

```diff
diff --git a/packages/frontend-tauri/src-tauri/tauri.conf.json b/packages/frontend-tauri/src-tauri/tauri.conf.json
-    "devUrl": "http://localhost:1420",
+    "devUrl": "http://127.0.0.1:1420",

diff --git a/packages/frontend-tauri/vite.config.ts b/packages/frontend-tauri/vite.config.ts
   server: {
     port: DEV_PORT,
     strictPort: true,
+    host: '127.0.0.1',
   },
```

Untouched: CSP, lib.rs setup hook, SPA code, smoke orchestrator (it already passes `VITE_DEV_PORT` + `--config` overrides per existing comments; smoke uses its own host wiring).

## Runtime verification (host: Windows 11)

### vite listen — IPv4 only

```
$ netstat -ano | grep :1420
  TCP    127.0.0.1:1420         0.0.0.0:0              LISTENING       52884
# (no [::1]:1420 entry)

$ curl -sI http://127.0.0.1:1420 | head -3
HTTP/1.1 200 OK
Vary: Origin
Content-Type: text/html

$ curl -sI -g 'http://[::1]:1420' | head -3
# (empty — connection refused on IPv6, as intended)
```

vite log:
```
VITE v5.4.21  ready in 614 ms
➜  Local:   http://127.0.0.1:1420/
```

### Tauri exe — daemon spawn + tunnel ok, no webview error

```
$ ./src-tauri/target/debug/ccsm-tauri.exe
[daemon-mgr] resolved daemon script: ...packages\daemon\dist\index.mjs
[daemon-mgr] CCSM_DB_PATH=...\dev.ccsm.tauri\ccsm.db
[daemon-mgr] spawned daemon pid=45392
[daemon-mgr] assigned pid=45392 to Job Object
[daemon stderr] [ccsm] tunnel: connecting wss://cc-sm.pages.dev/tunnel/default
[daemon-mgr] handshake ok port=54625 token=9a7773…
[daemon stderr] [ccsm] tunnel: connected
```

No `ERR_CONNECTION_REFUSED`, no webview console error, normal handshake.

## Local checks (host: Windows 11, mode: fast)

- lint: 3 pre-existing baseline errors in `packages/daemon/test/persist.test.ts`, `packages/ui/test/BootstrapRefresh.test.tsx`, `tools/cloud-e2e/specs/two-tab-pairing.spec.ts` — verified by stripping diff and re-running lint, same 3 errors (unrelated to this PR's scope: frontend-tauri only).
- typecheck: ✓ (exit 0, all 8 packages pass)
- build: ✓ (exit 0, `pnpm -w build` all packages including frontend-tauri vite build + cargo build of `ccsm-tauri.exe` 2m 35s)
- unit tests: frontend-tauri has no test files (`No test files found, exiting with code 0`)
- e2e: skipped — change is dev-only (vite host + devUrl); no e2e harness covers Tauri dev shell directly. Runtime verification above replaces e2e for this fix.

## Test plan

- [x] vite binds 127.0.0.1:1420 (not [::1]:1420)
- [x] `curl -sI http://127.0.0.1:1420` → 200 OK
- [x] `cargo build` succeeds with new devUrl
- [x] `ccsm-tauri.exe` launches, spawns daemon, completes handshake without webview connection error