### PR TITLE
docs(s4): T1 — GitHub App setup doc + .dev.vars template (Task #113)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,12 @@ coverage/
 .env
 .env.local
 
+# S4 (Task #113): Cloudflare Worker local dev secrets. `.dev.vars` is read by
+# `wrangler dev`; production uses `wrangler secret put`. Never commit real
+# values — `.dev.vars.example` is the committed template.
+packages/*/.dev.vars
+.dev.vars
+
 # R-9 v3.A (Task #15): smoke build artifacts — release ccsm-tauri.exe + isolated
 # cargo target — produced by `pnpm smoke:build`, consumed by `pnpm smoke:run`.
 # Physically isolated from the developer's `packages/frontend-tauri/src-tauri/target/`

--- a/docs/S4-SETUP.md
+++ b/docs/S4-SETUP.md
@@ -1,0 +1,134 @@
+# S4 Setup — GitHub App + Secret Provisioning
+
+S4 introduces web-side authentication for ccsm-cloud (the Cloudflare Worker / Pages
+frontend). This doc covers the **manual one-time setup** required before S4-T2+
+code can run. Code lives under `packages/cf-worker/`.
+
+## Scope
+
+This doc covers:
+
+- Registering a GitHub App for ccsm-cloud (production + local dev callbacks).
+- Generating JWT signing keys.
+- Injecting credentials as Cloudflare Worker secrets (production) and `.dev.vars`
+  (local dev).
+
+Out of scope (handled by later S4 tasks):
+
+- OAuth callback handler implementation (S4-T2).
+- Device Flow handler for the desktop client (S4-T8).
+- UserDO and refresh-token rotation (S4-T3+).
+
+## Design decisions (locked by S4 plan, do not re-litigate)
+
+- **D1**: Use a **GitHub App** (not an OAuth App). GitHub Apps support Device
+  Flow, which S4-T8 needs for the desktop client login.
+- **D2**: **JWT** (not cookies) for web auth. Per-tunnel JWT is signed by the
+  Worker and verified by the daemon's tunnel client.
+- **D3**: Issue a per-tunnel **access JWT** plus a long-lived **refresh token**.
+- **D4**: `UserDO` is keyed by `github_id` (stable, immutable per GitHub user).
+- **D5**: Production secrets via `wrangler secret put`. Local dev via `.dev.vars`
+  (gitignored). No secrets in repo.
+
+## Step 1 — Register GitHub App
+
+Go to <https://github.com/settings/apps> → **New GitHub App**.
+
+Recommended values:
+
+| Field | Value |
+|-------|-------|
+| GitHub App name | `ccsm-cloud` (or any unique slug) |
+| Homepage URL | `https://cc-sm.pages.dev` |
+| Callback URLs | `https://cc-sm.pages.dev/api/auth/github/callback` |
+|               | `http://127.0.0.1:8788/api/auth/github/callback` |
+| Request user authorization (OAuth) during installation | unchecked |
+| Enable Device Flow | **checked** (required for S4-T8 desktop login) |
+| Webhook → Active | **unchecked** (we don't consume webhooks) |
+| Where can this GitHub App be installed? | **Any account** |
+
+**Permissions** (all default to "No access" except where noted):
+
+- **Account permissions** → **Email addresses**: **Read-only**
+- All other permissions: leave at "No access"
+
+Click **Create GitHub App**.
+
+### Step 1b — Capture credentials
+
+On the newly created App's settings page:
+
+1. Note the **Client ID** (looks like `Iv1.xxxxxxxxxxxxxxxx`).
+2. Click **Generate a new client secret**. Copy the secret immediately
+   (looks like `ghs_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx`); GitHub only shows
+   it once.
+3. **Do NOT** generate a private key — ccsm-cloud does not use GitHub App
+   installations or sign JWT for GitHub API. Client ID + Client secret are
+   sufficient for OAuth user-to-server and Device Flow.
+
+## Step 2 — Generate JWT signing keys
+
+Two independent 32-byte random keys. Use openssl:
+
+```bash
+# Access-token signing key
+openssl rand -hex 32
+
+# Refresh-token signing key (must differ from access key)
+openssl rand -hex 32
+```
+
+Keep both values; they go in step 3 / step 4. Losing them invalidates all
+issued tokens (users re-login).
+
+## Step 3 — Production secrets (Cloudflare Worker)
+
+Run from `packages/cf-worker/`. Each command prompts for the value and stores
+it encrypted on Cloudflare:
+
+```bash
+cd packages/cf-worker
+wrangler secret put GITHUB_APP_CLIENT_ID
+wrangler secret put GITHUB_APP_CLIENT_SECRET
+wrangler secret put JWT_SIGNING_KEY           # 32-byte hex from step 2
+wrangler secret put JWT_REFRESH_SIGNING_KEY   # 32-byte hex from step 2 (different)
+```
+
+Verify with `wrangler secret list` — should show all four names (values masked).
+
+## Step 4 — Local dev (`.dev.vars`)
+
+`packages/cf-worker/.dev.vars` is read by `wrangler dev` and `wrangler dev
+--local`. The file is **gitignored** (see `.gitignore`).
+
+```bash
+cd packages/cf-worker
+cp .dev.vars.example .dev.vars
+# Edit .dev.vars with the real values from steps 1b + 2
+```
+
+Do **not** commit `.dev.vars`. If you accidentally add it, run `git rm
+--cached packages/cf-worker/.dev.vars` and rotate every secret it contained.
+
+## Verification
+
+After steps 1-4, S4-T2 can begin OAuth callback implementation. To verify
+secrets are accessible without writing code yet:
+
+```bash
+cd packages/cf-worker
+wrangler secret list                # production: 4 entries
+test -f .dev.vars && echo "dev OK"  # local
+```
+
+## Rotation
+
+To rotate a secret (compromise or scheduled rotation):
+
+1. Re-run `wrangler secret put <NAME>` with the new value (overwrites).
+2. Update `.dev.vars` for any local devs.
+3. For `JWT_SIGNING_KEY` / `JWT_REFRESH_SIGNING_KEY` rotation, all live tokens
+   are invalidated; users re-login. Plan accordingly.
+
+GitHub App **client secret** can be rotated from the App settings page; the old
+secret remains valid for a brief grace window.

--- a/packages/cf-worker/.dev.vars.example
+++ b/packages/cf-worker/.dev.vars.example
@@ -1,0 +1,12 @@
+# Local dev secrets for `wrangler dev`. Copy this file to `.dev.vars` (which
+# is gitignored) and replace the placeholders with real values.
+#
+# Production: use `wrangler secret put <NAME>` (see docs/S4-SETUP.md).
+# DO NOT commit `.dev.vars`. DO NOT put real values in this `.example` file.
+#
+# How to obtain values: docs/S4-SETUP.md (Task #113 / S4-T1).
+
+GITHUB_APP_CLIENT_ID=Iv1.xxxxxxxxxxxx
+GITHUB_APP_CLIENT_SECRET=ghs_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+JWT_SIGNING_KEY=00000000000000000000000000000000000000000000000000000000000000ff
+JWT_REFRESH_SIGNING_KEY=00000000000000000000000000000000000000000000000000000000000000aa

--- a/packages/cf-worker/wrangler.toml
+++ b/packages/cf-worker/wrangler.toml
@@ -2,6 +2,15 @@ name = "ccsm-worker"
 main = "src/index.ts"
 compatibility_date = "2026-01-01"
 
+# S4 (Task #113): GitHub OAuth App credentials + JWT signing keys.
+# Set in production via:
+#   wrangler secret put GITHUB_APP_CLIENT_ID
+#   wrangler secret put GITHUB_APP_CLIENT_SECRET
+#   wrangler secret put JWT_SIGNING_KEY
+#   wrangler secret put JWT_REFRESH_SIGNING_KEY
+# Local dev: copy `.dev.vars.example` → `.dev.vars` (gitignored) and fill in.
+# Full setup steps: docs/S4-SETUP.md.
+
 # Durable Object binding for the tunnel pairing logic. The class itself is
 # implemented as a stub in T1 so wrangler can resolve the binding; T2 (#774)
 # replaces the stub with the real TunnelDO that pairs browser ws ↔ daemon ws.


### PR DESCRIPTION
## Summary

S4-T1 — manual / config setup for ccsm-cloud web auth. **No source code changes.**
Sets up the doc + templates so S4-T2 (OAuth callback) and S4-T8 (Device Flow)
can begin once a user manually registers the GitHub App.

- \`docs/S4-SETUP.md\` (new): step-by-step GitHub App registration (Device
  Flow enabled, email-read-only, dual callback URLs for prod + 127.0.0.1
  local dev), JWT signing-key generation (\`openssl rand -hex 32\` × 2),
  \`wrangler secret put\` commands for the four secrets, \`.dev.vars\`
  usage, rotation guidance.
- \`packages/cf-worker/.dev.vars.example\` (new): committed template with
  placeholder values (\`Iv1.xxx\` / \`ghs_xxx\` / hex zeros — no real
  secrets). Header points at \`docs/S4-SETUP.md\`.
- \`packages/cf-worker/wrangler.toml\`: header comment lists the four
  secret names and points to \`.dev.vars.example\` + \`S4-SETUP.md\`.
- \`.gitignore\`: ignore \`packages/*/.dev.vars\` and bare \`.dev.vars\`
  to prevent accidental secret commits. Verified with \`git check-ignore\`.

## Locked design decisions (S4 plan, do not re-litigate)

- D1: GitHub App (not OAuth App) — Device Flow needed for S4-T8 desktop login
- D2: JWT (not cookies) for web auth
- D3: Per-tunnel access JWT + refresh token
- D4: UserDO keyed by \`github_id\`
- D5: \`wrangler secret put\` (prod) + \`.dev.vars\` (dev)

## Out of scope (handled later)

- OAuth callback handler (S4-T2)
- Device Flow handler (S4-T8)
- UserDO + refresh token rotation (S4-T3+)
- Any \`packages/cf-worker/src/\` changes
- ROADMAP.md status update (S4 not complete yet)

## Local checks (host: Windows, mode: fast)

- lint: skipped — no \`.ts\`/\`.tsx\` touched. (Repo lint baseline already has
  3 unrelated pre-existing errors in \`persist.test.ts\`,
  \`BootstrapRefresh.test.tsx\`, \`two-tab-pairing.spec.ts\` — none in files
  touched by this PR.)
- typecheck: skipped — no \`.ts\`/\`.tsx\` touched.
- build: skipped — no \`.ts\`/\`.tsx\` touched.
- unit tests: skipped — no source change.
- e2e: skipped — no source change.
- gitignore verify: \`git check-ignore -v packages/cf-worker/.dev.vars\` →
  matches \`.gitignore:16:.dev.vars\` ✓

## Test plan

- [ ] User manually registers \`ccsm-cloud\` GitHub App per docs/S4-SETUP.md
- [ ] User runs \`wrangler secret put\` for the four secret names
- [ ] User \`cp packages/cf-worker/.dev.vars.example .dev.vars\` and fills values
- [ ] Real verification deferred to S4-T2 (callback handler can read the secrets)