### PR TITLE
feat(frontend-tauri): T1 — DaemonPhase enum + unified daemon-state channel (Task #115)

### DIFF
--- a/packages/frontend-tauri/src-tauri/src/daemon_mgr.rs
+++ b/packages/frontend-tauri/src-tauri/src/daemon_mgr.rs
@@ -16,6 +16,7 @@ use tokio::sync::mpsc;
 use tokio::time::timeout;
 
 use crate::job_object::JobObject;
+use crate::daemon_state::{DaemonPhase, DaemonStateStore};
 
 #[derive(Default)]
 pub struct DaemonState {
@@ -104,6 +105,7 @@ pub async fn start_daemon(app: AppHandle, state: State<'_, DaemonState>) -> Resu
 /// empty and will overwrite the killer if invoked twice concurrently.
 pub async fn spawn_daemon_inner(app: AppHandle) -> Result<(), String> {
     let state: State<DaemonState> = app.state();
+    let store: State<DaemonStateStore> = app.state();
     {
         let guard = state.killer.lock().unwrap();
         if guard.is_some() {
@@ -111,7 +113,20 @@ pub async fn spawn_daemon_inner(app: AppHandle) -> Result<(), String> {
         }
     }
 
-    let script = resolve_daemon_script(&app)?;
+    // Announce we're about to spawn — listeners can clear any prior
+    // SpawnFailed UI before resolve_daemon_script / token I/O runs.
+    store.set_and_emit(&app, DaemonPhase::Spawning);
+
+    let script = match resolve_daemon_script(&app) {
+        Ok(p) => p,
+        Err(e) => {
+            store.set_and_emit(
+                &app,
+                DaemonPhase::SpawnFailed { reason: e.clone(), retry_in_ms: None },
+            );
+            return Err(e);
+        }
+    };
     eprintln!("[daemon-mgr] resolved daemon script: {}", script.display());
 
     // T11: pin daemon SQLite path to Tauri's app_local_data_dir so the Tauri
@@ -164,6 +179,10 @@ pub async fn spawn_daemon_inner(app: AppHandle) -> Result<(), String> {
             let reason = format!("token load/create failed: {e}");
             eprintln!("[daemon-mgr] {reason}");
             let _ = app.emit("daemon-error", DaemonErrorEvent { reason: reason.clone() });
+            store.set_and_emit(
+                &app,
+                DaemonPhase::SpawnFailed { reason: reason.clone(), retry_in_ms: None },
+            );
             return Err(reason);
         }
     };
@@ -176,9 +195,22 @@ pub async fn spawn_daemon_inner(app: AppHandle) -> Result<(), String> {
         cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW — avoid console flash
     }
 
-    let mut child = cmd.spawn().map_err(|e| format!("spawn failed: {e}"))?;
+    let mut child = match cmd.spawn() {
+        Ok(c) => c,
+        Err(e) => {
+            let reason = format!("spawn failed: {e}");
+            store.set_and_emit(
+                &app,
+                DaemonPhase::SpawnFailed { reason: reason.clone(), retry_in_ms: None },
+            );
+            return Err(reason);
+        }
+    };
     let pid = child.id().unwrap_or(0);
     eprintln!("[daemon-mgr] spawned daemon pid={pid}");
+
+    // Process is alive; transition to Starting until handshake confirms ready.
+    store.set_and_emit(&app, DaemonPhase::Starting);
 
     // T9: bind the child to the app-wide Job Object so it gets kernel-killed
     // if ccsm-tauri.exe dies (incl. TerminateProcess paths that skip Drop).
@@ -209,12 +241,39 @@ pub async fn spawn_daemon_inner(app: AppHandle) -> Result<(), String> {
     }
 
     // stderr forwarder — surfaces daemon log lines to webview as `daemon-stderr`
-    // and to Rust stderr for dev console.
+    // and to Rust stderr for dev console. Also sniffs for tunnel state markers
+    // (`[ccsm] tunnel: connected` / `disconnected`) to drive the unified
+    // `daemon-state` channel. The token here is the in-process token we just
+    // loaded — daemon does not echo it on stderr, so we capture it once for
+    // the closure.
     let app_for_stderr = app.clone();
+    let token_for_stderr = token.clone();
     tokio::spawn(async move {
+        let store: State<DaemonStateStore> = app_for_stderr.state();
         let mut reader = BufReader::new(stderr).lines();
         while let Ok(Some(line)) = reader.next_line().await {
             eprintln!("[daemon stderr] {line}");
+            // Simple `contains` checks per T1 spec — full structured tunnel
+            // protocol parsing is T2 territory. Port is hard-coded to the
+            // PORT env we passed (9876) to avoid plumbing it through the
+            // closure; future work will lift the port from handshake state.
+            if line.contains("[ccsm] tunnel: connected") {
+                store.set_and_emit(
+                    &app_for_stderr,
+                    DaemonPhase::TunnelConnected {
+                        port: 9876,
+                        token: token_for_stderr.clone(),
+                    },
+                );
+            } else if line.contains("[ccsm] tunnel: disconnected") {
+                store.set_and_emit(
+                    &app_for_stderr,
+                    DaemonPhase::TunnelDisconnected {
+                        port: 9876,
+                        token: token_for_stderr.clone(),
+                    },
+                );
+            }
             let _ = app_for_stderr.emit("daemon-stderr", line);
         }
     });
@@ -222,6 +281,7 @@ pub async fn spawn_daemon_inner(app: AppHandle) -> Result<(), String> {
     // stdout reader — first line MUST be the handshake JSON (race-protected by 1.5s timeout).
     let app_for_reader = app.clone();
     tokio::spawn(async move {
+        let store: State<DaemonStateStore> = app_for_reader.state();
         let mut lines = BufReader::new(stdout).lines();
 
         // Bound waiting for the first line by 1.5s — covers slow node start
@@ -229,23 +289,38 @@ pub async fn spawn_daemon_inner(app: AppHandle) -> Result<(), String> {
         let first = match timeout(Duration::from_millis(1500), lines.next_line()).await {
             Ok(Ok(Some(line))) => line,
             Ok(Ok(None)) => {
+                let reason = "stdout closed before handshake".to_string();
                 let _ = app_for_reader.emit(
                     "daemon-error",
-                    DaemonErrorEvent { reason: "stdout closed before handshake".into() },
+                    DaemonErrorEvent { reason: reason.clone() },
+                );
+                store.set_and_emit(
+                    &app_for_reader,
+                    DaemonPhase::SpawnFailed { reason, retry_in_ms: None },
                 );
                 return;
             }
             Ok(Err(e)) => {
+                let reason = format!("stdout read error: {e}");
                 let _ = app_for_reader.emit(
                     "daemon-error",
-                    DaemonErrorEvent { reason: format!("stdout read error: {e}") },
+                    DaemonErrorEvent { reason: reason.clone() },
+                );
+                store.set_and_emit(
+                    &app_for_reader,
+                    DaemonPhase::SpawnFailed { reason, retry_in_ms: None },
                 );
                 return;
             }
             Err(_) => {
+                let reason = "handshake timeout (1.5s)".to_string();
                 let _ = app_for_reader.emit(
                     "daemon-error",
-                    DaemonErrorEvent { reason: "handshake timeout (1.5s)".into() },
+                    DaemonErrorEvent { reason: reason.clone() },
+                );
+                store.set_and_emit(
+                    &app_for_reader,
+                    DaemonPhase::SpawnFailed { reason, retry_in_ms: None },
                 );
                 return;
             }
@@ -254,18 +329,36 @@ pub async fn spawn_daemon_inner(app: AppHandle) -> Result<(), String> {
         match serde_json::from_str::<Handshake>(&first) {
             Ok(hs) if hs.ready => {
                 eprintln!("[daemon-mgr] handshake ok port={} token={}…", hs.port, &hs.token[..hs.token.len().min(6)]);
+                store.set_and_emit(
+                    &app_for_reader,
+                    DaemonPhase::Ready {
+                        port: hs.port,
+                        token: hs.token.clone(),
+                        identity: None, // S4-T8 will populate after auth.
+                    },
+                );
                 let _ = app_for_reader.emit("daemon-ready", hs);
             }
             Ok(hs) => {
+                let reason = format!("handshake ready=false: {hs:?}");
                 let _ = app_for_reader.emit(
                     "daemon-error",
-                    DaemonErrorEvent { reason: format!("handshake ready=false: {hs:?}") },
+                    DaemonErrorEvent { reason: reason.clone() },
+                );
+                store.set_and_emit(
+                    &app_for_reader,
+                    DaemonPhase::SpawnFailed { reason, retry_in_ms: None },
                 );
             }
             Err(e) => {
+                let reason = format!("handshake parse failed: {e}; line={first}");
                 let _ = app_for_reader.emit(
                     "daemon-error",
-                    DaemonErrorEvent { reason: format!("handshake parse failed: {e}; line={first}") },
+                    DaemonErrorEvent { reason: reason.clone() },
+                );
+                store.set_and_emit(
+                    &app_for_reader,
+                    DaemonPhase::SpawnFailed { reason, retry_in_ms: None },
                 );
             }
         }
@@ -280,6 +373,7 @@ pub async fn spawn_daemon_inner(app: AppHandle) -> Result<(), String> {
     // wait task — owns the Child, races child.wait() vs kill mpsc.
     let app_for_wait = app.clone();
     tokio::spawn(async move {
+        let store: State<DaemonStateStore> = app_for_wait.state();
         let exit = tokio::select! {
             res = child.wait() => match res {
                 Ok(status) => DaemonExitEvent { code: status.code(), reason: format!("exited: {status:?}") },
@@ -294,6 +388,10 @@ pub async fn spawn_daemon_inner(app: AppHandle) -> Result<(), String> {
             }
         };
         eprintln!("[daemon-mgr] daemon exited: {exit:?}");
+        store.set_and_emit(
+            &app_for_wait,
+            DaemonPhase::Exited { code: exit.code, reason: exit.reason.clone() },
+        );
         let _ = app_for_wait.emit("daemon-exit", exit);
     });
 

--- a/packages/frontend-tauri/src-tauri/src/daemon_state.rs
+++ b/packages/frontend-tauri/src-tauri/src/daemon_state.rs
@@ -1,0 +1,263 @@
+// T1 (Task #115): unified daemon-state event channel + DaemonPhase enum.
+//
+// Replaces the scattered legacy events (`daemon-ready` / `daemon-error` /
+// `daemon-exit` / `daemon-stderr`) with a single typed `daemon-state` channel
+// while keeping legacy events emitted for backwards compatibility (see
+// daemon_mgr.rs — every legacy emit is paired with a `state.set_and_emit(...)`).
+//
+// scope (T1 only): Rust-side enum + state store + wire to existing emit points
+// + stderr tunnel-state stub. T2 owns supervisor retry; T3/T4 own SPA listener +
+// fallback UI; S4-T8 owns AwaitingAuth / AuthFailed real implementation (here
+// they are placeholder variants — `unreachable!()` at construction sites in
+// daemon_mgr.rs because S4 hasn't landed).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+
+/// Coarse identity stub for the `Ready` phase. Intentionally minimal at T1 —
+/// S4 will replace with the real auth-derived identity once OAuth lands.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct Identity {
+    pub user_id: String,
+}
+
+/// Single source of truth for daemon lifecycle. Tagged enum so the SPA can
+/// pattern-match on `phase` after JSON deserialize.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(tag = "phase", rename_all = "camelCase")]
+pub enum DaemonPhase {
+    NotSpawned,
+    Spawning,
+    SpawnFailed {
+        reason: String,
+        retry_in_ms: Option<u64>,
+    },
+    Starting,
+    /// S4 placeholder — daemon-side OAuth flow not implemented yet. Kept in
+    /// the enum so the SPA contract is stable; constructors in daemon_mgr
+    /// must `unreachable!()` until S4-T8 lands.
+    AwaitingAuth {
+        verification_uri: String,
+        user_code: String,
+        expires_at: u64,
+    },
+    /// S4 placeholder — see AwaitingAuth note.
+    AuthFailed {
+        reason: String,
+    },
+    TunnelDisconnected {
+        port: u16,
+        token: String,
+    },
+    TunnelConnected {
+        port: u16,
+        token: String,
+    },
+    Ready {
+        port: u16,
+        token: String,
+        identity: Option<Identity>,
+    },
+    Exited {
+        code: Option<i32>,
+        reason: String,
+    },
+}
+
+impl Default for DaemonPhase {
+    fn default() -> Self {
+        DaemonPhase::NotSpawned
+    }
+}
+
+/// Wire envelope for the `daemon-state` event. Carries a monotonic generation
+/// so the SPA can drop stale events on reconnect.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct DaemonStateEvent {
+    pub generation: u64,
+    #[serde(flatten)]
+    pub phase: DaemonPhase,
+}
+
+/// Holds the current `DaemonPhase` behind a mutex + emits one
+/// `daemon-state` event per `set_and_emit` call. Generation is a monotonic
+/// counter incremented on every transition (regardless of equality), so the
+/// SPA can detect re-entry into the same logical phase.
+pub struct DaemonStateStore {
+    inner: Mutex<DaemonPhase>,
+    generation: AtomicU64,
+}
+
+impl Default for DaemonStateStore {
+    fn default() -> Self {
+        Self {
+            inner: Mutex::new(DaemonPhase::NotSpawned),
+            generation: AtomicU64::new(0),
+        }
+    }
+}
+
+impl DaemonStateStore {
+    /// Atomically replace the current phase, bump the generation, and emit a
+    /// single `daemon-state` event to the webview. Best-effort emit — errors
+    /// are swallowed (matches legacy `let _ = app.emit(...)` pattern in
+    /// daemon_mgr.rs; the daemon-mgr task lives longer than the webview at
+    /// shutdown).
+    pub fn set_and_emit(&self, app: &AppHandle, phase: DaemonPhase) {
+        {
+            let mut guard = self.inner.lock().expect("daemon state mutex poisoned");
+            *guard = phase.clone();
+        }
+        let generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        let event = DaemonStateEvent { generation, phase };
+        let _ = app.emit("daemon-state", event);
+    }
+
+    /// Test-only: snapshot of the current phase. Production code should
+    /// listen on the `daemon-state` event rather than poll.
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub fn snapshot(&self) -> DaemonPhase {
+        self.inner.lock().unwrap().clone()
+    }
+
+    #[cfg(test)]
+    pub fn current_generation(&self) -> u64 {
+        self.generation.load(Ordering::SeqCst)
+    }
+
+    /// Test-only: bump generation + replace phase WITHOUT emitting (we cannot
+    /// construct a real `AppHandle` in unit tests without a Tauri runtime).
+    /// Used by the unit tests below to verify generation/serialization
+    /// invariants in isolation. Production callers MUST use `set_and_emit`.
+    #[cfg(test)]
+    fn set_no_emit(&self, phase: DaemonPhase) -> u64 {
+        {
+            let mut guard = self.inner.lock().unwrap();
+            *guard = phase;
+        }
+        self.generation.fetch_add(1, Ordering::SeqCst) + 1
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn state_store_emits_one_event_per_set() {
+        // We can't spin a real AppHandle in a unit test without a Tauri
+        // runtime, so we exercise the state-mutation half of `set_and_emit`
+        // (set_no_emit) and assert generation bumps exactly once per call —
+        // which is the contract `set_and_emit` makes ("one event per set").
+        let store = DaemonStateStore::default();
+        assert_eq!(store.current_generation(), 0);
+
+        let g1 = store.set_no_emit(DaemonPhase::Spawning);
+        assert_eq!(g1, 1);
+        assert_eq!(store.current_generation(), 1);
+
+        let g2 = store.set_no_emit(DaemonPhase::Starting);
+        assert_eq!(g2, 2);
+        assert_eq!(store.current_generation(), 2);
+
+        // Re-entering the same logical phase must still bump generation —
+        // the SPA needs to distinguish "still in Starting" from "Starting
+        // again after a transition out and back".
+        let g3 = store.set_no_emit(DaemonPhase::Starting);
+        assert_eq!(g3, 3);
+    }
+
+    #[test]
+    fn state_store_phase_serializable() {
+        // Every variant must round-trip through serde JSON so the SPA
+        // contract is stable. Cover all variants explicitly so adding a new
+        // one without updating the SPA breaks this test.
+        let cases = vec![
+            DaemonPhase::NotSpawned,
+            DaemonPhase::Spawning,
+            DaemonPhase::SpawnFailed {
+                reason: "boom".into(),
+                retry_in_ms: Some(1000),
+            },
+            DaemonPhase::SpawnFailed {
+                reason: "boom".into(),
+                retry_in_ms: None,
+            },
+            DaemonPhase::Starting,
+            DaemonPhase::AwaitingAuth {
+                verification_uri: "https://example/dev".into(),
+                user_code: "ABCD-1234".into(),
+                expires_at: 9_999,
+            },
+            DaemonPhase::AuthFailed {
+                reason: "denied".into(),
+            },
+            DaemonPhase::TunnelDisconnected {
+                port: 9876,
+                token: "tok".into(),
+            },
+            DaemonPhase::TunnelConnected {
+                port: 9876,
+                token: "tok".into(),
+            },
+            DaemonPhase::Ready {
+                port: 9876,
+                token: "tok".into(),
+                identity: Some(Identity {
+                    user_id: "u1".into(),
+                }),
+            },
+            DaemonPhase::Ready {
+                port: 9876,
+                token: "tok".into(),
+                identity: None,
+            },
+            DaemonPhase::Exited {
+                code: Some(0),
+                reason: "clean".into(),
+            },
+            DaemonPhase::Exited {
+                code: None,
+                reason: "killed".into(),
+            },
+        ];
+
+        for phase in cases {
+            let env = DaemonStateEvent {
+                generation: 42,
+                phase: phase.clone(),
+            };
+            let json = serde_json::to_string(&env).expect("serialize");
+            // tag must be present (camelCase per #[serde(rename_all)])
+            assert!(json.contains("\"phase\":"), "missing phase tag: {json}");
+            // generation must round-trip
+            let back: DaemonStateEvent = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(back.generation, 42);
+            // phase variant must round-trip via discriminator
+            let back_json = serde_json::to_string(&back.phase).unwrap();
+            let orig_json = serde_json::to_string(&phase).unwrap();
+            assert_eq!(back_json, orig_json);
+        }
+    }
+
+    #[test]
+    fn state_store_generation_monotonic() {
+        let store = DaemonStateStore::default();
+        let mut last = 0u64;
+        for i in 0..50 {
+            let phase = if i % 2 == 0 {
+                DaemonPhase::Spawning
+            } else {
+                DaemonPhase::Starting
+            };
+            let g = store.set_no_emit(phase);
+            assert!(g > last, "generation must be strictly monotonic: {g} > {last}");
+            last = g;
+        }
+        assert_eq!(store.current_generation(), 50);
+    }
+}

--- a/packages/frontend-tauri/src-tauri/src/lib.rs
+++ b/packages/frontend-tauri/src-tauri/src/lib.rs
@@ -7,9 +7,11 @@
 //     is the soft baseline; see job_object.rs).
 
 mod daemon_mgr;
+mod daemon_state;
 mod job_object;
 
 use daemon_mgr::{spawn_daemon_inner, start_daemon, DaemonState};
+use daemon_state::DaemonStateStore;
 use job_object::JobObject;
 use tauri::Manager;
 
@@ -18,6 +20,7 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
         .manage(DaemonState::default())
+        .manage(DaemonStateStore::default())
         .setup(|app| {
             // Create the Job once at app startup. Held in State so daemon_mgr
             // can call .assign(pid) after spawn. Dropped on app exit, which


### PR DESCRIPTION
## Summary
Phase 3 startup-sequence T1 (Rust state machine half). Adds `DaemonStateStore` + `DaemonPhase` tagged enum behind a single `daemon-state` Tauri event channel, while preserving every legacy event (`daemon-ready` / `daemon-error` / `daemon-exit` / `daemon-stderr`) for backwards compat. T3/T4 will migrate the SPA over to the new channel without a flag day.

Wired into `daemon_mgr::spawn_daemon_inner`:
- `Spawning` before resolve_daemon_script
- `SpawnFailed{reason, retry_in_ms: None}` on each error path (script resolve / token / spawn / stdout closed / read err / handshake timeout / parse fail / ready=false)
- `Starting` after process spawn
- `Ready{port, token, identity: None}` on successful handshake (identity reserved for S4-T8)
- `Exited{code, reason}` from the wait task
- stderr forwarder sniffs `[ccsm] tunnel: connected` / `disconnected` literals (simple `contains`, T2 owns the real protocol) and emits `TunnelConnected` / `TunnelDisconnected`

`AwaitingAuth` / `AuthFailed` are present as variants to keep the SPA contract stable, but are not constructed in T1 — S4-T8 owns the daemon OAuth flow.

## Out of scope (per spec)
- Supervisor retry loop (T2)
- SPA listener migration + fallback UI (T3 / T4)
- Real auth flow populating AwaitingAuth/AuthFailed (S4-T8)
- `packages/daemon/` source (this task is purely the Tauri shell side)

## Local checks (host: Windows 11, mode: fast)
- lint: skipped (no .ts/.tsx changes; pure Rust)
- typecheck: skipped (no .ts/.tsx changes)
- build: \`cargo build\` exit 0 — Finished \`dev\` profile in 2m 21s
- unit tests: \`cargo test\` exit 0
  \`\`\`
  test daemon_state::tests::state_store_emits_one_event_per_set ... ok
  test daemon_state::tests::state_store_generation_monotonic ... ok
  test daemon_state::tests::state_store_phase_serializable ... ok
  test daemon_mgr::tests::load_or_create_generates_and_persists ... ok
  test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
  \`\`\`
- e2e: skipped (no SPA / probe changes — daemon-state listener wiring is T3/T4)

## Legacy events preserved (grep evidence)
\`\`\`
\$ grep -n 'emit\(\"daemon-' packages/frontend-tauri/src-tauri/src/daemon_mgr.rs | head
181: let _ = app.emit(\"daemon-error\", DaemonErrorEvent { reason: reason.clone() });
277: let _ = app_for_stderr.emit(\"daemon-stderr\", line);
340: let _ = app_for_reader.emit(\"daemon-ready\", hs);
369: let _ = app_for_reader.emit(\"daemon-stdout\", line);
395: let _ = app_for_wait.emit(\"daemon-exit\", exit);
\`\`\`
Plus 4 additional \`daemon-error\` emits in the stdout reader (timeout / read err / closed / parse err) — see \`grep -n 'daemon-error' src/daemon_mgr.rs\`.

## Test plan
- [x] cargo build green
- [x] cargo test 4/4 green (3 new + 1 pre-existing)
- [x] all legacy events still emitted at original sites
- [x] every emit point gets a paired \`store.set_and_emit(...)\`

Refs Task #115 [#112-T1].