### PR TITLE
feat(cf-worker): S4-T2 — JWT helpers + UserDO skeleton (Task #121)

### DIFF
--- a/packages/cf-worker/src/auth/bindings.ts
+++ b/packages/cf-worker/src/auth/bindings.ts
@@ -1,0 +1,25 @@
+/**
+ * S4-T2 (Task #121): augmented Env for the auth subsystem.
+ *
+ * Extends the base `Env` (TUNNEL DO binding, defined in `../index.ts`) with
+ * the GitHub App credentials, JWT signing keys, and the UserDO namespace
+ * binding. Set in production via `wrangler secret put` (see wrangler.toml +
+ * docs/S4-SETUP.md). Local dev: copy `.dev.vars.example` → `.dev.vars`.
+ *
+ * Routes / handlers introduced in T3 (OAuth callback) and T5 (JWT middleware)
+ * will type-narrow against `AuthEnv` so the bindings flow through naturally.
+ */
+import type { Env } from '../index';
+
+export interface AuthEnv extends Env {
+  /** GitHub OAuth App client id (public-ish, but stored as secret for parity). */
+  GITHUB_APP_CLIENT_ID: string;
+  /** GitHub OAuth App client secret. wrangler secret. */
+  GITHUB_APP_CLIENT_SECRET: string;
+  /** HS256 hex key for short-lived browser session JWTs (kind='web'). */
+  JWT_SIGNING_KEY: string;
+  /** HS256 hex key for refresh tokens / per-tunnel JWTs (kind='tunnel'). */
+  JWT_REFRESH_SIGNING_KEY: string;
+  /** Per-user Durable Object namespace (UserDO). idFromName(login). */
+  USER_DO: DurableObjectNamespace;
+}

--- a/packages/cf-worker/src/auth/jwt.ts
+++ b/packages/cf-worker/src/auth/jwt.ts
@@ -1,0 +1,167 @@
+/**
+ * S4-T2 (Task #121): HS256 JWT helpers for the cf-worker auth subsystem.
+ *
+ * Implemented with the SubtleCrypto WebCrypto API (no new npm dep). HS256
+ * matches the GitHub OAuth + per-tunnel JWT design locked in S4 D1-D5.
+ *
+ * Two claim shapes:
+ *   - WebJwtClaims  — short-lived browser session token (kind: 'web')
+ *   - TunnelJwtClaims — per-tunnel daemon-presented token (kind: 'tunnel')
+ *
+ * Keys are passed in as hex strings (matching `wrangler secret` / `.dev.vars`
+ * style); we decode to raw bytes inside `importHmacKey`. Sign + verify both
+ * round-trip through base64url (RFC 7515 §2). `verifyJwt` is exp-aware (token
+ * is rejected if `now >= exp`); a small clock-skew window can be added later
+ * when devices re-enter the system.
+ *
+ * NOT exported / NOT used here: refresh-token rotation, JWK, RS256, kid
+ * routing — T3/T4 task scope. This file is pure primitives.
+ */
+
+/** Browser session JWT (Task #121, kind='web'). exp/iat in epoch seconds. */
+export interface WebJwtClaims {
+  sub: string;
+  login: string;
+  exp: number;
+  iat: number;
+  kind: 'web';
+}
+
+/** Per-tunnel JWT (Task #121, kind='tunnel'). `jti` is the tunnel id. */
+export interface TunnelJwtClaims {
+  sub: string;
+  login: string;
+  exp: number;
+  iat: number;
+  kind: 'tunnel';
+  jti: string;
+}
+
+/** Any well-formed JWT claim shape with required `exp`. */
+type JwtClaims = WebJwtClaims | TunnelJwtClaims;
+
+const HS256_HEADER = { alg: 'HS256', typ: 'JWT' } as const;
+
+function base64urlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(
+      null,
+      Array.from(bytes.subarray(i, i + CHUNK)),
+    );
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function base64urlDecode(s: string): Uint8Array {
+  const pad = s.length % 4 === 0 ? '' : '='.repeat(4 - (s.length % 4));
+  const b64 = s.replace(/-/g, '+').replace(/_/g, '/') + pad;
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex;
+  if (clean.length % 2 !== 0) {
+    throw new Error('jwt: hex key has odd length');
+  }
+  const out = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    const byte = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+    if (Number.isNaN(byte)) {
+      throw new Error('jwt: invalid hex char in key');
+    }
+    out[i] = byte;
+  }
+  return out;
+}
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+async function importHmacKey(hexKey: string, usage: KeyUsage): Promise<CryptoKey> {
+  const raw = hexToBytes(hexKey);
+  return crypto.subtle.importKey(
+    'raw',
+    raw as unknown as BufferSource,
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    [usage],
+  );
+}
+
+/**
+ * Sign a claim set as an HS256 JWT. `claims.exp` / `claims.iat` are NOT auto-
+ * filled — caller passes the full claim object. Returns `header.payload.sig`.
+ */
+export async function signJwt<T extends JwtClaims>(
+  claims: T,
+  hexKey: string,
+): Promise<string> {
+  const key = await importHmacKey(hexKey, 'sign');
+  const headerB64 = base64urlEncode(enc.encode(JSON.stringify(HS256_HEADER)));
+  const payloadB64 = base64urlEncode(enc.encode(JSON.stringify(claims)));
+  const signingInput = headerB64 + '.' + payloadB64;
+  const sig = await crypto.subtle.sign('HMAC', key, enc.encode(signingInput));
+  const sigB64 = base64urlEncode(new Uint8Array(sig));
+  return signingInput + '.' + sigB64;
+}
+
+/**
+ * Verify an HS256 JWT and return the decoded claims, or `null` if anything
+ * fails (bad shape, bad signature, expired). The caller is responsible for
+ * narrowing the resulting type via `kind` discriminant — verifyJwt does NOT
+ * inspect `kind`, only `exp`.
+ */
+export async function verifyJwt<T extends JwtClaims>(
+  token: string,
+  hexKey: string,
+): Promise<T | null> {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  const [headerB64, payloadB64, sigB64] = parts as [string, string, string];
+  if (headerB64.length === 0 || payloadB64.length === 0 || sigB64.length === 0) {
+    return null;
+  }
+
+  let key: CryptoKey;
+  try {
+    key = await importHmacKey(hexKey, 'verify');
+  } catch {
+    return null;
+  }
+
+  let sigBytes: Uint8Array;
+  try {
+    sigBytes = base64urlDecode(sigB64);
+  } catch {
+    return null;
+  }
+
+  const signingInput = enc.encode(headerB64 + '.' + payloadB64);
+  let ok: boolean;
+  try {
+    ok = await crypto.subtle.verify('HMAC', key, sigBytes as unknown as BufferSource, signingInput);
+  } catch {
+    return null;
+  }
+  if (!ok) return null;
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(dec.decode(base64urlDecode(payloadB64)));
+  } catch {
+    return null;
+  }
+  if (payload === null || typeof payload !== 'object') return null;
+  const claims = payload as Record<string, unknown>;
+  if (typeof claims.exp !== 'number' || !Number.isFinite(claims.exp)) return null;
+
+  const nowSec = Math.floor(Date.now() / 1000);
+  if (nowSec >= claims.exp) return null;
+
+  return claims as unknown as T;
+}

--- a/packages/cf-worker/src/auth/userDO.ts
+++ b/packages/cf-worker/src/auth/userDO.ts
@@ -1,0 +1,142 @@
+/**
+ * S4-T2 (Task #121): UserDO skeleton.
+ *
+ * Per-user Durable Object that owns auth state for one GitHub login:
+ *   - github_id / login (set at OAuth callback time, T3)
+ *   - refresh_token_hash (rotation, T3/T4)
+ *   - created_at
+ *
+ * T2 scope: KV-like RPC over HTTP (`fetch` handler routes by path). No ws
+ * routing, no hibernation API — those land in T5 when the auth middleware
+ * starts attaching JWT-validated browsers to per-user UserDO instances.
+ *
+ * Wire format (internal, called only by other Worker code):
+ *   GET  /getLogin                       → 200 JSON | 404
+ *   POST /setLogin       { github_id, login }   → 204
+ *   POST /setRefreshTokenHash { hash }   → 204
+ *   POST /verifyRefreshTokenHash { hash } → 200 { ok: bool }
+ *   POST /revoke                         → 204
+ *
+ * Storage keys are flat strings under `state.storage`. We do NOT use the SQL
+ * surface yet (TunnelDO doesn't either) — KV is enough for these primitives.
+ */
+import { DurableObject } from 'cloudflare:workers';
+import type { AuthEnv } from './bindings';
+
+const KEY_GITHUB_ID = 'github_id';
+const KEY_LOGIN = 'login';
+const KEY_REFRESH_HASH = 'refresh_token_hash';
+const KEY_CREATED_AT = 'created_at';
+
+export interface UserLoginRecord {
+  github_id: string;
+  login: string;
+  created_at: number;
+}
+
+export class UserDO extends DurableObject<AuthEnv> {
+  constructor(state: DurableObjectState, env: AuthEnv) {
+    super(state, env);
+  }
+
+  private get storage(): DurableObjectStorage {
+    return this.ctx.storage;
+  }
+
+  /** Persist github_id + login. Sets created_at on first call only. */
+  async setLogin(github_id: string, login: string): Promise<void> {
+    await this.storage.put(KEY_GITHUB_ID, github_id);
+    await this.storage.put(KEY_LOGIN, login);
+    const existing = await this.storage.get<number>(KEY_CREATED_AT);
+    if (existing === undefined) {
+      await this.storage.put(KEY_CREATED_AT, Math.floor(Date.now() / 1000));
+    }
+  }
+
+  /** Read the persisted login record, or null if setLogin was never called. */
+  async getLogin(): Promise<UserLoginRecord | null> {
+    const github_id = await this.storage.get<string>(KEY_GITHUB_ID);
+    const login = await this.storage.get<string>(KEY_LOGIN);
+    const created_at = await this.storage.get<number>(KEY_CREATED_AT);
+    if (
+      github_id === undefined ||
+      login === undefined ||
+      created_at === undefined
+    ) {
+      return null;
+    }
+    return { github_id, login, created_at };
+  }
+
+  /** Store a refresh-token hash (caller responsible for hashing). */
+  async setRefreshTokenHash(hash: string): Promise<void> {
+    await this.storage.put(KEY_REFRESH_HASH, hash);
+  }
+
+  /** Constant-time-ish compare against the stored hash. */
+  async verifyRefreshTokenHash(hash: string): Promise<boolean> {
+    const stored = await this.storage.get<string>(KEY_REFRESH_HASH);
+    if (stored === undefined) return false;
+    if (stored.length !== hash.length) return false;
+    let mismatch = 0;
+    for (let i = 0; i < stored.length; i++) {
+      mismatch |= stored.charCodeAt(i) ^ hash.charCodeAt(i);
+    }
+    return mismatch === 0;
+  }
+
+  /** Wipe all stored state for this user (logout / token rotation reset). */
+  async revoke(): Promise<void> {
+    await this.storage.deleteAll();
+  }
+
+  /**
+   * Internal RPC fetch handler. Other Worker code calls
+   * `env.USER_DO.get(id).fetch(new Request('https://do/<method>', ...))`.
+   *
+   * Not exposed externally — index.ts routes only public paths into this DO,
+   * and there are none yet (T5 adds them).
+   */
+  override async fetch(req: Request): Promise<Response> {
+    const url = new URL(req.url);
+    const path = url.pathname;
+    try {
+      if (req.method === 'GET' && path === '/getLogin') {
+        const rec = await this.getLogin();
+        if (rec === null) return new Response('not found', { status: 404 });
+        return Response.json(rec);
+      }
+      if (req.method === 'POST' && path === '/setLogin') {
+        const body = await req.json<{ github_id?: unknown; login?: unknown }>();
+        if (typeof body.github_id !== 'string' || typeof body.login !== 'string') {
+          return new Response('bad request', { status: 400 });
+        }
+        await this.setLogin(body.github_id, body.login);
+        return new Response(null, { status: 204 });
+      }
+      if (req.method === 'POST' && path === '/setRefreshTokenHash') {
+        const body = await req.json<{ hash?: unknown }>();
+        if (typeof body.hash !== 'string') {
+          return new Response('bad request', { status: 400 });
+        }
+        await this.setRefreshTokenHash(body.hash);
+        return new Response(null, { status: 204 });
+      }
+      if (req.method === 'POST' && path === '/verifyRefreshTokenHash') {
+        const body = await req.json<{ hash?: unknown }>();
+        if (typeof body.hash !== 'string') {
+          return new Response('bad request', { status: 400 });
+        }
+        const ok = await this.verifyRefreshTokenHash(body.hash);
+        return Response.json({ ok });
+      }
+      if (req.method === 'POST' && path === '/revoke') {
+        await this.revoke();
+        return new Response(null, { status: 204 });
+      }
+      return new Response('not found', { status: 404 });
+    } catch (err) {
+      return new Response('internal error: ' + String(err), { status: 500 });
+    }
+  }
+}

--- a/packages/cf-worker/src/index.ts
+++ b/packages/cf-worker/src/index.ts
@@ -3,6 +3,10 @@ export interface Env {
 }
 
 export { TunnelDO } from './tunnel-do';
+// S4-T2 (Task #121): UserDO is bound in wrangler.toml so it must be re-exported
+// from the worker entrypoint for the runtime to resolve the class. Routes that
+// dispatch into UserDO are introduced in T5 — this is a binding-only export.
+export { UserDO } from './auth/userDO';
 
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {

--- a/packages/cf-worker/test/jwt.test.ts
+++ b/packages/cf-worker/test/jwt.test.ts
@@ -1,0 +1,173 @@
+/**
+ * S4-T2 (Task #121): JWT helper unit tests.
+ *
+ * Runs under vitest's default node environment — Node 22 ships globalThis.crypto
+ * with SubtleCrypto, the same surface workerd exposes, so the helpers exercise
+ * the real WebCrypto path (no shim).
+ *
+ * Placeholder hex key matches `.dev.vars.example` (32 bytes = 64 hex chars).
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  signJwt,
+  verifyJwt,
+  type WebJwtClaims,
+  type TunnelJwtClaims,
+} from '../src/auth/jwt';
+
+const KEY_A =
+  '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff';
+const KEY_B =
+  'ffeeddccbbaa99887766554433221100ffeeddccbbaa99887766554433221100';
+
+function nowSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+describe('jwt', () => {
+  it('roundtrip: signed web claims verify back to identical payload', async () => {
+    const claims: WebJwtClaims = {
+      sub: 'gh:12345',
+      login: 'octocat',
+      iat: nowSec(),
+      exp: nowSec() + 60,
+      kind: 'web',
+    };
+    const token = await signJwt(claims, KEY_A);
+    expect(token.split('.')).toHaveLength(3);
+    const verified = await verifyJwt<WebJwtClaims>(token, KEY_A);
+    expect(verified).not.toBeNull();
+    expect(verified).toEqual(claims);
+  });
+
+  it('roundtrip: tunnel claims with jti round-trip identically', async () => {
+    const claims: TunnelJwtClaims = {
+      sub: 'gh:12345',
+      login: 'octocat',
+      iat: nowSec(),
+      exp: nowSec() + 3600,
+      kind: 'tunnel',
+      jti: 'tunnel-uuid-abc',
+    };
+    const token = await signJwt(claims, KEY_A);
+    const verified = await verifyJwt<TunnelJwtClaims>(token, KEY_A);
+    expect(verified).toEqual(claims);
+  });
+
+  it('expired token (exp <= now) returns null', async () => {
+    const claims: WebJwtClaims = {
+      sub: 'u',
+      login: 'l',
+      iat: nowSec() - 120,
+      exp: nowSec() - 1,
+      kind: 'web',
+    };
+    const token = await signJwt(claims, KEY_A);
+    const verified = await verifyJwt<WebJwtClaims>(token, KEY_A);
+    expect(verified).toBeNull();
+  });
+
+  it('exp exactly equal to now is rejected (>= exp policy)', async () => {
+    const exp = nowSec();
+    const claims: WebJwtClaims = {
+      sub: 'u',
+      login: 'l',
+      iat: exp - 60,
+      exp,
+      kind: 'web',
+    };
+    const token = await signJwt(claims, KEY_A);
+    const verified = await verifyJwt<WebJwtClaims>(token, KEY_A);
+    expect(verified).toBeNull();
+  });
+
+  it('tampered signature is rejected', async () => {
+    const claims: WebJwtClaims = {
+      sub: 'u',
+      login: 'l',
+      iat: nowSec(),
+      exp: nowSec() + 60,
+      kind: 'web',
+    };
+    const token = await signJwt(claims, KEY_A);
+    const parts = token.split('.');
+    // Flip a single base64url char in the signature.
+    const sig = parts[2];
+    const flipped = (sig[0] === 'A' ? 'B' : 'A') + sig.slice(1);
+    const tampered = parts[0] + '.' + parts[1] + '.' + flipped;
+    expect(await verifyJwt(tampered, KEY_A)).toBeNull();
+  });
+
+  it('tampered payload (claim mutated) is rejected', async () => {
+    const claims: WebJwtClaims = {
+      sub: 'u',
+      login: 'alice',
+      iat: nowSec(),
+      exp: nowSec() + 60,
+      kind: 'web',
+    };
+    const token = await signJwt(claims, KEY_A);
+    const parts = token.split('.');
+    // Substitute a different payload (re-base64url-encoded) but keep the
+    // original signature → must fail verify.
+    const evil = btoa(JSON.stringify({ ...claims, login: 'mallory' }))
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=+$/, '');
+    const tampered = parts[0] + '.' + evil + '.' + parts[2];
+    expect(await verifyJwt(tampered, KEY_A)).toBeNull();
+  });
+
+  it('verify with the wrong key returns null', async () => {
+    const claims: WebJwtClaims = {
+      sub: 'u',
+      login: 'l',
+      iat: nowSec(),
+      exp: nowSec() + 60,
+      kind: 'web',
+    };
+    const token = await signJwt(claims, KEY_A);
+    expect(await verifyJwt(token, KEY_B)).toBeNull();
+  });
+
+  it('malformed token (not 3 parts) returns null', async () => {
+    expect(await verifyJwt('not.a.valid.jwt', KEY_A)).toBeNull();
+    expect(await verifyJwt('twoparts.only', KEY_A)).toBeNull();
+    expect(await verifyJwt('', KEY_A)).toBeNull();
+  });
+
+  it('invalid hex key returns null (does not throw)', async () => {
+    const claims: WebJwtClaims = {
+      sub: 'u',
+      login: 'l',
+      iat: nowSec(),
+      exp: nowSec() + 60,
+      kind: 'web',
+    };
+    const token = await signJwt(claims, KEY_A);
+    expect(await verifyJwt(token, 'not-hex-zz')).toBeNull();
+  });
+
+  it('payload missing exp is rejected', async () => {
+    // Manually construct a token with no exp claim, signed with KEY_A.
+    const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const payload = btoa(JSON.stringify({ sub: 'u' }))
+      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const signingInput = header + '.' + payload;
+    const keyBytes = new Uint8Array(KEY_A.length / 2);
+    for (let i = 0; i < keyBytes.length; i++) {
+      keyBytes[i] = parseInt(KEY_A.slice(i * 2, i * 2 + 2), 16);
+    }
+    const key = await crypto.subtle.importKey(
+      'raw', keyBytes, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign'],
+    );
+    const sig = await crypto.subtle.sign(
+      'HMAC', key, new TextEncoder().encode(signingInput),
+    );
+    const sigB64 = btoa(String.fromCharCode(...new Uint8Array(sig)))
+      .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    const token = signingInput + '.' + sigB64;
+    expect(await verifyJwt(token, KEY_A)).toBeNull();
+  });
+});

--- a/packages/cf-worker/test/userDO.test.ts
+++ b/packages/cf-worker/test/userDO.test.ts
@@ -1,0 +1,193 @@
+/**
+ * S4-T2 (Task #121): UserDO storage + RPC unit tests.
+ *
+ * Mirrors the TunnelDO test strategy — fake the DurableObjectState surface
+ * (here: just `storage` with get/put/deleteAll) and drive the DO directly.
+ * Uses the same `cloudflare:workers` stub as TunnelDO via vitest alias.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+interface FakeStorage {
+  data: Map<string, unknown>;
+  get<T>(key: string): Promise<T | undefined>;
+  put(key: string, value: unknown): Promise<void>;
+  deleteAll(): Promise<void>;
+}
+
+function makeStorage(): FakeStorage {
+  const data = new Map<string, unknown>();
+  return {
+    data,
+    async get<T>(key: string): Promise<T | undefined> {
+      return data.has(key) ? (data.get(key) as T) : undefined;
+    },
+    async put(key: string, value: unknown): Promise<void> {
+      data.set(key, value);
+    },
+    async deleteAll(): Promise<void> {
+      data.clear();
+    },
+  };
+}
+
+function makeState(storage: FakeStorage): DurableObjectState {
+  return { storage } as unknown as DurableObjectState;
+}
+
+const fakeEnv = {} as unknown as import('../src/auth/bindings').AuthEnv;
+
+async function loadDO() {
+  const mod = await import('../src/auth/userDO');
+  return mod.UserDO;
+}
+
+beforeEach(() => {
+  // No globals to install — UserDO uses only `Date.now`, `URL`, `Response`.
+});
+
+afterEach(() => {
+  /* nothing to restore */
+});
+
+describe('UserDO', () => {
+  it('setLogin then getLogin returns the persisted record', async () => {
+    const UserDO = await loadDO();
+    const storage = makeStorage();
+    const inst = new UserDO(makeState(storage), fakeEnv);
+
+    expect(await inst.getLogin()).toBeNull();
+
+    await inst.setLogin('12345', 'octocat');
+    const rec = await inst.getLogin();
+    expect(rec).not.toBeNull();
+    expect(rec?.github_id).toBe('12345');
+    expect(rec?.login).toBe('octocat');
+    expect(typeof rec?.created_at).toBe('number');
+    expect(rec!.created_at).toBeGreaterThan(0);
+  });
+
+  it('setLogin called twice keeps the original created_at', async () => {
+    const UserDO = await loadDO();
+    const storage = makeStorage();
+    const inst = new UserDO(makeState(storage), fakeEnv);
+
+    await inst.setLogin('12345', 'octocat');
+    const rec1 = await inst.getLogin();
+    // Force a clock-tick so a second created_at would visibly differ.
+    await new Promise((r) => setTimeout(r, 1100));
+    await inst.setLogin('12345', 'octocat-renamed');
+    const rec2 = await inst.getLogin();
+    expect(rec2?.created_at).toBe(rec1?.created_at);
+    expect(rec2?.login).toBe('octocat-renamed');
+  });
+
+  it('verifyRefreshTokenHash matches positive sample', async () => {
+    const UserDO = await loadDO();
+    const inst = new UserDO(makeState(makeStorage()), fakeEnv);
+    await inst.setRefreshTokenHash('hash-abc-123');
+    expect(await inst.verifyRefreshTokenHash('hash-abc-123')).toBe(true);
+  });
+
+  it('verifyRefreshTokenHash rejects negative samples', async () => {
+    const UserDO = await loadDO();
+    const inst = new UserDO(makeState(makeStorage()), fakeEnv);
+    // No hash stored yet → false.
+    expect(await inst.verifyRefreshTokenHash('hash-abc-123')).toBe(false);
+
+    await inst.setRefreshTokenHash('hash-abc-123');
+    expect(await inst.verifyRefreshTokenHash('hash-abc-124')).toBe(false);
+    expect(await inst.verifyRefreshTokenHash('hash-abc-12')).toBe(false); // length differs
+    expect(await inst.verifyRefreshTokenHash('')).toBe(false);
+  });
+
+  it('revoke wipes login + refresh hash', async () => {
+    const UserDO = await loadDO();
+    const inst = new UserDO(makeState(makeStorage()), fakeEnv);
+    await inst.setLogin('1', 'a');
+    await inst.setRefreshTokenHash('h');
+    await inst.revoke();
+    expect(await inst.getLogin()).toBeNull();
+    expect(await inst.verifyRefreshTokenHash('h')).toBe(false);
+  });
+
+  it('fetch /getLogin returns 404 before setLogin, 200 JSON after', async () => {
+    const UserDO = await loadDO();
+    const inst = new UserDO(makeState(makeStorage()), fakeEnv);
+
+    const r1 = await inst.fetch(new Request('https://do/getLogin'));
+    expect(r1.status).toBe(404);
+
+    await inst.setLogin('42', 'alice');
+    const r2 = await inst.fetch(new Request('https://do/getLogin'));
+    expect(r2.status).toBe(200);
+    const json = (await r2.json()) as { github_id: string; login: string };
+    expect(json.github_id).toBe('42');
+    expect(json.login).toBe('alice');
+  });
+
+  it('fetch POST /setLogin persists, then GET /getLogin returns it', async () => {
+    const UserDO = await loadDO();
+    const inst = new UserDO(makeState(makeStorage()), fakeEnv);
+    const r1 = await inst.fetch(
+      new Request('https://do/setLogin', {
+        method: 'POST',
+        body: JSON.stringify({ github_id: '7', login: 'bob' }),
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    expect(r1.status).toBe(204);
+    const r2 = await inst.fetch(new Request('https://do/getLogin'));
+    expect(r2.status).toBe(200);
+    expect((await r2.json() as { login: string }).login).toBe('bob');
+  });
+
+  it('fetch /setLogin rejects malformed body with 400', async () => {
+    const UserDO = await loadDO();
+    const inst = new UserDO(makeState(makeStorage()), fakeEnv);
+    const r = await inst.fetch(
+      new Request('https://do/setLogin', {
+        method: 'POST',
+        body: JSON.stringify({ login: 'no-id' }),
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    expect(r.status).toBe(400);
+  });
+
+  it('fetch /verifyRefreshTokenHash returns { ok } JSON', async () => {
+    const UserDO = await loadDO();
+    const inst = new UserDO(makeState(makeStorage()), fakeEnv);
+    await inst.fetch(new Request('https://do/setRefreshTokenHash', {
+      method: 'POST',
+      body: JSON.stringify({ hash: 'h-1' }),
+    }));
+    const okRes = await inst.fetch(new Request('https://do/verifyRefreshTokenHash', {
+      method: 'POST',
+      body: JSON.stringify({ hash: 'h-1' }),
+    }));
+    expect(okRes.status).toBe(200);
+    expect(await okRes.json()).toEqual({ ok: true });
+
+    const bad = await inst.fetch(new Request('https://do/verifyRefreshTokenHash', {
+      method: 'POST',
+      body: JSON.stringify({ hash: 'h-2' }),
+    }));
+    expect(await bad.json()).toEqual({ ok: false });
+  });
+
+  it('fetch /revoke clears state', async () => {
+    const UserDO = await loadDO();
+    const inst = new UserDO(makeState(makeStorage()), fakeEnv);
+    await inst.setLogin('1', 'a');
+    const r = await inst.fetch(new Request('https://do/revoke', { method: 'POST' }));
+    expect(r.status).toBe(204);
+    expect(await inst.getLogin()).toBeNull();
+  });
+
+  it('fetch unknown path returns 404', async () => {
+    const UserDO = await loadDO();
+    const inst = new UserDO(makeState(makeStorage()), fakeEnv);
+    const r = await inst.fetch(new Request('https://do/nope'));
+    expect(r.status).toBe(404);
+  });
+});

--- a/packages/cf-worker/wrangler.toml
+++ b/packages/cf-worker/wrangler.toml
@@ -18,6 +18,16 @@ compatibility_date = "2026-01-01"
 name = "TUNNEL"
 class_name = "TunnelDO"
 
+# S4-T2 (Task #121): per-user auth Durable Object. T2 only adds the binding +
+# class skeleton; routes that dispatch into UserDO arrive in T5.
+[[durable_objects.bindings]]
+name = "USER_DO"
+class_name = "UserDO"
+
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["TunnelDO"]
+
+[[migrations]]
+tag = "v2"
+new_sqlite_classes = ["UserDO"]


### PR DESCRIPTION
## Summary

S4-T2 cf-worker auth primitives — **no routes, just building blocks** for T3/T4/T5 to compose.

- `src/auth/jwt.ts` — HS256 sign/verify via SubtleCrypto (no new npm dep). Two claim shapes (`WebJwtClaims`, `TunnelJwtClaims`) discriminated by `kind`. `verifyJwt` returns `null` on bad shape / bad sig / wrong key / expired / missing exp.
- `src/auth/userDO.ts` — per-user Durable Object skeleton: KV-style storage for `github_id` / `login` / `refresh_token_hash` / `created_at`, plus an internal RPC `fetch` handler (`/getLogin`, `/setLogin`, `/setRefreshTokenHash`, `/verifyRefreshTokenHash`, `/revoke`). No ws / hibernation yet — that's T5.
- `src/auth/bindings.ts` — `AuthEnv extends Env` with `GITHUB_APP_CLIENT_ID/SECRET`, `JWT_SIGNING_KEY`, `JWT_REFRESH_SIGNING_KEY`, `USER_DO`.
- `src/index.ts` — re-export `UserDO` for the wrangler binding (mirrors `TunnelDO`).
- `wrangler.toml` — adds `USER_DO` binding + migration `v2` (TunnelDO stays v1).

Tests: 21 new (10 jwt + 11 userDO). Existing 32 cf-worker tests untouched.

## Out of scope (per spec)
- OAuth callback (T3)
- Device flow (T4)
- JWT middleware + actual UserDO routing through index.ts (T5)
- TunnelDO unchanged
- No real GitHub OAuth, only placeholder hex keys in tests

## Local checks (host: Windows, mode: fast)
- lint: ✓ (exit 0)
- typecheck: ✓ (exit 0)
- build: n/a (cf-worker `build` === `tsc --noEmit`, same as typecheck)
- unit tests: `pnpm --filter @ccsm/cf-worker test` →

  ```
  Test Files  4 passed (4)
       Tests  53 passed (53)
    Duration  3.22s
  ```

  4 files = `health.test.ts` + `tunnel-do.test.ts` (32 pre-existing) + new `jwt.test.ts` (10) + new `userDO.test.ts` (11).
- e2e: skipped, change is cf-worker-only and does not affect any electron / Tauri / probe path.

## Test plan
- [x] HS256 roundtrip both claim shapes
- [x] expired + exp == now rejected
- [x] tampered signature + tampered payload rejected
- [x] wrong key + malformed token + invalid hex key + missing exp rejected
- [x] UserDO storage roundtrip; `setLogin` twice keeps original `created_at`
- [x] refresh-token hash positive + negative samples (length-mismatch, empty, none-set)
- [x] `revoke` wipes login + refresh hash
- [x] internal RPC: 200/204/400/404 for each method
- [x] existing TunnelDO + /health tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)