### PR TITLE
feat(frontend-tauri): T3 — non-blocking SPA bootstrap + DaemonStateProvider (Task #120)

### DIFF
--- a/packages/frontend-tauri/src/App.tsx
+++ b/packages/frontend-tauri/src/App.tsx
@@ -1,31 +1,82 @@
-// Tauri shell App — same composition as frontend-web (Wave-2 T6 / T10):
-// <RuntimeProvider hostConfig={...}> wraps useBootstrap + AppShell. The
-// hostConfig is built by main.tsx from the daemon handshake and passed in
-// as a prop, so that re-spawning the daemon (future) just re-mounts <App>
-// with a fresh config.
+// Tauri shell App — Task #112-T3 (non-blocking bootstrap):
+//   <App>
+//     = <DaemonStateProvider>
+//         <PhaseSwitch>
+//           Ready → <RuntimeProvider hostConfig={...}><AppContent/></...>
+//           else  → <DaemonStatusOverlay phase={phase} ... />
+//
+// hostConfig is no longer built in main.tsx and threaded as a prop; instead
+// PhaseSwitch builds it from the `Ready` payload of the daemon-state event
+// once it arrives. Re-spawning the daemon (future) re-enters Ready with a
+// fresh port/token and PhaseSwitch will re-mount RuntimeProvider with the
+// new config because hostConfig identity changes (a new object literal per
+// render of the Ready branch — RuntimeProvider's `useMemo` keys off the
+// fields, see runtime-context.tsx).
 
 import {
   AppShell,
+  DaemonStatusOverlay,
   MainPane,
   RuntimeProvider,
   Sidebar,
   useBootstrap,
   type HostConfig,
 } from '@ccsm/ui';
+import { DaemonStateProvider, useDaemonPhase } from './DaemonStateProvider';
+import type { DaemonPhase } from './types';
 
 function AppContent() {
   useBootstrap();
   return <AppShell sidebar={<Sidebar />} main={<MainPane />} />;
 }
 
-export interface AppProps {
-  hostConfig: HostConfig;
+function buildHostConfig(port: number, token: string): HostConfig {
+  return {
+    httpBase: `http://127.0.0.1:${port}`,
+    getToken: () => token,
+  };
 }
 
-export function App({ hostConfig }: AppProps) {
+function PhaseSwitch() {
+  const phase = useDaemonPhase();
+  switch (phase.phase) {
+    case 'ready': {
+      const hostConfig = buildHostConfig(phase.port, phase.token);
+      return (
+        <RuntimeProvider hostConfig={hostConfig}>
+          <AppContent />
+        </RuntimeProvider>
+      );
+    }
+    case 'notSpawned':
+    case 'spawning':
+    case 'starting':
+    case 'tunnelDisconnected':
+    case 'tunnelConnected':
+      return <DaemonStatusOverlay phase={phase} variant="info" />;
+    case 'spawnFailed':
+    case 'exited':
+    case 'authFailed':
+      return <DaemonStatusOverlay phase={phase} variant="error" />;
+    case 'awaitingAuth':
+      // S4-T8 owns the real awaiting-auth UI. Until then we render the same
+      // overlay with a distinct variant so the user has feedback.
+      return <DaemonStatusOverlay phase={phase} variant="auth" />;
+    default: {
+      // Exhaustiveness check: any new DaemonPhase variant added without a
+      // case here will fail to type-check.
+      const _exhaustive: never = phase;
+      throw new Error(
+        `unreachable daemon phase: ${(_exhaustive as DaemonPhase).phase}`,
+      );
+    }
+  }
+}
+
+export function App() {
   return (
-    <RuntimeProvider hostConfig={hostConfig}>
-      <AppContent />
-    </RuntimeProvider>
+    <DaemonStateProvider>
+      <PhaseSwitch />
+    </DaemonStateProvider>
   );
 }

--- a/packages/frontend-tauri/src/DaemonStateProvider.tsx
+++ b/packages/frontend-tauri/src/DaemonStateProvider.tsx
@@ -1,0 +1,74 @@
+// Task #112-T3: DaemonStateProvider — listens to the unified `daemon-state`
+// Tauri event channel (T1, daemon_state.rs) and exposes the latest payload
+// to descendants via React context.
+//
+// Bootstrap is non-blocking: `main.tsx` mounts React immediately with a
+// default `notSpawned` state; this provider attaches the listener inside a
+// useEffect so the first render does not block on Tauri IPC. Stale events
+// from previous bootstraps are filtered by the monotonic `generation`
+// counter — we never roll back generation.
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type PropsWithChildren,
+} from 'react';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import type { DaemonPhase, DaemonStatePayload } from './types';
+
+const INITIAL_STATE: DaemonStatePayload = {
+  generation: 0,
+  phase: 'notSpawned',
+};
+
+export const DaemonStateContext =
+  createContext<DaemonStatePayload>(INITIAL_STATE);
+
+export function DaemonStateProvider({ children }: PropsWithChildren) {
+  const [state, setState] = useState<DaemonStatePayload>(INITIAL_STATE);
+
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined;
+    let cancelled = false;
+
+    void listen<DaemonStatePayload>('daemon-state', (e) => {
+      const payload = e.payload;
+      // Drop stale events: generation is monotonic (daemon_state.rs bumps on
+      // every transition), so any payload with a lower generation than what
+      // we already have is from a previous bootstrap or out-of-order delivery.
+      setState((prev) =>
+        payload.generation >= prev.generation ? payload : prev,
+      );
+    }).then((u) => {
+      if (cancelled) {
+        u();
+      } else {
+        unlisten = u;
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+
+  return (
+    <DaemonStateContext.Provider value={state}>
+      {children}
+    </DaemonStateContext.Provider>
+  );
+}
+
+export function useDaemonState(): DaemonStatePayload {
+  return useContext(DaemonStateContext);
+}
+
+export function useDaemonPhase(): DaemonPhase {
+  const { generation: _g, ...rest } = useContext(DaemonStateContext);
+  // The context value is `{ generation } & DaemonPhase` (a flattened union),
+  // so stripping `generation` yields the discriminated union.
+  return rest as DaemonPhase;
+}

--- a/packages/frontend-tauri/src/main.tsx
+++ b/packages/frontend-tauri/src/main.tsx
@@ -1,211 +1,43 @@
-// Tauri shell entrypoint — Wave-2 T10 (#685) + T12 (#678).
+// Tauri shell entrypoint — Task #112-T3: non-blocking SPA bootstrap.
 //
-// Listener race contract (see ~/.claude/projects/.../project_tauri2_spike_2026_05_07.md):
-// `daemon-ready` / `daemon-exit` / `daemon-error` are emitted by the Rust
-// side from a `tokio::spawn`-ed task that starts the moment `start_daemon`
-// returns Ok. If we `await invoke('start_daemon')` BEFORE registering the
-// listeners, fast handshakes can race past us and we lose the event.
+// Why this looks different from Wave-2 T10 / T12 (#685 / #678):
+// the old `bootstrap()` did 8 steps of `await` before calling
+// `createRoot(...).render(...)`. If the Rust side was slow to spawn the
+// daemon (or stuck altogether) the React tree never mounted and the user
+// saw a black window. T1 (#1211) replaced the scattered `daemon-ready` /
+// `daemon-error` / `daemon-exit` events with a single typed `daemon-state`
+// channel — which means we can listen for the full lifecycle from inside
+// React (DaemonStateProvider) instead of gating bootstrap on it.
 //
-// Therefore the order below is fixed:
-//   1. listen('daemon-ready', ...)   — register, await unlisten Promise
-//   2. listen('daemon-exit', ...)    — T12 surfaces this in a UI banner
-//   3. listen('daemon-error', ...)
-//   4. listen('daemon-stderr', ...)  — optional, log only
-//   5. invoke('start_daemon')        — fire spawn AFTER listeners are live
-//   6. await readyPromise            — block on first daemon-ready / error
-//   7. build hostConfig from handshake
-//   8. createRoot(...).render(<ShellRoot hostConfig={...} />)
+// New shape:
+//   1. createRoot(...).render(<StrictMode><ShellRoot/></StrictMode>) — sync,
+//      runs before any Tauri IPC.
+//   2. ShellRoot mounts <DaemonStateProvider> which attaches the
+//      `daemon-state` listener inside a useEffect.
+//   3. <PhaseSwitch> (App.tsx) reads the current phase and renders either
+//      <DaemonStatusOverlay> (pre-Ready) or <RuntimeProvider><App/></...>
+//      once the daemon emits `Ready { port, token, ... }`.
 //
-// T12 scope (#678): close (×) + reconnect verification. Close button + WS
-// reconnect already work end-to-end via @ccsm/ui Sidebar + @ccsm/core
-// SessionRuntime (5-attempt budget, identical to wave-1). The only code
-// change required is surfacing `daemon-exit` to the user — T10 only logged
-// it to the console. ShellRoot below owns that state and renders a thin
-// banner above <App> when the daemon process dies (e.g. external taskkill).
+// We do NOT call `invoke('start_daemon')` here anymore — the Rust setup
+// hook spawns the daemon supervisor itself (T2). The legacy
+// `daemon-ready` / `daemon-exit` listeners are also gone from this file;
+// they remain wired on the Rust side for backwards compatibility but the
+// SPA only needs `daemon-state` now.
 
-import { StrictMode, useEffect, useState } from 'react';
+import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { invoke } from '@tauri-apps/api/core';
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { App } from './App';
-import { buildTauriHostConfig, type Handshake } from './hostConfig';
-import type { HostConfig } from '@ccsm/ui';
 import '@ccsm/ui/styles.css';
 
-interface DaemonExitEvent {
-  code: number | null;
-  reason: string;
-}
-interface DaemonErrorEvent {
-  reason: string;
-}
-
-interface ShellRootProps {
-  hostConfig: HostConfig;
+const rootEl = document.getElementById('root');
+if (!rootEl) {
+  // Fail loudly — index.html is shipped with the bundle, a missing #root
+  // means the build is corrupt.
+  throw new Error('Root element #root not found');
 }
 
-/**
- * ShellRoot — owns the post-bootstrap UI state.
- *
- * Currently tracks one thing: whether the daemon process is still alive.
- * `daemon-exit` is emitted by the Rust side when the spawned `node daemon`
- * child exits for any reason (clean shutdown, crash, external taskkill).
- * After bootstrap we are past the readyPromise, so the listener registered
- * in `bootstrap()` is gone; we register a fresh one here that sets state
- * instead of just logging.
- *
- * UX: a single non-dismissable banner above <App>. The user can keep
- * interacting with already-attached sessions (their ws will reconnect up
- * to the SessionRuntime budget then go to `disconnected`), but new
- * actions like + New Session will fail with the existing alert path.
- * Restarting the app re-spawns the daemon (Job Object cleans up first),
- * which is the documented recovery (Plan §C item 1).
- */
-function ShellRoot({ hostConfig }: ShellRootProps) {
-  const [daemonExit, setDaemonExit] = useState<DaemonExitEvent | null>(null);
-
-  useEffect(() => {
-    let unlisten: UnlistenFn | undefined;
-    let cancelled = false;
-    void listen<DaemonExitEvent>('daemon-exit', (e) => {
-      // eslint-disable-next-line no-console
-      console.warn('[tauri] daemon-exit', e.payload);
-      setDaemonExit(e.payload);
-    }).then((u) => {
-      if (cancelled) {
-        u();
-      } else {
-        unlisten = u;
-      }
-    });
-    return () => {
-      cancelled = true;
-      unlisten?.();
-    };
-  }, []);
-
-  return (
-    <>
-      {daemonExit !== null && (
-        <div
-          role="alert"
-          data-testid="daemon-exit-banner"
-          style={{
-            background: '#3a1f1f',
-            color: '#f5d0d0',
-            padding: '6px 12px',
-            fontSize: '13px',
-            fontFamily: 'system-ui, sans-serif',
-            borderBottom: '1px solid #6b2a2a',
-          }}
-        >
-          Daemon offline ({daemonExit.reason}
-          {daemonExit.code !== null ? `, code=${daemonExit.code}` : ''}).
-          Restart the app to reconnect.
-        </div>
-      )}
-      <App hostConfig={hostConfig} />
-    </>
-  );
-}
-
-async function bootstrap(): Promise<void> {
-  const rootEl = document.getElementById('root');
-  if (!rootEl) throw new Error('Root element #root not found');
-
-  // Promise that resolves on the first `daemon-ready` event or rejects on
-  // the first `daemon-error`. Created BEFORE invoke() so the listener is
-  // guaranteed live when the Rust side starts emitting.
-  let resolveReady!: (hs: Handshake) => void;
-  let rejectReady!: (reason: Error) => void;
-  const readyPromise = new Promise<Handshake>((resolve, reject) => {
-    resolveReady = resolve;
-    rejectReady = reject;
-  });
-
-  // 1. daemon-ready (one-shot for the initial handshake — we keep the
-  //    unlisten so future reloads can clear it; T12 will revisit).
-  const unlistenReady: UnlistenFn = await listen<Handshake>(
-    'daemon-ready',
-    (e) => {
-      // eslint-disable-next-line no-console
-      console.log('[tauri] daemon-ready', {
-        port: e.payload.port,
-        tokenLen: e.payload.token.length,
-      });
-      resolveReady(e.payload);
-    },
-  );
-
-  // 2. daemon-exit — bootstrap-time listener. We log here AND keep the
-  //    listener live (no unlisten on success path) so an exit during the
-  //    bootstrap window between invoke() and ShellRoot's effect mounting
-  //    is not lost. ShellRoot registers its own listener that drives the
-  //    UI banner; events arriving after both are live will fire both
-  //    callbacks, which is fine (idempotent: console.warn + setState).
-  const unlistenExit: UnlistenFn = await listen<DaemonExitEvent>(
-    'daemon-exit',
-    (e) => {
-      // eslint-disable-next-line no-console
-      console.warn('[tauri] daemon-exit', e.payload);
-    },
-  );
-
-  // 3. daemon-error — handshake failure / spawn failure. If this fires
-  //    before daemon-ready, it rejects the bootstrap promise.
-  const unlistenError: UnlistenFn = await listen<DaemonErrorEvent>(
-    'daemon-error',
-    (e) => {
-      // eslint-disable-next-line no-console
-      console.error('[tauri] daemon-error', e.payload);
-      rejectReady(new Error(`daemon-error: ${e.payload.reason}`));
-    },
-  );
-
-  // 4. daemon-stderr — log forwarder (optional, useful in dev console).
-  const unlistenStderr: UnlistenFn = await listen<string>(
-    'daemon-stderr',
-    (e) => {
-      // eslint-disable-next-line no-console
-      console.debug('[daemon stderr]', e.payload);
-    },
-  );
-
-  // 5. invoke spawn — listeners are now live, no race window.
-  await invoke('start_daemon');
-
-  // 6. block on first daemon-ready (or daemon-error rejection).
-  let handshake: Handshake;
-  try {
-    handshake = await readyPromise;
-  } catch (err) {
-    // Clean up listeners so a future retry can re-register cleanly.
-    unlistenReady();
-    unlistenExit();
-    unlistenError();
-    unlistenStderr();
-    rootEl.textContent = `Failed to start daemon: ${(err as Error).message}`;
-    throw err;
-  }
-
-  // 7. build hostConfig from the handshake.
-  const hostConfig = buildTauriHostConfig(handshake);
-  // eslint-disable-next-line no-console
-  console.log('[tauri] hostConfig', {
-    httpBase: hostConfig.httpBase,
-    tokenPresent: !!hostConfig.getToken(),
-  });
-
-  // 8. mount the React app with the freshly-built hostConfig wrapped in
-  //    ShellRoot so post-bootstrap daemon-exit events surface as a banner.
-  createRoot(rootEl).render(
-    <StrictMode>
-      <ShellRoot hostConfig={hostConfig} />
-    </StrictMode>,
-  );
-}
-
-bootstrap().catch((err) => {
-  // eslint-disable-next-line no-console
-  console.error('[tauri] bootstrap failed', err);
-});
+createRoot(rootEl).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/packages/frontend-tauri/src/types.ts
+++ b/packages/frontend-tauri/src/types.ts
@@ -1,0 +1,46 @@
+// TS mirror of the Rust `DaemonPhase` enum + `DaemonStateEvent` envelope
+// emitted on the `daemon-state` Tauri event channel.
+//
+// Source of truth: packages/frontend-tauri/src-tauri/src/daemon_state.rs
+//
+// Wire shape: the Rust enum uses
+//   #[serde(tag = "phase", rename_all = "camelCase")]
+// so the discriminator field is `phase` and variant names are camelCase
+// (`notSpawned`, `spawnFailed`, `awaitingAuth`, ...).
+//
+// The `DaemonStateEvent` envelope flattens the variant payload alongside
+// `generation`, so a `Ready` event arrives on the wire as:
+//   { generation: 7, phase: "ready", port: 9876, token: "...", identity: ... }
+// and a `SpawnFailed` event as:
+//   { generation: 3, phase: "spawnFailed", reason: "...", retryInMs: 1000 }
+//
+// Field names within payloads are also camelCase (`retryInMs`, `verificationUri`,
+// `userCode`, `expiresAt`, `userId`).
+
+export interface Identity {
+  userId: string;
+}
+
+export type DaemonPhase =
+  | { phase: 'notSpawned' }
+  | { phase: 'spawning' }
+  | { phase: 'spawnFailed'; reason: string; retryInMs: number | null }
+  | { phase: 'starting' }
+  | {
+      phase: 'awaitingAuth';
+      verificationUri: string;
+      userCode: string;
+      expiresAt: number;
+    }
+  | { phase: 'authFailed'; reason: string }
+  | { phase: 'tunnelDisconnected'; port: number; token: string }
+  | { phase: 'tunnelConnected'; port: number; token: string }
+  | { phase: 'ready'; port: number; token: string; identity: Identity | null }
+  | { phase: 'exited'; code: number | null; reason: string };
+
+/**
+ * Wire envelope for the `daemon-state` Tauri event. The Rust side flattens
+ * the `DaemonPhase` payload into the same JSON object alongside `generation`,
+ * so `DaemonStatePayload` is `{ generation } & DaemonPhase`.
+ */
+export type DaemonStatePayload = { generation: number } & DaemonPhase;

--- a/packages/ui/src/components/DaemonStatusOverlay.tsx
+++ b/packages/ui/src/components/DaemonStatusOverlay.tsx
@@ -1,0 +1,72 @@
+// Task #112-T3: minimal pre-Ready overlay. Renders while the daemon has not
+// reached `Ready` yet so the user sees something instead of a black screen.
+// T4 owns the polished visuals; this stub only proves the wiring.
+
+import type { ReactNode } from 'react';
+
+export type DaemonStatusVariant = 'info' | 'error' | 'auth';
+
+// Loose phase shape: this component is rendered by the Tauri shell for any
+// non-Ready phase. We only read `.phase` (the discriminator) and a couple of
+// optional fields, so we keep the type minimal here to avoid pulling shell
+// types into @ccsm/ui.
+export interface DaemonStatusPhase {
+  phase: string;
+  reason?: string;
+  verificationUri?: string;
+  userCode?: string;
+}
+
+export interface DaemonStatusOverlayProps {
+  phase: DaemonStatusPhase;
+  variant?: DaemonStatusVariant;
+}
+
+const COLORS: Record<DaemonStatusVariant, { bg: string; fg: string }> = {
+  info: { bg: '#1e1e1e', fg: '#e6e6e6' },
+  error: { bg: '#3a1f1f', fg: '#f5d0d0' },
+  auth: { bg: '#1f2a3a', fg: '#d0e0f5' },
+};
+
+function describe(phase: DaemonStatusPhase): ReactNode {
+  switch (phase.phase) {
+    case 'spawnFailed':
+      return `Failed to start daemon: ${phase.reason ?? 'unknown'}`;
+    case 'authFailed':
+      return `Authentication failed: ${phase.reason ?? 'unknown'}`;
+    case 'exited':
+      return `Daemon exited: ${phase.reason ?? 'unknown'}`;
+    case 'awaitingAuth':
+      return `Awaiting authentication. Visit ${phase.verificationUri ?? ''} and enter ${phase.userCode ?? ''}.`;
+    default:
+      return `Phase: ${phase.phase}`;
+  }
+}
+
+export function DaemonStatusOverlay({
+  phase,
+  variant = 'info',
+}: DaemonStatusOverlayProps) {
+  const { bg, fg } = COLORS[variant];
+  return (
+    <div
+      data-testid="daemon-status-overlay"
+      data-variant={variant}
+      data-phase={phase.phase}
+      style={{
+        position: 'fixed',
+        inset: 0,
+        background: bg,
+        color: fg,
+        padding: 24,
+        fontFamily: 'system-ui, sans-serif',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      <h1 style={{ margin: 0, fontSize: 20 }}>ccsm</h1>
+      <p style={{ margin: 0, fontSize: 14 }}>{describe(phase)}</p>
+    </div>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -17,6 +17,12 @@
 export { AppShell } from './components/AppShell';
 export { Sidebar } from './components/Sidebar';
 export { MainPane } from './components/MainPane';
+export {
+  DaemonStatusOverlay,
+  type DaemonStatusOverlayProps,
+  type DaemonStatusPhase,
+  type DaemonStatusVariant,
+} from './components/DaemonStatusOverlay';
 export { useBootstrap } from './hooks/useBootstrap';
 export { useStore } from './store';
 export {


### PR DESCRIPTION
## Summary
Task #120 / #112-T3. Fixes the black-screen bug when daemon spawn is slow or stuck.

- main.tsx no longer awaits an 8-step \`bootstrap()\` chain before \`createRoot.render\`. React mounts synchronously now.
- New \`DaemonStateProvider\` listens on the unified \`daemon-state\` channel (T1, #1211) inside a \`useEffect\` and exposes the latest \`DaemonStatePayload\` via React context.
- New \`PhaseSwitch\` in App.tsx exhaustively matches the Rust \`DaemonPhase\` enum and renders either \`<DaemonStatusOverlay>\` (pre-Ready phases) or \`<RuntimeProvider><AppContent/></...>\` once \`Ready { port, token, ... }\` arrives.
- New \`DaemonStatusOverlay\` (stub in \`@ccsm/ui\`) — T4 owns polish.
- New \`types.ts\` mirrors the Rust enum: \`{ phase: 'notSpawned' | 'spawning' | ... }\` (camelCase discriminator, flattened envelope with \`generation\`).

Generation is monotonic; the provider drops payloads with lower generation than what it has already seen.

## Out of scope
- Does NOT modify \`packages/frontend-tauri/src-tauri/\` (T1/T2 territory).
- Does NOT modify \`packages/daemon/\`.
- Does NOT modify \`packages/ui/src/runtime-context.tsx\` / \`store.ts\` / \`session-runtime\`.
- Legacy \`daemon-ready\` / \`daemon-exit\` / \`daemon-error\` listeners on the Rust side are left intact for backwards compatibility — the SPA just no longer subscribes to them.
- \`AwaitingAuth\` UI is the same overlay stub; S4-T8 owns the real flow.

## Wire-shape note for reviewers
Rust \`DaemonPhase\` uses \`#[serde(tag = \"phase\", rename_all = \"camelCase\")]\` and the envelope flattens via \`#[serde(flatten)]\`, so \`daemon-state\` payloads land as e.g. \`{ generation: 7, phase: \"ready\", port: 9876, token: \"...\", identity: ... }\`. The TS \`DaemonPhase\` mirrors this exactly (see \`types.ts\` source-of-truth comment).

## Local checks (host: Windows 11, mode: fast)
- lint: ✓ (frontend-tauri exit 0; ui exit 0)
- typecheck: ✓ (frontend-tauri exit 0; ui exit 0)
- build: ✓ (\`pnpm -F @ccsm/ui build\` → tsc clean; \`pnpm -F @ccsm/frontend-tauri build\` → vite \`✓ built in 2.42s\`, 62 modules)
- unit tests: ui — 5 spec files, 40 passed (Sidebar, BootstrapRefresh, MainPane.strictmode, etc.). frontend-tauri has no test files (\`vitest run --passWithNoTests\` → exit 0).
- e2e: skipped — Tauri shell has no probe-e2e harness; behavioral verification is documented for the dev to run locally per task spec ("pnpm dev + ccsm-tauri.exe + 不起 cf-worker, 验证窗口能看到 Phase: ... 文本然后切换到真 UI"). Full Tauri-driven smoke is reviewer/manager territory once T2 lands.

Not a bug fix (refactor of bootstrap path), so no reverse-verify section.