### PR TITLE
feat(cf-worker): Task #127 — temp debug endpoints (secrets + JWT POC)

### DIFF
--- a/packages/cf-worker/src/index.ts
+++ b/packages/cf-worker/src/index.ts
@@ -8,6 +8,20 @@ export { TunnelDO } from './tunnel-do';
 // dispatch into UserDO are introduced in T5 — this is a binding-only export.
 export { UserDO } from './auth/userDO';
 
+import { signJwt, verifyJwt } from './auth/jwt';
+
+// Task #127 (POC, temporary): typed view of the 4 production secrets the user
+// already `wrangler secret put`-ed under their NEW names (`GITHUB_OAUTH_*`,
+// not the older `GITHUB_APP_*` interface in auth/bindings.ts — rename is
+// tracked by Task #125, intentionally NOT touched here to avoid race). This
+// inline type is scoped to the debug endpoints below; AuthEnv stays as-is.
+interface SecretsPocEnv {
+  GITHUB_OAUTH_CLIENT_ID?: string;
+  GITHUB_OAUTH_CLIENT_SECRET?: string;
+  JWT_SIGNING_KEY?: string;
+  JWT_REFRESH_SIGNING_KEY?: string;
+}
+
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     const url = new URL(req.url);
@@ -24,6 +38,65 @@ export default {
     // a stuck listener.
     if (url.pathname === '/health') {
       return new Response('ok\n', { status: 200 });
+    }
+
+    // Task #127 (POC, temporary — remove after verification): debug endpoints
+    // to confirm (a) the 4 production secrets the user `wrangler secret put`-ed
+    // are reachable inside the deployed worker, and (b) the S4-T2 JWT helpers
+    // round-trip sign+verify under workerd's real SubtleCrypto. Both endpoints
+    // are read-only and never expose full secret values — only booleans,
+    // length, and a short prefix of the (public) Client ID. To be deleted
+    // along with this comment block once production verification is done.
+    if (url.pathname === '/api/debug/secrets-poc') {
+      const e = env as Env & SecretsPocEnv;
+      return Response.json({
+        has_client_id: !!e.GITHUB_OAUTH_CLIENT_ID,
+        client_id_prefix: e.GITHUB_OAUTH_CLIENT_ID?.slice(0, 6) ?? null,
+        has_client_secret: !!e.GITHUB_OAUTH_CLIENT_SECRET,
+        client_secret_length: e.GITHUB_OAUTH_CLIENT_SECRET?.length ?? 0,
+        has_jwt_key: !!e.JWT_SIGNING_KEY,
+        jwt_key_length: e.JWT_SIGNING_KEY?.length ?? 0,
+        has_refresh_key: !!e.JWT_REFRESH_SIGNING_KEY,
+        refresh_key_length: e.JWT_REFRESH_SIGNING_KEY?.length ?? 0,
+      });
+    }
+
+    if (url.pathname === '/api/debug/jwt-poc') {
+      const e = env as Env & SecretsPocEnv;
+      const jwtKey = e.JWT_SIGNING_KEY;
+      if (!jwtKey) {
+        return Response.json(
+          { error: 'JWT_SIGNING_KEY not bound' },
+          { status: 500 },
+        );
+      }
+      const nowSec = Math.floor(Date.now() / 1000);
+      const claims = {
+        sub: 'poc-user',
+        login: 'poc',
+        exp: nowSec + 60,
+        iat: nowSec,
+        kind: 'web' as const,
+      };
+      try {
+        const token = await signJwt(claims, jwtKey);
+        const verified = await verifyJwt<typeof claims>(token, jwtKey);
+        return Response.json({
+          sign_ok: !!token,
+          token_length: token.length,
+          verify_ok: !!verified,
+          verified_sub: verified?.sub ?? null,
+        });
+      } catch (err) {
+        return Response.json(
+          {
+            sign_ok: false,
+            verify_ok: false,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          { status: 500 },
+        );
+      }
     }
 
     if (


### PR DESCRIPTION
Task #127 — temporary debug endpoints to verify the 4 production secrets the user already \`wrangler secret put\`-ed (under new \`GITHUB_OAUTH_*\` names) are reachable inside the deployed worker, and that the S4-T2 JWT helpers round-trip in real workerd.

POC, to be removed once verification is done.

## Diff

\`packages/cf-worker/src/index.ts\` — adds two endpoints + an inline local \`SecretsPocEnv\` type:

\`\`\`typescript
interface SecretsPocEnv {
  GITHUB_OAUTH_CLIENT_ID?: string;
  GITHUB_OAUTH_CLIENT_SECRET?: string;
  JWT_SIGNING_KEY?: string;
  JWT_REFRESH_SIGNING_KEY?: string;
}

if (url.pathname === '/api/debug/secrets-poc') {
  const e = env as Env & SecretsPocEnv;
  return Response.json({
    has_client_id: !!e.GITHUB_OAUTH_CLIENT_ID,
    client_id_prefix: e.GITHUB_OAUTH_CLIENT_ID?.slice(0, 6) ?? null,
    has_client_secret: !!e.GITHUB_OAUTH_CLIENT_SECRET,
    client_secret_length: e.GITHUB_OAUTH_CLIENT_SECRET?.length ?? 0,
    has_jwt_key: !!e.JWT_SIGNING_KEY,
    jwt_key_length: e.JWT_SIGNING_KEY?.length ?? 0,
    has_refresh_key: !!e.JWT_REFRESH_SIGNING_KEY,
    refresh_key_length: e.JWT_REFRESH_SIGNING_KEY?.length ?? 0,
  });
}

if (url.pathname === '/api/debug/jwt-poc') {
  // sign + verify a 60s ephemeral JWT, return only booleans + sub
}
\`\`\`

Why inline cast and not edit \`auth/bindings.ts\`: the rename from \`GITHUB_APP_*\` to \`GITHUB_OAUTH_*\` is Task #125's scope. Touching \`bindings.ts\` here would race that task. POC reads the new names through a local cast; \`AuthEnv\` is left alone.

## Safety

- Never returns full secret values — only booleans, length, and first-6-char prefix of the public Client ID.
- Both endpoints are read-only, no DO writes, no GitHub calls.
- Will be deleted (along with the marker comment in \`index.ts\`) once verification is complete.

## Local checks (host: Windows, mode: fast)
- lint: ✓ (exit 0)
- typecheck: ✓ (exit 0)
- build: ✓ (\`tsc --noEmit\`, exit 0 — same as typecheck for this package)
- unit tests: \`npm test\` → \`Test Files 4 passed (4) | Tests 53 passed (53)\` in 2.07s. R-41 + S4-T2 suites all green.
- e2e: skipped — cf-worker package has no e2e probes; this PR adds two trivial endpoints with zero impact on \`/ws/*\`, \`/tunnel/*\`, \`/api/sessions/*\`, \`/token\` flows that e2e covers.

## Local POC verification (\`wrangler dev --port 8787 --local\`)

\`.dev.vars\` (gitignored, local-only) populated with the new \`GITHUB_OAUTH_*\` names plus the same hex zero JWT keys from \`.dev.vars.example\`:

wrangler boot log confirms 4 bindings:
\`\`\`
env.GITHUB_OAUTH_CLIENT_ID ("(hidden)")          Environment Variable      local
env.GITHUB_OAUTH_CLIENT_SECRET ("(hidden)")      Environment Variable      local
env.JWT_SIGNING_KEY ("(hidden)")                 Environment Variable      local
env.JWT_REFRESH_SIGNING_KEY ("(hidden)")         Environment Variable      local
\`\`\`

\`curl http://127.0.0.1:8787/api/debug/secrets-poc\`:
\`\`\`json
{"has_client_id":true,"client_id_prefix":"Iv1.po","has_client_secret":true,"client_secret_length":39,"has_jwt_key":true,"jwt_key_length":64,"has_refresh_key":true,"refresh_key_length":64}
\`\`\`

\`curl http://127.0.0.1:8787/api/debug/jwt-poc\`:
\`\`\`json
{"sign_ok":true,"token_length":187,"verify_ok":true,"verified_sub":"poc-user"}
\`\`\`

Both match expected: 4 has_* = true, Client ID prefix matches \`.dev.vars\` placeholder, JWT round-trip succeeds against the hex-zero \`JWT_SIGNING_KEY\` proving \`signJwt\`/\`verifyJwt\` work end-to-end inside workerd.

## Out of scope
- TunnelDO, existing routes (\`/ws/*\`, \`/tunnel/*\`, \`/api/sessions/*\`, \`/token\`)
- \`auth/bindings.ts\` rename (Task #125)
- \`auth/jwt.ts\` / \`auth/userDO.ts\` (S4-T2 done, untouched)
- daemon / frontend / Tauri