### PR TITLE
chore(cf-worker): Task #131 — remove POC debug endpoints from #127

### DIFF
--- a/packages/cf-worker/src/index.ts
+++ b/packages/cf-worker/src/index.ts
@@ -8,20 +8,6 @@ export { TunnelDO } from './tunnel-do';
 // dispatch into UserDO are introduced in T5 — this is a binding-only export.
 export { UserDO } from './auth/userDO';
 
-import { signJwt, verifyJwt } from './auth/jwt';
-
-// Task #127 (POC, temporary): typed view of the 4 production secrets the user
-// already `wrangler secret put`-ed under their NEW names (`GITHUB_OAUTH_*`,
-// not the older `GITHUB_APP_*` interface in auth/bindings.ts — rename is
-// tracked by Task #125, intentionally NOT touched here to avoid race). This
-// inline type is scoped to the debug endpoints below; AuthEnv stays as-is.
-interface SecretsPocEnv {
-  GITHUB_OAUTH_CLIENT_ID?: string;
-  GITHUB_OAUTH_CLIENT_SECRET?: string;
-  JWT_SIGNING_KEY?: string;
-  JWT_REFRESH_SIGNING_KEY?: string;
-}
-
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     const url = new URL(req.url);
@@ -38,65 +24,6 @@ export default {
     // a stuck listener.
     if (url.pathname === '/health') {
       return new Response('ok\n', { status: 200 });
-    }
-
-    // Task #127 (POC, temporary — remove after verification): debug endpoints
-    // to confirm (a) the 4 production secrets the user `wrangler secret put`-ed
-    // are reachable inside the deployed worker, and (b) the S4-T2 JWT helpers
-    // round-trip sign+verify under workerd's real SubtleCrypto. Both endpoints
-    // are read-only and never expose full secret values — only booleans,
-    // length, and a short prefix of the (public) Client ID. To be deleted
-    // along with this comment block once production verification is done.
-    if (url.pathname === '/api/debug/secrets-poc') {
-      const e = env as Env & SecretsPocEnv;
-      return Response.json({
-        has_client_id: !!e.GITHUB_OAUTH_CLIENT_ID,
-        client_id_prefix: e.GITHUB_OAUTH_CLIENT_ID?.slice(0, 6) ?? null,
-        has_client_secret: !!e.GITHUB_OAUTH_CLIENT_SECRET,
-        client_secret_length: e.GITHUB_OAUTH_CLIENT_SECRET?.length ?? 0,
-        has_jwt_key: !!e.JWT_SIGNING_KEY,
-        jwt_key_length: e.JWT_SIGNING_KEY?.length ?? 0,
-        has_refresh_key: !!e.JWT_REFRESH_SIGNING_KEY,
-        refresh_key_length: e.JWT_REFRESH_SIGNING_KEY?.length ?? 0,
-      });
-    }
-
-    if (url.pathname === '/api/debug/jwt-poc') {
-      const e = env as Env & SecretsPocEnv;
-      const jwtKey = e.JWT_SIGNING_KEY;
-      if (!jwtKey) {
-        return Response.json(
-          { error: 'JWT_SIGNING_KEY not bound' },
-          { status: 500 },
-        );
-      }
-      const nowSec = Math.floor(Date.now() / 1000);
-      const claims = {
-        sub: 'poc-user',
-        login: 'poc',
-        exp: nowSec + 60,
-        iat: nowSec,
-        kind: 'web' as const,
-      };
-      try {
-        const token = await signJwt(claims, jwtKey);
-        const verified = await verifyJwt<typeof claims>(token, jwtKey);
-        return Response.json({
-          sign_ok: !!token,
-          token_length: token.length,
-          verify_ok: !!verified,
-          verified_sub: verified?.sub ?? null,
-        });
-      } catch (err) {
-        return Response.json(
-          {
-            sign_ok: false,
-            verify_ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          },
-          { status: 500 },
-        );
-      }
     }
 
     if (


### PR DESCRIPTION
## Summary
POC #127 (PR #1215) verified production secrets + JWT round-trip on 2026-05-10. This PR removes the two temporary debug endpoints to avoid leaving debug surface in production.

POC verification results (manager curl 2026-05-10):
- \`/api/debug/secrets-poc\`: prefix=\`Ov23li\`, client_secret_length=40, jwt_key_length=64, refresh_key_length=64 (4 secrets all reachable)
- \`/api/debug/jwt-poc\`: sign_ok=true, verify_ok=true

## Changes
\`packages/cf-worker/src/index.ts\` — pure deletions (73 lines, exact reverse of commit \`60e7354\`):
- Remove \`/api/debug/secrets-poc\` route handler
- Remove \`/api/debug/jwt-poc\` route handler
- Remove inline \`SecretsPocEnv\` type
- Remove \`import { signJwt, verifyJwt } from './auth/jwt'\` (only used by jwt-poc)

## Out of scope (intentionally untouched)
- \`packages/cf-worker/src/auth/jwt.ts\` — \`signJwt\`/\`verifyJwt\` retained, S4-T3/T4 need them
- \`packages/cf-worker/src/auth/bindings.ts\` — Task #125 scope (rename \`GITHUB_APP_*\` → \`GITHUB_OAUTH_*\`)
- 53 existing tests — no test changes

## Diff stat
\`\`\`
 packages/cf-worker/src/index.ts | 73 -----------------------------------------
 1 file changed, 73 deletions(-)
\`\`\`

## Local checks (host: Windows 11, mode: fast)
- lint: ✓ (exit 0, eslint src --max-warnings=0)
- typecheck: ✓ (exit 0, tsc --noEmit)
- build: ✓ (exit 0, tsc --noEmit)
- unit tests: ✓ \`npm test\` (vitest run, full cf-worker suite)
  \`\`\`
   Test Files  4 passed (4)
        Tests  53 passed (53)
     Duration  2.95s
  \`\`\`
- e2e: skipped — cf-worker package has no e2e probes; cleanup is pure deletion of POC endpoints, no behavioral change to retained routes.

## Test plan
- [x] All 53 cf-worker unit tests pass locally
- [x] TypeScript build clean
- [x] No lint warnings
- [x] Diff is exact reverse of \`60e7354\` (no collateral edits)