### PR TITLE
Task #133 — daemon hello identity + CCSM_TRUST_TUNNEL switch (S4-T6)

### DIFF
--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -73,6 +73,24 @@ interface HelloFrame {
   sid?: string;
   /** Task #793: ring-buffer replay cursor (`lastSeq` query param, default 0). */
   lastSeq?: number;
+  /**
+   * Task #133 (S4-T6): cloud-authenticated browser identity. When present,
+   * a daemon running with `CCSM_TRUST_TUNNEL=1` accepts the hello on the
+   * strength of this field alone (cloud has already verified the OAuth
+   * session via the worker's JWT mint endpoint). Older daemons ignore the
+   * field. Optional during S4 rollout — the OAuth flow that populates it
+   * lands in T3/T4; T6 only carries the wire field.
+   */
+  identity?: BrowserIdentity;
+}
+
+/**
+ * Browser identity emitted to the daemon in trust-tunnel mode (Task #133,
+ * S4-T6). Mirrors the `BrowserIdentity` shape on the daemon side.
+ */
+interface BrowserIdentity {
+  login: string;
+  github_id: string;
 }
 
 /**
@@ -116,6 +134,13 @@ interface BrowserAttachment {
    * DO can route daemon→browser binary frames by sid (envelope header) and
    * label browser→daemon binary frames before forwarding. */
   sid: string;
+  /**
+   * Task #133 (S4-T6): cloud-authenticated identity attached to this
+   * browser ws. Forwarded to the daemon inside the hello frame; the daemon
+   * accepts it (in lieu of token validation) when running with
+   * `CCSM_TRUST_TUNNEL=1`. Undefined until the OAuth wire-up (T3/T4) lands.
+   */
+  identity?: BrowserIdentity;
 }
 
 interface DaemonAttachment {
@@ -124,8 +149,16 @@ interface DaemonAttachment {
 
 type SocketAttachment = BrowserAttachment | DaemonAttachment;
 
-function buildHelloFrame(token: string, sid: string, lastSeq: number): string {
+function buildHelloFrame(
+  token: string,
+  sid: string,
+  lastSeq: number,
+  identity?: BrowserIdentity,
+): string {
   const frame: HelloFrame = { type: 'hello', token, sid, lastSeq };
+  if (identity !== undefined) {
+    frame.identity = identity;
+  }
   return JSON.stringify(frame);
 }
 
@@ -349,7 +382,16 @@ export class TunnelDO extends DurableObject<Env> {
       // daemon path above. readyState filtering picks the live one.
       // Task #105 (R-41): tag the browser ws with `browser-sid:<sid>` so
       // post-hibernation lookups can recover the right ws per sid.
-      const attachment: BrowserAttachment = { role: 'browser', token: extracted.token, sid };
+      // Task #133 (S4-T6): identity comes from the cloud OAuth session once
+      // T3/T4 lands. Until then, leave it undefined — the daemon stays on
+      // the legacy token-validation path. When an identity IS available
+      // (future cloud-issued tunnel credential) it will be plumbed through
+      // here and surfaced inside the hello frame so trust-tunnel daemons
+      // can authenticate without re-validating the per-browser token.
+      const identity: BrowserIdentity | undefined = undefined;
+      const attachment: BrowserAttachment = identity !== undefined
+        ? { role: 'browser', token: extracted.token, sid, identity }
+        : { role: 'browser', token: extracted.token, sid };
       this.state.acceptWebSocket(server, [TAG_BROWSER, TAG_BROWSER_SID_PREFIX + sid]);
       server.serializeAttachment(attachment);
       // R-17 log #2 (Task #45): browser ws accepted, about to emit hello.
@@ -357,7 +399,7 @@ export class TunnelDO extends DurableObject<Env> {
 
       // Emit hello as the first daemon-bound frame after this browser pair.
       try {
-        daemon.send(buildHelloFrame(extracted.token, sid, lastSeq));
+        daemon.send(buildHelloFrame(extracted.token, sid, lastSeq, identity));
         // R-17 log #3 (Task #45): hello successfully sent to daemon.
         console.log('[do] hello sent to daemon');
       } catch (err) {

--- a/packages/cf-worker/test/tunnel-do.test.ts
+++ b/packages/cf-worker/test/tunnel-do.test.ts
@@ -453,6 +453,28 @@ describe('TunnelDO', () => {
     expect(browser.closed).toBe(false);
   });
 
+  // ---- Task #133 (S4-T6): hello frame identity field --------------------
+
+  it('hello frame omits identity field when cloud identity is unknown', async () => {
+    // T6 only carries the wire shape; OAuth wire-up lands in T3/T4. So the
+    // current build always emits hello WITHOUT identity (back-compat with
+    // legacy daemons + smoke). The wire shape must therefore not regress
+    // with a stray `"identity":null` or empty object.
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(makeState(), fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+    await inst.fetch(makeBrowserWsReq({ sid: 'sess-x', protocol: BROWSER_PROTO }));
+    const daemon = created[0].server;
+    const hello = JSON.parse(daemon.sent[0] as string);
+    expect(hello).toEqual({
+      type: 'hello',
+      token: 'test-token-xyz',
+      sid: 'sess-x',
+      lastSeq: 0,
+    });
+    expect('identity' in hello).toBe(false);
+  });
+
   // ---- HTTP-over-tunnel (Task #787, S3-C) -------------------------------
 
   function makeHttpReq(path: string, method = 'GET', body?: string): Request {    return new Request(`https://example.test${path}`, {

--- a/packages/daemon/src/tunnel.mts
+++ b/packages/daemon/src/tunnel.mts
@@ -110,6 +110,12 @@ export interface BrowserAttachInfo {
   lastSeq: number;
   /** Send a binary frame back to the browser via the tunnel. */
   send: (data: Uint8Array | Buffer) => void;
+  /**
+   * Cloud-authenticated browser identity (Task #133, S4-T6). Present only
+   * when the daemon is in trust-tunnel mode AND the hello carried an
+   * `identity` block. Legacy token-only pairings leave this `undefined`.
+   */
+  identity?: BrowserIdentity;
 }
 
 /**
@@ -144,13 +150,57 @@ function defaultWsFactory(url: string): WsLike {
   return new WebSocket(url) as unknown as WsLike;
 }
 
+/**
+ * Per-browser identity that the cloud has already authenticated on our
+ * behalf (Task #133, S4-T6). Present only when the daemon is running in
+ * trust-tunnel mode (env `CCSM_TRUST_TUNNEL=1`); legacy / smoke / dogfood
+ * paths still ride the per-browser bearer token in `HelloFrame.token` and
+ * leave `identity` undefined.
+ *
+ * `login` is the GitHub login (handle) and `github_id` is the numeric
+ * GitHub user id rendered as a string so we don't lose precision on the
+ * wire. Both are minted by the cloud token mint endpoint (T3/T4) once OAuth
+ * lands; T6 only carries the field through.
+ */
+export interface BrowserIdentity {
+  login: string;
+  github_id: string;
+}
+
+function parseIdentity(value: unknown): BrowserIdentity | null {
+  if (value === null || typeof value !== 'object') return null;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.login !== 'string' || obj.login.length === 0) return null;
+  if (typeof obj.github_id !== 'string' || obj.github_id.length === 0) return null;
+  return { login: obj.login, github_id: obj.github_id };
+}
+
 interface HelloFrame {
   type: 'hello';
-  token: string;
+  /** Legacy per-browser bearer token (constant-time-checked vs daemon token).
+   * Optional when the daemon is in trust-tunnel mode AND the hello carries an
+   * `identity` instead. */
+  token?: string;
   /** Task #793 (S3-G): session id from the browser ws `?sid=` query. */
   sid?: string;
   /** Task #793 (S3-G): replay cursor from the browser ws `?lastSeq=` query. */
   lastSeq?: number;
+  /** Task #133 (S4-T6): cloud-authenticated browser identity (trust-tunnel). */
+  identity?: BrowserIdentity;
+}
+
+/**
+ * Returns true when the daemon process is configured to trust the cloud
+ * tunnel for browser identity (env `CCSM_TRUST_TUNNEL=1`). Read on every
+ * call so tests / runtime toggles take effect without re-importing.
+ *
+ * In trust-tunnel mode the daemon accepts hello frames that carry only
+ * `identity` (no `token`) — the Cloudflare Worker has already authenticated
+ * the browser via OAuth and signed the JWT. Legacy / dogfood deployments
+ * leave the env unset and continue to require the per-browser bearer token.
+ */
+export function isTrustTunnelEnabled(): boolean {
+  return process.env.CCSM_TRUST_TUNNEL === '1';
 }
 
 /**
@@ -196,8 +246,23 @@ function parseHello(text: string): HelloFrame | null {
   if (parsed === null || typeof parsed !== 'object') return null;
   const obj = parsed as Record<string, unknown>;
   if (obj.type !== 'hello') return null;
-  if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
-  const out: HelloFrame = { type: 'hello', token: obj.token };
+  // Task #133 (S4-T6): token is optional in trust-tunnel mode; presence is
+  // re-validated at the call site against env + identity. We just require
+  // that IF token is present it be a non-empty string.
+  let token: string | undefined;
+  if (obj.token !== undefined) {
+    if (typeof obj.token !== 'string' || obj.token.length === 0) return null;
+    token = obj.token;
+  }
+  const identity = obj.identity !== undefined ? parseIdentity(obj.identity) : null;
+  if (obj.identity !== undefined && identity === null) return null;
+  // Reject hello with neither token nor identity outright — there's nothing
+  // to authenticate against. (The trust-mode env check still happens at the
+  // call site to also reject identity-only hellos when env is unset.)
+  if (token === undefined && identity === null) return null;
+  const out: HelloFrame = { type: 'hello' };
+  if (token !== undefined) out.token = token;
+  if (identity !== null) out.identity = identity;
   if (typeof obj.sid === 'string' && obj.sid.length > 0) {
     out.sid = obj.sid;
   }
@@ -291,6 +356,12 @@ export class TunnelClient {
   // (no tear-down of prior sids — that was the wave-1 R-27 behaviour). On
   // ws close all attach handles are dropped.
   private readonly attachHandles = new Map<string, BrowserAttachHandle>();
+  /**
+   * Task #133 (S4-T6): per-sid cloud identity map. Populated only in
+   * trust-tunnel mode when the hello frame carries an `identity` block.
+   * Cleared on dial() / ws close alongside `attachHandles`.
+   */
+  private readonly identities = new Map<string, BrowserIdentity>();
   private readonly onBrowserAttach: ((info: BrowserAttachInfo) => BrowserAttachHandle | null) | null;
 
   constructor(opts: TunnelClientOptions) {
@@ -316,6 +387,15 @@ export class TunnelClient {
    */
   getBrowserToken(): string | null {
     return this.browserToken;
+  }
+
+  /**
+   * Returns the cloud-authenticated identity for a given paired sid, or null
+   * if no hello has been received for that sid or hello carried no identity
+   * (legacy / token-only pairing). Task #133 (S4-T6).
+   */
+  getBrowserIdentity(sid: string): BrowserIdentity | null {
+    return this.identities.get(sid) ?? null;
   }
 
   start(): void {
@@ -364,6 +444,7 @@ export class TunnelClient {
     this.helloSeen = false;
     this.browserToken = null;
     this.attachHandles.clear();
+    this.identities.clear();
     let socket: WsLike;
     try {
       socket = this.wsFactory(this.url);
@@ -467,6 +548,26 @@ export class TunnelClient {
       // 2) hello frame — always sniffed, so SPA re-pair (Task #81) works.
       const hello = parseHello(text);
       if (hello !== null) {
+        // Task #133 (S4-T6): two accept paths.
+        //   - trust-tunnel mode (CCSM_TRUST_TUNNEL=1): cloud has authed the
+        //     browser; hello MUST carry identity. Token (if present) is
+        //     informational only — we don't validate it (cloud already did).
+        //   - legacy mode: hello MUST carry token, validated constant-time
+        //     against the daemon's expected token. identity is ignored if
+        //     present (forward-compat with cloud-issued frames during
+        //     rollout — server can't trust them when the env opt-in is off).
+        if (isTrustTunnelEnabled()) {
+          if (hello.identity === undefined) {
+            this.rejectHello('trust-tunnel mode but hello missing identity');
+            return;
+          }
+          this.handleHello(hello);
+          return;
+        }
+        if (hello.token === undefined) {
+          this.rejectHello('legacy mode but hello missing token');
+          return;
+        }
         if (!constantTimeTokenEquals(hello.token, this.token)) {
           this.rejectHello('bad token in hello');
           return;
@@ -504,6 +605,7 @@ export class TunnelClient {
         }
         this.attachHandles.clear();
       }
+      this.identities.clear();
       if (this.stopped) {
         this.state = 'stopped';
         return;
@@ -528,7 +630,10 @@ export class TunnelClient {
    */
   private handleHello(hello: HelloFrame): void {
     this.helloSeen = true;
-    this.browserToken = hello.token;
+    // Task #133 (S4-T6): in trust-tunnel mode hello.token is undefined; the
+    // browserToken passthrough (used by legacy auth introspection) stays
+    // null. Subsequent legacy-only code paths must tolerate that.
+    this.browserToken = hello.token ?? null;
     const newSid = typeof hello.sid === 'string' && hello.sid.length > 0
       ? hello.sid
       : null;
@@ -547,6 +652,12 @@ export class TunnelClient {
     }
 
     console.error('[ccsm] tunnel: hello received sid=' + newSid + ' lastSeq=' + (hello.lastSeq ?? 0) + ' (' + (this.attachHandles.size + 1) + ' active sids)');
+
+    // Task #133 (S4-T6): record identity if present so getBrowserIdentity()
+    // and BrowserAttachInfo.identity can surface it.
+    if (hello.identity !== undefined) {
+      this.identities.set(newSid, hello.identity);
+    }
 
     // Task #793 (S3-G) + Task #105 (R-41): bind a NEW attach handle for the
     // newly-paired sid. send wraps the daemon→browser binary frame in a sid
@@ -568,6 +679,7 @@ export class TunnelClient {
           sid: attachSid,
           lastSeq: hello.lastSeq ?? 0,
           send,
+          ...(hello.identity !== undefined ? { identity: hello.identity } : {}),
         });
         if (handle !== null) {
           this.attachHandles.set(attachSid, handle);

--- a/packages/daemon/test/tunnel.test.ts
+++ b/packages/daemon/test/tunnel.test.ts
@@ -905,4 +905,126 @@ describe('TunnelClient', () => {
     expect(sockets[0].closedCalls).toHaveLength(1);
     expect(sockets[0].closedCalls[0].code).toBe(1008);
   });
+
+  // ---- Task #133 (S4-T6): CCSM_TRUST_TUNNEL identity acceptance ---------
+
+  describe('trust-tunnel mode (CCSM_TRUST_TUNNEL=1)', () => {
+    const ORIGINAL_ENV = process.env.CCSM_TRUST_TUNNEL;
+
+    beforeEach(() => {
+      process.env.CCSM_TRUST_TUNNEL = '1';
+    });
+
+    afterEach(() => {
+      if (ORIGINAL_ENV === undefined) {
+        delete process.env.CCSM_TRUST_TUNNEL;
+      } else {
+        process.env.CCSM_TRUST_TUNNEL = ORIGINAL_ENV;
+      }
+    });
+
+    it('accepts hello with identity and no token', () => {
+      const attachCalls: Array<{ sid: string; identity?: { login: string; github_id: string } }> = [];
+      const client = new TunnelClient({
+        url: 'wss://x',
+        // daemon-side token kept for legacy callers but not consulted in trust mode.
+        token: 'ignored-in-trust-mode',
+        onFrame: () => {},
+        wsFactory: factory,
+        onBrowserAttach: ({ sid, identity }) => {
+          attachCalls.push({ sid, identity });
+          return { onFrame: () => {}, onClose: () => {} };
+        },
+      });
+      client.start();
+      sockets[0].open();
+
+      sockets[0].pushText(JSON.stringify({
+        type: 'hello',
+        sid: 'sess-A',
+        lastSeq: 0,
+        identity: { login: 'octocat', github_id: '583231' },
+      }));
+
+      expect(sockets[0].closedCalls).toHaveLength(0);
+      expect(attachCalls).toEqual([
+        { sid: 'sess-A', identity: { login: 'octocat', github_id: '583231' } },
+      ]);
+      expect(client.getBrowserIdentity('sess-A')).toEqual({
+        login: 'octocat',
+        github_id: '583231',
+      });
+      // Legacy browserToken stays null when no token rode along.
+      expect(client.getBrowserToken()).toBeNull();
+    });
+
+    it('rejects hello with neither token nor identity (1008)', () => {
+      const client = new TunnelClient({
+        url: 'wss://x',
+        token: 't',
+        onFrame: () => {},
+        wsFactory: factory,
+      });
+      client.start();
+      sockets[0].open();
+
+      // Note: parseHello rejects {type:'hello'} with no token+no identity
+      // outright, so the daemon falls into the "malformed hello frame"
+      // close path. Either way the contract is the same: ws is closed 1008.
+      sockets[0].pushText(JSON.stringify({ type: 'hello', sid: 'sess-A' }));
+
+      expect(sockets[0].closedCalls).toHaveLength(1);
+      expect(sockets[0].closedCalls[0].code).toBe(1008);
+    });
+  });
+
+  it('legacy mode (CCSM_TRUST_TUNNEL unset): hello with token + no identity is accepted (back-compat)', () => {
+    const prior = process.env.CCSM_TRUST_TUNNEL;
+    delete process.env.CCSM_TRUST_TUNNEL;
+    try {
+      const frames: Array<Buffer | string> = [];
+      const client = new TunnelClient({
+        url: 'wss://x',
+        token: 'good',
+        onFrame: (d) => frames.push(d),
+        wsFactory: factory,
+      });
+      client.start();
+      sockets[0].open();
+      sockets[0].pushText(JSON.stringify({ type: 'hello', token: 'good' }));
+      expect(sockets[0].closedCalls).toHaveLength(0);
+      expect(client.getBrowserToken()).toBe('good');
+
+      sockets[0].pushText('after');
+      expect(frames).toEqual(['after']);
+    } finally {
+      if (prior !== undefined) process.env.CCSM_TRUST_TUNNEL = prior;
+    }
+  });
+
+  it('legacy mode: hello with identity but no token is rejected (1008) — env opt-in required', () => {
+    const prior = process.env.CCSM_TRUST_TUNNEL;
+    delete process.env.CCSM_TRUST_TUNNEL;
+    try {
+      const client = new TunnelClient({
+        url: 'wss://x',
+        token: 'good',
+        onFrame: () => {},
+        wsFactory: factory,
+      });
+      client.start();
+      sockets[0].open();
+
+      sockets[0].pushText(JSON.stringify({
+        type: 'hello',
+        sid: 'sess-A',
+        identity: { login: 'octocat', github_id: '583231' },
+      }));
+
+      expect(sockets[0].closedCalls).toHaveLength(1);
+      expect(sockets[0].closedCalls[0].code).toBe(1008);
+    } finally {
+      if (prior !== undefined) process.env.CCSM_TRUST_TUNNEL = prior;
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Hello frame extends with optional `identity: {login, github_id}` (Task #133 / S4-T6).
- Daemon: `CCSM_TRUST_TUNNEL=1` accepts identity-only hellos (cloud-authenticated). Legacy mode (default) still requires token, ignores identity → safe back-compat with smoke + older daemons.
- cf-worker: `buildHelloFrame` accepts optional identity; `BrowserAttachment.identity` records it. T6 emits identity undefined — OAuth wire-up lands in T3/T4.
- Daemon exposes `getBrowserIdentity(sid)` + surfaces identity on `BrowserAttachInfo` so T8 SPA can pick it up without re-reading auth.mts.

Out-of-scope per task spec: OAuth flow (T3/T4), `getBrowserSocket(sid)` routing (T5), legacy `requireAuth` HTTP path, frontend / Tauri.

## Local checks (host: Windows 11, mode: fast)
- lint: ✓ (exit 0, daemon + cf-worker)
- typecheck: ✓ (exit 0, @ccsm/daemon + @ccsm/cf-worker + @ccsm/shared)
- build: ✓ (@ccsm/shared, @ccsm/core built locally to satisfy daemon import resolution)
- unit tests:
  - `pnpm --filter @ccsm/daemon test` → 158 passed / 1 skipped (was 155; +3 trust-tunnel cases)
  - `pnpm --filter @ccsm/cf-worker test` → 54 passed (was 53; +1 wire shape stability)
- e2e: skipped — change is wire-format additive on the daemon↔DO tunnel, no e2e harness exercises trust-mode env yet (T8 will).

## Test plan
- [x] daemon: `CCSM_TRUST_TUNNEL=1` + hello with identity (no token) → accept, identity surfaced via `getBrowserIdentity`/attach info
- [x] daemon: `CCSM_TRUST_TUNNEL=1` + hello with no token + no identity → 1008
- [x] daemon: env unset + hello with token (no identity) → accept (back-compat)
- [x] daemon: env unset + hello with identity but no token → 1008 (env opt-in required)
- [x] cf-worker: hello frame omits `identity` when cloud identity unknown (no `null` regression)
- [x] cf-worker existing 53 tests + daemon existing 155 tests untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)