### PR TITLE
feat(ui): Task #137 — DaemonStatusOverlay UI (replaces #112-T3 stub)

### DIFF
--- a/packages/ui/src/components/DaemonStatusOverlay.tsx
+++ b/packages/ui/src/components/DaemonStatusOverlay.tsx
@@ -29,8 +29,14 @@ export type DaemonStatusVariant = 'info' | 'error' | 'auth';
 export interface DaemonStatusPhase {
   phase: string;
   reason?: string;
-  code?: number;
-  retryInMs?: number;
+  // Mirrors `exited.code: Option<i32>` Rust wire shape (null = absent).
+  code?: number | null;
+  // Mirrors the Rust `Option<u64>` wire shape on `spawnFailed.retryInMs`,
+  // which serializes to JSON `null` when absent. Frontend-tauri's
+  // DaemonPhase['spawnFailed'] declares `retryInMs: number | null`, so this
+  // prop type accepts both `null` (wire absent) and `undefined` (other phases
+  // that omit the field entirely).
+  retryInMs?: number | null;
   verificationUri?: string;
   userCode?: string;
   expiresAt?: number;

--- a/packages/ui/src/components/DaemonStatusOverlay.tsx
+++ b/packages/ui/src/components/DaemonStatusOverlay.tsx
@@ -1,72 +1,342 @@
-// Task #112-T3: minimal pre-Ready overlay. Renders while the daemon has not
-// reached `Ready` yet so the user sees something instead of a black screen.
-// T4 owns the polished visuals; this stub only proves the wiring.
+// Task #137 / #112-T4: full UI for the pre-Ready / failure / auth overlay.
+// Replaces the T3 stub. Renders for any non-Ready daemon phase so the user
+// sees something instead of a black screen. Styles live in `styles.css`
+// alongside the rest of @ccsm/ui (the package builds via `tsc` only, so
+// CSS modules — which the spec hinted at — would not survive build; we
+// follow the existing BEM-in-styles.css convention instead).
+//
+// Phase coverage (matches frontend-tauri DaemonPhase discriminator):
+//   notSpawned / spawning / starting       → spinner + "Starting daemon..."
+//   tunnelDisconnected                     → spinner + "Connecting to cloud..."
+//   tunnelConnected                        → spinner + "Tunnel connected..."
+//   ready                                  → null (the real app takes over)
+//   spawnFailed { reason, retryInMs? }     → red banner + retry countdown
+//   exited { code, reason }                → red banner
+//   awaitingAuth { verificationUri,        → auth panel + Open browser btn
+//                  userCode, expiresAt? }
+//   authFailed { reason }                  → red banner + Try again btn
+//
+// The `View logs`, `Open browser`, and `Try again` buttons are wired to
+// console.log only — real IPC lands in S4-T8.
 
-import type { ReactNode } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 
 export type DaemonStatusVariant = 'info' | 'error' | 'auth';
 
-// Loose phase shape: this component is rendered by the Tauri shell for any
-// non-Ready phase. We only read `.phase` (the discriminator) and a couple of
-// optional fields, so we keep the type minimal here to avoid pulling shell
-// types into @ccsm/ui.
+// Loose phase shape: we only read the discriminator + a handful of optional
+// fields, keeping this independent from the shell's full DaemonPhase union
+// so @ccsm/ui doesn't pull in shell types.
 export interface DaemonStatusPhase {
   phase: string;
   reason?: string;
+  code?: number;
+  retryInMs?: number;
   verificationUri?: string;
   userCode?: string;
+  expiresAt?: number;
 }
 
 export interface DaemonStatusOverlayProps {
   phase: DaemonStatusPhase;
+  /**
+   * Optional override. When omitted the variant is inferred from
+   * phase.phase (failure phases → 'error', awaitingAuth → 'auth',
+   * everything else → 'info').
+   */
   variant?: DaemonStatusVariant;
 }
 
-const COLORS: Record<DaemonStatusVariant, { bg: string; fg: string }> = {
-  info: { bg: '#1e1e1e', fg: '#e6e6e6' },
-  error: { bg: '#3a1f1f', fg: '#f5d0d0' },
-  auth: { bg: '#1f2a3a', fg: '#d0e0f5' },
-};
-
-function describe(phase: DaemonStatusPhase): ReactNode {
-  switch (phase.phase) {
+function inferVariant(phase: string): DaemonStatusVariant {
+  switch (phase) {
     case 'spawnFailed':
-      return `Failed to start daemon: ${phase.reason ?? 'unknown'}`;
-    case 'authFailed':
-      return `Authentication failed: ${phase.reason ?? 'unknown'}`;
     case 'exited':
-      return `Daemon exited: ${phase.reason ?? 'unknown'}`;
+    case 'authFailed':
+      return 'error';
     case 'awaitingAuth':
-      return `Awaiting authentication. Visit ${phase.verificationUri ?? ''} and enter ${phase.userCode ?? ''}.`;
+      return 'auth';
     default:
-      return `Phase: ${phase.phase}`;
+      return 'info';
   }
+}
+
+function Spinner(): ReactNode {
+  return (
+    <span
+      className="daemon-overlay__spinner"
+      data-testid="daemon-status-overlay-spinner"
+      aria-hidden="true"
+    />
+  );
+}
+
+interface RetryCountdownProps {
+  retryInMs: number;
+}
+
+/**
+ * Local ticking countdown. We snapshot retryInMs once on mount and tick
+ * it down every second; the parent prop is treated as the initial value
+ * so re-renders driven by other state don't reset the clock.
+ */
+function RetryCountdown({ retryInMs }: RetryCountdownProps): ReactNode {
+  const [remaining, setRemaining] = useState(retryInMs);
+  useEffect(() => {
+    setRemaining(retryInMs);
+  }, [retryInMs]);
+  useEffect(() => {
+    if (remaining <= 0) return;
+    const t = setInterval(() => {
+      setRemaining((r) => Math.max(0, r - 1000));
+    }, 1000);
+    return () => clearInterval(t);
+  }, [remaining]);
+  const seconds = Math.ceil(remaining / 1000);
+  if (seconds <= 0) {
+    return (
+      <span
+        className="daemon-overlay__retry"
+        data-testid="daemon-status-overlay-retry"
+      >
+        Retrying now…
+      </span>
+    );
+  }
+  return (
+    <span
+      className="daemon-overlay__retry"
+      data-testid="daemon-status-overlay-retry"
+    >
+      Retrying in {seconds}s…
+    </span>
+  );
+}
+
+function StartingBody({ message }: { message: string }): ReactNode {
+  return (
+    <div
+      className="daemon-overlay__row"
+      data-testid="daemon-status-overlay-loading"
+    >
+      <Spinner />
+      <span className="daemon-overlay__message">{message}</span>
+    </div>
+  );
+}
+
+interface ErrorBannerProps {
+  title: string;
+  detail?: string;
+  retryInMs?: number;
+  actionLabel: string;
+  onAction: () => void;
+  actionTestId: string;
+}
+
+function ErrorBanner(props: ErrorBannerProps): ReactNode {
+  const { title, detail, retryInMs, actionLabel, onAction, actionTestId } =
+    props;
+  return (
+    <div
+      className="daemon-overlay__banner daemon-overlay__banner--error"
+      role="alert"
+      data-testid="daemon-status-overlay-banner"
+    >
+      <h2 className="daemon-overlay__title">{title}</h2>
+      {detail !== undefined && detail !== '' ? (
+        <p
+          className="daemon-overlay__detail"
+          data-testid="daemon-status-overlay-detail"
+        >
+          {detail}
+        </p>
+      ) : null}
+      {typeof retryInMs === 'number' && retryInMs > 0 ? (
+        <RetryCountdown retryInMs={retryInMs} />
+      ) : null}
+      <div className="daemon-overlay__actions">
+        <button
+          type="button"
+          className="daemon-overlay__btn"
+          onClick={onAction}
+          data-testid={actionTestId}
+        >
+          {actionLabel}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface AuthPanelProps {
+  verificationUri: string;
+  userCode: string;
+  expiresAt?: number;
+}
+
+function AuthPanel({
+  verificationUri,
+  userCode,
+  expiresAt,
+}: AuthPanelProps): ReactNode {
+  const expiresText =
+    typeof expiresAt === 'number' && expiresAt > Date.now()
+      ? `Code expires in ${Math.max(
+          1,
+          Math.floor((expiresAt - Date.now()) / 60_000),
+        )} min`
+      : null;
+  return (
+    <div
+      className="daemon-overlay__banner daemon-overlay__banner--auth"
+      role="dialog"
+      aria-label="Sign in with GitHub"
+      data-testid="daemon-status-overlay-auth"
+    >
+      <h2 className="daemon-overlay__title">Sign in with GitHub</h2>
+      <p className="daemon-overlay__detail">
+        Visit{' '}
+        <span
+          className="daemon-overlay__uri"
+          data-testid="daemon-status-overlay-uri"
+        >
+          {verificationUri}
+        </span>{' '}
+        and enter the code below.
+      </p>
+      <div
+        className="daemon-overlay__user-code"
+        data-testid="daemon-status-overlay-user-code"
+      >
+        {userCode}
+      </div>
+      {expiresText !== null ? (
+        <p className="daemon-overlay__hint">{expiresText}</p>
+      ) : null}
+      <div className="daemon-overlay__actions">
+        <button
+          type="button"
+          className="daemon-overlay__btn"
+          onClick={() => {
+            // Real shell.open lands in S4-T8; logging is a placeholder so
+            // the click is observable in the dev console + by tests.
+            // eslint-disable-next-line no-console
+            console.log(
+              '[DaemonStatusOverlay] open browser:',
+              verificationUri,
+            );
+          }}
+          data-testid="daemon-status-overlay-open-browser"
+        >
+          Open browser
+        </button>
+      </div>
+    </div>
+  );
 }
 
 export function DaemonStatusOverlay({
   phase,
-  variant = 'info',
-}: DaemonStatusOverlayProps) {
-  const { bg, fg } = COLORS[variant];
+  variant,
+}: DaemonStatusOverlayProps): ReactNode {
+  // Ready is owned by the real app — overlay must collapse out of the way.
+  if (phase.phase === 'ready') {
+    return null;
+  }
+
+  const resolvedVariant: DaemonStatusVariant = variant ?? inferVariant(phase.phase);
+
+  let body: ReactNode;
+  switch (phase.phase) {
+    case 'notSpawned':
+    case 'spawning':
+    case 'starting':
+      body = <StartingBody message="Starting daemon…" />;
+      break;
+    case 'tunnelDisconnected':
+      body = <StartingBody message="Connecting to cloud…" />;
+      break;
+    case 'tunnelConnected':
+      body = <StartingBody message="Tunnel connected, waiting…" />;
+      break;
+    case 'spawnFailed':
+      body = (
+        <ErrorBanner
+          title="Daemon failed to start"
+          detail={phase.reason ?? 'Unknown error.'}
+          {...(typeof phase.retryInMs === 'number'
+            ? { retryInMs: phase.retryInMs }
+            : {})}
+          actionLabel="View logs"
+          actionTestId="daemon-status-overlay-view-logs"
+          onAction={() => {
+            // eslint-disable-next-line no-console
+            console.log('[DaemonStatusOverlay] view logs (spawnFailed)');
+          }}
+        />
+      );
+      break;
+    case 'exited': {
+      const codeText =
+        typeof phase.code === 'number' ? ` (code ${phase.code})` : '';
+      body = (
+        <ErrorBanner
+          title={`Daemon exited${codeText}`}
+          detail={phase.reason ?? 'Process terminated unexpectedly.'}
+          actionLabel="View logs"
+          actionTestId="daemon-status-overlay-view-logs"
+          onAction={() => {
+            // eslint-disable-next-line no-console
+            console.log('[DaemonStatusOverlay] view logs (exited)');
+          }}
+        />
+      );
+      break;
+    }
+    case 'awaitingAuth':
+      body = (
+        <AuthPanel
+          verificationUri={phase.verificationUri ?? ''}
+          userCode={phase.userCode ?? ''}
+          {...(typeof phase.expiresAt === 'number'
+            ? { expiresAt: phase.expiresAt }
+            : {})}
+        />
+      );
+      break;
+    case 'authFailed':
+      body = (
+        <ErrorBanner
+          title="Sign-in failed"
+          detail={phase.reason ?? 'Authentication did not complete.'}
+          actionLabel="Try again"
+          actionTestId="daemon-status-overlay-try-again"
+          onAction={() => {
+            // eslint-disable-next-line no-console
+            console.log('[DaemonStatusOverlay] try again (authFailed)');
+          }}
+        />
+      );
+      break;
+    default:
+      // Unknown phase — surface it instead of going blank, so an out-of-sync
+      // shell/daemon is debuggable in the wild.
+      body = <StartingBody message={`Phase: ${phase.phase}`} />;
+      break;
+  }
+
   return (
     <div
+      className={`daemon-overlay daemon-overlay--${resolvedVariant}`}
       data-testid="daemon-status-overlay"
-      data-variant={variant}
+      data-variant={resolvedVariant}
       data-phase={phase.phase}
-      style={{
-        position: 'fixed',
-        inset: 0,
-        background: bg,
-        color: fg,
-        padding: 24,
-        fontFamily: 'system-ui, sans-serif',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 8,
-      }}
+      role="status"
+      aria-live="polite"
     >
-      <h1 style={{ margin: 0, fontSize: 20 }}>ccsm</h1>
-      <p style={{ margin: 0, fontSize: 14 }}>{describe(phase)}</p>
+      <div className="daemon-overlay__inner">
+        <div className="daemon-overlay__brand">ccsm</div>
+        {body}
+      </div>
     </div>
   );
 }

--- a/packages/ui/src/styles.css
+++ b/packages/ui/src/styles.css
@@ -259,3 +259,168 @@ button {
   height: 100%;
   width: 100%;
 }
+
+/* DaemonStatusOverlay (Task #137 / #112-T4) — full-viewport pre-Ready panel
+ * shown by the Tauri shell while the daemon is starting / tunnel is
+ * reconnecting / auth is pending / startup has failed. */
+.daemon-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #0d0d0d;
+  color: #e5e5e5;
+  z-index: 10000;
+}
+
+.daemon-overlay--info {
+  background: #0d0d0d;
+  color: #e5e5e5;
+}
+
+.daemon-overlay--error {
+  background: #1a0d0d;
+  color: #f5d0d0;
+}
+
+.daemon-overlay--auth {
+  background: #0d141a;
+  color: #d0e0f5;
+}
+
+.daemon-overlay__inner {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 16px;
+  max-width: 480px;
+  width: 100%;
+}
+
+.daemon-overlay__brand {
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  opacity: 0.7;
+  text-transform: lowercase;
+}
+
+.daemon-overlay__row {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+}
+
+.daemon-overlay__message {
+  font-size: 14px;
+}
+
+.daemon-overlay__spinner {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-radius: 50%;
+  opacity: 0.8;
+  animation: daemon-overlay-spin 0.9s linear infinite;
+}
+
+@keyframes daemon-overlay-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.daemon-overlay__banner {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px 20px;
+  border-radius: 8px;
+  border: 1px solid currentColor;
+  width: 100%;
+}
+
+.daemon-overlay__banner--error {
+  border-color: #5a2424;
+  background: #2a1414;
+}
+
+.daemon-overlay__banner--auth {
+  border-color: #244a5a;
+  background: #14242a;
+}
+
+.daemon-overlay__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.daemon-overlay__detail {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+  word-break: break-word;
+}
+
+.daemon-overlay__hint {
+  margin: 0;
+  font-size: 12px;
+  opacity: 0.75;
+}
+
+.daemon-overlay__retry {
+  font-size: 12px;
+  opacity: 0.75;
+}
+
+.daemon-overlay__uri {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 13px;
+  word-break: break-all;
+}
+
+.daemon-overlay__user-code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  padding: 10px 14px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 6px;
+  user-select: all;
+}
+
+.daemon-overlay__actions {
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.daemon-overlay__btn {
+  appearance: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 6px;
+  padding: 6px 14px;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.daemon-overlay__btn:hover {
+  background: rgba(255, 255, 255, 0.14);
+}
+
+.daemon-overlay__btn:focus-visible {
+  outline: 2px solid #4a90e2;
+  outline-offset: 2px;
+}

--- a/packages/ui/test/DaemonStatusOverlay.test.tsx
+++ b/packages/ui/test/DaemonStatusOverlay.test.tsx
@@ -1,0 +1,184 @@
+// Task #137 / #112-T4: vitest + Testing Library coverage for the polished
+// DaemonStatusOverlay. Each phase asserts the visible contract (text +
+// testids + variant attribute + button onClick wiring).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
+
+import { DaemonStatusOverlay } from '../src/components/DaemonStatusOverlay';
+
+describe('DaemonStatusOverlay', () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    logSpy.mockRestore();
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  // --- loading phases ------------------------------------------------------
+
+  it.each([
+    ['notSpawned', 'Starting daemon'],
+    ['spawning', 'Starting daemon'],
+    ['starting', 'Starting daemon'],
+    ['tunnelDisconnected', 'Connecting to cloud'],
+    ['tunnelConnected', 'Tunnel connected'],
+  ])('renders spinner + status text for %s', (phaseName, fragment) => {
+    render(<DaemonStatusOverlay phase={{ phase: phaseName }} />);
+    const root = screen.getByTestId('daemon-status-overlay');
+    expect(root.getAttribute('data-phase')).toBe(phaseName);
+    expect(root.getAttribute('data-variant')).toBe('info');
+    expect(screen.getByTestId('daemon-status-overlay-spinner')).toBeDefined();
+    const loading = screen.getByTestId('daemon-status-overlay-loading');
+    expect(loading.textContent ?? '').toContain(fragment);
+  });
+
+  // --- Ready collapses to null --------------------------------------------
+
+  it('returns null when phase is ready (the real app takes over)', () => {
+    const { container } = render(
+      <DaemonStatusOverlay phase={{ phase: 'ready' }} />,
+    );
+    expect(container.querySelector('[data-testid="daemon-status-overlay"]')).toBeNull();
+    expect(container.firstChild).toBeNull();
+  });
+
+  // --- spawnFailed --------------------------------------------------------
+
+  it('renders error banner + reason for spawnFailed and logs on View logs click', () => {
+    render(
+      <DaemonStatusOverlay
+        phase={{ phase: 'spawnFailed', reason: 'binary not found' }}
+      />,
+    );
+    const root = screen.getByTestId('daemon-status-overlay');
+    expect(root.getAttribute('data-variant')).toBe('error');
+    const banner = screen.getByTestId('daemon-status-overlay-banner');
+    expect(banner.textContent ?? '').toContain('Daemon failed to start');
+    expect(
+      screen.getByTestId('daemon-status-overlay-detail').textContent,
+    ).toContain('binary not found');
+    fireEvent.click(screen.getByTestId('daemon-status-overlay-view-logs'));
+    expect(logSpy).toHaveBeenCalled();
+    const firstArg = String(logSpy.mock.calls[0]?.[0] ?? '');
+    expect(firstArg).toContain('view logs');
+  });
+
+  it('renders retry countdown when spawnFailed carries retryInMs', () => {
+    vi.useFakeTimers();
+    render(
+      <DaemonStatusOverlay
+        phase={{
+          phase: 'spawnFailed',
+          reason: 'crash',
+          retryInMs: 5000,
+        }}
+      />,
+    );
+    const retry = screen.getByTestId('daemon-status-overlay-retry');
+    expect(retry.textContent ?? '').toMatch(/Retrying in 5s/);
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(
+      screen.getByTestId('daemon-status-overlay-retry').textContent ?? '',
+    ).toMatch(/Retrying in 3s/);
+  });
+
+  it('omits the retry countdown when spawnFailed has no retryInMs', () => {
+    render(
+      <DaemonStatusOverlay
+        phase={{ phase: 'spawnFailed', reason: 'fatal' }}
+      />,
+    );
+    expect(screen.queryByTestId('daemon-status-overlay-retry')).toBeNull();
+  });
+
+  // --- exited -------------------------------------------------------------
+
+  it('renders exit code + reason for exited phase', () => {
+    render(
+      <DaemonStatusOverlay
+        phase={{ phase: 'exited', code: 137, reason: 'killed' }}
+      />,
+    );
+    const banner = screen.getByTestId('daemon-status-overlay-banner');
+    expect(banner.textContent ?? '').toContain('Daemon exited');
+    expect(banner.textContent ?? '').toContain('137');
+    expect(banner.textContent ?? '').toContain('killed');
+    fireEvent.click(screen.getByTestId('daemon-status-overlay-view-logs'));
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  // --- awaitingAuth -------------------------------------------------------
+
+  it('renders auth panel with verificationUri + userCode and logs on Open browser click', () => {
+    render(
+      <DaemonStatusOverlay
+        phase={{
+          phase: 'awaitingAuth',
+          verificationUri: 'https://github.com/login/device',
+          userCode: 'ABCD-1234',
+        }}
+      />,
+    );
+    const root = screen.getByTestId('daemon-status-overlay');
+    expect(root.getAttribute('data-variant')).toBe('auth');
+    expect(
+      screen.getByTestId('daemon-status-overlay-uri').textContent,
+    ).toContain('https://github.com/login/device');
+    expect(
+      screen.getByTestId('daemon-status-overlay-user-code').textContent,
+    ).toContain('ABCD-1234');
+    fireEvent.click(screen.getByTestId('daemon-status-overlay-open-browser'));
+    expect(logSpy).toHaveBeenCalled();
+    const firstArg = String(logSpy.mock.calls[0]?.[0] ?? '');
+    expect(firstArg).toContain('open browser');
+  });
+
+  // --- authFailed ---------------------------------------------------------
+
+  it('renders authFailed banner with Try again button that logs', () => {
+    render(
+      <DaemonStatusOverlay
+        phase={{ phase: 'authFailed', reason: 'token rejected' }}
+      />,
+    );
+    const root = screen.getByTestId('daemon-status-overlay');
+    expect(root.getAttribute('data-variant')).toBe('error');
+    expect(
+      screen.getByTestId('daemon-status-overlay-banner').textContent,
+    ).toContain('Sign-in failed');
+    expect(
+      screen.getByTestId('daemon-status-overlay-detail').textContent,
+    ).toContain('token rejected');
+    fireEvent.click(screen.getByTestId('daemon-status-overlay-try-again'));
+    expect(logSpy).toHaveBeenCalled();
+    const firstArg = String(logSpy.mock.calls[0]?.[0] ?? '');
+    expect(firstArg).toContain('try again');
+  });
+
+  // --- variant override ---------------------------------------------------
+
+  it('respects an explicit variant prop over the inferred default', () => {
+    render(
+      <DaemonStatusOverlay phase={{ phase: 'spawning' }} variant="error" />,
+    );
+    expect(
+      screen.getByTestId('daemon-status-overlay').getAttribute('data-variant'),
+    ).toBe('error');
+  });
+
+  // --- unknown phase fallback (defensive) ---------------------------------
+
+  it('shows a fallback message for unknown phase strings instead of going blank', () => {
+    render(<DaemonStatusOverlay phase={{ phase: 'mystery' }} />);
+    expect(screen.getByTestId('daemon-status-overlay')).toBeDefined();
+    expect(
+      screen.getByTestId('daemon-status-overlay-loading').textContent ?? '',
+    ).toContain('mystery');
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the `#112-T3` placeholder `DaemonStatusOverlay` in `@ccsm/ui` with the polished pre-Ready overlay rendered by the Tauri shell while the daemon is starting / tunnel is reconnecting / sign-in is pending / startup has failed.

Phase coverage (matches the shell's `DaemonPhase` discriminator):

- `notSpawned` / `spawning` / `starting` — spinner + "Starting daemon…"
- `tunnelDisconnected` — spinner + "Connecting to cloud…" (info variant, does not block local Tauri use)
- `tunnelConnected` — spinner + "Tunnel connected, waiting…"
- `ready` — returns `null` so the real app takes over
- `spawnFailed { reason, retryInMs? }` — red banner + reason + ticking retry countdown + **View logs** button
- `exited { code, reason }` — red banner with `Daemon exited (code N)` + reason + **View logs**
- `awaitingAuth { verificationUri, userCode, expiresAt? }` — auth panel with a copyable user code + **Open browser** button (S4-T8 wires real IPC)
- `authFailed { reason }` — red banner + **Try again** button

`View logs`, `Open browser`, and `Try again` are wired to `console.log` only per the task spec — real IPC ships in S4-T8.

### Style location (deviation from spec note)

Spec hinted at a `DaemonStatusOverlay.module.css` CSS module. I appended the styles to `packages/ui/src/styles.css` (BEM `.daemon-overlay__*`) instead because:

1. `@ccsm/ui` builds via `tsc -p tsconfig.json` only — a `.module.css` would not survive the build (no CSS pipeline, no module typings).
2. Zero other component in this package uses CSS modules; consumers already import `@ccsm/ui/styles.css`, so this lands the styles on the same conventional path.
3. Adding a CSS module setup (loaders, `.d.ts` shim, asset copy step) would touch build infra outside this task's scope and add a "new abstraction" the spec also told me not to introduce.

The component does not import any new npm dep — pure React + existing setup.

## Test plan

- [x] `npm run lint` (ui)
- [x] `npm run typecheck` (ui)
- [x] `npm run build` (ui)
- [x] `npm test` (ui) — 6 files / 54 tests pass, including the new 14 specs in `DaemonStatusOverlay.test.tsx`
- [x] No changes to `frontend-tauri` (`DaemonStateProvider` / `PhaseSwitch` untouched)
- [x] No changes to daemon / cf-worker

## Local checks (host: Windows 11, mode: fast)

- lint: ✓ (exit 0)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0, `tsc -p tsconfig.json`)
- unit tests: ✓ — \`vitest run\` for \`@ccsm/ui\`:
  \`\`\`
  Test Files  6 passed (6)
       Tests  54 passed (54)
    Duration  25.20s
  \`\`\`
  New file \`test/DaemonStatusOverlay.test.tsx\`: 14 tests passed.
- e2e: skipped, change is UI-only inside @ccsm/ui and does not touch any electron/tauri e2e harness; full e2e matrix runs on CI.