### PR TITLE
feat(cf-worker): Task #142 — GitHub device flow + tunnel refresh routes (S4-T4)

### DIFF
--- a/packages/cf-worker/src/auth/deviceFlow.ts
+++ b/packages/cf-worker/src/auth/deviceFlow.ts
@@ -1,0 +1,354 @@
+/**
+ * S4-T4 (Task #142): cf-worker GitHub Device Flow handlers.
+ *
+ * Used by the Tauri/daemon side to obtain a tunnel JWT without opening a
+ * browser tab in the renderer. Three endpoints land here:
+ *
+ *   POST /api/auth/device/start
+ *     — kicks off device flow with GitHub
+ *       (https://github.com/login/device/code), returns the user_code +
+ *       verification_uri + device_code + polling interval to the caller.
+ *
+ *   POST /api/auth/device/poll      body: { device_code }
+ *     — polls GitHub's token endpoint with the
+ *       urn:ietf:params:oauth:grant-type:device_code grant. Maps the GitHub
+ *       error vocabulary onto a stable `{status: ...}` JSON envelope so the
+ *       Tauri side can drive a state machine without parsing GitHub's wire
+ *       format directly. On success: persists user, mints a tunnel JWT
+ *       (kind='tunnel', 24h) + a 32-byte opaque tunnel refresh token (hash
+ *       stored in UserDO under a separate key from web refresh).
+ *
+ *   POST /api/auth/tunnel/refresh   body: { tunnel_refresh_token }
+ *     — verifies the SHA-256 hash against the UserDO tunnel-refresh slot,
+ *       rotates: writes a new hash and returns a new tunnel JWT + new
+ *       opaque refresh token. Old hash no longer verifies after rotation.
+ *
+ * Tunnel refresh is intentionally rotated on every refresh (vs. T3 web
+ * refresh which keeps the same hash). The daemon already persists tokens
+ * to disk, so rotation here is cheap and gives us replay protection.
+ *
+ * NOT in scope: the actual TunnelDO routing of the resulting JWT (T5).
+ */
+import type { AuthEnv } from './bindings';
+import { signJwt, type TunnelJwtClaims } from './jwt';
+
+const GH_DEVICE_CODE_URL = 'https://github.com/login/device/code';
+const GH_TOKEN_URL = 'https://github.com/login/oauth/access_token';
+const GH_USER_URL = 'https://api.github.com/user';
+
+const TUNNEL_JWT_TTL_SEC = 60 * 60 * 24; // 24h
+const DEVICE_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code';
+
+function bytesToHex(bytes: Uint8Array): string {
+  let s = '';
+  for (let i = 0; i < bytes.length; i++) s += bytes[i]!.toString(16).padStart(2, '0');
+  return s;
+}
+
+function randomHex(byteLen: number): string {
+  const buf = new Uint8Array(byteLen);
+  crypto.getRandomValues(buf);
+  return bytesToHex(buf);
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(input));
+  return bytesToHex(new Uint8Array(digest));
+}
+
+interface GithubDeviceCodeResponse {
+  device_code?: string;
+  user_code?: string;
+  verification_uri?: string;
+  expires_in?: number;
+  interval?: number;
+  error?: string;
+}
+
+interface GithubTokenPollResponse {
+  access_token?: string;
+  token_type?: string;
+  scope?: string;
+  error?: string;
+  error_description?: string;
+  interval?: number;
+}
+
+interface GithubUserResponse {
+  id?: number;
+  login?: string;
+}
+
+/**
+ * POST /api/auth/device/start — proxy to GitHub's device-code endpoint and
+ * pass the returned user_code / verification_uri back to the caller.
+ */
+export async function handleDeviceStart(req: Request, env: AuthEnv): Promise<Response> {
+  void req;
+  const ghRes = await fetch(GH_DEVICE_CODE_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body: new URLSearchParams({
+      client_id: env.GITHUB_OAUTH_CLIENT_ID,
+      scope: 'read:user',
+    }).toString(),
+  });
+  if (!ghRes.ok) {
+    return new Response('github device/code failed', { status: 502 });
+  }
+  const json = (await ghRes.json()) as GithubDeviceCodeResponse;
+  if (
+    typeof json.device_code !== 'string' ||
+    typeof json.user_code !== 'string' ||
+    typeof json.verification_uri !== 'string' ||
+    typeof json.expires_in !== 'number' ||
+    typeof json.interval !== 'number'
+  ) {
+    return new Response('github device/code malformed', { status: 502 });
+  }
+  return Response.json({
+    device_code: json.device_code,
+    user_code: json.user_code,
+    verification_uri: json.verification_uri,
+    expires_in: json.expires_in,
+    interval: json.interval,
+  });
+}
+
+/**
+ * POST /api/auth/device/poll — single-shot poll. Caller drives the loop
+ * (Tauri-side); we just translate the GitHub response into a stable shape.
+ */
+export async function handleDevicePoll(req: Request, env: AuthEnv): Promise<Response> {
+  let body: { device_code?: unknown };
+  try {
+    body = (await req.json()) as { device_code?: unknown };
+  } catch {
+    return new Response('bad json', { status: 400 });
+  }
+  if (typeof body.device_code !== 'string' || body.device_code.length === 0) {
+    return new Response('missing device_code', { status: 400 });
+  }
+  const deviceCode = body.device_code;
+
+  const tokenRes = await fetch(GH_TOKEN_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      Accept: 'application/json',
+    },
+    body: new URLSearchParams({
+      client_id: env.GITHUB_OAUTH_CLIENT_ID,
+      client_secret: env.GITHUB_OAUTH_CLIENT_SECRET,
+      device_code: deviceCode,
+      grant_type: DEVICE_GRANT_TYPE,
+    }).toString(),
+  });
+  if (!tokenRes.ok) {
+    return new Response('github device token poll failed', { status: 502 });
+  }
+  const tokenJson = (await tokenRes.json()) as GithubTokenPollResponse;
+
+  // Pending / slow_down / expired / denied — translate.
+  if (tokenJson.error) {
+    switch (tokenJson.error) {
+      case 'authorization_pending':
+        return Response.json({ status: 'pending', interval: tokenJson.interval });
+      case 'slow_down':
+        // Honor the new interval GitHub gave us.
+        return Response.json({ status: 'slow_down', interval: tokenJson.interval });
+      case 'expired_token':
+        return new Response(JSON.stringify({ status: 'expired' }), {
+          status: 410,
+          headers: { 'content-type': 'application/json' },
+        });
+      case 'access_denied':
+        return new Response(JSON.stringify({ status: 'denied' }), {
+          status: 403,
+          headers: { 'content-type': 'application/json' },
+        });
+      default:
+        return new Response(
+          JSON.stringify({ status: 'error', error: tokenJson.error }),
+          { status: 502, headers: { 'content-type': 'application/json' } },
+        );
+    }
+  }
+
+  if (typeof tokenJson.access_token !== 'string' || tokenJson.access_token.length === 0) {
+    return new Response('github device token response malformed', { status: 502 });
+  }
+  const accessToken = tokenJson.access_token;
+
+  // Fetch the GitHub user identity.
+  const userRes = await fetch(GH_USER_URL, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: 'application/vnd.github+json',
+      'User-Agent': 'ccsm-cf-worker',
+    },
+  });
+  if (!userRes.ok) {
+    return new Response('github user fetch failed', { status: 502 });
+  }
+  const userJson = (await userRes.json()) as GithubUserResponse;
+  if (typeof userJson.id !== 'number' || typeof userJson.login !== 'string') {
+    return new Response('github user response malformed', { status: 502 });
+  }
+  const githubId = String(userJson.id);
+  const login = userJson.login;
+
+  // Persist into UserDO.
+  const userDoStub = env.USER_DO.get(env.USER_DO.idFromName(login));
+  const setLoginRes = await userDoStub.fetch(
+    new Request('https://do/setLogin', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ github_id: githubId, login }),
+    }),
+  );
+  if (!setLoginRes.ok) {
+    return new Response('userDO setLogin failed', { status: 500 });
+  }
+
+  // Mint tunnel refresh token + persist hash under the tunnel slot.
+  const tunnelRefreshToken = randomHex(32);
+  const tunnelRefreshHash = await sha256Hex(tunnelRefreshToken);
+  const setHashRes = await userDoStub.fetch(
+    new Request('https://do/setTunnelRefreshTokenHash', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ hash: tunnelRefreshHash }),
+    }),
+  );
+  if (!setHashRes.ok) {
+    return new Response('userDO setTunnelRefreshTokenHash failed', { status: 500 });
+  }
+
+  // Mint tunnel JWT.
+  const iat = Math.floor(Date.now() / 1000);
+  const claims: TunnelJwtClaims = {
+    sub: githubId,
+    login,
+    iat,
+    exp: iat + TUNNEL_JWT_TTL_SEC,
+    kind: 'tunnel',
+    jti: randomHex(16),
+  };
+  const tunnelJwt = await signJwt(claims, env.JWT_SIGNING_KEY);
+
+  return Response.json({
+    tunnel_jwt: tunnelJwt,
+    tunnel_refresh_token: tunnelRefreshToken,
+    login,
+  });
+}
+
+/**
+ * POST /api/auth/tunnel/refresh — verify the tunnel refresh token, rotate it,
+ * mint a fresh tunnel JWT.
+ *
+ * Body: { tunnel_refresh_token, login }. We need `login` because UserDO is
+ * keyed by login (idFromName); the refresh token alone has no identity. The
+ * daemon persists `login` alongside the refresh token at device-poll success.
+ */
+export async function handleTunnelRefresh(req: Request, env: AuthEnv): Promise<Response> {
+  let body: { tunnel_refresh_token?: unknown; login?: unknown };
+  try {
+    body = (await req.json()) as { tunnel_refresh_token?: unknown; login?: unknown };
+  } catch {
+    return new Response('bad json', { status: 400 });
+  }
+  if (
+    typeof body.tunnel_refresh_token !== 'string' ||
+    body.tunnel_refresh_token.length === 0 ||
+    typeof body.login !== 'string' ||
+    body.login.length === 0
+  ) {
+    return new Response('missing tunnel_refresh_token or login', { status: 400 });
+  }
+  const oldToken = body.tunnel_refresh_token;
+  const login = body.login;
+
+  const userDoStub = env.USER_DO.get(env.USER_DO.idFromName(login));
+
+  const oldHash = await sha256Hex(oldToken);
+  const verifyRes = await userDoStub.fetch(
+    new Request('https://do/verifyTunnelRefreshTokenHash', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ hash: oldHash }),
+    }),
+  );
+  if (!verifyRes.ok) {
+    return new Response('tunnel refresh verify failed', { status: 500 });
+  }
+  const verifyJson = (await verifyRes.json()) as { ok?: boolean };
+  if (verifyJson.ok !== true) {
+    return new Response('invalid tunnel refresh token', { status: 401 });
+  }
+
+  // Look up the canonical github_id.
+  const getLoginRes = await userDoStub.fetch(new Request('https://do/getLogin'));
+  if (getLoginRes.status === 404) {
+    return new Response('user not found', { status: 401 });
+  }
+  if (!getLoginRes.ok) {
+    return new Response('userDO getLogin failed', { status: 500 });
+  }
+  const rec = (await getLoginRes.json()) as { github_id: string; login: string };
+
+  // Rotate: new opaque refresh + new hash. Writing the new hash overwrites
+  // the old one, so the old token can no longer pass verifyTunnelRefreshTokenHash.
+  const newToken = randomHex(32);
+  const newHash = await sha256Hex(newToken);
+  const setHashRes = await userDoStub.fetch(
+    new Request('https://do/setTunnelRefreshTokenHash', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ hash: newHash }),
+    }),
+  );
+  if (!setHashRes.ok) {
+    return new Response('userDO setTunnelRefreshTokenHash failed', { status: 500 });
+  }
+
+  const iat = Math.floor(Date.now() / 1000);
+  const claims: TunnelJwtClaims = {
+    sub: rec.github_id,
+    login: rec.login,
+    iat,
+    exp: iat + TUNNEL_JWT_TTL_SEC,
+    kind: 'tunnel',
+    jti: randomHex(16),
+  };
+  const tunnelJwt = await signJwt(claims, env.JWT_SIGNING_KEY);
+
+  return Response.json({
+    tunnel_jwt: tunnelJwt,
+    tunnel_refresh_token: newToken,
+  });
+}
+
+/**
+ * Top-level dispatch for the device-flow + tunnel-refresh prefix. Returns
+ * null when the path is not ours so the caller (index.ts) can fall through
+ * to the web OAuth dispatcher.
+ */
+export async function dispatchDevice(req: Request, env: AuthEnv): Promise<Response | null> {
+  const url = new URL(req.url);
+  const path = url.pathname;
+  if (req.method === 'POST' && path === '/api/auth/device/start') {
+    return handleDeviceStart(req, env);
+  }
+  if (req.method === 'POST' && path === '/api/auth/device/poll') {
+    return handleDevicePoll(req, env);
+  }
+  if (req.method === 'POST' && path === '/api/auth/tunnel/refresh') {
+    return handleTunnelRefresh(req, env);
+  }
+  return null;
+}

--- a/packages/cf-worker/src/auth/userDO.ts
+++ b/packages/cf-worker/src/auth/userDO.ts
@@ -26,6 +26,7 @@ import type { AuthEnv } from './bindings';
 const KEY_GITHUB_ID = 'github_id';
 const KEY_LOGIN = 'login';
 const KEY_REFRESH_HASH = 'refresh_token_hash';
+const KEY_TUNNEL_REFRESH_HASH = 'tunnel_refresh_hash';
 const KEY_CREATED_AT = 'created_at';
 
 export interface UserLoginRecord {
@@ -91,6 +92,27 @@ export class UserDO extends DurableObject<AuthEnv> {
   }
 
   /**
+   * S4-T4 (Task #142): tunnel-side refresh-token hash. Stored under a
+   * separate key from the web refresh hash so the two flows are independent
+   * (revoking web doesn't kill the daemon, and vice versa). Caller hashes.
+   */
+  async setTunnelRefreshTokenHash(hash: string): Promise<void> {
+    await this.storage.put(KEY_TUNNEL_REFRESH_HASH, hash);
+  }
+
+  /** Constant-time-ish compare against the stored tunnel-refresh hash. */
+  async verifyTunnelRefreshTokenHash(hash: string): Promise<boolean> {
+    const stored = await this.storage.get<string>(KEY_TUNNEL_REFRESH_HASH);
+    if (stored === undefined) return false;
+    if (stored.length !== hash.length) return false;
+    let mismatch = 0;
+    for (let i = 0; i < stored.length; i++) {
+      mismatch |= stored.charCodeAt(i) ^ hash.charCodeAt(i);
+    }
+    return mismatch === 0;
+  }
+
+  /**
    * Internal RPC fetch handler. Other Worker code calls
    * `env.USER_DO.get(id).fetch(new Request('https://do/<method>', ...))`.
    *
@@ -128,6 +150,22 @@ export class UserDO extends DurableObject<AuthEnv> {
           return new Response('bad request', { status: 400 });
         }
         const ok = await this.verifyRefreshTokenHash(body.hash);
+        return Response.json({ ok });
+      }
+      if (req.method === 'POST' && path === '/setTunnelRefreshTokenHash') {
+        const body = await req.json<{ hash?: unknown }>();
+        if (typeof body.hash !== 'string') {
+          return new Response('bad request', { status: 400 });
+        }
+        await this.setTunnelRefreshTokenHash(body.hash);
+        return new Response(null, { status: 204 });
+      }
+      if (req.method === 'POST' && path === '/verifyTunnelRefreshTokenHash') {
+        const body = await req.json<{ hash?: unknown }>();
+        if (typeof body.hash !== 'string') {
+          return new Response('bad request', { status: 400 });
+        }
+        const ok = await this.verifyTunnelRefreshTokenHash(body.hash);
         return Response.json({ ok });
       }
       if (req.method === 'POST' && path === '/revoke') {

--- a/packages/cf-worker/src/index.ts
+++ b/packages/cf-worker/src/index.ts
@@ -18,6 +18,7 @@ export { TunnelDO } from './tunnel-do';
 export { UserDO } from './auth/userDO';
 
 import { dispatchAuth } from './auth/webOauth';
+import { dispatchDevice } from './auth/deviceFlow';
 
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
@@ -42,6 +43,9 @@ export default {
     // directly and read/write UserDO. Routing them before the TunnelDO
     // /api/* branch ensures /api/auth/* never reaches the daemon path.
     if (url.pathname.startsWith('/api/auth/')) {
+      // S4-T4 (Task #142): device flow + tunnel refresh land here first.
+      const devRes = await dispatchDevice(req, env);
+      if (devRes !== null) return devRes;
       const authRes = await dispatchAuth(req, env);
       if (authRes !== null) return authRes;
       // Path under /api/auth/ but not ours (e.g. wrong method) → 404.

--- a/packages/cf-worker/test/deviceFlow.test.ts
+++ b/packages/cf-worker/test/deviceFlow.test.ts
@@ -1,0 +1,497 @@
+/**
+ * S4-T4 (Task #142): GitHub Device Flow handler tests.
+ *
+ * Mocks `globalThis.fetch` with the GitHub device-flow shape, drives the
+ * three handlers + dispatcher:
+ *   - device/start happy path
+ *   - device/poll: pending → success state machine
+ *   - device/poll: slow_down honors GitHub's new interval
+ *   - device/poll: expired_token (410) + access_denied (403)
+ *   - tunnel/refresh: rotation invalidates the old refresh token
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  dispatchDevice,
+  handleDeviceStart,
+  handleDevicePoll,
+  handleTunnelRefresh,
+} from '../src/auth/deviceFlow';
+import type { AuthEnv } from '../src/auth/bindings';
+import { verifyJwt, type TunnelJwtClaims } from '../src/auth/jwt';
+
+const KEY_HEX =
+  '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff';
+
+interface UserDoState {
+  github_id?: string;
+  login?: string;
+  refresh_hash?: string;
+  tunnel_refresh_hash?: string;
+  created_at?: number;
+}
+
+interface UserDoFake {
+  state: UserDoState;
+  stub: { fetch: (req: Request) => Promise<Response> };
+}
+
+function makeUserDo(): UserDoFake {
+  const state: UserDoState = {};
+  const stub = {
+    async fetch(req: Request): Promise<Response> {
+      const url = new URL(req.url);
+      const path = url.pathname;
+      if (req.method === 'POST' && path === '/setLogin') {
+        const body = (await req.json()) as { github_id: string; login: string };
+        state.github_id = body.github_id;
+        state.login = body.login;
+        if (state.created_at === undefined) state.created_at = Math.floor(Date.now() / 1000);
+        return new Response(null, { status: 204 });
+      }
+      if (req.method === 'POST' && path === '/setTunnelRefreshTokenHash') {
+        const body = (await req.json()) as { hash: string };
+        state.tunnel_refresh_hash = body.hash;
+        return new Response(null, { status: 204 });
+      }
+      if (req.method === 'POST' && path === '/verifyTunnelRefreshTokenHash') {
+        const body = (await req.json()) as { hash: string };
+        const ok =
+          state.tunnel_refresh_hash !== undefined &&
+          state.tunnel_refresh_hash === body.hash;
+        return Response.json({ ok });
+      }
+      if (req.method === 'GET' && path === '/getLogin') {
+        if (
+          state.github_id === undefined ||
+          state.login === undefined ||
+          state.created_at === undefined
+        ) {
+          return new Response('not found', { status: 404 });
+        }
+        return Response.json({
+          github_id: state.github_id,
+          login: state.login,
+          created_at: state.created_at,
+        });
+      }
+      return new Response('not found', { status: 404 });
+    },
+  };
+  return { state, stub };
+}
+
+function makeEnv(userDo: UserDoFake): AuthEnv {
+  return {
+    TUNNEL: undefined as unknown as DurableObjectNamespace,
+    GITHUB_OAUTH_CLIENT_ID: 'test-client-id',
+    GITHUB_OAUTH_CLIENT_SECRET: 'test-client-secret',
+    JWT_SIGNING_KEY: KEY_HEX,
+    JWT_REFRESH_SIGNING_KEY: KEY_HEX,
+    USER_DO: {
+      idFromName: (_name: string) => ({ name: _name }) as unknown as DurableObjectId,
+      get: (_id: DurableObjectId) => userDo.stub as unknown as DurableObjectStub,
+    } as unknown as DurableObjectNamespace,
+  } as AuthEnv;
+}
+
+let realFetch: typeof fetch;
+
+beforeEach(() => {
+  realFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+/**
+ * Sequence-driven GitHub mock. Each call to a given URL pops the next
+ * response off the queue for that URL. Throws if the queue is empty so we
+ * see "unexpected extra call" instead of silent reuse.
+ */
+function makeGithubFetch(routes: Record<string, Array<() => Response | Promise<Response>>>): ReturnType<typeof vi.fn> {
+  const fn = vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    for (const prefix of Object.keys(routes)) {
+      if (url.startsWith(prefix)) {
+        const next = routes[prefix]!.shift();
+        if (!next) throw new Error('unexpected extra call to ' + prefix);
+        return await next();
+      }
+    }
+    throw new Error('unmocked fetch ' + url);
+  });
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+describe('handleDeviceStart', () => {
+  it('proxies github device/code response on happy path', async () => {
+    makeGithubFetch({
+      'https://github.com/login/device/code': [
+        () =>
+          Response.json({
+            device_code: 'devcode-xyz',
+            user_code: 'WDJB-MJHT',
+            verification_uri: 'https://github.com/login/device',
+            expires_in: 900,
+            interval: 5,
+          }),
+      ],
+    });
+    const env = makeEnv(makeUserDo());
+    const res = await handleDeviceStart(
+      new Request('https://example/api/auth/device/start', { method: 'POST' }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.device_code).toBe('devcode-xyz');
+    expect(body.user_code).toBe('WDJB-MJHT');
+    expect(body.verification_uri).toBe('https://github.com/login/device');
+    expect(body.expires_in).toBe(900);
+    expect(body.interval).toBe(5);
+  });
+
+  it('502s when github device/code returns malformed body', async () => {
+    makeGithubFetch({
+      'https://github.com/login/device/code': [
+        () => Response.json({ user_code: 'oops-no-device-code' }),
+      ],
+    });
+    const env = makeEnv(makeUserDo());
+    const res = await handleDeviceStart(
+      new Request('https://example/api/auth/device/start', { method: 'POST' }),
+      env,
+    );
+    expect(res.status).toBe(502);
+  });
+});
+
+describe('handleDevicePoll', () => {
+  it('returns {status: pending} when github says authorization_pending', async () => {
+    makeGithubFetch({
+      'https://github.com/login/oauth/access_token': [
+        () => Response.json({ error: 'authorization_pending', interval: 5 }),
+      ],
+    });
+    const env = makeEnv(makeUserDo());
+    const res = await handleDevicePoll(
+      new Request('https://example/api/auth/device/poll', {
+        method: 'POST',
+        body: JSON.stringify({ device_code: 'devcode-xyz' }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; interval: number };
+    expect(body.status).toBe('pending');
+    expect(body.interval).toBe(5);
+  });
+
+  it('returns {status: slow_down, interval} honoring github new interval', async () => {
+    makeGithubFetch({
+      'https://github.com/login/oauth/access_token': [
+        () => Response.json({ error: 'slow_down', interval: 10 }),
+      ],
+    });
+    const env = makeEnv(makeUserDo());
+    const res = await handleDevicePoll(
+      new Request('https://example/api/auth/device/poll', {
+        method: 'POST',
+        body: JSON.stringify({ device_code: 'devcode-xyz' }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { status: string; interval: number };
+    expect(body.status).toBe('slow_down');
+    expect(body.interval).toBe(10);
+  });
+
+  it('returns 410 {status: expired} when github says expired_token', async () => {
+    makeGithubFetch({
+      'https://github.com/login/oauth/access_token': [
+        () => Response.json({ error: 'expired_token' }),
+      ],
+    });
+    const env = makeEnv(makeUserDo());
+    const res = await handleDevicePoll(
+      new Request('https://example/api/auth/device/poll', {
+        method: 'POST',
+        body: JSON.stringify({ device_code: 'devcode-xyz' }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(410);
+    expect(((await res.json()) as { status: string }).status).toBe('expired');
+  });
+
+  it('returns 403 {status: denied} when github says access_denied', async () => {
+    makeGithubFetch({
+      'https://github.com/login/oauth/access_token': [
+        () => Response.json({ error: 'access_denied' }),
+      ],
+    });
+    const env = makeEnv(makeUserDo());
+    const res = await handleDevicePoll(
+      new Request('https://example/api/auth/device/poll', {
+        method: 'POST',
+        body: JSON.stringify({ device_code: 'devcode-xyz' }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { status: string }).status).toBe('denied');
+  });
+
+  it('happy path: persists user, mints tunnel jwt + tunnel refresh', async () => {
+    makeGithubFetch({
+      'https://github.com/login/oauth/access_token': [
+        () => Response.json({ access_token: 'gh-access' }),
+      ],
+      'https://api.github.com/user': [
+        () => Response.json({ id: 99, login: 'alice' }),
+      ],
+    });
+    const userDo = makeUserDo();
+    const env = makeEnv(userDo);
+    const res = await handleDevicePoll(
+      new Request('https://example/api/auth/device/poll', {
+        method: 'POST',
+        body: JSON.stringify({ device_code: 'devcode-xyz' }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      tunnel_jwt: string;
+      tunnel_refresh_token: string;
+      login: string;
+    };
+    expect(body.login).toBe('alice');
+    expect(body.tunnel_refresh_token).toMatch(/^[0-9a-f]{64}$/);
+
+    const claims = await verifyJwt<TunnelJwtClaims>(body.tunnel_jwt, KEY_HEX);
+    expect(claims).not.toBeNull();
+    expect(claims!.sub).toBe('99');
+    expect(claims!.login).toBe('alice');
+    expect(claims!.kind).toBe('tunnel');
+    expect(claims!.exp - claims!.iat).toBe(60 * 60 * 24);
+    expect(typeof claims!.jti).toBe('string');
+    expect(claims!.jti.length).toBeGreaterThan(0);
+
+    expect(userDo.state.github_id).toBe('99');
+    expect(userDo.state.login).toBe('alice');
+    expect(userDo.state.tunnel_refresh_hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('400s when device_code is missing from body', async () => {
+    const env = makeEnv(makeUserDo());
+    const res = await handleDevicePoll(
+      new Request('https://example/api/auth/device/poll', {
+        method: 'POST',
+        body: JSON.stringify({}),
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('full state machine: pending → slow_down → success', async () => {
+    let userMock = false;
+    makeGithubFetch({
+      'https://github.com/login/oauth/access_token': [
+        () => Response.json({ error: 'authorization_pending', interval: 5 }),
+        () => Response.json({ error: 'slow_down', interval: 10 }),
+        () => Response.json({ access_token: 'gh-access' }),
+      ],
+      'https://api.github.com/user': [
+        () => {
+          userMock = true;
+          return Response.json({ id: 7, login: 'bob' });
+        },
+      ],
+    });
+    const userDo = makeUserDo();
+    const env = makeEnv(userDo);
+
+    const r1 = await handleDevicePoll(
+      new Request('https://example/api/auth/device/poll', {
+        method: 'POST',
+        body: JSON.stringify({ device_code: 'd' }),
+      }),
+      env,
+    );
+    expect(((await r1.json()) as { status: string }).status).toBe('pending');
+
+    const r2 = await handleDevicePoll(
+      new Request('https://example/api/auth/device/poll', {
+        method: 'POST',
+        body: JSON.stringify({ device_code: 'd' }),
+      }),
+      env,
+    );
+    expect(((await r2.json()) as { status: string }).status).toBe('slow_down');
+
+    const r3 = await handleDevicePoll(
+      new Request('https://example/api/auth/device/poll', {
+        method: 'POST',
+        body: JSON.stringify({ device_code: 'd' }),
+      }),
+      env,
+    );
+    expect(r3.status).toBe(200);
+    const body = (await r3.json()) as { login: string };
+    expect(body.login).toBe('bob');
+    expect(userMock).toBe(true);
+    expect(userDo.state.login).toBe('bob');
+  });
+});
+
+describe('handleTunnelRefresh', () => {
+  /** Helper: drive a device-poll happy path so UserDO has a tunnel refresh. */
+  async function seedTunnel(userDo: UserDoFake, env: AuthEnv): Promise<{
+    token: string;
+    login: string;
+  }> {
+    makeGithubFetch({
+      'https://github.com/login/oauth/access_token': [
+        () => Response.json({ access_token: 'gh-access' }),
+      ],
+      'https://api.github.com/user': [
+        () => Response.json({ id: 11, login: 'carol' }),
+      ],
+    });
+    const res = await handleDevicePoll(
+      new Request('https://example/api/auth/device/poll', {
+        method: 'POST',
+        body: JSON.stringify({ device_code: 'd' }),
+      }),
+      env,
+    );
+    const body = (await res.json()) as {
+      tunnel_refresh_token: string;
+      login: string;
+    };
+    return { token: body.tunnel_refresh_token, login: body.login };
+  }
+
+  it('mints new tunnel jwt + new refresh, invalidates old refresh (rotation)', async () => {
+    const userDo = makeUserDo();
+    const env = makeEnv(userDo);
+    const { token: oldToken, login } = await seedTunnel(userDo, env);
+    const oldHash = userDo.state.tunnel_refresh_hash!;
+
+    // No GitHub fetch happens during refresh.
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error('refresh should not call GitHub');
+    }) as unknown as typeof fetch;
+
+    const refreshRes = await handleTunnelRefresh(
+      new Request('https://example/api/auth/tunnel/refresh', {
+        method: 'POST',
+        body: JSON.stringify({ tunnel_refresh_token: oldToken, login }),
+      }),
+      env,
+    );
+    expect(refreshRes.status).toBe(200);
+    const body = (await refreshRes.json()) as {
+      tunnel_jwt: string;
+      tunnel_refresh_token: string;
+    };
+    expect(body.tunnel_refresh_token).toMatch(/^[0-9a-f]{64}$/);
+    expect(body.tunnel_refresh_token).not.toBe(oldToken);
+
+    const claims = await verifyJwt<TunnelJwtClaims>(body.tunnel_jwt, KEY_HEX);
+    expect(claims).not.toBeNull();
+    expect(claims!.kind).toBe('tunnel');
+    expect(claims!.login).toBe('carol');
+
+    // Storage rotated.
+    expect(userDo.state.tunnel_refresh_hash).not.toBe(oldHash);
+
+    // The OLD token must no longer verify.
+    const replay = await handleTunnelRefresh(
+      new Request('https://example/api/auth/tunnel/refresh', {
+        method: 'POST',
+        body: JSON.stringify({ tunnel_refresh_token: oldToken, login }),
+      }),
+      env,
+    );
+    expect(replay.status).toBe(401);
+  });
+
+  it('401s when token does not match storage', async () => {
+    const userDo = makeUserDo();
+    const env = makeEnv(userDo);
+    await seedTunnel(userDo, env);
+    const res = await handleTunnelRefresh(
+      new Request('https://example/api/auth/tunnel/refresh', {
+        method: 'POST',
+        body: JSON.stringify({ tunnel_refresh_token: 'wrong', login: 'carol' }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('400s when body is missing fields', async () => {
+    const env = makeEnv(makeUserDo());
+    const res = await handleTunnelRefresh(
+      new Request('https://example/api/auth/tunnel/refresh', {
+        method: 'POST',
+        body: JSON.stringify({ login: 'only-login' }),
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('dispatchDevice', () => {
+  it('returns null for non-device paths', async () => {
+    const env = makeEnv(makeUserDo());
+    const res = await dispatchDevice(
+      new Request('https://example/api/auth/github/login'),
+      env,
+    );
+    expect(res).toBeNull();
+  });
+
+  it('routes /api/auth/device/start to handleDeviceStart', async () => {
+    makeGithubFetch({
+      'https://github.com/login/device/code': [
+        () =>
+          Response.json({
+            device_code: 'd',
+            user_code: 'U',
+            verification_uri: 'https://github.com/login/device',
+            expires_in: 900,
+            interval: 5,
+          }),
+      ],
+    });
+    const env = makeEnv(makeUserDo());
+    const res = await dispatchDevice(
+      new Request('https://example/api/auth/device/start', { method: 'POST' }),
+      env,
+    );
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(200);
+  });
+
+  it('routes /api/auth/tunnel/refresh to handleTunnelRefresh (400 on empty body)', async () => {
+    const env = makeEnv(makeUserDo());
+    const res = await dispatchDevice(
+      new Request('https://example/api/auth/tunnel/refresh', {
+        method: 'POST',
+        body: JSON.stringify({}),
+      }),
+      env,
+    );
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(400);
+  });
+});

--- a/packages/cf-worker/test/userDO.test.ts
+++ b/packages/cf-worker/test/userDO.test.ts
@@ -190,4 +190,41 @@ describe('UserDO', () => {
     const r = await inst.fetch(new Request('https://do/nope'));
     expect(r.status).toBe(404);
   });
+
+  it('tunnel refresh hash is independent of web refresh hash', async () => {
+    const UserDO = await loadDO();
+    const inst = new UserDO(makeState(makeStorage()), fakeEnv);
+    await inst.setRefreshTokenHash('web-hash');
+    await inst.setTunnelRefreshTokenHash('tunnel-hash');
+    expect(await inst.verifyRefreshTokenHash('web-hash')).toBe(true);
+    expect(await inst.verifyRefreshTokenHash('tunnel-hash')).toBe(false);
+    expect(await inst.verifyTunnelRefreshTokenHash('tunnel-hash')).toBe(true);
+    expect(await inst.verifyTunnelRefreshTokenHash('web-hash')).toBe(false);
+  });
+
+  it('fetch /setTunnelRefreshTokenHash + /verifyTunnelRefreshTokenHash round-trip', async () => {
+    const UserDO = await loadDO();
+    const inst = new UserDO(makeState(makeStorage()), fakeEnv);
+    const set = await inst.fetch(
+      new Request('https://do/setTunnelRefreshTokenHash', {
+        method: 'POST',
+        body: JSON.stringify({ hash: 't-hash' }),
+      }),
+    );
+    expect(set.status).toBe(204);
+    const ok = await inst.fetch(
+      new Request('https://do/verifyTunnelRefreshTokenHash', {
+        method: 'POST',
+        body: JSON.stringify({ hash: 't-hash' }),
+      }),
+    );
+    expect(await ok.json()).toEqual({ ok: true });
+    const bad = await inst.fetch(
+      new Request('https://do/verifyTunnelRefreshTokenHash', {
+        method: 'POST',
+        body: JSON.stringify({ hash: 'nope' }),
+      }),
+    );
+    expect(await bad.json()).toEqual({ ok: false });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds POST /api/auth/device/start, /api/auth/device/poll, /api/auth/tunnel/refresh to cf-worker for daemon/Tauri-side GitHub auth.
- device/poll translates GitHub error vocabulary (authorization_pending, slow_down, expired_token, access_denied) into a stable {status} JSON envelope; honors GitHub's slow_down interval.
- On success: persists user via UserDO.setLogin, mints 24h tunnel JWT (kind='tunnel', random jti), mints 32-byte opaque tunnel refresh token (SHA-256 hash stored under a NEW UserDO slot tunnel_refresh_hash, separate from web refresh).
- /api/auth/tunnel/refresh verifies hash, rotates to a new opaque token + new hash, mints fresh tunnel JWT — old token can no longer verify (replay protection).
- UserDO gets setTunnelRefreshTokenHash / verifyTunnelRefreshTokenHash; tunnel slot is intentionally independent from the web refresh slot.
- dispatchDevice runs ahead of dispatchAuth in index.ts so /api/auth/device/* + /api/auth/tunnel/refresh land here, and the rest still routes to T3 web OAuth.

## Source
S4 plan T4. Builds on S4-T2 (UserDO + JWT, #1218 line) and S4-T3 (web OAuth, PR #1220 commit 2544ed2). Tunnel routing of the resulting JWT is T5 — out of scope.

## Local checks (host: Windows 11, mode: fast)
- lint: ✓ (cf-worker package, exit 0)
- typecheck: ✓ (cf-worker package, exit 0)
- build: ✓ (cf-worker package, exit 0)
- unit tests: ✓ — packages/cf-worker pnpm test, 6 files / 85 tests passing (was 68; +17 from new deviceFlow.test.ts + UserDO tunnel slot tests). New test/deviceFlow.test.ts covers: device/start happy + malformed; device/poll pending / slow_down (interval honored) / expired (410) / denied (403) / happy persist+JWT mint / 400 missing body / full pending→slow_down→success state machine; tunnel/refresh rotation invalidates old token / 401 on bad token / 400 on missing fields; dispatchDevice routing.
- e2e: skipped, change is cf-worker only and does not touch electron / e2e harness.

Repo-level pnpm lint + typecheck show pre-existing failures in tools/cloud-e2e/specs/two-tab-pairing.spec.ts (no-useless-escape, unused Mock) and packages/core (cannot find @ccsm/shared) — both untouched by this PR (git diff shows only packages/cf-worker/**).

## Test plan
- [x] cf-worker pnpm test green (85/85)
- [x] cf-worker lint + typecheck + build green
- [x] state machine: pending → slow_down (interval honored) → success
- [x] expired_token → 410, access_denied → 403
- [x] tunnel refresh rotation: new token mints fresh JWT, old token gets 401
- [x] tunnel refresh slot independent from web refresh slot in UserDO

🤖 Generated with [Claude Code](https://claude.com/claude-code)