### PR TITLE
feat(frontend-web): Task #139 — SignIn gate + AuthContext (S4-T7)

### DIFF
--- a/packages/frontend-web/package.json
+++ b/packages/frontend-web/package.json
@@ -19,9 +19,11 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240909.0",
+    "@testing-library/react": "^16.1.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.3",
+    "jsdom": "^25.0.1",
     "typescript": "^5.6.3",
     "vite": "^5.4.10",
     "vitest": "^2.1.4",

--- a/packages/frontend-web/src/App.tsx
+++ b/packages/frontend-web/src/App.tsx
@@ -5,6 +5,9 @@ import {
   Sidebar,
   useBootstrap,
 } from '@ccsm/ui';
+
+import { AuthProvider } from './auth/AuthContext';
+import { SignInGate } from './auth/SignInGate';
 import { webHostConfig } from './hostConfig';
 
 // Inner component so useBootstrap can run inside <RuntimeProvider> (it
@@ -14,10 +17,18 @@ function AppContent() {
   return <AppShell sidebar={<Sidebar />} main={<MainPane />} />;
 }
 
+// Task #139 (S4-T7): wrap the existing RuntimeProvider with AuthProvider +
+// SignInGate so a visitor without a web JWT lands on SignInScreen instead
+// of a hung session list. RuntimeProvider only mounts after the gate
+// passes, ensuring the WsClient never opens a connection without a token.
 export function App() {
   return (
-    <RuntimeProvider hostConfig={webHostConfig}>
-      <AppContent />
-    </RuntimeProvider>
+    <AuthProvider>
+      <SignInGate>
+        <RuntimeProvider hostConfig={webHostConfig}>
+          <AppContent />
+        </RuntimeProvider>
+      </SignInGate>
+    </AuthProvider>
   );
 }

--- a/packages/frontend-web/src/auth/AuthContext.tsx
+++ b/packages/frontend-web/src/auth/AuthContext.tsx
@@ -1,0 +1,193 @@
+// AuthContext — owns the SPA's view of the cf-worker OAuth session.
+//
+// Task #139 (S4-T7) wires up the browser side of the OAuth flow that
+// landed in Task #140 (S4-T3). The cf-worker mints a short-lived web JWT
+// after `/api/auth/github/callback` and redirects to `/?session=ok#jwt=...`
+// with an HttpOnly refresh cookie. This context:
+//
+//   1. On mount: reads the persisted web JWT + login from sessionStorage.
+//      If absent, attempts a silent `POST /api/auth/refresh` so a returning
+//      visitor with a still-valid refresh cookie skips the SignInScreen.
+//   2. signIn(): hard-redirects to `/api/auth/github/login`.
+//   3. signOut(): `POST /api/auth/logout` (best-effort), clears
+//      sessionStorage, then `window.location.reload()`.
+//   4. refresh(): re-reads sessionStorage. SignInGate calls this after
+//      consuming the URL fragment so the context picks up the new JWT
+//      without forcing a full page reload.
+//
+// The context never decodes the JWT to validate it — that's the cf-worker /
+// TunnelDO's job. The SPA only uses the value as an opaque bearer that's
+// presented on the WebSocket subprotocol header (see hostConfig.ts).
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+
+import { WEB_JWT_STORAGE_KEY, WEB_LOGIN_STORAGE_KEY } from '../hostConfig';
+
+export interface AuthState {
+  /** Web JWT (kind='web') or null when signed out. Opaque to the SPA. */
+  webJwt: string | null;
+  /** GitHub login hint for display. Sourced from sessionStorage. */
+  login: string | null;
+  /** True until the initial silent-refresh attempt has settled. */
+  loading: boolean;
+  /** Hard-redirect to `/api/auth/github/login`. */
+  signIn: () => void;
+  /** POST /api/auth/logout, clear sessionStorage, reload. */
+  signOut: () => Promise<void>;
+  /** Re-read sessionStorage so callers can publish a freshly-stored JWT. */
+  refresh: () => Promise<void>;
+}
+
+const AuthCtx = createContext<AuthState | null>(null);
+
+function readStoredJwt(): string | null {
+  if (typeof window === 'undefined') return null;
+  const v = sessionStorage.getItem(WEB_JWT_STORAGE_KEY);
+  return v && v.length > 0 ? v : null;
+}
+
+function readStoredLogin(): string | null {
+  if (typeof window === 'undefined') return null;
+  const v = sessionStorage.getItem(WEB_LOGIN_STORAGE_KEY);
+  return v && v.length > 0 ? v : null;
+}
+
+export interface AuthProviderProps {
+  children: ReactNode;
+  /**
+   * Fetch implementation used for `/api/auth/refresh` and `/api/auth/logout`.
+   * Defaults to `window.fetch`. Tests inject a stub.
+   */
+  fetchImpl?: typeof globalThis.fetch;
+  /**
+   * Skip the silent refresh on mount. Set when the SPA was just redirected
+   * back from `/api/auth/github/callback` (SignInGate consumes the URL
+   * fragment first, then calls refresh()).
+   */
+  skipInitialRefresh?: boolean;
+}
+
+export function AuthProvider({
+  children,
+  fetchImpl,
+  skipInitialRefresh,
+}: AuthProviderProps) {
+  const [webJwt, setWebJwt] = useState<string | null>(() => readStoredJwt());
+  const [login, setLogin] = useState<string | null>(() => readStoredLogin());
+  const [loading, setLoading] = useState<boolean>(() => {
+    if (skipInitialRefresh) return false;
+    // If we already have a JWT in storage there's nothing to wait for.
+    return readStoredJwt() === null;
+  });
+
+  // Keep a stable reference to fetch so we don't refetch on every render.
+  const fetchRef = useRef<typeof globalThis.fetch>(
+    fetchImpl ?? (typeof window !== 'undefined' ? window.fetch.bind(window) : (() => {
+      throw new Error('fetch unavailable in this environment');
+    }) as typeof globalThis.fetch),
+  );
+
+  const refresh = useCallback(async () => {
+    const stored = readStoredJwt();
+    if (stored !== null) {
+      setWebJwt(stored);
+      setLogin(readStoredLogin());
+      return;
+    }
+    // Try silent refresh against the HttpOnly cookie.
+    try {
+      const res = await fetchRef.current('/api/auth/refresh', {
+        method: 'POST',
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        setWebJwt(null);
+        setLogin(null);
+        return;
+      }
+      const body = (await res.json()) as { web_jwt?: unknown; login?: unknown };
+      if (typeof body.web_jwt === 'string' && body.web_jwt.length > 0) {
+        sessionStorage.setItem(WEB_JWT_STORAGE_KEY, body.web_jwt);
+        if (typeof body.login === 'string' && body.login.length > 0) {
+          sessionStorage.setItem(WEB_LOGIN_STORAGE_KEY, body.login);
+        }
+        setWebJwt(body.web_jwt);
+        setLogin(typeof body.login === 'string' ? body.login : readStoredLogin());
+        return;
+      }
+      setWebJwt(null);
+      setLogin(null);
+    } catch {
+      // Network error / cookie missing / refresh path 401 → signed out.
+      setWebJwt(null);
+      setLogin(null);
+    }
+  }, []);
+
+  const signIn = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    window.location.href = '/api/auth/github/login';
+  }, []);
+
+  const signOut = useCallback(async () => {
+    try {
+      await fetchRef.current('/api/auth/logout', {
+        method: 'POST',
+        credentials: 'include',
+      });
+    } catch {
+      // Best-effort; cookies may already be expired. Continue clearing local state.
+    }
+    if (typeof window !== 'undefined') {
+      sessionStorage.removeItem(WEB_JWT_STORAGE_KEY);
+      sessionStorage.removeItem(WEB_LOGIN_STORAGE_KEY);
+      // Reload so RuntimeProvider tears down and the SignInGate re-renders
+      // from a clean slate (no stale ws connection).
+      window.location.reload();
+    }
+    setWebJwt(null);
+    setLogin(null);
+  }, []);
+
+  // Initial mount: silent refresh unless caller already populated storage
+  // (SignInGate fragment-consume path) or explicitly opted out.
+  useEffect(() => {
+    if (skipInitialRefresh) return;
+    if (readStoredJwt() !== null) {
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      await refresh();
+      if (!cancelled) setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [refresh, skipInitialRefresh]);
+
+  const value = useMemo<AuthState>(
+    () => ({ webJwt, login, loading, signIn, signOut, refresh }),
+    [webJwt, login, loading, signIn, signOut, refresh],
+  );
+
+  return <AuthCtx.Provider value={value}>{children}</AuthCtx.Provider>;
+}
+
+export function useAuth(): AuthState {
+  const ctx = useContext(AuthCtx);
+  if (ctx === null) {
+    throw new Error('useAuth must be used inside <AuthProvider>');
+  }
+  return ctx;
+}

--- a/packages/frontend-web/src/auth/SignInGate.tsx
+++ b/packages/frontend-web/src/auth/SignInGate.tsx
@@ -1,0 +1,141 @@
+// SignInGate — gates the main UI behind a valid web JWT.
+//
+// Two responsibilities:
+//
+//   1. Consume the OAuth callback redirect. Task #140 (S4-T3) lands the
+//      visitor at `/?session=ok#jwt=<jwt>` after the cf-worker exchanges
+//      the GitHub `code`. We pull the JWT out of the URL fragment, peek at
+//      the `login` claim for a UX hint (NOT for trust — the worker already
+//      verified the signature), persist both to sessionStorage, then clean
+//      the URL via history.replaceState so a refresh doesn't re-process
+//      the fragment. AuthContext.refresh() then publishes the new state.
+//
+//   2. Render-time decision: webJwt null → <SignInScreen>; non-null →
+//      pass through to <children>. Loading state defers to a tiny inline
+//      spinner so the gate doesn't flash SignInScreen during the silent
+//      refresh on mount.
+//
+// The gate never validates the JWT itself; the cf-worker is the source of
+// trust. We only base64url-decode the payload to read the `login` claim
+// because Task #140's /api/auth/refresh response is the only authoritative
+// source of `login`, and the callback path doesn't expose a /me endpoint
+// (spec defers that to a follow-up task).
+
+import { useEffect, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
+
+import { WEB_JWT_STORAGE_KEY, WEB_LOGIN_STORAGE_KEY } from '../hostConfig';
+import { useAuth } from './AuthContext';
+import { SignInScreen } from './SignInScreen';
+
+/**
+ * Decode the payload of a JWT (no signature verification).
+ *
+ * Returns null on any structural error so callers can fall back to a
+ * cookie-based refresh that DOES verify the signature server-side.
+ */
+export function decodeJwtPayload(jwt: string): Record<string, unknown> | null {
+  const parts = jwt.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    const payload = parts[1] ?? '';
+    // base64url → base64
+    const padded = payload.replace(/-/g, '+').replace(/_/g, '/');
+    const padding = padded.length % 4 === 0 ? '' : '='.repeat(4 - (padded.length % 4));
+    const json = typeof atob === 'function'
+      ? atob(padded + padding)
+      : (() => { throw new Error('atob unavailable'); })();
+    const obj = JSON.parse(json) as unknown;
+    if (typeof obj === 'object' && obj !== null) {
+      return obj as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pull `?session=ok#jwt=<jwt>` out of the current URL and persist it.
+ *
+ * Returns true when a fragment was consumed (caller should refresh()).
+ * Exported for direct unit testing without RTL.
+ */
+export function consumeCallbackFragment(loc: Location, hist: History): boolean {
+  const params = new URLSearchParams(loc.search);
+  if (params.get('session') !== 'ok') return false;
+  const hash = loc.hash.startsWith('#') ? loc.hash.slice(1) : loc.hash;
+  const hashParams = new URLSearchParams(hash);
+  const jwt = hashParams.get('jwt');
+  if (!jwt || jwt.length === 0) return false;
+
+  sessionStorage.setItem(WEB_JWT_STORAGE_KEY, jwt);
+  const payload = decodeJwtPayload(jwt);
+  if (payload && typeof payload.login === 'string' && payload.login.length > 0) {
+    sessionStorage.setItem(WEB_LOGIN_STORAGE_KEY, payload.login);
+  }
+
+  // Clean the URL: drop ?session and #jwt so a reload doesn't re-process.
+  params.delete('session');
+  const remainingSearch = params.toString();
+  const cleanUrl =
+    loc.pathname + (remainingSearch.length > 0 ? `?${remainingSearch}` : '');
+  hist.replaceState(null, '', cleanUrl);
+  return true;
+}
+
+export interface SignInGateProps {
+  children: ReactNode;
+}
+
+export function SignInGate({ children }: SignInGateProps) {
+  const { webJwt, loading, refresh } = useAuth();
+
+  // Consume the callback fragment exactly once on mount, before deciding
+  // what to render. We do this in a ref-guarded layout-style effect to
+  // avoid a flash of SignInScreen on the redirect landing.
+  const consumed = useRef(false);
+  const [consuming, setConsuming] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false;
+    return new URLSearchParams(window.location.search).get('session') === 'ok';
+  });
+
+  useEffect(() => {
+    if (consumed.current) return;
+    consumed.current = true;
+    if (typeof window === 'undefined') {
+      setConsuming(false);
+      return;
+    }
+    const ok = consumeCallbackFragment(window.location, window.history);
+    if (ok) {
+      void refresh().finally(() => setConsuming(false));
+    } else {
+      setConsuming(false);
+    }
+  }, [refresh]);
+
+  if (loading || consuming) {
+    return (
+      <div
+        style={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: '#9aa0a6',
+          fontFamily: 'system-ui, -apple-system, sans-serif',
+          background: '#101216',
+        }}
+      >
+        Loading…
+      </div>
+    );
+  }
+
+  if (webJwt === null) {
+    return <SignInScreen />;
+  }
+
+  return <>{children}</>;
+}

--- a/packages/frontend-web/src/auth/SignInScreen.tsx
+++ b/packages/frontend-web/src/auth/SignInScreen.tsx
@@ -1,0 +1,53 @@
+// SignInScreen — the full-page placeholder rendered when the SPA has no
+// web JWT. A single primary CTA hard-redirects to /api/auth/github/login,
+// matching the cf-worker route landed in Task #140 (S4-T3).
+//
+// Intentionally minimal: ccsm wordmark + one button. The actual product UI
+// only loads after the OAuth callback writes a JWT into sessionStorage and
+// SignInGate flips to children.
+
+import { useAuth } from './AuthContext';
+
+export function SignInScreen() {
+  const { signIn, loading } = useAuth();
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 24,
+        fontFamily: 'system-ui, -apple-system, sans-serif',
+        color: '#e6e6e6',
+        background: '#101216',
+        padding: 24,
+      }}
+    >
+      <div style={{ fontSize: 28, fontWeight: 600, letterSpacing: 0.5 }}>ccsm</div>
+      <div style={{ color: '#9aa0a6', fontSize: 14, maxWidth: 360, textAlign: 'center' }}>
+        Sign in with your GitHub account to continue.
+      </div>
+      <button
+        type="button"
+        onClick={signIn}
+        disabled={loading}
+        style={{
+          appearance: 'none',
+          border: 'none',
+          background: '#24292f',
+          color: 'white',
+          fontSize: 14,
+          fontWeight: 500,
+          padding: '10px 18px',
+          borderRadius: 6,
+          cursor: loading ? 'progress' : 'pointer',
+          opacity: loading ? 0.6 : 1,
+        }}
+      >
+        Sign in with GitHub
+      </button>
+    </div>
+  );
+}

--- a/packages/frontend-web/src/hostConfig.ts
+++ b/packages/frontend-web/src/hostConfig.ts
@@ -31,6 +31,31 @@ import type { HostConfig } from '@ccsm/ui';
 export const TOKEN_STORAGE_KEY = 'ccsm.token';
 
 /**
+ * Web JWT storage key (Task #139, S4-T7).
+ *
+ * The cf-worker OAuth flow (Task #140 / S4-T3) mints a short-lived web JWT
+ * (kind='web', 1h, HS256) and delivers it in the `/?session=ok#jwt=...`
+ * redirect fragment. AuthContext decodes the fragment, persists the JWT
+ * here, and the SPA presents it on the WebSocket subprotocol header so the
+ * Worker / TunnelDO can authenticate the visitor without a daemon-minted
+ * token. The smoke / loopback path keeps writing the legacy daemon token to
+ * `ccsm.token` (`TOKEN_STORAGE_KEY`); `webHostConfig.getToken` prefers the
+ * web JWT and falls back to the daemon token, so the same `getWsProtocol`
+ * code path serves both deployment shapes.
+ */
+export const WEB_JWT_STORAGE_KEY = 'ccsm_web_jwt';
+
+/**
+ * GitHub login hint storage key (Task #139, S4-T7).
+ *
+ * Stored alongside the web JWT for display purposes only — the server is
+ * the source of truth on the JWT's `login` claim. The SPA never gates on
+ * this value; it's a UX nicety so SignInGate can show "Signed in as foo"
+ * without a round-trip.
+ */
+export const WEB_LOGIN_STORAGE_KEY = 'ccsm_login';
+
+/**
  * Default daemon base for production (same-origin relative).
  *
  * Task #25: empty string means "use the SPA's own origin" — `fetch('/token')`
@@ -213,11 +238,29 @@ export function getWsProtocol(deps: GetWsProtocolDeps): string[] {
   return [`${WS_SUBPROTOCOL_PREFIX}${token}`];
 }
 
+/**
+ * Token reader used by the SessionRuntime / WsClient (Task #139, S4-T7).
+ *
+ * Priority:
+ *   1. sessionStorage `ccsm_web_jwt` — set by AuthContext after the web
+ *      OAuth flow completes (cf-worker mints + redirects with #jwt=...).
+ *   2. sessionStorage `ccsm.token` — legacy daemon-minted token. Smoke and
+ *      Tauri shells still bootstrap from `?token=` / `/token` and write to
+ *      this key, so they keep working without an OAuth round-trip.
+ *   3. null — caller falls back to "signed out" UI (SignInScreen).
+ *
+ * Exposed as a standalone function so component tests can inject without
+ * stubbing `webHostConfig` itself.
+ */
+export function readSessionToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  const webJwt = sessionStorage.getItem(WEB_JWT_STORAGE_KEY);
+  if (webJwt && webJwt.length > 0) return webJwt;
+  return sessionStorage.getItem(TOKEN_STORAGE_KEY);
+}
+
 export const webHostConfig: HostConfig = {
   httpBase: currentDaemonBase(),
-  getToken: () => {
-    if (typeof window === 'undefined') return null;
-    return sessionStorage.getItem(TOKEN_STORAGE_KEY);
-  },
+  getToken: readSessionToken,
   ...(currentWsPath() !== undefined ? { wsPath: currentWsPath() as string } : {}),
 };

--- a/packages/frontend-web/src/main.tsx
+++ b/packages/frontend-web/src/main.tsx
@@ -56,26 +56,21 @@ async function bootstrap(): Promise<void> {
     daemonBase,
   });
 
-  if (!token) {
-    console.error('[ccsm spa] token resolved null — rendering daemon-offline fallback');
-    rootEl.innerHTML =
-      '<div style="font-family:system-ui;padding:24px;color:#888;">' +
-      'Daemon offline or no token available. Start the daemon, then reload this page.' +
-      '</div>';
-    return;
+  // Task #139 (S4-T7): no token from the daemon path is fine in cloud /
+  // OAuth deployments — AuthContext + SignInGate handle the signed-out
+  // state. We only persist the daemon token when present so smoke / Tauri /
+  // loopback shells still get the legacy `?token=` → sessionStorage path.
+  if (token) {
+    console.log('[ccsm spa] token resolved tokenLen=', token.length);
+    sessionStorage.setItem(TOKEN_STORAGE_KEY, token);
+
+    // R-13: log the ws url the SessionRuntime / WsClient is about to dial.
+    const wsBase = resolveWsBase({ search: window.location.search });
+    const wsPath = resolveWsPath({ search: window.location.search }) ?? '/ws';
+    console.log('[ccsm spa] ws connecting', `${wsBase}${wsPath}`);
+  } else {
+    console.log('[ccsm spa] no daemon token — deferring to AuthContext / SignInGate');
   }
-
-  console.log('[ccsm spa] token resolved tokenLen=', token.length);
-
-  sessionStorage.setItem(TOKEN_STORAGE_KEY, token);
-
-  // R-13: log the ws url the SessionRuntime / WsClient is about to dial.
-  // Computed identically to webHostConfig (resolveWsBase + resolveWsPath)
-  // so a mismatch between this log and the actual ws upgrade in worker logs
-  // pinpoints a hostConfig drift.
-  const wsBase = resolveWsBase({ search: window.location.search });
-  const wsPath = resolveWsPath({ search: window.location.search }) ?? '/ws';
-  console.log('[ccsm spa] ws connecting', `${wsBase}${wsPath}`);
 
   createRoot(rootEl).render(
     <StrictMode>

--- a/packages/frontend-web/test/auth.test.tsx
+++ b/packages/frontend-web/test/auth.test.tsx
@@ -1,0 +1,238 @@
+// AuthContext + SignInGate component tests (Task #139, S4-T7).
+//
+// Coverage target (per spec):
+//   1. AuthProvider mount with no JWT → SignInScreen rendered
+//   2. Callback `?session=ok#jwt=xxx` → fragment consumed, JWT stored,
+//      URL cleaned, gate flips to children
+//   3. signOut clears sessionStorage (reload is stubbed)
+//   4. signIn redirects to /api/auth/github/login
+//
+// Plus a guardrail on decodeJwtPayload (login-claim extraction) so the
+// fragment-consumer's UX hint doesn't drift.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+import { AuthProvider, useAuth } from '../src/auth/AuthContext';
+import {
+  consumeCallbackFragment,
+  decodeJwtPayload,
+  SignInGate,
+} from '../src/auth/SignInGate';
+import { WEB_JWT_STORAGE_KEY, WEB_LOGIN_STORAGE_KEY } from '../src/hostConfig';
+
+// A web JWT shape: header.payload.signature, base64url-encoded JSON.
+function makeJwt(payload: Record<string, unknown>): string {
+  const b64url = (s: string) =>
+    Buffer.from(s, 'utf8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT', kind: 'web' }));
+  const body = b64url(JSON.stringify(payload));
+  return `${header}.${body}.sig-not-checked-by-spa`;
+}
+
+describe('decodeJwtPayload', () => {
+  it('returns the parsed payload for a well-formed JWT', () => {
+    const jwt = makeJwt({ login: 'octocat', kind: 'web', exp: 9999999999 });
+    expect(decodeJwtPayload(jwt)).toEqual({
+      login: 'octocat',
+      kind: 'web',
+      exp: 9999999999,
+    });
+  });
+
+  it('returns null for non-three-part input', () => {
+    expect(decodeJwtPayload('not.a.jwt.extra')).toBeNull();
+    expect(decodeJwtPayload('only-one-part')).toBeNull();
+  });
+
+  it('returns null when the payload is not base64url-decodable JSON', () => {
+    expect(decodeJwtPayload('aaa.@@@.bbb')).toBeNull();
+  });
+});
+
+describe('consumeCallbackFragment', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('persists JWT + login from `?session=ok#jwt=...` and cleans the URL', () => {
+    const jwt = makeJwt({ login: 'mona', kind: 'web' });
+    const replaceState = vi.fn();
+    const fakeLoc = {
+      pathname: '/',
+      search: '?session=ok',
+      hash: `#jwt=${jwt}`,
+    } as unknown as Location;
+    const fakeHist = { replaceState } as unknown as History;
+
+    const ok = consumeCallbackFragment(fakeLoc, fakeHist);
+    expect(ok).toBe(true);
+    expect(sessionStorage.getItem(WEB_JWT_STORAGE_KEY)).toBe(jwt);
+    expect(sessionStorage.getItem(WEB_LOGIN_STORAGE_KEY)).toBe('mona');
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/');
+  });
+
+  it('returns false when ?session=ok is missing', () => {
+    const fakeLoc = { pathname: '/', search: '', hash: '#jwt=foo' } as unknown as Location;
+    const ok = consumeCallbackFragment(fakeLoc, { replaceState: vi.fn() } as unknown as History);
+    expect(ok).toBe(false);
+    expect(sessionStorage.getItem(WEB_JWT_STORAGE_KEY)).toBeNull();
+  });
+
+  it('returns false when the fragment has no jwt= entry', () => {
+    const fakeLoc = { pathname: '/', search: '?session=ok', hash: '#other=1' } as unknown as Location;
+    const ok = consumeCallbackFragment(fakeLoc, { replaceState: vi.fn() } as unknown as History);
+    expect(ok).toBe(false);
+  });
+});
+
+// ----- Component-level: AuthProvider + SignInGate ------------------------
+
+const ORIGINAL_HREF = 'http://127.0.0.1/';
+
+beforeEach(() => {
+  sessionStorage.clear();
+  // jsdom's location is read-only for href, but we can replace it via
+  // history.replaceState. signIn assigns to window.location.href which jsdom
+  // models as a navigation; we shim to capture the assignment.
+  window.history.replaceState(null, '', ORIGINAL_HREF);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function HrefProbe({ onHref }: { onHref: (href: string) => void }) {
+  const { signIn } = useAuth();
+  return (
+    <button type="button" data-testid="probe-signin" onClick={() => {
+      // Stub assignment side-effect so we don't actually navigate jsdom.
+      const originalHref = window.location.href;
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: new Proxy(window.location, {
+          set(_t, p, v) {
+            if (p === 'href') { onHref(String(v)); return true; }
+            return Reflect.set(_t, p, v);
+          },
+        }),
+      });
+      signIn();
+      // Restore so afterEach works
+      window.history.replaceState(null, '', originalHref);
+    }}>go</button>
+  );
+}
+
+describe('AuthProvider + SignInGate', () => {
+  it('renders SignInScreen when no JWT in sessionStorage and refresh fails', async () => {
+    const fetchImpl = vi.fn(async () => new Response('nope', { status: 401 })) as unknown as typeof fetch;
+    render(
+      <AuthProvider fetchImpl={fetchImpl}>
+        <SignInGate>
+          <div>protected-ui</div>
+        </SignInGate>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Sign in with GitHub')).toBeTruthy();
+    });
+    expect(screen.queryByText('protected-ui')).toBeNull();
+    expect(fetchImpl).toHaveBeenCalledWith('/api/auth/refresh', expect.objectContaining({
+      method: 'POST',
+      credentials: 'include',
+    }));
+  });
+
+  it('renders children when sessionStorage already has a JWT (no silent refresh)', async () => {
+    sessionStorage.setItem(WEB_JWT_STORAGE_KEY, makeJwt({ login: 'octocat', kind: 'web' }));
+    sessionStorage.setItem(WEB_LOGIN_STORAGE_KEY, 'octocat');
+    const fetchImpl = vi.fn(async () => new Response('{}', { status: 200 })) as unknown as typeof fetch;
+
+    render(
+      <AuthProvider fetchImpl={fetchImpl}>
+        <SignInGate>
+          <div>protected-ui</div>
+        </SignInGate>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('protected-ui')).toBeTruthy();
+    });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it('consumes ?session=ok#jwt=... fragment and flips to children', async () => {
+    const jwt = makeJwt({ login: 'callback-user', kind: 'web' });
+    window.history.replaceState(null, '', `/?session=ok#jwt=${jwt}`);
+    const fetchImpl = vi.fn(async () => new Response('{}', { status: 200 })) as unknown as typeof fetch;
+
+    render(
+      <AuthProvider fetchImpl={fetchImpl} skipInitialRefresh>
+        <SignInGate>
+          <div>protected-ui</div>
+        </SignInGate>
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('protected-ui')).toBeTruthy();
+    });
+    expect(sessionStorage.getItem(WEB_JWT_STORAGE_KEY)).toBe(jwt);
+    expect(sessionStorage.getItem(WEB_LOGIN_STORAGE_KEY)).toBe('callback-user');
+    // URL cleaned: ?session removed, #jwt dropped.
+    expect(window.location.search).toBe('');
+  });
+
+  it('signOut clears sessionStorage (reload stubbed)', async () => {
+    sessionStorage.setItem(WEB_JWT_STORAGE_KEY, 'old-jwt');
+    sessionStorage.setItem(WEB_LOGIN_STORAGE_KEY, 'old-user');
+    const fetchImpl = vi.fn(async () => new Response('', { status: 204 })) as unknown as typeof fetch;
+    const reloadSpy = vi.fn();
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy, href: ORIGINAL_HREF, search: '', hash: '', pathname: '/' },
+    });
+
+    function SignOutButton() {
+      const { signOut } = useAuth();
+      return <button type="button" onClick={() => { void signOut(); }} data-testid="signout">x</button>;
+    }
+
+    render(
+      <AuthProvider fetchImpl={fetchImpl} skipInitialRefresh>
+        <SignOutButton />
+      </AuthProvider>,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('signout'));
+    });
+
+    await waitFor(() => {
+      expect(sessionStorage.getItem(WEB_JWT_STORAGE_KEY)).toBeNull();
+      expect(sessionStorage.getItem(WEB_LOGIN_STORAGE_KEY)).toBeNull();
+    });
+    expect(fetchImpl).toHaveBeenCalledWith('/api/auth/logout', expect.objectContaining({
+      method: 'POST',
+      credentials: 'include',
+    }));
+    expect(reloadSpy).toHaveBeenCalled();
+  });
+
+  it('signIn redirects to /api/auth/github/login', async () => {
+    const seen: string[] = [];
+    const fetchImpl = vi.fn(async () => new Response('', { status: 401 })) as unknown as typeof fetch;
+
+    render(
+      <AuthProvider fetchImpl={fetchImpl} skipInitialRefresh>
+        <HrefProbe onHref={(h) => seen.push(h)} />
+      </AuthProvider>,
+    );
+
+    fireEvent.click(screen.getByTestId('probe-signin'));
+    expect(seen).toContain('/api/auth/github/login');
+  });
+});

--- a/packages/frontend-web/vitest.config.ts
+++ b/packages/frontend-web/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config';
+
+// frontend-web tests use jsdom for component-level coverage of AuthContext +
+// SignInGate (Task #139, S4-T7). Pure-logic suites (resolveToken,
+// hostConfig) run fine under jsdom too, so a single env keeps config small.
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    environmentOptions: {
+      jsdom: {
+        url: 'http://127.0.0.1/',
+      },
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20240909.0
         version: 4.20260508.1
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
@@ -147,6 +150,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.3
         version: 4.7.0(vite@5.4.21(@types/node@22.19.17))
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
       typescript:
         specifier: ^5.6.3
         version: 5.9.3


### PR DESCRIPTION
## Summary

Wire the browser side of the cf-worker OAuth flow that landed in #1220 (Task #140 / S4-T3). A visitor without a web JWT now lands on a SignInScreen instead of a hung session list; clicking "Sign in with GitHub" hands off to `/api/auth/github/login`. After the worker mints the JWT and redirects to `/?session=ok#jwt=...`, `SignInGate` consumes the fragment, persists `ccsm_web_jwt` + `ccsm_login` to sessionStorage, cleans the URL via `history.replaceState`, and flips to the wrapped `RuntimeProvider` so the existing app renders normally.

The legacy daemon-token bootstrap (`?token=` → `ccsm.token`) stays in place so smoke / Tauri / loopback shells keep working without an OAuth round-trip. `webHostConfig.getToken` now prefers the web JWT and falls back to the daemon token, so `getWsProtocol` returns the right value for both deployment shapes.

### Files

- `packages/frontend-web/src/auth/AuthContext.tsx` — `webJwt` / `login` state, silent `POST /api/auth/refresh` on mount, `signIn` / `signOut` / `refresh`.
- `packages/frontend-web/src/auth/SignInGate.tsx` — fragment consumer + render gate; exports `decodeJwtPayload` + `consumeCallbackFragment`.
- `packages/frontend-web/src/auth/SignInScreen.tsx` — single CTA.
- `packages/frontend-web/src/App.tsx` — wraps `RuntimeProvider` with `AuthProvider` + `SignInGate`.
- `packages/frontend-web/src/hostConfig.ts` — `readSessionToken` priority (`ccsm_web_jwt` → `ccsm.token`); `WEB_JWT_STORAGE_KEY` / `WEB_LOGIN_STORAGE_KEY`.
- `packages/frontend-web/src/main.tsx` — no longer bails on null daemon token; renders `<App>` and lets `SignInGate` handle the signed-out state. The `[ccsm spa]` log markers are preserved on the daemon-token path.
- `packages/frontend-web/test/auth.test.tsx` — 11 RTL + pure cases.
- `packages/frontend-web/vitest.config.ts` — jsdom env with explicit URL so `history.replaceState` can land on `/`.

### Out of scope (per spec)

- Device flow / `frontend-tauri` shell — S4-T8.
- `/me` endpoint for an authoritative `login` claim — deferred; SPA peeks at the JWT payload for the UX hint only.
- Refresh-token rotation on every refresh — cf-worker side, S4-T4.
- JWT signature verification on the SPA — server is the source of trust.

## Local checks (host: Windows, mode: fast)
- lint: ok (exit 0) — `pnpm --filter @ccsm/frontend-web run lint`
- typecheck: ok (exit 0) — `pnpm --filter @ccsm/frontend-web run typecheck`
- build: ok (exit 0) — `pnpm --filter @ccsm/frontend-web run build` (vite, 503 kB main chunk; size warning is unchanged baseline)
- unit tests: 42 passed (3 files: hostConfig 18, resolveToken 13, auth 11) in 3.13s — `pnpm --filter @ccsm/frontend-web run test`
- e2e: skipped, change is SPA-only and does not touch electron/daemon

## Test plan
- [ ] CI three-platform matrix green
- [ ] Manual smoke after deploy: visiting cc-sm.pages.dev with no cookies lands on SignInScreen; clicking "Sign in with GitHub" round-trips through GitHub and lands on the main UI with `ccsm_web_jwt` populated.
- [ ] Smoke fixture (`?token=...` legacy path) still boots straight into the main UI without a SignInScreen flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)