### PR TITLE
feat(cf-worker): Task #136 — JWT routing middleware + CCSM_AUTH_MODE flag (S4-T5)

### DIFF
--- a/packages/cf-worker/src/auth/middleware.ts
+++ b/packages/cf-worker/src/auth/middleware.ts
@@ -1,0 +1,134 @@
+/**
+ * S4-T5 (Task #136): JWT routing middleware for cf-worker.
+ *
+ * Two responsibilities:
+ *
+ *   1. **Auth-mode gating.** `CCSM_AUTH_MODE` env var (vars in wrangler.toml,
+ *      default `legacy`) gates whether browser ws / tunnel ws / REST API
+ *      requests must carry a verifiable JWT. `legacy` keeps the S3-era flow
+ *      (token in `Sec-WebSocket-Protocol`, no JWT, single shared TunnelDO
+ *      keyed by `'default'`). `jwt` requires the JWT; the github_id from the
+ *      verified claims is used to derive a **per-user TunnelDO id**
+ *      (`'user:<github_id>'`) so different GitHub users get isolated DO
+ *      instances.
+ *
+ *   2. **JWT extraction.** Browser-side: token is in the
+ *      `Sec-WebSocket-Protocol` header (subprotocol `ccsm.<jwt>`) for ws
+ *      upgrades, or `Authorization: Bearer <jwt>` for REST. Daemon-side
+ *      (`/tunnel/default`): always `Sec-WebSocket-Protocol: ccsm.<jwt>` since
+ *      WebSockets cannot set arbitrary headers. We verify against the right
+ *      key (web → `JWT_SIGNING_KEY`, tunnel → `JWT_REFRESH_SIGNING_KEY`) and
+ *      narrow on `kind`.
+ *
+ * The TunnelDO internals (sid envelope, getBrowserSocket, hello handling)
+ * are NOT touched — only the **DO id name** changes in jwt mode, plus the
+ * cf-worker tags the forwarded request with the `X-CCSM-Identity-Login` /
+ * `X-CCSM-Identity-Id` headers so the DO can echo them inside the hello
+ * frame to the daemon (Task #133 / S4-T6 wire format).
+ *
+ * Production rollout: deploy with `CCSM_AUTH_MODE = "legacy"` (default in
+ * wrangler.toml), then flip to `"jwt"` via `wrangler vars` once the SPA
+ * sign-in UI (T7/T8) is shipped and propagates JWTs to the WebSocket /
+ * Authorization layer.
+ */
+import type { AuthEnv } from './bindings';
+import { verifyJwt, type WebJwtClaims, type TunnelJwtClaims } from './jwt';
+
+/** Subprotocol prefix matching frontend-web/src/hostConfig.ts. */
+const WS_SUBPROTOCOL_PREFIX = 'ccsm.';
+
+export type AuthMode = 'legacy' | 'jwt';
+
+/**
+ * Read the auth mode from env. Anything other than the literal string `jwt`
+ * (incl. unset / empty / typo) falls back to `legacy` so a misconfigured
+ * deploy can never accidentally enforce JWT and lock everyone out.
+ */
+export function getAuthMode(env: { CCSM_AUTH_MODE?: string }): AuthMode {
+  return env.CCSM_AUTH_MODE === 'jwt' ? 'jwt' : 'legacy';
+}
+
+/**
+ * Per-user TunnelDO id name. Matches the spec in Task #136 — one GitHub
+ * user, one DO. github_id (the OAuth subject's numeric id, NOT login) is
+ * stable across login renames so the DO survives a username change.
+ */
+export function getUserDoIdName(github_id: string): string {
+  return 'user:' + github_id;
+}
+
+/**
+ * Extract `ccsm.<jwt>` subprotocol token from Sec-WebSocket-Protocol.
+ * Returns null if the header is absent / has no ccsm.* entry / token empty.
+ *
+ * Mirrors the `extractBrowserToken` helper in tunnel-do.ts — that one
+ * returns the protocol echo string too because the DO needs it for the
+ * 101 response, but middleware only cares about the bearer payload.
+ */
+function extractSubprotocolToken(req: Request): string | null {
+  const raw = req.headers.get('sec-websocket-protocol');
+  if (raw === null) return null;
+  const entries = raw.split(',').map((s) => s.trim()).filter((s) => s.length > 0);
+  for (const entry of entries) {
+    if (entry.startsWith(WS_SUBPROTOCOL_PREFIX)) {
+      const token = entry.slice(WS_SUBPROTOCOL_PREFIX.length);
+      if (token.length > 0) return token;
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract `Bearer <jwt>` from Authorization header. Returns null if header
+ * absent or scheme is not Bearer.
+ */
+function extractBearer(req: Request): string | null {
+  const raw = req.headers.get('authorization');
+  if (raw === null) return null;
+  // Authorization: Bearer <token> — case-insensitive scheme per RFC 7235.
+  const match = /^bearer\s+(\S+)\s*$/i.exec(raw);
+  if (match === null) return null;
+  return match[1] ?? null;
+}
+
+/**
+ * Verify a browser-presented web JWT. Looks first at the WS subprotocol,
+ * then at Authorization header (so the same helper covers both ws and REST).
+ *
+ * Returns null on:
+ *   - no token present
+ *   - signature invalid / expired (verifyJwt returns null)
+ *   - `kind` is not `'web'` (daemon-class token presented at browser path)
+ */
+export async function extractWebJwt(
+  req: Request,
+  env: AuthEnv,
+): Promise<WebJwtClaims | null> {
+  const token = extractSubprotocolToken(req) ?? extractBearer(req);
+  if (token === null) return null;
+  const claims = await verifyJwt<WebJwtClaims>(token, env.JWT_SIGNING_KEY);
+  if (claims === null) return null;
+  if (claims.kind !== 'web') return null;
+  return claims;
+}
+
+/**
+ * Verify a daemon-presented tunnel JWT. Daemons only ever present this via
+ * the WS subprotocol (no Authorization header path). Verifies against the
+ * refresh signing key (per S4 D5 — tunnel JWTs are minted with the refresh
+ * key so a leaked web key cannot mint daemon-class tokens).
+ */
+export async function extractTunnelJwt(
+  req: Request,
+  env: AuthEnv,
+): Promise<TunnelJwtClaims | null> {
+  const token = extractSubprotocolToken(req);
+  if (token === null) return null;
+  const claims = await verifyJwt<TunnelJwtClaims>(
+    token,
+    env.JWT_REFRESH_SIGNING_KEY,
+  );
+  if (claims === null) return null;
+  if (claims.kind !== 'tunnel') return null;
+  return claims;
+}

--- a/packages/cf-worker/src/index.ts
+++ b/packages/cf-worker/src/index.ts
@@ -10,6 +10,14 @@ export interface Env {
   JWT_SIGNING_KEY: string;
   JWT_REFRESH_SIGNING_KEY: string;
   USER_DO: DurableObjectNamespace;
+  /**
+   * S4-T5 (Task #136): auth mode toggle. `legacy` keeps the S3-era token-
+   * based flow with a single shared TunnelDO keyed by `'default'`. `jwt`
+   * enforces JWT verification on /ws/*, /tunnel/*, /api/*, /token and
+   * routes each user into a per-user TunnelDO id (`user:<github_id>`).
+   * Default `legacy` so unset / misconfigured deploys never lock users out.
+   */
+  CCSM_AUTH_MODE?: string;
 }
 
 export { TunnelDO } from './tunnel-do';
@@ -19,6 +27,31 @@ export { UserDO } from './auth/userDO';
 
 import { dispatchAuth } from './auth/webOauth';
 import { dispatchDevice } from './auth/deviceFlow';
+import {
+  extractTunnelJwt,
+  extractWebJwt,
+  getAuthMode,
+  getUserDoIdName,
+} from './auth/middleware';
+import type { AuthEnv } from './auth/bindings';
+
+/**
+ * S4-T5 (Task #136): clone the incoming request with cf-worker-injected
+ * identity headers so the TunnelDO can echo them into the daemon hello
+ * frame (Task #133 wire format). Browser ws path only — the daemon path
+ * does not need identity injection (the tunnel JWT itself carries login +
+ * github_id and the daemon already trusts the cloud-issued token).
+ */
+function withIdentityHeaders(
+  req: Request,
+  login: string,
+  github_id: string,
+): Request {
+  const headers = new Headers(req.headers);
+  headers.set('X-CCSM-Identity-Login', login);
+  headers.set('X-CCSM-Identity-Id', github_id);
+  return new Request(req, { headers });
+}
 
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
@@ -52,13 +85,31 @@ export default {
       return new Response('Not Found', { status: 404 });
     }
 
-    if (
-      (url.pathname === '/ws/default' || url.pathname === '/tunnel/default') &&
-      isUpgrade
-    ) {
-      // Route both directions into the same DO instance keyed by 'default'
-      // so the daemon ws and browser ws end up paired in one TunnelDO.
-      // Multi-tunnel routing (per-user / per-pairing-id) is future work.
+    // S4-T5 (Task #136): mode toggle. In `legacy` (default, current
+    // production) the routing below behaves exactly as before: single shared
+    // DO keyed by `'default'`, no JWT check. In `jwt` we extract + verify
+    // the per-user JWT, derive the per-user DO id, and inject identity
+    // headers (browser path) before forwarding into the DO.
+    const mode = getAuthMode(env);
+    const authEnv = env as AuthEnv;
+
+    if (url.pathname === '/ws/default' && isUpgrade) {
+      if (mode === 'jwt') {
+        const claims = await extractWebJwt(req, authEnv);
+        if (claims === null) {
+          // Browsers cannot read 401 bodies on a ws handshake reliably; the
+          // expected UX is a close frame after upgrade. We can't open the
+          // socket from the worker layer (TunnelDO does), so refuse the
+          // upgrade with 401 here. The SPA's WebSocket onclose handler
+          // will surface this as auth failure to the user.
+          return new Response('unauthorized', { status: 401 });
+        }
+        const id = env.TUNNEL.idFromName(getUserDoIdName(claims.sub));
+        const stub = env.TUNNEL.get(id);
+        console.log('[worker] route /ws/default upgrade=true mode=jwt user=' + claims.login);
+        return stub.fetch(withIdentityHeaders(req, claims.login, claims.sub));
+      }
+      // legacy: single shared DO, no JWT check.
       const id = env.TUNNEL.idFromName('default');
       const stub = env.TUNNEL.get(id);
       // R-17 log #12 (Task #45): record ws-route entry into the DO stub.
@@ -70,15 +121,43 @@ export default {
       return stub.fetch(req);
     }
 
+    if (url.pathname === '/tunnel/default' && isUpgrade) {
+      if (mode === 'jwt') {
+        const claims = await extractTunnelJwt(req, authEnv);
+        if (claims === null) {
+          return new Response('unauthorized', { status: 401 });
+        }
+        const id = env.TUNNEL.idFromName(getUserDoIdName(claims.sub));
+        const stub = env.TUNNEL.get(id);
+        console.log('[worker] route /tunnel/default upgrade=true mode=jwt user=' + claims.login + ' jti=' + claims.jti);
+        // Daemon side does not need X-CCSM-Identity-* headers — the daemon
+        // is the trusted side; identity is injected only on the browser
+        // path (so the DO can echo it into the daemon-bound hello frame).
+        return stub.fetch(req);
+      }
+      const id = env.TUNNEL.idFromName('default');
+      const stub = env.TUNNEL.get(id);
+      console.log('[worker] route ' + url.pathname + ' upgrade=' + isUpgrade);
+      return stub.fetch(req);
+    }
+
     // Task #787 (S3-C): REST `/api/*` and `/token` flow through the same DO
     // instance, which serializes them as http_req control frames over the
     // daemon-dialed ws and awaits the matching http_res. The browser only
     // ever talks to cc-sm.pages.dev; the DO bridges to the NAT'd daemon.
     if (url.pathname.startsWith('/api/') || url.pathname === '/token') {
-      const id = env.TUNNEL.idFromName('default');
+      let doIdName = 'default';
+      if (mode === 'jwt') {
+        const claims = await extractWebJwt(req, authEnv);
+        if (claims === null) {
+          return new Response('unauthorized', { status: 401 });
+        }
+        doIdName = getUserDoIdName(claims.sub);
+      }
+      const id = env.TUNNEL.idFromName(doIdName);
       const stub = env.TUNNEL.get(id);
       // R-17 log #12 (Task #45): record HTTP-mux route entry into the DO stub.
-      console.log('[worker] route ' + url.pathname + ' upgrade=' + isUpgrade);
+      console.log('[worker] route ' + url.pathname + ' upgrade=' + isUpgrade + ' mode=' + mode);
       // R-28 (Task #85): /token 502 取证 — log each /token request entry +
       // upstream response status, including method + the cf-ray + the
       // request id from cf headers so we can correlate with the DO log.

--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -382,13 +382,18 @@ export class TunnelDO extends DurableObject<Env> {
       // daemon path above. readyState filtering picks the live one.
       // Task #105 (R-41): tag the browser ws with `browser-sid:<sid>` so
       // post-hibernation lookups can recover the right ws per sid.
-      // Task #133 (S4-T6): identity comes from the cloud OAuth session once
-      // T3/T4 lands. Until then, leave it undefined — the daemon stays on
-      // the legacy token-validation path. When an identity IS available
-      // (future cloud-issued tunnel credential) it will be plumbed through
-      // here and surfaced inside the hello frame so trust-tunnel daemons
-      // can authenticate without re-validating the per-browser token.
-      const identity: BrowserIdentity | undefined = undefined;
+      // Task #133 (S4-T6) + Task #136 (S4-T5): in jwt-mode the cf-worker
+      // verifies the browser's web JWT and injects the resolved identity
+      // via `X-CCSM-Identity-Login` / `X-CCSM-Identity-Id` request headers
+      // before forwarding into this DO. In legacy mode (no JWT, S3-era
+      // smoke flow) the headers are absent and identity stays undefined —
+      // the daemon then falls back to validating the bearer token itself.
+      const idLogin = req.headers.get('X-CCSM-Identity-Login');
+      const idGithub = req.headers.get('X-CCSM-Identity-Id');
+      const identity: BrowserIdentity | undefined =
+        idLogin !== null && idGithub !== null
+          ? { login: idLogin, github_id: idGithub }
+          : undefined;
       const attachment: BrowserAttachment = identity !== undefined
         ? { role: 'browser', token: extracted.token, sid, identity }
         : { role: 'browser', token: extracted.token, sid };

--- a/packages/cf-worker/test/jwtRouting.test.ts
+++ b/packages/cf-worker/test/jwtRouting.test.ts
@@ -1,0 +1,340 @@
+/**
+ * S4-T5 (Task #136): cf-worker JWT routing integration tests.
+ *
+ * We exercise the worker's `fetch` handler directly with a fake
+ * DurableObjectNamespace that records every `idFromName` invocation, so we
+ * can assert:
+ *
+ *   - legacy mode (default): all routes still hit `idFromName('default')`,
+ *     no JWT required (regression guard for the 85+ S3-era tests).
+ *   - jwt mode: /ws/default + /tunnel/default + /api/* + /token reject
+ *     unauthenticated requests with 401.
+ *   - jwt mode cross-user isolation: alice's JWT routes into
+ *     `user:<alice_github_id>`, bob's JWT routes into `user:<bob_github_id>`,
+ *     and the two never collide.
+ *   - jwt mode browser path: identity headers (X-CCSM-Identity-Login /
+ *     X-CCSM-Identity-Id) are added to the request forwarded into the DO so
+ *     the DO can echo them inside the daemon hello frame (Task #133 wire).
+ *   - jwt mode expired token: 401 (browser-side ws upgrade, since we cannot
+ *     open the socket from worker layer; the SPA close handler will surface
+ *     this as auth failure to the user).
+ */
+import { describe, expect, it } from 'vitest';
+import worker from '../src/index';
+import { signJwt, type WebJwtClaims, type TunnelJwtClaims } from '../src/auth/jwt';
+
+const KEY_WEB =
+  '11112233445566778899aabbccddeeff00112233445566778899aabbccddeeff';
+const KEY_TUNNEL = '22ee'.repeat(16);
+
+function nowSec() {
+  return Math.floor(Date.now() / 1000);
+}
+
+interface RecordedFetch {
+  idName: string;
+  url: string;
+  headers: Record<string, string>;
+}
+
+function makeFakeNamespace(handler: (req: Request, idName: string) => Response | Promise<Response>) {
+  const calls: RecordedFetch[] = [];
+  const ns = {
+    idFromName(name: string) {
+      return { __idName: name } as unknown as DurableObjectId;
+    },
+    get(id: { __idName: string }) {
+      return {
+        async fetch(req: Request) {
+          const headers: Record<string, string> = {};
+          req.headers.forEach((v, k) => {
+            headers[k] = v;
+          });
+          calls.push({ idName: id.__idName, url: req.url, headers });
+          return handler(req, id.__idName);
+        },
+      };
+    },
+  } as unknown as DurableObjectNamespace;
+  return { ns, calls };
+}
+
+function makeEnv(opts: {
+  mode?: 'legacy' | 'jwt';
+  handler?: (req: Request, idName: string) => Response | Promise<Response>;
+}) {
+  const handler = opts.handler ?? (() => new Response('ok-from-do', { status: 200 }));
+  const { ns, calls } = makeFakeNamespace(handler);
+  const env = {
+    TUNNEL: ns,
+    USER_DO: undefined as unknown as DurableObjectNamespace,
+    GITHUB_OAUTH_CLIENT_ID: 'iv1.test',
+    GITHUB_OAUTH_CLIENT_SECRET: 'shh',
+    JWT_SIGNING_KEY: KEY_WEB,
+    JWT_REFRESH_SIGNING_KEY: KEY_TUNNEL,
+    CCSM_AUTH_MODE: opts.mode === 'jwt' ? 'jwt' : 'legacy',
+  };
+  return { env, calls };
+}
+
+async function makeWebJwt(over: Partial<WebJwtClaims> = {}) {
+  const claims: WebJwtClaims = {
+    sub: '12345',
+    login: 'octocat',
+    iat: nowSec() - 1,
+    exp: nowSec() + 60,
+    kind: 'web',
+    ...over,
+  };
+  return signJwt(claims, KEY_WEB);
+}
+
+async function makeTunnelJwt(over: Partial<TunnelJwtClaims> = {}) {
+  const claims: TunnelJwtClaims = {
+    sub: '12345',
+    login: 'octocat',
+    iat: nowSec() - 1,
+    exp: nowSec() + 3600,
+    kind: 'tunnel',
+    jti: 't-abc',
+    ...over,
+  };
+  return signJwt(claims, KEY_TUNNEL);
+}
+
+describe('cf-worker routing — legacy mode (default, regression guard)', () => {
+  it('/ws/default upgrade → idFromName("default"), no JWT required', async () => {
+    const { env, calls } = makeEnv({ mode: 'legacy' });
+    const req = new Request('http://x/ws/default', {
+      headers: { Upgrade: 'websocket', 'Sec-WebSocket-Protocol': 'ccsm.legacy-token' },
+    });
+    const res = await worker.fetch(req, env);
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.idName).toBe('default');
+    // No identity headers injected in legacy mode.
+    expect(calls[0]!.headers['x-ccsm-identity-login']).toBeUndefined();
+  });
+
+  it('/tunnel/default upgrade → idFromName("default"), no JWT required', async () => {
+    const { env, calls } = makeEnv({ mode: 'legacy' });
+    const req = new Request('http://x/tunnel/default', {
+      headers: { Upgrade: 'websocket', 'Sec-WebSocket-Protocol': 'ccsm.daemon-tok' },
+    });
+    const res = await worker.fetch(req, env);
+    expect(res.status).toBe(200);
+    expect(calls[0]!.idName).toBe('default');
+  });
+
+  it('/api/sessions → idFromName("default"), no JWT required', async () => {
+    const { env, calls } = makeEnv({ mode: 'legacy' });
+    const res = await worker.fetch(new Request('http://x/api/sessions'), env);
+    expect(res.status).toBe(200);
+    expect(calls[0]!.idName).toBe('default');
+  });
+
+  it('/token → idFromName("default"), no JWT required', async () => {
+    const { env, calls } = makeEnv({ mode: 'legacy' });
+    const res = await worker.fetch(new Request('http://x/token'), env);
+    expect(res.status).toBe(200);
+    expect(calls[0]!.idName).toBe('default');
+  });
+
+  it('default mode (CCSM_AUTH_MODE unset) behaves identically to legacy', async () => {
+    const { ns, calls } = makeFakeNamespace(() => new Response('ok', { status: 200 }));
+    const env = {
+      TUNNEL: ns,
+      USER_DO: undefined as unknown as DurableObjectNamespace,
+      GITHUB_OAUTH_CLIENT_ID: 'iv1',
+      GITHUB_OAUTH_CLIENT_SECRET: 'shh',
+      JWT_SIGNING_KEY: KEY_WEB,
+      JWT_REFRESH_SIGNING_KEY: KEY_TUNNEL,
+      // CCSM_AUTH_MODE intentionally omitted.
+    };
+    const res = await worker.fetch(new Request('http://x/api/sessions'), env);
+    expect(res.status).toBe(200);
+    expect(calls[0]!.idName).toBe('default');
+  });
+});
+
+describe('cf-worker routing — jwt mode rejects unauthenticated', () => {
+  it('/ws/default upgrade without JWT → 401', async () => {
+    const { env, calls } = makeEnv({ mode: 'jwt' });
+    const req = new Request('http://x/ws/default', {
+      headers: { Upgrade: 'websocket' },
+    });
+    const res = await worker.fetch(req, env);
+    expect(res.status).toBe(401);
+    expect(calls).toHaveLength(0); // never reached the DO
+  });
+
+  it('/tunnel/default upgrade without JWT → 401', async () => {
+    const { env, calls } = makeEnv({ mode: 'jwt' });
+    const req = new Request('http://x/tunnel/default', {
+      headers: { Upgrade: 'websocket' },
+    });
+    const res = await worker.fetch(req, env);
+    expect(res.status).toBe(401);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('/api/sessions without Authorization → 401', async () => {
+    const { env, calls } = makeEnv({ mode: 'jwt' });
+    const res = await worker.fetch(new Request('http://x/api/sessions'), env);
+    expect(res.status).toBe(401);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('/token without Authorization → 401', async () => {
+    const { env, calls } = makeEnv({ mode: 'jwt' });
+    const res = await worker.fetch(new Request('http://x/token'), env);
+    expect(res.status).toBe(401);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('/ws/default with expired JWT → 401', async () => {
+    const tok = await makeWebJwt({ iat: nowSec() - 120, exp: nowSec() - 1 });
+    const { env, calls } = makeEnv({ mode: 'jwt' });
+    const req = new Request('http://x/ws/default', {
+      headers: { Upgrade: 'websocket', 'Sec-WebSocket-Protocol': 'ccsm.' + tok },
+    });
+    const res = await worker.fetch(req, env);
+    expect(res.status).toBe(401);
+    expect(calls).toHaveLength(0);
+  });
+
+  it('/ws/default with a tunnel-kind JWT → 401 (kind discriminator enforced)', async () => {
+    // Token is signed with the right (web) key but carries kind='tunnel'.
+    // This guards against accidentally treating the daemon credential as a
+    // browser session. Use signJwt directly to avoid the kind-mismatch in
+    // makeTunnelJwt's default key choice.
+    const tok = await signJwt(
+      {
+        sub: '12345',
+        login: 'octocat',
+        iat: nowSec() - 1,
+        exp: nowSec() + 60,
+        kind: 'tunnel',
+        jti: 'wrong',
+      },
+      KEY_WEB,
+    );
+    const { env } = makeEnv({ mode: 'jwt' });
+    const req = new Request('http://x/ws/default', {
+      headers: { Upgrade: 'websocket', 'Sec-WebSocket-Protocol': 'ccsm.' + tok },
+    });
+    const res = await worker.fetch(req, env);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('cf-worker routing — jwt mode per-user DO isolation', () => {
+  it('alice and bob are routed into distinct TunnelDO instances', async () => {
+    const { env, calls } = makeEnv({ mode: 'jwt' });
+    const aliceTok = await makeWebJwt({ sub: 'gh-alice-1', login: 'alice' });
+    const bobTok = await makeWebJwt({ sub: 'gh-bob-2', login: 'bob' });
+
+    await worker.fetch(
+      new Request('http://x/api/sessions', {
+        headers: { Authorization: 'Bearer ' + aliceTok },
+      }),
+      env,
+    );
+    await worker.fetch(
+      new Request('http://x/api/sessions', {
+        headers: { Authorization: 'Bearer ' + bobTok },
+      }),
+      env,
+    );
+
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.idName).toBe('user:gh-alice-1');
+    expect(calls[1]!.idName).toBe('user:gh-bob-2');
+    expect(calls[0]!.idName).not.toBe(calls[1]!.idName);
+  });
+
+  it('/ws/default with a valid web JWT routes into user:<sub> DO', async () => {
+    const { env, calls } = makeEnv({ mode: 'jwt' });
+    const tok = await makeWebJwt({ sub: '999', login: 'mona' });
+    const res = await worker.fetch(
+      new Request('http://x/ws/default?sid=s1', {
+        headers: { Upgrade: 'websocket', 'Sec-WebSocket-Protocol': 'ccsm.' + tok },
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(calls[0]!.idName).toBe('user:999');
+  });
+
+  it('/ws/default jwt mode injects identity headers for daemon hello frame', async () => {
+    const { env, calls } = makeEnv({ mode: 'jwt' });
+    const tok = await makeWebJwt({ sub: '54321', login: 'hubot' });
+    await worker.fetch(
+      new Request('http://x/ws/default?sid=s1', {
+        headers: { Upgrade: 'websocket', 'Sec-WebSocket-Protocol': 'ccsm.' + tok },
+      }),
+      env,
+    );
+    expect(calls[0]!.headers['x-ccsm-identity-login']).toBe('hubot');
+    expect(calls[0]!.headers['x-ccsm-identity-id']).toBe('54321');
+    // The original ccsm.<jwt> subprotocol must still be present so the DO
+    // can echo it on the 101 response (RFC 6455 §4.2.2 step 4).
+    expect(calls[0]!.headers['sec-websocket-protocol']).toBe('ccsm.' + tok);
+  });
+
+  it('/tunnel/default with a valid tunnel JWT routes into user:<sub> DO (no identity header injected)', async () => {
+    const { env, calls } = makeEnv({ mode: 'jwt' });
+    const tok = await makeTunnelJwt({ sub: '777', login: 'daemon-user' });
+    const res = await worker.fetch(
+      new Request('http://x/tunnel/default', {
+        headers: { Upgrade: 'websocket', 'Sec-WebSocket-Protocol': 'ccsm.' + tok },
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    expect(calls[0]!.idName).toBe('user:777');
+    // Daemon path: identity is carried by the tunnel JWT itself; we don't
+    // inject identity headers on this branch (only browser-bound /ws/* does).
+    expect(calls[0]!.headers['x-ccsm-identity-login']).toBeUndefined();
+  });
+
+  it('cross-user safety: alice JWT cannot land in bob DO even with a colliding sid', async () => {
+    const { env, calls } = makeEnv({ mode: 'jwt' });
+    const aliceTok = await makeWebJwt({ sub: 'gh-alice', login: 'alice' });
+    const bobTok = await makeWebJwt({ sub: 'gh-bob', login: 'bob' });
+    await worker.fetch(
+      new Request('http://x/ws/default?sid=shared-sid', {
+        headers: {
+          Upgrade: 'websocket',
+          'Sec-WebSocket-Protocol': 'ccsm.' + aliceTok,
+        },
+      }),
+      env,
+    );
+    await worker.fetch(
+      new Request('http://x/ws/default?sid=shared-sid', {
+        headers: {
+          Upgrade: 'websocket',
+          'Sec-WebSocket-Protocol': 'ccsm.' + bobTok,
+        },
+      }),
+      env,
+    );
+    expect(calls[0]!.idName).toBe('user:gh-alice');
+    expect(calls[1]!.idName).toBe('user:gh-bob');
+  });
+});
+
+describe('cf-worker routing — /health bypasses auth in both modes', () => {
+  it('legacy', async () => {
+    const { env } = makeEnv({ mode: 'legacy' });
+    const res = await worker.fetch(new Request('http://x/health'), env);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ok\n');
+  });
+  it('jwt', async () => {
+    const { env } = makeEnv({ mode: 'jwt' });
+    const res = await worker.fetch(new Request('http://x/health'), env);
+    expect(res.status).toBe(200);
+  });
+});

--- a/packages/cf-worker/test/middleware.test.ts
+++ b/packages/cf-worker/test/middleware.test.ts
@@ -1,0 +1,233 @@
+/**
+ * S4-T5 (Task #136): cf-worker JWT routing middleware unit tests.
+ *
+ * Pure helper coverage — no DO / no fetch handler. We exercise:
+ *   - getAuthMode env-var gating (default legacy / explicit jwt / typo)
+ *   - getUserDoIdName format
+ *   - extractWebJwt: ws subprotocol, Authorization Bearer, missing,
+ *     expired, wrong-key, wrong-kind (tunnel JWT presented at web path)
+ *   - extractTunnelJwt: subprotocol-only path + wrong-kind rejection
+ *
+ * Uses the same KEY_A/KEY_B pattern as jwt.test.ts — 32-byte hex keys.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  extractTunnelJwt,
+  extractWebJwt,
+  getAuthMode,
+  getUserDoIdName,
+} from '../src/auth/middleware';
+import {
+  signJwt,
+  type TunnelJwtClaims,
+  type WebJwtClaims,
+} from '../src/auth/jwt';
+import type { AuthEnv } from '../src/auth/bindings';
+
+const KEY_WEB =
+  '11112233445566778899aabbccddeeff00112233445566778899aabbccddeeff';
+const KEY_TUNNEL =
+  '22ee'.repeat(16);
+
+function makeEnv(overrides: Partial<AuthEnv> = {}): AuthEnv {
+  return {
+    TUNNEL: undefined as unknown as DurableObjectNamespace,
+    USER_DO: undefined as unknown as DurableObjectNamespace,
+    GITHUB_OAUTH_CLIENT_ID: 'iv1.test',
+    GITHUB_OAUTH_CLIENT_SECRET: 'shh',
+    JWT_SIGNING_KEY: KEY_WEB,
+    JWT_REFRESH_SIGNING_KEY: KEY_TUNNEL,
+    CCSM_AUTH_MODE: undefined,
+    ...overrides,
+  };
+}
+
+function nowSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+function makeWebClaims(over: Partial<WebJwtClaims> = {}): WebJwtClaims {
+  return {
+    sub: '12345',
+    login: 'octocat',
+    iat: nowSec() - 1,
+    exp: nowSec() + 60,
+    kind: 'web',
+    ...over,
+  };
+}
+
+function makeTunnelClaims(over: Partial<TunnelJwtClaims> = {}): TunnelJwtClaims {
+  return {
+    sub: '12345',
+    login: 'octocat',
+    iat: nowSec() - 1,
+    exp: nowSec() + 3600,
+    kind: 'tunnel',
+    jti: 't-abc',
+    ...over,
+  };
+}
+
+describe('getAuthMode', () => {
+  it('defaults to legacy when unset', () => {
+    expect(getAuthMode({})).toBe('legacy');
+    expect(getAuthMode({ CCSM_AUTH_MODE: undefined })).toBe('legacy');
+  });
+  it('returns jwt when explicitly "jwt"', () => {
+    expect(getAuthMode({ CCSM_AUTH_MODE: 'jwt' })).toBe('jwt');
+  });
+  it('falls back to legacy on typo / unknown value', () => {
+    expect(getAuthMode({ CCSM_AUTH_MODE: 'JWT' })).toBe('legacy');
+    expect(getAuthMode({ CCSM_AUTH_MODE: 'enabled' })).toBe('legacy');
+    expect(getAuthMode({ CCSM_AUTH_MODE: '' })).toBe('legacy');
+  });
+});
+
+describe('getUserDoIdName', () => {
+  it('namespaces github_id under user: prefix', () => {
+    expect(getUserDoIdName('12345')).toBe('user:12345');
+    expect(getUserDoIdName('99')).toBe('user:99');
+  });
+  it('different ids produce different names (DO isolation)', () => {
+    expect(getUserDoIdName('1')).not.toBe(getUserDoIdName('2'));
+  });
+});
+
+describe('extractWebJwt', () => {
+  it('extracts from Sec-WebSocket-Protocol ccsm.<jwt>', async () => {
+    const claims = makeWebClaims();
+    const tok = await signJwt(claims, KEY_WEB);
+    const req = new Request('http://x/ws/default', {
+      headers: { 'Sec-WebSocket-Protocol': 'ccsm.' + tok },
+    });
+    const out = await extractWebJwt(req, makeEnv());
+    expect(out).not.toBeNull();
+    expect(out!.login).toBe('octocat');
+    expect(out!.sub).toBe('12345');
+  });
+
+  it('extracts from Authorization: Bearer header', async () => {
+    const tok = await signJwt(makeWebClaims(), KEY_WEB);
+    const req = new Request('http://x/api/sessions', {
+      headers: { Authorization: 'Bearer ' + tok },
+    });
+    const out = await extractWebJwt(req, makeEnv());
+    expect(out).not.toBeNull();
+    expect(out!.kind).toBe('web');
+  });
+
+  it('returns null when no token header present', async () => {
+    const req = new Request('http://x/api/sessions');
+    const out = await extractWebJwt(req, makeEnv());
+    expect(out).toBeNull();
+  });
+
+  it('returns null on expired token', async () => {
+    const tok = await signJwt(
+      makeWebClaims({ iat: nowSec() - 120, exp: nowSec() - 1 }),
+      KEY_WEB,
+    );
+    const req = new Request('http://x/ws/default', {
+      headers: { 'Sec-WebSocket-Protocol': 'ccsm.' + tok },
+    });
+    const out = await extractWebJwt(req, makeEnv());
+    expect(out).toBeNull();
+  });
+
+  it('returns null when signed with the wrong key', async () => {
+    const tok = await signJwt(makeWebClaims(), KEY_TUNNEL); // wrong key
+    const req = new Request('http://x/ws/default', {
+      headers: { 'Sec-WebSocket-Protocol': 'ccsm.' + tok },
+    });
+    const out = await extractWebJwt(req, makeEnv());
+    expect(out).toBeNull();
+  });
+
+  it('returns null when a tunnel JWT is presented at web path (kind mismatch)', async () => {
+    // Token is well-formed and signed with JWT_SIGNING_KEY but kind='tunnel'.
+    const claims: TunnelJwtClaims = makeTunnelClaims();
+    const tok = await signJwt(claims, KEY_WEB);
+    const req = new Request('http://x/ws/default', {
+      headers: { 'Sec-WebSocket-Protocol': 'ccsm.' + tok },
+    });
+    const out = await extractWebJwt(req, makeEnv());
+    expect(out).toBeNull();
+  });
+
+  it('Sec-WebSocket-Protocol takes precedence over Authorization header', async () => {
+    // A real client wouldn't send both, but the code path orders subprotocol
+    // first; document that explicitly so a future refactor doesn't flip it.
+    const wsTok = await signJwt(makeWebClaims({ login: 'fromWs' }), KEY_WEB);
+    const authTok = await signJwt(makeWebClaims({ login: 'fromAuth' }), KEY_WEB);
+    const req = new Request('http://x/ws/default', {
+      headers: {
+        'Sec-WebSocket-Protocol': 'ccsm.' + wsTok,
+        Authorization: 'Bearer ' + authTok,
+      },
+    });
+    const out = await extractWebJwt(req, makeEnv());
+    expect(out!.login).toBe('fromWs');
+  });
+
+  it('ignores non-ccsm subprotocol entries', async () => {
+    const tok = await signJwt(makeWebClaims(), KEY_WEB);
+    const req = new Request('http://x/ws/default', {
+      headers: { 'Sec-WebSocket-Protocol': 'graphql-ws, ccsm.' + tok + ', json' },
+    });
+    const out = await extractWebJwt(req, makeEnv());
+    expect(out).not.toBeNull();
+  });
+
+  it('returns null when ccsm. subprotocol present but token empty', async () => {
+    const req = new Request('http://x/ws/default', {
+      headers: { 'Sec-WebSocket-Protocol': 'ccsm.' },
+    });
+    const out = await extractWebJwt(req, makeEnv());
+    expect(out).toBeNull();
+  });
+});
+
+describe('extractTunnelJwt', () => {
+  it('extracts a tunnel-kind JWT from subprotocol', async () => {
+    const tok = await signJwt(makeTunnelClaims(), KEY_TUNNEL);
+    const req = new Request('http://x/tunnel/default', {
+      headers: { 'Sec-WebSocket-Protocol': 'ccsm.' + tok },
+    });
+    const out = await extractTunnelJwt(req, makeEnv());
+    expect(out).not.toBeNull();
+    expect(out!.kind).toBe('tunnel');
+    expect(out!.jti).toBe('t-abc');
+  });
+
+  it('rejects a web-kind JWT presented at tunnel path', async () => {
+    // Even if signed with the refresh key, kind='web' must be rejected.
+    const tok = await signJwt(makeWebClaims(), KEY_TUNNEL);
+    const req = new Request('http://x/tunnel/default', {
+      headers: { 'Sec-WebSocket-Protocol': 'ccsm.' + tok },
+    });
+    const out = await extractTunnelJwt(req, makeEnv());
+    expect(out).toBeNull();
+  });
+
+  it('returns null when subprotocol header missing (Authorization is NOT consulted)', async () => {
+    const tok = await signJwt(makeTunnelClaims(), KEY_TUNNEL);
+    const req = new Request('http://x/tunnel/default', {
+      headers: { Authorization: 'Bearer ' + tok },
+    });
+    const out = await extractTunnelJwt(req, makeEnv());
+    expect(out).toBeNull();
+  });
+
+  it('returns null on expired tunnel token', async () => {
+    const tok = await signJwt(
+      makeTunnelClaims({ iat: nowSec() - 7200, exp: nowSec() - 60 }),
+      KEY_TUNNEL,
+    );
+    const req = new Request('http://x/tunnel/default', {
+      headers: { 'Sec-WebSocket-Protocol': 'ccsm.' + tok },
+    });
+    const out = await extractTunnelJwt(req, makeEnv());
+    expect(out).toBeNull();
+  });
+});

--- a/packages/cf-worker/wrangler.toml
+++ b/packages/cf-worker/wrangler.toml
@@ -2,6 +2,19 @@ name = "ccsm-worker"
 main = "src/index.ts"
 compatibility_date = "2026-01-01"
 
+# S4-T5 (Task #136): auth mode toggle. `legacy` keeps the S3-era
+# token-based flow with a single shared TunnelDO keyed by `'default'` —
+# what production runs today and what `npm run smoke` exercises. `jwt`
+# enforces JWT verification on /ws/*, /tunnel/*, /api/* and /token, and
+# routes each user into a per-user TunnelDO id (`user:<github_id>`).
+#
+# Production rollout: deploy with `legacy`, then flip to `jwt` (via
+# `wrangler deploy --var CCSM_AUTH_MODE:jwt` or by editing this file) once
+# the SPA sign-in UI (T7/T8) is shipped and propagating JWTs on the
+# WebSocket subprotocol / Authorization header.
+[vars]
+CCSM_AUTH_MODE = "legacy"
+
 # S4 (Task #113): GitHub OAuth App credentials + JWT signing keys.
 # Set in production via:
 #   wrangler secret put GITHUB_OAUTH_CLIENT_ID


### PR DESCRIPTION
## Summary
- Adds `CCSM_AUTH_MODE` vars toggle to cf-worker (`legacy` default / `jwt` opt-in) so per-user JWT routing can roll out without breaking the S3-era token flow that production + smoke still rely on.
- New `packages/cf-worker/src/auth/middleware.ts` exports `getAuthMode`, `getUserDoIdName`, `extractWebJwt`, `extractTunnelJwt`. `extractWebJwt` looks at the `ccsm.<jwt>` WS subprotocol first, then `Authorization: Bearer`; both helpers narrow on `kind` so a tunnel JWT presented at a browser path (or vice versa) is rejected.
- In `jwt` mode the worker routes into `TUNNEL.idFromName('user:<github_id>')`. /ws/default also injects `X-CCSM-Identity-Login` / `X-CCSM-Identity-Id` request headers so the DO echoes them inside the daemon hello frame (Task #133 wire format). TunnelDO internals (sid envelope, getBrowserSocket, hello-frame format) are otherwise untouched.
- /api/* and /token in `jwt` mode require Authorization Bearer; missing/invalid → 401 before any DO touch.

## Test plan
- [x] `npx vitest run` — 8 files, 121 tests passed (85 baseline + 36 new across `middleware.test.ts` and `jwtRouting.test.ts`)
- [x] `npm run typecheck` — exit 0
- [x] `npm run lint` — exit 0
- [x] Cross-user isolation asserted: alice JWT → `user:gh-alice` DO, bob JWT → `user:gh-bob` DO, including with a colliding `?sid=` query.
- [x] Legacy regression guard: all four routes (/ws, /tunnel, /api/*, /token) still hit `idFromName('default')` with no JWT in `legacy` mode and when `CCSM_AUTH_MODE` is unset.

## Local checks (host: Windows 11, mode: fast)
- lint: ✓ (exit 0)
- typecheck: ✓ (exit 0)
- build: ✓ (cf-worker `npm run build` aliases to `tsc --noEmit`, exit 0)
- unit tests: cf-worker `vitest run` — `Test Files 8 passed (8)`, `Tests 121 passed (121)`, Duration 3.96s
- e2e: skipped — change is scoped to `packages/cf-worker/`; Electron e2e harness does not exercise the worker fetch handler (smoke only verifies legacy mode end-to-end via the daemon path, which is regressed-tested above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)