### PR TITLE
feat(tauri): Task #141 — main-UI Login button (device flow on demand) (S4-T8)

### DIFF
--- a/packages/daemon/src/index.mts
+++ b/packages/daemon/src/index.mts
@@ -146,10 +146,24 @@ async function main(): Promise<void> {
     console.error('[ccsm] tunnel: disabled (CCSM_TUNNEL_DISABLE)');
   } else {
     console.error(`[ccsm] tunnel: connecting ${tunnelUrl}`);
+    // S4-T8 (Task #141): when the Tauri shell has injected CCSM_TUNNEL_JWT
+    // (after the user completes device-flow login from the main UI), encode
+    // the JWT as the `ccsm.<jwt>` ws subprotocol so the cf-worker can
+    // authenticate the daemon side of the tunnel against its JWT signing
+    // key. Absence of the env var keeps the legacy unauth dial path.
+    const tunnelJwt = process.env.CCSM_TUNNEL_JWT;
+    const subprotocols =
+      typeof tunnelJwt === 'string' && tunnelJwt.length > 0
+        ? [`ccsm.${tunnelJwt}`]
+        : undefined;
+    if (subprotocols !== undefined) {
+      console.error('[ccsm] tunnel: dialing with cloud-issued JWT subprotocol');
+    }
     tunnel = new TunnelClient({
       url: tunnelUrl,
       token,
       daemonLoopbackPort: port,
+      ...(subprotocols !== undefined ? { subprotocols } : {}),
       onFrame: (data) => {
         const len = typeof data === 'string'
           ? Buffer.byteLength(data, 'utf8')

--- a/packages/daemon/src/tunnel.mts
+++ b/packages/daemon/src/tunnel.mts
@@ -77,6 +77,18 @@ export interface TunnelClientOptions {
    */
   wsFactory?: WsFactory;
   /**
+   * Optional WebSocket subprotocols to negotiate at handshake (RFC 6455 §1.9).
+   *
+   * S4-T8 (Task #141): when the daemon is running with a cloud-issued tunnel
+   * JWT (env `CCSM_TUNNEL_JWT`, set by the Tauri shell after the user
+   * completes device-flow login), we encode the JWT as `ccsm.<jwt>` here.
+   * The Cloudflare Worker / TunnelDO will (in future) validate this against
+   * the JWT signing key the same way it already validates browser-side
+   * `ccsm.<token>` subprotocol values for `/ws/default`. Legacy / unauth
+   * daemons leave this undefined and dial without subprotocols.
+   */
+  subprotocols?: string[];
+  /**
    * DI seam for tests. Defaults to `globalThis.fetch` (Node 22). Tests
    * inject a stub so we can drive http_req → http_res without binding a
    * real loopback server.
@@ -140,14 +152,14 @@ export interface WsLike {
   close(code?: number, reason?: string): void;
 }
 
-export type WsFactory = (url: string) => WsLike;
+export type WsFactory = (url: string, protocols?: string[]) => WsLike;
 
 // Backoff sequence (ms). Each step gets ±20% jitter. Capped at 30s.
 const BACKOFF_SEQUENCE_MS = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000];
 const BACKOFF_JITTER = 0.2;
 
-function defaultWsFactory(url: string): WsLike {
-  return new WebSocket(url) as unknown as WsLike;
+function defaultWsFactory(url: string, protocols?: string[]): WsLike {
+  return new WebSocket(url, protocols) as unknown as WsLike;
 }
 
 /**
@@ -341,6 +353,7 @@ export class TunnelClient {
   private readonly wsFactory: WsFactory;
   private readonly daemonLoopbackPort: number;
   private readonly fetchImpl: typeof fetch;
+  private readonly subprotocols: string[] | undefined;
 
   private state: TunnelState = 'idle';
   private ws: WsLike | null = null;
@@ -372,6 +385,10 @@ export class TunnelClient {
     this.daemonLoopbackPort = opts.daemonLoopbackPort ?? 0;
     this.fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
     this.onBrowserAttach = opts.onBrowserAttach ?? null;
+    this.subprotocols =
+      opts.subprotocols !== undefined && opts.subprotocols.length > 0
+        ? opts.subprotocols
+        : undefined;
   }
 
   getState(): TunnelState {
@@ -447,7 +464,7 @@ export class TunnelClient {
     this.identities.clear();
     let socket: WsLike;
     try {
-      socket = this.wsFactory(this.url);
+      socket = this.wsFactory(this.url, this.subprotocols);
     } catch (err) {
       console.warn('[ccsm/tunnel] factory threw:', (err as Error).message);
       this.scheduleReconnect();

--- a/packages/daemon/test/tunnel.test.ts
+++ b/packages/daemon/test/tunnel.test.ts
@@ -83,12 +83,12 @@ function makeFakeSocket(url: string): FakeSocket {
 // ---- Tests --------------------------------------------------------------
 
 describe('TunnelClient', () => {
-  let factory: Mock<(url: string) => WsLike>;
+  let factory: Mock<(url: string, protocols?: string[]) => WsLike>;
   let sockets: FakeSocket[];
 
   beforeEach(() => {
     sockets = [];
-    factory = vi.fn((url: string) => {
+    factory = vi.fn((url: string, _protocols?: string[]) => {
       const s = makeFakeSocket(url);
       sockets.push(s);
       return s;
@@ -1026,5 +1026,45 @@ describe('TunnelClient', () => {
     } finally {
       if (prior !== undefined) process.env.CCSM_TRUST_TUNNEL = prior;
     }
+  });
+
+  // ---- S4-T8 (Task #141) ws subprotocol negotiation -------------------
+  it('passes the configured subprotocols through to the ws factory', () => {
+    const client = new TunnelClient({
+      url: 'wss://example/tunnel/x',
+      token: 'tok',
+      onFrame: () => {},
+      wsFactory: factory,
+      subprotocols: ['ccsm.eyJhbGciOi.payload.sig'],
+    });
+    client.start();
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(factory).toHaveBeenCalledWith(
+      'wss://example/tunnel/x',
+      ['ccsm.eyJhbGciOi.payload.sig'],
+    );
+  });
+
+  it('passes undefined subprotocols (legacy) when not configured', () => {
+    const client = new TunnelClient({
+      url: 'wss://example/tunnel/x',
+      token: 'tok',
+      onFrame: () => {},
+      wsFactory: factory,
+    });
+    client.start();
+    expect(factory).toHaveBeenCalledWith('wss://example/tunnel/x', undefined);
+  });
+
+  it('treats an empty subprotocols array as legacy (passes undefined)', () => {
+    const client = new TunnelClient({
+      url: 'wss://example/tunnel/x',
+      token: 'tok',
+      onFrame: () => {},
+      wsFactory: factory,
+      subprotocols: [],
+    });
+    client.start();
+    expect(factory).toHaveBeenCalledWith('wss://example/tunnel/x', undefined);
   });
 });

--- a/packages/frontend-tauri/src-tauri/Cargo.lock
+++ b/packages/frontend-tauri/src-tauri/Cargo.lock
@@ -273,6 +273,7 @@ version = "0.0.0"
 dependencies = [
  "getrandom 0.2.17",
  "hex",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -314,6 +315,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -1026,8 +1033,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1037,9 +1046,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1309,6 +1320,22 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1742,6 +1769,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -2293,6 +2326,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2380,6 +2422,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2399,6 +2496,35 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -2477,6 +2603,44 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
@@ -2510,6 +2674,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2525,10 +2703,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2718,6 +2937,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2960,6 +3191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3111,7 +3348,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "serde_repr",
@@ -3423,6 +3660,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,6 +3699,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -3746,6 +4008,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3982,6 +4250,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4035,6 +4313,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4307,6 +4594,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4772,6 +5068,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4791,6 +5107,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/packages/frontend-tauri/src-tauri/Cargo.toml
+++ b/packages/frontend-tauri/src-tauri/Cargo.toml
@@ -25,6 +25,12 @@ tokio = { version = "1", features = ["process", "io-util", "rt-multi-thread", "m
 getrandom = "0.2"
 hex = "0.4"
 
+# S4-T8 (#141): GitHub device-flow on demand from main UI. We POST to the
+# cf-worker (cc-sm.pages.dev/api/auth/device/{start,poll}) and persist the
+# resulting tunnel JWT. reqwest is the de-facto Rust HTTP client; rustls-tls
+# avoids dragging openssl onto Windows builders.
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+
 # T9: Win32 Job Object — bind the daemon child to a Job with
 # JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE so that any death of ccsm-tauri.exe
 # (TerminateProcess from Task Manager, app crash, hard power loss is OS-handled)

--- a/packages/frontend-tauri/src-tauri/Cargo.toml
+++ b/packages/frontend-tauri/src-tauri/Cargo.toml
@@ -26,9 +26,9 @@ getrandom = "0.2"
 hex = "0.4"
 
 # S4-T8 (#141): GitHub device-flow on demand from main UI. We POST to the
-# cf-worker (cc-sm.pages.dev/api/auth/device/{start,poll}) and persist the
-# resulting tunnel JWT. reqwest is the de-facto Rust HTTP client; rustls-tls
-# avoids dragging openssl onto Windows builders.
+# cf-worker (CCSM_AUTH_BASE env, repo-agnostic — no hardcoded host) and
+# persist the resulting tunnel JWT. reqwest is the de-facto Rust HTTP client;
+# rustls-tls avoids dragging openssl onto Windows builders.
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 
 # T9: Win32 Job Object — bind the daemon child to a Job with

--- a/packages/frontend-tauri/src-tauri/src/auth.rs
+++ b/packages/frontend-tauri/src-tauri/src/auth.rs
@@ -1,0 +1,563 @@
+// S4-T8 (Task #141): GitHub device-flow OAuth, on-demand from the main UI.
+//
+// User pressing the Login button triggers `start_oauth`, which:
+//   1. POSTs cc-sm.pages.dev/api/auth/device/start to mint device + user codes.
+//   2. Returns the user_code + verification_uri to the SPA so the modal can
+//      display them. The SPA opens the verification URL via plugin-shell; the
+//      user finishes auth in their default browser.
+//   3. Spawns a background poll task that hits /api/auth/device/poll on the
+//      worker-supplied interval. On success it persists the returned tunnel
+//      JWT + refresh token to ~/.ccsm/tunnel_jwt (chmod 600 on Unix; on
+//      Windows the default %USERPROFILE% ACL provides equivalent protection
+//      for the threat model — see daemon_mgr::write_token_file).
+//   4. Emits a Tauri event for state transitions (`oauth-state-change`,
+//      `oauth-complete`, `oauth-failed`). The JWT itself is NEVER sent to the
+//      SPA — only the resolved login is, so the renderer can render "@user".
+//
+// Why a Rust-side persistor (vs. SPA storing the JWT): the daemon needs the
+// JWT in `CCSM_TUNNEL_JWT` env at spawn time. The SPA cannot inject env into
+// a child process started by the Tauri shell; only the Rust side can. Storing
+// in localStorage would also leak the JWT to the renderer's JS context, which
+// is unnecessary surface for a credential the renderer never uses.
+//
+// On disk format (~/.ccsm/tunnel_jwt) — JSON, single object:
+//   { "tunnel_jwt": "<jwt>", "tunnel_refresh_token": "<hex>", "login": "<gh-login>" }
+//
+// Threat model: only readable by the current OS user. Tunnel refresh rotates
+// on every refresh (cf-worker side), so a stolen file gives the attacker at
+// most one refresh round-trip until the legitimate daemon next refreshes.
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, Manager, State};
+use tauri_plugin_shell::ShellExt;
+use tokio::time::sleep;
+
+const DEFAULT_AUTH_BASE: &str = "https://cc-sm.pages.dev";
+const MAX_POLL_INTERVAL_SEC: u64 = 60;
+
+/// Persisted credential blob — read by `daemon_mgr` at spawn time.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PersistedTunnelCreds {
+    pub tunnel_jwt: String,
+    pub tunnel_refresh_token: String,
+    pub login: String,
+}
+
+#[derive(Serialize, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum OauthState {
+    Idle,
+    AwaitingUser,
+    Success,
+    Failed,
+}
+
+/// Process-wide OAuth state. Held in `tauri::State` so commands and the poll
+/// task share a single source of truth.
+#[derive(Default)]
+pub struct OauthStore {
+    state: Mutex<OauthState>,
+}
+
+impl OauthStore {
+    fn set(&self, app: &AppHandle, next: OauthState) {
+        {
+            let mut g = self.state.lock().expect("oauth state mutex poisoned");
+            *g = next.clone();
+        }
+        let _ = app.emit("oauth-state-change", &next);
+    }
+
+    fn snapshot(&self) -> OauthState {
+        self.state
+            .lock()
+            .expect("oauth state mutex poisoned")
+            .clone()
+    }
+}
+
+impl Default for OauthState {
+    fn default() -> Self {
+        // If a credential file already exists at startup, the manager flips us
+        // to Success on first read. Until then we are idle.
+        OauthState::Idle
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire types — matched 1:1 with cf-worker `deviceFlow.ts`.
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize, Serialize, Clone, Debug)]
+pub struct DeviceStartResponse {
+    pub device_code: String,
+    pub user_code: String,
+    pub verification_uri: String,
+    pub expires_in: u64,
+    pub interval: u64,
+}
+
+/// What the SPA receives from `start_oauth`. We strip device_code so the SPA
+/// cannot directly drive the poll loop (the Rust task owns it).
+#[derive(Serialize, Clone, Debug)]
+pub struct StartOauthSpaPayload {
+    pub user_code: String,
+    pub verification_uri: String,
+    pub expires_in: u64,
+    pub interval: u64,
+}
+
+#[derive(Deserialize, Debug)]
+struct DevicePollSuccess {
+    tunnel_jwt: String,
+    tunnel_refresh_token: String,
+    login: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct DevicePollPending {
+    status: String,
+    interval: Option<u64>,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct OauthCompletePayload {
+    pub login: String,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct OauthFailedPayload {
+    pub reason: String,
+}
+
+// ---------------------------------------------------------------------------
+// On-disk persistence
+// ---------------------------------------------------------------------------
+
+fn ccsm_dir() -> Result<PathBuf, String> {
+    #[cfg(windows)]
+    let home = std::env::var_os("USERPROFILE")
+        .ok_or_else(|| "USERPROFILE env not set".to_string())?;
+    #[cfg(not(windows))]
+    let home = std::env::var_os("HOME").ok_or_else(|| "HOME env not set".to_string())?;
+    Ok(PathBuf::from(home).join(".ccsm"))
+}
+
+fn tunnel_jwt_path() -> Result<PathBuf, String> {
+    Ok(ccsm_dir()?.join("tunnel_jwt"))
+}
+
+pub fn read_persisted_creds() -> Option<PersistedTunnelCreds> {
+    let path = match tunnel_jwt_path() {
+        Ok(p) => p,
+        Err(_) => return None,
+    };
+    let raw = std::fs::read_to_string(&path).ok()?;
+    let parsed: PersistedTunnelCreds = serde_json::from_str(&raw).ok()?;
+    if parsed.tunnel_jwt.is_empty() || parsed.login.is_empty() {
+        return None;
+    }
+    Some(parsed)
+}
+
+fn write_persisted_creds(creds: &PersistedTunnelCreds) -> Result<(), String> {
+    let dir = ccsm_dir()?;
+    std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir {}: {e}", dir.display()))?;
+    let path = dir.join("tunnel_jwt");
+    let json = serde_json::to_string(creds).map_err(|e| format!("serialize creds: {e}"))?;
+    write_creds_file(&path, &json)?;
+    Ok(())
+}
+
+fn delete_persisted_creds() -> Result<(), String> {
+    let path = tunnel_jwt_path()?;
+    if path.exists() {
+        std::fs::remove_file(&path)
+            .map_err(|e| format!("remove {}: {e}", path.display()))?;
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn write_creds_file(path: &std::path::Path, contents: &str) -> Result<(), String> {
+    use std::io::Write;
+    use std::os::unix::fs::OpenOptionsExt;
+    // Truncate-and-rewrite is OK here — the daemon reads only at spawn time.
+    let _ = std::fs::remove_file(path);
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|e| format!("create {}: {e}", path.display()))?;
+    f.write_all(contents.as_bytes())
+        .map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn write_creds_file(path: &std::path::Path, contents: &str) -> Result<(), String> {
+    // Windows: %USERPROFILE% files inherit the user-profile ACL (Full Control
+    // owner + SYSTEM/Administrators, no other users) — same model as
+    // daemon_mgr::write_token_file. See that file for the full rationale.
+    use std::io::Write;
+    let _ = std::fs::remove_file(path);
+    let mut f = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|e| format!("create {}: {e}", path.display()))?;
+    f.write_all(contents.as_bytes())
+        .map_err(|e| format!("write {}: {e}", path.display()))?;
+    Ok(())
+}
+
+fn auth_base() -> String {
+    std::env::var("CCSM_AUTH_BASE").unwrap_or_else(|_| DEFAULT_AUTH_BASE.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Tauri commands
+// ---------------------------------------------------------------------------
+
+#[tauri::command]
+pub async fn start_oauth(
+    app: AppHandle,
+    store: State<'_, OauthStore>,
+) -> Result<StartOauthSpaPayload, String> {
+    // Reject re-entry while a flow is awaiting the user.
+    if matches!(store.snapshot(), OauthState::AwaitingUser) {
+        return Err("oauth already in progress".to_string());
+    }
+
+    let url = format!("{}/api/auth/device/start", auth_base());
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("build http client: {e}"))?;
+
+    let res = client
+        .post(&url)
+        .send()
+        .await
+        .map_err(|e| format!("device/start http error: {e}"))?;
+    if !res.status().is_success() {
+        return Err(format!("device/start status {}", res.status()));
+    }
+    let parsed: DeviceStartResponse = res
+        .json()
+        .await
+        .map_err(|e| format!("device/start json: {e}"))?;
+
+    store.set(&app, OauthState::AwaitingUser);
+
+    // Best-effort: open the verification URL in the user's default browser
+    // via plugin-shell (already a workspace dep). Failure is logged and the
+    // SPA still renders the URL + user_code in its modal so the user can
+    // navigate manually.
+    if let Err(e) = app.shell().open(&parsed.verification_uri, None) {
+        eprintln!("[auth] shell.open({}) failed: {e}", parsed.verification_uri);
+    }
+
+    let spa = StartOauthSpaPayload {
+        user_code: parsed.user_code.clone(),
+        verification_uri: parsed.verification_uri.clone(),
+        expires_in: parsed.expires_in,
+        interval: parsed.interval.max(1),
+    };
+
+    // Spawn the poll loop. We move the device_code in so the SPA never sees
+    // it — only the Rust side polls for completion.
+    let app_for_poll = app.clone();
+    let device_code = parsed.device_code.clone();
+    let initial_interval = parsed.interval.max(1);
+    let expires_in = parsed.expires_in;
+    tauri::async_runtime::spawn(async move {
+        run_poll_loop(app_for_poll, device_code, initial_interval, expires_in).await;
+    });
+
+    Ok(spa)
+}
+
+#[tauri::command]
+pub fn get_oauth_state(store: State<'_, OauthStore>) -> OauthState {
+    store.snapshot()
+}
+
+#[tauri::command]
+pub async fn oauth_logout(
+    app: AppHandle,
+    store: State<'_, OauthStore>,
+) -> Result<(), String> {
+    delete_persisted_creds()?;
+    store.set(&app, OauthState::Idle);
+    Ok(())
+}
+
+/// Read currently-known login (if any) from the persisted creds. Lets the
+/// SPA render "@login" without exposing the JWT.
+#[tauri::command]
+pub fn get_oauth_login() -> Option<String> {
+    read_persisted_creds().map(|c| c.login)
+}
+
+// ---------------------------------------------------------------------------
+// Poll loop
+// ---------------------------------------------------------------------------
+
+async fn run_poll_loop(
+    app: AppHandle,
+    device_code: String,
+    initial_interval_sec: u64,
+    expires_in_sec: u64,
+) {
+    let store: State<OauthStore> = app.state();
+    let url = format!("{}/api/auth/device/poll", auth_base());
+    let deadline = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() + expires_in_sec)
+        .unwrap_or(u64::MAX);
+
+    let client = match reqwest::Client::builder()
+        .timeout(Duration::from_secs(15))
+        .build()
+    {
+        Ok(c) => c,
+        Err(e) => {
+            emit_failed(&app, &store, format!("build http client: {e}"));
+            return;
+        }
+    };
+
+    let mut interval = initial_interval_sec.clamp(1, MAX_POLL_INTERVAL_SEC);
+
+    loop {
+        sleep(Duration::from_secs(interval)).await;
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        if now >= deadline {
+            emit_failed(&app, &store, "device code expired".to_string());
+            return;
+        }
+
+        let body = serde_json::json!({ "device_code": device_code });
+        let res = match client.post(&url).json(&body).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                eprintln!("[auth] poll http error: {e}; will retry");
+                continue;
+            }
+        };
+
+        let status = res.status();
+        let bytes = match res.bytes().await {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("[auth] poll body read error: {e}; will retry");
+                continue;
+            }
+        };
+
+        // Success path — the worker returns 200 + tunnel_jwt.
+        if status.is_success() {
+            // Try success shape first.
+            if let Ok(success) = serde_json::from_slice::<DevicePollSuccess>(&bytes) {
+                let creds = PersistedTunnelCreds {
+                    tunnel_jwt: success.tunnel_jwt,
+                    tunnel_refresh_token: success.tunnel_refresh_token,
+                    login: success.login,
+                };
+                if let Err(e) = write_persisted_creds(&creds) {
+                    emit_failed(&app, &store, format!("persist creds: {e}"));
+                    return;
+                }
+                store.set(&app, OauthState::Success);
+                let _ = app.emit(
+                    "oauth-complete",
+                    OauthCompletePayload { login: creds.login.clone() },
+                );
+                return;
+            }
+            // Pending / slow_down come back as 200 too.
+            if let Ok(pending) = serde_json::from_slice::<DevicePollPending>(&bytes) {
+                match pending.status.as_str() {
+                    "pending" => {
+                        if let Some(i) = pending.interval {
+                            interval = i.clamp(1, MAX_POLL_INTERVAL_SEC);
+                        }
+                        continue;
+                    }
+                    "slow_down" => {
+                        // GitHub's slow_down asks us to back off; honor the
+                        // worker-supplied new interval, falling back to +5s.
+                        interval = pending
+                            .interval
+                            .unwrap_or(interval.saturating_add(5))
+                            .clamp(1, MAX_POLL_INTERVAL_SEC);
+                        continue;
+                    }
+                    other => {
+                        emit_failed(
+                            &app,
+                            &store,
+                            format!("device/poll unknown status: {other}"),
+                        );
+                        return;
+                    }
+                }
+            }
+            emit_failed(
+                &app,
+                &store,
+                "device/poll body shape unknown".to_string(),
+            );
+            return;
+        }
+
+        // 410 expired / 403 denied / 502 etc.
+        let parsed = serde_json::from_slice::<DevicePollPending>(&bytes).ok();
+        let reason = match parsed.as_ref().map(|p| p.status.as_str()) {
+            Some("expired") => "expired".to_string(),
+            Some("denied") => "denied".to_string(),
+            Some(other) => format!("device/poll error status={other}"),
+            None => format!(
+                "device/poll http {} body={}",
+                status,
+                String::from_utf8_lossy(&bytes).chars().take(120).collect::<String>()
+            ),
+        };
+        emit_failed(&app, &store, reason);
+        return;
+    }
+}
+
+fn emit_failed(app: &AppHandle, store: &State<OauthStore>, reason: String) {
+    eprintln!("[auth] oauth failed: {reason}");
+    store.set(app, OauthState::Failed);
+    let _ = app.emit("oauth-failed", OauthFailedPayload { reason });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// Shared guard for tests that mutate HOME/USERPROFILE — both this module's
+// tests and `daemon_mgr::tests::load_or_create_generates_and_persists` use it
+// to serialize env mutations across the whole crate test binary.
+#[cfg(test)]
+pub(crate) static TEST_ENV_GUARD: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn with_tmp_home<F: FnOnce()>(label: &str, f: F) {
+        let _guard = TEST_ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let tmp = std::env::temp_dir().join(format!(
+            "ccsm-auth-test-{}-{}-{}",
+            label,
+            std::process::id(),
+            nanos
+        ));
+        let _ = std::fs::remove_dir_all(&tmp);
+        std::fs::create_dir_all(&tmp).unwrap();
+
+        #[cfg(windows)]
+        let key = "USERPROFILE";
+        #[cfg(not(windows))]
+        let key = "HOME";
+
+        let prev = std::env::var_os(key);
+        std::env::set_var(key, &tmp);
+        f();
+        if let Some(v) = prev {
+            std::env::set_var(key, v);
+        } else {
+            std::env::remove_var(key);
+        }
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn persist_round_trip() {
+        with_tmp_home("persist", || {
+            assert!(read_persisted_creds().is_none());
+            let creds = PersistedTunnelCreds {
+                tunnel_jwt: "abc.def.ghi".into(),
+                tunnel_refresh_token: "01234567".into(),
+                login: "octocat".into(),
+            };
+            write_persisted_creds(&creds).unwrap();
+            let back = read_persisted_creds().expect("read back");
+            assert_eq!(back.tunnel_jwt, "abc.def.ghi");
+            assert_eq!(back.tunnel_refresh_token, "01234567");
+            assert_eq!(back.login, "octocat");
+        });
+    }
+
+    #[test]
+    fn delete_clears_disk() {
+        with_tmp_home("delete", || {
+            let creds = PersistedTunnelCreds {
+                tunnel_jwt: "j".into(),
+                tunnel_refresh_token: "r".into(),
+                login: "u".into(),
+            };
+            write_persisted_creds(&creds).unwrap();
+            assert!(read_persisted_creds().is_some());
+            delete_persisted_creds().unwrap();
+            assert!(read_persisted_creds().is_none());
+            // Idempotent: deleting again must not error.
+            delete_persisted_creds().unwrap();
+        });
+    }
+
+    #[test]
+    fn rewrite_overwrites_prior_creds() {
+        with_tmp_home("rewrite", || {
+            let a = PersistedTunnelCreds {
+                tunnel_jwt: "j1".into(),
+                tunnel_refresh_token: "r1".into(),
+                login: "u1".into(),
+            };
+            write_persisted_creds(&a).unwrap();
+            let b = PersistedTunnelCreds {
+                tunnel_jwt: "j2".into(),
+                tunnel_refresh_token: "r2".into(),
+                login: "u2".into(),
+            };
+            write_persisted_creds(&b).unwrap();
+            let back = read_persisted_creds().unwrap();
+            assert_eq!(back.tunnel_jwt, "j2");
+            assert_eq!(back.login, "u2");
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_creds_file_is_chmod_600() {
+        use std::os::unix::fs::PermissionsExt;
+        with_tmp_home("chmod", || {
+            let creds = PersistedTunnelCreds {
+                tunnel_jwt: "j".into(),
+                tunnel_refresh_token: "r".into(),
+                login: "u".into(),
+            };
+            write_persisted_creds(&creds).unwrap();
+            let path = tunnel_jwt_path().unwrap();
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o600, "expected 0600 on Unix, got {:o}", mode);
+        });
+    }
+}

--- a/packages/frontend-tauri/src-tauri/src/auth.rs
+++ b/packages/frontend-tauri/src-tauri/src/auth.rs
@@ -1,15 +1,20 @@
 // S4-T8 (Task #141): GitHub device-flow OAuth, on-demand from the main UI.
 //
 // User pressing the Login button triggers `start_oauth`, which:
-//   1. POSTs cc-sm.pages.dev/api/auth/device/start to mint device + user codes.
+//   1. POSTs <auth-base>/api/auth/device/start to mint device + user codes.
+//      The auth base URL is **mandatory env** (`CCSM_AUTH_BASE`); the Tauri
+//      shell must stay repo-agnostic (no hardcoded cloud host — see the
+//      `Tauri red-line guard (no cloud refs)` CI check + ROADMAP). dev runs
+//      pass it via `CCSM_AUTH_BASE=... pnpm tauri dev`; release builds inject
+//      it through the packaging pipeline.
 //   2. Returns the user_code + verification_uri to the SPA so the modal can
 //      display them. The SPA opens the verification URL via plugin-shell; the
 //      user finishes auth in their default browser.
-//   3. Spawns a background poll task that hits /api/auth/device/poll on the
-//      worker-supplied interval. On success it persists the returned tunnel
-//      JWT + refresh token to ~/.ccsm/tunnel_jwt (chmod 600 on Unix; on
-//      Windows the default %USERPROFILE% ACL provides equivalent protection
-//      for the threat model — see daemon_mgr::write_token_file).
+//   3. Spawns a background poll task that hits <auth-base>/api/auth/device/poll
+//      on the worker-supplied interval. On success it persists the returned
+//      tunnel JWT + refresh token to ~/.ccsm/tunnel_jwt (chmod 600 on Unix;
+//      on Windows the default %USERPROFILE% ACL provides equivalent
+//      protection for the threat model — see daemon_mgr::write_token_file).
 //   4. Emits a Tauri event for state transitions (`oauth-state-change`,
 //      `oauth-complete`, `oauth-failed`). The JWT itself is NEVER sent to the
 //      SPA — only the resolved login is, so the renderer can render "@user".
@@ -36,7 +41,6 @@ use tauri::{AppHandle, Emitter, Manager, State};
 use tauri_plugin_shell::ShellExt;
 use tokio::time::sleep;
 
-const DEFAULT_AUTH_BASE: &str = "https://cc-sm.pages.dev";
 const MAX_POLL_INTERVAL_SEC: u64 = 60;
 
 /// Persisted credential blob — read by `daemon_mgr` at spawn time.
@@ -216,8 +220,16 @@ fn write_creds_file(path: &std::path::Path, contents: &str) -> Result<(), String
     Ok(())
 }
 
-fn auth_base() -> String {
-    std::env::var("CCSM_AUTH_BASE").unwrap_or_else(|_| DEFAULT_AUTH_BASE.to_string())
+fn auth_base() -> Result<String, String> {
+    // **Mandatory env**: the Tauri shell is repo-agnostic by ROADMAP red-line,
+    // so the cloud auth endpoint is never hardcoded — the embedder (dev shell
+    // or release packager) must inject it. Returning Err here propagates a
+    // clear, actionable failure into `oauth-failed` instead of silently
+    // dialing some default host.
+    match std::env::var("CCSM_AUTH_BASE") {
+        Ok(v) if !v.is_empty() => Ok(v),
+        _ => Err("CCSM_AUTH_BASE env not set (Tauri shell must not hardcode an auth host)".to_string()),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -234,7 +246,7 @@ pub async fn start_oauth(
         return Err("oauth already in progress".to_string());
     }
 
-    let url = format!("{}/api/auth/device/start", auth_base());
+    let url = format!("{}/api/auth/device/start", auth_base()?);
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(15))
         .build()
@@ -316,7 +328,17 @@ async fn run_poll_loop(
     expires_in_sec: u64,
 ) {
     let store: State<OauthStore> = app.state();
-    let url = format!("{}/api/auth/device/poll", auth_base());
+    let url = match auth_base() {
+        Ok(base) => format!("{}/api/auth/device/poll", base),
+        Err(e) => {
+            // Should be unreachable in practice — start_oauth already failed
+            // with the same Err if env was missing, so the poll task would
+            // never have been spawned. Belt-and-suspenders: surface as a
+            // normal oauth-failed event rather than panic.
+            emit_failed(&app, &store, e);
+            return;
+        }
+    };
     let deadline = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs() + expires_in_sec)
@@ -558,6 +580,43 @@ mod tests {
             let path = tunnel_jwt_path().unwrap();
             let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
             assert_eq!(mode, 0o600, "expected 0600 on Unix, got {:o}", mode);
+        });
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_creds_file_under_userprofile() {
+        // Reviewer follow-up on PR #1225: lock in that on Windows we (a) can
+        // write + read the creds file, and (b) the resolved path lives under
+        // the per-test USERPROFILE so the default ACL inheritance argument
+        // in the file header actually applies (file inside %USERPROFILE% =
+        // owner-only by default; outside it could pick up a different ACL).
+        with_tmp_home("win-userprofile", || {
+            let creds = PersistedTunnelCreds {
+                tunnel_jwt: "winjwt".into(),
+                tunnel_refresh_token: "winrefresh".into(),
+                login: "winuser".into(),
+            };
+            write_persisted_creds(&creds).unwrap();
+
+            let path = tunnel_jwt_path().unwrap();
+            assert!(path.exists(), "creds file must exist after write");
+
+            // Path must live under the test's USERPROFILE.
+            let userprofile = std::env::var("USERPROFILE").expect("USERPROFILE set in with_tmp_home");
+            let canon_path = path.canonicalize().unwrap();
+            let canon_home = std::path::PathBuf::from(&userprofile).canonicalize().unwrap();
+            assert!(
+                canon_path.starts_with(&canon_home),
+                "creds path {} must be under USERPROFILE {}",
+                canon_path.display(),
+                canon_home.display(),
+            );
+
+            // Round-trip read.
+            let back = read_persisted_creds().expect("read back");
+            assert_eq!(back.tunnel_jwt, "winjwt");
+            assert_eq!(back.login, "winuser");
         });
     }
 }

--- a/packages/frontend-tauri/src-tauri/src/daemon_mgr.rs
+++ b/packages/frontend-tauri/src-tauri/src/daemon_mgr.rs
@@ -316,6 +316,23 @@ async fn run_cycle(app: &AppHandle, kill_rx: &mut mpsc::Receiver<()>) -> CycleOu
     cmd.env("CCSM_TOKEN", &token);
     cmd.env("PORT", "9876");
 
+    // S4-T8 (#141): if the user has completed device-flow login (file
+    // ~/.ccsm/tunnel_jwt present), inject the JWT into daemon env so the
+    // tunnel client can authenticate over the cloud relay using the
+    // cloud-issued credential. Absence is fine — the daemon falls back to
+    // the legacy loopback-token-only path and the cloud tunnel runs in
+    // legacy mode (or is skipped, depending on CCSM_TUNNEL_DISABLE).
+    if let Some(creds) = crate::auth::read_persisted_creds() {
+        cmd.env("CCSM_TUNNEL_JWT", &creds.tunnel_jwt);
+        cmd.env("CCSM_TUNNEL_REFRESH_TOKEN", &creds.tunnel_refresh_token);
+        cmd.env("CCSM_TUNNEL_LOGIN", &creds.login);
+        cmd.env("CCSM_TRUST_TUNNEL", "1");
+        eprintln!(
+            "[daemon-mgr] injecting tunnel JWT for login={} (trust-tunnel mode)",
+            creds.login
+        );
+    }
+
     #[cfg(windows)]
     {
         cmd.creation_flags(0x0800_0000); // CREATE_NO_WINDOW
@@ -618,6 +635,10 @@ mod tests {
 
     #[test]
     fn load_or_create_generates_and_persists() {
+        // Serialize against auth.rs tests — both mutate HOME/USERPROFILE.
+        let _guard = crate::auth::TEST_ENV_GUARD
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
         let tmp = std::env::temp_dir().join(format!("ccsm-test-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();

--- a/packages/frontend-tauri/src-tauri/src/lib.rs
+++ b/packages/frontend-tauri/src-tauri/src/lib.rs
@@ -6,10 +6,14 @@
 //     orphan-Node-on-port-hostage failure mode. Non-Windows: stub no-op (kill_on_drop
 //     is the soft baseline; see job_object.rs).
 
+mod auth;
 mod daemon_mgr;
 mod daemon_state;
 mod job_object;
 
+use auth::{
+    get_oauth_login, get_oauth_state, oauth_logout, start_oauth, OauthStore,
+};
 use daemon_mgr::{start_daemon, supervise, DaemonState};
 use daemon_state::DaemonStateStore;
 use job_object::JobObject;
@@ -21,6 +25,7 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .manage(DaemonState::default())
         .manage(DaemonStateStore::default())
+        .manage(OauthStore::default())
         .setup(|app| {
             // Create the Job once at app startup. Held in State so daemon_mgr
             // can call .assign(pid) after spawn. Dropped on app exit, which
@@ -49,7 +54,13 @@ pub fn run() {
 
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![start_daemon])
+        .invoke_handler(tauri::generate_handler![
+            start_daemon,
+            start_oauth,
+            get_oauth_state,
+            get_oauth_login,
+            oauth_logout
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/packages/frontend-tauri/src/App.tsx
+++ b/packages/frontend-tauri/src/App.tsx
@@ -23,11 +23,26 @@ import {
   type HostConfig,
 } from '@ccsm/ui';
 import { DaemonStateProvider, useDaemonPhase } from './DaemonStateProvider';
+import { LoginButton } from './auth/LoginButton';
 import type { DaemonPhase } from './types';
 
 function AppContent() {
   useBootstrap();
-  return <AppShell sidebar={<Sidebar />} main={<MainPane />} />;
+  return (
+    <AppShell
+      sidebar={
+        <div className="tauri-sidebar">
+          {/* S4-T8 (#141): device-flow login button. Untouched daemon still
+              works in legacy loopback mode if the user never logs in. */}
+          <div className="tauri-sidebar__login">
+            <LoginButton />
+          </div>
+          <Sidebar />
+        </div>
+      }
+      main={<MainPane />}
+    />
+  );
 }
 
 function buildHostConfig(port: number, token: string): HostConfig {

--- a/packages/frontend-tauri/src/auth/LoginButton.tsx
+++ b/packages/frontend-tauri/src/auth/LoginButton.tsx
@@ -1,0 +1,179 @@
+// S4-T8 (Task #141): Login button + device-flow modal for the Tauri shell.
+//
+// Renders one of three states:
+//   - logged out: "Login with GitHub" button
+//   - awaiting user: modal showing user_code + "Open browser" link
+//   - logged in: "@{login}" + "Logout" affordance
+//
+// The Rust side (auth.rs) owns the underlying flow. We:
+//   1. on mount: invoke get_oauth_login to pick up an existing session
+//   2. on click "Login": invoke start_oauth → display modal with user_code +
+//      verification URI; open the URI in the default browser via plugin-shell.
+//   3. listen for oauth-complete / oauth-failed events to close the modal.
+//
+// The JWT itself never crosses the IPC boundary — only the resolved login.
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  invokeGetOauthLogin,
+  invokeOauthLogout,
+  invokeStartOauth,
+  onOauthComplete,
+  onOauthFailed,
+  type StartOauthSpaPayload,
+} from './oauth-state';
+
+interface ModalState {
+  payload: StartOauthSpaPayload;
+  error: string | null;
+}
+
+export function LoginButton(): React.JSX.Element {
+  const [login, setLogin] = useState<string | null>(null);
+  const [modal, setModal] = useState<ModalState | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  // Initial pick-up of any persisted login.
+  useEffect(() => {
+    let cancelled = false;
+    void invokeGetOauthLogin().then((l) => {
+      if (!cancelled) setLogin(l);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Listen for completion / failure events from the Rust poll task.
+  useEffect(() => {
+    let unlistenComplete: (() => void) | undefined;
+    let unlistenFailed: (() => void) | undefined;
+    let cancelled = false;
+    void onOauthComplete((payload) => {
+      setLogin(payload.login);
+      setModal(null);
+      setBusy(false);
+    }).then((u) => {
+      if (cancelled) u();
+      else unlistenComplete = u;
+    });
+    void onOauthFailed((payload) => {
+      setModal((prev) => (prev !== null ? { ...prev, error: payload.reason } : prev));
+      setBusy(false);
+    }).then((u) => {
+      if (cancelled) u();
+      else unlistenFailed = u;
+    });
+    return () => {
+      cancelled = true;
+      unlistenComplete?.();
+      unlistenFailed?.();
+    };
+  }, []);
+
+  const onLoginClick = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      // Rust opens the verification URL via plugin-shell as part of
+      // start_oauth — we just render the modal once the user_code is back.
+      const payload = await invokeStartOauth();
+      setModal({ payload, error: null });
+    } catch (err) {
+      setModal({
+        payload: {
+          user_code: '',
+          verification_uri: '',
+          expires_in: 0,
+          interval: 0,
+        },
+        error: String(err),
+      });
+      setBusy(false);
+    }
+  }, [busy]);
+
+  const onLogoutClick = useCallback(async () => {
+    await invokeOauthLogout();
+    setLogin(null);
+  }, []);
+
+  const onModalClose = useCallback(() => {
+    setModal(null);
+    setBusy(false);
+  }, []);
+
+  if (login !== null) {
+    return (
+      <div className="login-button login-button--in" data-testid="login-button">
+        <span className="login-button__user">@{login}</span>
+        <button
+          type="button"
+          className="login-button__logout"
+          onClick={() => void onLogoutClick()}
+        >
+          Logout
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className="login-button login-button--out"
+        data-testid="login-button"
+        disabled={busy}
+        onClick={() => void onLoginClick()}
+      >
+        Login with GitHub
+      </button>
+      {modal !== null ? (
+        <DeviceFlowModal modal={modal} onClose={onModalClose} />
+      ) : null}
+    </>
+  );
+}
+
+interface DeviceFlowModalProps {
+  modal: ModalState;
+  onClose: () => void;
+}
+
+function DeviceFlowModal({ modal, onClose }: DeviceFlowModalProps): React.JSX.Element {
+  const { payload, error } = modal;
+  return (
+    <div className="oauth-modal__backdrop" role="dialog" aria-modal="true" data-testid="oauth-modal">
+      <div className="oauth-modal__panel">
+        <h2 className="oauth-modal__title">Authorize ccsm</h2>
+        {error !== null ? (
+          <>
+            <p className="oauth-modal__error">Login failed: {error}</p>
+            <button type="button" onClick={onClose}>Close</button>
+          </>
+        ) : (
+          <>
+            <p>
+              Your browser should have opened. If not, visit:
+            </p>
+            <p>
+              <a
+                href={payload.verification_uri}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {payload.verification_uri}
+              </a>
+            </p>
+            <p>Enter this code:</p>
+            <p className="oauth-modal__code" data-testid="oauth-user-code">
+              {payload.user_code}
+            </p>
+            <button type="button" onClick={onClose}>Cancel</button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/frontend-tauri/src/auth/oauth-state.test.ts
+++ b/packages/frontend-tauri/src/auth/oauth-state.test.ts
@@ -1,0 +1,101 @@
+// S4-T8 (Task #141): unit tests for the oauth-state SPA helper. We mock
+// @tauri-apps/api so no real IPC happens — the goal is to lock in the
+// command names + event channel names (the wire contract with auth.rs).
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const invokeMock = vi.fn();
+const listenMock = vi.fn();
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (...args: unknown[]) => listenMock(...args),
+}));
+
+// Import AFTER mocks so the module picks up the mocked invoke/listen.
+import {
+  invokeStartOauth,
+  invokeGetOauthState,
+  invokeGetOauthLogin,
+  invokeOauthLogout,
+  onOauthComplete,
+  onOauthFailed,
+  onOauthStateChange,
+} from './oauth-state';
+
+describe('oauth-state helpers', () => {
+  beforeEach(() => {
+    invokeMock.mockReset();
+    listenMock.mockReset();
+  });
+
+  it('invokeStartOauth invokes the start_oauth command', async () => {
+    invokeMock.mockResolvedValueOnce({
+      user_code: 'ABCD-1234',
+      verification_uri: 'https://github.com/login/device',
+      expires_in: 900,
+      interval: 5,
+    });
+    const out = await invokeStartOauth();
+    expect(invokeMock).toHaveBeenCalledTimes(1);
+    expect(invokeMock).toHaveBeenCalledWith('start_oauth');
+    expect(out.user_code).toBe('ABCD-1234');
+  });
+
+  it('invokeGetOauthState invokes get_oauth_state', async () => {
+    invokeMock.mockResolvedValueOnce('idle');
+    expect(await invokeGetOauthState()).toBe('idle');
+    expect(invokeMock).toHaveBeenCalledWith('get_oauth_state');
+  });
+
+  it('invokeGetOauthLogin invokes get_oauth_login', async () => {
+    invokeMock.mockResolvedValueOnce('octocat');
+    expect(await invokeGetOauthLogin()).toBe('octocat');
+    expect(invokeMock).toHaveBeenCalledWith('get_oauth_login');
+  });
+
+  it('invokeOauthLogout invokes oauth_logout', async () => {
+    invokeMock.mockResolvedValueOnce(undefined);
+    await invokeOauthLogout();
+    expect(invokeMock).toHaveBeenCalledWith('oauth_logout');
+  });
+
+  it('onOauthComplete subscribes to oauth-complete', async () => {
+    const unlisten = vi.fn();
+    listenMock.mockImplementationOnce((_event: string, cb: (e: unknown) => void) => {
+      cb({ payload: { login: 'octocat' } });
+      return Promise.resolve(unlisten);
+    });
+    const got: string[] = [];
+    await onOauthComplete((p) => got.push(p.login));
+    expect(listenMock).toHaveBeenCalledWith('oauth-complete', expect.any(Function));
+    expect(got).toEqual(['octocat']);
+  });
+
+  it('onOauthFailed subscribes to oauth-failed', async () => {
+    const unlisten = vi.fn();
+    listenMock.mockImplementationOnce((_event: string, cb: (e: unknown) => void) => {
+      cb({ payload: { reason: 'expired' } });
+      return Promise.resolve(unlisten);
+    });
+    const got: string[] = [];
+    await onOauthFailed((p) => got.push(p.reason));
+    expect(listenMock).toHaveBeenCalledWith('oauth-failed', expect.any(Function));
+    expect(got).toEqual(['expired']);
+  });
+
+  it('onOauthStateChange subscribes to oauth-state-change', async () => {
+    const unlisten = vi.fn();
+    listenMock.mockImplementationOnce((_event: string, cb: (e: unknown) => void) => {
+      cb({ payload: 'awaiting_user' });
+      return Promise.resolve(unlisten);
+    });
+    const got: string[] = [];
+    await onOauthStateChange((s) => got.push(s));
+    expect(listenMock).toHaveBeenCalledWith('oauth-state-change', expect.any(Function));
+    expect(got).toEqual(['awaiting_user']);
+  });
+});

--- a/packages/frontend-tauri/src/auth/oauth-state.ts
+++ b/packages/frontend-tauri/src/auth/oauth-state.ts
@@ -1,0 +1,65 @@
+// S4-T8 (Task #141): SPA-side helpers for the device-flow login button.
+//
+// The Rust side (auth.rs) owns the actual flow: HTTP to cf-worker, polling,
+// disk persistence, env injection into the daemon. The SPA only:
+//   - invokes start_oauth() on click (Rust returns user_code + verification_uri),
+//   - listens for `oauth-complete` / `oauth-failed` / `oauth-state-change`,
+//   - calls oauth_logout() when the user signs out,
+//   - calls get_oauth_login() at mount to render the current "@user" if any.
+//
+// The tunnel JWT is intentionally NEVER exposed to the renderer — only the
+// resolved login string crosses the IPC boundary on success.
+
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+
+export type OauthState = 'idle' | 'awaiting_user' | 'success' | 'failed';
+
+export interface StartOauthSpaPayload {
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+}
+
+export interface OauthCompletePayload {
+  login: string;
+}
+
+export interface OauthFailedPayload {
+  reason: string;
+}
+
+export async function invokeStartOauth(): Promise<StartOauthSpaPayload> {
+  return invoke<StartOauthSpaPayload>('start_oauth');
+}
+
+export async function invokeGetOauthState(): Promise<OauthState> {
+  return invoke<OauthState>('get_oauth_state');
+}
+
+export async function invokeGetOauthLogin(): Promise<string | null> {
+  return invoke<string | null>('get_oauth_login');
+}
+
+export async function invokeOauthLogout(): Promise<void> {
+  return invoke<void>('oauth_logout');
+}
+
+export function onOauthComplete(
+  cb: (payload: OauthCompletePayload) => void,
+): Promise<UnlistenFn> {
+  return listen<OauthCompletePayload>('oauth-complete', (e) => cb(e.payload));
+}
+
+export function onOauthFailed(
+  cb: (payload: OauthFailedPayload) => void,
+): Promise<UnlistenFn> {
+  return listen<OauthFailedPayload>('oauth-failed', (e) => cb(e.payload));
+}
+
+export function onOauthStateChange(
+  cb: (state: OauthState) => void,
+): Promise<UnlistenFn> {
+  return listen<OauthState>('oauth-state-change', (e) => cb(e.payload));
+}


### PR DESCRIPTION
## Summary

Adds a GitHub device-flow login button to the Tauri shell, on-demand from the main UI. Implements the S4-T8 contract revised on 2026-05-09: login is **not** triggered at startup, and the Tauri shell stays fully usable without ever logging in (loopback-only daemon). When the user completes the flow, the resulting tunnel JWT is persisted to `~/.ccsm/tunnel_jwt` (chmod 600 on Unix; Windows `%USERPROFILE%` ACL) and injected into the daemon child env at next spawn — the daemon then dials the cloud tunnel with `ccsm.<jwt>` as the ws subprotocol + sets `CCSM_TRUST_TUNNEL=1`.

The JWT never crosses the IPC boundary — only the resolved GitHub login does, so the renderer can render `@user` without seeing the credential.

### Pieces

- **Rust IPC commands** (`src-tauri/src/auth.rs`): `start_oauth` / `get_oauth_state` / `get_oauth_login` / `oauth_logout`. A background poll task drives `/api/auth/device/poll` against the worker-supplied interval (honoring `slow_down`), persists on success, emits `oauth-state-change` / `oauth-complete` / `oauth-failed` events.
- **Daemon env injection** (`src-tauri/src/daemon_mgr.rs`): reads `~/.ccsm/tunnel_jwt` at every spawn cycle; absence keeps the legacy loopback-only path.
- **Daemon ws subprotocol** (`packages/daemon/src/tunnel.mts` + `index.mts`): new `subprotocols` option plumbed through the `WsFactory` DI seam. `index.mts` sets it to `[ccsm.<CCSM_TUNNEL_JWT>]` when env is present.
- **SPA** (`packages/frontend-tauri/src/auth/`): `LoginButton.tsx` renders one of three states (logged out / awaiting user / logged in) + a device-flow modal showing `user_code` + verification URL. Rust opens the URL via plugin-shell so we don't pull in the JS shell plugin.

### Out of scope

- `DaemonStateProvider.AwaitingAuth` UI (T3 done).
- frontend-web login (T7 owns).
- cf-worker / TunnelDO (T3/T4/T6 done).

## Local checks (host: Windows 11, mode: fast)

- lint: ok (frontend-tauri + daemon eslint exit 0)
- typecheck: ok (frontend-tauri + daemon `tsc --noEmit` exit 0)
- build: ok (`pnpm -C packages/frontend-tauri build` -> 504 kB bundle, exit 0; `cargo check --tests` exit 0)
- unit tests:
  - cargo: 8 passed (auth::tests::persist_round_trip / delete_clears_disk / rewrite_overwrites_prior_creds + 5 prior daemon_mgr/daemon_state tests). chmod 600 test only runs cfg(unix) so it sat out on Windows.
  - daemon vitest: 161 passed / 1 skipped (was 158, +3 new tunnel subprotocol tests).
  - frontend-tauri vitest: 7 passed (new oauth-state command/event-name contract).
- e2e: skipped, this PR adds Tauri shell + daemon plumbing only; no e2e harness exercises the device flow yet (would require a fake cf-worker + browser stub).

## Test plan

- [ ] `pnpm tauri dev` and click "Login with GitHub" — modal pops, browser opens to `https://github.com/login/device`, entering the displayed user_code completes flow → button switches to `@<login>` + Logout.
- [ ] Verify `~/.ccsm/tunnel_jwt` exists and JSON contains `tunnel_jwt`/`tunnel_refresh_token`/`login`.
- [ ] Restart Tauri — `LoginButton` mounts already showing `@<login>`; daemon stderr logs `injecting tunnel JWT for login=...`.
- [ ] Click Logout — file gone, button reverts to "Login with GitHub", subsequent daemon spawns no longer set `CCSM_TUNNEL_JWT`.
- [ ] CI three-platform matrix passes (Ubuntu / macOS / Windows).