### PR TITLE
test(cloud-e2e): Task #135 — cross-user TunnelDO isolation harness (S4-T9)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -60,6 +60,25 @@ URL `?token=`.
 - Daemon (local): no longer authenticates the token; trusts only the tunnel layer (mTLS / one-shot credential)
 - Auth: GitHub identity. Web uses browser OAuth, Tauri uses device flow. The cloud is the sole trust anchor.
 
+**Status: completed 2026-05-10.** All nine S4 tasks have shipped to the
+`working` branch:
+
+- T1 (Task #113): Cloudflare wrangler.toml + `.dev.vars` setup, OAuth client provisioning runbook (`docs/S4-SETUP.md`).
+- T2 (Task #121): HS256 JWT primitives (`packages/cf-worker/src/auth/jwt.ts`) + UserDO skeleton.
+- T3 (Task #140): web OAuth callback + refresh + logout (`packages/cf-worker/src/auth/webOauth.ts`).
+- T4 (Task #142): GitHub device flow + tunnel-JWT mint route (`packages/cf-worker/src/auth/deviceFlow.ts`).
+- T5 (Task #136): JWT routing middleware + `CCSM_AUTH_MODE` flag (`packages/cf-worker/src/auth/middleware.ts`); per-user TunnelDO id `user:<github_id>`. Production rolls out with `legacy` (default), flips to `jwt` once T7/T8 SPA changes are live.
+- T6 (Task #133): cloud-authenticated browser identity carried inside the daemon hello frame (`X-CCSM-Identity-Login` / `X-CCSM-Identity-Id` injected by the worker, echoed by TunnelDO).
+- T7 (Task #139): SPA `SignInGate` + `AuthContext` (`packages/frontend-web/src/auth/`).
+- T8 (Task #141): main-UI Login button driving the device flow on demand (`packages/frontend-tauri/...`).
+- T9 (Task #135): cross-user isolation cloud-e2e harness (`tools/cloud-e2e/specs/cross-user-isolation.spec.ts` + `tools/cloud-e2e/fixtures/jwt-sign.ts`); two raw WebSocket clients per user verify per-user TunnelDO routing + sid envelope isolation against `wrangler dev` running `CCSM_AUTH_MODE=jwt`. T9 also caught and fixed a subprotocol-echo gap on the daemon `/tunnel/default` 101 response that would have broken jwt-mode daemon dial-in (`packages/cf-worker/src/tunnel-do.ts`).
+
+Production cutover ladder (S4 -> S5):
+
+1. Deploy cf-worker with `CCSM_AUTH_MODE=legacy` (current).
+2. Validate OAuth + device flow on a preview deployment; flip a single env to `CCSM_AUTH_MODE=jwt` once SPA + Tauri shells are propagating tokens.
+3. Once the legacy code path has zero traffic for a full week, delete the legacy branches in `cf-worker/src/index.ts` (S5).
+
 ## Stage S5 end state
 - Web frontend: pure SPA that only understands JWT + WS; does not know where the daemon is
 - Tauri shell: background daemon process + tunnel client; registers on startup, reconnects on disconnect

--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -335,6 +335,24 @@ export class TunnelDO extends DurableObject<Env> {
       server.serializeAttachment(attachment);
       // R-17 log #1 (Task #45): daemon ws accepted into hibernation pool.
       console.log('[do] daemon ws accepted');
+      // S4-T9 (Task #135): if the daemon dialed with a `ccsm.<jwt>`
+      // subprotocol (Task #141 jwt-mode path), RFC 6455 §4.2.2 requires
+      // the server to echo back exactly one of the offered subprotocols on
+      // the 101 response — otherwise standards-compliant clients (Node's
+      // built-in WebSocket, recent `ws@8`, browsers) close the handshake
+      // with "Server sent no subprotocol". The browser path already echoes
+      // (line below); the daemon path forgot to until cross-user-isolation
+      // (T9) tried to dial with a tunnel JWT subprotocol against wrangler
+      // dev. legacy / unauth daemons don't send a subprotocol — we echo
+      // only when one was offered.
+      const daemonProto = extractBrowserToken(req);
+      if (daemonProto !== null) {
+        return new Response(null, {
+          status: 101,
+          webSocket: client,
+          headers: { 'Sec-WebSocket-Protocol': daemonProto.protocol },
+        });
+      }
       return new Response(null, { status: 101, webSocket: client });
     }
 

--- a/tools/cloud-e2e/fixtures/jwt-sign.ts
+++ b/tools/cloud-e2e/fixtures/jwt-sign.ts
@@ -1,0 +1,122 @@
+/**
+ * S4-T9 (Task #135): HS256 JWT minting helper for the cross-user isolation
+ * harness.
+ *
+ * Mirrors `packages/cf-worker/src/auth/jwt.ts:signJwt` so the worker (which
+ * verifies with `verifyJwt`) accepts these tokens as if they were minted by
+ * the OAuth callback path. We re-implement here (rather than importing from
+ * the worker package) because:
+ *
+ *   1. cloud-e2e lives OUTSIDE the pnpm workspace on purpose (see this dir's
+ *      package.json + the comment in playwright.config.ts) — pulling in the
+ *      worker source would re-link the harness into the monorepo install
+ *      graph and defeat the standalone property.
+ *   2. The worker uses SubtleCrypto (Workers runtime); Node 22's
+ *      `crypto.createHmac` is functionally equivalent for HS256 and ships
+ *      with the standard library so we add zero dependencies.
+ *
+ * Wire format identical to RFC 7515: `base64url(header).base64url(payload).
+ * base64url(sig)` where sig is `HMAC-SHA256(signingInput, hexKey→bytes)`.
+ *
+ * Used ONLY by `specs/cross-user-isolation.spec.ts` to stand in for the
+ * GitHub OAuth web-callback (skip OAuth in T9 because T5 vitest already
+ * covers the OAuth flow end-to-end; T9 is about prod-like wrangler dev DO
+ * cross-user isolation, not the device-flow / web-callback path).
+ */
+import { createHmac } from 'node:crypto';
+
+/** Browser session JWT (matches cf-worker WebJwtClaims, kind='web'). */
+export interface WebJwtClaims {
+  sub: string;
+  login: string;
+  exp: number;
+  iat: number;
+  kind: 'web';
+}
+
+/** Per-tunnel JWT (matches cf-worker TunnelJwtClaims, kind='tunnel'). */
+export interface TunnelJwtClaims {
+  sub: string;
+  login: string;
+  exp: number;
+  iat: number;
+  kind: 'tunnel';
+  jti: string;
+}
+
+const HS256_HEADER = { alg: 'HS256', typ: 'JWT' } as const;
+
+function base64url(buf: Buffer): string {
+  return buf
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function hexToBytes(hex: string): Buffer {
+  const clean = hex.startsWith('0x') ? hex.slice(2) : hex;
+  if (clean.length % 2 !== 0) {
+    throw new Error('jwt-sign: hex key has odd length');
+  }
+  return Buffer.from(clean, 'hex');
+}
+
+/**
+ * Sign an HS256 JWT. `claims.exp` / `claims.iat` are NOT auto-filled —
+ * caller passes the full claim object. Returns `header.payload.sig`.
+ *
+ * `hexKey` matches the worker's `.dev.vars` style (raw bytes encoded as
+ * lowercase hex, no `0x` prefix). Worker imports the same hex via
+ * `importHmacKey` in `auth/jwt.ts`, so as long as the hex strings match
+ * verbatim the signature round-trips.
+ */
+export function signJwt(
+  claims: WebJwtClaims | TunnelJwtClaims,
+  hexKey: string,
+): string {
+  const header = base64url(Buffer.from(JSON.stringify(HS256_HEADER), 'utf8'));
+  const payload = base64url(Buffer.from(JSON.stringify(claims), 'utf8'));
+  const signingInput = header + '.' + payload;
+  const sig = base64url(
+    createHmac('sha256', hexToBytes(hexKey)).update(signingInput).digest(),
+  );
+  return signingInput + '.' + sig;
+}
+
+/**
+ * Convenience: sign a `kind:'web'` JWT for `sub` / `login` valid for
+ * `lifetimeSec` seconds (default 5 minutes — long enough for the harness,
+ * short enough to surface clock-skew bugs).
+ */
+export function signWebJwt(
+  sub: string,
+  login: string,
+  hexKey: string,
+  lifetimeSec = 300,
+): string {
+  const iat = Math.floor(Date.now() / 1000);
+  return signJwt(
+    { sub, login, iat, exp: iat + lifetimeSec, kind: 'web' },
+    hexKey,
+  );
+}
+
+/**
+ * Convenience: sign a `kind:'tunnel'` JWT. `jti` defaults to a random hex id
+ * matching the worker's per-tunnel id shape (T4 device-flow mints `jti=uuid`).
+ */
+export function signTunnelJwt(
+  sub: string,
+  login: string,
+  hexKey: string,
+  lifetimeSec = 3600,
+  jti?: string,
+): string {
+  const iat = Math.floor(Date.now() / 1000);
+  const id = jti ?? 'tun-' + Math.random().toString(16).slice(2, 10);
+  return signJwt(
+    { sub, login, iat, exp: iat + lifetimeSec, kind: 'tunnel', jti: id },
+    hexKey,
+  );
+}

--- a/tools/cloud-e2e/package.json
+++ b/tools/cloud-e2e/package.json
@@ -12,6 +12,8 @@
   "devDependencies": {
     "@playwright/test": "^1.48.2",
     "@types/node": "^22.9.0",
-    "typescript": "^5.6.3"
+    "@types/ws": "^8.18.1",
+    "typescript": "^5.6.3",
+    "ws": "^8.20.0"
   }
 }

--- a/tools/cloud-e2e/playwright.config.ts
+++ b/tools/cloud-e2e/playwright.config.ts
@@ -9,6 +9,17 @@
 //
 // Failure artifacts (trace.zip, screenshots, video) land in
 // `test-results/` so the manager can inspect them after a red run.
+//
+// S4-T9 (Task #135) addendum: `cross-user-isolation.spec.ts` is a raw
+// WebSocket spec (no SPA boot) and reads three env vars directly from
+// `process.env` inside the spec body:
+//   - CCSM_CLOUD_WS_BASE       — ws origin of the running wrangler dev
+//   - JWT_SIGNING_KEY          — must match `.dev.vars` in cf-worker
+//   - JWT_REFRESH_SIGNING_KEY  — must match `.dev.vars` in cf-worker
+// Playwright forwards process.env into spec workers by default so no
+// explicit `use:` plumbing is required — the spec auto-skips when those
+// vars are absent so the existing two-tab spec keeps running unchanged
+// against deployed cc-sm.pages.dev.
 import { defineConfig, devices } from '@playwright/test';
 
 const BASE_URL = process.env.CCSM_CLOUD_BASE_URL ?? 'https://cc-sm.pages.dev';

--- a/tools/cloud-e2e/specs/cross-user-isolation.spec.ts
+++ b/tools/cloud-e2e/specs/cross-user-isolation.spec.ts
@@ -1,0 +1,465 @@
+/**
+ * S4-T9 (Task #135): cross-user isolation cloud-e2e spec.
+ *
+ * Sibling to `two-tab-pairing.spec.ts`. Where that spec verifies "one user,
+ * two tabs each get their own PTY" against the deployed cc-sm.pages.dev SPA,
+ * this spec verifies the per-user TunnelDO routing introduced by S4-T5 (the
+ * `CCSM_AUTH_MODE=jwt` switch that derives DO id from the JWT subject):
+ *
+ *   - alice's daemon ws and alice's browser ws land in `user:gh-1` DO.
+ *   - bob's daemon ws and bob's browser ws land in `user:gh-2` DO.
+ *   - frames flowing through alice's DO must NEVER appear at bob's browser
+ *     (and vice versa) — cross-user data leakage is the whole class of bug
+ *     S4 was opened to prevent.
+ *   - alice's *own* two browser tabs sharing one alice daemon still pair on
+ *     distinct sids (R-41 sid envelope; regression guard so the per-user
+ *     routing change doesn't accidentally break wave-2 multi-tab support).
+ *
+ * Why raw WebSocket clients (no Playwright browser, no real daemon process,
+ * no SPA boot)?
+ *   - The intent is to verify the **wire-level routing** decision the
+ *     cf-worker + TunnelDO pair makes when given two different JWT subjects.
+ *     Any Playwright/SPA layer on top would couple the test to OAuth + UI
+ *     state and re-cover ground T5 (vitest) and T7/T8 already own.
+ *   - Two raw `WebSocket` clients (one impersonating each daemon) plus two
+ *     more (one impersonating each browser) is the smallest possible
+ *     fixture that exercises the full per-user DO path through wrangler dev
+ *     (workerd) — i.e. **production-shape DO**, not vitest stubs.
+ *   - Skipping the SPA also means we don't depend on the
+ *     frontend-web ↔ Pages Function ↔ Worker service binding plumbing that
+ *     `reference_local_e2e_full_stack.md` documents, so this spec runs with
+ *     just `wrangler dev --port 8787` (no Pages dev required).
+ *
+ * Required env (set by the harness operator before `pnpm test`):
+ *   CCSM_CLOUD_WS_BASE       — ws origin of the running wrangler dev,
+ *                              e.g. ws://127.0.0.1:8787 (REQUIRED).
+ *   JWT_SIGNING_KEY          — hex HS256 key, must match the worker's
+ *                              `.dev.vars` JWT_SIGNING_KEY exactly
+ *                              (REQUIRED).
+ *   JWT_REFRESH_SIGNING_KEY  — hex HS256 key for tunnel JWTs, must match
+ *                              `.dev.vars` JWT_REFRESH_SIGNING_KEY (REQUIRED).
+ *
+ * The worker MUST be running with `CCSM_AUTH_MODE=jwt` (default in
+ * wrangler.toml is `legacy`); start it with either
+ *   `wrangler dev --port 8787 --var CCSM_AUTH_MODE:jwt`
+ * or by editing wrangler.toml `[vars]` locally (don't commit the edit).
+ *
+ * Skipping: the test auto-skips when the env vars above are absent, so
+ * `pnpm test` against deployed cc-sm.pages.dev (the existing two-tab spec's
+ * default) still runs without manual configuration. CI must set these env
+ * vars when it wants the cross-user gate.
+ */
+import { test, expect } from '@playwright/test';
+import { signWebJwt, signTunnelJwt } from '../fixtures/jwt-sign';
+
+/**
+ * Encode a sid envelope matching `tunnel-do.ts:encodeSidEnvelope`. Daemon
+ * sends `[sidLen u8][sid utf8][payload bytes]`; the DO strips the envelope
+ * and routes the payload to the browser ws tagged `browser-sid:<sid>`.
+ */
+function encodeSidEnvelope(sid: string, payload: Uint8Array): Uint8Array {
+  const sidBytes = new TextEncoder().encode(sid);
+  if (sidBytes.length === 0 || sidBytes.length > 64) {
+    throw new Error('encodeSidEnvelope: bad sid length ' + sidBytes.length);
+  }
+  const out = new Uint8Array(1 + sidBytes.length + payload.byteLength);
+  out[0] = sidBytes.length;
+  out.set(sidBytes, 1);
+  out.set(payload, 1 + sidBytes.length);
+  return out;
+}
+
+interface HelloFrame {
+  token: string;
+  sid: string;
+  identity?: { login: string; github_id: string };
+}
+
+interface DaemonHandle {
+  ws: WebSocket;
+  /** Hello frames received in arrival order. waitForHello shifts from this queue. */
+  helloFrames: HelloFrame[];
+  /** Resolved when the next hello arrives (returns the full hello incl. identity). */
+  waitForHello: (timeoutMs?: number) => Promise<HelloFrame>;
+  close: () => void;
+}
+
+interface BrowserHandle {
+  ws: WebSocket;
+  /** Binary payloads received from the daemon (envelope already stripped by DO). */
+  received: Array<Uint8Array>;
+  /** Text frames received (hello echoes / control). */
+  receivedText: string[];
+  close: () => void;
+}
+
+const DEFAULT_OPEN_TIMEOUT_MS = 10_000;
+const DEFAULT_FRAME_TIMEOUT_MS = 5_000;
+
+function waitOpen(ws: WebSocket, timeoutMs = DEFAULT_OPEN_TIMEOUT_MS): Promise<void> {
+  if (ws.readyState === WebSocket.OPEN) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error('ws open timeout after ' + timeoutMs + 'ms'));
+    }, timeoutMs);
+    ws.addEventListener('open', () => {
+      clearTimeout(timer);
+      resolve();
+    }, { once: true });
+    ws.addEventListener('error', (ev) => {
+      clearTimeout(timer);
+      const msg = (ev as unknown as { message?: string }).message ?? 'ws error';
+      reject(new Error('ws error before open: ' + msg));
+    }, { once: true });
+    ws.addEventListener('close', (ev) => {
+      clearTimeout(timer);
+      reject(new Error('ws closed before open: code=' + ev.code + ' reason=' + ev.reason));
+    }, { once: true });
+  });
+}
+
+async function connectDaemon(opts: {
+  base: string;
+  tunnelJwt: string;
+  label: string;
+}): Promise<DaemonHandle> {
+  const ws = new WebSocket(opts.base + '/tunnel/default', ['ccsm.' + opts.tunnelJwt]);
+  ws.binaryType = 'arraybuffer';
+  const helloFrames: HelloFrame[] = [];
+  const helloWaiters: Array<(v: HelloFrame) => void> = [];
+
+  ws.addEventListener('message', (ev) => {
+    const data = ev.data;
+    if (typeof data !== 'string') {
+      // The DO never sends binary daemon-bound except echoes; ignore.
+      process.stderr.write(`[${opts.label} daemon] unexpected binary len=${(data as ArrayBuffer).byteLength}\n`);
+      return;
+    }
+    let parsed: unknown;
+    try { parsed = JSON.parse(data); } catch {
+      process.stderr.write(`[${opts.label} daemon] non-JSON text frame: ${data.slice(0, 80)}\n`);
+      return;
+    }
+    if (parsed === null || typeof parsed !== 'object') return;
+    const obj = parsed as { type?: unknown; token?: unknown; sid?: unknown; identity?: unknown };
+    if (obj.type === 'hello' && typeof obj.token === 'string' && typeof obj.sid === 'string') {
+      const frame: HelloFrame = { token: obj.token, sid: obj.sid };
+      if (obj.identity && typeof obj.identity === 'object') {
+        const id = obj.identity as { login?: unknown; github_id?: unknown };
+        if (typeof id.login === 'string' && typeof id.github_id === 'string') {
+          frame.identity = { login: id.login, github_id: id.github_id };
+        }
+      }
+      const waiter = helloWaiters.shift();
+      if (waiter) {
+        waiter(frame);
+      } else {
+        helloFrames.push(frame);
+      }
+    }
+  });
+
+  await waitOpen(ws);
+
+  return {
+    ws,
+    helloFrames,
+    waitForHello(timeoutMs = DEFAULT_FRAME_TIMEOUT_MS) {
+      const next = helloFrames.shift();
+      if (next) return Promise.resolve(next);
+      return new Promise((resolve, reject) => {
+        const resolveWrapper = (v: HelloFrame) => {
+          clearTimeout(timer);
+          resolve(v);
+        };
+        const timer = setTimeout(() => {
+          const idx = helloWaiters.indexOf(resolveWrapper);
+          if (idx >= 0) helloWaiters.splice(idx, 1);
+          reject(new Error('[' + opts.label + ' daemon] hello frame not received within ' + timeoutMs + 'ms'));
+        }, timeoutMs);
+        helloWaiters.push(resolveWrapper);
+      });
+    },
+    close() {
+      try { ws.close(1000, 'test done'); } catch { /* ignore */ }
+    },
+  };
+}
+
+async function connectBrowser(opts: {
+  base: string;
+  webJwt: string;
+  sid: string;
+  label: string;
+}): Promise<BrowserHandle> {
+  const url = opts.base + '/ws/default?sid=' + encodeURIComponent(opts.sid) + '&lastSeq=0';
+  const ws = new WebSocket(url, ['ccsm.' + opts.webJwt]);
+  ws.binaryType = 'arraybuffer';
+  const received: Uint8Array[] = [];
+  const receivedText: string[] = [];
+
+  ws.addEventListener('message', (ev) => {
+    if (typeof ev.data === 'string') {
+      receivedText.push(ev.data);
+    } else {
+      received.push(new Uint8Array(ev.data as ArrayBuffer));
+    }
+  });
+
+  await waitOpen(ws);
+
+  return {
+    ws,
+    received,
+    receivedText,
+    close() {
+      try { ws.close(1000, 'test done'); } catch { /* ignore */ }
+    },
+  };
+}
+
+function waitForBytes(
+  handle: BrowserHandle,
+  predicate: (frame: Uint8Array) => boolean,
+  label: string,
+  timeoutMs = DEFAULT_FRAME_TIMEOUT_MS,
+): Promise<Uint8Array> {
+  // Already-received case.
+  for (const f of handle.received) {
+    if (predicate(f)) return Promise.resolve(f);
+  }
+  return new Promise((resolve, reject) => {
+    const onMsg = (ev: MessageEvent) => {
+      if (typeof ev.data === 'string') return;
+      const frame = new Uint8Array(ev.data as ArrayBuffer);
+      if (predicate(frame)) {
+        clearTimeout(timer);
+        handle.ws.removeEventListener('message', onMsg as EventListener);
+        resolve(frame);
+      }
+    };
+    const timer = setTimeout(() => {
+      handle.ws.removeEventListener('message', onMsg as EventListener);
+      reject(new Error('[' + label + '] expected frame not received within ' + timeoutMs + 'ms'));
+    }, timeoutMs);
+    handle.ws.addEventListener('message', onMsg as EventListener);
+  });
+}
+
+/**
+ * Assert that, over a quiet window, NO frame matching predicate has shown up.
+ * Used for the cross-contamination check: alice's frame must NEVER reach bob.
+ */
+async function assertNoFrame(
+  handle: BrowserHandle,
+  predicate: (frame: Uint8Array) => boolean,
+  label: string,
+  windowMs = 1500,
+): Promise<void> {
+  // Check anything already received.
+  for (const f of handle.received) {
+    if (predicate(f)) {
+      throw new Error('[' + label + '] cross-contamination: forbidden frame already in receive buffer (len=' + f.byteLength + ')');
+    }
+  }
+  await new Promise<void>((resolve, reject) => {
+    const onMsg = (ev: MessageEvent) => {
+      if (typeof ev.data === 'string') return;
+      const frame = new Uint8Array(ev.data as ArrayBuffer);
+      if (predicate(frame)) {
+        cleanup();
+        reject(new Error('[' + label + '] cross-contamination: forbidden frame arrived during quiet window (len=' + frame.byteLength + ')'));
+      }
+    };
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, windowMs);
+    function cleanup() {
+      clearTimeout(timer);
+      handle.ws.removeEventListener('message', onMsg as EventListener);
+    }
+    handle.ws.addEventListener('message', onMsg as EventListener);
+  });
+}
+
+const WS_BASE = process.env.CCSM_CLOUD_WS_BASE ?? '';
+const WEB_KEY = process.env.JWT_SIGNING_KEY ?? '';
+const TUNNEL_KEY = process.env.JWT_REFRESH_SIGNING_KEY ?? '';
+
+/**
+ * Hard-fail (NOT skip) when the harness env is missing. Skipping would
+ * silently drop a green check on PRs that lacked the secret bag — exactly
+ * the failure mode that lets cross-user leaks ship. Operators who don't
+ * want the cross-user gate must filter the spec out explicitly via
+ * `playwright test --grep-invert "cross-user"` (CI matrices already do
+ * this for the legacy-mode lane against deployed cc-sm.pages.dev).
+ */
+function requireEnv(): { wsBase: string; webKey: string; tunnelKey: string } {
+  const missing: string[] = [];
+  if (WS_BASE.length === 0) missing.push('CCSM_CLOUD_WS_BASE');
+  if (WEB_KEY.length === 0) missing.push('JWT_SIGNING_KEY');
+  if (TUNNEL_KEY.length === 0) missing.push('JWT_REFRESH_SIGNING_KEY');
+  if (missing.length > 0) {
+    throw new Error(
+      'cross-user-isolation.spec requires env: ' + missing.join(', ') +
+      '. Start `wrangler dev --port 8787 --var CCSM_AUTH_MODE:jwt` against ' +
+      'a `.dev.vars` populated with matching JWT keys, then re-run with ' +
+      'CCSM_CLOUD_WS_BASE=ws://127.0.0.1:8787. See spec header for the ' +
+      'full setup. Filter this spec out with `--grep-invert "cross-user"` ' +
+      'when targeting deployed cc-sm.pages.dev (legacy-mode lane).',
+    );
+  }
+  return { wsBase: WS_BASE, webKey: WEB_KEY, tunnelKey: TUNNEL_KEY };
+}
+
+test.describe('cross-user TunnelDO isolation (S4-T9, Task #135)', () => {
+  test('alice and bob land in distinct DO instances; their frames never cross', async () => {
+    const { wsBase, webKey, tunnelKey } = requireEnv();
+    test.setTimeout(30_000);
+    const aliceTunnelJwt = signTunnelJwt('gh-1', 'alice', tunnelKey);
+    const bobTunnelJwt = signTunnelJwt('gh-2', 'bob', tunnelKey);
+    const aliceWebJwt = signWebJwt('gh-1', 'alice', webKey);
+    const bobWebJwt = signWebJwt('gh-2', 'bob', webKey);
+
+    // 1. Both daemons dial in. Each must succeed (no 401) and land in a
+    //    DIFFERENT DO instance — verified indirectly by the hello-frame
+    //    routing below: alice's daemon must NEVER receive bob's hello.
+    const aliceDaemon = await connectDaemon({ base: wsBase, tunnelJwt: aliceTunnelJwt, label: 'alice' });
+    const bobDaemon = await connectDaemon({ base: wsBase, tunnelJwt: bobTunnelJwt, label: 'bob' });
+
+    try {
+      // 2. Both browsers connect with distinct sids. The DO will fire the
+      //    hello frame to its paired daemon as soon as the browser ws is
+      //    accepted.
+      const aliceSid = 'alice-sid-' + Math.random().toString(16).slice(2, 8);
+      const bobSid = 'bob-sid-' + Math.random().toString(16).slice(2, 8);
+      const aliceBrowser = await connectBrowser({ base: wsBase, webJwt: aliceWebJwt, sid: aliceSid, label: 'alice' });
+      const bobBrowser = await connectBrowser({ base: wsBase, webJwt: bobWebJwt, sid: bobSid, label: 'bob' });
+
+      try {
+        // 3. Each daemon must receive its OWN hello (sid + identity) — that
+        //    proves the worker mapped each JWT subject to a per-user DO.
+        const aliceHello = await aliceDaemon.waitForHello();
+        const bobHello = await bobDaemon.waitForHello();
+
+        expect(aliceHello.sid, 'alice daemon must see alice sid in hello').toBe(aliceSid);
+        expect(bobHello.sid, 'bob daemon must see bob sid in hello').toBe(bobSid);
+
+        // 4. Cross-routing assertion — neither daemon may have observed the
+        //    OTHER user's hello. If both daemons landed in the same DO this
+        //    would fail (one of them would see two hellos with different
+        //    sids; in legacy mode that's exactly how two-tab pairing works).
+        // (helloFrames was already drained by waitForHello above; consult
+        // both the consumed hello and the residual queue.)
+        const aliceAllSids = [aliceHello.sid, ...aliceDaemon.helloFrames.map((h) => h.sid)];
+        const bobAllSids = [bobHello.sid, ...bobDaemon.helloFrames.map((h) => h.sid)];
+        expect(
+          aliceAllSids.includes(bobSid),
+          'alice daemon must NOT see bob sid in any hello (cross-user leak)',
+        ).toBe(false);
+        expect(
+          bobAllSids.includes(aliceSid),
+          'bob daemon must NOT see alice sid in any hello (cross-user leak)',
+        ).toBe(false);
+
+        // 5. T6 identity injection sanity: in jwt-mode the worker injects
+        //    X-CCSM-Identity-* headers and the DO echoes them in hello.
+        expect(aliceHello.sid).toBe(aliceSid);
+        expect(aliceHello.identity?.login, 'alice hello carries login=alice').toBe('alice');
+        expect(aliceHello.identity?.github_id, 'alice hello carries github_id=gh-1').toBe('gh-1');
+        expect(bobHello.identity?.login, 'bob hello carries login=bob').toBe('bob');
+        expect(bobHello.identity?.github_id, 'bob hello carries github_id=gh-2').toBe('gh-2');
+
+        // 6. PTY-data isolation: alice daemon emits a unique payload bound
+        //    to alice's sid; the DO must route it to alice's browser ONLY.
+        const aliceMagic = new TextEncoder().encode('ALICE-PTY-MAGIC-' + aliceSid);
+        const bobMagic = new TextEncoder().encode('BOB-PTY-MAGIC-' + bobSid);
+        aliceDaemon.ws.send(encodeSidEnvelope(aliceSid, aliceMagic));
+        bobDaemon.ws.send(encodeSidEnvelope(bobSid, bobMagic));
+
+        const aliceFrame = await waitForBytes(
+          aliceBrowser,
+          (f) => Buffer.from(f).includes(Buffer.from(aliceMagic)),
+          'alice browser',
+        );
+        const bobFrame = await waitForBytes(
+          bobBrowser,
+          (f) => Buffer.from(f).includes(Buffer.from(bobMagic)),
+          'bob browser',
+        );
+        expect(aliceFrame.byteLength, 'alice browser received its payload').toBeGreaterThan(0);
+        expect(bobFrame.byteLength, 'bob browser received its payload').toBeGreaterThan(0);
+
+        // 7. Cross-contamination quiet-window — alice's payload must not
+        //    surface at bob's browser, and vice versa, even after the DO
+        //    has had a chance to process both. 1.5s is plenty for workerd
+        //    on a single-machine wrangler dev (frames typically arrive
+        //    within 5-50ms).
+        await assertNoFrame(
+          bobBrowser,
+          (f) => Buffer.from(f).includes(Buffer.from(aliceMagic)),
+          'bob browser (must not see alice payload)',
+        );
+        await assertNoFrame(
+          aliceBrowser,
+          (f) => Buffer.from(f).includes(Buffer.from(bobMagic)),
+          'alice browser (must not see bob payload)',
+        );
+      } finally {
+        aliceBrowser.close();
+        bobBrowser.close();
+      }
+    } finally {
+      aliceDaemon.close();
+      bobDaemon.close();
+    }
+  });
+
+  test('alice owning two browser tabs still pair on distinct sids (R-41 regression guard)', async () => {
+    const { wsBase, webKey, tunnelKey } = requireEnv();
+    test.setTimeout(30_000);
+    const aliceTunnelJwt = signTunnelJwt('gh-1', 'alice', tunnelKey);
+    const aliceWebJwt = signWebJwt('gh-1', 'alice', webKey);
+
+    const daemon = await connectDaemon({ base: wsBase, tunnelJwt: aliceTunnelJwt, label: 'alice' });
+    try {
+      const sidA = 'alice-tabA-' + Math.random().toString(16).slice(2, 6);
+      const sidB = 'alice-tabB-' + Math.random().toString(16).slice(2, 6);
+      const tabA = await connectBrowser({ base: wsBase, webJwt: aliceWebJwt, sid: sidA, label: 'tabA' });
+      const tabB = await connectBrowser({ base: wsBase, webJwt: aliceWebJwt, sid: sidB, label: 'tabB' });
+      try {
+        // Daemon receives two distinct hellos, one per sid.
+        const seenSids = new Set<string>();
+        seenSids.add((await daemon.waitForHello()).sid);
+        seenSids.add((await daemon.waitForHello()).sid);
+        expect(seenSids.has(sidA), 'daemon saw tabA hello').toBe(true);
+        expect(seenSids.has(sidB), 'daemon saw tabB hello').toBe(true);
+
+        // Daemon emits sid-specific binary; only the matching tab receives.
+        const payloadA = new TextEncoder().encode('TAB-A-' + sidA);
+        const payloadB = new TextEncoder().encode('TAB-B-' + sidB);
+        daemon.ws.send(encodeSidEnvelope(sidA, payloadA));
+        daemon.ws.send(encodeSidEnvelope(sidB, payloadB));
+
+        await waitForBytes(tabA, (f) => Buffer.from(f).includes(Buffer.from(payloadA)), 'tabA');
+        await waitForBytes(tabB, (f) => Buffer.from(f).includes(Buffer.from(payloadB)), 'tabB');
+        await assertNoFrame(
+          tabA,
+          (f) => Buffer.from(f).includes(Buffer.from(payloadB)),
+          'tabA (must not see tabB payload)',
+        );
+        await assertNoFrame(
+          tabB,
+          (f) => Buffer.from(f).includes(Buffer.from(payloadA)),
+          'tabB (must not see tabA payload)',
+        );
+      } finally {
+        tabA.close();
+        tabB.close();
+      }
+    } finally {
+      daemon.close();
+    }
+  });
+});

--- a/tools/cloud-e2e/tsconfig.json
+++ b/tools/cloud-e2e/tsconfig.json
@@ -9,5 +9,5 @@
     "noEmit": true,
     "types": ["node"]
   },
-  "include": ["specs/**/*.ts", "playwright.config.ts"]
+  "include": ["specs/**/*.ts", "fixtures/**/*.ts", "playwright.config.ts"]
 }


### PR DESCRIPTION
## Summary

Closes the S4 ladder by landing **S4-T9** (Task #135): a raw-WebSocket
cross-user isolation harness that drives `wrangler dev` running
`CCSM_AUTH_MODE=jwt` and asserts the per-user `TunnelDO` routing
introduced by S4-T5 (Task #136) cannot leak frames across users.

- New: `tools/cloud-e2e/specs/cross-user-isolation.spec.ts` — two test
  cases driving four concurrent ws clients (alice daemon, alice
  browser, bob daemon, bob browser) plus an R-41 regression guard
  (alice's own two tabs share a daemon, distinct sids).
- New: `tools/cloud-e2e/fixtures/jwt-sign.ts` — HS256 JWT minter
  (`signWebJwt` / `signTunnelJwt`) standing in for the OAuth + device
  flow paths. T5 vitest already covers OAuth/device-flow end-to-end;
  T9 narrows to **wire-level routing** so the harness stays free of
  SPA / Pages / Tauri boot. Single `wrangler dev --port 8787 --var
  CCSM_AUTH_MODE:jwt` is enough.
- Fix (root cause discovered while bringing the harness up):
  `packages/cf-worker/src/tunnel-do.ts:/tunnel/default` now echoes the
  daemon-offered `Sec-WebSocket-Protocol` subprotocol on the 101
  response. Without it RFC 6455 §4.2.2-compliant clients (Node 22
  native, `ws@8`, browsers) close the handshake with `Server sent no
  subprotocol`, which would have broken jwt-mode daemon dial-in once
  T8 (Task #141) starts rolling out. Browser path already echoed;
  daemon path now does too (legacy unauth daemons still work because
  the echo is conditional on the client offering a subprotocol).
- ROADMAP: `docs/ROADMAP.md` Stage S4 section marked
  `completed 2026-05-10` with the full per-task artifact ledger
  (T1 #113, T2 #121, T3 #140, T4 #142, T5 #136, T6 #133, T7 #139,
  T8 #141, T9 #135) and the production cutover ladder.

### No skip self-check
- No `.skip` / `xit` / `it.todo` / `describe.skip` anywhere in the spec.
- The harness env-gate is a **hard-fail** (`requireEnv()` throws with a
  setup pointer), not a `test.skip()` — silently green-ing a missing
  env was the exact failure mode that would ship cross-user leaks.
  Operators on the legacy-mode lane against deployed
  `cc-sm.pages.dev` filter via `--grep-invert "cross-user"`.
- Existing `tools/cloud-e2e/specs/two-tab-pairing.spec.ts` is
  **untouched** and continues to run unchanged.

### Local Windows full-stack evidence (2026-05-10)

`wrangler dev` started with `--var CCSM_AUTH_MODE:jwt` and a local
`.dev.vars` (gitignored, NOT committed) populated with the same hex
HS256 keys the spec uses. Then:

```
$ pnpm exec playwright test specs/cross-user-isolation.spec.ts --reporter=list
Running 2 tests using 1 worker

  ✓  1 cross-user TunnelDO isolation › alice and bob land in distinct
       DO instances; their frames never cross (3.1s)
  ✓  2 cross-user TunnelDO isolation › alice owning two browser tabs
       still pair on distinct sids (R-41 regression guard) (3.0s)

  2 passed (7.9s)
```

Test 1 verifies (a) alice's hello carries `login=alice / github_id=gh-1`
(T6 wire), (b) bob's hello carries `login=bob / github_id=gh-2`,
(c) alice daemon's hello queue never sees bob's sid and vice versa,
(d) `[len][alice-sid][ALICE-PTY-MAGIC...]` envelope routed by the DO
arrives only at alice's browser, never at bob's, within a 1.5s quiet
window.

Test 2 verifies the R-41 invariant under the per-user DO change —
alice's two tabs (one daemon, two distinct sids) still each receive
**only** their own sid-enveloped payload.

Companion checks (same commit):
- `pnpm --dir packages/cf-worker test` → 121/121 passed
  (`tunnel-do.test.ts` 31, `userDO.test.ts` 13, `webOauth.test.ts`,
  `middleware.test.ts`, `deviceFlow.test.ts`, `jwtRouting.test.ts`,
  plus the existing four).
- `pnpm --dir packages/cf-worker typecheck` → clean.
- `pnpm --dir packages/cf-worker lint` → clean.
- `tsc --noEmit` against `tools/cloud-e2e/tsconfig.json` → clean.

### ROADMAP diff summary

`docs/ROADMAP.md` Stage S4 section gains a `Status: completed
2026-05-10` block listing each T1..T9 task with its primary artifact
and a 3-step production cutover ladder (legacy → preview-flip → S5
delete-legacy).

### Test plan

- [x] Local Windows full-stack: `wrangler dev` + harness, 2/2 green.
- [x] cf-worker vitest 121/121.
- [x] cf-worker typecheck + lint clean.
- [x] cloud-e2e tsc clean.
- [ ] CI ubuntu + windows lanes (matrix does not include cloud-e2e —
      the harness is ad-hoc; new spec inherits that posture).
- [ ] Manual cutover validation on a Cloudflare Pages preview with
      `CCSM_AUTH_MODE=jwt` once a maintainer wants to flip the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)