### PR TITLE
Task #152 — R-44 audit P0/P1 security 5 fixes

### DIFF
--- a/packages/cf-worker/src/auth/deviceFlow.ts
+++ b/packages/cf-worker/src/auth/deviceFlow.ts
@@ -27,6 +27,11 @@
  * refresh which keeps the same hash). The daemon already persists tokens
  * to disk, so rotation here is cheap and gives us replay protection.
  *
+ * Signing key: tunnel JWTs are signed with `JWT_REFRESH_SIGNING_KEY` so
+ * that a leaked `JWT_SIGNING_KEY` (web key) cannot mint daemon-class
+ * tokens. middleware.extractTunnelJwt verifies against the same refresh
+ * key — the two MUST match (audit F-S-1, Task #152).
+ *
  * NOT in scope: the actual TunnelDO routing of the resulting JWT (T5).
  */
 import type { AuthEnv } from './bindings';
@@ -238,7 +243,7 @@ export async function handleDevicePoll(req: Request, env: AuthEnv): Promise<Resp
     kind: 'tunnel',
     jti: randomHex(16),
   };
-  const tunnelJwt = await signJwt(claims, env.JWT_SIGNING_KEY);
+  const tunnelJwt = await signJwt(claims, env.JWT_REFRESH_SIGNING_KEY);
 
   return Response.json({
     tunnel_jwt: tunnelJwt,
@@ -325,7 +330,7 @@ export async function handleTunnelRefresh(req: Request, env: AuthEnv): Promise<R
     kind: 'tunnel',
     jti: randomHex(16),
   };
-  const tunnelJwt = await signJwt(claims, env.JWT_SIGNING_KEY);
+  const tunnelJwt = await signJwt(claims, env.JWT_REFRESH_SIGNING_KEY);
 
   return Response.json({
     tunnel_jwt: tunnelJwt,

--- a/packages/cf-worker/src/auth/jwt.ts
+++ b/packages/cf-worker/src/auth/jwt.ts
@@ -8,6 +8,17 @@
  *   - WebJwtClaims  — short-lived browser session token (kind: 'web')
  *   - TunnelJwtClaims — per-tunnel daemon-presented token (kind: 'tunnel')
  *
+ * Key separation invariant (audit F-S-1, Task #152):
+ *   - kind='web' tokens MUST be signed AND verified with `JWT_SIGNING_KEY`.
+ *   - kind='tunnel' tokens MUST be signed AND verified with
+ *     `JWT_REFRESH_SIGNING_KEY`.
+ *   The two keys live in separate `wrangler secret` slots so a leak of the
+ *   web key cannot mint daemon-class tokens (and vice versa). signJwt /
+ *   verifyJwt accept any hex key — the caller is responsible for pairing.
+ *   See deviceFlow.ts (signs tunnel) + middleware.extractTunnelJwt (verifies
+ *   tunnel) and webOauth.ts (signs web) + middleware.extractWebJwt
+ *   (verifies web).
+ *
  * Keys are passed in as hex strings (matching `wrangler secret` / `.dev.vars`
  * style); we decode to raw bytes inside `importHmacKey`. Sign + verify both
  * round-trip through base64url (RFC 7515 §2). `verifyJwt` is exp-aware (token

--- a/packages/cf-worker/src/auth/middleware.ts
+++ b/packages/cf-worker/src/auth/middleware.ts
@@ -40,12 +40,25 @@ const WS_SUBPROTOCOL_PREFIX = 'ccsm.';
 export type AuthMode = 'legacy' | 'jwt';
 
 /**
- * Read the auth mode from env. Anything other than the literal string `jwt`
- * (incl. unset / empty / typo) falls back to `legacy` so a misconfigured
- * deploy can never accidentally enforce JWT and lock everyone out.
+ * Read the auth mode from env. Recognized values:
+ *   - `'jwt'` — enforce per-user JWT verification.
+ *   - `'legacy'` / unset / undefined — S3-era token-based flow.
+ *
+ * Audit F-S-3 (Task #152): any other non-empty value (typo / bad config)
+ * THROWS rather than silently falling back to `legacy`. Silent fallback
+ * was the original behavior (Task #136) but the audit found it could mask
+ * a misconfigured `wrangler vars` (e.g. `CCSM_AUTH_MODE=JWT` upper-case)
+ * by quietly downgrading to legacy and skipping all JWT checks. We still
+ * treat unset / empty / undefined as legacy so a fresh deploy that hasn't
+ * set the var yet does not 500 — the failure mode targets typos only.
  */
 export function getAuthMode(env: { CCSM_AUTH_MODE?: string }): AuthMode {
-  return env.CCSM_AUTH_MODE === 'jwt' ? 'jwt' : 'legacy';
+  const raw = env.CCSM_AUTH_MODE;
+  if (raw === undefined || raw === '' || raw === 'legacy') return 'legacy';
+  if (raw === 'jwt') return 'jwt';
+  throw new Error(
+    'CCSM_AUTH_MODE must be "jwt" / "legacy" / unset; got: ' + JSON.stringify(raw),
+  );
 }
 
 /**
@@ -92,11 +105,47 @@ function extractBearer(req: Request): string | null {
 }
 
 /**
- * Verify a browser-presented web JWT. Looks first at the WS subprotocol,
- * then at Authorization header (so the same helper covers both ws and REST).
+ * Extract the `web_jwt` value from a `Cookie:` header. Returns null when
+ * the header is absent or the cookie is missing/empty.
+ *
+ * Audit F-S-4 (Task #152): the SPA web JWT now lives in an HttpOnly cookie
+ * (Path=/api) instead of URL fragment + sessionStorage so an XSS payload
+ * cannot reach it. REST `/api/*` requests carry the cookie automatically;
+ * `/ws/default` cannot (browsers don't send cookies on WebSocket subprotocol
+ * upgrades from cross-origin SPA + browsers strip them on subprotocol-only
+ * channels) so the SPA fetches a short-lived ws-ticket JWT first and passes
+ * it as the `Sec-WebSocket-Protocol` value (see `handleWsTicket`).
+ */
+export const WEB_JWT_COOKIE = 'web_jwt';
+
+function extractWebJwtCookie(req: Request): string | null {
+  const raw = req.headers.get('cookie');
+  if (raw === null) return null;
+  for (const pair of raw.split(';')) {
+    const eq = pair.indexOf('=');
+    if (eq <= 0) continue;
+    const k = pair.slice(0, eq).trim();
+    if (k !== WEB_JWT_COOKIE) continue;
+    const v = pair.slice(eq + 1).trim();
+    return v.length > 0 ? v : null;
+  }
+  return null;
+}
+
+/**
+ * Verify a browser-presented web JWT.
+ *
+ * Source priority (audit F-S-4, Task #152):
+ *   1. HttpOnly `web_jwt` cookie — REST `/api/*` requests in cookie-based
+ *      flow. The SPA never reads or sets this; only the cf-worker does.
+ *   2. WS subprotocol `ccsm.<jwt>` — `/ws/default` upgrades carry a
+ *      short-lived ws-ticket JWT here (cookies don't ride WebSocket
+ *      subprotocol channels).
+ *   3. Authorization Bearer — Tauri shell / smoke / loopback backstop where
+ *      the daemon-minted token path is still in play.
  *
  * Returns null on:
- *   - no token present
+ *   - no token present in any source
  *   - signature invalid / expired (verifyJwt returns null)
  *   - `kind` is not `'web'` (daemon-class token presented at browser path)
  */
@@ -104,7 +153,10 @@ export async function extractWebJwt(
   req: Request,
   env: AuthEnv,
 ): Promise<WebJwtClaims | null> {
-  const token = extractSubprotocolToken(req) ?? extractBearer(req);
+  const token =
+    extractWebJwtCookie(req) ??
+    extractSubprotocolToken(req) ??
+    extractBearer(req);
   if (token === null) return null;
   const claims = await verifyJwt<WebJwtClaims>(token, env.JWT_SIGNING_KEY);
   if (claims === null) return null;

--- a/packages/cf-worker/src/auth/webOauth.ts
+++ b/packages/cf-worker/src/auth/webOauth.ts
@@ -34,17 +34,26 @@
  * through TunnelDO. Only the /api/auth/* prefix routes here.
  */
 import type { AuthEnv } from './bindings';
-import { signJwt, type WebJwtClaims } from './jwt';
+import { signJwt, verifyJwt, type WebJwtClaims } from './jwt';
 
 const GH_AUTHORIZE_URL = 'https://github.com/login/oauth/authorize';
 const GH_TOKEN_URL = 'https://github.com/login/oauth/access_token';
 const GH_USER_URL = 'https://api.github.com/user';
 
 const WEB_JWT_TTL_SEC = 60 * 60; // 1h
+/**
+ * Audit F-S-4 (Task #152): ws subprotocol can't ride a cookie, so we mint
+ * a short-lived JWT (60s) the SPA fetches right before opening the
+ * WebSocket. Browser exposure window is one upgrade.
+ */
+const WS_TICKET_TTL_SEC = 60;
 const CSRF_COOKIE = 'csrf';
 const REFRESH_COOKIE = 'refresh';
+/** Audit F-S-4: HttpOnly session cookie carrying the web JWT, scoped to /api. */
+const WEB_JWT_COOKIE = 'web_jwt';
 const CALLBACK_PATH = '/api/auth/github/callback';
 const REFRESH_PATH = '/api/auth/refresh';
+const WEB_JWT_COOKIE_PATH = '/api';
 
 /** Hex-encode a Uint8Array. */
 function bytesToHex(bytes: Uint8Array): string {
@@ -242,12 +251,25 @@ export async function handleGithubCallback(
   };
   const webJwt = await signJwt(claims, env.JWT_SIGNING_KEY);
 
-  // Compose the redirect: SignInGate reads `#jwt=...` once and clears the
-  // fragment; the refresh cookie persists across visits.
+  // Compose the redirect: the web JWT now rides an HttpOnly cookie scoped to
+  // `/api` (audit F-S-4, Task #152). The SPA learns it's signed-in by
+  // `GET /api/auth/me`; the URL fragment used to carry the JWT (T3) is gone.
   const headers = new Headers();
-  headers.append('Location', `/?session=ok#jwt=${encodeURIComponent(webJwt)}`);
+  headers.append('Location', `/?session=ok`);
   // Clear the csrf cookie now that we've consumed it.
   headers.append('Set-Cookie', clearCookie(CSRF_COOKIE, CALLBACK_PATH));
+  // HttpOnly + Secure + SameSite=Strict so an XSS payload cannot exfiltrate
+  // the JWT and a cross-site link cannot ride the session.
+  headers.append(
+    'Set-Cookie',
+    buildCookie(WEB_JWT_COOKIE, webJwt, {
+      path: WEB_JWT_COOKIE_PATH,
+      maxAge: WEB_JWT_TTL_SEC,
+      httpOnly: true,
+      secure: true,
+      sameSite: 'Strict',
+    }),
+  );
   // Persist the refresh token in an HttpOnly cookie scoped to the refresh path.
   headers.append(
     'Set-Cookie',
@@ -275,16 +297,22 @@ export async function handleGithubCallback(
 }
 
 /**
- * POST /api/auth/refresh — verify the refresh cookie against the UserDO hash
- * and re-mint a fresh web JWT. The refresh token itself is NOT rotated in T3.
+ * POST /api/auth/refresh — verify the refresh cookie against the UserDO hash,
+ * **rotate** it (write a fresh hash + send a fresh cookie), and re-mint a web
+ * JWT.
+ *
+ * Audit F-S-5 (Task #152): web refresh now rotates on every call (parity
+ * with deviceFlow tunnel-refresh). Without rotation a leaked refresh
+ * token grants attacker indefinite access until manual revoke. The new
+ * opaque token is sent back as the same HttpOnly cookie; the old hash is
+ * overwritten so subsequent presentations of the old token 401.
  *
  * The browser has no other way to identify the user (web JWT may already be
  * gone), so we recover the login by stuffing the SHA-256 lookup into a
  * UserDO instance keyed by login... except we don't know the login yet. To
  * keep T3 simple, the refresh cookie is paired with a small hint cookie that
- * carries `login` (HttpOnly is fine, this isn't a secret). T4 / T5 may move
- * to a signed pointer instead; for now we trust the hint and validate the
- * hash before re-issuing anything.
+ * carries `login` (HttpOnly is fine, this isn't a secret). We trust the hint
+ * and validate the hash before re-issuing anything.
  */
 export async function handleRefresh(
   req: Request,
@@ -326,6 +354,22 @@ export async function handleRefresh(
   }
   const rec = (await getLoginRes.json()) as { github_id: string; login: string };
 
+  // Audit F-S-5: rotate the refresh token. Mint a new opaque hex + write
+  // its hash into UserDO (overwrites the previous slot). Old token's hash
+  // can no longer pass verifyRefreshTokenHash on a subsequent call.
+  const newRefreshToken = randomHex(32);
+  const newRefreshHash = await sha256Hex(newRefreshToken);
+  const setHashRes = await userDoStub.fetch(
+    new Request('https://do/setRefreshTokenHash', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ hash: newRefreshHash }),
+    }),
+  );
+  if (!setHashRes.ok) {
+    return new Response('userDO setRefreshTokenHash failed', { status: 500 });
+  }
+
   const iat = Math.floor(Date.now() / 1000);
   const claims: WebJwtClaims = {
     sub: rec.github_id,
@@ -335,7 +379,34 @@ export async function handleRefresh(
     kind: 'web',
   };
   const webJwt = await signJwt(claims, env.JWT_SIGNING_KEY);
-  return Response.json({ web_jwt: webJwt });
+  const headers = new Headers({ 'content-type': 'application/json' });
+  // Audit F-S-4: also re-set the web_jwt HttpOnly cookie so cookie-based
+  // SPAs pick the new JWT up automatically without storing it in JS-reachable
+  // state. body still echoes web_jwt for the legacy fragment-era callers.
+  headers.append(
+    'Set-Cookie',
+    buildCookie(WEB_JWT_COOKIE, webJwt, {
+      path: WEB_JWT_COOKIE_PATH,
+      maxAge: WEB_JWT_TTL_SEC,
+      httpOnly: true,
+      secure: true,
+      sameSite: 'Strict',
+    }),
+  );
+  headers.append(
+    'Set-Cookie',
+    buildCookie(REFRESH_COOKIE, newRefreshToken, {
+      path: REFRESH_PATH,
+      maxAge: 60 * 60 * 24 * 30, // 30 days, mirroring callback
+      httpOnly: true,
+      secure: true,
+      sameSite: 'Lax',
+    }),
+  );
+  return new Response(JSON.stringify({ web_jwt: webJwt, login: rec.login }), {
+    status: 200,
+    headers,
+  });
 }
 
 /**
@@ -356,7 +427,72 @@ export async function handleLogout(
   const headers = new Headers();
   headers.append('Set-Cookie', clearCookie(REFRESH_COOKIE, REFRESH_PATH));
   headers.append('Set-Cookie', clearCookie('login', '/api/auth'));
+  // Audit F-S-4: also nuke the web_jwt session cookie.
+  headers.append('Set-Cookie', clearCookie(WEB_JWT_COOKIE, WEB_JWT_COOKIE_PATH));
   return new Response(null, { status: 204, headers });
+}
+
+/**
+ * GET /api/auth/me — audit F-S-4 (Task #152).
+ *
+ * Reads the HttpOnly `web_jwt` cookie, verifies it, returns
+ * `{ login, github_id }`. The SPA mounts and calls this to learn whether
+ * the user is signed-in (replacing the old fragment-decode + sessionStorage
+ * read). 401 means "not signed-in" — caller renders SignInScreen.
+ *
+ * No CSRF token is required because:
+ *   (a) it's a GET / safe method,
+ *   (b) the cookie is SameSite=Strict so cross-site requests don't carry
+ *       the credential.
+ */
+export async function handleMe(req: Request, env: AuthEnv): Promise<Response> {
+  const cookies = parseCookies(req.headers.get('Cookie'));
+  const jwt = cookies.get(WEB_JWT_COOKIE);
+  if (!jwt) return new Response('unauthorized', { status: 401 });
+  const claims = await verifyJwt<WebJwtClaims>(jwt, env.JWT_SIGNING_KEY);
+  if (claims === null || claims.kind !== 'web') {
+    return new Response('unauthorized', { status: 401 });
+  }
+  return Response.json({ login: claims.login, github_id: claims.sub });
+}
+
+/**
+ * POST /api/auth/ws-ticket — audit F-S-4 (Task #152).
+ *
+ * Browsers cannot ride a cookie on `new WebSocket(url, protocols)`; the
+ * subprotocol is the only writable header. The SPA fetches a 60-second JWT
+ * (`kind='web'`, freshly minted from the same signing key) and presents it
+ * as `Sec-WebSocket-Protocol: ccsm.<ticket>`. middleware.extractWebJwt
+ * verifies the ticket on the upgrade like any other web JWT.
+ *
+ * Why a separate ticket: the long-lived (1h) `web_jwt` cookie never leaves
+ * server-managed storage. The short-lived ticket DOES briefly land in JS
+ * (we can't avoid it — `WebSocket` constructor takes the protocol from
+ * an argument), so we cap its TTL to 60s to bound the window of a leaked
+ * value.
+ *
+ * CSRF is naturally bound by SameSite=Strict on the source cookie + the
+ * fact that an attacker page cannot make a same-origin POST that reads
+ * the response body (CORS).
+ */
+export async function handleWsTicket(req: Request, env: AuthEnv): Promise<Response> {
+  const cookies = parseCookies(req.headers.get('Cookie'));
+  const jwt = cookies.get(WEB_JWT_COOKIE);
+  if (!jwt) return new Response('unauthorized', { status: 401 });
+  const claims = await verifyJwt<WebJwtClaims>(jwt, env.JWT_SIGNING_KEY);
+  if (claims === null || claims.kind !== 'web') {
+    return new Response('unauthorized', { status: 401 });
+  }
+  const iat = Math.floor(Date.now() / 1000);
+  const ticketClaims: WebJwtClaims = {
+    sub: claims.sub,
+    login: claims.login,
+    iat,
+    exp: iat + WS_TICKET_TTL_SEC,
+    kind: 'web',
+  };
+  const ticket = await signJwt(ticketClaims, env.JWT_SIGNING_KEY);
+  return Response.json({ ws_ticket: ticket, expires_in: WS_TICKET_TTL_SEC });
 }
 
 /**
@@ -381,6 +517,12 @@ export async function dispatchAuth(
   }
   if (req.method === 'POST' && path === '/api/auth/logout') {
     return handleLogout(req, env);
+  }
+  if (req.method === 'GET' && path === '/api/auth/me') {
+    return handleMe(req, env);
+  }
+  if (req.method === 'POST' && path === '/api/auth/ws-ticket') {
+    return handleWsTicket(req, env);
   }
   return null;
 }

--- a/packages/cf-worker/test/deviceFlow.test.ts
+++ b/packages/cf-worker/test/deviceFlow.test.ts
@@ -21,6 +21,15 @@ import { verifyJwt, type TunnelJwtClaims } from '../src/auth/jwt';
 
 const KEY_HEX =
   '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff';
+/**
+ * Audit F-S-1 (Task #152): tunnel JWTs are signed with the refresh key
+ * (kept separate from the web signing key so a web-key leak cannot mint
+ * daemon-class tokens). Tests use distinct hex constants for the two keys
+ * to lock the invariant: a token signed with the refresh key MUST verify
+ * with the refresh key AND fail to verify with the web key.
+ */
+const KEY_REFRESH_HEX =
+  '99887766554433221100ffeeddccbbaa99887766554433221100ffeeddccbbaa';
 
 interface UserDoState {
   github_id?: string;
@@ -86,7 +95,7 @@ function makeEnv(userDo: UserDoFake): AuthEnv {
     GITHUB_OAUTH_CLIENT_ID: 'test-client-id',
     GITHUB_OAUTH_CLIENT_SECRET: 'test-client-secret',
     JWT_SIGNING_KEY: KEY_HEX,
-    JWT_REFRESH_SIGNING_KEY: KEY_HEX,
+    JWT_REFRESH_SIGNING_KEY: KEY_REFRESH_HEX,
     USER_DO: {
       idFromName: (_name: string) => ({ name: _name }) as unknown as DurableObjectId,
       get: (_id: DurableObjectId) => userDo.stub as unknown as DurableObjectStub,
@@ -273,7 +282,7 @@ describe('handleDevicePoll', () => {
     expect(body.login).toBe('alice');
     expect(body.tunnel_refresh_token).toMatch(/^[0-9a-f]{64}$/);
 
-    const claims = await verifyJwt<TunnelJwtClaims>(body.tunnel_jwt, KEY_HEX);
+    const claims = await verifyJwt<TunnelJwtClaims>(body.tunnel_jwt, KEY_REFRESH_HEX);
     expect(claims).not.toBeNull();
     expect(claims!.sub).toBe('99');
     expect(claims!.login).toBe('alice');
@@ -285,6 +294,38 @@ describe('handleDevicePoll', () => {
     expect(userDo.state.github_id).toBe('99');
     expect(userDo.state.login).toBe('alice');
     expect(userDo.state.tunnel_refresh_hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('audit F-S-1: tunnel_jwt is signed with REFRESH key (cannot be verified with web key)', async () => {
+    // Lock the key-separation invariant. deviceFlow.ts MUST sign with
+    // env.JWT_REFRESH_SIGNING_KEY so middleware (which verifies with the
+    // same env.JWT_REFRESH_SIGNING_KEY) accepts the daemon dial. Pre-fix
+    // deviceFlow signed with JWT_SIGNING_KEY → every legit daemon dial
+    // was rejected.
+    makeGithubFetch({
+      'https://github.com/login/oauth/access_token': [
+        () => Response.json({ access_token: 'gh-access' }),
+      ],
+      'https://api.github.com/user': [
+        () => Response.json({ id: 99, login: 'alice' }),
+      ],
+    });
+    const env = makeEnv(makeUserDo());
+    const res = await handleDevicePoll(
+      new Request('https://example/api/auth/device/poll', {
+        method: 'POST',
+        body: JSON.stringify({ device_code: 'd' }),
+      }),
+      env,
+    );
+    const body = (await res.json()) as { tunnel_jwt: string };
+    // verifyJwt with the REFRESH key succeeds (the key middleware uses).
+    const okClaims = await verifyJwt<TunnelJwtClaims>(body.tunnel_jwt, KEY_REFRESH_HEX);
+    expect(okClaims).not.toBeNull();
+    // verifyJwt with the WEB key fails — proves the two keys are not
+    // collapsed by accident.
+    const wrongKeyClaims = await verifyJwt<TunnelJwtClaims>(body.tunnel_jwt, KEY_HEX);
+    expect(wrongKeyClaims).toBeNull();
   });
 
   it('400s when device_code is missing from body', async () => {
@@ -404,7 +445,7 @@ describe('handleTunnelRefresh', () => {
     expect(body.tunnel_refresh_token).toMatch(/^[0-9a-f]{64}$/);
     expect(body.tunnel_refresh_token).not.toBe(oldToken);
 
-    const claims = await verifyJwt<TunnelJwtClaims>(body.tunnel_jwt, KEY_HEX);
+    const claims = await verifyJwt<TunnelJwtClaims>(body.tunnel_jwt, KEY_REFRESH_HEX);
     expect(claims).not.toBeNull();
     expect(claims!.kind).toBe('tunnel');
     expect(claims!.login).toBe('carol');

--- a/packages/cf-worker/test/middleware.test.ts
+++ b/packages/cf-worker/test/middleware.test.ts
@@ -77,10 +77,19 @@ describe('getAuthMode', () => {
   it('returns jwt when explicitly "jwt"', () => {
     expect(getAuthMode({ CCSM_AUTH_MODE: 'jwt' })).toBe('jwt');
   });
-  it('falls back to legacy on typo / unknown value', () => {
-    expect(getAuthMode({ CCSM_AUTH_MODE: 'JWT' })).toBe('legacy');
-    expect(getAuthMode({ CCSM_AUTH_MODE: 'enabled' })).toBe('legacy');
+  it('returns legacy on the literal value "legacy" or empty string', () => {
+    expect(getAuthMode({ CCSM_AUTH_MODE: 'legacy' })).toBe('legacy');
     expect(getAuthMode({ CCSM_AUTH_MODE: '' })).toBe('legacy');
+  });
+  it('audit F-S-3: throws on unrecognized non-empty values (no silent fallback)', () => {
+    // Pre-audit behaviour: getAuthMode silently returned 'legacy' when the
+    // env var was a typo (e.g. 'JWT' upper-case). That meant a misconfigured
+    // wrangler vars deploy quietly skipped JWT enforcement. Audit F-S-3
+    // tightens the gate: anything other than the recognized literals
+    // throws so the worker fails closed at startup.
+    expect(() => getAuthMode({ CCSM_AUTH_MODE: 'JWT' })).toThrowError(/CCSM_AUTH_MODE/);
+    expect(() => getAuthMode({ CCSM_AUTH_MODE: 'enabled' })).toThrowError(/CCSM_AUTH_MODE/);
+    expect(() => getAuthMode({ CCSM_AUTH_MODE: 'on' })).toThrowError(/CCSM_AUTH_MODE/);
   });
 });
 
@@ -186,6 +195,33 @@ describe('extractWebJwt', () => {
     const out = await extractWebJwt(req, makeEnv());
     expect(out).toBeNull();
   });
+
+  it('audit F-S-4: extracts from web_jwt HttpOnly cookie', async () => {
+    const tok = await signJwt(makeWebClaims(), KEY_WEB);
+    const req = new Request('http://x/api/sessions', {
+      headers: { Cookie: `web_jwt=${tok}; other=x` },
+    });
+    const out = await extractWebJwt(req, makeEnv());
+    expect(out).not.toBeNull();
+    expect(out!.kind).toBe('web');
+  });
+
+  it('audit F-S-4: cookie takes precedence over subprotocol + Authorization', async () => {
+    // Documents the ordering — cookie path is the new default; subprotocol
+    // remains for ws upgrades, Bearer for Tauri loopback.
+    const cookieTok = await signJwt(makeWebClaims({ login: 'fromCookie' }), KEY_WEB);
+    const wsTok = await signJwt(makeWebClaims({ login: 'fromWs' }), KEY_WEB);
+    const authTok = await signJwt(makeWebClaims({ login: 'fromAuth' }), KEY_WEB);
+    const req = new Request('http://x/api/sessions', {
+      headers: {
+        Cookie: `web_jwt=${cookieTok}`,
+        'Sec-WebSocket-Protocol': 'ccsm.' + wsTok,
+        Authorization: 'Bearer ' + authTok,
+      },
+    });
+    const out = await extractWebJwt(req, makeEnv());
+    expect(out!.login).toBe('fromCookie');
+  });
 });
 
 describe('extractTunnelJwt', () => {
@@ -229,5 +265,34 @@ describe('extractTunnelJwt', () => {
     });
     const out = await extractTunnelJwt(req, makeEnv());
     expect(out).toBeNull();
+  });
+
+  it('audit F-S-1: tunnel JWT signed with web key (JWT_SIGNING_KEY) is rejected', async () => {
+    // Pre-audit deviceFlow.ts signed tunnel JWTs with `JWT_SIGNING_KEY`
+    // while middleware verified against `JWT_REFRESH_SIGNING_KEY` — every
+    // legit daemon dial would fail in jwt mode. The fix routes the
+    // signing call through `JWT_REFRESH_SIGNING_KEY` (separate key, kept
+    // distinct so a leaked web key cannot mint daemon tokens). This
+    // guard documents that a token signed with the WRONG key
+    // (JWT_SIGNING_KEY) still cannot pass tunnel verification — the key
+    // separation invariant holds.
+    const tok = await signJwt(makeTunnelClaims(), KEY_WEB); // web key, wrong for tunnel
+    const req = new Request('http://x/tunnel/default', {
+      headers: { 'Sec-WebSocket-Protocol': 'ccsm.' + tok },
+    });
+    const out = await extractTunnelJwt(req, makeEnv());
+    expect(out).toBeNull();
+  });
+
+  it('audit F-S-1: tunnel JWT signed with refresh key (post-fix) verifies', async () => {
+    // Mirror of the above — round-trip with the correct key passes, so
+    // the deviceFlow.ts → middleware contract works end-to-end.
+    const tok = await signJwt(makeTunnelClaims(), KEY_TUNNEL);
+    const req = new Request('http://x/tunnel/default', {
+      headers: { 'Sec-WebSocket-Protocol': 'ccsm.' + tok },
+    });
+    const out = await extractTunnelJwt(req, makeEnv());
+    expect(out).not.toBeNull();
+    expect(out!.kind).toBe('tunnel');
   });
 });

--- a/packages/cf-worker/test/webOauth.test.ts
+++ b/packages/cf-worker/test/webOauth.test.ts
@@ -1,28 +1,33 @@
 /**
- * S4-T3 (Task #140): browser OAuth flow tests.
+ * S4-T3 (Task #140) + audit F-S-1/F-S-4/F-S-5 (Task #152): browser OAuth
+ * flow tests.
  *
- * Each handler is exercised against an in-memory UserDO fake + a stubbed
- * `globalThis.fetch` that pretends to be GitHub. We verify:
- *
+ * Covers:
  *   - login: 302 to github.com/login/oauth/authorize, csrf state baked into
  *     URL + matching HttpOnly cookie scoped to the callback path.
- *   - callback (happy path): csrf round-trips, code is exchanged, user is
- *     fetched, UserDO sees setLogin + setRefreshTokenHash, response is a 302
- *     with `#jwt=...` fragment + a refresh cookie.
+ *   - callback (audit F-S-4): csrf round-trips, code is exchanged, user is
+ *     fetched, UserDO sees setLogin + setRefreshTokenHash, response is a
+ *     302 with a `web_jwt` HttpOnly + Secure + SameSite=Strict cookie
+ *     scoped to /api (NOT a URL fragment), plus a refresh cookie. The
+ *     redirect target is the bare `/?session=ok` (no #jwt=).
  *   - callback (csrf mismatch): rejected before any GitHub call.
  *   - callback (token exchange error): 502 surfaced.
- *   - refresh: hash check happens, web JWT re-issued.
+ *   - refresh (audit F-S-5): hash rotation invalidates the old refresh
+ *     token; second presentation with the same token returns 401.
  *   - refresh (bad hash): 401.
- *   - logout: clears cookies + hits UserDO /revoke.
- *   - dispatchAuth: returns null for non-auth paths.
+ *   - me + ws-ticket (audit F-S-4): cookie-based session probes.
+ *   - logout: clears cookies (incl. web_jwt) + hits UserDO /revoke.
+ *   - dispatchAuth: returns null for non-auth paths; routes /me / /ws-ticket.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   dispatchAuth,
   handleGithubLogin,
   handleGithubCallback,
+  handleMe,
   handleRefresh,
   handleLogout,
+  handleWsTicket,
 } from '../src/auth/webOauth';
 import type { AuthEnv } from '../src/auth/bindings';
 import { signJwt, verifyJwt, type WebJwtClaims } from '../src/auth/jwt';
@@ -199,7 +204,7 @@ describe('handleGithubCallback', () => {
     return fn;
   }
 
-  it('happy path: persists user, mints jwt + refresh, sets cookies, redirects', async () => {
+  it('happy path: persists user, mints jwt cookie + refresh, sets cookies, redirects', async () => {
     const userDo = makeUserDo();
     const env = makeEnv(userDo);
     const ghFetch = mockGithubFetch({ userId: 42, userLogin: 'alice' });
@@ -212,9 +217,20 @@ describe('handleGithubCallback', () => {
 
     expect(res.status).toBe(302);
     const loc = res.headers.get('Location')!;
-    expect(loc).toMatch(/^\/\?session=ok#jwt=/);
-    const jwt = decodeURIComponent(loc.split('#jwt=')[1]!);
-    const claims = await verifyJwt<WebJwtClaims>(jwt, KEY_HEX);
+    // Audit F-S-4: redirect target is bare `/?session=ok` — no #jwt fragment.
+    expect(loc).toBe('/?session=ok');
+    expect(loc).not.toMatch(/#jwt=/);
+
+    // Audit F-S-4: web_jwt rides an HttpOnly + Secure + SameSite=Strict
+    // cookie scoped to /api so an XSS payload cannot reach it.
+    const cookies = getSetCookies(res);
+    const webJwtCookie = findCookie(cookies, 'web_jwt');
+    expect(webJwtCookie).not.toBeNull();
+    expect(webJwtCookie!.attrs).toMatch(/HttpOnly/);
+    expect(webJwtCookie!.attrs).toMatch(/Secure/);
+    expect(webJwtCookie!.attrs).toMatch(/SameSite=Strict/);
+    expect(webJwtCookie!.attrs).toMatch(/Path=\/api/);
+    const claims = await verifyJwt<WebJwtClaims>(webJwtCookie!.value, KEY_HEX);
     expect(claims).not.toBeNull();
     expect(claims!.sub).toBe('42');
     expect(claims!.login).toBe('alice');
@@ -227,8 +243,6 @@ describe('handleGithubCallback', () => {
     expect(userDo.state.login).toBe('alice');
     expect(userDo.state.refresh_hash).toMatch(/^[0-9a-f]{64}$/);
 
-    // Cookies.
-    const cookies = getSetCookies(res);
     const refresh = findCookie(cookies, 'refresh');
     expect(refresh).not.toBeNull();
     expect(refresh!.value).toMatch(/^[0-9a-f]{64}$/);
@@ -315,7 +329,7 @@ describe('handleGithubCallback', () => {
 });
 
 describe('handleRefresh', () => {
-  it('mints a new web jwt when refresh hash matches', async () => {
+  it('mints a new web jwt + rotates refresh cookie when refresh hash matches', async () => {
     const userDo = makeUserDo();
     const env = makeEnv(userDo);
     // Pre-seed UserDO with a known login + refresh-hash pair.
@@ -351,6 +365,67 @@ describe('handleRefresh', () => {
     expect(claims!.sub).toBe('42');
     expect(claims!.login).toBe('alice');
     expect(claims!.kind).toBe('web');
+
+    // Audit F-S-5: a fresh refresh cookie must ship with rotated value.
+    const cookies = getSetCookies(res);
+    const newRefresh = findCookie(cookies, 'refresh');
+    expect(newRefresh).not.toBeNull();
+    expect(newRefresh!.value).toMatch(/^[0-9a-f]{64}$/);
+    expect(newRefresh!.value).not.toBe(refreshToken);
+    expect(newRefresh!.attrs).toMatch(/HttpOnly/);
+    expect(newRefresh!.attrs).toMatch(/Path=\/api\/auth\/refresh/);
+
+    // Storage rotated — old hash overwritten.
+    expect(userDo.state.refresh_hash).not.toBe(hashHex);
+
+    // Audit F-S-4: new web_jwt cookie set so SPA picks up via /api/auth/me.
+    const newWebJwt = findCookie(cookies, 'web_jwt');
+    expect(newWebJwt).not.toBeNull();
+    expect(newWebJwt!.attrs).toMatch(/HttpOnly/);
+    expect(newWebJwt!.attrs).toMatch(/SameSite=Strict/);
+  });
+
+  it('audit F-S-5: presenting the old refresh token after rotation 401s', async () => {
+    const userDo = makeUserDo();
+    const env = makeEnv(userDo);
+    await userDo.stub.fetch(
+      new Request('https://do/setLogin', {
+        method: 'POST',
+        body: JSON.stringify({ github_id: '42', login: 'alice' }),
+      }),
+    );
+    const oldToken = 'cafebabe'.repeat(8);
+    const oldHashBytes = new Uint8Array(
+      await crypto.subtle.digest('SHA-256', new TextEncoder().encode(oldToken)),
+    );
+    let oldHashHex = '';
+    for (const b of oldHashBytes) oldHashHex += b.toString(16).padStart(2, '0');
+    await userDo.stub.fetch(
+      new Request('https://do/setRefreshTokenHash', {
+        method: 'POST',
+        body: JSON.stringify({ hash: oldHashHex }),
+      }),
+    );
+
+    // First call rotates.
+    const r1 = await handleRefresh(
+      new Request('https://example/api/auth/refresh', {
+        method: 'POST',
+        headers: { Cookie: `refresh=${oldToken}; login=alice` },
+      }),
+      env,
+    );
+    expect(r1.status).toBe(200);
+
+    // Replay with the now-stale token must fail.
+    const r2 = await handleRefresh(
+      new Request('https://example/api/auth/refresh', {
+        method: 'POST',
+        headers: { Cookie: `refresh=${oldToken}; login=alice` },
+      }),
+      env,
+    );
+    expect(r2.status).toBe(401);
   });
 
   it('401s when refresh cookie is absent', async () => {
@@ -421,6 +496,11 @@ describe('handleLogout', () => {
     const loginHint = findCookie(cookies, 'login');
     expect(loginHint).not.toBeNull();
     expect(loginHint!.attrs).toMatch(/Max-Age=0/);
+    // Audit F-S-4: the web_jwt session cookie must also be cleared so a
+    // browser tab whose JS we don't control can't keep a stale signed-in UI.
+    const webJwt = findCookie(cookies, 'web_jwt');
+    expect(webJwt).not.toBeNull();
+    expect(webJwt!.attrs).toMatch(/Max-Age=0/);
   });
 
   it('still 204s when no cookies are present (best-effort)', async () => {
@@ -430,6 +510,145 @@ describe('handleLogout', () => {
       env,
     );
     expect(res.status).toBe(204);
+  });
+});
+
+describe('handleMe (audit F-S-4)', () => {
+  it('returns {login, github_id} when web_jwt cookie is valid', async () => {
+    const env = makeEnv(makeUserDo());
+    const claims: WebJwtClaims = {
+      sub: '7',
+      login: 'octocat',
+      iat: Math.floor(Date.now() / 1000) - 1,
+      exp: Math.floor(Date.now() / 1000) + 600,
+      kind: 'web',
+    };
+    const jwt = await signJwt(claims, KEY_HEX);
+    const res = await handleMe(
+      new Request('https://example/api/auth/me', {
+        headers: { Cookie: `web_jwt=${jwt}` },
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { login: string; github_id: string };
+    expect(body.login).toBe('octocat');
+    expect(body.github_id).toBe('7');
+  });
+
+  it('401s when no web_jwt cookie', async () => {
+    const env = makeEnv(makeUserDo());
+    const res = await handleMe(
+      new Request('https://example/api/auth/me'),
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('401s when web_jwt cookie is signed with the wrong key', async () => {
+    const env = makeEnv(makeUserDo());
+    const wrongKey = 'ff'.repeat(32);
+    const jwt = await signJwt(
+      {
+        sub: '7',
+        login: 'a',
+        iat: Math.floor(Date.now() / 1000) - 1,
+        exp: Math.floor(Date.now() / 1000) + 60,
+        kind: 'web',
+      },
+      wrongKey,
+    );
+    const res = await handleMe(
+      new Request('https://example/api/auth/me', {
+        headers: { Cookie: `web_jwt=${jwt}` },
+      }),
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('401s when web_jwt cookie is a tunnel-kind JWT (kind mismatch)', async () => {
+    const env = makeEnv(makeUserDo());
+    const jwt = await signJwt(
+      {
+        sub: '7',
+        login: 'a',
+        iat: Math.floor(Date.now() / 1000) - 1,
+        exp: Math.floor(Date.now() / 1000) + 60,
+        kind: 'tunnel',
+        jti: 'x',
+      } as never,
+      KEY_HEX,
+    );
+    const res = await handleMe(
+      new Request('https://example/api/auth/me', {
+        headers: { Cookie: `web_jwt=${jwt}` },
+      }),
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe('handleWsTicket (audit F-S-4)', () => {
+  it('mints a 60s ticket when cookie session is valid', async () => {
+    const env = makeEnv(makeUserDo());
+    const sessionClaims: WebJwtClaims = {
+      sub: '11',
+      login: 'carol',
+      iat: Math.floor(Date.now() / 1000) - 1,
+      exp: Math.floor(Date.now() / 1000) + 3600,
+      kind: 'web',
+    };
+    const sessionJwt = await signJwt(sessionClaims, KEY_HEX);
+    const res = await handleWsTicket(
+      new Request('https://example/api/auth/ws-ticket', {
+        method: 'POST',
+        headers: { Cookie: `web_jwt=${sessionJwt}` },
+      }),
+      env,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ws_ticket: string; expires_in: number };
+    expect(body.expires_in).toBe(60);
+    const ticketClaims = await verifyJwt<WebJwtClaims>(body.ws_ticket, KEY_HEX);
+    expect(ticketClaims).not.toBeNull();
+    expect(ticketClaims!.sub).toBe('11');
+    expect(ticketClaims!.login).toBe('carol');
+    expect(ticketClaims!.kind).toBe('web');
+    // Ticket TTL is 60s ± a couple of seconds.
+    expect(ticketClaims!.exp - ticketClaims!.iat).toBe(60);
+  });
+
+  it('401s when cookie absent', async () => {
+    const env = makeEnv(makeUserDo());
+    const res = await handleWsTicket(
+      new Request('https://example/api/auth/ws-ticket', { method: 'POST' }),
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('401s when cookie session is expired', async () => {
+    const env = makeEnv(makeUserDo());
+    const expired = await signJwt(
+      {
+        sub: '11',
+        login: 'carol',
+        iat: Math.floor(Date.now() / 1000) - 7200,
+        exp: Math.floor(Date.now() / 1000) - 60,
+        kind: 'web',
+      },
+      KEY_HEX,
+    );
+    const res = await handleWsTicket(
+      new Request('https://example/api/auth/ws-ticket', {
+        method: 'POST',
+        headers: { Cookie: `web_jwt=${expired}` },
+      }),
+      env,
+    );
+    expect(res.status).toBe(401);
   });
 });
 
@@ -451,6 +670,26 @@ describe('dispatchAuth', () => {
     );
     expect(res).not.toBeNull();
     expect(res!.status).toBe(302);
+  });
+
+  it('routes GET /api/auth/me to handleMe (401 without cookie)', async () => {
+    const env = makeEnv(makeUserDo());
+    const res = await dispatchAuth(
+      new Request('https://example/api/auth/me'),
+      env,
+    );
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+
+  it('routes POST /api/auth/ws-ticket to handleWsTicket (401 without cookie)', async () => {
+    const env = makeEnv(makeUserDo());
+    const res = await dispatchAuth(
+      new Request('https://example/api/auth/ws-ticket', { method: 'POST' }),
+      env,
+    );
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
   });
 
   // Make sure signJwt is referenced by the type-only import path so the lint

--- a/packages/daemon/src/tunnel.mts
+++ b/packages/daemon/src/tunnel.mts
@@ -216,6 +216,26 @@ export function isTrustTunnelEnabled(): boolean {
 }
 
 /**
+ * Audit F-S-2 (Task #152): in trust-tunnel mode the daemon must reject any
+ * hello whose cloud-authenticated identity does not match the GitHub user
+ * the daemon was started for. Without this check, a misconfigured cloud
+ * deploy that signs a JWT for ANY user would let that user hijack this
+ * daemon's tunnel.
+ *
+ * The expected owner is injected by the Tauri shell at spawn time
+ * (env `CCSM_EXPECTED_OWNER_ID`, parsed from the local `~/.ccsm/tunnel_jwt`
+ * `sub` claim). Empty / unset returns null and the bind check is skipped —
+ * legacy deployments without the Tauri shell stay unaffected.
+ *
+ * Read on every call so tests can toggle via process.env without re-import.
+ */
+export function getExpectedOwnerId(): string | null {
+  const raw = process.env.CCSM_EXPECTED_OWNER_ID;
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+  return raw;
+}
+
+/**
  * HTTP-over-tunnel control frames (Task #787, S3-C). Mux the loopback REST
  * surface over the same daemon-dialed ws so cloud browsers can hit
  * `cc-sm.pages.dev/api/*` without a direct path to the NAT'd daemon.
@@ -576,6 +596,22 @@ export class TunnelClient {
         if (isTrustTunnelEnabled()) {
           if (hello.identity === undefined) {
             this.rejectHello('trust-tunnel mode but hello missing identity');
+            return;
+          }
+          // Audit F-S-2 (Task #152): identity-bind check. The Tauri shell
+          // baked the expected GitHub user id into the daemon's env at
+          // spawn time (parsed from the persisted tunnel JWT's `sub`).
+          // Reject any hello whose cloud-stamped identity disagrees so a
+          // mis-issued JWT cannot hijack this user's daemon.
+          const expectedOwner = getExpectedOwnerId();
+          if (expectedOwner !== null && hello.identity.github_id !== expectedOwner) {
+            this.rejectHello(
+              'identity-mismatch (expected owner=' +
+                expectedOwner +
+                ' got=' +
+                hello.identity.github_id +
+                ')',
+            );
             return;
           }
           this.handleHello(hello);

--- a/packages/daemon/test/tunnel.test.ts
+++ b/packages/daemon/test/tunnel.test.ts
@@ -1067,4 +1067,95 @@ describe('TunnelClient', () => {
     client.start();
     expect(factory).toHaveBeenCalledWith('wss://example/tunnel/x', undefined);
   });
+
+  // ---- Audit F-S-2 (Task #152): trust-tunnel identity bind ---------------
+  it('audit F-S-2: trust-tunnel rejects hello whose identity does not match CCSM_EXPECTED_OWNER_ID', () => {
+    const priorTrust = process.env.CCSM_TRUST_TUNNEL;
+    const priorOwner = process.env.CCSM_EXPECTED_OWNER_ID;
+    process.env.CCSM_TRUST_TUNNEL = '1';
+    process.env.CCSM_EXPECTED_OWNER_ID = '583231';
+    try {
+      const client = new TunnelClient({
+        url: 'wss://example/tunnel/x',
+        token: 'tok',
+        onFrame: () => {},
+        wsFactory: factory,
+      });
+      client.start();
+      sockets[0].open();
+      sockets[0].pushText(
+        JSON.stringify({
+          type: 'hello',
+          sid: 'sess-A',
+          identity: { login: 'attacker', github_id: '999999' },
+        }),
+      );
+      expect(sockets[0].closedCalls).toHaveLength(1);
+      expect(sockets[0].closedCalls[0].code).toBe(1008);
+      const reason = sockets[0].closedCalls[0].reason ?? '';
+      expect(String(reason)).toMatch(/identity-mismatch/);
+    } finally {
+      if (priorTrust === undefined) delete process.env.CCSM_TRUST_TUNNEL;
+      else process.env.CCSM_TRUST_TUNNEL = priorTrust;
+      if (priorOwner === undefined) delete process.env.CCSM_EXPECTED_OWNER_ID;
+      else process.env.CCSM_EXPECTED_OWNER_ID = priorOwner;
+    }
+  });
+
+  it('audit F-S-2: trust-tunnel accepts hello whose identity matches CCSM_EXPECTED_OWNER_ID', () => {
+    const priorTrust = process.env.CCSM_TRUST_TUNNEL;
+    const priorOwner = process.env.CCSM_EXPECTED_OWNER_ID;
+    process.env.CCSM_TRUST_TUNNEL = '1';
+    process.env.CCSM_EXPECTED_OWNER_ID = '583231';
+    try {
+      const client = new TunnelClient({
+        url: 'wss://example/tunnel/x',
+        token: 'tok',
+        onFrame: () => {},
+        wsFactory: factory,
+      });
+      client.start();
+      sockets[0].open();
+      sockets[0].pushText(
+        JSON.stringify({
+          type: 'hello',
+          identity: { login: 'octocat', github_id: '583231' },
+        }),
+      );
+      expect(sockets[0].closedCalls).toHaveLength(0);
+    } finally {
+      if (priorTrust === undefined) delete process.env.CCSM_TRUST_TUNNEL;
+      else process.env.CCSM_TRUST_TUNNEL = priorTrust;
+      if (priorOwner === undefined) delete process.env.CCSM_EXPECTED_OWNER_ID;
+      else process.env.CCSM_EXPECTED_OWNER_ID = priorOwner;
+    }
+  });
+
+  it('audit F-S-2: trust-tunnel without CCSM_EXPECTED_OWNER_ID skips the bind check (back-compat)', () => {
+    const priorTrust = process.env.CCSM_TRUST_TUNNEL;
+    const priorOwner = process.env.CCSM_EXPECTED_OWNER_ID;
+    process.env.CCSM_TRUST_TUNNEL = '1';
+    delete process.env.CCSM_EXPECTED_OWNER_ID;
+    try {
+      const client = new TunnelClient({
+        url: 'wss://example/tunnel/x',
+        token: 'tok',
+        onFrame: () => {},
+        wsFactory: factory,
+      });
+      client.start();
+      sockets[0].open();
+      sockets[0].pushText(
+        JSON.stringify({
+          type: 'hello',
+          identity: { login: 'anyone', github_id: '11' },
+        }),
+      );
+      expect(sockets[0].closedCalls).toHaveLength(0);
+    } finally {
+      if (priorTrust === undefined) delete process.env.CCSM_TRUST_TUNNEL;
+      else process.env.CCSM_TRUST_TUNNEL = priorTrust;
+      if (priorOwner !== undefined) process.env.CCSM_EXPECTED_OWNER_ID = priorOwner;
+    }
+  });
 });

--- a/packages/frontend-tauri/src-tauri/src/auth.rs
+++ b/packages/frontend-tauri/src-tauri/src/auth.rs
@@ -168,6 +168,76 @@ pub fn read_persisted_creds() -> Option<PersistedTunnelCreds> {
     Some(parsed)
 }
 
+/// Audit F-S-2 (Task #152): extract the `sub` (GitHub user id) claim from a
+/// JWT payload **without verifying the signature**. The caller (daemon_mgr)
+/// uses the result only as an env-var hint that gets re-checked server-side
+/// against an already-verified hello.identity, so the lack of signature
+/// check here is intentional — a forged value just makes the daemon refuse
+/// every browser, it cannot grant access.
+///
+/// Returns None on any structural error (not 3 parts / bad base64url / bad
+/// JSON / missing string `sub`).
+pub fn parse_jwt_sub_unverified(jwt: &str) -> Option<String> {
+    let mut parts = jwt.split('.');
+    let _hdr = parts.next()?;
+    let payload = parts.next()?;
+    parts.next()?; // signature segment must exist
+    if parts.next().is_some() {
+        return None;
+    }
+    let bytes = base64url_decode(payload)?;
+    let v: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    let sub = v.get("sub")?.as_str()?;
+    if sub.is_empty() {
+        return None;
+    }
+    Some(sub.to_string())
+}
+
+/// Tiny RFC 4648 §5 base64url decoder. Returns None on any invalid char so
+/// callers can degrade to "skip identity-bind" rather than panic.
+fn base64url_decode(s: &str) -> Option<Vec<u8>> {
+    fn idx(c: u8) -> Option<u8> {
+        match c {
+            b'A'..=b'Z' => Some(c - b'A'),
+            b'a'..=b'z' => Some(c - b'a' + 26),
+            b'0'..=b'9' => Some(c - b'0' + 52),
+            b'-' => Some(62),
+            b'_' => Some(63),
+            _ => None,
+        }
+    }
+    // Strip optional `=` padding then drive 4-char groups by index math.
+    let bytes: Vec<u8> = s.bytes().filter(|b| *b != b'=').collect();
+    let mut out = Vec::with_capacity(bytes.len() * 3 / 4);
+    let mut chunk = [0u8; 4];
+    let mut have = 0usize;
+    for b in bytes {
+        let v = idx(b)?;
+        chunk[have] = v;
+        have += 1;
+        if have == 4 {
+            out.push((chunk[0] << 2) | (chunk[1] >> 4));
+            out.push((chunk[1] << 4) | (chunk[2] >> 2));
+            out.push((chunk[2] << 6) | chunk[3]);
+            have = 0;
+        }
+    }
+    match have {
+        0 => {}
+        1 => return None, // invalid leftover
+        2 => {
+            out.push((chunk[0] << 2) | (chunk[1] >> 4));
+        }
+        3 => {
+            out.push((chunk[0] << 2) | (chunk[1] >> 4));
+            out.push((chunk[1] << 4) | (chunk[2] >> 2));
+        }
+        _ => unreachable!(),
+    }
+    Some(out)
+}
+
 fn write_persisted_creds(creds: &PersistedTunnelCreds) -> Result<(), String> {
     let dir = ccsm_dir()?;
     std::fs::create_dir_all(&dir).map_err(|e| format!("mkdir {}: {e}", dir.display()))?;
@@ -618,5 +688,52 @@ mod tests {
             assert_eq!(back.tunnel_jwt, "winjwt");
             assert_eq!(back.login, "winuser");
         });
+    }
+
+    /// Audit F-S-2 (Task #152): unverified JWT `sub` extraction.
+    #[test]
+    fn parse_jwt_sub_extracts_sub_from_payload() {
+        // Manual JWT: header={alg:HS256,typ:JWT}, payload={sub:"583231",login:"octocat"},
+        // signature is a non-empty placeholder (we never verify it).
+        // base64url-encoded values pre-computed.
+        let header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9";
+        // {"sub":"583231","login":"octocat"}
+        let payload = "eyJzdWIiOiI1ODMyMzEiLCJsb2dpbiI6Im9jdG9jYXQifQ";
+        let sig = "ZmFrZS1zaWc";
+        let jwt = format!("{}.{}.{}", header, payload, sig);
+        assert_eq!(parse_jwt_sub_unverified(&jwt), Some("583231".to_string()));
+    }
+
+    #[test]
+    fn parse_jwt_sub_returns_none_on_two_part_jwt() {
+        assert_eq!(parse_jwt_sub_unverified("a.b"), None);
+    }
+
+    #[test]
+    fn parse_jwt_sub_returns_none_on_four_part_jwt() {
+        assert_eq!(parse_jwt_sub_unverified("a.b.c.d"), None);
+    }
+
+    #[test]
+    fn parse_jwt_sub_returns_none_when_payload_lacks_sub() {
+        // payload = {"login":"octocat"} (no sub)
+        let payload = "eyJsb2dpbiI6Im9jdG9jYXQifQ";
+        let jwt = format!("hdr.{}.sig", payload);
+        assert_eq!(parse_jwt_sub_unverified(&jwt), None);
+    }
+
+    #[test]
+    fn parse_jwt_sub_returns_none_on_garbage_payload() {
+        assert_eq!(parse_jwt_sub_unverified("hdr.@@@@.sig"), None);
+    }
+
+    #[test]
+    fn parse_jwt_sub_handles_padded_base64url() {
+        // Same as parse_jwt_sub_extracts_sub_from_payload but with explicit
+        // `=` padding (some encoders emit padding even for base64url).
+        let header = "eyJhbGciOiJIUzI1NiJ9";
+        let payload_padded = "eyJzdWIiOiIxIn0="; // {"sub":"1"}
+        let jwt = format!("{}.{}.s", header, payload_padded);
+        assert_eq!(parse_jwt_sub_unverified(&jwt), Some("1".to_string()));
     }
 }

--- a/packages/frontend-tauri/src-tauri/src/daemon_mgr.rs
+++ b/packages/frontend-tauri/src-tauri/src/daemon_mgr.rs
@@ -327,10 +327,27 @@ async fn run_cycle(app: &AppHandle, kill_rx: &mut mpsc::Receiver<()>) -> CycleOu
         cmd.env("CCSM_TUNNEL_REFRESH_TOKEN", &creds.tunnel_refresh_token);
         cmd.env("CCSM_TUNNEL_LOGIN", &creds.login);
         cmd.env("CCSM_TRUST_TUNNEL", "1");
-        eprintln!(
-            "[daemon-mgr] injecting tunnel JWT for login={} (trust-tunnel mode)",
-            creds.login
-        );
+        // Audit F-S-2 (Task #152): bind the daemon to the GitHub user id
+        // baked into the persisted tunnel JWT. The daemon-side hello
+        // handler (tunnel.mts handleHello trust-tunnel branch) refuses
+        // any cloud-stamped identity that does not match this value, so a
+        // mis-issued JWT for some other user cannot hijack the tunnel.
+        // Absence (malformed JWT) leaves the env unset and the daemon
+        // skips the bind check — degraded but not fail-open since hello
+        // identity is still checked against trust-tunnel's existing
+        // "must carry identity" gate.
+        if let Some(owner_id) = crate::auth::parse_jwt_sub_unverified(&creds.tunnel_jwt) {
+            cmd.env("CCSM_EXPECTED_OWNER_ID", &owner_id);
+            eprintln!(
+                "[daemon-mgr] injecting tunnel JWT for login={} owner_id={} (trust-tunnel mode)",
+                creds.login, owner_id,
+            );
+        } else {
+            eprintln!(
+                "[daemon-mgr] injecting tunnel JWT for login={} (trust-tunnel mode; owner_id parse failed, identity-bind disabled)",
+                creds.login,
+            );
+        }
     }
 
     #[cfg(windows)]

--- a/packages/frontend-web/src/auth/AuthContext.tsx
+++ b/packages/frontend-web/src/auth/AuthContext.tsx
@@ -1,23 +1,26 @@
 // AuthContext — owns the SPA's view of the cf-worker OAuth session.
 //
-// Task #139 (S4-T7) wires up the browser side of the OAuth flow that
-// landed in Task #140 (S4-T3). The cf-worker mints a short-lived web JWT
-// after `/api/auth/github/callback` and redirects to `/?session=ok#jwt=...`
-// with an HttpOnly refresh cookie. This context:
+// Audit F-S-4 (Task #152): the web JWT now lives in an HttpOnly cookie set
+// by the cf-worker callback. The SPA never sees the JWT directly; it learns
+// "am I signed-in" by calling `GET /api/auth/me` (returns {login, github_id}
+// or 401). The previous fragment + sessionStorage path was XSS-readable;
+// HttpOnly + SameSite=Strict closes that.
 //
-//   1. On mount: reads the persisted web JWT + login from sessionStorage.
-//      If absent, attempts a silent `POST /api/auth/refresh` so a returning
-//      visitor with a still-valid refresh cookie skips the SignInScreen.
-//   2. signIn(): hard-redirects to `/api/auth/github/login`.
-//   3. signOut(): `POST /api/auth/logout` (best-effort), clears
-//      sessionStorage, then `window.location.reload()`.
-//   4. refresh(): re-reads sessionStorage. SignInGate calls this after
-//      consuming the URL fragment so the context picks up the new JWT
-//      without forcing a full page reload.
+// Contract:
 //
-// The context never decodes the JWT to validate it — that's the cf-worker /
-// TunnelDO's job. The SPA only uses the value as an opaque bearer that's
-// presented on the WebSocket subprotocol header (see hostConfig.ts).
+//   1. On mount: `GET /api/auth/me`. 200 → signed in, surface the login
+//      hint; 401 → signed-out, render SignInScreen.
+//   2. signIn(): hard-redirect to `/api/auth/github/login`.
+//   3. signOut(): `POST /api/auth/logout` (clears the HttpOnly cookies
+//      server-side), then `window.location.reload()` so RuntimeProvider
+//      tears down cleanly.
+//   4. refresh(): re-runs `GET /api/auth/me`. Used by SignInGate after the
+//      OAuth callback redirect lands at `/?session=ok` so the freshly-set
+//      cookie is reflected without a full page reload.
+//
+// The context never decodes the JWT — there is no JWT in JS reach. The
+// `signedIn` boolean is the only auth signal the UI needs; the WebSocket /
+// API layer rides cookies (REST) and `/api/auth/ws-ticket` (ws subprotocol).
 
 import {
   createContext,
@@ -30,48 +33,33 @@ import {
   type ReactNode,
 } from 'react';
 
-import { WEB_JWT_STORAGE_KEY, WEB_LOGIN_STORAGE_KEY } from '../hostConfig';
+import { primeWsTicket } from '../hostConfig';
 
 export interface AuthState {
-  /** Web JWT (kind='web') or null when signed out. Opaque to the SPA. */
-  webJwt: string | null;
-  /** GitHub login hint for display. Sourced from sessionStorage. */
+  /** True when `/api/auth/me` returned 200 on the most recent check. */
+  signedIn: boolean;
+  /** GitHub login from `/api/auth/me`. null when signed out. */
   login: string | null;
-  /** True until the initial silent-refresh attempt has settled. */
+  /** True until the initial `/api/auth/me` probe has settled. */
   loading: boolean;
   /** Hard-redirect to `/api/auth/github/login`. */
   signIn: () => void;
-  /** POST /api/auth/logout, clear sessionStorage, reload. */
+  /** POST /api/auth/logout, reload. */
   signOut: () => Promise<void>;
-  /** Re-read sessionStorage so callers can publish a freshly-stored JWT. */
+  /** Re-run `/api/auth/me`. SignInGate calls this after a callback redirect. */
   refresh: () => Promise<void>;
 }
 
 const AuthCtx = createContext<AuthState | null>(null);
 
-function readStoredJwt(): string | null {
-  if (typeof window === 'undefined') return null;
-  const v = sessionStorage.getItem(WEB_JWT_STORAGE_KEY);
-  return v && v.length > 0 ? v : null;
-}
-
-function readStoredLogin(): string | null {
-  if (typeof window === 'undefined') return null;
-  const v = sessionStorage.getItem(WEB_LOGIN_STORAGE_KEY);
-  return v && v.length > 0 ? v : null;
-}
-
 export interface AuthProviderProps {
   children: ReactNode;
-  /**
-   * Fetch implementation used for `/api/auth/refresh` and `/api/auth/logout`.
-   * Defaults to `window.fetch`. Tests inject a stub.
-   */
+  /** Fetch impl — defaults to window.fetch. Tests inject a stub. */
   fetchImpl?: typeof globalThis.fetch;
   /**
-   * Skip the silent refresh on mount. Set when the SPA was just redirected
-   * back from `/api/auth/github/callback` (SignInGate consumes the URL
-   * fragment first, then calls refresh()).
+   * Skip the initial `/api/auth/me` probe. Set by SignInGate when the SPA
+   * just landed at `?session=ok` and we want to defer the probe to its
+   * `refresh()` call (avoids a redundant round-trip).
    */
   skipInitialRefresh?: boolean;
 }
@@ -81,54 +69,45 @@ export function AuthProvider({
   fetchImpl,
   skipInitialRefresh,
 }: AuthProviderProps) {
-  const [webJwt, setWebJwt] = useState<string | null>(() => readStoredJwt());
-  const [login, setLogin] = useState<string | null>(() => readStoredLogin());
-  const [loading, setLoading] = useState<boolean>(() => {
-    if (skipInitialRefresh) return false;
-    // If we already have a JWT in storage there's nothing to wait for.
-    return readStoredJwt() === null;
-  });
+  const [signedIn, setSignedIn] = useState<boolean>(false);
+  const [login, setLogin] = useState<string | null>(null);
+  const [loading, setLoading] = useState<boolean>(() => !skipInitialRefresh);
 
-  // Keep a stable reference to fetch so we don't refetch on every render.
   const fetchRef = useRef<typeof globalThis.fetch>(
-    fetchImpl ?? (typeof window !== 'undefined' ? window.fetch.bind(window) : (() => {
-      throw new Error('fetch unavailable in this environment');
-    }) as typeof globalThis.fetch),
+    fetchImpl ??
+      (typeof window !== 'undefined'
+        ? window.fetch.bind(window)
+        : ((() => {
+            throw new Error('fetch unavailable in this environment');
+          }) as typeof globalThis.fetch)),
   );
 
   const refresh = useCallback(async () => {
-    const stored = readStoredJwt();
-    if (stored !== null) {
-      setWebJwt(stored);
-      setLogin(readStoredLogin());
-      return;
-    }
-    // Try silent refresh against the HttpOnly cookie.
     try {
-      const res = await fetchRef.current('/api/auth/refresh', {
-        method: 'POST',
+      const res = await fetchRef.current('/api/auth/me', {
+        method: 'GET',
         credentials: 'include',
       });
       if (!res.ok) {
-        setWebJwt(null);
+        setSignedIn(false);
         setLogin(null);
         return;
       }
-      const body = (await res.json()) as { web_jwt?: unknown; login?: unknown };
-      if (typeof body.web_jwt === 'string' && body.web_jwt.length > 0) {
-        sessionStorage.setItem(WEB_JWT_STORAGE_KEY, body.web_jwt);
-        if (typeof body.login === 'string' && body.login.length > 0) {
-          sessionStorage.setItem(WEB_LOGIN_STORAGE_KEY, body.login);
-        }
-        setWebJwt(body.web_jwt);
-        setLogin(typeof body.login === 'string' ? body.login : readStoredLogin());
+      const body = (await res.json()) as { login?: unknown };
+      if (typeof body.login === 'string' && body.login.length > 0) {
+        setSignedIn(true);
+        setLogin(body.login);
+        // Audit F-S-4: prime the ws-ticket cache so the first WebSocket
+        // connect after sign-in does not have to wait on a separate round
+        // trip. Failure here doesn't sink sign-in — getCachedWsTicket
+        // falls through and a later connect will retry primeWsTicket.
+        void primeWsTicket(fetchRef.current);
         return;
       }
-      setWebJwt(null);
+      setSignedIn(false);
       setLogin(null);
     } catch {
-      // Network error / cookie missing / refresh path 401 → signed out.
-      setWebJwt(null);
+      setSignedIn(false);
       setLogin(null);
     }
   }, []);
@@ -145,27 +124,19 @@ export function AuthProvider({
         credentials: 'include',
       });
     } catch {
-      // Best-effort; cookies may already be expired. Continue clearing local state.
+      // best-effort
     }
+    setSignedIn(false);
+    setLogin(null);
     if (typeof window !== 'undefined') {
-      sessionStorage.removeItem(WEB_JWT_STORAGE_KEY);
-      sessionStorage.removeItem(WEB_LOGIN_STORAGE_KEY);
-      // Reload so RuntimeProvider tears down and the SignInGate re-renders
-      // from a clean slate (no stale ws connection).
       window.location.reload();
     }
-    setWebJwt(null);
-    setLogin(null);
   }, []);
 
-  // Initial mount: silent refresh unless caller already populated storage
-  // (SignInGate fragment-consume path) or explicitly opted out.
+  // Initial mount probe — skip when SignInGate is going to drive refresh()
+  // itself (callback landing path).
   useEffect(() => {
     if (skipInitialRefresh) return;
-    if (readStoredJwt() !== null) {
-      setLoading(false);
-      return;
-    }
     let cancelled = false;
     void (async () => {
       await refresh();
@@ -177,8 +148,8 @@ export function AuthProvider({
   }, [refresh, skipInitialRefresh]);
 
   const value = useMemo<AuthState>(
-    () => ({ webJwt, login, loading, signIn, signOut, refresh }),
-    [webJwt, login, loading, signIn, signOut, refresh],
+    () => ({ signedIn, login, loading, signIn, signOut, refresh }),
+    [signedIn, login, loading, signIn, signOut, refresh],
   );
 
   return <AuthCtx.Provider value={value}>{children}</AuthCtx.Provider>;

--- a/packages/frontend-web/src/auth/SignInGate.tsx
+++ b/packages/frontend-web/src/auth/SignInGate.tsx
@@ -1,85 +1,33 @@
-// SignInGate — gates the main UI behind a valid web JWT.
+// SignInGate — gates the main UI behind a verified server session.
 //
-// Two responsibilities:
+// Audit F-S-4 (Task #152): the JWT no longer rides URL fragment +
+// sessionStorage. The cf-worker's callback sets an HttpOnly `web_jwt`
+// cookie and redirects to `/?session=ok`. This gate:
 //
-//   1. Consume the OAuth callback redirect. Task #140 (S4-T3) lands the
-//      visitor at `/?session=ok#jwt=<jwt>` after the cf-worker exchanges
-//      the GitHub `code`. We pull the JWT out of the URL fragment, peek at
-//      the `login` claim for a UX hint (NOT for trust — the worker already
-//      verified the signature), persist both to sessionStorage, then clean
-//      the URL via history.replaceState so a refresh doesn't re-process
-//      the fragment. AuthContext.refresh() then publishes the new state.
-//
-//   2. Render-time decision: webJwt null → <SignInScreen>; non-null →
-//      pass through to <children>. Loading state defers to a tiny inline
-//      spinner so the gate doesn't flash SignInScreen during the silent
-//      refresh on mount.
-//
-// The gate never validates the JWT itself; the cf-worker is the source of
-// trust. We only base64url-decode the payload to read the `login` claim
-// because Task #140's /api/auth/refresh response is the only authoritative
-// source of `login`, and the callback path doesn't expose a /me endpoint
-// (spec defers that to a follow-up task).
+//   1. On mount: if URL has `?session=ok`, clean it via history.replaceState
+//      and call AuthContext.refresh() so the new cookie is reflected.
+//   2. Render-time: signedIn=false → <SignInScreen>; true → children.
 
 import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 
-import { WEB_JWT_STORAGE_KEY, WEB_LOGIN_STORAGE_KEY } from '../hostConfig';
 import { useAuth } from './AuthContext';
 import { SignInScreen } from './SignInScreen';
 
 /**
- * Decode the payload of a JWT (no signature verification).
+ * Strip `?session=ok` (and any other params we don't care about preserving)
+ * from the current URL. Returns true when something was cleaned (caller
+ * should refresh the auth context to pick up the freshly-set cookie).
  *
- * Returns null on any structural error so callers can fall back to a
- * cookie-based refresh that DOES verify the signature server-side.
- */
-export function decodeJwtPayload(jwt: string): Record<string, unknown> | null {
-  const parts = jwt.split('.');
-  if (parts.length !== 3) return null;
-  try {
-    const payload = parts[1] ?? '';
-    // base64url → base64
-    const padded = payload.replace(/-/g, '+').replace(/_/g, '/');
-    const padding = padded.length % 4 === 0 ? '' : '='.repeat(4 - (padded.length % 4));
-    const json = typeof atob === 'function'
-      ? atob(padded + padding)
-      : (() => { throw new Error('atob unavailable'); })();
-    const obj = JSON.parse(json) as unknown;
-    if (typeof obj === 'object' && obj !== null) {
-      return obj as Record<string, unknown>;
-    }
-    return null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Pull `?session=ok#jwt=<jwt>` out of the current URL and persist it.
- *
- * Returns true when a fragment was consumed (caller should refresh()).
  * Exported for direct unit testing without RTL.
  */
-export function consumeCallbackFragment(loc: Location, hist: History): boolean {
+export function consumeCallbackQuery(loc: Location, hist: History): boolean {
   const params = new URLSearchParams(loc.search);
   if (params.get('session') !== 'ok') return false;
-  const hash = loc.hash.startsWith('#') ? loc.hash.slice(1) : loc.hash;
-  const hashParams = new URLSearchParams(hash);
-  const jwt = hashParams.get('jwt');
-  if (!jwt || jwt.length === 0) return false;
-
-  sessionStorage.setItem(WEB_JWT_STORAGE_KEY, jwt);
-  const payload = decodeJwtPayload(jwt);
-  if (payload && typeof payload.login === 'string' && payload.login.length > 0) {
-    sessionStorage.setItem(WEB_LOGIN_STORAGE_KEY, payload.login);
-  }
-
-  // Clean the URL: drop ?session and #jwt so a reload doesn't re-process.
   params.delete('session');
-  const remainingSearch = params.toString();
+  const remaining = params.toString();
   const cleanUrl =
-    loc.pathname + (remainingSearch.length > 0 ? `?${remainingSearch}` : '');
+    loc.pathname + (remaining.length > 0 ? `?${remaining}` : '');
   hist.replaceState(null, '', cleanUrl);
   return true;
 }
@@ -89,11 +37,8 @@ export interface SignInGateProps {
 }
 
 export function SignInGate({ children }: SignInGateProps) {
-  const { webJwt, loading, refresh } = useAuth();
+  const { signedIn, loading, refresh } = useAuth();
 
-  // Consume the callback fragment exactly once on mount, before deciding
-  // what to render. We do this in a ref-guarded layout-style effect to
-  // avoid a flash of SignInScreen on the redirect landing.
   const consumed = useRef(false);
   const [consuming, setConsuming] = useState<boolean>(() => {
     if (typeof window === 'undefined') return false;
@@ -107,7 +52,7 @@ export function SignInGate({ children }: SignInGateProps) {
       setConsuming(false);
       return;
     }
-    const ok = consumeCallbackFragment(window.location, window.history);
+    const ok = consumeCallbackQuery(window.location, window.history);
     if (ok) {
       void refresh().finally(() => setConsuming(false));
     } else {
@@ -133,7 +78,7 @@ export function SignInGate({ children }: SignInGateProps) {
     );
   }
 
-  if (webJwt === null) {
+  if (!signedIn) {
     return <SignInScreen />;
   }
 

--- a/packages/frontend-web/src/hostConfig.ts
+++ b/packages/frontend-web/src/hostConfig.ts
@@ -3,66 +3,28 @@
 // Wave-2 T6 (#686): @ccsm/ui's RuntimeProvider takes a HostConfig and uses
 // it to construct the SessionRuntime + bind the REST API.
 //
-// Task #696: token bootstrap is a 3-step priority chain (URL ?token= →
-// fetch /token → fail). The pure resolver lives here so it can be
-// unit-tested without booting the full SPA.
-//
-// Task #712 (S2-T3): daemon base URL resolution supported 3 modes so the
-// SPA could be served from Cloudflare Pages (cross-origin) while still
-// talking to a local loopback daemon, without breaking the existing
-// daemon-embedded case (browser opens http://127.0.0.1:9876/, SPA
-// same-origin).
-//
-// Task #780 (S3-T5): default base flipped to a hard-coded
-// `https://cc-sm.pages.dev` URL so Pages-hosted SPA could reach the daemon
-// through the CF Worker tunnel.
-//
-// Task #25 (smoke R-5): the hard-coded prod URL is wrong — the SPA should
-// always reach `/token` and `/ws/default` via the SAME origin it was served
-// from. The Pages Function (`[[path]].ts`) already proxies these paths into
-// the Worker tunnel at the same origin, so a relative path Just Works in
-// production AND in dev (Vite proxy / Pages preview) AND when the SPA is
-// served from `127.0.0.1:<port>` by a smoke fixture. Default base is now
-// the empty string (same-origin relative); `?daemon=<absolute>` remains the
-// only escape hatch (loopback daemon / Tauri).
+// Audit F-S-4 (Task #152): the SPA no longer stores the long-lived web JWT
+// in sessionStorage. The cf-worker callback puts it in an HttpOnly
+// `web_jwt` cookie scoped to /api; REST `/api/*` requests pick it up
+// automatically (cookie). The WebSocket subprotocol channel cannot ride
+// cookies, so the SPA fetches a 60-second `ws_ticket` JWT via
+// `POST /api/auth/ws-ticket` and presents it as `ccsm.<ticket>`. This
+// module exposes:
+//   - `primeWsTicket(fetch)` — call at sign-in / before connecting ws.
+//   - `getCachedWsTicket()` — used by the (synchronous) HostConfig.getToken.
+// Smoke / Tauri loopback paths keep writing the daemon-minted token to
+// `sessionStorage[TOKEN_STORAGE_KEY]`; getToken falls back to it when no
+// ws-ticket has been primed (no OAuth in those flows).
 
 import type { HostConfig } from '@ccsm/ui';
 
 export const TOKEN_STORAGE_KEY = 'ccsm.token';
 
 /**
- * Web JWT storage key (Task #139, S4-T7).
- *
- * The cf-worker OAuth flow (Task #140 / S4-T3) mints a short-lived web JWT
- * (kind='web', 1h, HS256) and delivers it in the `/?session=ok#jwt=...`
- * redirect fragment. AuthContext decodes the fragment, persists the JWT
- * here, and the SPA presents it on the WebSocket subprotocol header so the
- * Worker / TunnelDO can authenticate the visitor without a daemon-minted
- * token. The smoke / loopback path keeps writing the legacy daemon token to
- * `ccsm.token` (`TOKEN_STORAGE_KEY`); `webHostConfig.getToken` prefers the
- * web JWT and falls back to the daemon token, so the same `getWsProtocol`
- * code path serves both deployment shapes.
- */
-export const WEB_JWT_STORAGE_KEY = 'ccsm_web_jwt';
-
-/**
- * GitHub login hint storage key (Task #139, S4-T7).
- *
- * Stored alongside the web JWT for display purposes only — the server is
- * the source of truth on the JWT's `login` claim. The SPA never gates on
- * this value; it's a UX nicety so SignInGate can show "Signed in as foo"
- * without a round-trip.
- */
-export const WEB_LOGIN_STORAGE_KEY = 'ccsm_login';
-
-/**
  * Default daemon base for production (same-origin relative).
  *
  * Task #25: empty string means "use the SPA's own origin" — `fetch('/token')`
- * and `new WebSocket('/ws/default')` resolve relative to `document.baseURI`,
- * which is the right answer whether the SPA is served from
- * `https://cc-sm.pages.dev`, a Pages preview deployment, the Vite dev
- * server, or the smoke fixture's static SPA host.
+ * and `new WebSocket('/ws/default')` resolve relative to `document.baseURI`.
  */
 export const DEFAULT_DAEMON_BASE = '';
 
@@ -239,24 +201,107 @@ export function getWsProtocol(deps: GetWsProtocolDeps): string[] {
 }
 
 /**
- * Token reader used by the SessionRuntime / WsClient (Task #139, S4-T7).
+ * Token reader used by the SessionRuntime / WsClient (audit F-S-4, Task #152).
  *
  * Priority:
- *   1. sessionStorage `ccsm_web_jwt` — set by AuthContext after the web
- *      OAuth flow completes (cf-worker mints + redirects with #jwt=...).
- *   2. sessionStorage `ccsm.token` — legacy daemon-minted token. Smoke and
- *      Tauri shells still bootstrap from `?token=` / `/token` and write to
- *      this key, so they keep working without an OAuth round-trip.
+ *   1. In-memory ws-ticket cache — populated by `primeWsTicket()` at
+ *      sign-in. The HttpOnly `web_jwt` cookie is server-side; the SPA
+ *      receives only this short-lived (60s) ticket as a token-shaped value.
+ *   2. sessionStorage `ccsm.token` — legacy daemon-minted token (smoke /
+ *      Tauri loopback). Skipped when a fresh ws-ticket exists.
  *   3. null — caller falls back to "signed out" UI (SignInScreen).
  *
  * Exposed as a standalone function so component tests can inject without
  * stubbing `webHostConfig` itself.
  */
 export function readSessionToken(): string | null {
+  const cached = getCachedWsTicket();
+  if (cached !== null) return cached;
   if (typeof window === 'undefined') return null;
-  const webJwt = sessionStorage.getItem(WEB_JWT_STORAGE_KEY);
-  if (webJwt && webJwt.length > 0) return webJwt;
   return sessionStorage.getItem(TOKEN_STORAGE_KEY);
+}
+
+// ---- ws-ticket cache (audit F-S-4) -------------------------------------
+
+interface WsTicketCacheEntry {
+  ticket: string;
+  /** epoch ms when this ticket expires; renew before this. */
+  expiresAtMs: number;
+}
+
+let wsTicketCache: WsTicketCacheEntry | null = null;
+/**
+ * Renew the ticket when within this many ms of expiry. ws-ticket TTL is
+ * 60s server-side; renewing at <= 10s ensures we never present an expired
+ * one and gives plenty of margin for a slow connect.
+ */
+const WS_TICKET_RENEW_MARGIN_MS = 10_000;
+
+function isCachedWsTicketFresh(now: number): boolean {
+  return (
+    wsTicketCache !== null &&
+    wsTicketCache.expiresAtMs - now > WS_TICKET_RENEW_MARGIN_MS
+  );
+}
+
+/** Read-only view of the cache. Used by readSessionToken (sync). */
+export function getCachedWsTicket(): string | null {
+  if (wsTicketCache === null) return null;
+  if (!isCachedWsTicketFresh(Date.now())) return null;
+  return wsTicketCache.ticket;
+}
+
+/** Test seam — clear the in-memory cache. */
+export function _resetWsTicketCacheForTests(): void {
+  wsTicketCache = null;
+}
+
+/**
+ * Fetch a fresh ws-ticket from `POST /api/auth/ws-ticket`. Caches it in
+ * module state; subsequent calls within the freshness window return the
+ * cached value without a round-trip. Throws on network / 401 so callers
+ * can surface a re-auth prompt.
+ *
+ * Used by AuthContext on sign-in (so `getCachedWsTicket()` is hot before
+ * the first ws connect) and by ws connect retry paths.
+ */
+export async function primeWsTicket(
+  fetchImpl: typeof globalThis.fetch = typeof window !== 'undefined'
+    ? window.fetch.bind(window)
+    : (() => {
+        throw new Error('fetch unavailable');
+      }) as typeof globalThis.fetch,
+): Promise<string | null> {
+  if (isCachedWsTicketFresh(Date.now())) {
+    return wsTicketCache!.ticket;
+  }
+  try {
+    const res = await fetchImpl('/api/auth/ws-ticket', {
+      method: 'POST',
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      wsTicketCache = null;
+      return null;
+    }
+    const body = (await res.json()) as { ws_ticket?: unknown; expires_in?: unknown };
+    if (typeof body.ws_ticket !== 'string' || body.ws_ticket.length === 0) {
+      wsTicketCache = null;
+      return null;
+    }
+    const ttlSec =
+      typeof body.expires_in === 'number' && body.expires_in > 0
+        ? body.expires_in
+        : 60;
+    wsTicketCache = {
+      ticket: body.ws_ticket,
+      expiresAtMs: Date.now() + ttlSec * 1000,
+    };
+    return body.ws_ticket;
+  } catch {
+    wsTicketCache = null;
+    return null;
+  }
 }
 
 export const webHostConfig: HostConfig = {

--- a/packages/frontend-web/test/auth.test.tsx
+++ b/packages/frontend-web/test/auth.test.tsx
@@ -1,88 +1,59 @@
-// AuthContext + SignInGate component tests (Task #139, S4-T7).
+// AuthContext + SignInGate component tests (audit F-S-4, Task #152).
 //
-// Coverage target (per spec):
-//   1. AuthProvider mount with no JWT → SignInScreen rendered
-//   2. Callback `?session=ok#jwt=xxx` → fragment consumed, JWT stored,
-//      URL cleaned, gate flips to children
-//   3. signOut clears sessionStorage (reload is stubbed)
-//   4. signIn redirects to /api/auth/github/login
+// Coverage target:
+//   1. AuthProvider mount: `/api/auth/me` 401 → SignInScreen rendered.
+//   2. AuthProvider mount: `/api/auth/me` 200 → children rendered, login
+//      surfaced, ws-ticket primed.
+//   3. Callback redirect (`?session=ok`): query cleaned, refresh() runs,
+//      gate flips to children when `/api/auth/me` returns 200.
+//   4. signOut hits /api/auth/logout (reload stubbed).
+//   5. signIn redirects to /api/auth/github/login.
+//   6. consumeCallbackQuery purity (no /me round-trip).
 //
-// Plus a guardrail on decodeJwtPayload (login-claim extraction) so the
-// fragment-consumer's UX hint doesn't drift.
+// All tests stub fetch; the cookie itself is opaque to the SPA so we only
+// care about request shape (path, credentials: include).
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import { AuthProvider, useAuth } from '../src/auth/AuthContext';
 import {
-  consumeCallbackFragment,
-  decodeJwtPayload,
+  consumeCallbackQuery,
   SignInGate,
 } from '../src/auth/SignInGate';
-import { WEB_JWT_STORAGE_KEY, WEB_LOGIN_STORAGE_KEY } from '../src/hostConfig';
+import { _resetWsTicketCacheForTests } from '../src/hostConfig';
 
-// A web JWT shape: header.payload.signature, base64url-encoded JSON.
-function makeJwt(payload: Record<string, unknown>): string {
-  const b64url = (s: string) =>
-    Buffer.from(s, 'utf8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-  const header = b64url(JSON.stringify({ alg: 'HS256', typ: 'JWT', kind: 'web' }));
-  const body = b64url(JSON.stringify(payload));
-  return `${header}.${body}.sig-not-checked-by-spa`;
-}
-
-describe('decodeJwtPayload', () => {
-  it('returns the parsed payload for a well-formed JWT', () => {
-    const jwt = makeJwt({ login: 'octocat', kind: 'web', exp: 9999999999 });
-    expect(decodeJwtPayload(jwt)).toEqual({
-      login: 'octocat',
-      kind: 'web',
-      exp: 9999999999,
-    });
-  });
-
-  it('returns null for non-three-part input', () => {
-    expect(decodeJwtPayload('not.a.jwt.extra')).toBeNull();
-    expect(decodeJwtPayload('only-one-part')).toBeNull();
-  });
-
-  it('returns null when the payload is not base64url-decodable JSON', () => {
-    expect(decodeJwtPayload('aaa.@@@.bbb')).toBeNull();
-  });
-});
-
-describe('consumeCallbackFragment', () => {
-  beforeEach(() => {
-    sessionStorage.clear();
-  });
-
-  it('persists JWT + login from `?session=ok#jwt=...` and cleans the URL', () => {
-    const jwt = makeJwt({ login: 'mona', kind: 'web' });
+describe('consumeCallbackQuery', () => {
+  it('strips ?session=ok and reports true', () => {
     const replaceState = vi.fn();
     const fakeLoc = {
       pathname: '/',
       search: '?session=ok',
-      hash: `#jwt=${jwt}`,
+      hash: '',
     } as unknown as Location;
     const fakeHist = { replaceState } as unknown as History;
-
-    const ok = consumeCallbackFragment(fakeLoc, fakeHist);
+    const ok = consumeCallbackQuery(fakeLoc, fakeHist);
     expect(ok).toBe(true);
-    expect(sessionStorage.getItem(WEB_JWT_STORAGE_KEY)).toBe(jwt);
-    expect(sessionStorage.getItem(WEB_LOGIN_STORAGE_KEY)).toBe('mona');
     expect(replaceState).toHaveBeenCalledWith(null, '', '/');
   });
 
   it('returns false when ?session=ok is missing', () => {
-    const fakeLoc = { pathname: '/', search: '', hash: '#jwt=foo' } as unknown as Location;
-    const ok = consumeCallbackFragment(fakeLoc, { replaceState: vi.fn() } as unknown as History);
+    const fakeLoc = { pathname: '/', search: '', hash: '' } as unknown as Location;
+    const ok = consumeCallbackQuery(fakeLoc, { replaceState: vi.fn() } as unknown as History);
     expect(ok).toBe(false);
-    expect(sessionStorage.getItem(WEB_JWT_STORAGE_KEY)).toBeNull();
   });
 
-  it('returns false when the fragment has no jwt= entry', () => {
-    const fakeLoc = { pathname: '/', search: '?session=ok', hash: '#other=1' } as unknown as Location;
-    const ok = consumeCallbackFragment(fakeLoc, { replaceState: vi.fn() } as unknown as History);
-    expect(ok).toBe(false);
+  it('preserves other query params when stripping session', () => {
+    const replaceState = vi.fn();
+    const fakeLoc = {
+      pathname: '/x',
+      search: '?session=ok&debug=1',
+      hash: '',
+    } as unknown as Location;
+    const fakeHist = { replaceState } as unknown as History;
+    const ok = consumeCallbackQuery(fakeLoc, fakeHist);
+    expect(ok).toBe(true);
+    expect(replaceState).toHaveBeenCalledWith(null, '', '/x?debug=1');
   });
 });
 
@@ -92,9 +63,7 @@ const ORIGINAL_HREF = 'http://127.0.0.1/';
 
 beforeEach(() => {
   sessionStorage.clear();
-  // jsdom's location is read-only for href, but we can replace it via
-  // history.replaceState. signIn assigns to window.location.href which jsdom
-  // models as a navigation; we shim to capture the assignment.
+  _resetWsTicketCacheForTests();
   window.history.replaceState(null, '', ORIGINAL_HREF);
 });
 
@@ -105,28 +74,58 @@ afterEach(() => {
 function HrefProbe({ onHref }: { onHref: (href: string) => void }) {
   const { signIn } = useAuth();
   return (
-    <button type="button" data-testid="probe-signin" onClick={() => {
-      // Stub assignment side-effect so we don't actually navigate jsdom.
-      const originalHref = window.location.href;
-      Object.defineProperty(window, 'location', {
-        configurable: true,
-        value: new Proxy(window.location, {
-          set(_t, p, v) {
-            if (p === 'href') { onHref(String(v)); return true; }
-            return Reflect.set(_t, p, v);
-          },
-        }),
-      });
-      signIn();
-      // Restore so afterEach works
-      window.history.replaceState(null, '', originalHref);
-    }}>go</button>
+    <button
+      type="button"
+      data-testid="probe-signin"
+      onClick={() => {
+        const originalHref = window.location.href;
+        Object.defineProperty(window, 'location', {
+          configurable: true,
+          value: new Proxy(window.location, {
+            set(_t, p, v) {
+              if (p === 'href') {
+                onHref(String(v));
+                return true;
+              }
+              return Reflect.set(_t, p, v);
+            },
+          }),
+        });
+        signIn();
+        window.history.replaceState(null, '', originalHref);
+      }}
+    >
+      go
+    </button>
   );
 }
 
+/**
+ * Build a fetch stub that maps url → response. Unmatched URLs throw so the
+ * test fails loudly on an unexpected call.
+ */
+function stubFetch(routes: Record<string, () => Response | Promise<Response>>): typeof fetch {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    for (const path of Object.keys(routes)) {
+      if (url === path || url.endsWith(path)) {
+        return await routes[path]!();
+      }
+    }
+    throw new Error('unexpected fetch ' + url);
+  }) as unknown as typeof fetch;
+}
+
 describe('AuthProvider + SignInGate', () => {
-  it('renders SignInScreen when no JWT in sessionStorage and refresh fails', async () => {
-    const fetchImpl = vi.fn(async () => new Response('nope', { status: 401 })) as unknown as typeof fetch;
+  it('renders SignInScreen when /api/auth/me returns 401', async () => {
+    const fetchImpl = stubFetch({
+      '/api/auth/me': () => new Response('nope', { status: 401 }),
+    });
     render(
       <AuthProvider fetchImpl={fetchImpl}>
         <SignInGate>
@@ -139,16 +138,18 @@ describe('AuthProvider + SignInGate', () => {
       expect(screen.getByText('Sign in with GitHub')).toBeTruthy();
     });
     expect(screen.queryByText('protected-ui')).toBeNull();
-    expect(fetchImpl).toHaveBeenCalledWith('/api/auth/refresh', expect.objectContaining({
-      method: 'POST',
-      credentials: 'include',
-    }));
+    expect(fetchImpl).toHaveBeenCalledWith(
+      '/api/auth/me',
+      expect.objectContaining({ credentials: 'include' }),
+    );
   });
 
-  it('renders children when sessionStorage already has a JWT (no silent refresh)', async () => {
-    sessionStorage.setItem(WEB_JWT_STORAGE_KEY, makeJwt({ login: 'octocat', kind: 'web' }));
-    sessionStorage.setItem(WEB_LOGIN_STORAGE_KEY, 'octocat');
-    const fetchImpl = vi.fn(async () => new Response('{}', { status: 200 })) as unknown as typeof fetch;
+  it('renders children when /api/auth/me returns 200, primes ws-ticket', async () => {
+    const fetchImpl = stubFetch({
+      '/api/auth/me': () => Response.json({ login: 'octocat', github_id: '7' }),
+      '/api/auth/ws-ticket': () =>
+        Response.json({ ws_ticket: 'tkt.aaa.bbb', expires_in: 60 }),
+    });
 
     render(
       <AuthProvider fetchImpl={fetchImpl}>
@@ -161,13 +162,26 @@ describe('AuthProvider + SignInGate', () => {
     await waitFor(() => {
       expect(screen.getByText('protected-ui')).toBeTruthy();
     });
-    expect(fetchImpl).not.toHaveBeenCalled();
+    // Both calls happened with credentials.
+    expect(fetchImpl).toHaveBeenCalledWith(
+      '/api/auth/me',
+      expect.objectContaining({ credentials: 'include' }),
+    );
+    await waitFor(() => {
+      expect(fetchImpl).toHaveBeenCalledWith(
+        '/api/auth/ws-ticket',
+        expect.objectContaining({ method: 'POST', credentials: 'include' }),
+      );
+    });
   });
 
-  it('consumes ?session=ok#jwt=... fragment and flips to children', async () => {
-    const jwt = makeJwt({ login: 'callback-user', kind: 'web' });
-    window.history.replaceState(null, '', `/?session=ok#jwt=${jwt}`);
-    const fetchImpl = vi.fn(async () => new Response('{}', { status: 200 })) as unknown as typeof fetch;
+  it('callback ?session=ok flips to children after refresh()', async () => {
+    window.history.replaceState(null, '', `/?session=ok`);
+    const fetchImpl = stubFetch({
+      '/api/auth/me': () => Response.json({ login: 'callback-user', github_id: '99' }),
+      '/api/auth/ws-ticket': () =>
+        Response.json({ ws_ticket: 't', expires_in: 60 }),
+    });
 
     render(
       <AuthProvider fetchImpl={fetchImpl} skipInitialRefresh>
@@ -180,25 +194,40 @@ describe('AuthProvider + SignInGate', () => {
     await waitFor(() => {
       expect(screen.getByText('protected-ui')).toBeTruthy();
     });
-    expect(sessionStorage.getItem(WEB_JWT_STORAGE_KEY)).toBe(jwt);
-    expect(sessionStorage.getItem(WEB_LOGIN_STORAGE_KEY)).toBe('callback-user');
-    // URL cleaned: ?session removed, #jwt dropped.
+    // URL cleaned: ?session removed.
     expect(window.location.search).toBe('');
   });
 
-  it('signOut clears sessionStorage (reload stubbed)', async () => {
-    sessionStorage.setItem(WEB_JWT_STORAGE_KEY, 'old-jwt');
-    sessionStorage.setItem(WEB_LOGIN_STORAGE_KEY, 'old-user');
-    const fetchImpl = vi.fn(async () => new Response('', { status: 204 })) as unknown as typeof fetch;
+  it('signOut hits /api/auth/logout (reload stubbed)', async () => {
     const reloadSpy = vi.fn();
     Object.defineProperty(window, 'location', {
       configurable: true,
-      value: { ...window.location, reload: reloadSpy, href: ORIGINAL_HREF, search: '', hash: '', pathname: '/' },
+      value: {
+        ...window.location,
+        reload: reloadSpy,
+        href: ORIGINAL_HREF,
+        search: '',
+        hash: '',
+        pathname: '/',
+      },
+    });
+    const fetchImpl = stubFetch({
+      '/api/auth/logout': () => new Response('', { status: 204 }),
     });
 
     function SignOutButton() {
       const { signOut } = useAuth();
-      return <button type="button" onClick={() => { void signOut(); }} data-testid="signout">x</button>;
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            void signOut();
+          }}
+          data-testid="signout"
+        >
+          x
+        </button>
+      );
     }
 
     render(
@@ -212,19 +241,19 @@ describe('AuthProvider + SignInGate', () => {
     });
 
     await waitFor(() => {
-      expect(sessionStorage.getItem(WEB_JWT_STORAGE_KEY)).toBeNull();
-      expect(sessionStorage.getItem(WEB_LOGIN_STORAGE_KEY)).toBeNull();
+      expect(reloadSpy).toHaveBeenCalled();
     });
-    expect(fetchImpl).toHaveBeenCalledWith('/api/auth/logout', expect.objectContaining({
-      method: 'POST',
-      credentials: 'include',
-    }));
-    expect(reloadSpy).toHaveBeenCalled();
+    expect(fetchImpl).toHaveBeenCalledWith(
+      '/api/auth/logout',
+      expect.objectContaining({ method: 'POST', credentials: 'include' }),
+    );
   });
 
   it('signIn redirects to /api/auth/github/login', async () => {
     const seen: string[] = [];
-    const fetchImpl = vi.fn(async () => new Response('', { status: 401 })) as unknown as typeof fetch;
+    const fetchImpl = stubFetch({
+      '/api/auth/me': () => new Response('', { status: 401 }),
+    });
 
     render(
       <AuthProvider fetchImpl={fetchImpl} skipInitialRefresh>


### PR DESCRIPTION
## Summary
- F-S-1 (P0): tunnel JWTs now signed with `JWT_REFRESH_SIGNING_KEY` to match middleware verification. Pre-fix every legit daemon dial in jwt mode would 401.
- F-S-2 (P1): trust-tunnel daemon binds to `CCSM_EXPECTED_OWNER_ID` (Tauri parses the persisted JWT's `sub`); `handleHello` closes 1008 on identity mismatch.
- F-S-3 (P1): `getAuthMode` THROWS on unrecognized values (typo / case mismatch) instead of silently returning legacy. `wrangler.toml` default stays legacy per spec.
- F-S-4 (P1): web JWT moved off URL fragment + sessionStorage to an HttpOnly + Secure + SameSite=Strict cookie scoped to `/api`. New endpoints: `GET /api/auth/me` + `POST /api/auth/ws-ticket` (60s ticket for ws subprotocol). SPA rewritten — never holds JWT in JS reach.
- F-S-5 (P1): `/api/auth/refresh` rotates the refresh token on every call (parity with deviceFlow tunnel-refresh). Replay-after-rotation returns 401.

Audit source: Task #150 derived from S4 OAuth completion (Task #142, #140, #136, #139, #141).

## Tests added (vitest + cargo)
- `middleware.test`: F-S-1 key-separation round-trip; F-S-3 strict throw; F-S-4 cookie extract + precedence.
- `deviceFlow.test`: F-S-1 explicit "tunnel_jwt verifies with refresh key NOT web key" assertion.
- `webOauth.test`: F-S-4 cookie callback (no fragment, `/?session=ok` only), `handleMe` / `handleWsTicket` happy + 401, dispatch routes /me + /ws-ticket. F-S-5 rotation + replay 401. Logout clears `web_jwt` cookie.
- `tunnel.test` (daemon): F-S-2 identity-bind reject / accept / no-env back-compat.
- `auth.rs` (Tauri rust): `parse_jwt_sub_unverified` happy + 2-part / 4-part / no-sub / garbage / padded base64url.

## Local checks (host: Windows, mode: full)
- lint (`pnpm -r lint`, CI shape): ✓
- typecheck per package (cf-worker, daemon, frontend-web, ui, etc.): ✓
- build (`pnpm -r build`): ✓
- unit tests:
  - vitest @ccsm/cf-worker: ✓ 137 passed
  - vitest @ccsm/frontend-web: ✓ 39 passed
  - vitest @ccsm/daemon: ✓ 164 passed (1 pre-existing skip in lifecycle.test, unrelated)
  - cargo test --lib auth:: (frontend-tauri): ✓ 10 passed (incl. 6 new `parse_jwt_sub` cases)
- e2e: deferred to CI matrix; F-S-1 jwt-mode invariant is locked by the new vitest cases (deviceFlow + middleware key-separation round-trip).

## Notes
- `pnpm run lint` (root) flags 4 pre-existing errors in test files (persist.test, PhaseSwitch.test, BootstrapRefresh.test, two-tab-pairing.spec). CI uses `pnpm -r lint` which only lints `src/`, so those are baseline-red and unrelated.
- frontend-tauri vitest emits a baseline post-test unhandled rejection (`__TAURI_INTERNALS__.invoke` undefined); 11/11 cases still PASS, no TS/test files in this package were touched.
- `wrangler.toml` NOT changed per spec — production stays `legacy` until the SPA cookie flow is verified end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)