### PR TITLE
daemon: tunnel JWT refresh client (R-45 audit-P0 F-T-13, Task #153)

### DIFF
--- a/packages/daemon/src/index.mts
+++ b/packages/daemon/src/index.mts
@@ -26,6 +26,10 @@ import { openDb } from './db.mjs';
 import { createDaemonHttp } from './http.mjs';
 import { createRuntimeRegistry } from './runtime.mjs';
 import { TunnelClient } from './tunnel.mjs';
+import {
+  TunnelRefreshClient,
+  readCredsFile,
+} from './tunnel-refresh.mjs';
 import { attachFrameRouter, attachWebSocket } from './ws.mjs';
 
 const DEFAULT_PORT = 17832;
@@ -142,6 +146,7 @@ async function main(): Promise<void> {
 
   let tunnel: TunnelClient | null = null;
   let tunnelStatePoll: ReturnType<typeof setInterval> | null = null;
+  let tunnelRefresh: TunnelRefreshClient | null = null;
   if (tunnelDisabled) {
     console.error('[ccsm] tunnel: disabled (CCSM_TUNNEL_DISABLE)');
   } else {
@@ -151,55 +156,72 @@ async function main(): Promise<void> {
     // the JWT as the `ccsm.<jwt>` ws subprotocol so the cf-worker can
     // authenticate the daemon side of the tunnel against its JWT signing
     // key. Absence of the env var keeps the legacy unauth dial path.
-    const tunnelJwt = process.env.CCSM_TUNNEL_JWT;
-    const subprotocols =
-      typeof tunnelJwt === 'string' && tunnelJwt.length > 0
-        ? [`ccsm.${tunnelJwt}`]
+    //
+    // Task #153 (R-45 audit-P0 F-T-13): the cloud-issued tunnel JWT has a
+    // 24h TTL; without an in-process refresh loop the daemon's tunnel ws
+    // would close hard at exp+ε. We stand up a TunnelRefreshClient that
+    // schedules a refresh 1h before exp (read from the persisted creds
+    // file the Tauri shell wrote). On successful refresh we stop the
+    // current TunnelClient and dial a new one with the new
+    // `ccsm.<newJwt>` subprotocol — same identity, fresh credential.
+    let currentJwt: string | undefined =
+      typeof process.env.CCSM_TUNNEL_JWT === 'string' && process.env.CCSM_TUNNEL_JWT.length > 0
+        ? process.env.CCSM_TUNNEL_JWT
         : undefined;
-    if (subprotocols !== undefined) {
-      console.error('[ccsm] tunnel: dialing with cloud-issued JWT subprotocol');
-    }
-    tunnel = new TunnelClient({
-      url: tunnelUrl,
-      token,
-      daemonLoopbackPort: port,
-      ...(subprotocols !== undefined ? { subprotocols } : {}),
-      onFrame: (data) => {
-        const len = typeof data === 'string'
-          ? Buffer.byteLength(data, 'utf8')
-          : data.length;
-        // Frames that arrive before any browser pairing (no hello+sid yet)
-        // land here. Once the browser sends hello with sid, onBrowserAttach
-        // takes over and routes binary frames into the per-session PTY.
-        console.error(`[ccsm] tunnel: rx frame len=${len}`);
-      },
-      // Task #793 (S3-G): wire the paired browser ws into the runtime
-      // registry's per-session fan-out. The router owns replay + subscribe
-      // + INPUT/RESIZE forwarding for the rest of this connection; we tear
-      // it down via the returned handle when the tunnel ws drops.
-      onBrowserAttach: ({ sid, lastSeq, send }) => {
-        // R-17 log #10 (Task #45): record browser-attach entry pre-routing so
-        // we can diff against tunnel.mts log #8 (hello received) and the DO
-        // log #2 (browser ws accepted) on the cloud side.
-        console.error('[ccsm] tunnel: browser attach sid=' + sid + ' lastSeq=' + lastSeq);
-        const router = attachFrameRouter({
-          sid,
-          lastSeq,
-          registry,
-          send: (data) => send(data),
-        });
-        if (!router.attached) {
-          console.warn(`[ccsm] tunnel: attach failed sid=${JSON.stringify(sid)} (not_spawned or exited)`);
-          return null;
-        }
-        console.error(`[ccsm] tunnel: attached sid=${sid} lastSeq=${lastSeq}`);
-        return {
-          onFrame: (data) => router.onFrame(data),
-          onClose: () => router.close(),
-        };
-      },
-    });
-    tunnel.start();
+
+    const startTunnel = (jwtForSubprotocol: string | undefined): TunnelClient => {
+      const subprotocols =
+        typeof jwtForSubprotocol === 'string' && jwtForSubprotocol.length > 0
+          ? [`ccsm.${jwtForSubprotocol}`]
+          : undefined;
+      if (subprotocols !== undefined) {
+        console.error('[ccsm] tunnel: dialing with cloud-issued JWT subprotocol');
+      }
+      const t = new TunnelClient({
+        url: tunnelUrl,
+        token,
+        daemonLoopbackPort: port,
+        ...(subprotocols !== undefined ? { subprotocols } : {}),
+        onFrame: (data) => {
+          const len = typeof data === 'string'
+            ? Buffer.byteLength(data, 'utf8')
+            : data.length;
+          // Frames that arrive before any browser pairing (no hello+sid yet)
+          // land here. Once the browser sends hello with sid, onBrowserAttach
+          // takes over and routes binary frames into the per-session PTY.
+          console.error(`[ccsm] tunnel: rx frame len=${len}`);
+        },
+        // Task #793 (S3-G): wire the paired browser ws into the runtime
+        // registry's per-session fan-out. The router owns replay + subscribe
+        // + INPUT/RESIZE forwarding for the rest of this connection; we tear
+        // it down via the returned handle when the tunnel ws drops.
+        onBrowserAttach: ({ sid, lastSeq, send }) => {
+          // R-17 log #10 (Task #45): record browser-attach entry pre-routing so
+          // we can diff against tunnel.mts log #8 (hello received) and the DO
+          // log #2 (browser ws accepted) on the cloud side.
+          console.error('[ccsm] tunnel: browser attach sid=' + sid + ' lastSeq=' + lastSeq);
+          const router = attachFrameRouter({
+            sid,
+            lastSeq,
+            registry,
+            send: (data) => send(data),
+          });
+          if (!router.attached) {
+            console.warn(`[ccsm] tunnel: attach failed sid=${JSON.stringify(sid)} (not_spawned or exited)`);
+            return null;
+          }
+          console.error(`[ccsm] tunnel: attached sid=${sid} lastSeq=${lastSeq}`);
+          return {
+            onFrame: (data) => router.onFrame(data),
+            onClose: () => router.close(),
+          };
+        },
+      });
+      t.start();
+      return t;
+    };
+
+    tunnel = startTunnel(currentJwt);
     // TunnelClient does not emit a 'connected' event; poll state until we
     // observe the first transition (or the client is stopped). Cheap timer,
     // unref'd so it never holds the loop open. Logged once per connect.
@@ -219,6 +241,54 @@ async function main(): Promise<void> {
       }
     }, TUNNEL_CONNECT_POLL_MS);
     tunnelStatePoll.unref?.();
+
+    // Task #153: bring up the refresh loop iff CCSM_TUNNEL_JWT was injected
+    // (i.e. the Tauri shell did device-flow). In legacy / unauth deployments
+    // there's no JWT to refresh and no creds file to consult — leave
+    // tunnelRefresh null. The creds file MUST exist when the env var is set
+    // (the Tauri shell writes it before spawning daemon); a missing file is
+    // logged but not fatal — the existing tunnel keeps running until exp.
+    if (currentJwt !== undefined) {
+      void readCredsFile().then((creds) => {
+        if (creds === null) {
+          console.warn(
+            '[ccsm/tunnel-refresh] creds file missing or malformed, refresh disabled for this run',
+          );
+          return;
+        }
+        tunnelRefresh = new TunnelRefreshClient({
+          authBase: process.env.CCSM_AUTH_BASE ?? 'https://cc-sm.pages.dev',
+          creds,
+          onRefreshed: (newJwt) => {
+            currentJwt = newJwt;
+            // Stop the existing tunnel synchronously, then dial a new one
+            // with the new subprotocol. The old ws may still be mid-frame;
+            // tunnel.stop() closes 1000 cleanly, the DO will see normal
+            // close, and the new dial reuses the same loopback port +
+            // browser routing wiring.
+            console.error('[ccsm] tunnel: refreshed JWT, redialing');
+            if (tunnel !== null) {
+              try {
+                tunnel.stop();
+              } catch (err) {
+                console.warn('[ccsm] tunnel.stop on refresh:', (err as Error).message);
+              }
+            }
+            tunnel = startTunnel(newJwt);
+            // The old state-poll interval still references this binding via
+            // the outer `tunnel` variable, which we just reassigned — the
+            // poll closure reads `tunnel` afresh each tick so it picks up
+            // the new client automatically.
+          },
+        });
+        tunnelRefresh.start();
+      }).catch((err: unknown) => {
+        console.warn(
+          '[ccsm/tunnel-refresh] init failed:',
+          (err as Error).message,
+        );
+      });
+    }
   }
 
   if (handshakeMode) {
@@ -243,6 +313,13 @@ async function main(): Promise<void> {
     console.error(`[ccsm] received ${signal}, shutting down`);
     // Stop the outbound tunnel first so we don't reconnect while the HTTP
     // server is closing. tunnel.stop() is synchronous + idempotent.
+    if (tunnelRefresh !== null) {
+      try {
+        tunnelRefresh.stop();
+      } catch (err) {
+        console.error('[ccsm] tunnelRefresh.stop error:', err);
+      }
+    }
     if (tunnel !== null) {
       try {
         tunnel.stop();

--- a/packages/daemon/src/tunnel-refresh.mts
+++ b/packages/daemon/src/tunnel-refresh.mts
@@ -1,0 +1,389 @@
+// Daemon-side tunnel-JWT refresh client (Task #153, R-45 audit-P0 F-T-13).
+//
+// Background
+// ----------
+// The cloud tunnel JWT minted by the cf-worker (`/api/auth/device/poll` and
+// `/api/auth/tunnel/refresh`) has a 24h TTL. The Tauri shell injects the JWT
+// into the daemon at spawn time via `CCSM_TUNNEL_JWT` (encoded as the
+// `ccsm.<jwt>` ws subprotocol — see tunnel.mts header). Without a refresh
+// loop the daemon's tunnel ws would close hard at exp+ε and never recover;
+// the user would have to restart the Tauri shell. Production hard-block.
+//
+// This module owns the daemon side of the refresh loop:
+//
+//   1. On start(), reads `~/.ccsm/tunnel_jwt` (JSON: tunnel_jwt /
+//      tunnel_refresh_token / login — same shape the Tauri shell writes),
+//      parses the JWT `exp` claim WITHOUT verifying the signature (the cloud
+//      already verified it; we only need the timestamp to schedule a timer).
+//   2. Schedules a single-shot timer to fire 1h before exp. If exp is already
+//      <= now+1h we fire immediately so a daemon resumed after a long suspend
+//      refreshes ASAP.
+//   3. On timer fire: POST `<authBase>/api/auth/tunnel/refresh` with body
+//      `{ tunnel_refresh_token, login }`. On 200 we get back
+//      `{ tunnel_jwt, tunnel_refresh_token }`, atomically rewrite the creds
+//      file, update the in-memory copy, invoke `onRefreshed(newJwt)` so the
+//      caller can tear the current tunnel ws down + dial a new one with the
+//      new subprotocol, and reschedule the next timer off the new exp.
+//   4. On any failure (non-2xx, network throw, JSON parse, missing exp in the
+//      new JWT) we LOG and stay parked — the existing tunnel keeps running
+//      until it actually closes; we do NOT force-disconnect. Refresh is
+//      retried on a short backoff (60s) so transient cloud blips self-heal.
+//      Permanent failure (401 — refresh token revoked) gives up after
+//      logging; the user has to re-login through the SPA.
+//
+// Why no signature verification: the daemon does NOT have the cf-worker's
+// `JWT_REFRESH_SIGNING_KEY` (and shouldn't — secrets live cloud-side). The
+// cloud signed the JWT, the cf-worker re-verifies on every ws upgrade
+// (subprotocol check), so the daemon trusts the file contents. A tampered
+// `exp` here would only cause early/late refresh attempts, not a privilege
+// escalation. Same trust model frontend-tauri's `parse_jwt_sub_unverified`
+// uses for the F-S-2 owner-bind check.
+//
+// Threat model: the creds file is %USERPROFILE%/.ccsm or ~/.ccsm with
+// 0600/user-only ACL (Tauri shell writes it; we only read+rewrite). A stolen
+// file gives the attacker at most one refresh round-trip — once we rotate,
+// the old refresh token no longer verifies cloud-side.
+
+import { promises as fs } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+// Refresh 1 hour before exp.
+const REFRESH_LEAD_MS = 60 * 60 * 1000;
+// Retry transient failures (network / 5xx) on this cadence.
+const RETRY_BACKOFF_MS = 60 * 1000;
+// Floor on the next-fire delay so we don't spin if exp is in the past.
+const MIN_TIMER_DELAY_MS = 0;
+
+export interface PersistedTunnelCreds {
+  tunnel_jwt: string;
+  tunnel_refresh_token: string;
+  login: string;
+}
+
+export interface TunnelRefreshOptions {
+  /** Cloud auth base, e.g. `https://cc-sm.pages.dev`. */
+  authBase: string;
+  /**
+   * Initial creds (parsed from `~/.ccsm/tunnel_jwt` by the caller — or
+   * provided directly by tests). The client takes a copy and mutates its own
+   * in-memory state on each refresh; the caller's object is not mutated.
+   */
+  creds: PersistedTunnelCreds;
+  /**
+   * Invoked synchronously after a successful refresh + file rewrite. The
+   * caller (daemon main / index.mts) tears the current TunnelClient down and
+   * dials a new one whose `subprotocols` carries the new JWT. Failure here is
+   * logged but does NOT abort the refresh loop — the next timer still fires.
+   */
+  onRefreshed: (newJwt: string) => void;
+  /** DI seam: HTTP fetch (defaults to globalThis.fetch). */
+  fetchImpl?: typeof fetch;
+  /** DI seam: timer (defaults to globalThis.setTimeout). */
+  setTimeoutImpl?: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimeoutImpl?: (id: ReturnType<typeof setTimeout>) => void;
+  /** DI seam: now (defaults to Date.now). */
+  nowMs?: () => number;
+  /**
+   * DI seam: where to write the refreshed creds. Default writes to
+   * `~/.ccsm/tunnel_jwt` (same path the Tauri shell uses) with 0600 perms on
+   * Unix. Tests inject a stub.
+   */
+  writeCredsFile?: (creds: PersistedTunnelCreds) => Promise<void>;
+}
+
+/**
+ * Parse the `exp` (expiration, seconds-since-epoch) claim from a JWT WITHOUT
+ * verifying the signature. Returns null on any structural failure. Mirrors
+ * frontend-tauri/src-tauri/src/auth.rs `parse_jwt_sub_unverified` modulo the
+ * field name. Public for tests.
+ */
+export function parseJwtExpUnverified(jwt: string): number | null {
+  const parts = jwt.split('.');
+  if (parts.length !== 3) return null;
+  const payload = parts[1];
+  if (payload === undefined || payload.length === 0) return null;
+  // base64url -> base64 -> Buffer
+  let b64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = b64.length % 4;
+  if (pad === 2) b64 += '==';
+  else if (pad === 3) b64 += '=';
+  else if (pad === 1) return null;
+  let json: string;
+  try {
+    json = Buffer.from(b64, 'base64').toString('utf8');
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object') return null;
+  const exp = (parsed as Record<string, unknown>).exp;
+  if (typeof exp !== 'number' || !Number.isFinite(exp) || exp <= 0) return null;
+  return exp;
+}
+
+/** Default creds-file path: `~/.ccsm/tunnel_jwt`. */
+export function defaultCredsPath(): string {
+  return path.join(os.homedir(), '.ccsm', 'tunnel_jwt');
+}
+
+/**
+ * Load + JSON-parse `~/.ccsm/tunnel_jwt`. Returns null if the file does not
+ * exist OR is malformed. Used by index.mts at boot to decide whether to spin
+ * up a refresh client.
+ */
+export async function readCredsFile(
+  filePath: string = defaultCredsPath(),
+): Promise<PersistedTunnelCreds | null> {
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== 'object') return null;
+  const obj = parsed as Record<string, unknown>;
+  if (
+    typeof obj.tunnel_jwt !== 'string' || obj.tunnel_jwt.length === 0 ||
+    typeof obj.tunnel_refresh_token !== 'string' || obj.tunnel_refresh_token.length === 0 ||
+    typeof obj.login !== 'string' || obj.login.length === 0
+  ) {
+    return null;
+  }
+  return {
+    tunnel_jwt: obj.tunnel_jwt,
+    tunnel_refresh_token: obj.tunnel_refresh_token,
+    login: obj.login,
+  };
+}
+
+/** Default writer: atomic-ish rewrite, 0600 on Unix. Same model as Tauri shell. */
+async function defaultWriteCredsFile(creds: PersistedTunnelCreds): Promise<void> {
+  const filePath = defaultCredsPath();
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  const json = JSON.stringify(creds);
+  // Truncate + rewrite. Daemon reads at boot only; in-flight refresh updates
+  // its in-memory copy via the client itself, so a partial write window has
+  // no observable consumer on the same machine.
+  if (process.platform === 'win32') {
+    // Windows: %USERPROFILE% ACL inheritance suffices (matches the Tauri
+    // shell's daemon_mgr::write_token_file rationale).
+    await fs.writeFile(filePath, json, { encoding: 'utf8' });
+  } else {
+    await fs.writeFile(filePath, json, { encoding: 'utf8', mode: 0o600 });
+    // chmod again in case the file already existed with looser perms.
+    try {
+      await fs.chmod(filePath, 0o600);
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+export type RefreshState =
+  | 'idle'
+  | 'scheduled'
+  | 'refreshing'
+  | 'stopped';
+
+export class TunnelRefreshClient {
+  private readonly authBase: string;
+  private readonly onRefreshed: (newJwt: string) => void;
+  private readonly fetchImpl: typeof fetch;
+  private readonly setTimeoutImpl: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  private readonly clearTimeoutImpl: (id: ReturnType<typeof setTimeout>) => void;
+  private readonly nowMs: () => number;
+  private readonly writeCredsFile: (creds: PersistedTunnelCreds) => Promise<void>;
+
+  private creds: PersistedTunnelCreds;
+  private state: RefreshState = 'idle';
+  private timer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(opts: TunnelRefreshOptions) {
+    this.authBase = opts.authBase.replace(/\/+$/, '');
+    this.creds = { ...opts.creds };
+    this.onRefreshed = opts.onRefreshed;
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
+    this.setTimeoutImpl = opts.setTimeoutImpl ?? ((cb, ms) => setTimeout(cb, ms));
+    this.clearTimeoutImpl = opts.clearTimeoutImpl ?? ((id) => clearTimeout(id));
+    this.nowMs = opts.nowMs ?? (() => Date.now());
+    this.writeCredsFile = opts.writeCredsFile ?? defaultWriteCredsFile;
+  }
+
+  getState(): RefreshState {
+    return this.state;
+  }
+
+  /** Current JWT in memory (reflects the most recent successful refresh). */
+  getCurrentJwt(): string {
+    return this.creds.tunnel_jwt;
+  }
+
+  /**
+   * Schedule the next refresh based on the current creds' JWT exp claim.
+   * Idempotent: subsequent calls cancel any prior timer first.
+   */
+  start(): void {
+    if (this.state === 'stopped') return;
+    this.scheduleNext();
+  }
+
+  stop(): void {
+    this.state = 'stopped';
+    if (this.timer !== null) {
+      this.clearTimeoutImpl(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private scheduleNext(): void {
+    if (this.state === 'stopped') return;
+    if (this.timer !== null) {
+      this.clearTimeoutImpl(this.timer);
+      this.timer = null;
+    }
+    const exp = parseJwtExpUnverified(this.creds.tunnel_jwt);
+    if (exp === null) {
+      console.warn('[ccsm/tunnel-refresh] cannot parse exp, refresh disabled');
+      this.state = 'idle';
+      return;
+    }
+    const expMs = exp * 1000;
+    const fireAt = expMs - REFRESH_LEAD_MS;
+    const delay = Math.max(MIN_TIMER_DELAY_MS, fireAt - this.nowMs());
+    console.error(
+      `[ccsm/tunnel-refresh] next refresh in ${delay}ms (exp=${exp}, lead=${REFRESH_LEAD_MS}ms)`,
+    );
+    this.state = 'scheduled';
+    this.timer = this.setTimeoutImpl(() => {
+      this.timer = null;
+      void this.fireRefresh();
+    }, delay);
+  }
+
+  private scheduleRetry(): void {
+    if (this.state === 'stopped') return;
+    if (this.timer !== null) {
+      this.clearTimeoutImpl(this.timer);
+      this.timer = null;
+    }
+    console.error(`[ccsm/tunnel-refresh] retry in ${RETRY_BACKOFF_MS}ms`);
+    this.state = 'scheduled';
+    this.timer = this.setTimeoutImpl(() => {
+      this.timer = null;
+      void this.fireRefresh();
+    }, RETRY_BACKOFF_MS);
+  }
+
+  private async fireRefresh(): Promise<void> {
+    if (this.state === 'stopped') return;
+    this.state = 'refreshing';
+    const url = `${this.authBase}/api/auth/tunnel/refresh`;
+    let response: Response;
+    try {
+      response = await this.fetchImpl(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          tunnel_refresh_token: this.creds.tunnel_refresh_token,
+          login: this.creds.login,
+        }),
+      });
+    } catch (err) {
+      console.warn(
+        '[ccsm/tunnel-refresh] network error:',
+        (err as Error).message,
+      );
+      this.scheduleRetry();
+      return;
+    }
+    if (response.status === 401 || response.status === 404) {
+      // Permanent: refresh token revoked or user unknown. The user has to
+      // re-login through the SPA. Park (no retry, no rethrow).
+      console.warn(
+        `[ccsm/tunnel-refresh] permanent failure status=${response.status}, refresh disabled until restart`,
+      );
+      this.state = 'idle';
+      return;
+    }
+    if (!response.ok) {
+      console.warn(
+        `[ccsm/tunnel-refresh] transient failure status=${response.status}, will retry`,
+      );
+      this.scheduleRetry();
+      return;
+    }
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch (err) {
+      console.warn(
+        '[ccsm/tunnel-refresh] bad json response:',
+        (err as Error).message,
+      );
+      this.scheduleRetry();
+      return;
+    }
+    if (body === null || typeof body !== 'object') {
+      console.warn('[ccsm/tunnel-refresh] response not an object');
+      this.scheduleRetry();
+      return;
+    }
+    const obj = body as Record<string, unknown>;
+    if (
+      typeof obj.tunnel_jwt !== 'string' || obj.tunnel_jwt.length === 0 ||
+      typeof obj.tunnel_refresh_token !== 'string' || obj.tunnel_refresh_token.length === 0
+    ) {
+      console.warn('[ccsm/tunnel-refresh] response missing fields');
+      this.scheduleRetry();
+      return;
+    }
+    if (parseJwtExpUnverified(obj.tunnel_jwt) === null) {
+      console.warn('[ccsm/tunnel-refresh] new JWT has no parseable exp');
+      this.scheduleRetry();
+      return;
+    }
+    // Persist before notifying so a crash between rotate and ws-redial leaves
+    // the new (already rotated cloud-side) creds on disk for next boot.
+    const nextCreds: PersistedTunnelCreds = {
+      tunnel_jwt: obj.tunnel_jwt,
+      tunnel_refresh_token: obj.tunnel_refresh_token,
+      login: this.creds.login,
+    };
+    try {
+      await this.writeCredsFile(nextCreds);
+    } catch (err) {
+      console.warn(
+        '[ccsm/tunnel-refresh] persist failed:',
+        (err as Error).message,
+      );
+      // Don't update in-memory creds — keep refresh_token in sync with disk.
+      this.scheduleRetry();
+      return;
+    }
+    this.creds = nextCreds;
+    console.error('[ccsm/tunnel-refresh] refresh ok, redialing tunnel');
+    try {
+      this.onRefreshed(nextCreds.tunnel_jwt);
+    } catch (err) {
+      console.warn(
+        '[ccsm/tunnel-refresh] onRefreshed threw:',
+        (err as Error).message,
+      );
+      // Continue regardless — the next timer will still fire.
+    }
+    this.scheduleNext();
+  }
+}

--- a/packages/daemon/test/tunnel-refresh.test.mts
+++ b/packages/daemon/test/tunnel-refresh.test.mts
@@ -1,0 +1,407 @@
+// Unit tests for daemon tunnel-refresh client (Task #153, R-45 audit-P0 F-T-13).
+//
+// Pure unit tests via DI seams: no real fetch, no real timers, no real fs.
+// Covers:
+//   - parseJwtExpUnverified (happy path + structural failure modes)
+//   - timer schedules (exp-1h, immediate when exp <= now+1h, retry backoff)
+//   - successful refresh: rewrites file, swaps in-memory JWT, fires
+//     onRefreshed, reschedules from new exp
+//   - 401 / 404 → permanent park (no retry, no onRefreshed)
+//   - network throw / 5xx → retry on RETRY_BACKOFF_MS, no onRefreshed
+//   - bad JSON / missing fields → retry, no onRefreshed
+//   - persist failure → retry, in-memory creds unchanged
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from 'vitest';
+
+import {
+  TunnelRefreshClient,
+  parseJwtExpUnverified,
+  type PersistedTunnelCreds,
+} from '../src/tunnel-refresh.mjs';
+
+// ---- helpers ------------------------------------------------------------
+
+function base64url(s: string): string {
+  return Buffer.from(s, 'utf8')
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+/** Build a fake JWT with the given payload (header / sig are constants). */
+function fakeJwt(payload: Record<string, unknown>): string {
+  const hdr = base64url(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body = base64url(JSON.stringify(payload));
+  const sig = base64url('not-a-real-sig');
+  return `${hdr}.${body}.${sig}`;
+}
+
+interface MockResponseInit {
+  status?: number;
+  json?: unknown;
+  jsonThrows?: boolean;
+}
+
+function mockResponse(init: MockResponseInit): Response {
+  const status = init.status ?? 200;
+  const ok = status >= 200 && status < 300;
+  return {
+    ok,
+    status,
+    json: async (): Promise<unknown> => {
+      if (init.jsonThrows === true) throw new Error('bad json');
+      return init.json ?? {};
+    },
+  } as unknown as Response;
+}
+
+// ---- parseJwtExpUnverified ---------------------------------------------
+
+describe('parseJwtExpUnverified', () => {
+  it('extracts exp from a valid JWT payload', () => {
+    const exp = 1_700_000_000;
+    const jwt = fakeJwt({ sub: '42', exp });
+    expect(parseJwtExpUnverified(jwt)).toBe(exp);
+  });
+
+  it('returns null when JWT is not 3 dot-separated parts', () => {
+    expect(parseJwtExpUnverified('foo.bar')).toBeNull();
+    expect(parseJwtExpUnverified('a.b.c.d')).toBeNull();
+    expect(parseJwtExpUnverified('not-a-jwt')).toBeNull();
+  });
+
+  it('returns null when payload is not valid base64url JSON', () => {
+    expect(parseJwtExpUnverified('a.!!!.c')).toBeNull();
+    expect(parseJwtExpUnverified(`a.${base64url('not-json')}.c`)).toBeNull();
+  });
+
+  it('returns null when exp is missing or not a positive number', () => {
+    expect(parseJwtExpUnverified(fakeJwt({ sub: '42' }))).toBeNull();
+    expect(parseJwtExpUnverified(fakeJwt({ exp: 'soon' }))).toBeNull();
+    expect(parseJwtExpUnverified(fakeJwt({ exp: 0 }))).toBeNull();
+    expect(parseJwtExpUnverified(fakeJwt({ exp: -1 }))).toBeNull();
+  });
+});
+
+// ---- TunnelRefreshClient -----------------------------------------------
+
+describe('TunnelRefreshClient', () => {
+  let nowMs: number;
+  let timers: Array<{ id: number; cb: () => void; ms: number; active: boolean }>;
+  let nextTimerId: number;
+  let setTimeoutImpl: Mock;
+  let clearTimeoutImpl: Mock;
+  let writeCredsFile: Mock;
+  let onRefreshed: Mock;
+  let fetchImpl: Mock;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    nowMs = 1_000_000_000_000; // arbitrary epoch ms
+    timers = [];
+    nextTimerId = 1;
+    setTimeoutImpl = vi.fn((cb: () => void, ms: number) => {
+      const id = nextTimerId++;
+      const rec = { id, cb, ms, active: true };
+      timers.push(rec);
+      return rec as unknown as ReturnType<typeof setTimeout>;
+    });
+    clearTimeoutImpl = vi.fn((id: { id: number; active: boolean }) => {
+      id.active = false;
+    });
+    writeCredsFile = vi.fn(async () => {});
+    onRefreshed = vi.fn();
+    fetchImpl = vi.fn();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  function fireActiveTimers(): void {
+    // Fire all currently-active timers in insertion order; they may schedule
+    // more (which we leave for the next call).
+    const snapshot = timers.filter((t) => t.active);
+    for (const t of snapshot) {
+      t.active = false;
+      t.cb();
+    }
+  }
+
+  function makeClient(creds: PersistedTunnelCreds): TunnelRefreshClient {
+    return new TunnelRefreshClient({
+      authBase: 'https://cc-sm.test',
+      creds,
+      onRefreshed,
+      fetchImpl: fetchImpl as unknown as typeof fetch,
+      setTimeoutImpl: setTimeoutImpl as unknown as (cb: () => void, ms: number) => ReturnType<typeof setTimeout>,
+      clearTimeoutImpl: clearTimeoutImpl as unknown as (id: ReturnType<typeof setTimeout>) => void,
+      nowMs: () => nowMs,
+      writeCredsFile,
+    });
+  }
+
+  it('schedules first refresh at exp - 1h', () => {
+    const exp = Math.floor(nowMs / 1000) + 24 * 3600; // 24h from now
+    const client = makeClient({
+      tunnel_jwt: fakeJwt({ exp }),
+      tunnel_refresh_token: 'r0',
+      login: 'octocat',
+    });
+    client.start();
+    expect(setTimeoutImpl).toHaveBeenCalledTimes(1);
+    const delay = setTimeoutImpl.mock.calls[0]![1] as number;
+    // Expect ~23h ± 1ms tolerance.
+    expect(delay).toBe(23 * 3600 * 1000);
+    expect(client.getState()).toBe('scheduled');
+  });
+
+  it('fires immediately when exp is already within the lead window', () => {
+    const exp = Math.floor(nowMs / 1000) + 30 * 60; // 30 min — inside 1h lead
+    const client = makeClient({
+      tunnel_jwt: fakeJwt({ exp }),
+      tunnel_refresh_token: 'r0',
+      login: 'octocat',
+    });
+    client.start();
+    expect(setTimeoutImpl.mock.calls[0]![1]).toBe(0);
+  });
+
+  it('successful refresh: writes file, swaps JWT, fires onRefreshed, reschedules', async () => {
+    const exp1 = Math.floor(nowMs / 1000) + 24 * 3600;
+    const exp2 = Math.floor(nowMs / 1000) + 48 * 3600; // new JWT, +24h
+    const newJwt = fakeJwt({ exp: exp2, sub: '42' });
+    fetchImpl.mockResolvedValueOnce(
+      mockResponse({
+        status: 200,
+        json: { tunnel_jwt: newJwt, tunnel_refresh_token: 'r1' },
+      }),
+    );
+
+    const client = makeClient({
+      tunnel_jwt: fakeJwt({ exp: exp1 }),
+      tunnel_refresh_token: 'r0',
+      login: 'octocat',
+    });
+    client.start();
+    // Advance "time" past exp - 1h.
+    nowMs += 23 * 3600 * 1000 + 1;
+    fireActiveTimers();
+    // Drain the microtask queue so the async fireRefresh resolves.
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchImpl.mock.calls[0]!;
+    expect(url).toBe('https://cc-sm.test/api/auth/tunnel/refresh');
+    expect((init as RequestInit).method).toBe('POST');
+    const body = JSON.parse((init as { body: string }).body);
+    expect(body).toEqual({ tunnel_refresh_token: 'r0', login: 'octocat' });
+
+    expect(writeCredsFile).toHaveBeenCalledTimes(1);
+    expect(writeCredsFile.mock.calls[0]![0]).toEqual({
+      tunnel_jwt: newJwt,
+      tunnel_refresh_token: 'r1',
+      login: 'octocat',
+    });
+
+    expect(onRefreshed).toHaveBeenCalledTimes(1);
+    expect(onRefreshed.mock.calls[0]![0]).toBe(newJwt);
+
+    expect(client.getCurrentJwt()).toBe(newJwt);
+    expect(client.getState()).toBe('scheduled');
+    // After scheduleNext using new exp, a new timer should exist.
+    expect(setTimeoutImpl.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('401 from cloud → permanent park, no retry, no onRefreshed', async () => {
+    const exp = Math.floor(nowMs / 1000) + 30 * 60;
+    fetchImpl.mockResolvedValueOnce(mockResponse({ status: 401 }));
+
+    const client = makeClient({
+      tunnel_jwt: fakeJwt({ exp }),
+      tunnel_refresh_token: 'r0',
+      login: 'octocat',
+    });
+    client.start();
+    fireActiveTimers();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    expect(writeCredsFile).not.toHaveBeenCalled();
+    expect(onRefreshed).not.toHaveBeenCalled();
+    expect(client.getState()).toBe('idle');
+    // No new timer after the initial one.
+    expect(setTimeoutImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('404 from cloud → permanent park (user unknown)', async () => {
+    const exp = Math.floor(nowMs / 1000) + 30 * 60;
+    fetchImpl.mockResolvedValueOnce(mockResponse({ status: 404 }));
+
+    const client = makeClient({
+      tunnel_jwt: fakeJwt({ exp }),
+      tunnel_refresh_token: 'r0',
+      login: 'octocat',
+    });
+    client.start();
+    fireActiveTimers();
+    await new Promise((r) => setImmediate(r));
+
+    expect(onRefreshed).not.toHaveBeenCalled();
+    expect(client.getState()).toBe('idle');
+    expect(setTimeoutImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('network throw → schedules retry, does not fire onRefreshed', async () => {
+    const exp = Math.floor(nowMs / 1000) + 30 * 60;
+    fetchImpl.mockRejectedValueOnce(new Error('ECONNRESET'));
+
+    const client = makeClient({
+      tunnel_jwt: fakeJwt({ exp }),
+      tunnel_refresh_token: 'r0',
+      login: 'octocat',
+    });
+    client.start();
+    fireActiveTimers();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(onRefreshed).not.toHaveBeenCalled();
+    // Initial + retry timer.
+    expect(setTimeoutImpl).toHaveBeenCalledTimes(2);
+    const retryDelay = setTimeoutImpl.mock.calls[1]![1] as number;
+    expect(retryDelay).toBe(60 * 1000);
+    expect(client.getState()).toBe('scheduled');
+    // In-memory JWT unchanged.
+    const initialJwt = fakeJwt({ exp });
+    expect(client.getCurrentJwt()).toBe(initialJwt);
+  });
+
+  it('5xx → retry, no onRefreshed', async () => {
+    const exp = Math.floor(nowMs / 1000) + 30 * 60;
+    fetchImpl.mockResolvedValueOnce(mockResponse({ status: 503 }));
+
+    const client = makeClient({
+      tunnel_jwt: fakeJwt({ exp }),
+      tunnel_refresh_token: 'r0',
+      login: 'octocat',
+    });
+    client.start();
+    fireActiveTimers();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(onRefreshed).not.toHaveBeenCalled();
+    expect(setTimeoutImpl).toHaveBeenCalledTimes(2);
+    expect((setTimeoutImpl.mock.calls[1]![1] as number)).toBe(60 * 1000);
+  });
+
+  it('malformed JSON response → retry, no onRefreshed', async () => {
+    const exp = Math.floor(nowMs / 1000) + 30 * 60;
+    fetchImpl.mockResolvedValueOnce(mockResponse({ status: 200, jsonThrows: true }));
+
+    const client = makeClient({
+      tunnel_jwt: fakeJwt({ exp }),
+      tunnel_refresh_token: 'r0',
+      login: 'octocat',
+    });
+    client.start();
+    fireActiveTimers();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(onRefreshed).not.toHaveBeenCalled();
+    expect(setTimeoutImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('response missing fields → retry, no onRefreshed', async () => {
+    const exp = Math.floor(nowMs / 1000) + 30 * 60;
+    fetchImpl.mockResolvedValueOnce(
+      mockResponse({ status: 200, json: { tunnel_jwt: 'foo' } }),
+    );
+
+    const client = makeClient({
+      tunnel_jwt: fakeJwt({ exp }),
+      tunnel_refresh_token: 'r0',
+      login: 'octocat',
+    });
+    client.start();
+    fireActiveTimers();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(onRefreshed).not.toHaveBeenCalled();
+    expect(setTimeoutImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('persist failure → retry, in-memory creds unchanged', async () => {
+    const exp1 = Math.floor(nowMs / 1000) + 30 * 60;
+    const exp2 = exp1 + 24 * 3600;
+    const newJwt = fakeJwt({ exp: exp2 });
+    fetchImpl.mockResolvedValueOnce(
+      mockResponse({
+        status: 200,
+        json: { tunnel_jwt: newJwt, tunnel_refresh_token: 'r1' },
+      }),
+    );
+    writeCredsFile.mockRejectedValueOnce(new Error('disk full'));
+
+    const initialJwt = fakeJwt({ exp: exp1 });
+    const client = makeClient({
+      tunnel_jwt: initialJwt,
+      tunnel_refresh_token: 'r0',
+      login: 'octocat',
+    });
+    client.start();
+    fireActiveTimers();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+
+    expect(onRefreshed).not.toHaveBeenCalled();
+    expect(client.getCurrentJwt()).toBe(initialJwt);
+    expect(setTimeoutImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it('stop() cancels pending timer and ignores subsequent state changes', () => {
+    const exp = Math.floor(nowMs / 1000) + 24 * 3600;
+    const client = makeClient({
+      tunnel_jwt: fakeJwt({ exp }),
+      tunnel_refresh_token: 'r0',
+      login: 'octocat',
+    });
+    client.start();
+    expect(setTimeoutImpl).toHaveBeenCalledTimes(1);
+    client.stop();
+    expect(clearTimeoutImpl).toHaveBeenCalledTimes(1);
+    expect(client.getState()).toBe('stopped');
+    // start() after stop is a no-op.
+    client.start();
+    expect(setTimeoutImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('JWT without parseable exp disables refresh (no timer scheduled)', () => {
+    const client = makeClient({
+      tunnel_jwt: 'not-a-valid-jwt',
+      tunnel_refresh_token: 'r0',
+      login: 'octocat',
+    });
+    client.start();
+    expect(setTimeoutImpl).not.toHaveBeenCalled();
+    expect(client.getState()).toBe('idle');
+  });
+});


### PR DESCRIPTION
## Task #153 — R-45 audit-P0 F-T-13: daemon tunnel-refresh client (24h JWT 自愈)

The cf-worker mints tunnel JWTs with a 24h TTL. Without an in-process refresh loop on the daemon side, the outbound tunnel ws closes hard at `exp + epsilon` and never recovers. Production hard-block flagged by R-45 audit.

## Summary

- New `packages/daemon/src/tunnel-refresh.mts`:
  - `parseJwtExpUnverified` — unsigned base64url payload `exp` extract (mirrors frontend-tauri `parse_jwt_sub_unverified`).
  - `readCredsFile` / `defaultCredsPath` — load `~/.ccsm/tunnel_jwt` JSON (same shape the Tauri shell writes).
  - `TunnelRefreshClient` — timer fires at `exp - 1h`, POSTs `/api/auth/tunnel/refresh` with persisted `refresh_token + login`, rewrites creds file (chmod 600 on Unix), swaps in-memory JWT, invokes `onRefreshed(newJwt)`.
- `packages/daemon/src/index.mts`: `startTunnel(jwt)` closure called at boot + on every successful refresh. Old `TunnelClient.stop()` then new dial with new `ccsm.<jwt>` subprotocol. Legacy/unauth daemons skip refresh entirely.

## Failure modes

| Status | Action |
|---|---|
| 200 | rotate disk + memory, fire onRefreshed, reschedule from new exp |
| 401 / 404 | permanent park; existing tunnel runs until natural exp |
| 5xx / network throw / bad JSON / missing fields / persist error | retry on 60s backoff; in-memory creds unchanged |

## Evidence

- daemon vitest: **164 -> 181 passing** (+16 new in `test/tunnel-refresh.test.mts`, +1 file). 1 pre-existing skip preserved.
- cf-worker vitest: **137 passing** (baseline preserved).
- tsc clean; eslint clean.
- grep skip in new test file: 0 hits.
- Local Windows verified.

## Test plan
- [x] daemon vitest green on Windows
- [x] cf-worker baseline preserved
- [x] typecheck + lint
- [x] no .skip / .todo / xit introduced
- [ ] post-merge: real Tauri-spawned daemon, wait for exp-1h timer, observe refresh + redial