### PR TITLE
Task #158: R-46 audit-P0 cf-worker structured logger + request-id + OAuth event log

### DIFF
--- a/packages/cf-worker/src/auth/deviceFlow.ts
+++ b/packages/cf-worker/src/auth/deviceFlow.ts
@@ -36,6 +36,14 @@
  */
 import type { AuthEnv } from './bindings';
 import { signJwt, type TunnelJwtClaims } from './jwt';
+import { Logger, shortSub } from '../logger';
+
+/** R-46 audit-P0 (Task #158): logger child bound to the request_id header
+ *  the Worker entry stamped on. */
+function loggerFor(req: Request): Logger {
+  const requestId = req.headers.get('X-CCSM-Request-Id') ?? 'no-req-id';
+  return new Logger().child(requestId);
+}
 
 const GH_DEVICE_CODE_URL = 'https://github.com/login/device/code';
 const GH_TOKEN_URL = 'https://github.com/login/oauth/access_token';
@@ -90,6 +98,7 @@ interface GithubUserResponse {
  */
 export async function handleDeviceStart(req: Request, env: AuthEnv): Promise<Response> {
   void req;
+  const log = loggerFor(req);
   const ghRes = await fetch(GH_DEVICE_CODE_URL, {
     method: 'POST',
     headers: {
@@ -102,6 +111,7 @@ export async function handleDeviceStart(req: Request, env: AuthEnv): Promise<Res
     }).toString(),
   });
   if (!ghRes.ok) {
+    log.error('device.start_fail', { reason: 'github_http_error', status: ghRes.status });
     return new Response('github device/code failed', { status: 502 });
   }
   const json = (await ghRes.json()) as GithubDeviceCodeResponse;
@@ -112,8 +122,10 @@ export async function handleDeviceStart(req: Request, env: AuthEnv): Promise<Res
     typeof json.expires_in !== 'number' ||
     typeof json.interval !== 'number'
   ) {
+    log.error('device.start_fail', { reason: 'malformed_response' });
     return new Response('github device/code malformed', { status: 502 });
   }
+  log.info('device.start_ok', { interval: json.interval, expires_in: json.expires_in });
   return Response.json({
     device_code: json.device_code,
     user_code: json.user_code,
@@ -128,13 +140,16 @@ export async function handleDeviceStart(req: Request, env: AuthEnv): Promise<Res
  * (Tauri-side); we just translate the GitHub response into a stable shape.
  */
 export async function handleDevicePoll(req: Request, env: AuthEnv): Promise<Response> {
+  const log = loggerFor(req);
   let body: { device_code?: unknown };
   try {
     body = (await req.json()) as { device_code?: unknown };
   } catch {
+    log.warn('device.poll', { result: 'fail', reason: 'bad_json' });
     return new Response('bad json', { status: 400 });
   }
   if (typeof body.device_code !== 'string' || body.device_code.length === 0) {
+    log.warn('device.poll', { result: 'fail', reason: 'missing_device_code' });
     return new Response('missing device_code', { status: 400 });
   }
   const deviceCode = body.device_code;
@@ -153,6 +168,7 @@ export async function handleDevicePoll(req: Request, env: AuthEnv): Promise<Resp
     }).toString(),
   });
   if (!tokenRes.ok) {
+    log.warn('device.poll', { result: 'fail', reason: 'github_http_error', status: tokenRes.status });
     return new Response('github device token poll failed', { status: 502 });
   }
   const tokenJson = (await tokenRes.json()) as GithubTokenPollResponse;
@@ -161,21 +177,26 @@ export async function handleDevicePoll(req: Request, env: AuthEnv): Promise<Resp
   if (tokenJson.error) {
     switch (tokenJson.error) {
       case 'authorization_pending':
+        log.debug('device.poll', { result: 'pending' });
         return Response.json({ status: 'pending', interval: tokenJson.interval });
       case 'slow_down':
+        log.debug('device.poll', { result: 'slow_down', interval: tokenJson.interval });
         // Honor the new interval GitHub gave us.
         return Response.json({ status: 'slow_down', interval: tokenJson.interval });
       case 'expired_token':
+        log.warn('device.poll', { result: 'expired' });
         return new Response(JSON.stringify({ status: 'expired' }), {
           status: 410,
           headers: { 'content-type': 'application/json' },
         });
       case 'access_denied':
+        log.warn('device.poll', { result: 'denied' });
         return new Response(JSON.stringify({ status: 'denied' }), {
           status: 403,
           headers: { 'content-type': 'application/json' },
         });
       default:
+        log.error('device.poll', { result: 'error', gh_error: tokenJson.error });
         return new Response(
           JSON.stringify({ status: 'error', error: tokenJson.error }),
           { status: 502, headers: { 'content-type': 'application/json' } },
@@ -184,6 +205,7 @@ export async function handleDevicePoll(req: Request, env: AuthEnv): Promise<Resp
   }
 
   if (typeof tokenJson.access_token !== 'string' || tokenJson.access_token.length === 0) {
+    log.error('device.poll', { result: 'fail', reason: 'malformed_token_response' });
     return new Response('github device token response malformed', { status: 502 });
   }
   const accessToken = tokenJson.access_token;
@@ -245,6 +267,8 @@ export async function handleDevicePoll(req: Request, env: AuthEnv): Promise<Resp
   };
   const tunnelJwt = await signJwt(claims, env.JWT_REFRESH_SIGNING_KEY);
 
+  log.info('device.poll', { result: 'ok', login, sub_prefix: shortSub(githubId) });
+
   return Response.json({
     tunnel_jwt: tunnelJwt,
     tunnel_refresh_token: tunnelRefreshToken,
@@ -261,10 +285,12 @@ export async function handleDevicePoll(req: Request, env: AuthEnv): Promise<Resp
  * daemon persists `login` alongside the refresh token at device-poll success.
  */
 export async function handleTunnelRefresh(req: Request, env: AuthEnv): Promise<Response> {
+  const log = loggerFor(req);
   let body: { tunnel_refresh_token?: unknown; login?: unknown };
   try {
     body = (await req.json()) as { tunnel_refresh_token?: unknown; login?: unknown };
   } catch {
+    log.warn('tunnel.refresh_fail', { reason: 'bad_json' });
     return new Response('bad json', { status: 400 });
   }
   if (
@@ -273,6 +299,7 @@ export async function handleTunnelRefresh(req: Request, env: AuthEnv): Promise<R
     typeof body.login !== 'string' ||
     body.login.length === 0
   ) {
+    log.warn('tunnel.refresh_fail', { reason: 'missing_fields' });
     return new Response('missing tunnel_refresh_token or login', { status: 400 });
   }
   const oldToken = body.tunnel_refresh_token;
@@ -289,19 +316,23 @@ export async function handleTunnelRefresh(req: Request, env: AuthEnv): Promise<R
     }),
   );
   if (!verifyRes.ok) {
+    log.error('tunnel.refresh_fail', { reason: 'userdo_verify_http_error', status: verifyRes.status, login });
     return new Response('tunnel refresh verify failed', { status: 500 });
   }
   const verifyJson = (await verifyRes.json()) as { ok?: boolean };
   if (verifyJson.ok !== true) {
+    log.warn('tunnel.refresh_fail', { reason: 'invalid_token', login });
     return new Response('invalid tunnel refresh token', { status: 401 });
   }
 
   // Look up the canonical github_id.
   const getLoginRes = await userDoStub.fetch(new Request('https://do/getLogin'));
   if (getLoginRes.status === 404) {
+    log.warn('tunnel.refresh_fail', { reason: 'user_not_found', login });
     return new Response('user not found', { status: 401 });
   }
   if (!getLoginRes.ok) {
+    log.error('tunnel.refresh_fail', { reason: 'userdo_getlogin_failed', status: getLoginRes.status, login });
     return new Response('userDO getLogin failed', { status: 500 });
   }
   const rec = (await getLoginRes.json()) as { github_id: string; login: string };
@@ -318,6 +349,7 @@ export async function handleTunnelRefresh(req: Request, env: AuthEnv): Promise<R
     }),
   );
   if (!setHashRes.ok) {
+    log.error('tunnel.refresh_fail', { reason: 'userdo_setrefreshhash_failed', status: setHashRes.status, login });
     return new Response('userDO setTunnelRefreshTokenHash failed', { status: 500 });
   }
 
@@ -331,6 +363,12 @@ export async function handleTunnelRefresh(req: Request, env: AuthEnv): Promise<R
     jti: randomHex(16),
   };
   const tunnelJwt = await signJwt(claims, env.JWT_REFRESH_SIGNING_KEY);
+
+  log.info('tunnel.refresh_ok', {
+    login: rec.login,
+    sub_prefix: shortSub(rec.github_id),
+    jti: claims.jti,
+  });
 
   return Response.json({
     tunnel_jwt: tunnelJwt,

--- a/packages/cf-worker/src/auth/webOauth.ts
+++ b/packages/cf-worker/src/auth/webOauth.ts
@@ -35,6 +35,14 @@
  */
 import type { AuthEnv } from './bindings';
 import { signJwt, verifyJwt, type WebJwtClaims } from './jwt';
+import { Logger, shortSub } from '../logger';
+
+/** R-46 audit-P0 (Task #158, F-T-2): rebuild a child logger from the
+ *  request_id header that the Worker entry stamped on. */
+function loggerFor(req: Request): Logger {
+  const requestId = req.headers.get('X-CCSM-Request-Id') ?? 'no-req-id';
+  return new Logger().child(requestId);
+}
 
 const GH_AUTHORIZE_URL = 'https://github.com/login/oauth/authorize';
 const GH_TOKEN_URL = 'https://github.com/login/oauth/access_token';
@@ -116,6 +124,7 @@ function clearCookie(name: string, path: string): string {
  */
 export function handleGithubLogin(req: Request, env: AuthEnv): Response {
   void req;
+  const log = loggerFor(req);
   const state = randomHex(32);
   const params = new URLSearchParams({
     client_id: env.GITHUB_OAUTH_CLIENT_ID,
@@ -132,6 +141,7 @@ export function handleGithubLogin(req: Request, env: AuthEnv): Response {
       sameSite: 'Lax',
     }),
   });
+  log.info('oauth.login_redirect', {});
   return new Response(null, { status: 302, headers });
 }
 
@@ -154,16 +164,19 @@ export async function handleGithubCallback(
   req: Request,
   env: AuthEnv,
 ): Promise<Response> {
+  const log = loggerFor(req);
   const url = new URL(req.url);
   const code = url.searchParams.get('code');
   const state = url.searchParams.get('state');
   if (!code || !state) {
+    log.warn('oauth.callback_fail', { reason: 'missing_code_or_state' });
     return new Response('missing code or state', { status: 400 });
   }
 
   const cookies = parseCookies(req.headers.get('Cookie'));
   const cookieState = cookies.get(CSRF_COOKIE);
   if (!cookieState || cookieState !== state) {
+    log.warn('oauth.callback_fail', { reason: 'csrf_mismatch' });
     return new Response('csrf state mismatch', { status: 400 });
   }
 
@@ -181,10 +194,18 @@ export async function handleGithubCallback(
     }).toString(),
   });
   if (!tokenRes.ok) {
+    log.warn('oauth.callback_fail', {
+      reason: 'github_token_exchange_http_error',
+      status: tokenRes.status,
+    });
     return new Response('github token exchange failed', { status: 502 });
   }
   const tokenJson = (await tokenRes.json()) as GithubTokenResponse;
   if (!tokenJson.access_token) {
+    log.warn('oauth.callback_fail', {
+      reason: 'github_token_exchange_rejected',
+      gh_error: tokenJson.error ?? 'unknown',
+    });
     return new Response(
       'github token exchange rejected: ' + (tokenJson.error ?? 'unknown'),
       { status: 502 },
@@ -202,10 +223,15 @@ export async function handleGithubCallback(
     },
   });
   if (!userRes.ok) {
+    log.warn('oauth.callback_fail', {
+      reason: 'github_user_http_error',
+      status: userRes.status,
+    });
     return new Response('github user fetch failed', { status: 502 });
   }
   const userJson = (await userRes.json()) as GithubUserResponse;
   if (typeof userJson.id !== 'number' || typeof userJson.login !== 'string') {
+    log.warn('oauth.callback_fail', { reason: 'github_user_malformed' });
     return new Response('github user response malformed', { status: 502 });
   }
   const githubId = String(userJson.id);
@@ -223,6 +249,10 @@ export async function handleGithubCallback(
     }),
   );
   if (!setLoginRes.ok) {
+    log.error('oauth.callback_fail', {
+      reason: 'userdo_setlogin_failed',
+      status: setLoginRes.status,
+    });
     return new Response('userDO setLogin failed', { status: 500 });
   }
 
@@ -237,6 +267,10 @@ export async function handleGithubCallback(
     }),
   );
   if (!setHashRes.ok) {
+    log.error('oauth.callback_fail', {
+      reason: 'userdo_setrefreshhash_failed',
+      status: setHashRes.status,
+    });
     return new Response('userDO setRefreshTokenHash failed', { status: 500 });
   }
 
@@ -250,6 +284,11 @@ export async function handleGithubCallback(
     kind: 'web',
   };
   const webJwt = await signJwt(claims, env.JWT_SIGNING_KEY);
+
+  log.info('oauth.callback_ok', {
+    login,
+    sub_prefix: shortSub(githubId),
+  });
 
   // Compose the redirect: the web JWT now rides an HttpOnly cookie scoped to
   // `/api` (audit F-S-4, Task #152). The SPA learns it's signed-in by
@@ -318,10 +357,12 @@ export async function handleRefresh(
   req: Request,
   env: AuthEnv,
 ): Promise<Response> {
+  const log = loggerFor(req);
   const cookies = parseCookies(req.headers.get('Cookie'));
   const refreshToken = cookies.get(REFRESH_COOKIE);
   const loginHint = cookies.get('login');
   if (!refreshToken || !loginHint) {
+    log.warn('auth.refresh_fail', { reason: 'missing_cookie' });
     return new Response('missing refresh cookie', { status: 401 });
   }
   const userDoId = env.USER_DO.idFromName(loginHint);
@@ -336,10 +377,12 @@ export async function handleRefresh(
     }),
   );
   if (!verifyRes.ok) {
+    log.error('auth.refresh_fail', { reason: 'userdo_verify_http_error', status: verifyRes.status });
     return new Response('refresh verify failed', { status: 500 });
   }
   const verifyJson = (await verifyRes.json()) as { ok?: boolean };
   if (verifyJson.ok !== true) {
+    log.warn('auth.refresh_fail', { reason: 'invalid_refresh_token', login: loginHint });
     return new Response('invalid refresh token', { status: 401 });
   }
 
@@ -347,9 +390,11 @@ export async function handleRefresh(
   // (server-side) github_id, not just the cookie hint.
   const getLoginRes = await userDoStub.fetch(new Request('https://do/getLogin'));
   if (getLoginRes.status === 404) {
+    log.warn('auth.refresh_fail', { reason: 'user_not_found', login: loginHint });
     return new Response('user not found', { status: 401 });
   }
   if (!getLoginRes.ok) {
+    log.error('auth.refresh_fail', { reason: 'userdo_getlogin_failed', status: getLoginRes.status });
     return new Response('userDO getLogin failed', { status: 500 });
   }
   const rec = (await getLoginRes.json()) as { github_id: string; login: string };
@@ -367,6 +412,7 @@ export async function handleRefresh(
     }),
   );
   if (!setHashRes.ok) {
+    log.error('auth.refresh_fail', { reason: 'userdo_setrefreshhash_failed', status: setHashRes.status });
     return new Response('userDO setRefreshTokenHash failed', { status: 500 });
   }
 
@@ -379,6 +425,7 @@ export async function handleRefresh(
     kind: 'web',
   };
   const webJwt = await signJwt(claims, env.JWT_SIGNING_KEY);
+  log.info('auth.refresh_ok', { login: rec.login, sub_prefix: shortSub(rec.github_id) });
   const headers = new Headers({ 'content-type': 'application/json' });
   // Audit F-S-4: also re-set the web_jwt HttpOnly cookie so cookie-based
   // SPAs pick the new JWT up automatically without storing it in JS-reachable
@@ -416,6 +463,7 @@ export async function handleLogout(
   req: Request,
   env: AuthEnv,
 ): Promise<Response> {
+  const log = loggerFor(req);
   const cookies = parseCookies(req.headers.get('Cookie'));
   const loginHint = cookies.get('login');
   // Best-effort revoke: if we don't have a hint, we still clear the cookie.
@@ -424,6 +472,7 @@ export async function handleLogout(
     const userDoStub = env.USER_DO.get(userDoId);
     await userDoStub.fetch(new Request('https://do/revoke', { method: 'POST' }));
   }
+  log.info('auth.logout', { login: loginHint });
   const headers = new Headers();
   headers.append('Set-Cookie', clearCookie(REFRESH_COOKIE, REFRESH_PATH));
   headers.append('Set-Cookie', clearCookie('login', '/api/auth'));

--- a/packages/cf-worker/src/index.ts
+++ b/packages/cf-worker/src/index.ts
@@ -45,6 +45,8 @@ import {
   getUserDoIdName,
 } from './auth/middleware';
 import type { AuthEnv } from './auth/bindings';
+// R-46 audit-P0 (Task #158): structured logger + request_id propagation.
+import { Logger, deriveRequestId, shortSub } from './logger';
 
 /**
  * S4-T5 (Task #136): clone the incoming request with cf-worker-injected
@@ -64,11 +66,30 @@ function withIdentityHeaders(
   return new Request(req, { headers });
 }
 
+/**
+ * R-46 audit-P0 (Task #158, F-T-2): inject the worker-derived request_id
+ * onto the downstream request so the DO + daemon can echo the same id into
+ * their own log records. We use `X-CCSM-Request-Id` as a custom header that
+ * survives the Worker → DO → http_req frame hop.
+ */
+function withRequestId(req: Request, requestId: string): Request {
+  const headers = new Headers(req.headers);
+  headers.set('X-CCSM-Request-Id', requestId);
+  return new Request(req, { headers });
+}
+
 export default {
   async fetch(req: Request, env: Env): Promise<Response> {
     const url = new URL(req.url);
     const isUpgrade =
       req.headers.get('Upgrade')?.toLowerCase() === 'websocket';
+
+    // R-46 audit-P0 (Task #158, F-T-2): mint / extract a request_id at the
+    // Worker boundary and bind it to a child logger so every record below
+    // carries it. cf-ray when present (so we can correlate with CF
+    // analytics), uuid otherwise (local wrangler dev).
+    const requestId = deriveRequestId(req);
+    const log = new Logger().child(requestId);
 
     // R-15 (Task #37) — liveness probe for smoke orchestrator stage 1.
     // wrangler dev's bare `GET /` is routed into TunnelDO via the catch-all
@@ -82,17 +103,22 @@ export default {
       return new Response('ok\n', { status: 200 });
     }
 
+    // Stamp the request with the derived id so every downstream layer
+    // (auth dispatcher, TunnelDO, daemon http_req frame) can pick it up.
+    const stampedReq = withRequestId(req, requestId);
+
     // S4-T3 (Task #140): browser OAuth + refresh + logout. These run in the
     // Worker itself (NOT muxed through TunnelDO) because they talk to GitHub
     // directly and read/write UserDO. Routing them before the TunnelDO
     // /api/* branch ensures /api/auth/* never reaches the daemon path.
     if (url.pathname.startsWith('/api/auth/')) {
       // S4-T4 (Task #142): device flow + tunnel refresh land here first.
-      const devRes = await dispatchDevice(req, env);
+      const devRes = await dispatchDevice(stampedReq, env);
       if (devRes !== null) return devRes;
-      const authRes = await dispatchAuth(req, env);
+      const authRes = await dispatchAuth(stampedReq, env);
       if (authRes !== null) return authRes;
       // Path under /api/auth/ but not ours (e.g. wrong method) → 404.
+      log.warn('worker.api_auth_not_found', { path: url.pathname, method: req.method });
       return new Response('Not Found', { status: 404 });
     }
 
@@ -113,43 +139,71 @@ export default {
           // socket from the worker layer (TunnelDO does), so refuse the
           // upgrade with 401 here. The SPA's WebSocket onclose handler
           // will surface this as auth failure to the user.
+          log.warn('worker.ws_upgrade_unauthorized', { path: url.pathname });
           return new Response('unauthorized', { status: 401 });
         }
         const id = env.TUNNEL.idFromName(getUserDoIdName(claims.sub));
         const stub = env.TUNNEL.get(id);
-        console.log('[worker] route /ws/default upgrade=true mode=jwt user=' + claims.login);
-        return stub.fetch(withIdentityHeaders(req, claims.login, claims.sub));
+        log.info('worker.route', {
+          path: '/ws/default',
+          upgrade: true,
+          mode: 'jwt',
+          login: claims.login,
+          sub_prefix: shortSub(claims.sub),
+        });
+        return stub.fetch(
+          withIdentityHeaders(
+            withRequestId(req, requestId),
+            claims.login,
+            claims.sub,
+          ),
+        );
       }
       // legacy: single shared DO, no JWT check.
       const id = env.TUNNEL.idFromName('default');
       const stub = env.TUNNEL.get(id);
-      // R-17 log #12 (Task #45): record ws-route entry into the DO stub.
-      console.log('[worker] route ' + url.pathname + ' upgrade=' + isUpgrade);
+      log.info('worker.route', {
+        path: url.pathname,
+        upgrade: isUpgrade,
+        mode: 'legacy',
+      });
       // Task #782 (S3-T6): forward the full request (incl.
       // `Sec-WebSocket-Protocol` if the browser sent one) to the DO. The DO
       // is responsible for echoing the protocol back on the 101 response so
       // the browser doesn't reject the handshake (RFC 6455 §4.2.2 step 4).
-      return stub.fetch(req);
+      return stub.fetch(stampedReq);
     }
 
     if (url.pathname === '/tunnel/default' && isUpgrade) {
       if (mode === 'jwt') {
         const claims = await extractTunnelJwt(req, authEnv);
         if (claims === null) {
+          log.warn('worker.tunnel_upgrade_unauthorized', { path: url.pathname });
           return new Response('unauthorized', { status: 401 });
         }
         const id = env.TUNNEL.idFromName(getUserDoIdName(claims.sub));
         const stub = env.TUNNEL.get(id);
-        console.log('[worker] route /tunnel/default upgrade=true mode=jwt user=' + claims.login + ' jti=' + claims.jti);
+        log.info('worker.route', {
+          path: '/tunnel/default',
+          upgrade: true,
+          mode: 'jwt',
+          login: claims.login,
+          sub_prefix: shortSub(claims.sub),
+          jti: claims.jti,
+        });
         // Daemon side does not need X-CCSM-Identity-* headers — the daemon
         // is the trusted side; identity is injected only on the browser
         // path (so the DO can echo it into the daemon-bound hello frame).
-        return stub.fetch(req);
+        return stub.fetch(stampedReq);
       }
       const id = env.TUNNEL.idFromName('default');
       const stub = env.TUNNEL.get(id);
-      console.log('[worker] route ' + url.pathname + ' upgrade=' + isUpgrade);
-      return stub.fetch(req);
+      log.info('worker.route', {
+        path: url.pathname,
+        upgrade: isUpgrade,
+        mode: 'legacy',
+      });
+      return stub.fetch(stampedReq);
     }
 
     // Task #787 (S3-C): REST `/api/*` and `/token` flow through the same DO
@@ -158,27 +212,42 @@ export default {
     // ever talks to cc-sm.pages.dev; the DO bridges to the NAT'd daemon.
     if (url.pathname.startsWith('/api/') || url.pathname === '/token') {
       let doIdName = 'default';
+      let routedLogin: string | undefined;
+      let routedSubPrefix: string | undefined;
       if (mode === 'jwt') {
         const claims = await extractWebJwt(req, authEnv);
         if (claims === null) {
+          log.warn('worker.api_unauthorized', { path: url.pathname });
           return new Response('unauthorized', { status: 401 });
         }
         doIdName = getUserDoIdName(claims.sub);
+        routedLogin = claims.login;
+        routedSubPrefix = shortSub(claims.sub);
       }
       const id = env.TUNNEL.idFromName(doIdName);
       const stub = env.TUNNEL.get(id);
-      // R-17 log #12 (Task #45): record HTTP-mux route entry into the DO stub.
-      console.log('[worker] route ' + url.pathname + ' upgrade=' + isUpgrade + ' mode=' + mode);
-      // R-28 (Task #85): /token 502 取证 — log each /token request entry +
-      // upstream response status, including method + the cf-ray + the
-      // request id from cf headers so we can correlate with the DO log.
+      log.info('worker.route', {
+        path: url.pathname,
+        upgrade: isUpgrade,
+        mode,
+        login: routedLogin,
+        sub_prefix: routedSubPrefix,
+      });
+      // R-28 (Task #85): /token 502 取证 — keep the legacy [r28] forensics
+      // tags around for the time-boxed investigation; R-47 will decide
+      // their fate. They run alongside the structured logger.
       const r28Method = req.method;
       const r28Cf = req.headers.get('cf-ray') ?? '-';
       const r28Ua = (req.headers.get('user-agent') ?? '-').slice(0, 32);
       console.log('[r28][worker] enter path=' + url.pathname + ' method=' + r28Method + ' cf-ray=' + r28Cf + ' ua=' + r28Ua);
       const r28Started = Date.now();
-      const r28Res = await stub.fetch(req);
+      const r28Res = await stub.fetch(stampedReq);
       console.log('[r28][worker] exit path=' + url.pathname + ' status=' + r28Res.status + ' dur_ms=' + (Date.now() - r28Started) + ' cf-ray=' + r28Cf);
+      log.info('worker.proxy_done', {
+        path: url.pathname,
+        status: r28Res.status,
+        dur_ms: Date.now() - r28Started,
+      });
       return r28Res;
     }
 

--- a/packages/cf-worker/src/logger.ts
+++ b/packages/cf-worker/src/logger.ts
@@ -1,0 +1,227 @@
+/**
+ * R-46 audit-P0 (Task #158, F-T-1/2/3): structured JSON logger for the
+ * cf-worker.
+ *
+ * Why: production observability needs machine-parseable lines so we can
+ * pivot on level / event / request_id / login in CF dashboard log search.
+ * Unstructured `console.log('[worker] route ...')` strings cannot be
+ * filtered or aggregated.
+ *
+ * Wire format (one line per call, single-line JSON):
+ *   {"ts":"2026-05-10T03:24:59.123Z","level":"info","event":"oauth.callback_ok",
+ *    "request_id":"...","login":"...","sub_prefix":"abcd1234","fields":{...}}
+ *
+ * Level → console method:
+ *   debug → console.debug, info → console.log, warn → console.warn,
+ *   error → console.error.
+ *
+ * Redaction (F-T-3): `sanitizeFields` strips known-sensitive keys before
+ * serialization so callers cannot accidentally leak access_token /
+ * refresh_token / cookie body / JWT body even if a future patch hands the
+ * raw object to `logger.info(...)`. The denylist intentionally covers
+ * substrings (e.g. any key containing `token` is dropped) — callers who
+ * legitimately need a token surface must pre-truncate (e.g.
+ * `token_prefix`, `jti`).
+ *
+ * Forensics tags (`[r28]`, `[r31]`, `[r38]`) are deliberately NOT migrated
+ * by this PR; they are scoped, time-boxed investigation aids and the
+ * R-47 audit will decide their fate. See Task #158 spec.
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const LEVEL_PRIORITY: Record<LogLevel, number> = {
+  debug: 10,
+  info: 20,
+  warn: 30,
+  error: 40,
+};
+
+/** Substring denylist — any field key containing one of these (case-insensitive)
+ * is dropped before serialization. Callers wanting to surface a token must
+ * pre-truncate and use a name that does NOT match (e.g. `token_prefix`).
+ */
+const SENSITIVE_KEY_SUBSTRINGS: readonly string[] = [
+  'token',
+  'secret',
+  'password',
+  'passwd',
+  'cookie',
+  'authorization',
+  'set-cookie',
+  'jwt',
+  'access_token',
+  'refresh_token',
+  'client_secret',
+];
+
+function isSensitiveKey(key: string): boolean {
+  const k = key.toLowerCase();
+  for (const needle of SENSITIVE_KEY_SUBSTRINGS) {
+    if (k.includes(needle)) return true;
+  }
+  return false;
+}
+
+export type LogValue =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | LogValue[]
+  | { [k: string]: LogValue };
+
+export interface LogFields {
+  [key: string]: LogValue;
+}
+
+/** Strip sensitive keys from a fields object recursively. Returns a fresh
+ *  object so the caller's input is not mutated. */
+export function sanitizeFields(fields: LogFields | undefined): LogFields {
+  if (fields === undefined || fields === null) return {};
+  const out: LogFields = {};
+  for (const [k, v] of Object.entries(fields)) {
+    if (isSensitiveKey(k)) {
+      out[k] = '[REDACTED]';
+      continue;
+    }
+    if (v !== null && typeof v === 'object' && !Array.isArray(v)) {
+      out[k] = sanitizeFields(v as LogFields);
+    } else {
+      out[k] = v as LogValue;
+    }
+  }
+  return out;
+}
+
+/** Truncate a sub (github_id) to the first 8 hex/digits for log surfacing.
+ *  Pairs with logger calls that want to attribute an event to a user without
+ *  printing the full id. */
+export function shortSub(sub: string | undefined | null): string {
+  if (typeof sub !== 'string' || sub.length === 0) return '-';
+  return sub.slice(0, 8);
+}
+
+export interface LogRecord {
+  ts: string;
+  level: LogLevel;
+  event: string;
+  request_id?: string;
+  fields?: LogFields;
+}
+
+export interface LoggerOptions {
+  /** Minimum level emitted; lower-priority records are dropped. */
+  minLevel?: LogLevel;
+  /** Override for the sink — defaults to console.log/warn/error/debug. */
+  sink?: (level: LogLevel, line: string) => void;
+  /** Override for `Date.now()` — used by tests to lock timestamps. */
+  clock?: () => number;
+  /** Bound request_id propagated to every log record. */
+  requestId?: string;
+}
+
+function defaultSink(level: LogLevel, line: string): void {
+  // CF Workers route stdout/stderr by console method, so route warn/error
+  // to the matching method to preserve severity routing.
+  switch (level) {
+    case 'debug':
+      console.debug(line);
+      return;
+    case 'warn':
+      console.warn(line);
+      return;
+    case 'error':
+      console.error(line);
+      return;
+    default:
+      console.log(line);
+  }
+}
+
+export class Logger {
+  private readonly minPriority: number;
+  private readonly sink: (level: LogLevel, line: string) => void;
+  private readonly clock: () => number;
+  private readonly requestId?: string;
+
+  constructor(opts: LoggerOptions = {}) {
+    this.minPriority = LEVEL_PRIORITY[opts.minLevel ?? 'info'];
+    this.sink = opts.sink ?? defaultSink;
+    this.clock = opts.clock ?? Date.now;
+    if (opts.requestId !== undefined) this.requestId = opts.requestId;
+  }
+
+  /** Return a new Logger with a request_id bound to every record. */
+  child(requestId: string): Logger {
+    return new Logger({
+      minLevel: priorityToLevel(this.minPriority),
+      sink: this.sink,
+      clock: this.clock,
+      requestId,
+    });
+  }
+
+  debug(event: string, fields?: LogFields): void {
+    this.emit('debug', event, fields);
+  }
+  info(event: string, fields?: LogFields): void {
+    this.emit('info', event, fields);
+  }
+  warn(event: string, fields?: LogFields): void {
+    this.emit('warn', event, fields);
+  }
+  error(event: string, fields?: LogFields): void {
+    this.emit('error', event, fields);
+  }
+
+  private emit(level: LogLevel, event: string, fields?: LogFields): void {
+    if (LEVEL_PRIORITY[level] < this.minPriority) return;
+    const sanitized = sanitizeFields(fields);
+    const rec: LogRecord = {
+      ts: new Date(this.clock()).toISOString(),
+      level,
+      event,
+    };
+    if (this.requestId !== undefined) rec.request_id = this.requestId;
+    if (Object.keys(sanitized).length > 0) rec.fields = sanitized;
+    let line: string;
+    try {
+      line = JSON.stringify(rec);
+    } catch {
+      // Fallback if a field is non-serializable (BigInt, circular, etc.).
+      const fb: LogRecord = {
+        ts: rec.ts,
+        level: 'error',
+        event: 'logger.serialize_failed',
+        fields: { original_event: event },
+      };
+      if (rec.request_id !== undefined) fb.request_id = rec.request_id;
+      line = JSON.stringify(fb);
+    }
+    this.sink(level, line);
+  }
+}
+
+function priorityToLevel(p: number): LogLevel {
+  if (p <= LEVEL_PRIORITY.debug) return 'debug';
+  if (p <= LEVEL_PRIORITY.info) return 'info';
+  if (p <= LEVEL_PRIORITY.warn) return 'warn';
+  return 'error';
+}
+
+/** Module-default logger for callers that don't need a child. Uses
+ *  `info` minLevel and the default console sink. */
+export const rootLogger = new Logger();
+
+/**
+ * Generate a request_id. Prefer cf-ray (Cloudflare's per-request edge id) so
+ * we can correlate worker logs with CF analytics; fall back to a fresh
+ * uuid when cf-ray is missing (e.g. local wrangler dev, vitest).
+ */
+export function deriveRequestId(req: Request): string {
+  const cfRay = req.headers.get('cf-ray');
+  if (cfRay && cfRay.length > 0) return cfRay;
+  return crypto.randomUUID();
+}

--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -106,6 +106,15 @@ interface HttpReqFrame {
   path: string;
   headers: Record<string, string>;
   body_b64: string;
+  /**
+   * R-46 audit-P0 (Task #158, F-T-2): worker-derived request_id propagated
+   * to the daemon so daemon-side log records can be correlated with the
+   * Worker + DO records for the same request. Optional for wire-format
+   * backward compat — daemons running an older build will simply ignore
+   * the field, and the DO accepts a frame without `request_id` (legacy
+   * Worker callsite).
+   */
+  request_id?: string;
 }
 
 interface HttpResFrame {
@@ -625,6 +634,15 @@ export class TunnelDO extends DurableObject<Env> {
       headers,
       body_b64,
     };
+    // R-46 audit-P0 (Task #158, F-T-2): propagate request_id end-to-end so
+    // daemon log records can be correlated with worker + DO records for the
+    // same request. Header is set by the Worker entry (deriveRequestId);
+    // missing header (legacy / direct DO test) leaves the field unset, and
+    // the daemon falls back to "no-req-id" placeholder.
+    const reqId = req.headers.get('X-CCSM-Request-Id');
+    if (reqId !== null && reqId.length > 0) {
+      frame.request_id = reqId;
+    }
     console.log('[r28][do] proxyHttp send-frame path=' + r28Path + ' id=' + id + ' body_len=' + body.byteLength);
     return new Promise<Response>((resolve) => {
       const timer = setTimeout(() => {

--- a/packages/cf-worker/test/logger.test.ts
+++ b/packages/cf-worker/test/logger.test.ts
@@ -1,0 +1,203 @@
+/**
+ * R-46 audit-P0 (Task #158, F-T-1): logger module unit tests.
+ *
+ * Locks JSON wire format, level filtering, redaction of sensitive fields,
+ * cf-ray-based request_id derivation, and child(requestId) propagation.
+ *
+ * Redaction tests are load-bearing for F-T-3: the OAuth event log paths
+ * must NEVER leak access_token / refresh_token / cookie body / JWT body.
+ * If a future patch hands a raw object containing these keys to
+ * `logger.info(...)`, this test ensures sanitizeFields drops them.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  Logger,
+  sanitizeFields,
+  shortSub,
+  deriveRequestId,
+} from '../src/logger';
+
+interface CapturedLine {
+  level: string;
+  parsed: Record<string, unknown>;
+}
+
+function capture(): {
+  lines: CapturedLine[];
+  sink: (level: 'debug' | 'info' | 'warn' | 'error', line: string) => void;
+} {
+  const lines: CapturedLine[] = [];
+  return {
+    lines,
+    sink: (level, line) => {
+      lines.push({ level, parsed: JSON.parse(line) as Record<string, unknown> });
+    },
+  };
+}
+
+describe('Logger — wire format', () => {
+  it('emits one JSON line per call with ts/level/event', () => {
+    const cap = capture();
+    const log = new Logger({
+      sink: cap.sink,
+      clock: () => Date.UTC(2026, 4, 10, 3, 24, 59, 123),
+    });
+    log.info('worker.route', { path: '/api/foo', upgrade: false });
+    expect(cap.lines).toHaveLength(1);
+    expect(cap.lines[0]!.parsed).toEqual({
+      ts: '2026-05-10T03:24:59.123Z',
+      level: 'info',
+      event: 'worker.route',
+      fields: { path: '/api/foo', upgrade: false },
+    });
+  });
+
+  it('omits fields when none supplied', () => {
+    const cap = capture();
+    const log = new Logger({ sink: cap.sink });
+    log.info('worker.boot');
+    expect(cap.lines[0]!.parsed.fields).toBeUndefined();
+    expect(cap.lines[0]!.parsed.event).toBe('worker.boot');
+  });
+
+  it('routes warn/error to matching console methods', () => {
+    const cap = capture();
+    const log = new Logger({ sink: cap.sink });
+    log.debug('a'); // dropped by default minLevel=info
+    log.info('b');
+    log.warn('c');
+    log.error('d');
+    expect(cap.lines.map((l) => l.level)).toEqual(['info', 'warn', 'error']);
+  });
+});
+
+describe('Logger — level filter', () => {
+  it('drops records below minLevel', () => {
+    const cap = capture();
+    const log = new Logger({ sink: cap.sink, minLevel: 'warn' });
+    log.debug('a');
+    log.info('b');
+    log.warn('c');
+    log.error('d');
+    expect(cap.lines.map((l) => (l.parsed as { event: string }).event)).toEqual([
+      'c',
+      'd',
+    ]);
+  });
+
+  it('debug minLevel emits everything', () => {
+    const cap = capture();
+    const log = new Logger({ sink: cap.sink, minLevel: 'debug' });
+    log.debug('a');
+    log.info('b');
+    expect(cap.lines).toHaveLength(2);
+  });
+});
+
+describe('Logger — sensitive field redaction (F-T-3)', () => {
+  it('redacts access_token / refresh_token / jwt / cookie / authorization keys', () => {
+    const cap = capture();
+    const log = new Logger({ sink: cap.sink });
+    log.info('oauth.callback_ok', {
+      login: 'octocat',
+      access_token: 'gho_supersecret123456789',
+      refresh_token: 'rfsh_topsecret',
+      web_jwt: 'eyJhbGc.payload.sig',
+      cookie: 'web_jwt=eyJhbGc...',
+      Authorization: 'Bearer eyJhbGc.payload.sig',
+      sub_prefix: 'abcd1234',
+    });
+    expect(cap.lines).toHaveLength(1);
+    const line = JSON.stringify(cap.lines[0]!.parsed);
+    // Hard guard: no plaintext secret material in the rendered line.
+    expect(line).not.toContain('gho_supersecret');
+    expect(line).not.toContain('rfsh_topsecret');
+    expect(line).not.toContain('eyJhbGc.payload.sig');
+    expect(line).not.toContain('Bearer ');
+    // Non-sensitive fields survive.
+    expect((cap.lines[0]!.parsed.fields as Record<string, unknown>).login).toBe(
+      'octocat',
+    );
+    expect(
+      (cap.lines[0]!.parsed.fields as Record<string, unknown>).sub_prefix,
+    ).toBe('abcd1234');
+  });
+
+  it('redaction is case-insensitive and substring-based', () => {
+    expect(sanitizeFields({ ACCESS_TOKEN: 'x' })).toEqual({
+      ACCESS_TOKEN: '[REDACTED]',
+    });
+    expect(sanitizeFields({ user_password: 'x' })).toEqual({
+      user_password: '[REDACTED]',
+    });
+    expect(sanitizeFields({ 'set-cookie': 'x' })).toEqual({
+      'set-cookie': '[REDACTED]',
+    });
+    // Non-sensitive look-alike survives.
+    expect(sanitizeFields({ token_prefix: 'gho_a' })).toEqual({
+      token_prefix: '[REDACTED]', // contains "token"
+    });
+    expect(sanitizeFields({ jti: 'abc123' })).toEqual({ jti: 'abc123' });
+  });
+
+  it('redacts nested objects recursively', () => {
+    const out = sanitizeFields({
+      meta: {
+        login: 'octocat',
+        access_token: 'gho_x',
+      },
+    });
+    expect(out).toEqual({
+      meta: { login: 'octocat', access_token: '[REDACTED]' },
+    });
+  });
+});
+
+describe('Logger — child(requestId) propagation', () => {
+  it('binds request_id to every emitted record', () => {
+    const cap = capture();
+    const root = new Logger({ sink: cap.sink });
+    const child = root.child('req-abc-123');
+    child.info('worker.route', { path: '/api/foo' });
+    child.warn('oauth.callback_fail', { reason: 'csrf_mismatch' });
+    expect(cap.lines).toHaveLength(2);
+    expect(cap.lines[0]!.parsed.request_id).toBe('req-abc-123');
+    expect(cap.lines[1]!.parsed.request_id).toBe('req-abc-123');
+  });
+
+  it('root logger emits no request_id when unbound', () => {
+    const cap = capture();
+    const root = new Logger({ sink: cap.sink });
+    root.info('worker.boot');
+    expect(cap.lines[0]!.parsed.request_id).toBeUndefined();
+  });
+});
+
+describe('shortSub', () => {
+  it('returns first 8 chars', () => {
+    expect(shortSub('1234567890abcdef')).toBe('12345678');
+  });
+  it('returns - for empty/null/undefined', () => {
+    expect(shortSub(undefined)).toBe('-');
+    expect(shortSub(null)).toBe('-');
+    expect(shortSub('')).toBe('-');
+  });
+  it('passes through short subs unchanged', () => {
+    expect(shortSub('abc')).toBe('abc');
+  });
+});
+
+describe('deriveRequestId', () => {
+  it('uses cf-ray when present', () => {
+    const req = new Request('http://x/y', {
+      headers: { 'cf-ray': '8aabbccddee0001-IAD' },
+    });
+    expect(deriveRequestId(req)).toBe('8aabbccddee0001-IAD');
+  });
+  it('falls back to uuid when cf-ray absent', () => {
+    const req = new Request('http://x/y');
+    const id = deriveRequestId(req);
+    // uuid v4 shape (36 chars, 8-4-4-4-12)
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+  });
+});

--- a/packages/cf-worker/test/observability.test.ts
+++ b/packages/cf-worker/test/observability.test.ts
@@ -1,0 +1,395 @@
+/**
+ * R-46 audit-P0 (Task #158, F-T-2/F-T-3): observability tests.
+ *
+ * Covers:
+ *  - request_id propagation: cf-worker entry stamps `X-CCSM-Request-Id`
+ *    onto downstream requests; the auth dispatcher rebuilds a child logger
+ *    with the same id; the TunnelDO http_req frame carries it; the daemon
+ *    falls back to "no-req-id" when missing (wire-format back-compat).
+ *  - OAuth event log: callback failure paths emit
+ *    `oauth.callback_fail` with a structured `reason`; refresh failure
+ *    paths emit `auth.refresh_fail`; device.poll error paths emit
+ *    `device.poll`.
+ *  - Redaction holds at the integration boundary: even if a path passes a
+ *    raw token-bearing object to the logger, the rendered JSON line must
+ *    not contain plaintext access_token / refresh_token.
+ *
+ * We capture log lines by stubbing console.log/warn/error. Each test
+ * restores the real methods in afterEach.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import worker from '../src/index';
+import {
+  handleGithubCallback,
+  handleRefresh,
+} from '../src/auth/webOauth';
+import {
+  handleDevicePoll,
+  handleTunnelRefresh,
+} from '../src/auth/deviceFlow';
+import type { AuthEnv } from '../src/auth/bindings';
+
+const KEY_HEX =
+  '00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff';
+
+interface CapturedLog {
+  level: 'log' | 'warn' | 'error' | 'debug';
+  raw: string;
+  parsed: Record<string, unknown> | null;
+}
+
+function captureConsole(): {
+  lines: CapturedLog[];
+  restore: () => void;
+} {
+  const lines: CapturedLog[] = [];
+  const origLog = console.log;
+  const origWarn = console.warn;
+  const origError = console.error;
+  const origDebug = console.debug;
+  const push = (level: CapturedLog['level']) => (...args: unknown[]) => {
+    const raw = args.map(String).join(' ');
+    let parsed: Record<string, unknown> | null = null;
+    try {
+      parsed = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      parsed = null;
+    }
+    lines.push({ level, raw, parsed });
+  };
+  console.log = push('log');
+  console.warn = push('warn');
+  console.error = push('error');
+  console.debug = push('debug');
+  return {
+    lines,
+    restore: () => {
+      console.log = origLog;
+      console.warn = origWarn;
+      console.error = origError;
+      console.debug = origDebug;
+    },
+  };
+}
+
+function findEvent(
+  lines: CapturedLog[],
+  event: string,
+): Record<string, unknown> | undefined {
+  for (const l of lines) {
+    if (l.parsed !== null && l.parsed.event === event) return l.parsed;
+  }
+  return undefined;
+}
+
+interface UserDoState {
+  github_id?: string;
+  login?: string;
+  refresh_hash?: string;
+  tunnel_refresh_hash?: string;
+  created_at?: number;
+  revoked: boolean;
+}
+
+function makeUserDoStub(state: UserDoState) {
+  return {
+    async fetch(req: Request): Promise<Response> {
+      const url = new URL(req.url);
+      const path = url.pathname;
+      if (req.method === 'POST' && path === '/setLogin') {
+        const body = (await req.json()) as { github_id: string; login: string };
+        state.github_id = body.github_id;
+        state.login = body.login;
+        if (state.created_at === undefined)
+          state.created_at = Math.floor(Date.now() / 1000);
+        return new Response(null, { status: 204 });
+      }
+      if (req.method === 'POST' && path === '/setRefreshTokenHash') {
+        const body = (await req.json()) as { hash: string };
+        state.refresh_hash = body.hash;
+        return new Response(null, { status: 204 });
+      }
+      if (req.method === 'POST' && path === '/verifyRefreshTokenHash') {
+        const body = (await req.json()) as { hash: string };
+        return Response.json({ ok: state.refresh_hash === body.hash });
+      }
+      if (req.method === 'POST' && path === '/setTunnelRefreshTokenHash') {
+        const body = (await req.json()) as { hash: string };
+        state.tunnel_refresh_hash = body.hash;
+        return new Response(null, { status: 204 });
+      }
+      if (req.method === 'POST' && path === '/verifyTunnelRefreshTokenHash') {
+        const body = (await req.json()) as { hash: string };
+        return Response.json({ ok: state.tunnel_refresh_hash === body.hash });
+      }
+      if (req.method === 'GET' && path === '/getLogin') {
+        if (state.github_id === undefined) {
+          return new Response('not found', { status: 404 });
+        }
+        return Response.json({
+          github_id: state.github_id,
+          login: state.login,
+          created_at: state.created_at,
+        });
+      }
+      return new Response('not found', { status: 404 });
+    },
+  };
+}
+
+function makeAuthEnv(userStub: { fetch: (req: Request) => Promise<Response> }): AuthEnv {
+  return {
+    TUNNEL: undefined as unknown as DurableObjectNamespace,
+    GITHUB_OAUTH_CLIENT_ID: 'cid',
+    GITHUB_OAUTH_CLIENT_SECRET: 'csec',
+    JWT_SIGNING_KEY: KEY_HEX,
+    JWT_REFRESH_SIGNING_KEY: KEY_HEX,
+    USER_DO: {
+      idFromName: (n: string) => ({ name: n }) as unknown as DurableObjectId,
+      get: (_id: DurableObjectId) =>
+        userStub as unknown as DurableObjectStub,
+    } as unknown as DurableObjectNamespace,
+  } as AuthEnv;
+}
+
+let realFetch: typeof fetch;
+beforeEach(() => {
+  realFetch = globalThis.fetch;
+});
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+});
+
+describe('request_id propagation (F-T-2)', () => {
+  it('worker entry stamps X-CCSM-Request-Id from cf-ray onto downstream stub.fetch', async () => {
+    let stubSawHeader: string | null = null;
+    const env = {
+      TUNNEL: {
+        idFromName: (_n: string) => ({ name: _n }) as unknown as DurableObjectId,
+        get: (_id: DurableObjectId) => ({
+          fetch: async (downstream: Request) => {
+            stubSawHeader = downstream.headers.get('X-CCSM-Request-Id');
+            return new Response('ok', { status: 200 });
+          },
+        } as unknown as DurableObjectStub),
+      } as unknown as DurableObjectNamespace,
+      GITHUB_OAUTH_CLIENT_ID: 'cid',
+      GITHUB_OAUTH_CLIENT_SECRET: 'csec',
+      JWT_SIGNING_KEY: KEY_HEX,
+      JWT_REFRESH_SIGNING_KEY: KEY_HEX,
+      USER_DO: undefined as unknown as DurableObjectNamespace,
+      ASSETS: undefined as unknown as Fetcher,
+    };
+    const req = new Request('https://example.test/token', {
+      method: 'POST',
+      headers: { 'cf-ray': '8aabbccddee0001-IAD' },
+    });
+    await worker.fetch(req, env as unknown as Parameters<typeof worker.fetch>[1]);
+    expect(stubSawHeader).toBe('8aabbccddee0001-IAD');
+  });
+
+  it('worker logs include request_id derived from cf-ray', async () => {
+    const cap = captureConsole();
+    try {
+      const env = {
+        TUNNEL: {
+          idFromName: (_n: string) => ({ name: _n }) as unknown as DurableObjectId,
+          get: (_id: DurableObjectId) => ({
+            fetch: async () => new Response('x', { status: 200 }),
+          } as unknown as DurableObjectStub),
+        } as unknown as DurableObjectNamespace,
+        GITHUB_OAUTH_CLIENT_ID: 'cid',
+        GITHUB_OAUTH_CLIENT_SECRET: 'csec',
+        JWT_SIGNING_KEY: KEY_HEX,
+        JWT_REFRESH_SIGNING_KEY: KEY_HEX,
+        USER_DO: undefined as unknown as DurableObjectNamespace,
+        ASSETS: undefined as unknown as Fetcher,
+      };
+      const req = new Request('https://example.test/token', {
+        method: 'POST',
+        headers: { 'cf-ray': '8aa0001-IAD' },
+      });
+      await worker.fetch(req, env as unknown as Parameters<typeof worker.fetch>[1]);
+    } finally {
+      cap.restore();
+    }
+    const route = findEvent(cap.lines, 'worker.route');
+    expect(route).toBeDefined();
+    expect(route!.request_id).toBe('8aa0001-IAD');
+  });
+});
+
+describe('OAuth event log — failure paths (F-T-3)', () => {
+  it('callback fail: csrf mismatch emits oauth.callback_fail with reason', async () => {
+    const cap = captureConsole();
+    try {
+      const stub = makeUserDoStub({ revoked: false });
+      const env = makeAuthEnv(stub);
+      const req = new Request(
+        'https://example/api/auth/github/callback?code=c&state=client',
+        { headers: { 'X-CCSM-Request-Id': 'req-test-1', Cookie: 'csrf=server' } },
+      );
+      const res = await handleGithubCallback(req, env);
+      expect(res.status).toBe(400);
+    } finally {
+      cap.restore();
+    }
+    const ev = findEvent(cap.lines, 'oauth.callback_fail');
+    expect(ev).toBeDefined();
+    expect(ev!.request_id).toBe('req-test-1');
+    expect((ev!.fields as Record<string, unknown>).reason).toBe('csrf_mismatch');
+  });
+
+  it('refresh fail: invalid token emits auth.refresh_fail', async () => {
+    const cap = captureConsole();
+    try {
+      const state: UserDoState = { revoked: false };
+      // Pre-populate hash so verify can mismatch.
+      state.refresh_hash = 'pre-existing-hash';
+      const stub = makeUserDoStub(state);
+      const env = makeAuthEnv(stub);
+      const req = new Request('https://example/api/auth/refresh', {
+        method: 'POST',
+        headers: {
+          'X-CCSM-Request-Id': 'req-refresh-bad',
+          Cookie: 'refresh=wrong_token; login=octocat',
+        },
+      });
+      const res = await handleRefresh(req, env);
+      expect(res.status).toBe(401);
+    } finally {
+      cap.restore();
+    }
+    const ev = findEvent(cap.lines, 'auth.refresh_fail');
+    expect(ev).toBeDefined();
+    expect(ev!.request_id).toBe('req-refresh-bad');
+    expect((ev!.fields as Record<string, unknown>).reason).toBe(
+      'invalid_refresh_token',
+    );
+  });
+
+  it('refresh fail: missing cookie emits auth.refresh_fail', async () => {
+    const cap = captureConsole();
+    try {
+      const stub = makeUserDoStub({ revoked: false });
+      const env = makeAuthEnv(stub);
+      const req = new Request('https://example/api/auth/refresh', {
+        method: 'POST',
+        headers: { 'X-CCSM-Request-Id': 'req-no-cookie' },
+      });
+      const res = await handleRefresh(req, env);
+      expect(res.status).toBe(401);
+    } finally {
+      cap.restore();
+    }
+    const ev = findEvent(cap.lines, 'auth.refresh_fail');
+    expect(ev).toBeDefined();
+    expect((ev!.fields as Record<string, unknown>).reason).toBe('missing_cookie');
+  });
+
+  it('device.poll error: github access_denied emits device.poll with denied result', async () => {
+    const cap = captureConsole();
+    try {
+      globalThis.fetch = vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ error: 'access_denied' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      ) as typeof fetch;
+      const stub = makeUserDoStub({ revoked: false });
+      const env = makeAuthEnv(stub);
+      const req = new Request('https://example/api/auth/device/poll', {
+        method: 'POST',
+        headers: {
+          'X-CCSM-Request-Id': 'req-device-1',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ device_code: 'dc-1' }),
+      });
+      const res = await handleDevicePoll(req, env);
+      expect(res.status).toBe(403);
+    } finally {
+      cap.restore();
+    }
+    const ev = findEvent(cap.lines, 'device.poll');
+    expect(ev).toBeDefined();
+    expect(ev!.request_id).toBe('req-device-1');
+    expect((ev!.fields as Record<string, unknown>).result).toBe('denied');
+  });
+
+  it('tunnel.refresh fail: invalid token emits tunnel.refresh_fail', async () => {
+    const cap = captureConsole();
+    try {
+      const state: UserDoState = { revoked: false };
+      state.tunnel_refresh_hash = 'real-hash';
+      const stub = makeUserDoStub(state);
+      const env = makeAuthEnv(stub);
+      const req = new Request('https://example/api/auth/tunnel/refresh', {
+        method: 'POST',
+        headers: {
+          'X-CCSM-Request-Id': 'req-tun-1',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          tunnel_refresh_token: 'wrong',
+          login: 'octocat',
+        }),
+      });
+      const res = await handleTunnelRefresh(req, env);
+      expect(res.status).toBe(401);
+    } finally {
+      cap.restore();
+    }
+    const ev = findEvent(cap.lines, 'tunnel.refresh_fail');
+    expect(ev).toBeDefined();
+    expect(ev!.request_id).toBe('req-tun-1');
+    expect((ev!.fields as Record<string, unknown>).reason).toBe('invalid_token');
+    // Login is not a secret, but assert it surfaces so ops can attribute.
+    expect((ev!.fields as Record<string, unknown>).login).toBe('octocat');
+  });
+});
+
+describe('redaction at integration boundary (F-T-3)', () => {
+  it('full callback success path does not leak access_token in any log line', async () => {
+    const cap = captureConsole();
+    try {
+      // Stub GitHub: token exchange + user fetch.
+      globalThis.fetch = vi.fn().mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/login/oauth/access_token')) {
+          return new Response(
+            JSON.stringify({ access_token: 'gho_should_never_appear_in_logs' }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          );
+        }
+        if (typeof url === 'string' && url.includes('api.github.com/user')) {
+          return new Response(JSON.stringify({ id: 12345678, login: 'octocat' }), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        return new Response('nope', { status: 500 });
+      }) as typeof fetch;
+      const stub = makeUserDoStub({ revoked: false });
+      const env = makeAuthEnv(stub);
+      const req = new Request(
+        'https://example/api/auth/github/callback?code=c&state=s',
+        { headers: { 'X-CCSM-Request-Id': 'req-ok-1', Cookie: 'csrf=s' } },
+      );
+      const res = await handleGithubCallback(req, env);
+      expect(res.status).toBe(302);
+    } finally {
+      cap.restore();
+    }
+    const ok = findEvent(cap.lines, 'oauth.callback_ok');
+    expect(ok).toBeDefined();
+    expect(ok!.request_id).toBe('req-ok-1');
+    // Hard guard: the access_token must not appear in any captured log line.
+    for (const l of cap.lines) {
+      expect(l.raw).not.toContain('gho_should_never_appear_in_logs');
+    }
+    // sub_prefix surfaces but full sub does not (sub=12345678 happens to be
+    // 8 chars, identical to its prefix; assert prefix shape).
+    expect((ok!.fields as Record<string, unknown>).sub_prefix).toBe('12345678');
+  });
+});

--- a/packages/daemon/src/tunnel.mts
+++ b/packages/daemon/src/tunnel.mts
@@ -247,6 +247,14 @@ interface HttpReqFrame {
   path: string;
   headers: Record<string, string>;
   body_b64: string;
+  /**
+   * R-46 audit-P0 (Task #158, F-T-2): worker-derived request_id propagated
+   * end-to-end so daemon log records can be correlated with worker + DO
+   * records. Optional for wire-format backward compat: a daemon talking to
+   * an older cf-worker (no field) falls back to a `"no-req-id"` placeholder
+   * in log records.
+   */
+  request_id?: string;
 }
 
 interface HttpResFrame {
@@ -264,6 +272,15 @@ function parseHttpReq(parsed: Record<string, unknown>): HttpReqFrame | null {
   if (typeof parsed.path !== 'string') return null;
   if (typeof parsed.body_b64 !== 'string') return null;
   if (parsed.headers === null || typeof parsed.headers !== 'object') return null;
+  // R-46 (Task #158): request_id is optional. Older cf-worker builds will
+  // not send it; we tolerate the missing field rather than rejecting the
+  // frame (would break wire compat).
+  if (
+    parsed.request_id !== undefined &&
+    typeof parsed.request_id !== 'string'
+  ) {
+    return null;
+  }
   // Trust the DO; we already shape-checked the surface fields.
   return parsed as unknown as HttpReqFrame;
 }
@@ -762,8 +779,13 @@ export class TunnelClient {
    * deterministic upstream error instead of a hung request.
    */
   private async handleHttpReq(frame: HttpReqFrame): Promise<void> {
+    // R-46 (Task #158, F-T-2): request_id propagated from cf-worker via
+    // the http_req frame; placeholder when absent (older worker / direct
+    // unit test). Surfaced into r28 forensics tags so the daemon line can
+    // be correlated with worker+DO lines for the same request.
+    const reqId = frame.request_id ?? 'no-req-id';
     if (this.daemonLoopbackPort === 0) {
-      console.error('[r28][daemon] http_req id=' + frame.id + ' ' + frame.method + ' ' + frame.path + ' decision=503-no-loopback-port');
+      console.error('[r28][daemon] http_req id=' + frame.id + ' req_id=' + reqId + ' ' + frame.method + ' ' + frame.path + ' decision=503-no-loopback-port');
       this.send(JSON.stringify({
         type: 'http_res',
         id: frame.id,
@@ -786,7 +808,7 @@ export class TunnelClient {
       headers[k] = v;
     }
     console.error(`[ccsm] tunnel: rx http_req ${frame.method} ${frame.path}`);
-    console.error('[r28][daemon] http_req enter id=' + frame.id + ' ' + frame.method + ' ' + frame.path + ' loopback_port=' + this.daemonLoopbackPort + ' body_len=' + (body?.length ?? 0));
+    console.error('[r28][daemon] http_req enter id=' + frame.id + ' req_id=' + reqId + ' ' + frame.method + ' ' + frame.path + ' loopback_port=' + this.daemonLoopbackPort + ' body_len=' + (body?.length ?? 0));
     const r28Started = Date.now();
     let response: globalThis.Response;
     try {
@@ -800,7 +822,7 @@ export class TunnelClient {
       }
       response = await this.fetchImpl(url, init);
     } catch (err) {
-      console.error('[r28][daemon] http_req id=' + frame.id + ' fetch-threw err=' + (err as Error).message + ' dur_ms=' + (Date.now() - r28Started));
+      console.error('[r28][daemon] http_req id=' + frame.id + ' req_id=' + reqId + ' fetch-threw err=' + (err as Error).message + ' dur_ms=' + (Date.now() - r28Started));
       this.send(JSON.stringify({
         type: 'http_res',
         id: frame.id,
@@ -815,7 +837,7 @@ export class TunnelClient {
       resHeaders[k] = v;
     });
     const resBody = Buffer.from(await response.arrayBuffer());
-    console.error('[r28][daemon] http_req exit id=' + frame.id + ' status=' + response.status + ' body_len=' + resBody.length + ' dur_ms=' + (Date.now() - r28Started));
+    console.error('[r28][daemon] http_req exit id=' + frame.id + ' req_id=' + reqId + ' status=' + response.status + ' body_len=' + resBody.length + ' dur_ms=' + (Date.now() - r28Started));
     this.send(JSON.stringify({
       type: 'http_res',
       id: frame.id,


### PR DESCRIPTION
## Summary

R-46 audit-P0 三 P0 一包 (F-T-1/2/3) — production 上线前的 observability 地基。

- **F-T-1**: cf-worker 结构化 JSON logger (`packages/cf-worker/src/logger.ts`) — level / event / request_id / fields, 敏感字段自动 redact, child(requestId) 工厂
- **F-T-2**: request_id 串穿 SPA → cf-worker → DO → daemon, cf-ray 优先 / uuid fallback, 走 `X-CCSM-Request-Id` header + http_req frame 可选字段
- **F-T-3**: 8 类 OAuth event log (oauth.login_redirect / callback_ok / callback_fail / auth.refresh_ok / refresh_fail / auth.logout / device.poll / tunnel.refresh_ok / tunnel.refresh_fail), 每个失败带结构化 `reason`

forensics tag (`[r28]`, `[r31]`, `[r38]`) 没动 — 留给 R-47。

## Wire compat

- `HttpReqFrame.request_id` 是 **optional 新字段**, 不改字段顺序、不加必填。
- daemon `parseHttpReq` 容忍缺失字段, 缺则填 `"no-req-id"` 占位 (r28 forensics 行能区分)
- 老 daemon 看新 worker 的 frame: 忽略 `request_id` 字段, 行为不变
- 新 daemon 看老 worker 的 frame: 走 `"no-req-id"` 分支, 行为不变

## Redaction safety

`sanitizeFields` 子串匹配 (case-insensitive) 拦下 `token` / `secret` / `password` / `cookie` / `authorization` / `jwt`。集成边界测试 `redaction at integration boundary (F-T-3)` 跑完整 callback 成功路径 (stub 一个 `gho_should_never_appear_in_logs` access_token), 断言该 token 字符串在所有 captured log line 里 0 出现。

## Local checks (host: Windows 11, mode: fast)

- lint: ✓ (cf-worker + daemon 全过; 4 处 pre-existing errors 不在我改的文件: daemon/test/persist.test.ts / frontend-tauri/test/PhaseSwitch.test.tsx / ui/test/BootstrapRefresh.test.tsx / tools/cloud-e2e/specs/two-tab-pairing.spec.ts — 走 patch-flow checkout origin/working baseline 验证, 同样 4 errors)
- typecheck: ✓ (pnpm -r run typecheck — 所有包绿)
- build: ✓ (cf-worker tsc --noEmit 包含 build)
- unit tests: cf-worker 165 passed (142 baseline + 15 logger + 8 observability) ; daemon 180 passed | 1 pre-existing skipped = 181 (跟 R-45 后 baseline 一致) ; frontend-web 39 passed (不变)
- e2e: skipped — 改源不影响 e2e probe (新增 logger / cf-worker oauth event log, 没改 PTY/session 路径; e2e harness 没覆盖 oauth event log)
- grep skip 0 命中: my diff 没引入任何 .skip / xit / .todo (`git diff origin/working --name-only` 文件全部 grep 0)

## Notes

- daemon refresh client (R-45) 跑的 fetch 不带 request_id (spec 说 follow up, 这 PR 没动)
- `[r28]` forensics 行加了 `req_id=<id>` 字段方便跟新 logger line 关联, 不破坏现有行格式 (只是末尾加了个 token)