### PR TITLE
shared: R-48 audit-P0 sid envelope + tunnel frame schema SoT (Task #160)

### DIFF
--- a/packages/cf-worker/package.json
+++ b/packages/cf-worker/package.json
@@ -11,6 +11,9 @@
     "lint": "eslint src --max-warnings=0",
     "test": "vitest run"
   },
+  "dependencies": {
+    "@ccsm/shared": "workspace:*"
+  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240909.0",
     "typescript": "^5.6.3",

--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -1,8 +1,30 @@
 import { DurableObject } from 'cloudflare:workers';
 import type { Env } from './index';
 
-/** Subprotocol prefix matching frontend-web/src/hostConfig.ts (Task #782). */
-const WS_SUBPROTOCOL_PREFIX = 'ccsm.';
+// R-48 (Task #160): sid envelope codec + tunnel control-frame types are SoT
+// in @ccsm/shared. The daemon-side codec (packages/daemon/src/tunnel.mts)
+// imports the same module; envelope.test.ts proves the two ends agree
+// byte-for-byte (R-41 envelope regression history).
+import {
+  WS_SUBPROTOCOL_PREFIX,
+  decodeSidEnvelope as decodeSidEnvelopeShared,
+  encodeSidEnvelope,
+  type BrowserIdentity,
+  type HelloFrame,
+  type HttpReqFrame,
+  type HttpResFrame,
+} from '@ccsm/shared';
+
+/**
+ * DO-side decode adapter: the WebSocket Hibernation API delivers binary
+ * frames as `ArrayBuffer`; the shared codec works on `Uint8Array`. Wrap
+ * once at the call boundary so the rest of the file stays unchanged.
+ */
+function decodeSidEnvelope(
+  buf: ArrayBuffer,
+): { sid: string; payload: Uint8Array } | null {
+  return decodeSidEnvelopeShared(new Uint8Array(buf));
+}
 
 /**
  * HTTP-over-tunnel timeout. Cloudflare Worker subrequest cap is 30s; we
@@ -24,106 +46,11 @@ const TAG_BROWSER = 'browser';
  */
 const TAG_BROWSER_SID_PREFIX = 'browser-sid:';
 
-/** Bound on inbound sid-envelope sidLen — must match daemon-side helper. */
-const ENVELOPE_MAX_SID_LEN = 64;
-
-function encodeSidEnvelope(sid: string, payload: ArrayBuffer | Uint8Array): Uint8Array {
-  const sidBytes = new TextEncoder().encode(sid);
-  if (sidBytes.length === 0 || sidBytes.length > ENVELOPE_MAX_SID_LEN) {
-    throw new Error('encodeSidEnvelope: bad sid length ' + sidBytes.length);
-  }
-  const payloadView = payload instanceof Uint8Array
-    ? payload
-    : new Uint8Array(payload);
-  const out = new Uint8Array(1 + sidBytes.length + payloadView.byteLength);
-  out[0] = sidBytes.length;
-  out.set(sidBytes, 1);
-  out.set(payloadView, 1 + sidBytes.length);
-  return out;
-}
-
-function decodeSidEnvelope(buf: ArrayBuffer): { sid: string; payload: Uint8Array } | null {
-  const view = new Uint8Array(buf);
-  if (view.byteLength < 2) return null;
-  const sidLen = view[0] ?? 0;
-  if (sidLen === 0 || sidLen > ENVELOPE_MAX_SID_LEN) return null;
-  if (view.byteLength < 1 + sidLen) return null;
-  const sid = new TextDecoder().decode(view.subarray(1, 1 + sidLen));
-  const payload = view.subarray(1 + sidLen);
-  return { sid, payload };
-}
-
-/**
- * Hello control frame the DO injects ahead of any browser→daemon traffic so
- * the daemon can run the browser-presented token through its existing
- * classifyOrigin / token check path (Task #782, S3-T6).
- *
- * Wire format: JSON text frame `{"type":"hello","token":"<t>","sid":"<s>","lastSeq":<n>}`.
- * `sid` + `lastSeq` were added in Task #793 (S3-G) so the daemon can route
- * the paired browser ws into the right per-session PTY ring buffer; older
- * deployments without those fields fall back to "no session attached"
- * behaviour on the daemon side. Subsequent frames are raw passthrough. The
- * daemon side parses ONLY the first text frame as hello; if it's missing or
- * malformed the daemon closes 1008.
- */
-interface HelloFrame {
-  type: 'hello';
-  token: string;
-  /** Task #793: session id the browser is attaching to (`sid` query param). */
-  sid?: string;
-  /** Task #793: ring-buffer replay cursor (`lastSeq` query param, default 0). */
-  lastSeq?: number;
-  /**
-   * Task #133 (S4-T6): cloud-authenticated browser identity. When present,
-   * a daemon running with `CCSM_TRUST_TUNNEL=1` accepts the hello on the
-   * strength of this field alone (cloud has already verified the OAuth
-   * session via the worker's JWT mint endpoint). Older daemons ignore the
-   * field. Optional during S4 rollout — the OAuth flow that populates it
-   * lands in T3/T4; T6 only carries the wire field.
-   */
-  identity?: BrowserIdentity;
-}
-
-/**
- * Browser identity emitted to the daemon in trust-tunnel mode (Task #133,
- * S4-T6). Mirrors the `BrowserIdentity` shape on the daemon side.
- */
-interface BrowserIdentity {
-  login: string;
-  github_id: string;
-}
-
-/**
- * HTTP-over-tunnel frames (Task #787, S3-C). Mux REST `/api/*` + `/token`
- * over the same daemon-dialed ws so the browser only ever talks to
- * cc-sm.pages.dev. Distinguished from S3-T6 raw OUTPUT/INPUT frames by the
- * `type` field — raw frames are binary OR text without a JSON `type`.
- */
-interface HttpReqFrame {
-  type: 'http_req';
-  id: string;
-  method: string;
-  path: string;
-  headers: Record<string, string>;
-  body_b64: string;
-  /**
-   * R-46 audit-P0 (Task #158, F-T-2): worker-derived request_id propagated
-   * to the daemon so daemon-side log records can be correlated with the
-   * Worker + DO records for the same request. Optional for wire-format
-   * backward compat — daemons running an older build will simply ignore
-   * the field, and the DO accepts a frame without `request_id` (legacy
-   * Worker callsite).
-   */
-  request_id?: string;
-}
-
-interface HttpResFrame {
-  type: 'http_res';
-  id: string;
-  status: number;
-  headers: Record<string, string>;
-  body_b64: string;
-}
+// R-48 (Task #160): `ENVELOPE_MAX_SID_LEN`, `encodeSidEnvelope`,
+// `HelloFrame`, `BrowserIdentity`, `HttpReqFrame`, `HttpResFrame` all live
+// in @ccsm/shared. Imports at the top of this file. The daemon-side
+// equivalent (packages/daemon/src/tunnel.mts) imports the same module so
+// wire format cannot drift.
 
 interface PendingHttp {
   resolve: (res: Response) => void;
@@ -554,7 +481,7 @@ export class TunnelDO extends DurableObject<Env> {
     // PTY when multiple browser tabs share one tunnel ws.
     let envelope: Uint8Array;
     try {
-      envelope = encodeSidEnvelope(sid, data);
+      envelope = encodeSidEnvelope(sid, new Uint8Array(data));
     } catch (err) {
       console.log('[do] drop browser->daemon binary: envelope encode failed sid=' + sid + ' err=' + String(err));
       return;

--- a/packages/daemon/src/tunnel.mts
+++ b/packages/daemon/src/tunnel.mts
@@ -46,6 +46,20 @@ import { timingSafeEqual } from 'node:crypto';
 
 import WebSocket, { type RawData } from 'ws';
 
+// R-48 (Task #160): sid envelope codec + tunnel control-frame types are SoT
+// in @ccsm/shared. Both daemon and cf-worker DO import the same module so
+// wire-format drift is impossible (R-41 envelope regression history).
+import {
+  decodeSidEnvelope as decodeSidEnvelopeShared,
+  encodeSidEnvelope as encodeSidEnvelopeShared,
+  type BrowserIdentity,
+  type HelloFrame,
+  type HttpReqFrame,
+  type HttpResFrame,
+} from '@ccsm/shared';
+
+export type { BrowserIdentity };
+
 export type TunnelState =
   | 'idle'
   | 'connecting'
@@ -163,21 +177,12 @@ function defaultWsFactory(url: string, protocols?: string[]): WsLike {
 }
 
 /**
- * Per-browser identity that the cloud has already authenticated on our
- * behalf (Task #133, S4-T6). Present only when the daemon is running in
- * trust-tunnel mode (env `CCSM_TRUST_TUNNEL=1`); legacy / smoke / dogfood
- * paths still ride the per-browser bearer token in `HelloFrame.token` and
- * leave `identity` undefined.
- *
- * `login` is the GitHub login (handle) and `github_id` is the numeric
- * GitHub user id rendered as a string so we don't lose precision on the
- * wire. Both are minted by the cloud token mint endpoint (T3/T4) once OAuth
- * lands; T6 only carries the field through.
+ * `BrowserIdentity`, `HelloFrame`, `HttpReqFrame`, `HttpResFrame` are
+ * imported from `@ccsm/shared` (R-48, Task #160). The daemon-side runtime
+ * parsers (`parseIdentity`, `parseHello`, `parseHttpReq`,
+ * `tryParseControlFrame`) live below — type SoT is shared, validation is
+ * local because daemon and DO have asymmetric strictness.
  */
-export interface BrowserIdentity {
-  login: string;
-  github_id: string;
-}
 
 function parseIdentity(value: unknown): BrowserIdentity | null {
   if (value === null || typeof value !== 'object') return null;
@@ -185,20 +190,6 @@ function parseIdentity(value: unknown): BrowserIdentity | null {
   if (typeof obj.login !== 'string' || obj.login.length === 0) return null;
   if (typeof obj.github_id !== 'string' || obj.github_id.length === 0) return null;
   return { login: obj.login, github_id: obj.github_id };
-}
-
-interface HelloFrame {
-  type: 'hello';
-  /** Legacy per-browser bearer token (constant-time-checked vs daemon token).
-   * Optional when the daemon is in trust-tunnel mode AND the hello carries an
-   * `identity` instead. */
-  token?: string;
-  /** Task #793 (S3-G): session id from the browser ws `?sid=` query. */
-  sid?: string;
-  /** Task #793 (S3-G): replay cursor from the browser ws `?lastSeq=` query. */
-  lastSeq?: number;
-  /** Task #133 (S4-T6): cloud-authenticated browser identity (trust-tunnel). */
-  identity?: BrowserIdentity;
 }
 
 /**
@@ -236,34 +227,10 @@ export function getExpectedOwnerId(): string | null {
 }
 
 /**
- * HTTP-over-tunnel control frames (Task #787, S3-C). Mux the loopback REST
- * surface over the same daemon-dialed ws so cloud browsers can hit
- * `cc-sm.pages.dev/api/*` without a direct path to the NAT'd daemon.
+ * HTTP-over-tunnel control frames (Task #787, S3-C) — `HttpReqFrame` and
+ * `HttpResFrame` types are imported from `@ccsm/shared` (R-48, Task #160).
+ * `parseHttpReq` below is the daemon-side runtime validator.
  */
-interface HttpReqFrame {
-  type: 'http_req';
-  id: string;
-  method: string;
-  path: string;
-  headers: Record<string, string>;
-  body_b64: string;
-  /**
-   * R-46 audit-P0 (Task #158, F-T-2): worker-derived request_id propagated
-   * end-to-end so daemon log records can be correlated with worker + DO
-   * records. Optional for wire-format backward compat: a daemon talking to
-   * an older cf-worker (no field) falls back to a `"no-req-id"` placeholder
-   * in log records.
-   */
-  request_id?: string;
-}
-
-interface HttpResFrame {
-  type: 'http_res';
-  id: string;
-  status: number;
-  headers: Record<string, string>;
-  body_b64: string;
-}
 
 function parseHttpReq(parsed: Record<string, unknown>): HttpReqFrame | null {
   if (parsed.type !== 'http_req') return null;
@@ -340,35 +307,33 @@ function parseHello(text: string): HelloFrame | null {
 // strings (~32 chars). A malformed envelope (sidLen=0, sidLen>buf-1, or
 // sidLen exceeding the cap) is dropped with a warn log on either side.
 
-const ENVELOPE_MAX_SID_LEN = 64;
+// R-48 (Task #160): wire-format helpers live in @ccsm/shared. The two
+// wrappers below preserve the legacy daemon-side return type (Node Buffer)
+// without touching call sites; the encoded BYTES are produced by the
+// shared codec and proven byte-aligned with the cf-worker side via
+// shared/test/envelope.test.ts.
 
-export function encodeSidEnvelope(sid: string, payload: Uint8Array | Buffer): Buffer {
-  const sidBuf = Buffer.from(sid, 'utf8');
-  if (sidBuf.length === 0 || sidBuf.length > ENVELOPE_MAX_SID_LEN) {
-    throw new Error(
-      `[ccsm/tunnel] encodeSidEnvelope: bad sid length ${sidBuf.length}`,
-    );
-  }
-  const payloadBuf = Buffer.isBuffer(payload)
-    ? payload
-    : Buffer.from(payload.buffer, payload.byteOffset, payload.byteLength);
-  const out = Buffer.allocUnsafe(1 + sidBuf.length + payloadBuf.length);
-  out.writeUInt8(sidBuf.length, 0);
-  sidBuf.copy(out, 1);
-  payloadBuf.copy(out, 1 + sidBuf.length);
-  return out;
+function encodeSidEnvelope(
+  sid: string,
+  payload: Uint8Array | Buffer,
+): Buffer {
+  const out = encodeSidEnvelopeShared(sid, payload);
+  return Buffer.from(out.buffer, out.byteOffset, out.byteLength);
 }
 
-export function decodeSidEnvelope(
+function decodeSidEnvelope(
   buf: Buffer,
 ): { sid: string; payload: Buffer } | null {
-  if (buf.length < 2) return null;
-  const sidLen = buf.readUInt8(0);
-  if (sidLen === 0 || sidLen > ENVELOPE_MAX_SID_LEN) return null;
-  if (buf.length < 1 + sidLen) return null;
-  const sid = buf.subarray(1, 1 + sidLen).toString('utf8');
-  const payload = buf.subarray(1 + sidLen);
-  return { sid, payload };
+  const out = decodeSidEnvelopeShared(buf);
+  if (out === null) return null;
+  return {
+    sid: out.sid,
+    payload: Buffer.from(
+      out.payload.buffer,
+      out.payload.byteOffset,
+      out.payload.byteLength,
+    ),
+  };
 }
 
 function constantTimeTokenEquals(presented: string, expected: string): boolean {

--- a/packages/shared/src/envelope.ts
+++ b/packages/shared/src/envelope.ts
@@ -1,0 +1,85 @@
+// Sid envelope codec shared by daemon (Node) and cf-worker DO (Cloudflare
+// Workers runtime).
+//
+// Wave-2 multi-tab routing (Task #105, R-41): the daemon and the DO share
+// ONE tunnel ws but must fan out N concurrent browser↔PTY sessions over it.
+// Every BINARY frame on the tunnel carries a small sid header so the
+// receiving side can route into the correct per-sid PTY (daemon side) or
+// per-sid browser ws (DO side). Control TEXT frames (hello / http_req /
+// http_res) are unchanged and are never wrapped.
+//
+// Wire format (binary frames only):
+//   byte 0:        sidLen (uint8, MUST be > 0 and <= ENVELOPE_MAX_SID_LEN)
+//   bytes 1..N:    sid as utf8
+//   bytes N+1..:   raw payload (the encoded INPUT / OUTPUT / RESIZE / EXIT
+//                  frame produced by encodeFrame)
+//
+// 64-byte cap on sid is a sanity bound — real sids are short hex/base64url
+// strings (~32 chars). A malformed envelope (sidLen=0, sidLen > cap, or
+// sidLen exceeding the buffer) decodes to null; both sides drop with a warn
+// log.
+//
+// R-48 (Task #160): single source of truth. Previously the daemon
+// (packages/daemon/src/tunnel.mts) and the DO (packages/cf-worker/src/
+// tunnel-do.ts) each kept their own copy. Wire-format drift here is a
+// silent corruption bug (frames decode but route to the wrong sid), so the
+// two implementations must NEVER diverge. Both call sites now import this
+// module and `envelope.test.ts` proves they agree byte-for-byte.
+
+/**
+ * Sanity bound on sid length (utf8 bytes). Real ccsm sids are short
+ * hex/base64url strings, well under 64 bytes. Frames whose sidLen header
+ * exceeds this cap are dropped on the receive side.
+ */
+export const ENVELOPE_MAX_SID_LEN = 64;
+
+/**
+ * Encode `payload` with a leading sid header. Returns a fresh `Uint8Array`
+ * — the caller does NOT need to copy. Throws when `sid` is empty or its
+ * utf8 encoding exceeds {@link ENVELOPE_MAX_SID_LEN} (programmer error).
+ *
+ * Accepts both `Uint8Array` (DO / cf-worker) and Node `Buffer` (daemon) for
+ * `payload`; `Buffer` is a `Uint8Array` subclass so `instanceof Uint8Array`
+ * is true and no special-casing is needed. The returned `Uint8Array`
+ * inter-operates with both runtimes — Node consumers can wrap it with
+ * `Buffer.from(out.buffer, out.byteOffset, out.byteLength)` when a `Buffer`
+ * is expected on the wire-send API.
+ */
+export function encodeSidEnvelope(
+  sid: string,
+  payload: Uint8Array,
+): Uint8Array {
+  const sidBytes = new TextEncoder().encode(sid);
+  if (sidBytes.length === 0 || sidBytes.length > ENVELOPE_MAX_SID_LEN) {
+    throw new Error(
+      `encodeSidEnvelope: bad sid length ${sidBytes.length} (sid must be 1..${ENVELOPE_MAX_SID_LEN} utf8 bytes)`,
+    );
+  }
+  const out = new Uint8Array(1 + sidBytes.length + payload.byteLength);
+  out[0] = sidBytes.length;
+  out.set(sidBytes, 1);
+  out.set(payload, 1 + sidBytes.length);
+  return out;
+}
+
+/**
+ * Decode a sid-envelope buffer. Returns `null` when the buffer is too
+ * short, has `sidLen === 0`, has `sidLen > ENVELOPE_MAX_SID_LEN`, or has
+ * `sidLen` larger than the remaining bytes (malformed). Successful decodes
+ * return `{ sid, payload }` where `payload` is a sub-array view into the
+ * input — copy if you need to outlive the input.
+ *
+ * Accepts `Uint8Array` (DO) or anything `Uint8Array`-shaped (Node `Buffer`
+ * is a `Uint8Array` subclass).
+ */
+export function decodeSidEnvelope(
+  buf: Uint8Array,
+): { sid: string; payload: Uint8Array } | null {
+  if (buf.byteLength < 2) return null;
+  const sidLen = buf[0] ?? 0;
+  if (sidLen === 0 || sidLen > ENVELOPE_MAX_SID_LEN) return null;
+  if (buf.byteLength < 1 + sidLen) return null;
+  const sid = new TextDecoder().decode(buf.subarray(1, 1 + sidLen));
+  const payload = buf.subarray(1 + sidLen);
+  return { sid, payload };
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,4 @@
 export * from './frame.js';
 export * from './api.js';
+export * from './envelope.js';
+export * from './tunnel-frame.js';

--- a/packages/shared/src/tunnel-frame.ts
+++ b/packages/shared/src/tunnel-frame.ts
@@ -1,0 +1,122 @@
+// Tunnel control-frame types + ws subprotocol constant shared between the
+// daemon (packages/daemon/src/tunnel.mts) and the cf-worker TunnelDO
+// (packages/cf-worker/src/tunnel-do.ts).
+//
+// R-48 (Task #160): single source of truth. The daemon and DO previously
+// each redeclared HelloFrame / HttpReqFrame / HttpResFrame / BrowserIdentity
+// and each held their own `WS_SUBPROTOCOL_PREFIX = 'ccsm.'` constant. Wire
+// drift between the two was a silent-corruption class of bug (R-41 envelope
+// regression history); putting the type & constant SoT here removes one
+// drift surface.
+//
+// NOTE: only the *type* declarations live here. Each side keeps its own
+// runtime parser (`parseHttpReq`, `parseHello`, `tryParseControlFrame`)
+// because the two sides need different validation strictness:
+//   - daemon validates the FIRST text frame as a hello and accepts http_req
+//     mid-stream; rejects anything else 1008.
+//   - DO validates daemon-side text frames as http_res; raw text without a
+//     JSON `type` is OUTPUT passthrough.
+// Sharing the type definitions is the structural anchor; the runtime
+// validators stay local because their failure modes are not symmetric.
+
+/**
+ * WebSocket subprotocol prefix used by both browser↔DO and daemon↔DO
+ * handshakes (RFC 6455 §1.9). Browsers cannot set custom headers on
+ * `new WebSocket(url, protocols)` so the per-conn token rides
+ * `Sec-WebSocket-Protocol: ccsm.<token>`. The daemon does the same with its
+ * cloud-issued tunnel JWT (`ccsm.<jwt>`, S4-T8 / Task #141).
+ *
+ * Same value also lives at packages/frontend-web/src/hostConfig.ts and
+ * packages/core/src/ws/client.ts for the SPA / xterm side; those copies
+ * predate this SoT and are left untouched here so this PR's blast radius
+ * stays contained to daemon + cf-worker (Task #160). A follow-up can fold
+ * them in.
+ */
+export const WS_SUBPROTOCOL_PREFIX = 'ccsm.';
+
+/**
+ * Per-browser identity that the cloud has already authenticated on our
+ * behalf (Task #133, S4-T6). Present only when the daemon is running in
+ * trust-tunnel mode (env `CCSM_TRUST_TUNNEL=1`); legacy / smoke / dogfood
+ * paths still ride the per-browser bearer token in `HelloFrame.token` and
+ * leave `identity` undefined.
+ *
+ * `login` is the GitHub login (handle); `github_id` is the numeric GitHub
+ * user id rendered as a string so we don't lose precision on the wire.
+ */
+export interface BrowserIdentity {
+  login: string;
+  github_id: string;
+}
+
+/**
+ * First text frame the DO injects on the tunnel ws ahead of any
+ * browser→daemon traffic so the daemon can run the browser-presented token
+ * (or trust-tunnel identity) through its existing auth check path.
+ *
+ * Wire format: JSON text frame
+ *   `{"type":"hello","token":"<t>","sid":"<s>","lastSeq":<n>,"identity":{...}}`
+ *
+ * Field optionality:
+ *   - `token` is optional in trust-tunnel mode (Task #133, S4-T6); present
+ *     on legacy / dogfood deployments.
+ *   - `sid` + `lastSeq` are absent on legacy DO builds without per-session
+ *     attach (Task #793 added them); newer DOs always send them.
+ *   - `identity` is present only when the cloud verified an OAuth session
+ *     and the daemon trusts the cloud (`CCSM_TRUST_TUNNEL=1`).
+ *
+ * Subsequent frames are raw passthrough. The daemon parses ONLY the first
+ * text frame as hello; if it's missing or malformed the daemon closes 1008.
+ */
+export interface HelloFrame {
+  type: 'hello';
+  /**
+   * Legacy per-browser bearer token (constant-time-checked vs daemon
+   * token). Optional when the daemon is in trust-tunnel mode AND the hello
+   * carries an `identity` instead.
+   */
+  token?: string;
+  /** Task #793 (S3-G): session id from the browser ws `?sid=` query. */
+  sid?: string;
+  /** Task #793 (S3-G): replay cursor from the browser ws `?lastSeq=` query. */
+  lastSeq?: number;
+  /** Task #133 (S4-T6): cloud-authenticated browser identity (trust-tunnel). */
+  identity?: BrowserIdentity;
+}
+
+/**
+ * HTTP-over-tunnel request control frame (Task #787, S3-C). The DO mux'es
+ * `/api/*` and `/token` over the daemon ws by serializing the inbound
+ * Request as one of these frames; the daemon fetches it against the
+ * loopback REST surface and replies with an {@link HttpResFrame} of the
+ * same `id`.
+ */
+export interface HttpReqFrame {
+  type: 'http_req';
+  id: string;
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  body_b64: string;
+  /**
+   * R-46 audit-P0 (Task #158, F-T-2): worker-derived request_id propagated
+   * end-to-end so daemon log records can be correlated with worker + DO
+   * records. Optional for wire-format backward compat: a daemon talking to
+   * an older cf-worker (no field) falls back to a `"no-req-id"` placeholder
+   * in log records, and the DO accepts a frame without `request_id`
+   * (legacy Worker callsite).
+   */
+  request_id?: string;
+}
+
+/**
+ * HTTP-over-tunnel response control frame (Task #787, S3-C). Daemon-→DO
+ * reply for an inbound {@link HttpReqFrame} with matching `id`.
+ */
+export interface HttpResFrame {
+  type: 'http_res';
+  id: string;
+  status: number;
+  headers: Record<string, string>;
+  body_b64: string;
+}

--- a/packages/shared/test/envelope.test.ts
+++ b/packages/shared/test/envelope.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ENVELOPE_MAX_SID_LEN,
+  decodeSidEnvelope,
+  encodeSidEnvelope,
+} from '../src/envelope.js';
+
+describe('encodeSidEnvelope / decodeSidEnvelope roundtrip', () => {
+  it('roundtrips a typical sid + small payload', () => {
+    const sid = 'abc123';
+    const payload = new Uint8Array([0x01, 0x02, 0x03, 0xff]);
+    const encoded = encodeSidEnvelope(sid, payload);
+    // Header byte is the sidLen (utf8 bytes); 'abc123' is ASCII so 6.
+    expect(encoded[0]).toBe(6);
+    const decoded = decodeSidEnvelope(encoded);
+    expect(decoded).not.toBeNull();
+    expect(decoded?.sid).toBe(sid);
+    expect(Array.from(decoded!.payload)).toEqual(Array.from(payload));
+  });
+
+  it('roundtrips a multibyte-utf8 sid', () => {
+    // 'café' encodes to 5 utf8 bytes (c,a,f,0xc3,0xa9).
+    const sid = 'café';
+    const payload = new Uint8Array([42]);
+    const encoded = encodeSidEnvelope(sid, payload);
+    expect(encoded[0]).toBe(5);
+    const decoded = decodeSidEnvelope(encoded);
+    expect(decoded?.sid).toBe(sid);
+    expect(decoded?.payload.byteLength).toBe(1);
+    expect(decoded?.payload[0]).toBe(42);
+  });
+
+  it('roundtrips an empty payload', () => {
+    const encoded = encodeSidEnvelope('s', new Uint8Array(0));
+    expect(encoded.byteLength).toBe(2); // 1 (sidLen) + 1 (sid) + 0
+    const decoded = decodeSidEnvelope(encoded);
+    expect(decoded?.sid).toBe('s');
+    expect(decoded?.payload.byteLength).toBe(0);
+  });
+
+  it('roundtrips at the sid length cap', () => {
+    const sid = 'a'.repeat(ENVELOPE_MAX_SID_LEN);
+    const payload = new Uint8Array([7]);
+    const encoded = encodeSidEnvelope(sid, payload);
+    expect(encoded[0]).toBe(ENVELOPE_MAX_SID_LEN);
+    const decoded = decodeSidEnvelope(encoded);
+    expect(decoded?.sid).toBe(sid);
+    expect(decoded?.payload[0]).toBe(7);
+  });
+});
+
+describe('encodeSidEnvelope rejects invalid sid', () => {
+  it('throws on empty sid', () => {
+    expect(() => encodeSidEnvelope('', new Uint8Array(0))).toThrow(
+      /bad sid length/i,
+    );
+  });
+
+  it('throws on sid utf8 length > cap', () => {
+    const sid = 'a'.repeat(ENVELOPE_MAX_SID_LEN + 1);
+    expect(() => encodeSidEnvelope(sid, new Uint8Array(0))).toThrow(
+      /bad sid length/i,
+    );
+  });
+});
+
+describe('decodeSidEnvelope rejects malformed input', () => {
+  it('returns null for buffer too short (< 2 bytes)', () => {
+    expect(decodeSidEnvelope(new Uint8Array(0))).toBeNull();
+    expect(decodeSidEnvelope(new Uint8Array(1))).toBeNull();
+  });
+
+  it('returns null for sidLen === 0', () => {
+    const buf = new Uint8Array([0, 0xaa]);
+    expect(decodeSidEnvelope(buf)).toBeNull();
+  });
+
+  it('returns null for sidLen > cap', () => {
+    const buf = new Uint8Array(2 + ENVELOPE_MAX_SID_LEN);
+    buf[0] = ENVELOPE_MAX_SID_LEN + 1;
+    expect(decodeSidEnvelope(buf)).toBeNull();
+  });
+
+  it('returns null when sidLen exceeds remaining bytes', () => {
+    // Header claims 10-byte sid but only 3 bytes follow.
+    const buf = new Uint8Array([10, 0x61, 0x62, 0x63]);
+    expect(decodeSidEnvelope(buf)).toBeNull();
+  });
+});
+
+describe('cross-runtime byte alignment (daemon Buffer ↔ cf-worker Uint8Array)', () => {
+  // R-48 (Task #160): the daemon historically wrapped the encoder output
+  // with `Buffer.allocUnsafe` while the DO used `new Uint8Array`. The wire
+  // bytes MUST be identical so both ends decode each other's frames. We
+  // simulate the daemon side by wrapping the encoder output in a Node
+  // Buffer (Buffer is a Uint8Array subclass) and the DO side as plain
+  // Uint8Array; the byte sequence must match.
+  it('produces identical bytes when called via Uint8Array vs Buffer payload', () => {
+    const sid = 'sess-7';
+    const payloadBytes = new Uint8Array([0x10, 0x20, 0x30, 0x40]);
+
+    // DO-side: payload as Uint8Array straight in.
+    const fromUint8 = encodeSidEnvelope(sid, payloadBytes);
+
+    // Daemon-side simulation: payload arrives as a Node Buffer (subclass
+    // of Uint8Array). Buffer.from over the same bytes must yield identical
+    // wire output.
+    const bufferPayload = Buffer.from(payloadBytes);
+    const fromBuffer = encodeSidEnvelope(sid, bufferPayload);
+
+    expect(Array.from(fromBuffer)).toEqual(Array.from(fromUint8));
+  });
+
+  it('decodes bytes produced via Buffer-wrapped encoder output (daemon→DO direction)', () => {
+    const sid = 'sess-8';
+    const payload = new Uint8Array([1, 2, 3]);
+    const encoded = encodeSidEnvelope(sid, payload);
+    // Daemon side may hand the bytes off as a Buffer via
+    // `Buffer.from(out.buffer, out.byteOffset, out.byteLength)`. The DO
+    // receives an ArrayBuffer from the WS API; in either case decoding
+    // through `Uint8Array` view must produce the same sid + payload.
+    const asBuffer = Buffer.from(
+      encoded.buffer,
+      encoded.byteOffset,
+      encoded.byteLength,
+    );
+    const decoded = decodeSidEnvelope(asBuffer);
+    expect(decoded?.sid).toBe(sid);
+    expect(Array.from(decoded!.payload)).toEqual([1, 2, 3]);
+  });
+
+  it('decode is symmetric: encode on one side, decode on the other roundtrips byte-for-byte', () => {
+    // Pick a sid + payload representative of real PTY OUTPUT frame bytes
+    // (5-byte frame header + arbitrary payload).
+    const sid = 'tab-0xfeedface';
+    const payload = new Uint8Array(64);
+    for (let i = 0; i < payload.byteLength; i++) payload[i] = (i * 31) & 0xff;
+
+    const encodedDaemonSide = encodeSidEnvelope(sid, Buffer.from(payload));
+    // Verify wire layout explicitly: [sidLen][sid utf8][payload].
+    expect(encodedDaemonSide[0]).toBe(new TextEncoder().encode(sid).byteLength);
+
+    const decodedDoSide = decodeSidEnvelope(encodedDaemonSide);
+    expect(decodedDoSide?.sid).toBe(sid);
+    expect(Array.from(decodedDoSide!.payload)).toEqual(Array.from(payload));
+  });
+});

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -6,7 +6,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "target": "ES2022",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "WebWorker"],
     "declaration": true,
     "sourceMap": true
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,10 @@ importers:
         version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
   packages/cf-worker:
+    dependencies:
+      '@ccsm/shared':
+        specifier: workspace:*
+        version: link:../shared
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20240909.0


### PR DESCRIPTION
## Summary

R-48 audit-P0 F-Q-2: move sid-envelope codec and tunnel control-frame types out of daemon/cf-worker duplicates and into `@ccsm/shared`. R-41 envelope regression history shows that wire-format drift between the two ends is silent corruption (frames decode but route to the wrong sid), so this is a structural anchor — not a refactor.

## Changes

- **New** `packages/shared/src/envelope.ts`: `encodeSidEnvelope` / `decodeSidEnvelope` / `ENVELOPE_MAX_SID_LEN`. Uint8Array-based, runtime-portable (Node + Workers).
- **New** `packages/shared/src/tunnel-frame.ts`: `HelloFrame` / `HttpReqFrame` / `HttpResFrame` / `BrowserIdentity` types + `WS_SUBPROTOCOL_PREFIX` constant.
- **New** `packages/shared/test/envelope.test.ts`: 13 cases (roundtrip + multibyte utf8 + cap + empty payload + invalid sid + malformed decode + cross-runtime byte alignment trio).
- `packages/daemon/src/tunnel.mts`: deletes inline `BrowserIdentity` / `HelloFrame` / `HttpReqFrame` / `HttpResFrame` interfaces + inline envelope helpers (~125 lines). Imports from `@ccsm/shared`. Two thin wrappers preserve Node Buffer return type at call sites without changing wire bytes.
- `packages/cf-worker/src/tunnel-do.ts`: deletes inline interfaces + envelope helpers + `WS_SUBPROTOCOL_PREFIX` + `ENVELOPE_MAX_SID_LEN` (~133 lines). Imports from `@ccsm/shared`. Adds an `ArrayBuffer → Uint8Array` adapter at the WebSocket Hibernation API boundary.
- `packages/cf-worker/package.json`: adds `@ccsm/shared: workspace:*` dep so wrangler bundling resolves it.
- `packages/shared/tsconfig.json`: adds `WebWorker` to `lib` so `TextEncoder` / `TextDecoder` typecheck.

Wire format unchanged. Daemon-side `encodeSidEnvelope` still returns a Node `Buffer`; cf-worker-side still returns a `Uint8Array`. The encoded BYTES are produced by the same shared codec on both ends, proven byte-equivalent by `envelope.test.ts`.

## Evidence

- `shared` vitest: 46 tests pass (33 frame + 13 envelope), inc. cross-runtime byte-alignment trio (`encodeSidEnvelope` over Node Buffer vs Uint8Array yields identical wire bytes).
- `daemon` vitest: 180 passed + 1 skipped = 181 total (baseline matches Task #160 spec, `tunnel.test.ts` 31 cases inc. envelope routing all green).
- `cf-worker` vitest: 165 passed (baseline matches Task #160 spec; `tunnel-do.test.ts` 31 cases all green inc. R-41 sid-envelope routing tests).
- `frontend-web` vitest: 39 passed (no regression).
- `cloud-e2e` `cross-user-isolation.spec.ts`: both tests pass against local `wrangler dev --port 8787 --var CCSM_AUTH_MODE:jwt` with mint'd `.dev.vars`. Includes R-41 regression guard ("alice owning two browser tabs still pair on distinct sids").
- Lint: shared / daemon / cf-worker all `--max-warnings=0` clean.
- Typecheck: shared build emits .d.ts cleanly; daemon `tsc --noEmit` clean; cf-worker `tsc --noEmit` clean.

## Wire-format safety

The risk class this PR addresses (R-41 envelope regression) is silent corruption when the two ends drift. Three guards keep them locked:

1. Single source of truth — both daemon and cf-worker `import` from `@ccsm/shared`. There is no second copy left to drift from.
2. `envelope.test.ts` cross-runtime byte alignment cases assert that `encodeSidEnvelope(sid, Uint8Array)` and `encodeSidEnvelope(sid, Buffer.from(Uint8Array))` produce **identical bytes**, and that bytes encoded as Buffer-on-the-wire decode through `Uint8Array` view to the same sid + payload.
3. The cloud-e2e `cross-user-isolation.spec.ts` exercises real wrangler-dev TunnelDO + a raw daemon-impersonating ws + a raw browser-impersonating ws, including the R-41 regression case ("two tabs sharing one daemon → distinct sids in DO routing"). It passes.

## Out of scope (follow-up)

`WS_SUBPROTOCOL_PREFIX = 'ccsm.'` also lives at `packages/frontend-web/src/hostConfig.ts` and `packages/core/src/ws/client.ts` for the SPA / xterm side. Those copies predate this SoT and are intentionally left untouched here so this PR's blast radius stays contained to daemon + cf-worker (Task #160's stated scope). A follow-up can fold them in with a single-line import swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)