### PR TITLE
fix(frontend-tauri): R-50 tunnel as Ready sub-state (Task #164)

### DIFF
--- a/packages/frontend-tauri/src-tauri/src/daemon_mgr.rs
+++ b/packages/frontend-tauri/src-tauri/src/daemon_mgr.rs
@@ -21,7 +21,7 @@ use tokio::sync::mpsc;
 use tokio::time::{sleep, timeout};
 
 use crate::job_object::JobObject;
-use crate::daemon_state::{next_backoff, DaemonPhase, DaemonStateStore};
+use crate::daemon_state::{next_backoff, DaemonPhase, DaemonStateStore, TunnelState};
 
 #[derive(Default)]
 pub struct DaemonState {
@@ -418,29 +418,23 @@ async fn run_cycle(app: &AppHandle, kill_rx: &mut mpsc::Receiver<()>) -> CycleOu
 
     // stderr forwarder — surfaces daemon log lines + sniffs tunnel state
     // markers. Lives only as long as the stderr pipe (closes on child exit).
+    //
+    // R-50 (Task #164): tunnel state is now a sub-state of `Ready`, not a
+    // top-level phase. We call `set_tunnel_state` which (a) mutates Ready in
+    // place when the handshake has already landed, or (b) stashes the value
+    // when stderr races ahead of the handshake parse — preventing the bug
+    // where a top-level `TunnelConnected` emit overwrote `Ready` and froze
+    // the SPA on the "Tunnel connected, waiting…" overlay.
     let app_for_stderr = app.clone();
-    let token_for_stderr = token.clone();
     tokio::spawn(async move {
         let store: State<DaemonStateStore> = app_for_stderr.state();
         let mut reader = BufReader::new(stderr).lines();
         while let Ok(Some(line)) = reader.next_line().await {
             eprintln!("[daemon stderr] {line}");
             if line.contains("[ccsm] tunnel: connected") {
-                store.set_and_emit(
-                    &app_for_stderr,
-                    DaemonPhase::TunnelConnected {
-                        port: 9876,
-                        token: token_for_stderr.clone(),
-                    },
-                );
+                store.set_tunnel_state(&app_for_stderr, TunnelState::Connected);
             } else if line.contains("[ccsm] tunnel: disconnected") {
-                store.set_and_emit(
-                    &app_for_stderr,
-                    DaemonPhase::TunnelDisconnected {
-                        port: 9876,
-                        token: token_for_stderr.clone(),
-                    },
-                );
+                store.set_tunnel_state(&app_for_stderr, TunnelState::Disconnected);
             }
             let _ = app_for_stderr.emit("daemon-stderr", line);
         }
@@ -465,6 +459,12 @@ async fn run_cycle(app: &AppHandle, kill_rx: &mut mpsc::Receiver<()>) -> CycleOu
                     port: hs.port,
                     token: hs.token.clone(),
                     identity: None, // S4-T8 will populate after auth.
+                    // R-50 (Task #164): tunnel sub-state defaults to Pending
+                    // here. If the stderr observer already saw "tunnel:
+                    // connected" before this commit, the store's
+                    // `fold_pending_tunnel` step swaps Pending out for the
+                    // stashed value automatically.
+                    tunnel: TunnelState::Pending,
                 },
             );
             let _ = app.emit("daemon-ready", hs);

--- a/packages/frontend-tauri/src-tauri/src/daemon_state.rs
+++ b/packages/frontend-tauri/src-tauri/src/daemon_state.rs
@@ -5,6 +5,31 @@
 // while keeping legacy events emitted for backwards compatibility (see
 // daemon_mgr.rs — every legacy emit is paired with a `state.set_and_emit(...)`).
 //
+// R-50 (Task #164): tunnel state is no longer a top-level phase. It is now a
+// sub-state of `Ready`, because tunnel up/down is orthogonal to whether the
+// local PTY+HTTP daemon is serving the webview. The previous design — top-level
+// `TunnelConnected` / `TunnelDisconnected` variants — caused a regression where
+// a stderr-driven `TunnelConnected` emit, racing the inline handshake `Ready`
+// emit, would *overwrite* `Ready` and freeze the SPA on the "Tunnel connected,
+// waiting…" overlay. Reproducer evidence captured in /tmp/tauri-prod.log:
+//   1. handshake ok            → set Ready
+//   2. stderr "tunnel: connected" → set TunnelConnected (clobbers Ready)
+//
+// New design:
+//   * `TunnelState { Pending | Connected | Disconnected }` lives inside `Ready`.
+//   * Handshake transitions to `Ready { tunnel: Pending }` (or to whatever the
+//     stderr observer has already stashed — see `pending_tunnel` below).
+//   * The stderr observer calls `set_tunnel_state(...)`, which mutates the
+//     `tunnel` field in place when the current phase is `Ready` and re-emits.
+//     If the observer fires before the handshake (e.g. tunnel client connects
+//     before stdout handshake parse completes), the new state is *stashed* so
+//     the next Ready transition picks it up — no Ready overwrite, no lost
+//     update.
+//
+// This is the "fix at architecture layer" remedy (memory:
+// feedback_fix_arch_not_glue) for the phase-semantics confusion. Adding an
+// "if phase < new_phase" guard inside `set_and_emit` was rejected as a hack.
+//
 // scope (T1 only): Rust-side enum + state store + wire to existing emit points
 // + stderr tunnel-state stub. T2 owns supervisor retry; T3/T4 own SPA listener +
 // fallback UI; S4-T8 owns AwaitingAuth / AuthFailed real implementation (here
@@ -24,8 +49,31 @@ pub struct Identity {
     pub user_id: String,
 }
 
+/// Cloud tunnel sub-state, scoped to the `Ready` phase. The local daemon is
+/// already serving HTTP/PTY (that is what `Ready` means); the tunnel layer is
+/// orthogonal and may flap independently without disturbing the local UI.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum TunnelState {
+    /// Default sub-state at handshake time — tunnel has not reported up yet.
+    Pending,
+    /// stderr observed `[ccsm] tunnel: connected`.
+    Connected,
+    /// stderr observed `[ccsm] tunnel: disconnected`.
+    Disconnected,
+}
+
+impl Default for TunnelState {
+    fn default() -> Self {
+        TunnelState::Pending
+    }
+}
+
 /// Single source of truth for daemon lifecycle. Tagged enum so the SPA can
 /// pattern-match on `phase` after JSON deserialize.
+///
+/// R-50 (Task #164): top-level `TunnelConnected` / `TunnelDisconnected`
+/// variants were removed. Tunnel state moved into `Ready { tunnel }`.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(tag = "phase", rename_all = "camelCase")]
 pub enum DaemonPhase {
@@ -48,18 +96,14 @@ pub enum DaemonPhase {
     AuthFailed {
         reason: String,
     },
-    TunnelDisconnected {
-        port: u16,
-        token: String,
-    },
-    TunnelConnected {
-        port: u16,
-        token: String,
-    },
     Ready {
         port: u16,
         token: String,
         identity: Option<Identity>,
+        /// Sub-state of the cloud tunnel client. Defaults to `Pending`. Updated
+        /// by `DaemonStateStore::set_tunnel_state` when the daemon stderr
+        /// observer sees `[ccsm] tunnel: connected` / `disconnected`.
+        tunnel: TunnelState,
     },
     Exited {
         code: Option<i32>,
@@ -86,8 +130,19 @@ pub struct DaemonStateEvent {
 /// `daemon-state` event per `set_and_emit` call. Generation is a monotonic
 /// counter incremented on every transition (regardless of equality), so the
 /// SPA can detect re-entry into the same logical phase.
+///
+/// R-50 (Task #164): also tracks a `pending_tunnel` slot. The daemon stderr
+/// observer can race the inline handshake — if it sees `tunnel: connected`
+/// before handshake commits Ready, we stash the tunnel state here and apply
+/// it on the next Ready transition (see `set_and_emit` Ready branch). Without
+/// the stash the early stderr signal would be lost (it cannot legally promote
+/// us out of `Starting` because we don't have a port/token yet).
 pub struct DaemonStateStore {
     inner: Mutex<DaemonPhase>,
+    /// `Some(state)` if the stderr observer reported a tunnel transition while
+    /// the phase was not yet `Ready`. Consumed by the next Ready transition.
+    /// Reset to `None` after consumption.
+    pending_tunnel: Mutex<Option<TunnelState>>,
     generation: AtomicU64,
 }
 
@@ -95,6 +150,7 @@ impl Default for DaemonStateStore {
     fn default() -> Self {
         Self {
             inner: Mutex::new(DaemonPhase::NotSpawned),
+            pending_tunnel: Mutex::new(None),
             generation: AtomicU64::new(0),
         }
     }
@@ -106,14 +162,102 @@ impl DaemonStateStore {
     /// are swallowed (matches legacy `let _ = app.emit(...)` pattern in
     /// daemon_mgr.rs; the daemon-mgr task lives longer than the webview at
     /// shutdown).
+    ///
+    /// R-50 (Task #164): when transitioning to `Ready`, fold any stashed
+    /// `pending_tunnel` into the new phase's `tunnel` sub-state. This is how
+    /// we recover the "stderr saw tunnel: connected before handshake parsed"
+    /// race — the early signal is preserved instead of being dropped on the
+    /// floor (and the late signal can no longer overwrite Ready).
     pub fn set_and_emit(&self, app: &AppHandle, phase: DaemonPhase) {
+        let phase = self.fold_pending_tunnel(phase);
         {
             let mut guard = self.inner.lock().expect("daemon state mutex poisoned");
             *guard = phase.clone();
         }
         let generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+        // R-50 (Task #164): observability for the phase-vs-tunnel race. One
+        // line per transition is cheap and lets us replay the exact emit
+        // sequence from the daemon-mgr log when triaging future regressions
+        // in this area.
+        eprintln!(
+            "[daemon-state] set_and_emit gen={generation} phase={}",
+            serde_json::to_string(&phase).unwrap_or_else(|_| "<unserializable>".into()),
+        );
         let event = DaemonStateEvent { generation, phase };
         let _ = app.emit("daemon-state", event);
+    }
+
+    /// R-50 (Task #164): update the tunnel sub-state from the daemon stderr
+    /// observer. If the current phase is `Ready`, the tunnel field is mutated
+    /// in place and a fresh `daemon-state` event is emitted (with bumped
+    /// generation). If the current phase is anything else (e.g. `Starting`,
+    /// pre-handshake), the new tunnel state is stashed in `pending_tunnel`
+    /// and applied on the next Ready transition.
+    ///
+    /// Crucially, this method NEVER promotes the phase out of a non-Ready
+    /// state — that was the whole bug. Tunnel up/down is orthogonal to local
+    /// daemon readiness.
+    pub fn set_tunnel_state(&self, app: &AppHandle, tunnel: TunnelState) {
+        let next_phase = {
+            let mut guard = self.inner.lock().expect("daemon state mutex poisoned");
+            match &mut *guard {
+                DaemonPhase::Ready { tunnel: cur, .. } => {
+                    *cur = tunnel;
+                    Some(guard.clone())
+                }
+                _ => {
+                    // Stash for the next Ready transition; do NOT change
+                    // current phase, do NOT emit.
+                    *self
+                        .pending_tunnel
+                        .lock()
+                        .expect("pending_tunnel mutex poisoned") = Some(tunnel);
+                    None
+                }
+            }
+        };
+        if let Some(phase) = next_phase {
+            let generation = self.generation.fetch_add(1, Ordering::SeqCst) + 1;
+            eprintln!(
+                "[daemon-state] set_tunnel_state gen={generation} tunnel={:?} phase={}",
+                tunnel,
+                serde_json::to_string(&phase).unwrap_or_else(|_| "<unserializable>".into()),
+            );
+            let event = DaemonStateEvent { generation, phase };
+            let _ = app.emit("daemon-state", event);
+        } else {
+            eprintln!(
+                "[daemon-state] set_tunnel_state stashed tunnel={tunnel:?} (phase != Ready)",
+            );
+        }
+    }
+
+    /// Internal: if `phase` is a Ready transition and a tunnel state is
+    /// stashed, fold the stash into `phase.tunnel` and clear the stash.
+    /// Returns the (possibly modified) phase. No-op for non-Ready phases.
+    ///
+    /// Visible for unit tests so we can exercise the fold without an
+    /// `AppHandle` (which requires a Tauri runtime to construct).
+    fn fold_pending_tunnel(&self, mut phase: DaemonPhase) -> DaemonPhase {
+        if let DaemonPhase::Ready { tunnel, .. } = &mut phase {
+            let mut stash = self
+                .pending_tunnel
+                .lock()
+                .expect("pending_tunnel mutex poisoned");
+            if let Some(stashed) = stash.take() {
+                *tunnel = stashed;
+            }
+        } else {
+            // Leaving Ready (or never entered). Drop any stash so a stale
+            // tunnel signal from a prior cycle cannot bleed into a new Ready
+            // after a respawn. The supervisor calls set_and_emit(Spawning)
+            // at the top of every cycle, which lands here.
+            *self
+                .pending_tunnel
+                .lock()
+                .expect("pending_tunnel mutex poisoned") = None;
+        }
+        phase
     }
 
     /// Test-only: snapshot of the current phase. Production code should
@@ -133,13 +277,42 @@ impl DaemonStateStore {
     /// construct a real `AppHandle` in unit tests without a Tauri runtime).
     /// Used by the unit tests below to verify generation/serialization
     /// invariants in isolation. Production callers MUST use `set_and_emit`.
+    ///
+    /// Mirrors `set_and_emit`'s pending-tunnel fold so the race regression
+    /// tests can exercise the same merge logic without an `AppHandle`.
     #[cfg(test)]
     fn set_no_emit(&self, phase: DaemonPhase) -> u64 {
+        let phase = self.fold_pending_tunnel(phase);
         {
             let mut guard = self.inner.lock().unwrap();
             *guard = phase;
         }
         self.generation.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    /// Test-only: counterpart to `set_tunnel_state` that does not emit. Returns
+    /// the new generation if the call mutated `Ready`, or `None` if the call
+    /// stashed the tunnel state because the phase was not `Ready`.
+    #[cfg(test)]
+    fn set_tunnel_state_no_emit(&self, tunnel: TunnelState) -> Option<u64> {
+        let mutated = {
+            let mut guard = self.inner.lock().unwrap();
+            match &mut *guard {
+                DaemonPhase::Ready { tunnel: cur, .. } => {
+                    *cur = tunnel;
+                    true
+                }
+                _ => {
+                    *self.pending_tunnel.lock().unwrap() = Some(tunnel);
+                    false
+                }
+            }
+        };
+        if mutated {
+            Some(self.generation.fetch_add(1, Ordering::SeqCst) + 1)
+        } else {
+            None
+        }
     }
 }
 
@@ -228,25 +401,25 @@ mod tests {
             DaemonPhase::AuthFailed {
                 reason: "denied".into(),
             },
-            DaemonPhase::TunnelDisconnected {
-                port: 9876,
-                token: "tok".into(),
-            },
-            DaemonPhase::TunnelConnected {
-                port: 9876,
-                token: "tok".into(),
-            },
             DaemonPhase::Ready {
                 port: 9876,
                 token: "tok".into(),
                 identity: Some(Identity {
                     user_id: "u1".into(),
                 }),
+                tunnel: TunnelState::Pending,
             },
             DaemonPhase::Ready {
                 port: 9876,
                 token: "tok".into(),
                 identity: None,
+                tunnel: TunnelState::Connected,
+            },
+            DaemonPhase::Ready {
+                port: 9876,
+                token: "tok".into(),
+                identity: None,
+                tunnel: TunnelState::Disconnected,
             },
             DaemonPhase::Exited {
                 code: Some(0),
@@ -291,5 +464,132 @@ mod tests {
             last = g;
         }
         assert_eq!(store.current_generation(), 50);
+    }
+
+    // ---------------------------------------------------------------------
+    // R-50 (Task #164): tunnel-as-sub-state race regression tests.
+    //
+    // The original bug (see header): handshake sets Ready, stderr async sees
+    // "tunnel: connected" and overwrites Ready with the (now-deleted) top-
+    // level TunnelConnected variant. The SPA freezes on the
+    // "Tunnel connected, waiting…" overlay because phase != ready.
+    //
+    // These tests exercise the merge invariants on the state store directly:
+    //   1. happy path: handshake-then-tunnel    => Ready{tunnel=Connected}
+    //   2. race path:  tunnel-then-handshake    => Ready{tunnel=Connected}
+    //   3. orthogonality: tunnel updates while Ready never demote phase
+    //   4. cycle reset: Spawning drops a stale stash from a prior Ready
+    // ---------------------------------------------------------------------
+
+    fn ready_pending() -> DaemonPhase {
+        DaemonPhase::Ready {
+            port: 9876,
+            token: "tok".into(),
+            identity: None,
+            tunnel: TunnelState::Pending,
+        }
+    }
+
+    fn extract_tunnel(phase: &DaemonPhase) -> Option<TunnelState> {
+        match phase {
+            DaemonPhase::Ready { tunnel, .. } => Some(*tunnel),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn ready_then_tunnel_connected_keeps_ready_with_connected_substate() {
+        // Real-world ordering #1: handshake commits Ready first, then the
+        // stderr observer sees "tunnel: connected".
+        let store = DaemonStateStore::default();
+        store.set_no_emit(ready_pending());
+        assert!(matches!(store.snapshot(), DaemonPhase::Ready { .. }));
+        assert_eq!(extract_tunnel(&store.snapshot()), Some(TunnelState::Pending));
+
+        let g = store.set_tunnel_state_no_emit(TunnelState::Connected);
+        assert!(g.is_some(), "Ready -> tunnel update must emit");
+
+        let snap = store.snapshot();
+        match snap {
+            DaemonPhase::Ready { tunnel, .. } => assert_eq!(tunnel, TunnelState::Connected),
+            other => panic!("expected Ready, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tunnel_connected_then_ready_preserves_tunnel_via_stash() {
+        // Real-world ordering #2 (the race): stderr observer fires before
+        // handshake commits Ready (stderr task spawned BEFORE inline read in
+        // daemon_mgr.rs). The pre-Ready signal must be stashed and folded
+        // into the next Ready so we don't lose it.
+        let store = DaemonStateStore::default();
+        // Pre-handshake phase:
+        store.set_no_emit(DaemonPhase::Starting);
+
+        // stderr fires first — must NOT promote phase, must NOT clobber.
+        let g_stash = store.set_tunnel_state_no_emit(TunnelState::Connected);
+        assert!(g_stash.is_none(), "pre-Ready tunnel update must not emit");
+        // Phase still Starting:
+        assert!(matches!(store.snapshot(), DaemonPhase::Starting));
+
+        // Now handshake commits Ready{Pending} — fold should swap in Connected.
+        store.set_no_emit(ready_pending());
+        match store.snapshot() {
+            DaemonPhase::Ready { tunnel, .. } => assert_eq!(tunnel, TunnelState::Connected),
+            other => panic!("expected Ready{{Connected}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tunnel_disconnect_while_ready_does_not_demote_phase() {
+        // Tunnel flap must never bounce the user back to a "no-app" overlay.
+        // Before R-50 a top-level TunnelDisconnected variant existed and the
+        // SPA routed it to a non-Ready overlay. Now disconnect is a sub-state
+        // of Ready and the SPA stays mounted.
+        let store = DaemonStateStore::default();
+        store.set_no_emit(ready_pending());
+        store.set_tunnel_state_no_emit(TunnelState::Connected);
+        store.set_tunnel_state_no_emit(TunnelState::Disconnected);
+        match store.snapshot() {
+            DaemonPhase::Ready { tunnel, .. } => assert_eq!(tunnel, TunnelState::Disconnected),
+            other => panic!("expected Ready (still), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn cycle_restart_drops_stale_pending_tunnel_stash() {
+        // Supervisor restarts the daemon: it calls set_and_emit(Spawning) at
+        // the top of every cycle. A stale tunnel signal stashed from a prior
+        // cycle must NOT survive into the new Ready (port/token differ).
+        let store = DaemonStateStore::default();
+        store.set_no_emit(DaemonPhase::Starting);
+        store.set_tunnel_state_no_emit(TunnelState::Connected); // stashed
+        // Cycle restart:
+        store.set_no_emit(DaemonPhase::Spawning);
+        store.set_no_emit(DaemonPhase::Starting);
+        store.set_no_emit(ready_pending());
+        match store.snapshot() {
+            DaemonPhase::Ready { tunnel, .. } => assert_eq!(
+                tunnel,
+                TunnelState::Pending,
+                "stale tunnel stash must be dropped on cycle restart"
+            ),
+            other => panic!("expected Ready{{Pending}}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ready_serializes_tunnel_substate_camel_case() {
+        // SPA contract: tunnel field is camelCase ("pending"/"connected"/
+        // "disconnected"). Anchored test so a serde rename slip breaks loud.
+        let phase = DaemonPhase::Ready {
+            port: 9876,
+            token: "tok".into(),
+            identity: None,
+            tunnel: TunnelState::Connected,
+        };
+        let json = serde_json::to_string(&phase).unwrap();
+        assert!(json.contains("\"phase\":\"ready\""), "json={json}");
+        assert!(json.contains("\"tunnel\":\"connected\""), "json={json}");
     }
 }

--- a/packages/frontend-tauri/src/App.tsx
+++ b/packages/frontend-tauri/src/App.tsx
@@ -69,8 +69,6 @@ export function PhaseSwitch() {
     case 'notSpawned':
     case 'spawning':
     case 'starting':
-    case 'tunnelDisconnected':
-    case 'tunnelConnected':
       return <DaemonStatusOverlay phase={phase} variant="info" />;
     case 'spawnFailed':
     case 'exited':

--- a/packages/frontend-tauri/src/types.ts
+++ b/packages/frontend-tauri/src/types.ts
@@ -10,16 +10,30 @@
 //
 // The `DaemonStateEvent` envelope flattens the variant payload alongside
 // `generation`, so a `Ready` event arrives on the wire as:
-//   { generation: 7, phase: "ready", port: 9876, token: "...", identity: ... }
+//   { generation: 7, phase: "ready", port: 9876, token: "...",
+//     identity: ..., tunnel: "pending" | "connected" | "disconnected" }
 // and a `SpawnFailed` event as:
 //   { generation: 3, phase: "spawnFailed", reason: "...", retryInMs: 1000 }
 //
 // Field names within payloads are also camelCase (`retryInMs`, `verificationUri`,
-// `userCode`, `expiresAt`, `userId`).
+// `userCode`, `expiresAt`, `userId`, `tunnel`).
+//
+// R-50 (Task #164): tunnel state is now a sub-state of `Ready`. The previous
+// top-level `tunnelConnected` / `tunnelDisconnected` variants were removed
+// because they were causing a stderr-vs-handshake race to overwrite Ready
+// (freezing the SPA on the "Tunnel connected, waiting…" overlay). Tunnel
+// up/down is orthogonal to local PTY/HTTP readiness, so it lives inside
+// Ready as `tunnel: TunnelState`.
 
 export interface Identity {
   userId: string;
 }
+
+/**
+ * Cloud tunnel sub-state inside `phase=ready`. Mirrors the Rust
+ * `TunnelState` enum (camelCase serde).
+ */
+export type TunnelState = 'pending' | 'connected' | 'disconnected';
 
 export type DaemonPhase =
   | { phase: 'notSpawned' }
@@ -33,9 +47,13 @@ export type DaemonPhase =
       expiresAt: number;
     }
   | { phase: 'authFailed'; reason: string }
-  | { phase: 'tunnelDisconnected'; port: number; token: string }
-  | { phase: 'tunnelConnected'; port: number; token: string }
-  | { phase: 'ready'; port: number; token: string; identity: Identity | null }
+  | {
+      phase: 'ready';
+      port: number;
+      token: string;
+      identity: Identity | null;
+      tunnel: TunnelState;
+    }
   | { phase: 'exited'; code: number | null; reason: string };
 
 /**

--- a/packages/frontend-tauri/test/PhaseSwitch.test.tsx
+++ b/packages/frontend-tauri/test/PhaseSwitch.test.tsx
@@ -90,6 +90,16 @@ vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn().mockResolvedValue(() => undefined),
 }));
 
+// LoginButton's mount effect calls Tauri `invoke('get_oauth_login')` which
+// throws in jsdom because `window.__TAURI_INTERNALS__` is undefined. Stub the
+// component so tests that render the Ready branch (which mounts AppContent →
+// AppShell → sidebar slot containing <LoginButton />) don't surface unhandled
+// rejections from a side-effect that is irrelevant to the routing contract
+// under test.
+vi.mock('../src/auth/LoginButton', () => ({
+  LoginButton: () => <div data-testid="stub-login-button" />,
+}));
+
 // --- helpers -------------------------------------------------------------
 
 function renderWithPhase(payload: DaemonStatePayload) {
@@ -129,32 +139,41 @@ describe('PhaseSwitch (Task #138 / #112-T5)', () => {
   );
 
   it('renders DaemonStatusOverlay (info) for tunnelDisconnected', () => {
+    // R-50 (Task #164) regression guard: previously this case rendered an
+    // overlay that froze the SPA. Now `tunnelDisconnected` is no longer a
+    // top-level phase — it lives inside `ready` as `tunnel: 'disconnected'`,
+    // and the overlay must collapse so the main app stays mounted while the
+    // tunnel reconnects in the background.
     renderWithPhase({
       generation: 2,
-      phase: 'tunnelDisconnected',
+      phase: 'ready',
       port: 9876,
       token: 't',
+      identity: null,
+      tunnel: 'disconnected',
     });
-    const overlay = screen.getByTestId('daemon-status-overlay');
-    expect(overlay.getAttribute('data-variant')).toBe('info');
-    expect(
-      screen.getByTestId('daemon-status-overlay-loading').textContent ?? '',
-    ).toContain('Connecting to cloud');
-    expect(screen.queryByTestId('terminal-pane')).toBeNull();
+    expect(screen.queryByTestId('daemon-status-overlay')).toBeNull();
+    expect(screen.getByTestId('runtime-provider')).toBeDefined();
   });
 
   it('renders DaemonStatusOverlay (info) for tunnelConnected', () => {
+    // R-50 regression guard: handshake-then-tunnel:connected sequence used to
+    // overwrite Ready with a top-level TunnelConnected, freezing the SPA on
+    // the "Tunnel connected, waiting…" overlay. The fix moves tunnel to a
+    // Ready sub-state, so the overlay must NEVER show that text once Ready
+    // has landed (regardless of tunnel value).
     renderWithPhase({
       generation: 3,
-      phase: 'tunnelConnected',
+      phase: 'ready',
       port: 9876,
       token: 't',
+      identity: null,
+      tunnel: 'connected',
     });
-    const overlay = screen.getByTestId('daemon-status-overlay');
-    expect(overlay.getAttribute('data-variant')).toBe('info');
-    expect(
-      screen.getByTestId('daemon-status-overlay-loading').textContent ?? '',
-    ).toContain('Tunnel connected');
+    expect(screen.queryByTestId('daemon-status-overlay')).toBeNull();
+    expect(screen.queryByText(/Tunnel connected, waiting/)).toBeNull();
+    expect(screen.queryByText(/Starting daemon/)).toBeNull();
+    expect(screen.getByTestId('runtime-provider')).toBeDefined();
   });
 
   // Failure phases — error variant + reason text surfaced (this is the
@@ -231,6 +250,7 @@ describe('PhaseSwitch (Task #138 / #112-T5)', () => {
       port: 9876,
       token: 'tok-xyz',
       identity: { userId: 'u1' },
+      tunnel: 'pending',
     });
     expect(screen.queryByTestId('daemon-status-overlay')).toBeNull();
     const rp = screen.getByTestId('runtime-provider');
@@ -271,6 +291,7 @@ describe('PhaseSwitch (Task #138 / #112-T5)', () => {
           port: 4321,
           token: 'tok2',
           identity: null,
+          tunnel: 'pending',
         }}
       >
         <PhaseSwitch />

--- a/packages/ui/src/components/DaemonStatusOverlay.tsx
+++ b/packages/ui/src/components/DaemonStatusOverlay.tsx
@@ -7,14 +7,20 @@
 //
 // Phase coverage (matches frontend-tauri DaemonPhase discriminator):
 //   notSpawned / spawning / starting       → spinner + "Starting daemon..."
-//   tunnelDisconnected                     → spinner + "Connecting to cloud..."
-//   tunnelConnected                        → spinner + "Tunnel connected..."
 //   ready                                  → null (the real app takes over)
 //   spawnFailed { reason, retryInMs? }     → red banner + retry countdown
 //   exited { code, reason }                → red banner
 //   awaitingAuth { verificationUri,        → auth panel + Open browser btn
 //                  userCode, expiresAt? }
 //   authFailed { reason }                  → red banner + Try again btn
+//
+// R-50 (Task #164): the previous top-level `tunnelConnected` /
+// `tunnelDisconnected` cases were removed. Tunnel state is now a sub-state
+// of `ready` (see types.ts `TunnelState`), so once the daemon is Ready the
+// overlay collapses regardless of tunnel up/down — preventing the regression
+// where a stderr-driven tunnel emit froze the SPA on
+// "Tunnel connected, waiting…". Tunnel sub-state UI (e.g. a status-bar icon)
+// is owned by the main app shell, not this overlay.
 //
 // The `View logs`, `Open browser`, and `Try again` buttons are wired to
 // console.log only — real IPC lands in S4-T8.
@@ -257,12 +263,6 @@ export function DaemonStatusOverlay({
     case 'spawning':
     case 'starting':
       body = <StartingBody message="Starting daemon…" />;
-      break;
-    case 'tunnelDisconnected':
-      body = <StartingBody message="Connecting to cloud…" />;
-      break;
-    case 'tunnelConnected':
-      body = <StartingBody message="Tunnel connected, waiting…" />;
       break;
     case 'spawnFailed':
       body = (

--- a/packages/ui/test/DaemonStatusOverlay.test.tsx
+++ b/packages/ui/test/DaemonStatusOverlay.test.tsx
@@ -24,8 +24,6 @@ describe('DaemonStatusOverlay', () => {
     ['notSpawned', 'Starting daemon'],
     ['spawning', 'Starting daemon'],
     ['starting', 'Starting daemon'],
-    ['tunnelDisconnected', 'Connecting to cloud'],
-    ['tunnelConnected', 'Tunnel connected'],
   ])('renders spinner + status text for %s', (phaseName, fragment) => {
     render(<DaemonStatusOverlay phase={{ phase: phaseName }} />);
     const root = screen.getByTestId('daemon-status-overlay');
@@ -35,6 +33,30 @@ describe('DaemonStatusOverlay', () => {
     const loading = screen.getByTestId('daemon-status-overlay-loading');
     expect(loading.textContent ?? '').toContain(fragment);
   });
+
+  // --- R-50 (Task #164): Ready collapses regardless of tunnel sub-state ---
+
+  it.each(['pending', 'connected', 'disconnected'] as const)(
+    'returns null when phase=ready with tunnel=%s (overlay must not freeze SPA)',
+    (tunnel) => {
+      // Regression guard: previously a stderr-driven `tunnelConnected` emit
+      // overwrote `Ready` and kept the overlay mounted on
+      // "Tunnel connected, waiting…". Tunnel state is now a Ready sub-state;
+      // the overlay must collapse for every tunnel value.
+      const { container } = render(
+        <DaemonStatusOverlay
+          phase={{ phase: 'ready', tunnel } as { phase: string }}
+        />,
+      );
+      expect(
+        container.querySelector('[data-testid="daemon-status-overlay"]'),
+      ).toBeNull();
+      expect(container.firstChild).toBeNull();
+      // And the deleted overlay text must never render under Ready.
+      expect(container.textContent ?? '').not.toContain('Tunnel connected, waiting');
+      expect(container.textContent ?? '').not.toContain('Starting daemon');
+    },
+  );
 
   // --- Ready collapses to null --------------------------------------------
 


### PR DESCRIPTION
## Summary

Task #164 — R-50 bug-arch fix: the Tauri SPA was freezing on the
\"Tunnel connected, waiting…\" overlay because the daemon stderr async
observer's \`DaemonPhase::TunnelConnected\` emit raced and overwrote the
inline-handshake \`Ready\` emit.

Architecture-layer root cause (per \`feedback_fix_arch_not_glue\`): phase
semantics were wrong. \`Ready\` means \"local PTY/HTTP daemon is serving the
webview\"; tunnel state is orthogonal. Modeling tunnel as a top-level phase
forced an ordering invariant the pipes don't guarantee.

Fix: tunnel becomes a sub-state of \`Ready\`.

- New \`TunnelState { Pending | Connected | Disconnected }\`.
- \`DaemonPhase::Ready { tunnel }\`; top-level \`TunnelConnected\` /
  \`TunnelDisconnected\` deleted.
- \`DaemonStateStore::set_tunnel_state\` mutates Ready in place when the
  phase is Ready, or stashes the value when it isn't (handles
  stderr-races-handshake without an ordering hack).
- Cycle restart drops stale stash so a prior cycle's tunnel signal can't
  bleed into a new Ready with new port/token.

## Evidence — local Tauri smoke (Windows, pool-2 vite on 1430)

\`\`\`
[daemon-state] set_and_emit gen=1 phase={\"phase\":\"spawning\"}
[daemon-mgr] spawned daemon pid=58204
[daemon-state] set_and_emit gen=2 phase={\"phase\":\"starting\"}
[daemon stderr] [ccsm] tunnel: connecting wss://cc-sm.pages.dev/tunnel/default
[daemon stderr] [ccsm] tunnel: dialing with cloud-issued JWT subprotocol
[daemon-mgr] handshake ok port=51710 token=9a7773…
[daemon-state] set_and_emit gen=3 phase={\"phase\":\"ready\",\"port\":51710,\"token\":\"9a77733559e2ce35fbcce7c3d2075069\",\"identity\":null,\"tunnel\":\"pending\"}
[daemon stderr] [ccsm] tunnel: connected
[daemon-state] set_tunnel_state gen=4 tunnel=Connected phase={\"phase\":\"ready\",\"port\":51710,\"token\":\"9a77733559e2ce35fbcce7c3d2075069\",\"identity\":null,\"tunnel\":\"connected\"}
\`\`\`

- gen=3: handshake commits \`Ready{tunnel:Pending}\`.
- gen=4: stderr-driven tunnel update mutates Ready in place;
  **phase stays \`ready\`** (was \`tunnelConnected\` pre-fix).
- The deleted top-level \`tunnelConnected\` / \`tunnelDisconnected\`
  variants are absent from every emission.
- SPA's \`PhaseSwitch\` routes \`ready\` → \`AppContent\`, the overlay
  collapses, the user sees the real app instead of a black screen.

## Test plan

- [x] \`cargo test --lib\` (frontend-tauri/src-tauri): 20 passed,
  including 5 new R-50 race regression tests
  - \`ready_then_tunnel_connected_keeps_ready_with_connected_substate\`
  - \`tunnel_connected_then_ready_preserves_tunnel_via_stash\`
  - \`tunnel_disconnect_while_ready_does_not_demote_phase\`
  - \`cycle_restart_drops_stale_pending_tunnel_stash\`
  - \`ready_serializes_tunnel_substate_camel_case\`
- [x] \`pnpm --filter @ccsm/ui test\`: 55 passed (incl. 2 new
  Ready+tunnel-substate overlay regression tests)
- [x] \`pnpm --filter @ccsm/frontend-tauri test\`: 11 passed (PhaseSwitch
  tunnelConnected/tunnelDisconnected cases rewritten as Ready+sub-state
  regression guards)
- [x] \`pnpm --filter @ccsm/daemon test\`: 187 passed, 1 skipped
  (unchanged)
- [x] typecheck + lint clean
- [x] manual Tauri smoke on Windows captured the exact bug-evidence
  sequence (see Evidence above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)