### PR TITLE
R-51c: SPA PKCE-default sign-in + collapsible device-flow fallback (Task #169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,27 @@ ccsm-tauri
 
 Detailed architecture diagrams: see [DESIGN.md §13 Deployment Modes](./DESIGN.md#13-deployment-modes-architecture-diagrams).
 
+#### Local Tauri dev — `CCSM_AUTH_BASE` is mandatory (R-51c / Task #169)
+
+Per the Tauri shell's repo-agnostic ROADMAP red-line, the auth host is
+**never hardcoded** — it must be injected via the `CCSM_AUTH_BASE` env
+var. Without it, the in-app sign-in flows surface a clear failure
+("CCSM_AUTH_BASE env not set …") instead of dialing a default host.
+
+```sh
+# Production / staging
+CCSM_AUTH_BASE=https://cc-sm.pages.dev pnpm tauri dev
+
+# Local cf-worker (run `pnpm --filter @ccsm/cf-worker dev` in another terminal)
+CCSM_AUTH_BASE=http://127.0.0.1:8787 pnpm tauri dev
+```
+
+Release builds inject this value through the packaging pipeline; end
+users do not need to set it manually.
+
+See [docs/S4-SETUP.md](./docs/S4-SETUP.md#desktop-sign-in-flows-r-51--tasks-167-169)
+for the full PKCE-vs-device-flow flow description.
+
 ## Tests
 
 - **Daemon** (`packages/daemon`): `pnpm -F @ccsm/daemon test` — unit /

--- a/docs/S4-SETUP.md
+++ b/docs/S4-SETUP.md
@@ -144,3 +144,72 @@ To rotate a secret (compromise or scheduled rotation):
 GitHub OAuth App **client secret** can be rotated from the App settings page
 ("Generate a new client secret"); the old secret remains valid for a brief
 grace window so you can roll the new value into Cloudflare without downtime.
+
+## Desktop sign-in flows (R-51 / Tasks #167-#169)
+
+The Tauri shell ships with **two** sign-in paths, gated through the same
+GitHub OAuth App as the web flow. The SPA (`LoginButton`) shows the PKCE
+path as the primary affordance and the device-flow path as a collapsible
+fallback.
+
+### Primary — PKCE deep-link (R-51b/c)
+
+Default for installed Windows / Linux desktops where the OS can dispatch
+`ccsm://` URLs back to a running app instance.
+
+1. User clicks **"Sign in with GitHub"**.
+2. Tauri command `start_pkce_oauth` POSTs `/api/auth/desktop/start` to
+   cf-worker. The worker mints a `state` + `code_verifier` (verifier
+   persisted server-side in the PKCE-state UserDO role) and returns the
+   GitHub authorize URL.
+3. The shell opens the URL via `tauri-plugin-shell`. The user authorizes
+   on github.com.
+4. GitHub redirects back to `https://cc-sm.pages.dev/oauth/desktop/cb`,
+   which renders a tiny bounce page that immediately navigates to
+   `ccsm://oauth?token=<jwt>&refresh=<token>&state=<state>`.
+5. The OS routes the deep link to the running Tauri instance (single-
+   instance plugin forwards across instances). The `on_open_url` listener
+   verifies `state` against `PkceStateStore`, persists the credentials to
+   `~/.ccsm/tunnel_jwt`, and emits `oauth-complete`.
+
+The JWT never travels through the SPA — only the resolved login string
+crosses the IPC boundary.
+
+### Fallback — Device flow (S4-T8 / R-51c)
+
+Reachable from the **"Trouble signing in? Use a code instead"** link
+under the primary button. The link auto-expands 5 s after a PKCE click
+that has not resolved.
+
+Same wire flow as before R-51 (Task #141): cf-worker `/api/auth/device/start`
+mints a `user_code` + `verification_uri`; SPA shows the modal; Rust polls
+`/api/auth/device/poll` until success or timeout.
+
+### GitHub OAuth App configuration for desktop
+
+The single OAuth App registered in step 1 above already supports both
+desktop paths. No second app is needed:
+
+- **Authorization callback URL**: `https://cc-sm.pages.dev/oauth/desktop/cb`
+  (R-51a re-routed the desktop path to this endpoint; the legacy
+  `/api/auth/github/callback` continues to serve the web flow). If your
+  app was registered before R-51a, update the callback URL in the GitHub
+  App settings.
+- **Enable Device Flow**: must remain checked for the fallback path.
+
+### Local dev / preview
+
+The Tauri shell is repo-agnostic by ROADMAP red-line, so the auth host is
+**injected via env**, never hardcoded:
+
+```bash
+# Production / staging
+CCSM_AUTH_BASE=https://cc-sm.pages.dev pnpm tauri dev
+
+# Local cf-worker dev
+CCSM_AUTH_BASE=http://127.0.0.1:8787 pnpm tauri dev
+```
+
+Without `CCSM_AUTH_BASE`, the `start_pkce_oauth` / `start_device_oauth`
+commands surface a clear `oauth-failed` event with reason
+`"CCSM_AUTH_BASE env not set ..."` rather than dialing a default host.

--- a/packages/frontend-tauri/src/auth/LoginButton.tsx
+++ b/packages/frontend-tauri/src/auth/LoginButton.tsx
@@ -1,23 +1,38 @@
 // S4-T8 (Task #141): Login button + device-flow modal for the Tauri shell.
+// R-51c (Task #169): PKCE-first UX with collapsible device-flow fallback.
 //
-// Renders one of three states:
-//   - logged out: "Login with GitHub" button
-//   - awaiting user: modal showing user_code + "Open browser" link
+// Renders one of these states:
+//   - logged out:
+//       Primary: "Sign in with GitHub" (PKCE / deep-link).
+//       Below:   "Trouble signing in? Use a code instead" — collapsed link.
+//                Expanding it reveals the device-flow trigger button which,
+//                when clicked, runs start_device_oauth and surfaces the
+//                user_code modal as before.
+//       Auto-expand: 5 s after the PKCE button is pressed without an
+//       `oauth-complete` arriving, the fallback row expands itself so the
+//       user sees the alternative without having to read the small grey link.
+//   - awaiting user (device flow only): modal showing user_code +
+//                                        "Open browser" link
 //   - logged in: "@{login}" + "Logout" affordance
 //
 // The Rust side (auth.rs) owns the underlying flow. We:
 //   1. on mount: invoke get_oauth_login to pick up an existing session
-//   2. on click "Login": invoke start_oauth → display modal with user_code +
-//      verification URI; open the URI in the default browser via plugin-shell.
-//   3. listen for oauth-complete / oauth-failed events to close the modal.
+//   2. on click "Sign in" (PKCE): invoke start_pkce_oauth — Rust opens the
+//      browser, the OS hands back a `ccsm://oauth?...` deep link, the Rust
+//      side persists creds and emits `oauth-complete`.
+//   3. on click "Use a code instead" (device): invoke start_device_oauth →
+//      display modal with user_code + verification URI; Rust polls and
+//      emits `oauth-complete` / `oauth-failed`.
+//   4. listen for oauth-complete / oauth-failed events to close the modal.
 //
 // The JWT itself never crosses the IPC boundary — only the resolved login.
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   invokeGetOauthLogin,
   invokeOauthLogout,
-  invokeStartOauth,
+  invokeStartDeviceOauth,
+  invokeStartPkceOauth,
   onOauthComplete,
   onOauthFailed,
   type StartOauthSpaPayload,
@@ -28,10 +43,38 @@ interface ModalState {
   error: string | null;
 }
 
+/// R-51c (Task #169): how long after pressing "Sign in with GitHub" we wait
+/// before auto-expanding the fallback row. Picked at 5 s based on the spec —
+/// long enough for the OS to launch the browser and for the user to see the
+/// authorize page, short enough that a stuck deep-link registration surfaces
+/// the alternative quickly.
+export const PKCE_AUTOFALLBACK_MS = 5_000;
+
 export function LoginButton(): React.JSX.Element {
   const [login, setLogin] = useState<string | null>(null);
   const [modal, setModal] = useState<ModalState | null>(null);
   const [busy, setBusy] = useState(false);
+  // R-51c: which path is currently in flight, for both pkce-vs-device
+  // dispatch in the UI and so we can cancel the auto-fallback timer if
+  // the PKCE path resolves first. We use a ref (not state) because the
+  // value is only consulted from event handlers (oauth-failed routing) —
+  // it never affects rendering, so a re-render on every transition would
+  // be wasted work.
+  const activeFlowRef = useRef<'pkce' | 'device' | null>(null);
+  // R-51c: whether the "Trouble?" row is expanded. Clicking the link toggles
+  // it manually; the 5 s auto-fallback timer expands it implicitly.
+  const [fallbackOpen, setFallbackOpen] = useState(false);
+  // R-51c: surface PKCE start errors (e.g. cf-worker 5xx) inline. Device
+  // flow errors continue to land inside the modal alongside the user_code.
+  const [pkceError, setPkceError] = useState<string | null>(null);
+
+  const autoFallbackTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearAutoFallback = useCallback(() => {
+    if (autoFallbackTimer.current !== null) {
+      clearTimeout(autoFallbackTimer.current);
+      autoFallbackTimer.current = null;
+    }
+  }, []);
 
   // Initial pick-up of any persisted login.
   useEffect(() => {
@@ -44,7 +87,9 @@ export function LoginButton(): React.JSX.Element {
     };
   }, []);
 
-  // Listen for completion / failure events from the Rust poll task.
+  // Listen for completion / failure events from the Rust poll task or the
+  // deep-link callback. Both PKCE and device-flow paths funnel through the
+  // same `oauth-complete` / `oauth-failed` channels (R-51b auth.rs).
   useEffect(() => {
     let unlistenComplete: (() => void) | undefined;
     let unlistenFailed: (() => void) | undefined;
@@ -53,13 +98,26 @@ export function LoginButton(): React.JSX.Element {
       setLogin(payload.login);
       setModal(null);
       setBusy(false);
+      activeFlowRef.current = null;
+      setPkceError(null);
+      clearAutoFallback();
     }).then((u) => {
       if (cancelled) u();
       else unlistenComplete = u;
     });
     void onOauthFailed((payload) => {
-      setModal((prev) => (prev !== null ? { ...prev, error: payload.reason } : prev));
+      // R-51c: route the failure to the path that triggered it.
+      const flow = activeFlowRef.current;
+      if (flow === 'pkce') {
+        setPkceError(payload.reason);
+        // Auto-expand fallback so the user has an immediate next step.
+        setFallbackOpen(true);
+      } else {
+        setModal((prev) => (prev !== null ? { ...prev, error: payload.reason } : prev));
+      }
+      activeFlowRef.current = null;
       setBusy(false);
+      clearAutoFallback();
     }).then((u) => {
       if (cancelled) u();
       else unlistenFailed = u;
@@ -69,15 +127,46 @@ export function LoginButton(): React.JSX.Element {
       unlistenComplete?.();
       unlistenFailed?.();
     };
-  }, []);
+  }, [clearAutoFallback]);
 
-  const onLoginClick = useCallback(async () => {
+  // Cleanup on unmount: don't leak timers across re-renders.
+  useEffect(() => clearAutoFallback, [clearAutoFallback]);
+
+  const onPkceClick = useCallback(async () => {
     if (busy) return;
     setBusy(true);
+    activeFlowRef.current = 'pkce';
+    setPkceError(null);
+    // Schedule the 5 s auto-expand; cancelled if oauth-complete or
+    // oauth-failed arrives first.
+    clearAutoFallback();
+    autoFallbackTimer.current = setTimeout(() => {
+      setFallbackOpen(true);
+      autoFallbackTimer.current = null;
+    }, PKCE_AUTOFALLBACK_MS);
     try {
-      // Rust opens the verification URL via plugin-shell as part of
-      // start_oauth — we just render the modal once the user_code is back.
-      const payload = await invokeStartOauth();
+      await invokeStartPkceOauth();
+      // start_pkce_oauth returns once the browser has been launched. The SPA
+      // now waits for the deep-link round-trip; oauth-complete / oauth-failed
+      // listeners (above) handle resolution.
+    } catch (err) {
+      // cf-worker returned non-2xx, env not set, etc. — surface inline,
+      // expand fallback so the user is unblocked.
+      setPkceError(String(err));
+      setFallbackOpen(true);
+      setBusy(false);
+      activeFlowRef.current = null;
+      clearAutoFallback();
+    }
+  }, [busy, clearAutoFallback]);
+
+  const onDeviceClick = useCallback(async () => {
+    if (busy) return;
+    setBusy(true);
+    activeFlowRef.current = 'device';
+    clearAutoFallback();
+    try {
+      const payload = await invokeStartDeviceOauth();
       setModal({ payload, error: null });
     } catch (err) {
       setModal({
@@ -90,8 +179,9 @@ export function LoginButton(): React.JSX.Element {
         error: String(err),
       });
       setBusy(false);
+      activeFlowRef.current = null;
     }
-  }, [busy]);
+  }, [busy, clearAutoFallback]);
 
   const onLogoutClick = useCallback(async () => {
     await invokeOauthLogout();
@@ -101,6 +191,11 @@ export function LoginButton(): React.JSX.Element {
   const onModalClose = useCallback(() => {
     setModal(null);
     setBusy(false);
+    activeFlowRef.current = null;
+  }, []);
+
+  const onToggleFallback = useCallback(() => {
+    setFallbackOpen((open) => !open);
   }, []);
 
   if (login !== null) {
@@ -119,20 +214,53 @@ export function LoginButton(): React.JSX.Element {
   }
 
   return (
-    <>
+    <div className="login-button login-button--out" data-testid="login-button">
       <button
         type="button"
-        className="login-button login-button--out"
-        data-testid="login-button"
+        className="login-button__primary"
+        data-testid="login-button-pkce"
         disabled={busy}
-        onClick={() => void onLoginClick()}
+        onClick={() => void onPkceClick()}
       >
-        Login with GitHub
+        Sign in with GitHub
       </button>
+      {pkceError !== null ? (
+        <p className="login-button__error" data-testid="login-button-pkce-error">
+          Sign-in failed: {pkceError}
+        </p>
+      ) : null}
+      <div className="login-button__fallback">
+        <button
+          type="button"
+          className="login-button__fallback-toggle"
+          data-testid="login-button-fallback-toggle"
+          aria-expanded={fallbackOpen}
+          onClick={onToggleFallback}
+        >
+          {fallbackOpen ? 'Hide code option' : 'Trouble signing in? Use a code instead'}
+        </button>
+        {fallbackOpen ? (
+          <div className="login-button__fallback-body" data-testid="login-button-fallback-body">
+            <p className="login-button__fallback-hint">
+              If the browser sign-in didn&apos;t come back to ccsm, you can finish
+              authorizing with a one-time code instead.
+            </p>
+            <button
+              type="button"
+              className="login-button__device"
+              data-testid="login-button-device"
+              disabled={busy}
+              onClick={() => void onDeviceClick()}
+            >
+              Use a code
+            </button>
+          </div>
+        ) : null}
+      </div>
       {modal !== null ? (
         <DeviceFlowModal modal={modal} onClose={onModalClose} />
       ) : null}
-    </>
+    </div>
   );
 }
 

--- a/packages/frontend-tauri/src/auth/oauth-state.test.ts
+++ b/packages/frontend-tauri/src/auth/oauth-state.test.ts
@@ -18,6 +18,8 @@ vi.mock('@tauri-apps/api/event', () => ({
 // Import AFTER mocks so the module picks up the mocked invoke/listen.
 import {
   invokeStartOauth,
+  invokeStartPkceOauth,
+  invokeStartDeviceOauth,
   invokeGetOauthState,
   invokeGetOauthLogin,
   invokeOauthLogout,
@@ -43,6 +45,28 @@ describe('oauth-state helpers', () => {
     expect(invokeMock).toHaveBeenCalledTimes(1);
     expect(invokeMock).toHaveBeenCalledWith('start_oauth');
     expect(out.user_code).toBe('ABCD-1234');
+  });
+
+  it('invokeStartPkceOauth invokes the start_pkce_oauth command', async () => {
+    // R-51c (Task #169): default sign-in path. The Rust command resolves
+    // void once the browser has been launched; completion arrives later
+    // via the oauth-complete event listener.
+    invokeMock.mockResolvedValueOnce(undefined);
+    await invokeStartPkceOauth();
+    expect(invokeMock).toHaveBeenCalledWith('start_pkce_oauth');
+  });
+
+  it('invokeStartDeviceOauth invokes the start_device_oauth command', async () => {
+    // R-51c (Task #169): fallback path. Same payload shape as start_oauth.
+    invokeMock.mockResolvedValueOnce({
+      user_code: 'EFGH-5678',
+      verification_uri: 'https://github.com/login/device',
+      expires_in: 900,
+      interval: 5,
+    });
+    const out = await invokeStartDeviceOauth();
+    expect(invokeMock).toHaveBeenCalledWith('start_device_oauth');
+    expect(out.user_code).toBe('EFGH-5678');
   });
 
   it('invokeGetOauthState invokes get_oauth_state', async () => {

--- a/packages/frontend-tauri/src/auth/oauth-state.ts
+++ b/packages/frontend-tauri/src/auth/oauth-state.ts
@@ -1,14 +1,23 @@
 // S4-T8 (Task #141): SPA-side helpers for the device-flow login button.
+// R-51c (Task #169): added PKCE helpers for the deep-link primary path.
 //
-// The Rust side (auth.rs) owns the actual flow: HTTP to cf-worker, polling,
-// disk persistence, env injection into the daemon. The SPA only:
-//   - invokes start_oauth() on click (Rust returns user_code + verification_uri),
+// The Rust side (auth.rs) owns the actual flow: HTTP to cf-worker, polling
+// or deep-link reception, disk persistence, env injection into the daemon.
+// The SPA only:
+//   - invokes start_pkce_oauth() (default, deep-link round-trip via OS),
+//   - invokes start_device_oauth() (fallback, user-code modal + polling),
 //   - listens for `oauth-complete` / `oauth-failed` / `oauth-state-change`,
 //   - calls oauth_logout() when the user signs out,
 //   - calls get_oauth_login() at mount to render the current "@user" if any.
 //
 // The tunnel JWT is intentionally NEVER exposed to the renderer — only the
 // resolved login string crosses the IPC boundary on success.
+//
+// R-51c note: cf-worker emits a single `oauth-failed` event for both flows;
+// R-51b did NOT introduce a separate `pkce_oauth_failed` channel — the SPA
+// must distinguish locally based on which command was last invoked. We model
+// that by tracking a small in-memory flag in LoginButton instead of inventing
+// a backend channel that doesn't exist yet.
 
 import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
@@ -32,6 +41,24 @@ export interface OauthFailedPayload {
 
 export async function invokeStartOauth(): Promise<StartOauthSpaPayload> {
   return invoke<StartOauthSpaPayload>('start_oauth');
+}
+
+/// R-51c (Task #169): kick off the PKCE / deep-link primary path. The Rust
+/// command POSTs to cf-worker `/api/auth/desktop/start`, opens the GitHub
+/// authorize URL via plugin-shell, and parks state in PkceStateStore so the
+/// `ccsm://oauth?...` deep link can be verified on return. The command
+/// returns once the browser has been launched — completion is signaled by
+/// the existing `oauth-complete` event (no extra payload).
+export async function invokeStartPkceOauth(): Promise<void> {
+  return invoke<void>('start_pkce_oauth');
+}
+
+/// R-51c (Task #169): kick off the device-flow fallback path. Same shape
+/// (and same SPA UI) as the legacy `start_oauth` — kept as a separate
+/// command so the Rust side can later diverge (e.g. extra telemetry on
+/// fallback frequency) without affecting the PKCE path.
+export async function invokeStartDeviceOauth(): Promise<StartOauthSpaPayload> {
+  return invoke<StartOauthSpaPayload>('start_device_oauth');
 }
 
 export async function invokeGetOauthState(): Promise<OauthState> {

--- a/packages/frontend-tauri/test/LoginButton.test.tsx
+++ b/packages/frontend-tauri/test/LoginButton.test.tsx
@@ -1,0 +1,263 @@
+// R-51c (Task #169): vitest coverage of LoginButton's PKCE-default + device
+// fallback UX, plus the 5 s auto-expand timer and the
+// `oauth-failed`-routing-by-active-flow logic.
+//
+// Why vitest + RTL stand in for an e2e Tauri assertion:
+//   The PR includes a manual end-to-end Tauri smoke (PR body) that proves
+//   the real `start_pkce_oauth` -> browser -> deep-link -> daemon-ready
+//   round-trip works on Windows. This suite locks in the SPA contract:
+//   which command name fires on which click, the auto-expand timing, and
+//   the error-surfacing routing — none of which depend on real IPC.
+//
+// What we mock and why:
+//   - `@tauri-apps/api/core` and `@tauri-apps/api/event`: the Tauri runtime
+//     is absent under jsdom (no `window.__TAURI_INTERNALS__`). The mocks
+//     hold per-test handles so we can assert command names + drive the
+//     event callbacks deterministically.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, act, cleanup } from '@testing-library/react';
+
+// --- module mocks --------------------------------------------------------
+
+const invokeMock = vi.fn();
+type Listener = (e: { payload: unknown }) => void;
+const listeners = new Map<string, Set<Listener>>();
+const listenMock = vi.fn(async (event: string, cb: Listener) => {
+  let set = listeners.get(event);
+  if (!set) {
+    set = new Set();
+    listeners.set(event, set);
+  }
+  set.add(cb);
+  return () => {
+    set?.delete(cb);
+  };
+});
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (...args: unknown[]) => listenMock(...(args as [string, Listener])),
+}));
+
+// Import AFTER mocks so the component picks up the mocked Tauri runtime.
+import { LoginButton, PKCE_AUTOFALLBACK_MS } from '../src/auth/LoginButton';
+
+function emit(event: string, payload: unknown) {
+  const set = listeners.get(event);
+  if (!set) return;
+  for (const cb of [...set]) cb({ payload });
+}
+
+beforeEach(() => {
+  invokeMock.mockReset();
+  listenMock.mockClear();
+  listeners.clear();
+  // Default: get_oauth_login returns null so we render the logged-out tree.
+  invokeMock.mockImplementation(async (cmd: string) => {
+    if (cmd === 'get_oauth_login') return null;
+    return undefined;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+});
+
+describe('LoginButton (R-51c / Task #169)', () => {
+  it('renders the PKCE primary button by default with the fallback link collapsed', async () => {
+    await act(async () => {
+      render(<LoginButton />);
+    });
+    expect(screen.getByTestId('login-button-pkce').textContent).toContain('Sign in with GitHub');
+    // Fallback toggle visible, fallback body collapsed.
+    const toggle = screen.getByTestId('login-button-fallback-toggle');
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByTestId('login-button-fallback-body')).toBeNull();
+    expect(screen.queryByTestId('login-button-device')).toBeNull();
+    // No modal until device flow runs.
+    expect(screen.queryByTestId('oauth-modal')).toBeNull();
+  });
+
+  it('clicking the primary button invokes start_pkce_oauth (not start_oauth / not device)', async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_oauth_login') return null;
+      if (cmd === 'start_pkce_oauth') return undefined;
+      throw new Error(`unexpected invoke ${cmd}`);
+    });
+    await act(async () => {
+      render(<LoginButton />);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('login-button-pkce'));
+    });
+    const calls = invokeMock.mock.calls.map((c) => c[0]);
+    expect(calls).toContain('start_pkce_oauth');
+    expect(calls).not.toContain('start_oauth');
+    expect(calls).not.toContain('start_device_oauth');
+  });
+
+  it('toggling the fallback link expands the device-flow row and reveals the "Use a code" button', async () => {
+    await act(async () => {
+      render(<LoginButton />);
+    });
+    fireEvent.click(screen.getByTestId('login-button-fallback-toggle'));
+    expect(screen.getByTestId('login-button-fallback-toggle').getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByTestId('login-button-fallback-body')).toBeDefined();
+    expect(screen.getByTestId('login-button-device').textContent).toContain('Use a code');
+  });
+
+  it('clicking "Use a code" invokes start_device_oauth and shows the user_code modal', async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_oauth_login') return null;
+      if (cmd === 'start_device_oauth') {
+        return {
+          user_code: 'ABCD-1234',
+          verification_uri: 'https://github.com/login/device',
+          expires_in: 900,
+          interval: 5,
+        };
+      }
+      throw new Error(`unexpected invoke ${cmd}`);
+    });
+    await act(async () => {
+      render(<LoginButton />);
+    });
+    fireEvent.click(screen.getByTestId('login-button-fallback-toggle'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('login-button-device'));
+    });
+    expect(invokeMock.mock.calls.map((c) => c[0])).toContain('start_device_oauth');
+    expect(screen.getByTestId('oauth-modal')).toBeDefined();
+    expect(screen.getByTestId('oauth-user-code').textContent).toContain('ABCD-1234');
+  });
+
+  it('an oauth-complete event after PKCE click switches to the logged-in view and clears the auto-fallback timer', async () => {
+    vi.useFakeTimers();
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_oauth_login') return null;
+      if (cmd === 'start_pkce_oauth') return undefined;
+      throw new Error(`unexpected invoke ${cmd}`);
+    });
+    await act(async () => {
+      render(<LoginButton />);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('login-button-pkce'));
+    });
+    // Simulate the deep-link round-trip succeeding well before the 5 s
+    // auto-fallback fires.
+    await act(async () => {
+      emit('oauth-complete', { login: 'octocat' });
+    });
+    expect(screen.getByTestId('login-button').textContent).toContain('@octocat');
+    // Advancing past the auto-fallback window must NOT pop the fallback
+    // open after a successful login.
+    await act(async () => {
+      vi.advanceTimersByTime(PKCE_AUTOFALLBACK_MS + 1_000);
+    });
+    expect(screen.queryByTestId('login-button-fallback-body')).toBeNull();
+  });
+
+  it('5 s after PKCE click without resolution, the fallback row auto-expands', async () => {
+    vi.useFakeTimers();
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_oauth_login') return null;
+      if (cmd === 'start_pkce_oauth') return undefined;
+      throw new Error(`unexpected invoke ${cmd}`);
+    });
+    await act(async () => {
+      render(<LoginButton />);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('login-button-pkce'));
+    });
+    expect(screen.queryByTestId('login-button-fallback-body')).toBeNull();
+    await act(async () => {
+      vi.advanceTimersByTime(PKCE_AUTOFALLBACK_MS + 100);
+    });
+    expect(screen.getByTestId('login-button-fallback-body')).toBeDefined();
+    expect(screen.getByTestId('login-button-device')).toBeDefined();
+  });
+
+  it('an oauth-failed event after PKCE click surfaces the inline error and auto-expands the fallback', async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_oauth_login') return null;
+      if (cmd === 'start_pkce_oauth') return undefined;
+      throw new Error(`unexpected invoke ${cmd}`);
+    });
+    await act(async () => {
+      render(<LoginButton />);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('login-button-pkce'));
+    });
+    await act(async () => {
+      emit('oauth-failed', { reason: 'state mismatch' });
+    });
+    expect(screen.getByTestId('login-button-pkce-error').textContent).toContain('state mismatch');
+    // PKCE failure must auto-open the fallback row so the user has a
+    // visible next step instead of being stuck.
+    expect(screen.getByTestId('login-button-fallback-body')).toBeDefined();
+  });
+
+  it('an oauth-failed event during device flow surfaces the error inside the modal (not as inline PKCE error)', async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_oauth_login') return null;
+      if (cmd === 'start_device_oauth') {
+        return {
+          user_code: 'ABCD-1234',
+          verification_uri: 'https://github.com/login/device',
+          expires_in: 900,
+          interval: 5,
+        };
+      }
+      throw new Error(`unexpected invoke ${cmd}`);
+    });
+    await act(async () => {
+      render(<LoginButton />);
+    });
+    fireEvent.click(screen.getByTestId('login-button-fallback-toggle'));
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('login-button-device'));
+    });
+    await act(async () => {
+      emit('oauth-failed', { reason: 'device code expired' });
+    });
+    expect(screen.getByTestId('oauth-modal').textContent).toContain('device code expired');
+    expect(screen.queryByTestId('login-button-pkce-error')).toBeNull();
+  });
+
+  it('a synchronous start_pkce_oauth rejection (e.g. CCSM_AUTH_BASE missing) shows inline error and opens fallback', async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_oauth_login') return null;
+      if (cmd === 'start_pkce_oauth') {
+        throw 'CCSM_AUTH_BASE env not set';
+      }
+      throw new Error(`unexpected invoke ${cmd}`);
+    });
+    await act(async () => {
+      render(<LoginButton />);
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('login-button-pkce'));
+    });
+    expect(screen.getByTestId('login-button-pkce-error').textContent).toContain('CCSM_AUTH_BASE');
+    expect(screen.getByTestId('login-button-fallback-body')).toBeDefined();
+  });
+
+  it('renders the logged-in view when get_oauth_login returns a username on mount', async () => {
+    invokeMock.mockImplementation(async (cmd: string) => {
+      if (cmd === 'get_oauth_login') return 'octocat';
+      return undefined;
+    });
+    await act(async () => {
+      render(<LoginButton />);
+    });
+    expect(screen.getByTestId('login-button').textContent).toContain('@octocat');
+  });
+});

--- a/packages/frontend-tauri/vitest.config.ts
+++ b/packages/frontend-tauri/vitest.config.ts
@@ -19,6 +19,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    include: ['test/**/*.test.{ts,tsx}'],
+    include: ['test/**/*.test.{ts,tsx}', 'src/**/*.test.{ts,tsx}'],
   },
 });


### PR DESCRIPTION
Task #169 — R-51c (PR 3 of 3 in the R-51 split). Builds on:

- R-51a (#167, PR #1234, 2026-05-10) — cf-worker schema rebuild + oauthLinker.
- R-51b (#168, PR #1235, 2026-05-10) — Tauri PKCE plugin + cf-worker `/api/auth/desktop/start` + `/oauth/desktop/cb`.

R-51c wires the SPA to those plumbing layers and updates user-facing docs.

## Summary

- `LoginButton.tsx`: PKCE is now the default sign-in path. A collapsible
  "Trouble signing in? Use a code instead" link reveals the device-flow
  fallback. The fallback auto-expands 5 s after a PKCE click that has
  not resolved, so a stuck deep-link registration surfaces the
  alternative without forcing the user to read the small grey link.
- `oauth-state.ts`: adds `invokeStartPkceOauth` (returns void — completion
  signaled via the existing `oauth-complete` event) and
  `invokeStartDeviceOauth`. `invokeStartOauth` is preserved for any
  legacy caller although LoginButton no longer uses it.
- `oauth-failed` routing: the SPA tracks which command was last invoked
  via a ref and routes the failure event either to an inline PKCE error
  (auto-opening the fallback row) or to the existing device-flow modal.
  No separate `pkce_oauth_failed` channel was added — R-51b's auth.rs
  already emits a unified `oauth-failed` for both paths and adding a
  second channel would have been unused weight.
- `vitest.config.ts`: include glob extended to also pick up
  `src/**/*.test.{ts,tsx}`, which reactivates the previously-orphaned
  `oauth-state.test.ts` (it was outside the prior `test/**` glob).
- Docs: `docs/S4-SETUP.md` adds a "Desktop sign-in flows" section with
  full PKCE + device-flow descriptions; `README.md` calls out that
  `CCSM_AUTH_BASE` is mandatory for local Tauri dev (consistent with the
  Rust side's "no hardcoded auth host" red-line).

## Local checks (host: Windows 11, mode: fast)

- lint: ✓ (frontend-tauri, exit 0)
- typecheck: ✓ (frontend-tauri, exit 0)
- build: ✓ (`pnpm --filter @ccsm/shared --filter @ccsm/ui --filter @ccsm/frontend-tauri build`, all green; cargo build of `ccsm-tauri` debug profile also OK — 1m54s, only pre-existing R-51b deprecation warnings on `app.shell().open()`)
- unit tests:
  - `pnpm --filter @ccsm/frontend-tauri test`: **3 files, 30 tests passed**
    (PhaseSwitch 11 + oauth-state 9 + LoginButton 10) — duration 3.62 s.
    Spec target was 16+; landed at 30.
  - `pnpm --filter @ccsm/cf-worker test`: 13 files, **201 passed** (R-51c
    does not touch cf-worker; baseline confirmed unbroken).
  - `pnpm --filter @ccsm/shared test`: 2 files, **46 passed**.
- e2e: skipped — no probe-e2e harness exists in this repo (the legacy
  `packages/e2e` was removed in S3 cleanup, see README "Tests" section).
  End-to-end coverage for this feature is the manual Tauri smoke
  described under "End-to-end evidence" below.

## End-to-end evidence — BLOCKED on infra (manager attention)

Spec Part D requires a real Windows Tauri run + a manager-driven GitHub
authorize step against `https://cc-sm.pages.dev`. **Two infra blockers
prevent that smoke from running today**, neither of which is in
R-51c's scope:

1. **`deploy-worker` workflow has been red since 2026-05-09** (every
   push from R-47 through R-51b inclusive). Failure is consistent:

   ```
   src/tunnel-do.ts(16,8): error TS2307:
     Cannot find module '@ccsm/shared' or its corresponding type declarations.
   ```

   The deploy job runs `pnpm -F @ccsm/cf-worker typecheck` without first
   building the shared package. Production is therefore still serving a
   pre-R-51a build — `curl -X POST https://cc-sm.pages.dev/api/auth/desktop/start`
   currently returns **HTTP 404**.

2. The end-to-end smoke also requires manager-driven GitHub authorize
   (Jiahui-Gu, ccsm-oAuth admin) against the production callback URL,
   which only resolves once (1) is unblocked.

Per dev §5 ("缺权限 / 缺账号 / 缺数据 / 工具坏了 → push back manager"),
I am not patching the deploy workflow inside this PR (out of scope, would
violate the SRP boundary between R-51c UI work and CI infra) and not
hacking the auth host to a tunneled local cf-worker (would mask the very
issue the smoke is supposed to validate).

**Suggested manager next steps after this PR lands:**
- File a small infra task to fix `deploy-worker.yml` to run
  `pnpm -F @ccsm/shared build` (or `pnpm -r build --filter='@ccsm/shared^...'`)
  before the cf-worker typecheck step.
- Once production redeploys, re-run the manual Tauri smoke locally with
  `CCSM_AUTH_BASE=https://cc-sm.pages.dev`, verify the deep-link round
  trip lands `~/.ccsm/tunnel_jwt`, and tag this PR / a follow-up with
  the captured stderr log + daemon-state event sequence.

## What was deliberately not done

- **No SignInGate change**: the spec mentioned `SignInGate.tsx` "if it
  exists". It exists in `packages/frontend-web` (the cloud SPA, R-46
  scope), not in `packages/frontend-tauri`. Touching the web variant is
  outside R-51 (the desktop OAuth refactor) and would conflate concerns.
- **No `pkce_oauth_failed` event**: R-51b's auth.rs deliberately uses a
  single `oauth-failed` channel for both flows. Adding a second channel
  would require backend changes (out of R-51c scope) and bring no
  observable benefit since the SPA already knows which command it just
  invoked.

## Skip-pattern audit

`grep -E '\.skip\(|xit\(|it\.todo\(|describe\.skip\(' packages/frontend-tauri/`:
0 matches in test code. (One match in `src-tauri/src/lib.rs` is
`args.iter().skip(1)` — Rust iterator, not a test skip.)