### PR TITLE
ci(deploy-worker): R-52 build shared before typecheck cf-worker (Task #172)

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -70,14 +70,20 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
+      # Task #172 [R-52 bug-infra]: build workspace deps BEFORE typecheck.
+      # cf-worker imports @ccsm/shared (since R-48 sid envelope SoT moved to
+      # shared), and frontend-web depends on shared/core/ui. Without dist
+      # artifacts on disk, `tsc` resolving `@ccsm/shared` falls through to
+      # the source pnpm symlink whose `package.json#types` points at the
+      # *built* `.d.ts`, yielding `TS2307: Cannot find module '@ccsm/shared'`.
+      # ci.yml already builds these before its `pnpm -r typecheck`; this
+      # workflow had the build step AFTER typecheck — fixed below.
+      # See gh run 25610689776..25619387306 (5 consecutive failures from R-48).
+      - name: Build workspace deps (shared + core + ui — required by cf-worker typecheck and frontend-web build)
+        run: pnpm -F @ccsm/shared build && pnpm -F @ccsm/core build && pnpm -F @ccsm/ui build
+
       - name: Typecheck cf-worker
         run: pnpm -F @ccsm/cf-worker typecheck
-
-      # Task #154: build the SPA before `wrangler deploy` so the
-      # `[assets] directory = "../frontend-web/dist"` binding has content
-      # to upload alongside the Worker script.
-      - name: Build workspace deps (shared + core + ui required by frontend-web)
-        run: pnpm -F @ccsm/shared build && pnpm -F @ccsm/core build && pnpm -F @ccsm/ui build
 
       - name: Build frontend-web (SPA assets bundled into the Worker deploy)
         run: pnpm -F @ccsm/frontend-web build


### PR DESCRIPTION
## Summary

deploy-worker.yml has been **failing 5 consecutive PRs** since R-48 (production frozen on pre-R-48 code for ~5 days). Users are not seeing R-44 cookie auth, R-46 OAuth state, R-48 envelope SoT, R-50 Tunnel sub-state, R-51a uuid schema, or R-51b PKCE deep-link OAuth.

## Ground truth

5 consecutive failures (gh run list --workflow=deploy-worker.yml):

| run id | trigger | step that failed |
|---|---|---|
| 25619387306 | R-51b merge | Typecheck cf-worker |
| 25618878975 | R-51a merge | Typecheck cf-worker |
| 25618058671 | R-50 merge | Typecheck cf-worker |
| 25611181933 | R-47 merge | Typecheck cf-worker |
| 25610689776 | R-48 merge | Typecheck cf-worker |

Last green: 25610155833 (R-46, before R-48 introduced the @ccsm/shared dep).

Failure log (gh run view 25610689776 --log-failed):

\`\`\`
src/tunnel-do.ts(16,8): error TS2307: Cannot find module '@ccsm/shared' or its corresponding type declarations.
##[error]Process completed with exit code 2.
\`\`\`

## Root cause (architecture layer)

R-48 moved sid envelope + tunnel frame schema SoT into \`@ccsm/shared\` and added \`import { ... } from '@ccsm/shared'\` to \`packages/cf-worker/src/tunnel-do.ts\`. tsc resolves workspace packages via \`package.json#types\` which points at \`dist/index.d.ts\`. deploy-worker.yml ran the \`Typecheck cf-worker\` step BEFORE building shared, so the type declarations did not exist on disk → TS2307.

ci.yml on PRs already builds shared/core/ui before \`pnpm -r typecheck\` (line 51-52), which is why R-48..R-51b PRs passed CI green but every post-merge deploy hit the same wall.

## Fix

Move the existing \`Build workspace deps\` step to BEFORE \`Typecheck cf-worker\`. No new commands, no business code change, no \`wrangler.toml\` change, no glue / retry / fallback.

Per pnpm filter docs (https://pnpm.io/filtering, \`<pkg>^...\` = "ONLY select the dependencies of a package"), we could write \`pnpm -r build --filter='@ccsm/cf-worker^...'\` — but explicit \`-F @ccsm/shared && -F @ccsm/core && -F @ccsm/ui\` mirrors ci.yml line 52 and avoids surprising fan-out, so kept explicit.

## Local Windows reproduction (per repo policy: local before CI)

\`\`\`
$ rm -rf packages/{shared,core,ui}/dist
$ pnpm -F @ccsm/cf-worker typecheck
src/tunnel-do.ts(16,8): error TS2307: Cannot find module '@ccsm/shared' ...
Exit status 2

$ pnpm -F @ccsm/shared build && pnpm -F @ccsm/core build \
    && pnpm -F @ccsm/ui build && pnpm -F @ccsm/cf-worker typecheck
(green)
\`\`\`

## Production verification (will be run after merge)

After merge, the next deploy-worker run on \`working\` is expected to:

- typecheck step: pass
- deploy step: pass (wrangler-action deploys script + assets)

curl evidence (will be appended as a follow-up comment after the deploy run goes green, per Task #172 spec):

- \`POST https://cc-sm.pages.dev/api/auth/desktop/start\` → expect 400/200, NOT 404 (R-51b endpoint live)
- \`GET  https://cc-sm.pages.dev/api/auth/me\` → expect 401, NOT 404 (R-44 cookie change live)

## Test plan

- [x] Local Windows: failure reproduced (TS2307 with no dist)
- [x] Local Windows: fix verified green (typecheck after build)
- [ ] CI: deploy-worker.yml run on this branch's merge to working passes both typecheck and deploy steps
- [ ] Prod: curl evidence confirms R-44/R-51b endpoints reachable