### PR TITLE
R-53: static OAuth callback page + /api/auth/desktop/exchange (Task #175)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,15 +57,17 @@ jobs:
       - name: Build
         run: pnpm -r build
 
-      - name: Tauri shell guard (Task #711, S2-T10) — frontend-tauri must never reference Pages
+      - name: Tauri shell guard (Task #711, S2-T10) — frontend-tauri must never reference cloud host
         # Architectural red-line: the Tauri desktop shell embeds frontend-web
-        # and loads loopback daemon; it must NEVER fetch https://cc-sm.pages.dev.
-        # See DESIGN.md §11 Deployment Topologies. Any hit here is a regression.
+        # and loads loopback daemon; it must NEVER fetch the cloud host
+        # (was https://cc-sm.pages.dev pre-R-53; now
+        # https://ccsm-worker.jiahuigu.workers.dev). See DESIGN.md §11
+        # Deployment Topologies. Any hit here is a regression.
         shell: bash
         run: |
           set -e
           fail=0
-          for pat in 'pages\.dev' 'cc-sm' 'Pages'; do
+          for pat in 'pages\.dev' 'cc-sm' 'Pages' 'workers\.dev' 'ccsm-worker'; do
             hits=$(git grep -nE "$pat" -- packages/frontend-tauri/ || true)
             if [ -n "$hits" ]; then
               echo "::error::Tauri shell guard tripped — pattern '$pat' found in packages/frontend-tauri/:"
@@ -74,7 +76,7 @@ jobs:
             fi
           done
           if [ "$fail" = "1" ]; then exit 1; fi
-          echo "Tauri shell guard OK — no Pages references in packages/frontend-tauri/."
+          echo "Tauri shell guard OK — no cloud host references in packages/frontend-tauri/."
 
   tauri-build:
     # T14 (#681): nightly Windows tauri build producing the .msi artifact.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -479,7 +479,7 @@ one of them being offline does not affect the others:
    own `http://127.0.0.1:<port>/` in a regular browser and gets the SPA
    that the daemon serves directly.
 3. **Browser -> Cloudflare Pages -> local daemon** (S2) — the user
-   opens `https://cc-sm.pages.dev` in a regular browser; Pages
+   opens `https://ccsm-worker.jiahuigu.workers.dev` in a regular browser; Pages
    distributes the same SPA, and the SPA fetches the loopback daemon
    (`http://127.0.0.1:<port>`) from inside the browser. Pages is just a
    static-asset CDN — it does not participate in auth and does not
@@ -488,7 +488,7 @@ one of them being offline does not affect the others:
 ### Red lines (architectural invariants)
 
 - The Tauri shell's webview URL **must** be `http://127.0.0.1:<port>/...`;
-  it **must not** point to `https://cc-sm.pages.dev` or any remote host.
+  it **must not** point to `https://ccsm-worker.jiahuigu.workers.dev` or any remote host.
 - The Tauri shell source (`packages/frontend-tauri/`) **must not**
   contain `pages.dev` / `cc-sm` / remote-fetch logic. CI grep guards
   enforce this; see `.github/workflows/ci.yml`.
@@ -538,7 +538,7 @@ from a developer's perspective.
                                              |  CDN)                |
                                              +----------------------+
 
-origin (browser)   : https://cc-sm.pages.dev
+origin (browser)   : https://ccsm-worker.jiahuigu.workers.dev
 origin (daemon)    : http://127.0.0.1:9876
 relation           : cross-origin (HTTPS -> HTTP loopback)
 static asset path  : Cloudflare CDN (`/_headers` immutable for /assets/*)
@@ -549,7 +549,7 @@ token bootstrap    : URL `?token=` -> sessionStorage; or `GET <daemonBase>/token
 Security constraints:
 
 - The daemon's `classifyOrigin()` allow-list must include
-  `https://cc-sm.pages.dev` (S2-T1). Look-alike domains / PR-preview
+  `https://ccsm-worker.jiahuigu.workers.dev` (S2-T1). Look-alike domains / PR-preview
   subdomains are rejected by default (unless
   `CCSM_ALLOW_PAGES_PREVIEWS=1`, S2-T8).
 - Chromium >=120 PNA: when an HTTPS page fetches loopback, the browser
@@ -636,7 +636,7 @@ token bootstrap    : Rust reads daemon stdout, splices it into the initial webvi
 Security constraints:
 
 - The Tauri webview URL **must** be `http://127.0.0.1:<port>/...`; it
-  **must not** point to `https://cc-sm.pages.dev` (§11 red line + CI
+  **must not** point to `https://ccsm-worker.jiahuigu.workers.dev` (§11 red line + CI
   grep guard, S2-T10).
 - The daemon's `classifyOrigin()` is the same as mode 2: only loopback
   origins are allowed. Tauri's own `tauri://localhost` (custom-protocol
@@ -655,7 +655,7 @@ Security constraints:
 |-----------|----------------------|-------------------|----------------|
 | static-asset location | Cloudflare CDN | daemon-embedded serve | daemon-embedded (ships with the app) |
 | daemon location | user machine loopback | user machine loopback | child spawned by Tauri |
-| browser origin | `https://cc-sm.pages.dev` | `http://127.0.0.1:<port>` | `http://127.0.0.1:<port>` |
+| browser origin | `https://ccsm-worker.jiahuigu.workers.dev` | `http://127.0.0.1:<port>` | `http://127.0.0.1:<port>` |
 | daemon origin | `http://127.0.0.1:9876` | same as browser | same as browser |
 | same/cross-origin | cross | same | same |
 | CORS | required (Pages allow-list) | not needed | not needed |

--- a/README.md
+++ b/README.md
@@ -70,15 +70,15 @@ authentication nor proxies traffic.
 node packages/daemon/dist/index.mjs
 
 # 2. Open in a browser:
-#    https://cc-sm.pages.dev
+#    https://ccsm-worker.jiahuigu.workers.dev
 ```
 
 Two paths for token bootstrap:
 
 - Append the `?token=<t>` from the daemon stdout line to the Pages URL:
-  `https://cc-sm.pages.dev/?token=<token>`. The SPA writes it to
+  `https://ccsm-worker.jiahuigu.workers.dev/?token=<token>`. The SPA writes it to
   sessionStorage.
-- Or open `https://cc-sm.pages.dev/` directly. The SPA automatically
+- Or open `https://ccsm-worker.jiahuigu.workers.dev/` directly. The SPA automatically
   `GET http://127.0.0.1:9876/token` (this endpoint is exposed only to
   loopback origins and Pages allow-list origins) to retrieve the token.
 
@@ -90,7 +90,7 @@ must be on a version with PNA (Private Network Access) preflight support
 CI: every push to `main` or `working` whose diff touches
 `packages/{frontend-web,ui,core,shared}` triggers
 `.github/workflows/deploy-pages.yml`, which builds and deploys to
-https://cc-sm.pages.dev (no manual `gh workflow run` needed). You can also
+https://ccsm-worker.jiahuigu.workers.dev (no manual `gh workflow run` needed). You can also
 `workflow_dispatch` it manually from the Actions page (e.g. after rotating
 Cloudflare env vars).
 
@@ -133,7 +133,7 @@ var. Without it, the in-app sign-in flows surface a clear failure
 
 ```sh
 # Production / staging
-CCSM_AUTH_BASE=https://cc-sm.pages.dev pnpm tauri dev
+CCSM_AUTH_BASE=https://ccsm-worker.jiahuigu.workers.dev pnpm tauri dev
 
 # Local cf-worker (run `pnpm --filter @ccsm/cf-worker dev` in another terminal)
 CCSM_AUTH_BASE=http://127.0.0.1:8787 pnpm tauri dev

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -81,7 +81,7 @@ Production cutover ladder (S4 -> S5):
 
 ## Deployment topology change — Task #154 (R-49 audit P1, F-A-2), 2026-05-10
 
-The standalone Cloudflare **Pages** project (`cc-sm.pages.dev`) and its
+The standalone Cloudflare **Pages** project (`ccsm-worker.jiahuigu.workers.dev`) and its
 reproxy Pages Function (`packages/frontend-web/functions/[[path]].ts`) have
 been folded into the same Worker that owns `TunnelDO`. The Worker now uses
 [Cloudflare Workers Static Assets](https://developers.cloudflare.com/workers/static-assets/)
@@ -90,7 +90,7 @@ to serve the SPA bundle (`packages/frontend-web/dist`) directly:
 - `packages/cf-worker/wrangler.toml` declares `[assets] directory = "../frontend-web/dist"` with `not_found_handling = "single-page-application"` for SPA history-mode fallback and `run_worker_first = ["/health", "/ws/default", "/tunnel/default", "/token", "/api/*"]` so dynamic paths still hit the Worker script.
 - `.github/workflows/deploy-pages.yml` is removed; `.github/workflows/deploy-worker.yml` now builds `frontend-web` before `wrangler deploy` so the Worker upload includes both the script and the SPA bundle in a single atomic deploy.
 - `packages/frontend-web/wrangler.toml`, `packages/frontend-web/functions/[[path]].ts`, and `packages/frontend-web/tsconfig.functions.json` are deleted.
-- `cc-sm.pages.dev` is left intact for now — this PR only prepares the Worker side. The production DNS cutover (point the canonical SPA hostname at the Worker) is a follow-up.
+- `ccsm-worker.jiahuigu.workers.dev` is left intact for now — this PR only prepares the Worker side. The production DNS cutover (point the canonical SPA hostname at the Worker) is a follow-up.
 
 Why: the prior topology required two deploy pipelines, two wrangler configs, and a Pages-Function reproxy hop on every browser request that already terminated in the Worker. The folded topology halves the deploy surface and eliminates the reproxy latency.
 

--- a/docs/S4-SETUP.md
+++ b/docs/S4-SETUP.md
@@ -43,8 +43,8 @@ Recommended values:
 | Field | Value |
 |-------|-------|
 | Application name | `ccsm` |
-| Homepage URL | `https://cc-sm.pages.dev` |
-| Authorization callback URL | `https://cc-sm.pages.dev/api/auth/github/callback` |
+| Homepage URL | `https://ccsm-worker.jiahuigu.workers.dev` |
+| Authorization callback URL | `https://ccsm-worker.jiahuigu.workers.dev/api/auth/github/callback` |
 | Enable Device Flow | **checked** (required for S4-T8 desktop login) |
 
 OAuth Apps allow only **one** Authorization callback URL. We use the
@@ -164,7 +164,7 @@ Default for installed Windows / Linux desktops where the OS can dispatch
    GitHub authorize URL.
 3. The shell opens the URL via `tauri-plugin-shell`. The user authorizes
    on github.com.
-4. GitHub redirects back to `https://cc-sm.pages.dev/oauth/desktop/cb`,
+4. GitHub redirects back to `https://ccsm-worker.jiahuigu.workers.dev/oauth/desktop/cb`,
    which renders a tiny bounce page that immediately navigates to
    `ccsm://oauth?token=<jwt>&refresh=<token>&state=<state>`.
 5. The OS routes the deep link to the running Tauri instance (single-
@@ -190,7 +190,7 @@ mints a `user_code` + `verification_uri`; SPA shows the modal; Rust polls
 The single OAuth App registered in step 1 above already supports both
 desktop paths. No second app is needed:
 
-- **Authorization callback URL**: `https://cc-sm.pages.dev/oauth/desktop/cb`
+- **Authorization callback URL**: `https://ccsm-worker.jiahuigu.workers.dev/oauth/desktop/cb`
   (R-51a re-routed the desktop path to this endpoint; the legacy
   `/api/auth/github/callback` continues to serve the web flow). If your
   app was registered before R-51a, update the callback URL in the GitHub
@@ -204,7 +204,7 @@ The Tauri shell is repo-agnostic by ROADMAP red-line, so the auth host is
 
 ```bash
 # Production / staging
-CCSM_AUTH_BASE=https://cc-sm.pages.dev pnpm tauri dev
+CCSM_AUTH_BASE=https://ccsm-worker.jiahuigu.workers.dev pnpm tauri dev
 
 # Local cf-worker dev
 CCSM_AUTH_BASE=http://127.0.0.1:8787 pnpm tauri dev

--- a/packages/cf-worker/src/auth/desktopOauth.ts
+++ b/packages/cf-worker/src/auth/desktopOauth.ts
@@ -1,9 +1,13 @@
 /**
- * R-51b (Task #168): cf-worker desktop OAuth (PKCE) flow handlers.
+ * R-51b (Task #168) + R-53 (Task #175): cf-worker desktop OAuth (PKCE) flow
+ * handlers.
  *
  * Tauri shells use this path instead of device flow when the OS supports a
- * `ccsm://` deep link (R-51c will demote device flow to a fallback UI). The
- * round-trip:
+ * `ccsm://` deep link. R-53 split the callback handling so Cloudflare Pages
+ * legacy routing (which can return 308 on the bare /oauth/desktop/cb path
+ * before the Worker ever sees it) cannot break sign-in.
+ *
+ * Round-trip:
  *
  *   POST /api/auth/desktop/start
  *     — mint random `state` + PKCE `code_verifier` + `code_challenge` (S256),
@@ -11,41 +15,41 @@
  *       role (`pkce:state:<state>`), return `{auth_url}` containing the
  *       GitHub authorize URL with state + code_challenge + redirect_uri.
  *
- *   GET  /oauth/desktop/cb?code=&state=
+ *   GET  /oauth/desktop/cb?code=&state=  (R-53: STATIC — not handled here)
+ *     — served as a static HTML page out of `frontend-web/dist`. The page
+ *       extracts code + state from the URL and POSTs them to the exchange
+ *       endpoint below. See
+ *       `packages/frontend-web/public/oauth/desktop/cb/index.html`.
+ *
+ *   POST /api/auth/desktop/exchange  body { code, state }
  *     — verify state (UserDO hit + age <5min), exchange `code` + the stored
- *       `code_verifier` against GitHub /access_token (PKCE: client side does
- *       NOT need a client_secret — but GitHub OAuth Apps still demand it so
- *       we send both, GitHub still validates the verifier), fetch user info,
- *       run shared linker (R-51a), mint tunnel JWT + refresh token, render an
- *       HTML page that immediately redirects to
- *       `ccsm://oauth?token=<jwt>&refresh=<refresh>&state=<state>` with a
- *       fallback button + copy.
+ *       `code_verifier` against GitHub /access_token (PKCE), fetch user
+ *       info, run shared linker (R-51a), mint tunnel JWT + refresh token,
+ *       return JSON { tunnel_jwt, refresh_token }. The static page composes
+ *       the `ccsm://oauth?...` deep link from the response and triggers
+ *       location.replace.
  *
  * Why PKCE in addition to client_secret: although the GitHub Web flow does
  * not strictly require PKCE, it accepts the PKCE verifier and is the recipe
  * that lets us be CSRF-tight even with the public redirect_uri scheme. The
- * stored `code_verifier` ties the started authorize to the callback.
+ * stored `code_verifier` ties the started authorize to the exchange.
  *
  * State row TTL: 5 minutes. After expiry the entry is treated as missing and
- * the callback returns 400 even if the row is still on disk (UserDO storage
+ * the exchange returns 400 even if the row is still on disk (UserDO storage
  * does not auto-expire).
  *
  * Redirect URI: `<auth_base>/oauth/desktop/cb`. v0.4 uses
  * `https://cc-sm.pages.dev/oauth/desktop/cb` in production, matching the
  * GitHub OAuth App's prefix-allowed callback. The `auth_base` is derived
  * from the request URL so wrangler dev / cloud tunnel both resolve the same
- * way without baking in a hostname.
+ * way without baking in a hostname. R-53 keeps this URL stable so the GH
+ * OAuth App configuration does not need to change.
  *
- * State storage role (added to UserDO in this PR):
+ * State storage role:
  *   - idFromName('pkce:state:<state>') → { code_verifier, created_at }
  *
  * Logger event prefix: `oauth.desktop.*` (start_ok / start_fail /
- * callback_ok / callback_fail). Token-bearing fields are dropped by the
- * logger redactor (R-46) so the rendered URL never appears in logs.
- *
- * NOT in scope for this PR (R-51c):
- *   - Tauri renderer SPA UI changes
- *   - cf-worker deploy (left to R-51c end-to-end verification)
+ * exchange_ok / exchange_fail).
  */
 import type { AuthEnv } from './bindings';
 import { signJwt, type TunnelJwtClaims } from './jwt';
@@ -59,6 +63,7 @@ const GH_USER_URL = 'https://api.github.com/user';
 const TUNNEL_JWT_TTL_SEC = 60 * 60 * 24; // 24h, mirrors deviceFlow
 const PKCE_STATE_TTL_SEC = 5 * 60; // 5 minutes — short by design.
 const DESKTOP_CALLBACK_PATH = '/oauth/desktop/cb';
+const DESKTOP_EXCHANGE_PATH = '/api/auth/desktop/exchange';
 
 function loggerFor(req: Request): Logger {
   const requestId = req.headers.get('X-CCSM-Request-Id') ?? 'no-req-id';
@@ -134,7 +139,7 @@ async function takePkceState(
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`getPkceState http ${res.status}`);
   const row = (await res.json()) as PkceStateRow;
-  // One-shot use: clear immediately so a replayed callback cannot reuse the
+  // One-shot use: clear immediately so a replayed exchange cannot reuse the
   // verifier even if the GitHub /access_token call below fails.
   await stub.fetch(new Request('https://do/clearPkceState', { method: 'POST' }));
   return row;
@@ -143,7 +148,7 @@ async function takePkceState(
 /**
  * POST /api/auth/desktop/start — Tauri shell calls this before opening the
  * system browser. We mint state + verifier + challenge, persist (state →
- * verifier) for the callback, and return the GitHub authorize URL the shell
+ * verifier) for the exchange, and return the GitHub authorize URL the shell
  * should open via Shell.open.
  */
 export async function handleDesktopStart(
@@ -201,77 +206,40 @@ interface GithubUserResponse {
   email?: string | null;
 }
 
-/** Render the deep-link bounce page. Uses location.replace so the user does
- *  not see an intermediate URL in history; provides a manual button + copy
- *  in case the OS prompt was dismissed. The token bearing URL never lands
- *  in `Location:` (which CF logs); it lives in the inline script + button. */
-function renderBouncePage(deepLink: string): Response {
-  // We deliberately interpolate the token-bearing URL into the page body.
-  // It is one-shot (PKCE state has been cleared by takePkceState above) and
-  // never logged: cf-worker emits no log line containing the deep link.
-  const html = `<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Signing in to ccsm-tauri</title>
-  <style>
-    body { font: 14px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
-           max-width: 480px; margin: 6rem auto; padding: 0 1rem; color: #222; }
-    h1 { font-size: 1.25rem; margin: 0 0 1rem; }
-    p { margin: 0 0 1rem; }
-    a.btn { display: inline-block; padding: 0.6rem 1rem; background: #1f2937;
-            color: #fff; text-decoration: none; border-radius: 6px;
-            font-weight: 600; }
-    a.btn:hover { background: #111827; }
-    .muted { color: #6b7280; font-size: 0.9rem; }
-  </style>
-</head>
-<body>
-  <h1>Sign-in successful</h1>
-  <p>Returning to the ccsm desktop app&hellip;</p>
-  <p><a id="open" class="btn" href="${escapeHtml(deepLink)}">Open ccsm desktop</a></p>
-  <p class="muted">If nothing happens, click the button above. You can close this tab afterwards.</p>
-  <script>
-    // Immediate handoff. location.replace avoids a back-button ghost.
-    location.replace(${JSON.stringify(deepLink)});
-  </script>
-</body>
-</html>`;
-  return new Response(html, {
-    status: 200,
-    headers: { 'content-type': 'text/html; charset=utf-8' },
-  });
+interface ExchangeRequestBody {
+  code?: unknown;
+  state?: unknown;
 }
 
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+interface ExchangeResponseBody {
+  tunnel_jwt: string;
+  refresh_token: string;
 }
 
 /**
- * GET /oauth/desktop/cb?code=&state= — desktop OAuth callback.
+ * POST /api/auth/desktop/exchange — desktop OAuth code exchange.
  *
- * On success renders an HTML page that location.replace()s into
- * `ccsm://oauth?token=<jwt>&refresh=<refresh_token>&state=<state>` so the
- * Tauri shell's deep-link listener picks it up. The Tauri side
- * (`auth.rs::handle_desktop_callback`) verifies `state` against an in-memory
- * map populated when `start_pkce_oauth` ran, then writes the creds file.
+ * Body: { code: string, state: string }. The static
+ * `/oauth/desktop/cb/index.html` page POSTs this after extracting the params
+ * GitHub put on the redirect URL.
  */
-export async function handleDesktopCallback(
+export async function handleDesktopExchange(
   req: Request,
   env: AuthEnv,
 ): Promise<Response> {
   const log = loggerFor(req);
-  const url = new URL(req.url);
-  const code = url.searchParams.get('code');
-  const state = url.searchParams.get('state');
+
+  let body: ExchangeRequestBody;
+  try {
+    body = (await req.json()) as ExchangeRequestBody;
+  } catch (_err) {
+    log.warn('oauth.desktop.exchange_fail', { reason: 'malformed_json' });
+    return new Response('malformed JSON body', { status: 400 });
+  }
+  const code = typeof body.code === 'string' ? body.code : '';
+  const state = typeof body.state === 'string' ? body.state : '';
   if (!code || !state) {
-    log.warn('oauth.desktop.callback_fail', {
+    log.warn('oauth.desktop.exchange_fail', {
       reason: 'missing_code_or_state',
     });
     return new Response('missing code or state', { status: 400 });
@@ -281,14 +249,14 @@ export async function handleDesktopCallback(
   try {
     row = await takePkceState(env, state);
   } catch (err) {
-    log.error('oauth.desktop.callback_fail', {
+    log.error('oauth.desktop.exchange_fail', {
       reason: 'userdo_takepkce_failed',
       err: String(err),
     });
     return new Response('userDO takePkceState failed', { status: 500 });
   }
   if (row === null) {
-    log.warn('oauth.desktop.callback_fail', {
+    log.warn('oauth.desktop.exchange_fail', {
       reason: 'unknown_state',
       state_prefix: shortSub(state),
     });
@@ -296,7 +264,7 @@ export async function handleDesktopCallback(
   }
   const ageSec = Math.floor(Date.now() / 1000) - row.created_at;
   if (ageSec > PKCE_STATE_TTL_SEC) {
-    log.warn('oauth.desktop.callback_fail', {
+    log.warn('oauth.desktop.exchange_fail', {
       reason: 'state_expired',
       age_sec: ageSec,
     });
@@ -307,7 +275,7 @@ export async function handleDesktopCallback(
 
   // Exchange code → access_token, including code_verifier (PKCE). GitHub
   // OAuth Apps require client_secret too; PKCE is layered on top, providing
-  // proof that the callback caller is the same shell that opened the
+  // proof that the exchange caller is the same shell that opened the
   // authorize URL (verifier never leaves cf-worker storage).
   const tokenRes = await fetch(GH_TOKEN_URL, {
     method: 'POST',
@@ -324,7 +292,7 @@ export async function handleDesktopCallback(
     }).toString(),
   });
   if (!tokenRes.ok) {
-    log.warn('oauth.desktop.callback_fail', {
+    log.warn('oauth.desktop.exchange_fail', {
       reason: 'github_token_exchange_http_error',
       status: tokenRes.status,
     });
@@ -334,7 +302,7 @@ export async function handleDesktopCallback(
   if (!tokenJson.access_token) {
     // PKCE verifier mismatch shows up here as `error: bad_verification_code`
     // (or invalid_grant) — GitHub returns 200 with an error payload.
-    log.warn('oauth.desktop.callback_fail', {
+    log.warn('oauth.desktop.exchange_fail', {
       reason: 'github_token_exchange_rejected',
       gh_error: tokenJson.error ?? 'unknown',
     });
@@ -353,7 +321,7 @@ export async function handleDesktopCallback(
     },
   });
   if (!userRes.ok) {
-    log.warn('oauth.desktop.callback_fail', {
+    log.warn('oauth.desktop.exchange_fail', {
       reason: 'github_user_http_error',
       status: userRes.status,
     });
@@ -361,7 +329,7 @@ export async function handleDesktopCallback(
   }
   const userJson = (await userRes.json()) as GithubUserResponse;
   if (typeof userJson.id !== 'number' || typeof userJson.login !== 'string') {
-    log.warn('oauth.desktop.callback_fail', {
+    log.warn('oauth.desktop.exchange_fail', {
       reason: 'github_user_malformed',
     });
     return new Response('github user response malformed', { status: 502 });
@@ -382,14 +350,14 @@ export async function handleDesktopCallback(
     });
   } catch (err) {
     if (err instanceof MultipleAccountsError) {
-      log.warn('oauth.desktop.callback_fail', {
+      log.warn('oauth.desktop.exchange_fail', {
         reason: 'multiple_accounts',
         email_index_user_id: err.emailIndexUserId,
         identity_user_id: err.identityUserId,
       });
       return new Response('multiple-accounts', { status: 409 });
     }
-    log.error('oauth.desktop.callback_fail', {
+    log.error('oauth.desktop.exchange_fail', {
       reason: 'linker_failed',
       err: String(err),
     });
@@ -409,7 +377,7 @@ export async function handleDesktopCallback(
     }),
   );
   if (!setHashRes.ok) {
-    log.error('oauth.desktop.callback_fail', {
+    log.error('oauth.desktop.exchange_fail', {
       reason: 'userdo_settunnelrefreshhash_failed',
       status: setHashRes.status,
     });
@@ -430,33 +398,31 @@ export async function handleDesktopCallback(
   };
   const tunnelJwt = await signJwt(claims, env.JWT_REFRESH_SIGNING_KEY);
 
-  log.info('oauth.desktop.callback_ok', {
+  log.info('oauth.desktop.exchange_ok', {
     decision: linkResult.decision,
     login,
     sub_prefix: shortSub(userId),
     jti: claims.jti,
   });
 
-  // Compose the deep link. `state` is echoed back so the Tauri-side listener
-  // can verify it against the in-memory state minted at start_pkce_oauth
-  // and reject replays / cross-instance bounces.
-  const deepLink =
-    'ccsm://oauth?' +
-    new URLSearchParams({
-      token: tunnelJwt,
-      refresh: tunnelRefreshToken,
-      state,
-    }).toString();
-
-  return renderBouncePage(deepLink);
+  const body_out: ExchangeResponseBody = {
+    tunnel_jwt: tunnelJwt,
+    refresh_token: tunnelRefreshToken,
+  };
+  return Response.json(body_out);
 }
 
 /**
  * Top-level dispatch. Returns null when the path is not ours.
  *
- * Two prefixes:
+ * Two routes (R-53):
  *   POST /api/auth/desktop/start
- *   GET  /oauth/desktop/cb
+ *   POST /api/auth/desktop/exchange
+ *
+ * Note: `/oauth/desktop/cb` is no longer handled by the Worker — the static
+ * HTML page in `frontend-web/public/oauth/desktop/cb/index.html` serves it
+ * directly. wrangler.toml has been updated to remove `/oauth/desktop/cb`
+ * from `[assets].run_worker_first`.
  */
 export async function dispatchDesktop(
   req: Request,
@@ -467,8 +433,8 @@ export async function dispatchDesktop(
   if (req.method === 'POST' && path === '/api/auth/desktop/start') {
     return handleDesktopStart(req, env);
   }
-  if (req.method === 'GET' && path === DESKTOP_CALLBACK_PATH) {
-    return handleDesktopCallback(req, env);
+  if (req.method === 'POST' && path === DESKTOP_EXCHANGE_PATH) {
+    return handleDesktopExchange(req, env);
   }
   return null;
 }

--- a/packages/cf-worker/src/auth/desktopOauth.ts
+++ b/packages/cf-worker/src/auth/desktopOauth.ts
@@ -62,7 +62,14 @@ const GH_USER_URL = 'https://api.github.com/user';
 
 const TUNNEL_JWT_TTL_SEC = 60 * 60 * 24; // 24h, mirrors deviceFlow
 const PKCE_STATE_TTL_SEC = 5 * 60; // 5 minutes — short by design.
-const DESKTOP_CALLBACK_PATH = '/oauth/desktop/cb';
+// R-53 (Task #175): trailing slash matters. Cloudflare Workers Static
+// Assets serves directory index files (`oauth/desktop/cb/index.html`) by
+// 307-redirecting `/oauth/desktop/cb` → `/oauth/desktop/cb/` (with the
+// query string preserved). To avoid the redirect hop on every callback
+// (and to keep the redirect_uri stable on both sides), we standardise on
+// the trailing-slash form. The GitHub OAuth App callback URL must be
+// configured with a prefix that allows `/oauth/desktop/cb/`.
+const DESKTOP_CALLBACK_PATH = '/oauth/desktop/cb/';
 const DESKTOP_EXCHANGE_PATH = '/api/auth/desktop/exchange';
 
 function loggerFor(req: Request): Logger {

--- a/packages/cf-worker/src/auth/desktopOauth.ts
+++ b/packages/cf-worker/src/auth/desktopOauth.ts
@@ -39,7 +39,7 @@
  * does not auto-expire).
  *
  * Redirect URI: `<auth_base>/oauth/desktop/cb`. v0.4 uses
- * `https://cc-sm.pages.dev/oauth/desktop/cb` in production, matching the
+ * `https://ccsm-worker.jiahuigu.workers.dev/oauth/desktop/cb` in production, matching the
  * GitHub OAuth App's prefix-allowed callback. The `auth_base` is derived
  * from the request URL so wrangler dev / cloud tunnel both resolve the same
  * way without baking in a hostname. R-53 keeps this URL stable so the GH
@@ -104,7 +104,7 @@ async function pkceChallengeS256(verifier: string): Promise<string> {
 
 /** Derive the auth base (origin) from the inbound request URL so we don't
  *  hard-code a host name. wrangler dev sees `http://127.0.0.1:8787`,
- *  production sees `https://cc-sm.pages.dev`. */
+ *  production sees `https://ccsm-worker.jiahuigu.workers.dev`. */
 function authOrigin(req: Request): string {
   return new URL(req.url).origin;
 }
@@ -232,7 +232,7 @@ export async function handleDesktopExchange(
   let body: ExchangeRequestBody;
   try {
     body = (await req.json()) as ExchangeRequestBody;
-  } catch (_err) {
+  } catch {
     log.warn('oauth.desktop.exchange_fail', { reason: 'malformed_json' });
     return new Response('malformed JSON body', { status: 400 });
   }

--- a/packages/cf-worker/src/index.ts
+++ b/packages/cf-worker/src/index.ts
@@ -221,7 +221,7 @@ export default {
     // Task #787 (S3-C): REST `/api/*` and `/token` flow through the same DO
     // instance, which serializes them as http_req control frames over the
     // daemon-dialed ws and awaits the matching http_res. The browser only
-    // ever talks to cc-sm.pages.dev; the DO bridges to the NAT'd daemon.
+    // ever talks to ccsm-worker.jiahuigu.workers.dev; the DO bridges to the NAT'd daemon.
     if (url.pathname.startsWith('/api/') || url.pathname === '/token') {
       let doIdName = 'default';
       let routedLogin: string | undefined;

--- a/packages/cf-worker/src/index.ts
+++ b/packages/cf-worker/src/index.ts
@@ -127,17 +127,12 @@ export default {
       return new Response('Not Found', { status: 404 });
     }
 
-    // R-51b (Task #168): desktop OAuth callback lives at
-    // `GET /oauth/desktop/cb` (NOT under /api/auth/*) so the GitHub OAuth App
-    // callback URL prefix `https://cc-sm.pages.dev/` stays compatible. The
-    // worker run_first glob in wrangler.toml needs to include /oauth/* — see
-    // wrangler.toml updates in this PR. Routing this branch BEFORE the
-    // /api/* + /token + ws branches keeps the static-asset catch-all at the
-    // tail of the function intact.
-    if (url.pathname === '/oauth/desktop/cb') {
-      const deskRes = await dispatchDesktop(stampedReq, env);
-      if (deskRes !== null) return deskRes;
-    }
+    // R-53 (Task #175): `/oauth/desktop/cb` is now a static HTML page served
+    // straight out of `frontend-web/dist/oauth/desktop/cb/index.html` via
+    // Workers Static Assets. The Worker no longer handles that path — the
+    // static page POSTs to `/api/auth/desktop/exchange` (handled above by
+    // dispatchDesktop) for the PKCE verifier exchange + JWT mint. See
+    // packages/cf-worker/src/auth/desktopOauth.ts header comment.
 
     // S4-T5 (Task #136): mode toggle. In `legacy` (default, current
     // production) the routing below behaves exactly as before: single shared

--- a/packages/cf-worker/test/desktopOauth.test.ts
+++ b/packages/cf-worker/test/desktopOauth.test.ts
@@ -1,30 +1,36 @@
 /**
- * R-51b (Task #168): cf-worker desktop OAuth (PKCE) flow tests.
+ * R-51b (Task #168) + R-53 (Task #175): cf-worker desktop OAuth (PKCE)
+ * flow tests.
+ *
+ * R-53 split the legacy GET `/oauth/desktop/cb` (which the Worker rendered
+ * as an HTML deep-link bounce page) into:
+ *   - a static `frontend-web/public/oauth/desktop/cb/index.html` (NOT
+ *     tested here — see frontend-web/test/oauth-callback-page.test.ts)
+ *   - a JSON-returning POST `/api/auth/desktop/exchange` endpoint, tested
+ *     below as `handleDesktopExchange`.
  *
  * Covers:
  *   - start: returns auth_url with required params + persists pkce-state row
  *     in UserDO under idFromName(`pkce:state:<state>`).
- *   - callback (state unknown): 400 before any GitHub call.
- *   - callback (state expired, >5min): 400 before GitHub.
- *   - callback (PKCE verifier mismatch): GitHub 200 + error payload → 400.
- *   - callback (happy path) — runs decideAndLink branches:
+ *   - exchange (state unknown): 400 before any GitHub call.
+ *   - exchange (state expired, >5min): 400 before GitHub.
+ *   - exchange (PKCE verifier mismatch): GitHub 200 + error payload → 400.
+ *   - exchange (missing code/state in body): 400.
+ *   - exchange (malformed JSON body): 400.
+ *   - exchange (GitHub /access_token 5xx): 502.
+ *   - exchange (happy path) — runs decideAndLink branches:
  *       * create_no_email (private email)
- *       * create_new (verified email, fresh)  — synthesized via fixture
- *       * link_to_existing (verified email pre-mapped to a user)
  *       * login_existing (identity row already present)
- *   - callback HTML page: contains `location.replace`, has a button, and
- *     the deep link string `ccsm://oauth?token=`.
- *   - dispatchDesktop: routing.
- *
- * The test fake routes UserDO storage by idFromName so identity row,
- * user blob, email index, AND pkce-state can coexist in one env. The
- * test mocks GitHub fetch the same way webOauth.test.ts does.
+ *       * link_to_existing seed (verified email pre-mapped, behaves as
+ *         create_no_email under read:user scope — assertion locks that in)
+ *   - exchange JSON shape: { tunnel_jwt, refresh_token } both strings.
+ *   - dispatchDesktop: routing + null on legacy /oauth/desktop/cb path.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   dispatchDesktop,
   handleDesktopStart,
-  handleDesktopCallback,
+  handleDesktopExchange,
 } from '../src/auth/desktopOauth';
 import type { AuthEnv } from '../src/auth/bindings';
 import { verifyJwt, type TunnelJwtClaims } from '../src/auth/jwt';
@@ -148,17 +154,6 @@ function makeEnv(): { env: AuthEnv; instances: Map<string, DoState> } {
   return { env, instances };
 }
 
-/** Pull the deep-link URL out of the rendered HTML's `location.replace("…")`
- *  call. We deliberately read the script side rather than the `<a href>` so
- *  the URL has raw `&` separators (the href is HTML-escaped to `&amp;`,
- *  which URLSearchParams would mis-parse). */
-function extractDeepLink(html: string): URLSearchParams {
-  const m = html.match(/location\.replace\("(ccsm:\/\/oauth\?[^"]+)"\)/);
-  if (!m) throw new Error('deep link not found in rendered HTML');
-  const url = m[1]!;
-  return new URLSearchParams(url.slice('ccsm://oauth?'.length));
-}
-
 let realFetch: typeof fetch;
 
 beforeEach(() => {
@@ -177,6 +172,7 @@ interface MockGhOpts {
   userLogin?: string;
   userEmail?: string | null;
   userStatus?: number;
+  tokenStatus?: number;
   /** Capture the last token-exchange body (URLSearchParams form). */
   capture?: (body: URLSearchParams) => void;
 }
@@ -193,6 +189,9 @@ function mockGithubFetch(opts: MockGhOpts): ReturnType<typeof vi.fn> {
       if (opts.capture) {
         const raw = (init?.body ?? '') as string;
         opts.capture(new URLSearchParams(raw));
+      }
+      if (opts.tokenStatus && opts.tokenStatus >= 400) {
+        return new Response('bad', { status: opts.tokenStatus });
       }
       if (opts.tokenError) {
         return Response.json({ error: opts.tokenError });
@@ -235,6 +234,15 @@ async function startAndExtractState(
   return { state, auth_url: body.auth_url };
 }
 
+/** Build a POST /api/auth/desktop/exchange request with the given JSON body. */
+function exchangeReq(body: unknown): Request {
+  return new Request('https://example.com/api/auth/desktop/exchange', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+}
+
 describe('handleDesktopStart', () => {
   it('returns auth_url with client_id/state/scope/redirect_uri/code_challenge_method=S256 + persists pkce row', async () => {
     const { env, instances } = makeEnv();
@@ -274,14 +282,12 @@ describe('handleDesktopStart', () => {
   });
 });
 
-describe('handleDesktopCallback', () => {
+describe('handleDesktopExchange', () => {
   it('400s when state has no matching pkce row (mismatch / replay)', async () => {
     const { env } = makeEnv();
     const ghFetch = mockGithubFetch({});
-    const res = await handleDesktopCallback(
-      new Request(
-        'https://example.com/oauth/desktop/cb?code=abc&state=' + 'a'.repeat(64),
-      ),
+    const res = await handleDesktopExchange(
+      exchangeReq({ code: 'abc', state: 'a'.repeat(64) }),
       env,
     );
     expect(res.status).toBe(400);
@@ -304,10 +310,8 @@ describe('handleDesktopCallback', () => {
     });
 
     const ghFetch = mockGithubFetch({});
-    const res = await handleDesktopCallback(
-      new Request(
-        `https://example.com/oauth/desktop/cb?code=abc&state=${state}`,
-      ),
+    const res = await handleDesktopExchange(
+      exchangeReq({ code: 'abc', state }),
       env,
     );
     expect(res.status).toBe(400);
@@ -319,31 +323,41 @@ describe('handleDesktopCallback', () => {
     const { env } = makeEnv();
     const { state } = await startAndExtractState(env);
     mockGithubFetch({ tokenError: 'bad_verification_code' });
-    const res = await handleDesktopCallback(
-      new Request(
-        `https://example.com/oauth/desktop/cb?code=abc&state=${state}`,
-      ),
+    const res = await handleDesktopExchange(
+      exchangeReq({ code: 'abc', state }),
       env,
     );
     expect(res.status).toBe(400);
     expect(await res.text()).toMatch(/bad_verification_code/);
   });
 
-  it('400s when code or state query param is missing', async () => {
+  it('400s when code or state body field is missing', async () => {
     const { env } = makeEnv();
-    const r1 = await handleDesktopCallback(
-      new Request('https://example.com/oauth/desktop/cb?state=abc'),
-      env,
-    );
+    const r1 = await handleDesktopExchange(exchangeReq({ state: 'abc' }), env);
     expect(r1.status).toBe(400);
-    const r2 = await handleDesktopCallback(
-      new Request('https://example.com/oauth/desktop/cb?code=abc'),
-      env,
-    );
+    const r2 = await handleDesktopExchange(exchangeReq({ code: 'abc' }), env);
     expect(r2.status).toBe(400);
   });
 
-  it('happy path (create_no_email): forwards verifier to GitHub, mints tunnel JWT, renders deep-link bounce page', async () => {
+  it('400s when body is malformed JSON', async () => {
+    const { env } = makeEnv();
+    const res = await handleDesktopExchange(exchangeReq('not-json{'), env);
+    expect(res.status).toBe(400);
+    expect(await res.text()).toMatch(/malformed JSON/);
+  });
+
+  it('502s when GitHub /access_token is HTTP 5xx', async () => {
+    const { env } = makeEnv();
+    const { state } = await startAndExtractState(env);
+    mockGithubFetch({ tokenStatus: 503 });
+    const res = await handleDesktopExchange(
+      exchangeReq({ code: 'abc', state }),
+      env,
+    );
+    expect(res.status).toBe(502);
+  });
+
+  it('happy path (create_no_email): forwards verifier to GitHub, mints tunnel JWT, returns JSON tokens', async () => {
     const { env, instances } = makeEnv();
     const { state } = await startAndExtractState(env);
     const pkceInst = instances.get(`pkce:state:${state}`)!;
@@ -365,15 +379,16 @@ describe('handleDesktopCallback', () => {
       },
     });
 
-    const res = await handleDesktopCallback(
-      new Request(
-        `https://example.com/oauth/desktop/cb?code=abc&state=${state}`,
-      ),
+    const res = await handleDesktopExchange(
+      exchangeReq({ code: 'abc', state }),
       env,
     );
     expect(res.status).toBe(200);
-    expect(res.headers.get('content-type')).toMatch(/text\/html/);
-    const html = await res.text();
+    expect(res.headers.get('content-type')).toMatch(/application\/json/);
+    const body = (await res.json()) as {
+      tunnel_jwt: string;
+      refresh_token: string;
+    };
 
     // PKCE verifier was forwarded; redirect_uri matched start; client_secret
     // present (GitHub OAuth Apps require it even with PKCE).
@@ -384,19 +399,11 @@ describe('handleDesktopCallback', () => {
     // pkce row consumed (one-shot use).
     expect(pkceInst.data.has('pkce_state_record')).toBe(false);
 
-    // Bounce page structure.
-    expect(html).toMatch(/location\.replace\(/);
-    expect(html).toMatch(/<a[^>]+id="open"[^>]+class="btn"/);
-    expect(html).toMatch(/ccsm:\/\/oauth\?token=/);
+    // JSON shape.
+    expect(typeof body.tunnel_jwt).toBe('string');
+    expect(body.refresh_token).toMatch(/^[0-9a-f]{64}$/);
 
-    // The deep link in the page contains tunnel JWT + refresh + state.
-    const params = extractDeepLink(html);
-    const token = params.get('token')!;
-    const refresh = params.get('refresh')!;
-    expect(params.get('state')).toBe(state);
-    expect(refresh).toMatch(/^[0-9a-f]{64}$/);
-
-    const claims = await verifyJwt<TunnelJwtClaims>(token, KEY_HEX);
+    const claims = await verifyJwt<TunnelJwtClaims>(body.tunnel_jwt, KEY_HEX);
     expect(claims).not.toBeNull();
     expect(claims!.kind).toBe('tunnel');
     expect(claims!.login).toBe('alice');
@@ -427,30 +434,24 @@ describe('handleDesktopCallback', () => {
     // First round.
     const first = await startAndExtractState(env);
     mockGithubFetch({ userId: 42, userLogin: 'alice', userEmail: null });
-    const r1 = await handleDesktopCallback(
-      new Request(
-        `https://example.com/oauth/desktop/cb?code=c&state=${first.state}`,
-      ),
+    const r1 = await handleDesktopExchange(
+      exchangeReq({ code: 'c', state: first.state }),
       env,
     );
     expect(r1.status).toBe(200);
-    const html1 = await r1.text();
-    const token1 = extractDeepLink(html1).get('token')!;
-    const claims1 = await verifyJwt<TunnelJwtClaims>(token1, KEY_HEX);
+    const body1 = (await r1.json()) as { tunnel_jwt: string };
+    const claims1 = await verifyJwt<TunnelJwtClaims>(body1.tunnel_jwt, KEY_HEX);
 
     // Second round, same github sub — should hit Branch 1 (login_existing).
     const second = await startAndExtractState(env);
     mockGithubFetch({ userId: 42, userLogin: 'alice', userEmail: null });
-    const r2 = await handleDesktopCallback(
-      new Request(
-        `https://example.com/oauth/desktop/cb?code=c2&state=${second.state}`,
-      ),
+    const r2 = await handleDesktopExchange(
+      exchangeReq({ code: 'c2', state: second.state }),
       env,
     );
     expect(r2.status).toBe(200);
-    const html2 = await r2.text();
-    const token2 = extractDeepLink(html2).get('token')!;
-    const claims2 = await verifyJwt<TunnelJwtClaims>(token2, KEY_HEX);
+    const body2 = (await r2.json()) as { tunnel_jwt: string };
+    const claims2 = await verifyJwt<TunnelJwtClaims>(body2.tunnel_jwt, KEY_HEX);
 
     expect(claims2!.sub).toBe(claims1!.sub);
     // Only one user blob instance — same uuid both rounds.
@@ -458,41 +459,7 @@ describe('handleDesktopCallback', () => {
     expect(userInstances).toHaveLength(1);
   });
 
-  it('happy path (create_new): verified email lands in email-index', async () => {
-    // The shared linker reads `email_verified` from oauthLinker's input. The
-    // worker hard-codes false (read:user scope), so to exercise create_new
-    // we synthesize the linker call indirectly by seeding the email index
-    // already tied to this user; that converts the second login to
-    // link_to_existing.
-    //
-    // For "create_new" coverage (verified email, fresh — Branch 4) we need
-    // the linker to emit it. Since this PR keeps email_verified=false in the
-    // desktop callback (matching webOauth + deviceFlow), Branch 4 is the
-    // same code-path tested by oauthLinker.test.ts. Here we lock in that
-    // the desktop handler does write the user blob + identity row in the
-    // create_no_email Branch 2 path (Branch 4 code lives in oauthLinker.ts
-    // and is exercised there).
-    const { env, instances } = makeEnv();
-    const { state } = await startAndExtractState(env);
-    mockGithubFetch({
-      userId: 99,
-      userLogin: 'bob',
-      userEmail: 'bob@example.com',
-    });
-    const res = await handleDesktopCallback(
-      new Request(
-        `https://example.com/oauth/desktop/cb?code=c&state=${state}`,
-      ),
-      env,
-    );
-    expect(res.status).toBe(200);
-    // Identity stored even though email_verified=false.
-    expect(instances.get('identity:github:99')).toBeDefined();
-    // Email index NOT written (verified=false).
-    expect(instances.get('email:bob@example.com')).toBeUndefined();
-  });
-
-  it('happy path (link_to_existing): pre-existing email index with verified flag pulls the new identity onto the same user_id', async () => {
+  it('happy path (link_to_existing seed under read:user): pre-existing email index does not link because email_verified=false', async () => {
     // Seed: an existing user A keyed by uuid 'uuid-A' has a verified email
     // index. A fresh GitHub identity (different sub) signs in with that
     // same email, but the desktop handler hard-codes email_verified=false
@@ -521,35 +488,17 @@ describe('handleDesktopCallback', () => {
       userLogin: 'b-user',
       userEmail: 'b@example.com',
     });
-    const res = await handleDesktopCallback(
-      new Request(
-        `https://example.com/oauth/desktop/cb?code=c&state=${state}`,
-      ),
+    const res = await handleDesktopExchange(
+      exchangeReq({ code: 'c', state }),
       env,
     );
     expect(res.status).toBe(200);
-    const html = await res.text();
-    const token = extractDeepLink(html).get('token')!;
-    const claims = await verifyJwt<TunnelJwtClaims>(token, KEY_HEX);
+    const body = (await res.json()) as { tunnel_jwt: string };
+    const claims = await verifyJwt<TunnelJwtClaims>(body.tunnel_jwt, KEY_HEX);
     // email_verified=false in the linker call → Branch 2 (create_no_email),
     // a fresh uuid is minted, NOT linked to user A.
     expect(claims!.sub).not.toBe(userA);
     expect(claims!.sub).toMatch(/^[0-9a-f-]{36}$/i);
-  });
-
-  it('renders a fallback button alongside location.replace', async () => {
-    const { env } = makeEnv();
-    const { state } = await startAndExtractState(env);
-    mockGithubFetch({ userId: 1, userLogin: 'u' });
-    const res = await handleDesktopCallback(
-      new Request(`https://example.com/oauth/desktop/cb?code=c&state=${state}`),
-      env,
-    );
-    expect(res.status).toBe(200);
-    const html = await res.text();
-    expect(html).toMatch(/<a[^>]+id="open"[^>]+class="btn"[^>]*>/);
-    expect(html).toMatch(/Open ccsm desktop/);
-    expect(html).toMatch(/location\.replace\(/);
   });
 });
 
@@ -566,14 +515,31 @@ describe('dispatchDesktop', () => {
     expect(res!.status).toBe(200);
   });
 
-  it('routes GET /oauth/desktop/cb', async () => {
+  it('routes POST /api/auth/desktop/exchange', async () => {
     const { env } = makeEnv();
     const res = await dispatchDesktop(
-      new Request('https://example.com/oauth/desktop/cb'),
+      new Request('https://example.com/api/auth/desktop/exchange', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ code: 'c', state: 'unknown-state' }),
+      }),
       env,
     );
     expect(res).not.toBeNull();
-    expect(res!.status).toBe(400); // missing code+state
+    // Unknown state → 400.
+    expect(res!.status).toBe(400);
+  });
+
+  it('returns null for the legacy GET /oauth/desktop/cb path (now a static page)', async () => {
+    // R-53 (Task #175): the Worker no longer handles GET /oauth/desktop/cb;
+    // it is served as a static asset. dispatchDesktop must return null so
+    // index.ts falls through to the ASSETS binding catch-all.
+    const { env } = makeEnv();
+    const res = await dispatchDesktop(
+      new Request('https://example.com/oauth/desktop/cb?code=c&state=s'),
+      env,
+    );
+    expect(res).toBeNull();
   });
 
   it('returns null for unrelated paths', async () => {
@@ -589,6 +555,17 @@ describe('dispatchDesktop', () => {
     const { env } = makeEnv();
     const res = await dispatchDesktop(
       new Request('https://example.com/api/auth/desktop/start', {
+        method: 'GET',
+      }),
+      env,
+    );
+    expect(res).toBeNull();
+  });
+
+  it('returns null for wrong method on desktop/exchange', async () => {
+    const { env } = makeEnv();
+    const res = await dispatchDesktop(
+      new Request('https://example.com/api/auth/desktop/exchange', {
         method: 'GET',
       }),
       env,

--- a/packages/cf-worker/test/desktopOauth.test.ts
+++ b/packages/cf-worker/test/desktopOauth.test.ts
@@ -263,7 +263,7 @@ describe('handleDesktopStart', () => {
     expect(state).toMatch(/^[0-9a-f]{64}$/);
     expect(u.searchParams.get('scope')).toBe('read:user');
     expect(u.searchParams.get('redirect_uri')).toBe(
-      'https://example.com/oauth/desktop/cb',
+      'https://example.com/oauth/desktop/cb/',
     );
     const challenge = u.searchParams.get('code_challenge')!;
     // base64url, no padding, length 43 for SHA-256.
@@ -393,7 +393,7 @@ describe('handleDesktopExchange', () => {
     // PKCE verifier was forwarded; redirect_uri matched start; client_secret
     // present (GitHub OAuth Apps require it even with PKCE).
     expect(capturedVerifier).toBe(expectedVerifier);
-    expect(capturedRedirect).toBe('https://example.com/oauth/desktop/cb');
+    expect(capturedRedirect).toBe('https://example.com/oauth/desktop/cb/');
     expect(capturedClientSecret).toBe('test-client-secret');
 
     // pkce row consumed (one-shot use).

--- a/packages/cf-worker/wrangler.toml
+++ b/packages/cf-worker/wrangler.toml
@@ -2,6 +2,19 @@ name = "ccsm-worker"
 main = "src/index.ts"
 compatibility_date = "2026-01-01"
 
+# R-53 (Task #175): expose this Worker on the account's workers.dev subdomain
+# so the SPA + tunnel + OAuth all live under
+# `https://ccsm-worker.<account-subdomain>.workers.dev`. This replaces the
+# `cc-sm.pages.dev` Pages project (deleted as part of R-53). The account's
+# `workers.dev` subdomain prefix is set per-account in the Cloudflare dashboard
+# (Workers & Pages → Workers Subdomain); for jiahuigu@sjtu.edu.cn it is
+# `jiahuigu`, so the production hostname is
+# `ccsm-worker.jiahuigu.workers.dev`.
+#
+# Refs (verified via Cloudflare docs 2026-05-10):
+#   - https://developers.cloudflare.com/workers/configuration/routing/workers-dev/
+workers_dev = true
+
 # Task #154 (R-49 audit P1, F-A-2): Cloudflare Workers Static Assets binding
 # folds the cc-sm Pages site into this Worker, eliminating the prior
 # Pages-Function reproxy hop (`packages/frontend-web/functions/[[path]].ts`)
@@ -40,12 +53,13 @@ run_worker_first = [
   "/tunnel/default",
   "/token",
   "/api/*",
-  # R-51b (Task #168): desktop OAuth callback. Lives outside /api/* because
-  # the GitHub OAuth App callback URL prefix is the bare origin
-  # (`https://cc-sm.pages.dev/`), and the desktop redirect_uri is
-  # `<origin>/oauth/desktop/cb`. List it explicitly so the Worker (not the
-  # static asset server) renders the deep-link bounce page.
-  "/oauth/desktop/cb",
+  # R-53 (Task #175): `/oauth/desktop/cb` is intentionally NOT listed here.
+  # It is a static HTML page (`frontend-web/public/oauth/desktop/cb/index.html`
+  # → `frontend-web/dist/oauth/desktop/cb/index.html`) and must be served on
+  # the Workers Static Assets fast path so it bypasses any Pages-side legacy
+  # routing (which previously returned 308 and broke the desktop OAuth flow).
+  # The browser-side script then POSTs to `/api/auth/desktop/exchange` (in
+  # the `/api/*` glob above) which the Worker handles.
 ]
 
 # S4-T5 (Task #136): auth mode toggle. `legacy` keeps the S3-era

--- a/packages/core/test/ws-client.test.ts
+++ b/packages/core/test/ws-client.test.ts
@@ -98,10 +98,10 @@ describe('buildWsUrl (hostBase injection)', () => {
   // through to the SPA index.html.
   it('honours an explicit wsPath override', () => {
     const url = buildWsUrl('s', 't', 0, {
-      httpBase: 'https://cc-sm.pages.dev',
+      httpBase: 'https://ccsm-worker.jiahuigu.workers.dev',
       wsPath: '/ws/default',
     });
-    expect(url).toBe('wss://cc-sm.pages.dev/ws/default?sid=s&token=t');
+    expect(url).toBe('wss://ccsm-worker.jiahuigu.workers.dev/ws/default?sid=s&token=t');
   });
 
   it('falls back to API_PATHS.ws when wsPath is omitted', () => {

--- a/packages/daemon/src/auth.mts
+++ b/packages/daemon/src/auth.mts
@@ -8,43 +8,45 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 // Origin allow-list:
 //   - http(s)://127.0.0.1 / localhost  (web SPA, dev vite proxy)
 //   - tauri://localhost                 (T2 #675 — Tauri 2 webview origin)
-//   - https://cc-sm.pages.dev           (S2 #702 — Cloudflare Pages prod host)
+//   - https://ccsm-worker.jiahuigu.workers.dev
+//                                       (R-53 #175 — Cloudflare Workers prod host)
 // The Tauri webview always sends `Origin: tauri://localhost` for in-app fetch
 // and ws upgrade; we whitelist it explicitly rather than open up arbitrary
 // cross-origin. See plan doc `logical-swinging-brook.md` §A / T2.
 //
-// S2 #702: the production web SPA is served from `https://cc-sm.pages.dev`
-// (Cloudflare Pages). It issues cross-origin loopback fetches to the local
-// daemon (which still binds 127.0.0.1) so we must allow the exact origin
-// `https://cc-sm.pages.dev` and ONLY that — no PR-preview subdomains
-// (`https://abc123.cc-sm.pages.dev` is reject-by-default; see S2 #721 / T8
-// below for the opt-in env flag), no spoof variants
-// (`https://cc-sm-evil.pages.dev`, `https://cc-sm.pages.dev.attacker.com`),
+// R-53 #175 (was S2 #702): the production web SPA was previously served from
+// `https://cc-sm.pages.dev` (Cloudflare Pages). R-53 folded the SPA + tunnel
+// + OAuth callback into a single Worker on the account `workers.dev`
+// subdomain — the prod host is now `https://ccsm-worker.jiahuigu.workers.dev`.
+// Same security shape: cross-origin loopback fetches from the SPA into the
+// local daemon (still binding 127.0.0.1) must allow the exact prod origin
+// and ONLY that — no spoof variants
+// (`https://ccsm-worker-evil.jiahuigu.workers.dev`,
+//  `https://ccsm-worker.jiahuigu.workers.dev.attacker.com`),
 // and no http (Chrome's PNA + mixed-content rules require https for the
 // loopback initiator).
 //
-// S2 #721 / T8: when `CCSM_ALLOW_PAGES_PREVIEWS=1` is set in the daemon's
-// process env, single-label `*.cc-sm.pages.dev` preview subdomains over https
-// are additionally allow-listed. This is a developer / dogfood opt-in for
-// reviewing Cloudflare Pages PR previews against a local daemon; it is OFF
-// by default so end-user installs keep the tightest possible origin surface.
-// Constraints kept even when opt-in is on:
-//   - protocol MUST be https (no http preview)
-//   - exactly ONE label between scheme and `cc-sm.pages.dev`
-//     (`abc123.cc-sm.pages.dev` ✓, `a.b.cc-sm.pages.dev` ✗,
-//      `cc-sm.pages.dev` is the prod host handled separately)
-//   - that label MUST be a non-empty DNS label (alnum + hyphen, no dot)
-//   - suffix matched as `.cc-sm.pages.dev` (with leading dot) so
-//     `evil-cc-sm.pages.dev` cannot squeeze through
+// CCSM_ALLOW_PAGES_PREVIEWS opt-in (kept name for back-compat with R-53
+// migration): when `CCSM_ALLOW_PAGES_PREVIEWS=1` is set in the daemon's
+// process env, single-label `*-ccsm-worker.jiahuigu.workers.dev`-shaped
+// preview subdomains over https are additionally allow-listed. Cloudflare
+// Workers versioned-preview URLs follow the
+// `<version-id>-<worker-name>.<subdomain>.workers.dev` pattern, so we
+// allowlist any single label that ends with `.<worker>.<account>.workers.dev`.
+// OFF by default; mirrors the prior Pages preview opt-in.
 const ALLOWED_ORIGIN_HOSTS = new Set(['127.0.0.1', 'localhost']);
 const ALLOWED_ORIGIN_PROTOCOLS = new Set(['http:', 'https:']);
 const TAURI_ORIGIN = 'tauri://localhost';
-const PAGES_PROD_ORIGIN = 'https://cc-sm.pages.dev';
-const PAGES_PREVIEW_SUFFIX = '.cc-sm.pages.dev';
+const WORKER_PROD_ORIGIN = 'https://ccsm-worker.jiahuigu.workers.dev';
+// R-53: Workers versioned preview URLs prefix the prod hostname with a
+// version label, e.g. `https://abc123-ccsm-worker.jiahuigu.workers.dev`. We
+// match the suffix `-ccsm-worker.jiahuigu.workers.dev` so a bare
+// `ccsm-worker.jiahuigu.workers.dev` is NOT treated as a preview.
+const WORKER_PREVIEW_SUFFIX = '-ccsm-worker.jiahuigu.workers.dev';
 // Single DNS label: alnum, may contain internal hyphens, 1..63 chars.
-// (Conservative; Cloudflare Pages preview hosts are deploy-id hashes that
+// (Conservative; Cloudflare workers.dev preview labels are hashes that
 // match this shape.)
-const PAGES_PREVIEW_LABEL_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
+const WORKER_PREVIEW_LABEL_RE = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i;
 
 function pagesPreviewsEnabled(): boolean {
   // Read on every call so tests can flip the flag mid-suite without
@@ -85,30 +87,35 @@ function constantTimeEquals(a: string, b: string): boolean {
 export function classifyOrigin(rawOrigin: string | undefined): 'absent' | 'allowed' | 'rejected' {
   if (rawOrigin === undefined || rawOrigin.length === 0) return 'absent';
   if (rawOrigin === TAURI_ORIGIN) return 'allowed';
-  // S2 #702 — exact-string match for the Cloudflare Pages prod origin BEFORE
+  // R-53 #175 — exact-string match for the cf-worker prod origin BEFORE
   // we hand off to URL parsing. Doing this as an exact string compare (rather
   // than parsing then checking host) makes spoof variants impossible:
-  //   - `https://cc-sm-evil.pages.dev`              → !== PAGES_PROD_ORIGIN
-  //   - `https://cc-sm.pages.dev.attacker.com`      → !== PAGES_PROD_ORIGIN
-  //   - `http://cc-sm.pages.dev`                    → !== PAGES_PROD_ORIGIN
-  //   - `https://abc123.cc-sm.pages.dev` (PR preview) → !== PAGES_PROD_ORIGIN
-  // All fall through to the loopback host check below and are rejected.
-  if (rawOrigin === PAGES_PROD_ORIGIN) return 'allowed';
+  //   - `https://ccsm-worker-evil.jiahuigu.workers.dev`        → !== WORKER_PROD_ORIGIN
+  //   - `https://ccsm-worker.jiahuigu.workers.dev.attacker.com`→ !== WORKER_PROD_ORIGIN
+  //   - `http://ccsm-worker.jiahuigu.workers.dev`              → !== WORKER_PROD_ORIGIN
+  //   - `https://abc123-ccsm-worker.jiahuigu.workers.dev` (Workers preview)
+  //                                                            → !== WORKER_PROD_ORIGIN
+  // All fall through to the loopback host check below and are rejected
+  // (unless the preview opt-in below matches).
+  if (rawOrigin === WORKER_PROD_ORIGIN) return 'allowed';
   let url: URL;
   try {
     url = new URL(rawOrigin);
   } catch {
     return 'rejected';
   }
-  // S2 #721 / T8: opt-in `*.cc-sm.pages.dev` preview subdomains.
+  // R-53 (kept env name CCSM_ALLOW_PAGES_PREVIEWS for migration back-compat):
+  // opt-in Cloudflare Workers versioned-preview origins of the shape
+  // `https://<version>-ccsm-worker.jiahuigu.workers.dev`.
   // Checked BEFORE the loopback host gate so a preview origin doesn't get
   // spuriously rejected as "not 127.0.0.1/localhost". Must still be https,
-  // exactly one label deep, and that label must look like a real DNS label.
+  // exactly one version label deep, and that label must look like a real
+  // DNS label.
   if (pagesPreviewsEnabled() && url.protocol === 'https:') {
     const host = url.hostname;
-    if (host.endsWith(PAGES_PREVIEW_SUFFIX) && host !== PAGES_PREVIEW_SUFFIX.slice(1)) {
-      const label = host.slice(0, host.length - PAGES_PREVIEW_SUFFIX.length);
-      if (label.length > 0 && !label.includes('.') && PAGES_PREVIEW_LABEL_RE.test(label)) {
+    if (host.endsWith(WORKER_PREVIEW_SUFFIX)) {
+      const label = host.slice(0, host.length - WORKER_PREVIEW_SUFFIX.length);
+      if (label.length > 0 && !label.includes('.') && WORKER_PREVIEW_LABEL_RE.test(label)) {
         return 'allowed';
       }
     }

--- a/packages/daemon/src/http.mts
+++ b/packages/daemon/src/http.mts
@@ -140,8 +140,8 @@ function handleCorsPreflight(req: IncomingMessage, res: ServerResponse): void {
   // Cache preflight for 10 min — keeps Tauri webview from re-issuing OPTIONS
   // on every fetch. Spec lets browsers cap at their discretion (Chromium 2h).
   res.setHeader('Access-Control-Max-Age', '600');
-  // S2 #702 — Chrome 120+ Private Network Access (PNA): when a public-network
-  // page (https://cc-sm.pages.dev) initiates a fetch to a private/loopback
+  // S2 #702 / R-53 #175 — Chrome 120+ Private Network Access (PNA): when a public-network
+  // page (https://ccsm-worker.jiahuigu.workers.dev) initiates a fetch to a private/loopback
   // address (127.0.0.1), the browser sends `Access-Control-Request-Private-
   // Network: true` on the preflight and REQUIRES the response to echo back
   // `Access-Control-Allow-Private-Network: true`, otherwise the actual

--- a/packages/daemon/src/index.mts
+++ b/packages/daemon/src/index.mts
@@ -35,7 +35,11 @@ import { attachFrameRouter, attachWebSocket } from './ws.mjs';
 const DEFAULT_PORT = 17832;
 const PORT_RETRY_MAX = 20;
 const SHUTDOWN_TIMEOUT_MS = 2000;
-const DEFAULT_TUNNEL_URL = 'wss://cc-sm.pages.dev/tunnel/default';
+// R-53 (Task #175): production host moved from the cc-sm Pages project
+// (`cc-sm.pages.dev`, deleted) to the cf-worker on the account workers.dev
+// subdomain (`ccsm-worker.jiahuigu.workers.dev`). Same script now serves
+// the SPA + the tunnel + the OAuth callback path on a single origin.
+const DEFAULT_TUNNEL_URL = 'wss://ccsm-worker.jiahuigu.workers.dev/tunnel/default';
 const TUNNEL_CONNECT_POLL_MS = 100;
 
 const HANDSHAKE_FLAG = '--handshake-stdout';
@@ -257,7 +261,7 @@ async function main(): Promise<void> {
           return;
         }
         tunnelRefresh = new TunnelRefreshClient({
-          authBase: process.env.CCSM_AUTH_BASE ?? 'https://cc-sm.pages.dev',
+          authBase: process.env.CCSM_AUTH_BASE ?? 'https://ccsm-worker.jiahuigu.workers.dev',
           creds,
           onRefreshed: (newJwt) => {
             currentJwt = newJwt;

--- a/packages/daemon/src/tunnel-refresh.mts
+++ b/packages/daemon/src/tunnel-refresh.mts
@@ -62,7 +62,7 @@ export interface PersistedTunnelCreds {
 }
 
 export interface TunnelRefreshOptions {
-  /** Cloud auth base, e.g. `https://cc-sm.pages.dev`. */
+  /** Cloud auth base, e.g. `https://ccsm-worker.jiahuigu.workers.dev`. */
   authBase: string;
   /**
    * Initial creds (parsed from `~/.ccsm/tunnel_jwt` by the caller — or

--- a/packages/daemon/test/auth.test.ts
+++ b/packages/daemon/test/auth.test.ts
@@ -265,38 +265,38 @@ describe('sessions CRUD (in-memory stub)', () => {
 });
 
 // S2 #702 — Cloudflare Pages prod origin allow-list + Chrome PNA preflight.
-// The web SPA is hosted at `https://cc-sm.pages.dev`. From the user's browser
+// The web SPA is hosted at `https://ccsm-worker.jiahuigu.workers.dev`. From the user's browser
 // it issues cross-origin loopback fetches into the daemon. Only the exact
 // production origin is allowed; spoof variants and PR-preview subdomains are
 // rejected. Chrome 120+ PNA further requires the daemon to opt-in to private
 // network access via a preflight echo header.
 describe('S2 #702 — Cloudflare Pages origin allow-list (classifyOrigin)', () => {
-  it('classifyOrigin("https://cc-sm.pages.dev") === "allowed" (prod host)', () => {
-    expect(classifyOrigin('https://cc-sm.pages.dev')).toBe('allowed');
+  it('classifyOrigin("https://ccsm-worker.jiahuigu.workers.dev") === "allowed" (prod host)', () => {
+    expect(classifyOrigin('https://ccsm-worker.jiahuigu.workers.dev')).toBe('allowed');
   });
 
-  it('classifyOrigin("https://cc-sm-evil.pages.dev") === "rejected" (sibling spoof)', () => {
-    expect(classifyOrigin('https://cc-sm-evil.pages.dev')).toBe('rejected');
+  it('classifyOrigin("https://ccsm-worker-evil.jiahuigu.workers.dev") === "rejected" (sibling spoof)', () => {
+    expect(classifyOrigin('https://ccsm-worker-evil.jiahuigu.workers.dev')).toBe('rejected');
   });
 
-  it('classifyOrigin("https://cc-sm.pages.dev.attacker.com") === "rejected" (suffix spoof)', () => {
-    expect(classifyOrigin('https://cc-sm.pages.dev.attacker.com')).toBe('rejected');
+  it('classifyOrigin("https://ccsm-worker.jiahuigu.workers.dev.attacker.com") === "rejected" (suffix spoof)', () => {
+    expect(classifyOrigin('https://ccsm-worker.jiahuigu.workers.dev.attacker.com')).toBe('rejected');
   });
 
-  it('classifyOrigin("http://cc-sm.pages.dev") === "rejected" (http stripped, must be https)', () => {
-    expect(classifyOrigin('http://cc-sm.pages.dev')).toBe('rejected');
+  it('classifyOrigin("http://ccsm-worker.jiahuigu.workers.dev") === "rejected" (http stripped, must be https)', () => {
+    expect(classifyOrigin('http://ccsm-worker.jiahuigu.workers.dev')).toBe('rejected');
   });
 
-  it('classifyOrigin("https://abc123.cc-sm.pages.dev") === "rejected" (PR-preview default off)', () => {
+  it('classifyOrigin("https://abc123-ccsm-worker.jiahuigu.workers.dev") === "rejected" (PR-preview default off)', () => {
     // T8 will introduce an opt-in flag for preview deploys; until then,
     // every preview subdomain MUST be rejected to keep the prod attack
     // surface tight.
-    expect(classifyOrigin('https://abc123.cc-sm.pages.dev')).toBe('rejected');
+    expect(classifyOrigin('https://abc123-ccsm-worker.jiahuigu.workers.dev')).toBe('rejected');
   });
 
   it('classifyOrigin(undefined) === "absent" (regression for #672 same-origin)', () => {
     // Browsers omit Origin on same-origin GET/HEAD; daemon treats absent
-    // as same-origin. This must keep working alongside the new pages.dev
+    // as same-origin. This must keep working alongside the new workers.dev
     // allow-list entry.
     expect(classifyOrigin(undefined)).toBe('absent');
   });
@@ -306,27 +306,27 @@ describe('S2 #702 — Cloudflare Pages origin allow-list (classifyOrigin)', () =
   });
 });
 
-describe('S2 #702 — pages.dev integration through the HTTP server', () => {
-  it('accepts POST /api/sessions with Origin: https://cc-sm.pages.dev (200)', async () => {
+describe('R-53 #175 — workers.dev integration through the HTTP server', () => {
+  it('accepts POST /api/sessions with Origin: https://ccsm-worker.jiahuigu.workers.dev (200)', async () => {
     const r = await fetch(`${baseUrl}/api/sessions`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${TOKEN}`,
-        Origin: 'https://cc-sm.pages.dev',
+        Origin: 'https://ccsm-worker.jiahuigu.workers.dev',
         'Content-Type': 'application/json',
       },
       body: '{}',
     });
     expect(r.status).toBe(200);
-    expect(r.headers.get('access-control-allow-origin')).toBe('https://cc-sm.pages.dev');
+    expect(r.headers.get('access-control-allow-origin')).toBe('https://ccsm-worker.jiahuigu.workers.dev');
   });
 
-  it('rejects POST /api/sessions with Origin: https://cc-sm-evil.pages.dev (403)', async () => {
+  it('rejects POST /api/sessions with Origin: https://ccsm-worker-evil.jiahuigu.workers.dev (403)', async () => {
     const r = await fetch(`${baseUrl}/api/sessions`, {
       method: 'POST',
       headers: {
         Authorization: `Bearer ${TOKEN}`,
-        Origin: 'https://cc-sm-evil.pages.dev',
+        Origin: 'https://ccsm-worker-evil.jiahuigu.workers.dev',
         'Content-Type': 'application/json',
       },
       body: '{}',
@@ -336,13 +336,13 @@ describe('S2 #702 — pages.dev integration through the HTTP server', () => {
 });
 
 // S2 T2 (Task #727) — verify applyCorsHeaders + ws upgrade auto-inherit T1's
-// classifyOrigin allow-list for `https://cc-sm.pages.dev`. T1 (PR #1141) added
+// classifyOrigin allow-list for `https://ccsm-worker.jiahuigu.workers.dev`. T1 (PR #1141) added
 // the host to classifyOrigin; this group asserts that the HTTP CORS path
 // (applyCorsHeaders in http.mts) and the OPTIONS preflight handler echo the
 // origin (NOT `*`) and emit the standard CORS response headers — without any
 // further changes to http.mts. Companion ws.test.ts case covers ws.mts.
-describe('S2 T2 #727 — applyCorsHeaders auto-inherits cc-sm.pages.dev (no src changes)', () => {
-  it('echoes Origin (not *) on a normal POST from https://cc-sm.pages.dev', async () => {
+describe('S2 T2 #727 — applyCorsHeaders auto-inherits ccsm-worker.jiahuigu.workers.dev (no src changes)', () => {
+  it('echoes Origin (not *) on a normal POST from https://ccsm-worker.jiahuigu.workers.dev', async () => {
     // applyCorsHeaders branch: origin defined && classifyOrigin === 'allowed'
     // → ACAO echoes `origin`. The * fallback is exercised by the
     // "falls back to Allow-Origin: * when Origin header is absent" case.
@@ -350,31 +350,31 @@ describe('S2 T2 #727 — applyCorsHeaders auto-inherits cc-sm.pages.dev (no src 
       method: 'POST',
       headers: {
         Authorization: `Bearer ${TOKEN}`,
-        Origin: 'https://cc-sm.pages.dev',
+        Origin: 'https://ccsm-worker.jiahuigu.workers.dev',
         'Content-Type': 'application/json',
       },
       body: '{}',
     });
     expect(r.status).toBe(200);
-    expect(r.headers.get('access-control-allow-origin')).toBe('https://cc-sm.pages.dev');
+    expect(r.headers.get('access-control-allow-origin')).toBe('https://ccsm-worker.jiahuigu.workers.dev');
     expect(r.headers.get('access-control-allow-origin')).not.toBe('*');
     expect(r.headers.get('vary')).toContain('Origin');
   });
 
-  it('OPTIONS preflight from https://cc-sm.pages.dev → 200 + echo + standard CORS headers', async () => {
+  it('OPTIONS preflight from https://ccsm-worker.jiahuigu.workers.dev → 200 + echo + standard CORS headers', async () => {
     // Standard CORS preflight (no PNA): different from the PNA echo case
     // above — this asserts the baseline preflight response is correct when
     // the origin is the prod Pages host. Pre-auth: no Authorization header.
     const r = await fetch(`${baseUrl}/api/sessions`, {
       method: 'OPTIONS',
       headers: {
-        Origin: 'https://cc-sm.pages.dev',
+        Origin: 'https://ccsm-worker.jiahuigu.workers.dev',
         'Access-Control-Request-Method': 'POST',
         'Access-Control-Request-Headers': 'authorization, content-type',
       },
     });
     expect(r.status).toBe(200);
-    expect(r.headers.get('access-control-allow-origin')).toBe('https://cc-sm.pages.dev');
+    expect(r.headers.get('access-control-allow-origin')).toBe('https://ccsm-worker.jiahuigu.workers.dev');
     expect(r.headers.get('access-control-allow-origin')).not.toBe('*');
     const allowMethods = r.headers.get('access-control-allow-methods') ?? '';
     expect(allowMethods).toMatch(/GET/);
@@ -395,7 +395,7 @@ describe('S2 #702 — Chrome PNA preflight echo', () => {
     const r = await fetch(`${baseUrl}/api/sessions`, {
       method: 'OPTIONS',
       headers: {
-        Origin: 'https://cc-sm.pages.dev',
+        Origin: 'https://ccsm-worker.jiahuigu.workers.dev',
         'Access-Control-Request-Method': 'POST',
         'Access-Control-Request-Headers': 'authorization, content-type',
         'Access-Control-Request-Private-Network': 'true',
@@ -403,7 +403,7 @@ describe('S2 #702 — Chrome PNA preflight echo', () => {
     });
     expect(r.status).toBe(200);
     expect(r.headers.get('access-control-allow-private-network')).toBe('true');
-    expect(r.headers.get('access-control-allow-origin')).toBe('https://cc-sm.pages.dev');
+    expect(r.headers.get('access-control-allow-origin')).toBe('https://ccsm-worker.jiahuigu.workers.dev');
   });
 
   it('OPTIONS WITHOUT the PNA request header does NOT advertise Allow-Private-Network', async () => {
@@ -411,19 +411,19 @@ describe('S2 #702 — Chrome PNA preflight echo', () => {
     const r = await fetch(`${baseUrl}/api/sessions`, {
       method: 'OPTIONS',
       headers: {
-        Origin: 'https://cc-sm.pages.dev',
+        Origin: 'https://ccsm-worker.jiahuigu.workers.dev',
         'Access-Control-Request-Method': 'POST',
       },
     });
     expect(r.status).toBe(200);
     expect(r.headers.get('access-control-allow-private-network')).toBeNull();
     // Other preflight headers still intact.
-    expect(r.headers.get('access-control-allow-origin')).toBe('https://cc-sm.pages.dev');
+    expect(r.headers.get('access-control-allow-origin')).toBe('https://ccsm-worker.jiahuigu.workers.dev');
     expect(r.headers.get('access-control-allow-methods')).toMatch(/POST/);
   });
 });
 
-// S2 #721 / T8 — opt-in `*.cc-sm.pages.dev` preview subdomain allow-list.
+// S2 #721 / T8 — opt-in `*.ccsm-worker.jiahuigu.workers.dev` preview subdomain allow-list.
 // Default OFF: PR-preview subdomains are rejected (already covered above).
 // When `CCSM_ALLOW_PAGES_PREVIEWS=1` is set, single-label https preview
 // subdomains are accepted; spoof / multi-label / http variants stay rejected.
@@ -442,52 +442,52 @@ describe('S2 #721 / T8 — CCSM_ALLOW_PAGES_PREVIEWS opt-in', () => {
 
   it('default (env unset): preview subdomain rejected', () => {
     delete process.env[ENV_KEY];
-    expect(classifyOrigin('https://abc123.cc-sm.pages.dev')).toBe('rejected');
+    expect(classifyOrigin('https://abc123-ccsm-worker.jiahuigu.workers.dev')).toBe('rejected');
   });
 
   it('CCSM_ALLOW_PAGES_PREVIEWS=0: preview subdomain still rejected', () => {
     process.env[ENV_KEY] = '0';
-    expect(classifyOrigin('https://abc123.cc-sm.pages.dev')).toBe('rejected');
+    expect(classifyOrigin('https://abc123-ccsm-worker.jiahuigu.workers.dev')).toBe('rejected');
   });
 
   it('CCSM_ALLOW_PAGES_PREVIEWS=1: single-label https preview accepted', () => {
     process.env[ENV_KEY] = '1';
-    expect(classifyOrigin('https://abc123.cc-sm.pages.dev')).toBe('allowed');
-    expect(classifyOrigin('https://deploy-preview-42.cc-sm.pages.dev')).toBe('allowed');
+    expect(classifyOrigin('https://abc123-ccsm-worker.jiahuigu.workers.dev')).toBe('allowed');
+    expect(classifyOrigin('https://deploy-preview-42-ccsm-worker.jiahuigu.workers.dev')).toBe('allowed');
   });
 
   it('opt-in: prod host still allowed (regression)', () => {
     process.env[ENV_KEY] = '1';
-    expect(classifyOrigin('https://cc-sm.pages.dev')).toBe('allowed');
+    expect(classifyOrigin('https://ccsm-worker.jiahuigu.workers.dev')).toBe('allowed');
   });
 
   it('opt-in: http preview rejected (must be https)', () => {
     process.env[ENV_KEY] = '1';
-    expect(classifyOrigin('http://abc123.cc-sm.pages.dev')).toBe('rejected');
+    expect(classifyOrigin('http://abc123-ccsm-worker.jiahuigu.workers.dev')).toBe('rejected');
   });
 
   it('opt-in: multi-label preview rejected (only single label allowed)', () => {
     process.env[ENV_KEY] = '1';
-    expect(classifyOrigin('https://a.b.cc-sm.pages.dev')).toBe('rejected');
+    expect(classifyOrigin('https://a.b-ccsm-worker.jiahuigu.workers.dev')).toBe('rejected');
   });
 
-  it('opt-in: sibling spoof still rejected (cc-sm-evil.pages.dev)', () => {
+  it('opt-in: sibling spoof still rejected (ccsm-worker-evil.jiahuigu.workers.dev)', () => {
     process.env[ENV_KEY] = '1';
-    expect(classifyOrigin('https://cc-sm-evil.pages.dev')).toBe('rejected');
-    expect(classifyOrigin('https://x.cc-sm-evil.pages.dev')).toBe('rejected');
+    expect(classifyOrigin('https://ccsm-worker-evil.jiahuigu.workers.dev')).toBe('rejected');
+    expect(classifyOrigin('https://x-ccsm-worker-evil.jiahuigu.workers.dev')).toBe('rejected');
   });
 
-  it('opt-in: suffix spoof still rejected (cc-sm.pages.dev.attacker.com)', () => {
+  it('opt-in: suffix spoof still rejected (ccsm-worker.jiahuigu.workers.dev.attacker.com)', () => {
     process.env[ENV_KEY] = '1';
-    expect(classifyOrigin('https://abc.cc-sm.pages.dev.attacker.com')).toBe('rejected');
+    expect(classifyOrigin('https://abc-ccsm-worker.jiahuigu.workers.dev.attacker.com')).toBe('rejected');
   });
 
   it('opt-in: empty / dotted label rejected (defensive)', () => {
     process.env[ENV_KEY] = '1';
-    // `.cc-sm.pages.dev` parses to host `cc-sm.pages.dev` (the prod host) so
+    // `.ccsm-worker.jiahuigu.workers.dev` parses to host `ccsm-worker.jiahuigu.workers.dev` (the prod host) so
     // is handled by the exact-match branch; the empty-label form below would
     // only arise via crafted hostnames and must not become "allowed".
-    expect(classifyOrigin('https://_.cc-sm.pages.dev')).toBe('rejected');
+    expect(classifyOrigin('https://_-ccsm-worker.jiahuigu.workers.dev')).toBe('rejected');
   });
 
   it('opt-in does not loosen unrelated origins (evil.com still rejected)', () => {

--- a/packages/daemon/test/ws.test.ts
+++ b/packages/daemon/test/ws.test.ts
@@ -273,27 +273,27 @@ describe('ws upgrade auth', () => {
   });
 
   // S2 T2 (Task #727): ws upgrade must auto-inherit T1's classifyOrigin
-  // allow-list for `https://cc-sm.pages.dev`. ws.mts calls
+  // allow-list for `https://ccsm-worker.jiahuigu.workers.dev`. ws.mts calls
   // `classifyOrigin(origin)` and rejects on 'rejected'. After T1 (PR #1141)
   // the prod Pages host classifies as 'allowed', so the upgrade should yield
   // a 101 (ws OPEN) without any further change to ws.mts.
-  it('accepts Origin: https://cc-sm.pages.dev (S2 T2 #727)', async () => {
+  it('accepts Origin: https://ccsm-worker.jiahuigu.workers.dev (S2 T2 #727)', async () => {
     const sid = await createSid();
     const d = dial(`${baseWs}/ws?sid=${sid}&token=${TOKEN}`, {
-      Origin: 'https://cc-sm.pages.dev',
+      Origin: 'https://ccsm-worker.jiahuigu.workers.dev',
     });
     await waitOpen(d.ws);
     expect(d.ws.readyState).toBe(WebSocket.OPEN);
     d.ws.close();
   });
 
-  it('rejects Origin: https://cc-sm-evil.pages.dev (sibling spoof, S2 T2 #727)', async () => {
+  it('rejects Origin: https://ccsm-worker-evil.jiahuigu.workers.dev (sibling spoof, S2 T2 #727)', async () => {
     // Defense-in-depth: confirm the ws path also rejects the spoof variant
     // that classifyOrigin marks 'rejected'. Without this we could regress
     // ws.mts independently of http.mts.
     const sid = await createSid();
     const d = dial(`${baseWs}/ws?sid=${sid}&token=${TOKEN}`, {
-      Origin: 'https://cc-sm-evil.pages.dev',
+      Origin: 'https://ccsm-worker-evil.jiahuigu.workers.dev',
     });
     const closed = await d.closed;
     expect(closed.code).toBeGreaterThanOrEqual(1000);

--- a/packages/frontend-web/public/oauth/desktop/cb/index.html
+++ b/packages/frontend-web/public/oauth/desktop/cb/index.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<!--
+  R-53 (Task #175): static GitHub OAuth callback page for the Tauri desktop
+  PKCE flow.
+
+  Why static (not Worker-rendered): the Cloudflare Worker fold-in (R-49 P1,
+  Task #154) put the SPA on Workers Static Assets, but the Worker only
+  receives requests for paths listed in `[assets].run_worker_first` in
+  wrangler.toml. Pages-side legacy routing (308) intermittently won the
+  race for `/oauth/desktop/cb` and short-circuited before the Worker handler
+  ran, breaking the callback for desktop sign-in. R-53 splits the work:
+
+    - this static page is served from `cc-sm.pages.dev/oauth/desktop/cb`
+      directly out of `frontend-web/dist`. It contains no token logic; it
+      just receives `?code=&state=` from GitHub and POSTs them to the
+      Worker.
+    - `POST /api/auth/desktop/exchange` (handled by the Worker) does the
+      PKCE verifier exchange + JWT mint + deep-link composition, returning
+      the tokens as JSON.
+    - this page then `location.replace`s into `ccsm://oauth?token=...` to
+      trigger the desktop deep-link listener.
+
+  Self-contained: no React, no bundler, no module imports. Deploys verbatim
+  via Vite's `public/` passthrough into `dist/oauth/desktop/cb/index.html`.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Signing in to ccsm-tauri</title>
+  <style>
+    body {
+      font: 14px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+      max-width: 480px;
+      margin: 6rem auto;
+      padding: 0 1rem;
+      color: #222;
+    }
+    h1 { font-size: 1.25rem; margin: 0 0 1rem; }
+    p { margin: 0 0 1rem; }
+    a.btn, button.btn {
+      display: inline-block;
+      padding: 0.6rem 1rem;
+      background: #1f2937;
+      color: #fff;
+      text-decoration: none;
+      border: 0;
+      border-radius: 6px;
+      font: inherit;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    a.btn:hover, button.btn:hover { background: #111827; }
+    .muted { color: #6b7280; font-size: 0.9rem; }
+    .err { color: #b91c1c; }
+    #fallback, #error { display: none; }
+  </style>
+</head>
+<body>
+  <h1 id="title">Signing in&hellip;</h1>
+  <p id="status">Completing GitHub sign-in&hellip;</p>
+
+  <div id="fallback">
+    <p>If your browser blocked the redirect, click below to open the desktop app.</p>
+    <p><a id="open" class="btn" href="#">Open in App</a></p>
+    <p class="muted">You can close this tab once the desktop app has focused.</p>
+  </div>
+
+  <div id="error">
+    <p class="err" id="errorMessage">Sign-in failed.</p>
+    <p><button class="btn" id="retry" type="button">Try again</button></p>
+    <p class="muted">You can close this tab and start over from the desktop app.</p>
+  </div>
+
+  <script>
+  (function () {
+    var statusEl = document.getElementById('status');
+    var titleEl = document.getElementById('title');
+    var fallbackEl = document.getElementById('fallback');
+    var errorEl = document.getElementById('error');
+    var errorMessageEl = document.getElementById('errorMessage');
+    var openBtn = document.getElementById('open');
+    var retryBtn = document.getElementById('retry');
+
+    function showError(msg) {
+      titleEl.textContent = 'Sign-in failed';
+      statusEl.style.display = 'none';
+      errorMessageEl.textContent = msg;
+      errorEl.style.display = 'block';
+    }
+
+    function showFallback(deepLink) {
+      titleEl.textContent = 'Sign-in successful';
+      statusEl.textContent = 'Returning to the ccsm desktop app…';
+      openBtn.setAttribute('href', deepLink);
+      fallbackEl.style.display = 'block';
+    }
+
+    retryBtn.addEventListener('click', function () {
+      try { window.close(); } catch (_e) { /* ignore */ }
+      window.location.replace('/');
+    });
+
+    var params = new URLSearchParams(window.location.search);
+    var code = params.get('code');
+    var state = params.get('state');
+    var ghError = params.get('error');
+
+    if (ghError) {
+      showError('GitHub returned an error: ' + ghError);
+      return;
+    }
+    if (!code || !state) {
+      showError('Missing code or state parameter from GitHub.');
+      return;
+    }
+
+    fetch('/api/auth/desktop/exchange', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ code: code, state: state }),
+    })
+      .then(function (res) {
+        if (!res.ok) {
+          return res.text().then(function (txt) {
+            throw new Error('exchange failed (' + res.status + '): ' + txt);
+          });
+        }
+        return res.json();
+      })
+      .then(function (data) {
+        if (!data || typeof data.tunnel_jwt !== 'string' || typeof data.refresh_token !== 'string') {
+          throw new Error('exchange response malformed');
+        }
+        var deepLink =
+          'ccsm://oauth?' +
+          new URLSearchParams({
+            token: data.tunnel_jwt,
+            refresh: data.refresh_token,
+            state: state,
+          }).toString();
+
+        // Always render the fallback button so it's clickable if the browser
+        // blocks the deep-link or the OS prompt was dismissed. Schedule the
+        // visible reveal a touch after the redirect attempt so successful
+        // hand-offs don't flash UI.
+        setTimeout(function () { showFallback(deepLink); }, 5000);
+        // Immediate hand-off attempt. location.replace avoids a back-button
+        // ghost; if the OS handles ccsm:// the page is unloaded.
+        window.location.replace(deepLink);
+      })
+      .catch(function (err) {
+        showError(String(err && err.message ? err.message : err));
+      });
+  })();
+  </script>
+</body>
+</html>

--- a/packages/frontend-web/public/oauth/desktop/cb/index.html
+++ b/packages/frontend-web/public/oauth/desktop/cb/index.html
@@ -10,7 +10,7 @@
   race for `/oauth/desktop/cb` and short-circuited before the Worker handler
   ran, breaking the callback for desktop sign-in. R-53 splits the work:
 
-    - this static page is served from `cc-sm.pages.dev/oauth/desktop/cb`
+    - this static page is served from `ccsm-worker.jiahuigu.workers.dev/oauth/desktop/cb`
       directly out of `frontend-web/dist`. It contains no token logic; it
       just receives `?code=&state=` from GitHub and POSTs them to the
       Worker.

--- a/packages/frontend-web/src/hostConfig.ts
+++ b/packages/frontend-web/src/hostConfig.ts
@@ -104,7 +104,10 @@ function normalizeBase(raw: string): string {
  * `https://cc-sm.pages.dev`. Task #25 went back to same-origin because the
  * hard-coded URL broke smoke (SPA at `127.0.0.1:8788` cannot fetch a Pages
  * URL — `ERR_FAILED` / CORS) AND was redundant in cloud (Pages serves the
- * SPA AND proxies the tunnel from the same origin).
+ * SPA AND proxies the tunnel from the same origin). R-53 #175 retired
+ * Cloudflare Pages entirely — same-origin now means
+ * `https://ccsm-worker.jiahuigu.workers.dev` (the cf-worker on workers.dev),
+ * which serves both the SPA static assets and the tunnel/api routes.
  */
 export function resolveDaemonBase(deps: ResolveDaemonBaseDeps): string {
   const fromUrl = new URLSearchParams(deps.search).get('daemon');

--- a/packages/frontend-web/src/main.tsx
+++ b/packages/frontend-web/src/main.tsx
@@ -18,6 +18,9 @@ import '@ccsm/ui/styles.css';
 // Task #780 (S3-T5): the default daemon base flipped to the CF Pages
 // tunnel, so `/token` now goes to `https://cc-sm.pages.dev/token` unless
 // the user passes `?daemon=` to redirect at a local loopback daemon.
+// R-53 (Task #175): Pages was retired; the same-origin host is now the
+// cf-worker on `https://ccsm-worker.jiahuigu.workers.dev` which serves
+// both the SPA and `/token` itself.
 //
 // Task #31 (R-13): the boot path emits `[ccsm spa] …` console.log markers
 // so the smoke spec's beforeEach console-forwarder can fingerprint where

--- a/packages/frontend-web/test/hostConfig.test.ts
+++ b/packages/frontend-web/test/hostConfig.test.ts
@@ -59,10 +59,10 @@ describe('resolveWsBase', () => {
 
   it('synthesizes wss:// from window.location for the same-origin default', () => {
     (globalThis as { window?: unknown }).window = {
-      location: { protocol: 'https:', host: 'cc-sm.pages.dev', search: '' },
+      location: { protocol: 'https:', host: 'ccsm-worker.jiahuigu.workers.dev', search: '' },
     };
     const got = resolveWsBase({ search: '' });
-    expect(got).toBe('wss://cc-sm.pages.dev');
+    expect(got).toBe('wss://ccsm-worker.jiahuigu.workers.dev');
   });
 
   it('synthesizes ws:// when the SPA is served over plain http (smoke / Vite dev)', () => {

--- a/packages/frontend-web/test/oauth-callback-page.test.ts
+++ b/packages/frontend-web/test/oauth-callback-page.test.ts
@@ -59,16 +59,40 @@ async function runPage(opts: {
     .replace(/<\/html>[\s\S]*$/i, '');
   document.documentElement.innerHTML = stripped;
 
+  // jsdom's `Location.prototype.replace` is non-configurable, so neither
+  // vi.spyOn nor Object.defineProperty(location, 'replace', ...) work. We
+  // replace the entire `window.location` with a plain mock object that
+  // captures `replace()` calls and proxies `search` to a mutable string.
+  // window-level properties ARE configurable in jsdom, so this works.
   const replaceCalls: string[] = [];
-  vi.spyOn(window.location, 'replace').mockImplementation(
-    (url: string | URL) => {
+  const mockLocation = {
+    href: 'http://127.0.0.1/oauth/desktop/cb' + opts.search,
+    origin: 'http://127.0.0.1',
+    pathname: '/oauth/desktop/cb',
+    search: opts.search,
+    hash: '',
+    host: '127.0.0.1',
+    hostname: '127.0.0.1',
+    port: '',
+    protocol: 'http:',
+    replace(url: string | URL): void {
       replaceCalls.push(String(url));
     },
-  );
-
-  // Set the search via history.replaceState (jsdom backs location.search
-  // with the current URL; `location.search = ` is read-only here).
-  window.history.replaceState({}, '', '/oauth/desktop/cb' + opts.search);
+    assign(url: string | URL): void {
+      replaceCalls.push(String(url));
+    },
+    reload(): void {
+      /* no-op */
+    },
+    toString(): string {
+      return this.href;
+    },
+  };
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    writable: true,
+    value: mockLocation,
+  });
 
   // Stub fetch on both window and global so the script (running in indirect
   // eval) finds it.
@@ -81,7 +105,17 @@ async function runPage(opts: {
   (0, eval)(script);
 
   // Let microtasks (fetch promise resolution + .then chain) flush.
-  for (let i = 0; i < 6; i++) await Promise.resolve();
+  // Response.json() returns a promise so we need several flushes.
+  for (let i = 0; i < 20; i++) {
+    await Promise.resolve();
+    // If fake timers are running, advance them so any awaited
+    // setTimeout(0)-ish microtask scheduler also progresses.
+    try {
+      await vi.advanceTimersByTimeAsync(0);
+    } catch (_e) {
+      /* fake timers not active in this test */
+    }
+  }
 
   return { replaceCalls, document };
 }
@@ -96,11 +130,9 @@ describe('static oauth callback page', () => {
   });
 
   it('on success: POSTs code+state to /api/auth/desktop/exchange and location.replaces into ccsm://oauth?token=...', async () => {
+    const fetchCalls: Array<{ input: string; init?: RequestInit }> = [];
     const fetchSpy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
-      expect(String(input)).toBe('/api/auth/desktop/exchange');
-      expect(init?.method).toBe('POST');
-      const body = JSON.parse(init?.body as string) as { code: string; state: string };
-      expect(body).toEqual({ code: 'gh-code-123', state: 'state-abc' });
+      fetchCalls.push({ input: String(input), init });
       return new Response(
         JSON.stringify({
           tunnel_jwt: 'jwt.value.here',
@@ -115,7 +147,15 @@ describe('static oauth callback page', () => {
       fetchImpl: fetchSpy as unknown as typeof globalThis.fetch,
     });
 
-    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]!.input).toBe('/api/auth/desktop/exchange');
+    expect(fetchCalls[0]!.init?.method).toBe('POST');
+    const body = JSON.parse(fetchCalls[0]!.init?.body as string) as {
+      code: string;
+      state: string;
+    };
+    expect(body).toEqual({ code: 'gh-code-123', state: 'state-abc' });
+
     expect(replaceCalls).toHaveLength(1);
     const target = replaceCalls[0]!;
     expect(target.startsWith('ccsm://oauth?')).toBe(true);
@@ -200,8 +240,11 @@ describe('static oauth callback page', () => {
 
   it('page HTML is self-contained (no <script src>, no React, no module import)', () => {
     const html = readPage();
-    expect(html).not.toMatch(/<script[^>]*\bsrc=/);
-    expect(html).not.toMatch(/import\s+.*from/);
-    expect(html).not.toMatch(/\breact\b/i);
+    // Strip HTML comments before scanning so our own "no React" prose
+    // doesn't trip the regex.
+    const stripped = html.replace(/<!--[\s\S]*?-->/g, '');
+    expect(stripped).not.toMatch(/<script[^>]*\bsrc=/);
+    expect(stripped).not.toMatch(/import\s+.*from/);
+    expect(stripped).not.toMatch(/\breact\b/i);
   });
 });

--- a/packages/frontend-web/test/oauth-callback-page.test.ts
+++ b/packages/frontend-web/test/oauth-callback-page.test.ts
@@ -1,0 +1,207 @@
+/**
+ * R-53 (Task #175): static OAuth callback page tests.
+ *
+ * The static `/oauth/desktop/cb/index.html` page (deployed straight out of
+ * Vite's `public/` directory) is responsible for:
+ *   1. Reading `?code=&state=` from `window.location.search`.
+ *   2. POSTing them to `/api/auth/desktop/exchange`.
+ *   3. On success: composing `ccsm://oauth?token=...&refresh=...&state=...`
+ *      and triggering `window.location.replace(deepLink)`.
+ *   4. On failure: showing an error message + a "Try again" button.
+ *   5. Showing a fallback "Open in App" button after a 5s delay so users can
+ *      retry the deep link if the OS prompt was blocked.
+ *
+ * We exercise the inline script by reading the HTML file off disk, parsing
+ * out the `<script>` body, and executing it in a jsdom window with a stubbed
+ * `fetch` and a captured `location.replace`.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const PAGE_PATH = resolve(
+  __dirname,
+  '..',
+  'public',
+  'oauth',
+  'desktop',
+  'cb',
+  'index.html',
+);
+
+function readPage(): string {
+  return readFileSync(PAGE_PATH, 'utf8');
+}
+
+/** Extract the inline `<script>` body (the one that runs the exchange). */
+function extractInlineScript(html: string): string {
+  const m = html.match(/<script>([\s\S]*?)<\/script>/);
+  if (!m) throw new Error('no inline <script> in page');
+  return m[1]!;
+}
+
+/** Mount the page into the current jsdom document, capture location.replace,
+ *  and run the inline script. */
+async function runPage(opts: {
+  search: string;
+  fetchImpl: typeof globalThis.fetch;
+}): Promise<{
+  replaceCalls: string[];
+  document: Document;
+}> {
+  const html = readPage();
+  const stripped = html
+    .replace(/<script>[\s\S]*?<\/script>/g, '')
+    .replace(/^[\s\S]*?<html[^>]*>/i, '')
+    .replace(/<\/html>[\s\S]*$/i, '');
+  document.documentElement.innerHTML = stripped;
+
+  const replaceCalls: string[] = [];
+  vi.spyOn(window.location, 'replace').mockImplementation(
+    (url: string | URL) => {
+      replaceCalls.push(String(url));
+    },
+  );
+
+  // Set the search via history.replaceState (jsdom backs location.search
+  // with the current URL; `location.search = ` is read-only here).
+  window.history.replaceState({}, '', '/oauth/desktop/cb' + opts.search);
+
+  // Stub fetch on both window and global so the script (running in indirect
+  // eval) finds it.
+  window.fetch = opts.fetchImpl;
+  globalThis.fetch = opts.fetchImpl;
+
+  const script = extractInlineScript(html);
+  // Indirect eval — runs in the global scope of the jsdom window.
+  // eslint-disable-next-line no-eval
+  (0, eval)(script);
+
+  // Let microtasks (fetch promise resolution + .then chain) flush.
+  for (let i = 0; i < 6; i++) await Promise.resolve();
+
+  return { replaceCalls, document };
+}
+
+describe('static oauth callback page', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('on success: POSTs code+state to /api/auth/desktop/exchange and location.replaces into ccsm://oauth?token=...', async () => {
+    const fetchSpy = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe('/api/auth/desktop/exchange');
+      expect(init?.method).toBe('POST');
+      const body = JSON.parse(init?.body as string) as { code: string; state: string };
+      expect(body).toEqual({ code: 'gh-code-123', state: 'state-abc' });
+      return new Response(
+        JSON.stringify({
+          tunnel_jwt: 'jwt.value.here',
+          refresh_token: 'rrr',
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    });
+
+    const { replaceCalls } = await runPage({
+      search: '?code=gh-code-123&state=state-abc',
+      fetchImpl: fetchSpy as unknown as typeof globalThis.fetch,
+    });
+
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(replaceCalls).toHaveLength(1);
+    const target = replaceCalls[0]!;
+    expect(target.startsWith('ccsm://oauth?')).toBe(true);
+    const params = new URLSearchParams(target.slice('ccsm://oauth?'.length));
+    expect(params.get('token')).toBe('jwt.value.here');
+    expect(params.get('refresh')).toBe('rrr');
+    expect(params.get('state')).toBe('state-abc');
+  });
+
+  it('on missing code/state in URL: shows error, does NOT call fetch', async () => {
+    const fetchSpy = vi.fn(async () => new Response('nope', { status: 500 }));
+    const { document, replaceCalls } = await runPage({
+      search: '?state=only',
+      fetchImpl: fetchSpy as unknown as typeof globalThis.fetch,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(replaceCalls).toHaveLength(0);
+    const errEl = document.getElementById('error') as HTMLElement;
+    expect(errEl).not.toBeNull();
+    expect(errEl.style.display).toBe('block');
+    const msg = document.getElementById('errorMessage')!.textContent ?? '';
+    expect(msg).toMatch(/Missing code or state/);
+  });
+
+  it('on GitHub error= param: shows the error message, no fetch', async () => {
+    const fetchSpy = vi.fn(async () => new Response('nope', { status: 500 }));
+    const { document } = await runPage({
+      search: '?error=access_denied',
+      fetchImpl: fetchSpy as unknown as typeof globalThis.fetch,
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const msg = document.getElementById('errorMessage')!.textContent ?? '';
+    expect(msg).toMatch(/access_denied/);
+  });
+
+  it('on exchange 4xx: shows error with the response body, no location.replace', async () => {
+    const fetchSpy = vi.fn(
+      async () => new Response('unknown or used state', { status: 400 }),
+    );
+    const { document, replaceCalls } = await runPage({
+      search: '?code=c&state=s',
+      fetchImpl: fetchSpy as unknown as typeof globalThis.fetch,
+    });
+    // Let the .catch chain settle.
+    for (let i = 0; i < 6; i++) await Promise.resolve();
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(replaceCalls).toHaveLength(0);
+    const errEl = document.getElementById('error') as HTMLElement;
+    expect(errEl.style.display).toBe('block');
+    const msg = document.getElementById('errorMessage')!.textContent ?? '';
+    expect(msg).toMatch(/exchange failed \(400\)/);
+    expect(msg).toMatch(/unknown or used state/);
+    expect(document.getElementById('retry')).not.toBeNull();
+  });
+
+  it('after 5s the fallback "Open in App" button is shown with the deep link href', async () => {
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(JSON.stringify({ tunnel_jwt: 'tjt', refresh_token: 'rrr' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    );
+    const { document } = await runPage({
+      search: '?code=c&state=s',
+      fetchImpl: fetchSpy as unknown as typeof globalThis.fetch,
+    });
+
+    const fallback = document.getElementById('fallback') as HTMLElement;
+    // Before the 5s timer fires, fallback is hidden.
+    expect(fallback.style.display).not.toBe('block');
+
+    // Advance the fake timer past 5s.
+    await vi.advanceTimersByTimeAsync(5100);
+    expect(fallback.style.display).toBe('block');
+    const href = (document.getElementById('open') as HTMLAnchorElement).getAttribute('href');
+    expect(href!.startsWith('ccsm://oauth?')).toBe(true);
+    expect(href).toContain('token=tjt');
+    expect(href).toContain('refresh=rrr');
+    expect(href).toContain('state=s');
+  });
+
+  it('page HTML is self-contained (no <script src>, no React, no module import)', () => {
+    const html = readPage();
+    expect(html).not.toMatch(/<script[^>]*\bsrc=/);
+    expect(html).not.toMatch(/import\s+.*from/);
+    expect(html).not.toMatch(/\breact\b/i);
+  });
+});

--- a/tools/cloud-e2e/README.md
+++ b/tools/cloud-e2e/README.md
@@ -1,7 +1,7 @@
 # cloud-e2e
 
 Standalone Playwright harness that exercises the **deployed** cloud SPA at
-`https://cc-sm.pages.dev` end-to-end. Built for Task #82 so manager (or any
+`https://ccsm-worker.jiahuigu.workers.dev` end-to-end. Built for Task #82 so manager (or any
 maintainer) can verify "real users on two machines" scenarios without
 hand-clicking a browser.
 
@@ -28,7 +28,7 @@ pnpm install:browsers   # downloads Chromium (~150 MB, one-time)
 
 ```bash
 cd tools/cloud-e2e
-pnpm test                       # headless, default base = https://cc-sm.pages.dev
+pnpm test                       # headless, default base = https://ccsm-worker.jiahuigu.workers.dev
 pnpm test:headed                # eyeballs mode for debugging
 CCSM_CLOUD_BASE_URL=https://my-preview.pages.dev pnpm test  # custom origin
 ```

--- a/tools/cloud-e2e/package.json
+++ b/tools/cloud-e2e/package.json
@@ -2,7 +2,7 @@
   "name": "ccsm-cloud-e2e",
   "version": "0.0.0",
   "private": true,
-  "description": "Standalone Playwright harness that exercises the deployed cc-sm.pages.dev cloud SPA end-to-end (Task #82). Lives outside the pnpm workspace on purpose so installing browsers / @playwright/test does not perturb the monorepo lockfile.",
+  "description": "Standalone Playwright harness that exercises the deployed ccsm-worker.jiahuigu.workers.dev cloud SPA end-to-end (Task #82). Lives outside the pnpm workspace on purpose so installing browsers / @playwright/test does not perturb the monorepo lockfile.",
   "type": "module",
   "scripts": {
     "test": "playwright test",

--- a/tools/cloud-e2e/playwright.config.ts
+++ b/tools/cloud-e2e/playwright.config.ts
@@ -4,7 +4,7 @@
 //   - The monorepo's `pnpm-workspace.yaml` only globs `packages/*`, so this
 //     tool stays out of the workspace install graph and avoids hot-file
 //     mutex contention on the root lockfile when manager runs it ad-hoc.
-//   - Target is the *deployed* cc-sm.pages.dev cloud SPA; no local fixtures,
+//   - Target is the *deployed* ccsm-worker.jiahuigu.workers.dev cloud SPA; no local fixtures,
 //     no orchestrator, no daemon spawn — manager just runs `pnpm test`.
 //
 // Failure artifacts (trace.zip, screenshots, video) land in
@@ -19,10 +19,10 @@
 // Playwright forwards process.env into spec workers by default so no
 // explicit `use:` plumbing is required — the spec auto-skips when those
 // vars are absent so the existing two-tab spec keeps running unchanged
-// against deployed cc-sm.pages.dev.
+// against deployed ccsm-worker.jiahuigu.workers.dev.
 import { defineConfig, devices } from '@playwright/test';
 
-const BASE_URL = process.env.CCSM_CLOUD_BASE_URL ?? 'https://cc-sm.pages.dev';
+const BASE_URL = process.env.CCSM_CLOUD_BASE_URL ?? 'https://ccsm-worker.jiahuigu.workers.dev';
 
 export default defineConfig({
   testDir: './specs',

--- a/tools/cloud-e2e/specs/cross-user-isolation.spec.ts
+++ b/tools/cloud-e2e/specs/cross-user-isolation.spec.ts
@@ -2,7 +2,7 @@
  * S4-T9 (Task #135): cross-user isolation cloud-e2e spec.
  *
  * Sibling to `two-tab-pairing.spec.ts`. Where that spec verifies "one user,
- * two tabs each get their own PTY" against the deployed cc-sm.pages.dev SPA,
+ * two tabs each get their own PTY" against the deployed ccsm-worker.jiahuigu.workers.dev SPA,
  * this spec verifies the per-user TunnelDO routing introduced by S4-T5 (the
  * `CCSM_AUTH_MODE=jwt` switch that derives DO id from the JWT subject):
  *
@@ -45,7 +45,7 @@
  * or by editing wrangler.toml `[vars]` locally (don't commit the edit).
  *
  * Skipping: the test auto-skips when the env vars above are absent, so
- * `pnpm test` against deployed cc-sm.pages.dev (the existing two-tab spec's
+ * `pnpm test` against deployed ccsm-worker.jiahuigu.workers.dev (the existing two-tab spec's
  * default) still runs without manual configuration. CI must set these env
  * vars when it wants the cross-user gate.
  */
@@ -293,7 +293,7 @@ const TUNNEL_KEY = process.env.JWT_REFRESH_SIGNING_KEY ?? '';
  * the failure mode that lets cross-user leaks ship. Operators who don't
  * want the cross-user gate must filter the spec out explicitly via
  * `playwright test --grep-invert "cross-user"` (CI matrices already do
- * this for the legacy-mode lane against deployed cc-sm.pages.dev).
+ * this for the legacy-mode lane against deployed ccsm-worker.jiahuigu.workers.dev).
  */
 function requireEnv(): { wsBase: string; webKey: string; tunnelKey: string } {
   const missing: string[] = [];
@@ -307,7 +307,7 @@ function requireEnv(): { wsBase: string; webKey: string; tunnelKey: string } {
       'a `.dev.vars` populated with matching JWT keys, then re-run with ' +
       'CCSM_CLOUD_WS_BASE=ws://127.0.0.1:8787. See spec header for the ' +
       'full setup. Filter this spec out with `--grep-invert "cross-user"` ' +
-      'when targeting deployed cc-sm.pages.dev (legacy-mode lane).',
+      'when targeting deployed ccsm-worker.jiahuigu.workers.dev (legacy-mode lane).',
     );
   }
   return { wsBase: WS_BASE, webKey: WEB_KEY, tunnelKey: TUNNEL_KEY };

--- a/tools/cloud-e2e/specs/two-tab-pairing.spec.ts
+++ b/tools/cloud-e2e/specs/two-tab-pairing.spec.ts
@@ -1,6 +1,6 @@
 // Two-tab pairing spec (Task #82).
 //
-// Simulates two independent machines hitting the deployed cc-sm.pages.dev
+// Simulates two independent machines hitting the deployed ccsm-worker.jiahuigu.workers.dev
 // SPA simultaneously. Each "machine" gets its own browser context (fresh
 // storage / cookies — equivalent to a separate browser profile), opens the
 // SPA, creates a new session, types a unique echo, and asserts that the
@@ -13,7 +13,7 @@
 //   - aria-label="Terminal input"  — xterm's hidden textarea (focus target)
 //
 // Token bootstrap: the SPA's hostConfig.ts already does the 3-step priority
-// chain (URL ?token= → fetch /token → fail). cc-sm.pages.dev serves /token
+// chain (URL ?token= → fetch /token → fail). ccsm-worker.jiahuigu.workers.dev serves /token
 // via the Pages Function + Worker tunnel, so we just navigate to '/' and
 // let the SPA do its thing.
 //


### PR DESCRIPTION
## Summary

R-53 fixes the Cloudflare Pages 308 that broke desktop GitHub OAuth callback by splitting the worker-rendered bounce page into:

1. A static HTML page at `frontend-web/public/oauth/desktop/cb/index.html`, deployed verbatim into `dist/` via Vite's `public/` passthrough. Served by Workers Static Assets on the asset-first fast path so Pages legacy routing cannot intercept it.
2. A new JSON endpoint `POST /api/auth/desktop/exchange` (handled by the Worker on the `/api/*` glob, which already works) that does PKCE verifier exchange + GitHub user fetch + linker decision + tunnel JWT mint, returning `{tunnel_jwt, refresh_token}`.

The static page POSTs to the exchange endpoint, then `location.replace`s into `ccsm://oauth?token=...&refresh=...&state=...` to trigger the Tauri deep-link listener.

`DESKTOP_CALLBACK_PATH` standardised to the trailing-slash form `/oauth/desktop/cb/` so Cloudflare Static Assets serves the directory index without a 307 hop.

No changes to the GitHub OAuth App configuration or Tauri shell code (`auth.rs` still opens `auth_url` from `/api/auth/desktop/start` and listens for the same `ccsm://oauth?...` deep link).

## Files

- `packages/frontend-web/public/oauth/desktop/cb/index.html` — new static page (158 lines, self-contained, no React, no bundler)
- `packages/cf-worker/src/auth/desktopOauth.ts` — replaces `handleDesktopCallback` (HTML render) with `handleDesktopExchange` (JSON); trailing-slash redirect_uri
- `packages/cf-worker/src/index.ts` — drop the `GET /oauth/desktop/cb` route (now static)
- `packages/cf-worker/wrangler.toml` — drop `/oauth/desktop/cb` from `run_worker_first`
- `packages/cf-worker/test/desktopOauth.test.ts` — rewrite around exchange endpoint (203 tests vs 201 baseline, +2)
- `packages/frontend-web/test/oauth-callback-page.test.ts` — new jsdom-based tests for the inline script (45 vs 39, +6)

## Local checks (host: Windows 11, mode: fast)

- lint: ✓ cf-worker (exit 0), frontend-web (exit 0)
- typecheck: ✓ cf-worker (exit 0), frontend-web (exit 0)
- unit tests:
  - cf-worker: 13 files / **203 passed** (baseline 201, +2 net after rewrite)
  - frontend-web: 4 files / **45 passed** (baseline 39, +6 new oauth-callback-page tests)
- e2e: skipped (changes are cf-worker handler + static HTML; no Tauri / electron e2e harness applies)

## Deploy + curl evidence (deployed Worker)

deploy-worker run: https://github.com/Jiahui-Gu/ccsm/actions/runs/25634914095 (success)

```
GET /                                             → HTTP 200  (SPA)
GET /sessions/abc                                 → HTTP 200  (SPA history-mode)
POST /api/auth/desktop/start                      → HTTP 200  + auth_url contains redirect_uri=...%2Foauth%2Fdesktop%2Fcb%2F
GET /oauth/desktop/cb/?code=test&state=test       → HTTP 200  + static HTML (no Worker hop)
POST /api/auth/desktop/exchange {code,state}      → HTTP 400  "unknown or used state" (state mismatch path)
```

## End-to-end notes

Real end-to-end PKCE flow (live GitHub authorize) requires a logged-in user driving the Tauri shell. Per the task spec, manager will coordinate the user-driven leg once this PR is reviewed. The unit + curl coverage above exercises every code path that does NOT need a real GitHub `code`.

## Concurrency notes

Three branches for Task #175 were created during dispatch (`task-175-pages-to-workers`, `task-175-static-callback`, `task-175-workers-static`). Only this branch (`task-175-r53-static-html`) has commits on origin; the trailing-slash refinement (commit `60e216a1`) incorporates an in-flight tweak found in the worktree from a sibling agent, kept here because it's directly required for the `redirect_uri` to land on the asset-first fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)