### PR TITLE
R-54: forward GitHub login through desktop OAuth exchange (Task #177)

### DIFF
--- a/packages/cf-worker/src/auth/desktopOauth.ts
+++ b/packages/cf-worker/src/auth/desktopOauth.ts
@@ -221,6 +221,21 @@ interface ExchangeRequestBody {
 interface ExchangeResponseBody {
   tunnel_jwt: string;
   refresh_token: string;
+  /**
+   * GitHub login (handle) of the signed-in user, sourced from the GitHub
+   * `/user` response after PKCE exchange. Returned alongside the tokens so
+   * the Tauri shell can persist it in `~/.ccsm/tunnel_jwt` without parsing
+   * the JWT on the desktop side (the JWT's `login` claim is the same value,
+   * but parsing on the desktop would duplicate the SSOT and require base64
+   * decode logic in the shell — keep the linker as the only producer).
+   *
+   * Why a wire field instead of "Tauri reads JWT": Task #177 — desktop side
+   * previously persisted the placeholder string "pending" because the deep
+   * link only carried `{token, refresh, state}`, so the SPA rendered the
+   * literal `@pending`. The fix is to ship the resolved login alongside the
+   * tokens — same shape as the device-flow response (`DevicePollSuccess`).
+   */
+  login: string;
 }
 
 /**
@@ -415,6 +430,7 @@ export async function handleDesktopExchange(
   const body_out: ExchangeResponseBody = {
     tunnel_jwt: tunnelJwt,
     refresh_token: tunnelRefreshToken,
+    login,
   };
   return Response.json(body_out);
 }

--- a/packages/cf-worker/test/desktopOauth.test.ts
+++ b/packages/cf-worker/test/desktopOauth.test.ts
@@ -388,6 +388,7 @@ describe('handleDesktopExchange', () => {
     const body = (await res.json()) as {
       tunnel_jwt: string;
       refresh_token: string;
+      login: string;
     };
 
     // PKCE verifier was forwarded; redirect_uri matched start; client_secret
@@ -402,11 +403,29 @@ describe('handleDesktopExchange', () => {
     // JSON shape.
     expect(typeof body.tunnel_jwt).toBe('string');
     expect(body.refresh_token).toMatch(/^[0-9a-f]{64}$/);
+    // Task #177: login on the wire mirrors the GitHub /user `login` field and
+    // matches the JWT's `login` claim — Tauri persists this verbatim into
+    // `~/.ccsm/tunnel_jwt` so the SPA renders "@alice", not "@pending".
+    expect(body.login).toBe('alice');
+
+    // Task #177 (coverage hardening): response object keys are EXACTLY the
+    // expected set. Catches future "dropped field" regressions (the original
+    // bug shipped because the desktop side defaulted login to "pending"
+    // instead of getting it from the wire — locking the wire shape down here
+    // means any field rename / removal trips this test immediately).
+    expect(Object.keys(body).sort()).toEqual(
+      ['login', 'refresh_token', 'tunnel_jwt'].sort(),
+    );
 
     const claims = await verifyJwt<TunnelJwtClaims>(body.tunnel_jwt, KEY_HEX);
     expect(claims).not.toBeNull();
     expect(claims!.kind).toBe('tunnel');
     expect(claims!.login).toBe('alice');
+    // Task #177 (coverage hardening): the response `login` and the JWT
+    // `login` claim are sourced from the same `userJson.login` value in
+    // handleDesktopExchange. Lock that consistency in so a future refactor
+    // can't split them.
+    expect(body.login).toBe(claims!.login);
     // sub is uuid (R-51a) — not the github_id 42.
     expect(claims!.sub).not.toBe('42');
     expect(claims!.sub).toMatch(/^[0-9a-f-]{36}$/i);

--- a/packages/frontend-tauri/src-tauri/src/auth.rs
+++ b/packages/frontend-tauri/src-tauri/src/auth.rs
@@ -614,21 +614,26 @@ pub struct DeepLinkPayload {
     pub token: String,
     pub refresh: String,
     pub state: String,
+    /// GitHub login (handle) of the signed-in user. Task #177: the static
+    /// callback page now forwards the cf-worker `exchange` response's `login`
+    /// field into the deep link so the desktop shell can persist a real value
+    /// instead of the legacy placeholder "pending".
+    pub login: String,
 }
 
-/// Parse `ccsm://oauth?token=<jwt>&refresh=<token>&state=<state>` into its
-/// three required fields. Returns `None` on any structural failure:
+/// Parse `ccsm://oauth?token=<jwt>&refresh=<token>&state=<state>&login=<login>`
+/// into its four required fields. Returns `None` on any structural failure:
 ///   - scheme is not `ccsm`
 ///   - host (URL "authority") is not `oauth`
-///   - any of token / refresh / state is missing or empty
+///   - any of token / refresh / state / login is missing or empty
 ///
 /// The verifier is run on the parsed URL only; signature validity / state
 /// freshness are the caller's job (`PkceStateStore::take`).
 pub fn parse_deeplink_url(url: &str) -> Option<DeepLinkPayload> {
     // We deliberately do NOT pull in a URL parser dep — the format is fully
-    // controlled by cf-worker's renderBouncePage and is `ccsm://oauth?...`
-    // with percent-encoded values. Hand-rolling 30 lines is cheaper than
-    // adding `url = "2"` to Cargo for one call site.
+    // controlled by the static callback page's URLSearchParams encoder and is
+    // `ccsm://oauth?...` with percent-encoded values. Hand-rolling 30 lines
+    // is cheaper than adding `url = "2"` to Cargo for one call site.
     let after_scheme = url.strip_prefix("ccsm://")?;
     // Split at the first `?` — the part before is `<authority>[/<path>]`,
     // after is the query string.
@@ -645,6 +650,7 @@ pub fn parse_deeplink_url(url: &str) -> Option<DeepLinkPayload> {
     let mut token: Option<String> = None;
     let mut refresh: Option<String> = None;
     let mut state: Option<String> = None;
+    let mut login: Option<String> = None;
     for pair in query.split('&') {
         let (k, v) = match pair.find('=') {
             Some(i) => (&pair[..i], &pair[i + 1..]),
@@ -662,16 +668,18 @@ pub fn parse_deeplink_url(url: &str) -> Option<DeepLinkPayload> {
             "token" => token = Some(decoded),
             "refresh" => refresh = Some(decoded),
             "state" => state = Some(decoded),
+            "login" => login = Some(decoded),
             _ => {}
         }
     }
     let token = token?;
     let refresh = refresh?;
     let state = state?;
-    if token.is_empty() || refresh.is_empty() || state.is_empty() {
+    let login = login?;
+    if token.is_empty() || refresh.is_empty() || state.is_empty() || login.is_empty() {
         return None;
     }
-    Some(DeepLinkPayload { token, refresh, state })
+    Some(DeepLinkPayload { token, refresh, state, login })
 }
 
 /// RFC 3986 §2.1 percent-decoding of an URL component. Invalid escape
@@ -723,18 +731,18 @@ pub fn handle_desktop_callback(app: &AppHandle, url: &str) -> Result<(), String>
             "deep-link state not recognized (state mismatch / replay / expired)".to_string(),
         );
     }
-    // Best-effort sub extraction so persisted creds stay shape-compatible
-    // with the device-flow path. The persisted blob's `login` is what the
-    // SPA renders, so we leave it empty here — R-51c will surface the
-    // `/api/auth/me`-derived login on first daemon connect.
+    // Task #177: persist the login that the cf-worker `exchange` endpoint
+    // resolved (sourced from the GitHub /user response inside the linker).
+    // Previously this hard-coded "pending" because the deep-link only carried
+    // {token, refresh, state}, and the SPA ended up rendering "@pending".
+    // The static callback page now forwards `login` from the exchange
+    // response into the `ccsm://oauth?...&login=<login>` query, so the
+    // desktop side can store it verbatim — keeping cf-worker's oauthLinker
+    // as the single producer of the login value (no JWT parsing here).
     let creds = PersistedTunnelCreds {
         tunnel_jwt: payload.token,
         tunnel_refresh_token: payload.refresh,
-        // login is unknown until the daemon reports back; persistence
-        // round-trip works either way (read_persisted_creds rejects empty
-        // login though, so we fill in a placeholder). This will be
-        // refreshed on first /api/auth/me call (R-51c scope).
-        login: String::from("pending"),
+        login: payload.login,
     };
     write_persisted_creds(&creds)
         .map_err(|e| format!("persist desktop creds: {e}"))?;
@@ -1031,18 +1039,21 @@ mod tests {
 
     #[test]
     fn parse_deeplink_url_extracts_token_refresh_state() {
-        let url = "ccsm://oauth?token=abc.def.ghi&refresh=01234567&state=feedface";
+        let url = "ccsm://oauth?token=abc.def.ghi&refresh=01234567&state=feedface&login=octocat";
         let p = parse_deeplink_url(url).expect("must parse");
         assert_eq!(p.token, "abc.def.ghi");
         assert_eq!(p.refresh, "01234567");
         assert_eq!(p.state, "feedface");
+        // Task #177: login is the resolved GitHub handle, not a placeholder.
+        assert_eq!(p.login, "octocat");
     }
 
     #[test]
     fn parse_deeplink_url_handles_percent_encoded_values() {
-        // cf-worker URLSearchParams encodes `+` as `%2B` etc. Make sure the
-        // parser round-trips a percent-encoded JWT sig (rare but possible).
-        let url = "ccsm://oauth?token=a.b%2Bc&refresh=r&state=s";
+        // The static callback page's URLSearchParams encodes `+` as `%2B` etc.
+        // Make sure the parser round-trips a percent-encoded JWT sig (rare but
+        // possible).
+        let url = "ccsm://oauth?token=a.b%2Bc&refresh=r&state=s&login=u";
         let p = parse_deeplink_url(url).expect("must parse");
         assert_eq!(p.token, "a.b+c");
     }
@@ -1050,20 +1061,27 @@ mod tests {
     #[test]
     fn parse_deeplink_url_rejects_wrong_authority() {
         // `ccsm://other?...` and `ccsm://oauth/extra?...` both reject.
-        assert!(parse_deeplink_url("ccsm://other?token=t&refresh=r&state=s").is_none());
-        assert!(parse_deeplink_url("ccsm://oauth/extra?token=t&refresh=r&state=s").is_none());
+        assert!(parse_deeplink_url("ccsm://other?token=t&refresh=r&state=s&login=u").is_none());
+        assert!(
+            parse_deeplink_url("ccsm://oauth/extra?token=t&refresh=r&state=s&login=u").is_none()
+        );
     }
 
     #[test]
     fn parse_deeplink_url_rejects_missing_or_empty_fields() {
         // missing state
-        assert!(parse_deeplink_url("ccsm://oauth?token=t&refresh=r").is_none());
+        assert!(parse_deeplink_url("ccsm://oauth?token=t&refresh=r&login=u").is_none());
         // empty token
-        assert!(parse_deeplink_url("ccsm://oauth?token=&refresh=r&state=s").is_none());
+        assert!(parse_deeplink_url("ccsm://oauth?token=&refresh=r&state=s&login=u").is_none());
+        // Task #177: missing login is now a structural failure (no fallback
+        // to "pending" placeholder).
+        assert!(parse_deeplink_url("ccsm://oauth?token=t&refresh=r&state=s").is_none());
+        // empty login
+        assert!(parse_deeplink_url("ccsm://oauth?token=t&refresh=r&state=s&login=").is_none());
         // entirely malformed
         assert!(parse_deeplink_url("ccsm://oauth?invalid").is_none());
         // wrong scheme
-        assert!(parse_deeplink_url("https://oauth?token=t&refresh=r&state=s").is_none());
+        assert!(parse_deeplink_url("https://oauth?token=t&refresh=r&state=s&login=u").is_none());
     }
 
     #[test]
@@ -1113,5 +1131,94 @@ mod tests {
         assert_eq!(extract_query_param(url, "state"), Some("feedface".to_string()));
         assert_eq!(extract_query_param(url, "scope"), Some("read:user".to_string()));
         assert_eq!(extract_query_param(url, "missing"), None);
+    }
+
+    /// Task #177 (coverage hardening): explicit serde round-trip on the
+    /// persisted blob shape. Catches "dropped field" regressions on the
+    /// on-disk schema — if anyone removes the `login` field from
+    /// `PersistedTunnelCreds`, deserialization here will fail to populate
+    /// it and the SPA bug from Task #177 returns. By pinning the JSON
+    /// keys explicitly we also catch silent renames (serde's default is
+    /// snake_case but it does not validate "unknown fields", and a
+    /// missing field on the struct silently drops it from the wire).
+    #[test]
+    fn persisted_tunnel_creds_serde_round_trip_includes_login() {
+        let json = r#"{"tunnel_jwt":"jwt.body.sig","tunnel_refresh_token":"abcd","login":"alice"}"#;
+        let parsed: PersistedTunnelCreds = serde_json::from_str(json).expect("deserialize");
+        assert_eq!(parsed.tunnel_jwt, "jwt.body.sig");
+        assert_eq!(parsed.tunnel_refresh_token, "abcd");
+        assert_eq!(parsed.login, "alice");
+
+        // Re-serialize and assert the produced JSON contains all three keys —
+        // this defends against a future `#[serde(skip_serializing)]` slipping
+        // onto the login field.
+        let out = serde_json::to_string(&parsed).expect("serialize");
+        assert!(out.contains("\"tunnel_jwt\""));
+        assert!(out.contains("\"tunnel_refresh_token\""));
+        assert!(out.contains("\"login\""));
+        assert!(out.contains("alice"));
+    }
+
+    /// Task #177 (coverage hardening): regression guard that the `login`
+    /// field stored by the desktop OAuth deep-link path is NOT the literal
+    /// placeholder string "pending". The original bug shipped because
+    /// `handle_desktop_callback` wrote `login: String::from("pending")`
+    /// when it had real data on the wire — this test mirrors the deep-link
+    /// happy path and asserts the literal can never sneak back in for that
+    /// code path.
+    ///
+    /// Note: we deliberately don't grep the whole module for the string
+    /// "pending" because GitHub's device-flow API uses `"pending"` as a
+    /// legitimate poll-status value (see `run_poll_loop`), and a coarse
+    /// grep would generate false positives on that legitimate match.
+    #[test]
+    fn deep_link_login_is_never_pending_literal() {
+        with_tmp_home("never-pending", || {
+            let url =
+                "ccsm://oauth?token=jwt.body.sig&refresh=rrr&state=feedface&login=octocat";
+            let payload = parse_deeplink_url(url).expect("must parse");
+            let creds = PersistedTunnelCreds {
+                tunnel_jwt: payload.token,
+                tunnel_refresh_token: payload.refresh,
+                login: payload.login,
+            };
+            assert_ne!(creds.login, "pending");
+            assert_eq!(creds.login, "octocat");
+        });
+    }
+
+    /// uses — take a deep link string, parse it, copy the parsed `login` (and
+    /// the other two credential fields) into `PersistedTunnelCreds`, write to
+    /// disk, read back, and verify the persisted `login` matches the deep
+    /// link's `login` (NOT the legacy literal "pending").
+    ///
+    /// We can't drive the real `handle_desktop_callback` directly from a
+    /// `#[test]` because it needs a `tauri::AppHandle` (live Tauri runtime).
+    /// Instead we mirror the exact composition it performs — same fields,
+    /// same write_persisted_creds path — so any future drift that puts
+    /// "pending" back into the persisted blob will fail this test.
+    #[test]
+    fn deep_link_login_round_trips_through_persisted_creds() {
+        with_tmp_home("deeplink-login", || {
+            let url =
+                "ccsm://oauth?token=jwt.value.here&refresh=rrr&state=feedface&login=Jiahui-Gu";
+            let payload = parse_deeplink_url(url).expect("must parse");
+            assert_eq!(payload.login, "Jiahui-Gu");
+
+            let creds = PersistedTunnelCreds {
+                tunnel_jwt: payload.token.clone(),
+                tunnel_refresh_token: payload.refresh.clone(),
+                login: payload.login.clone(),
+            };
+            write_persisted_creds(&creds).unwrap();
+
+            let back = read_persisted_creds().expect("read back");
+            assert_eq!(back.tunnel_jwt, "jwt.value.here");
+            assert_eq!(back.tunnel_refresh_token, "rrr");
+            // The bug from Task #177 wrote the literal string "pending" here.
+            // Lock in the real login.
+            assert_eq!(back.login, "Jiahui-Gu");
+            assert_ne!(back.login, "pending");
+        });
     }
 }

--- a/packages/frontend-web/public/oauth/desktop/cb/index.html
+++ b/packages/frontend-web/public/oauth/desktop/cb/index.html
@@ -129,7 +129,12 @@
         return res.json();
       })
       .then(function (data) {
-        if (!data || typeof data.tunnel_jwt !== 'string' || typeof data.refresh_token !== 'string') {
+        if (
+          !data ||
+          typeof data.tunnel_jwt !== 'string' ||
+          typeof data.refresh_token !== 'string' ||
+          typeof data.login !== 'string'
+        ) {
           throw new Error('exchange response malformed');
         }
         var deepLink =
@@ -138,6 +143,7 @@
             token: data.tunnel_jwt,
             refresh: data.refresh_token,
             state: state,
+            login: data.login,
           }).toString();
 
         // Always render the fallback button so it's clickable if the browser

--- a/packages/frontend-web/test/oauth-callback-page.test.ts
+++ b/packages/frontend-web/test/oauth-callback-page.test.ts
@@ -137,6 +137,7 @@ describe('static oauth callback page', () => {
         JSON.stringify({
           tunnel_jwt: 'jwt.value.here',
           refresh_token: 'rrr',
+          login: 'alice',
         }),
         { status: 200, headers: { 'content-type': 'application/json' } },
       );
@@ -163,6 +164,10 @@ describe('static oauth callback page', () => {
     expect(params.get('token')).toBe('jwt.value.here');
     expect(params.get('refresh')).toBe('rrr');
     expect(params.get('state')).toBe('state-abc');
+    // Task #177: login is forwarded into the deep link so the Tauri shell can
+    // persist it verbatim (instead of writing the literal "pending" placeholder
+    // and rendering "@pending" in the SPA).
+    expect(params.get('login')).toBe('alice');
   });
 
   it('on missing code/state in URL: shows error, does NOT call fetch', async () => {
@@ -211,13 +216,41 @@ describe('static oauth callback page', () => {
     expect(document.getElementById('retry')).not.toBeNull();
   });
 
+  it('Task #177: on exchange response missing `login` field: shows malformed error, no location.replace', async () => {
+    // Locks in that the page treats a `{tunnel_jwt, refresh_token}` response
+    // (without `login`) as malformed. The original Task #177 bug shipped
+    // because nothing on the wire forced login to be present — guard against
+    // a future refactor dropping it again.
+    const fetchSpy = vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({ tunnel_jwt: 'jwt', refresh_token: 'rrr' }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+    );
+    const { document, replaceCalls } = await runPage({
+      search: '?code=c&state=s',
+      fetchImpl: fetchSpy as unknown as typeof globalThis.fetch,
+    });
+    for (let i = 0; i < 6; i++) await Promise.resolve();
+    expect(fetchSpy).toHaveBeenCalledOnce();
+    expect(replaceCalls).toHaveLength(0);
+    const errEl = document.getElementById('error') as HTMLElement;
+    expect(errEl.style.display).toBe('block');
+    const msg = document.getElementById('errorMessage')!.textContent ?? '';
+    expect(msg).toMatch(/malformed/);
+  });
+
   it('after 5s the fallback "Open in App" button is shown with the deep link href', async () => {
     const fetchSpy = vi.fn(
       async () =>
-        new Response(JSON.stringify({ tunnel_jwt: 'tjt', refresh_token: 'rrr' }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' },
-        }),
+        new Response(
+          JSON.stringify({ tunnel_jwt: 'tjt', refresh_token: 'rrr', login: 'alice' }),
+          {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          },
+        ),
     );
     const { document } = await runPage({
       search: '?code=c&state=s',


### PR DESCRIPTION
## Summary

Task #177 / R-54 bug fix: Tauri shell was persisting the literal string `"pending"` as `PersistedTunnelCreds.login` in `~/.ccsm/tunnel_jwt`, causing the SPA to render `@pending` after a successful PKCE sign-in even though the JWT itself carried the correct `login` claim.

## Bug evidence (from manager + user live test)

- `~/.ccsm/tunnel_jwt` after PKCE sign-in: `"login": "pending"`
- Same file, JWT payload decoded: `"login":"Jiahui-Gu"` — server-signed value is correct
- daemon reads `creds.login=pending` → `hello.identity.login=pending` → SPA renders `@pending`

## Root cause

The cf-worker `/api/auth/desktop/exchange` response only returned `{tunnel_jwt, refresh_token}`. The static callback page composed `ccsm://oauth?token=...&refresh=...&state=...` — no login. So the Tauri `handle_desktop_callback` had no real login on the wire and defaulted to `String::from("pending")` as a placeholder.

## Fix (architecture layer, no glue)

Single producer = `oauthLinker` (cf-worker side) which already knows the login from the GitHub `/user` response. We forward it through:

1. **cf-worker `/api/auth/desktop/exchange`** — response now includes `login` (`packages/cf-worker/src/auth/desktopOauth.ts`). Same value that feeds the JWT `login` claim, no second source of truth.
2. **Static `/oauth/desktop/cb/index.html`** — composes `ccsm://oauth?...&login=<login>` into the deep link; rejects exchange responses missing `login` as malformed.
3. **Tauri `DeepLinkPayload`** — gains `login: String`; `parse_deeplink_url` requires it. `handle_desktop_callback` writes `payload.login` into `PersistedTunnelCreds.login`. No JWT parsing on the desktop side (per task spec — keeps cf-worker's linker as the only producer).

## Coverage hardening (per coordinator follow-up)

To prevent this class of "dropped wire field" bug from shipping again:

**Layer A — cf-worker `desktopOauth.test.ts`**:
- Happy path now asserts `body.login === 'alice'` (mock GitHub user info).
- Happy path now asserts `Object.keys(body).sort() === ['login', 'refresh_token', 'tunnel_jwt'].sort()` — locks down the EXACT wire shape.
- Happy path now asserts `body.login === claims.login` — locks consistency between wire `login` and JWT `login` claim.

**Layer B — frontend-web `oauth-callback-page.test.ts`**:
- New test: exchange response missing `login` → page shows malformed error, no `location.replace`.

**Layer C — Tauri `auth.rs` `#[cfg(test)]`**:
- New: `deep_link_login_round_trips_through_persisted_creds` — end-to-end: parse deep link → write to disk → read back; asserts `login == "Jiahui-Gu"` (manager evidence) and `!= "pending"`.
- New: `persisted_tunnel_creds_serde_round_trip_includes_login` — explicit serde JSON round-trip; defends against `#[serde(skip_serializing)]` or struct-field removal silently dropping `login`.
- New: `deep_link_login_is_never_pending_literal` — focused regression guard for the original bug.
- Existing `parse_deeplink_url_*` tests updated: `login` is now a required field of the deep link.

**Not done (push-back to coordinator)**:
- Coordinator Layer B2 ("`handle_desktop_callback` writes correct login" as a unit test) — requires a real `tauri::AppHandle`; not easily mockable in a `#[test]`. The new `deep_link_login_round_trips_through_persisted_creds` covers the same composition path without needing the runtime.
- Coordinator Layer D refactor (`Option<String>` / typed enum instead of placeholder) — not needed: the production code now NEVER writes a placeholder. `login` is required at the wire (cf-worker → page → deep link → Tauri), and missing it fails parsing. `Option<String>` would just push the question downstream.
- Coordinator Layer D source-grep "no pending literal anywhere": GitHub's device-flow API legitimately uses `"pending"` as a poll status (`run_poll_loop` match arm), so a blanket grep would false-positive. The focused `deep_link_login_is_never_pending_literal` test covers the actual bug path.
- Coordinator Layer E (JSON schema harness across all endpoints) — out of scope, would be its own task.

## Local checks (host: Windows 11, mode: full)

- lint: clean (cf-worker, frontend-web)
- typecheck: clean (cf-worker, frontend-web)
- cf-worker `pnpm test`: **13 files / 203 tests passed** (existing happy-path case picked up 3 new asserts; no new test files)
- frontend-web `pnpm test`: **4 files / 46 tests passed** (+1 new malformed test)
- Tauri `cargo test --lib`: **31 passed, 0 failed** (28 baseline + 3 new auth tests)

## Manual verification (for manager to coordinate with user post-merge)

After this lands + `deploy-worker.yml` reruns:

1. Open the Tauri shell.
2. Click sign-in (PKCE path).
3. Complete GitHub authorize in the browser.
4. Observe `~/.ccsm/tunnel_jwt` — `login` field should now match the GitHub handle (e.g. `"login":"Jiahui-Gu"`), NOT `"pending"`.
5. SPA should render `@<your-handle>`, not `@pending`.

## Files

- `packages/cf-worker/src/auth/desktopOauth.ts`
- `packages/cf-worker/test/desktopOauth.test.ts`
- `packages/frontend-web/public/oauth/desktop/cb/index.html`
- `packages/frontend-web/test/oauth-callback-page.test.ts`
- `packages/frontend-tauri/src-tauri/src/auth.rs`