### PR TITLE
R-58: rename identity.github_id -> user_id (align R-51a uuid PK) + fill daemon-state identity

### DIFF
--- a/packages/cf-worker/src/index.ts
+++ b/packages/cf-worker/src/index.ts
@@ -54,16 +54,22 @@ import { Logger, deriveRequestId, shortSub } from './logger';
  * identity headers so the TunnelDO can echo them into the daemon hello
  * frame (Task #133 wire format). Browser ws path only — the daemon path
  * does not need identity injection (the tunnel JWT itself carries login +
- * github_id and the daemon already trusts the cloud-issued token).
+ * user_id and the daemon already trusts the cloud-issued token).
+ *
+ * R-58 (Task #182): `user_id` here is the uuid PK from `claims.sub`
+ * (R-51a Task #167), NOT a GitHub numeric id. The `X-CCSM-Identity-Id`
+ * HTTP header name is kept stable on the wire (changing it would need a
+ * lockstep DO + worker deploy); the DO reads it and fills
+ * `BrowserIdentity.user_id` (renamed from `github_id` in R-58).
  */
 function withIdentityHeaders(
   req: Request,
   login: string,
-  github_id: string,
+  user_id: string,
 ): Request {
   const headers = new Headers(req.headers);
   headers.set('X-CCSM-Identity-Login', login);
-  headers.set('X-CCSM-Identity-Id', github_id);
+  headers.set('X-CCSM-Identity-Id', user_id);
   return new Request(req, { headers });
 }
 

--- a/packages/cf-worker/src/tunnel-do.ts
+++ b/packages/cf-worker/src/tunnel-do.ts
@@ -356,11 +356,16 @@ export class TunnelDO extends DurableObject<Env> {
       // before forwarding into this DO. In legacy mode (no JWT, S3-era
       // smoke flow) the headers are absent and identity stays undefined —
       // the daemon then falls back to validating the bearer token itself.
+      //
+      // R-58 (Task #182): `X-CCSM-Identity-Id` carries the uuid user PK
+      // (claims.sub since R-51a Task #167), NOT the GitHub numeric id. The
+      // wire field on `BrowserIdentity` was renamed `github_id` → `user_id`
+      // to match.
       const idLogin = req.headers.get('X-CCSM-Identity-Login');
-      const idGithub = req.headers.get('X-CCSM-Identity-Id');
+      const idUserId = req.headers.get('X-CCSM-Identity-Id');
       const identity: BrowserIdentity | undefined =
-        idLogin !== null && idGithub !== null
-          ? { login: idLogin, github_id: idGithub }
+        idLogin !== null && idUserId !== null
+          ? { login: idLogin, user_id: idUserId }
           : undefined;
       const attachment: BrowserAttachment = identity !== undefined
         ? { role: 'browser', token: extracted.token, sid, identity }

--- a/packages/cf-worker/test/middleware.test.ts
+++ b/packages/cf-worker/test/middleware.test.ts
@@ -94,7 +94,7 @@ describe('getAuthMode', () => {
 });
 
 describe('getUserDoIdName', () => {
-  it('namespaces github_id under user: prefix', () => {
+  it('namespaces user_id under user: prefix', () => {
     expect(getUserDoIdName('12345')).toBe('user:12345');
     expect(getUserDoIdName('99')).toBe('user:99');
   });

--- a/packages/cf-worker/test/tunnel-do.test.ts
+++ b/packages/cf-worker/test/tunnel-do.test.ts
@@ -475,6 +475,44 @@ describe('TunnelDO', () => {
     expect('identity' in hello).toBe(false);
   });
 
+  // R-58 (Task #182): when the cf-worker has injected X-CCSM-Identity-Login
+  // + X-CCSM-Identity-Id headers (jwt mode, middleware extracted them from
+  // the verified web JWT), the DO must surface them in the daemon-bound
+  // hello frame under `identity.user_id` — NOT `identity.github_id` (the
+  // pre-R-58 field name lied, since R-51a moved sub to the uuid PK).
+  it('R-58: hello frame echoes X-CCSM-Identity-* under identity.user_id (uuid PK from R-51a)', async () => {
+    const TunnelDO = await loadDO();
+    const inst = new TunnelDO(makeState(), fakeEnv);
+    await inst.fetch(makeReq('/tunnel/default'));
+
+    // Browser ws upgrade with the identity headers the middleware would
+    // inject after verifyJwt against the web JWT (claims.sub = uuid).
+    const browserReq = new Request('https://example.test/ws/default?sid=sess-y', {
+      headers: {
+        Upgrade: 'websocket',
+        'Sec-WebSocket-Protocol': BROWSER_PROTO,
+        'X-CCSM-Identity-Login': 'octocat',
+        'X-CCSM-Identity-Id': 'a3c7ac23-2d79-4810-8c61-207179e44e91',
+      },
+    });
+    await inst.fetch(browserReq);
+    const daemon = created[0].server;
+    const hello = JSON.parse(daemon.sent[0] as string);
+    expect(hello).toEqual({
+      type: 'hello',
+      token: 'test-token-xyz',
+      sid: 'sess-y',
+      lastSeq: 0,
+      identity: {
+        login: 'octocat',
+        user_id: 'a3c7ac23-2d79-4810-8c61-207179e44e91',
+      },
+    });
+    // Defensive: the legacy field name must NOT be emitted (any double-write
+    // would re-introduce the schema lie R-58 explicitly removed).
+    expect('github_id' in hello.identity).toBe(false);
+  });
+
   // ---- HTTP-over-tunnel (Task #787, S3-C) -------------------------------
 
   function makeHttpReq(path: string, method = 'GET', body?: string): Request {    return new Request(`https://example.test${path}`, {

--- a/packages/daemon/src/tunnel.mts
+++ b/packages/daemon/src/tunnel.mts
@@ -195,8 +195,8 @@ function parseIdentity(value: unknown): BrowserIdentity | null {
   if (value === null || typeof value !== 'object') return null;
   const obj = value as Record<string, unknown>;
   if (typeof obj.login !== 'string' || obj.login.length === 0) return null;
-  if (typeof obj.github_id !== 'string' || obj.github_id.length === 0) return null;
-  return { login: obj.login, github_id: obj.github_id };
+  if (typeof obj.user_id !== 'string' || obj.user_id.length === 0) return null;
+  return { login: obj.login, user_id: obj.user_id };
 }
 
 /**
@@ -215,14 +215,15 @@ export function isTrustTunnelEnabled(): boolean {
 
 /**
  * Audit F-S-2 (Task #152): in trust-tunnel mode the daemon must reject any
- * hello whose cloud-authenticated identity does not match the GitHub user
- * the daemon was started for. Without this check, a misconfigured cloud
+ * hello whose cloud-authenticated identity does not match the user the
+ * daemon was started for. Without this check, a misconfigured cloud
  * deploy that signs a JWT for ANY user would let that user hijack this
  * daemon's tunnel.
  *
  * The expected owner is injected by the Tauri shell at spawn time
  * (env `CCSM_EXPECTED_OWNER_ID`, parsed from the local `~/.ccsm/tunnel_jwt`
- * `sub` claim). Empty / unset returns null and the bind check is skipped —
+ * `sub` claim — a uuid since R-51a Task #167; pre-R-51 it was the GitHub
+ * numeric id). Empty / unset returns null and the bind check is skipped —
  * legacy deployments without the Tauri shell stay unaffected.
  *
  * Read on every call so tests can toggle via process.env without re-import.
@@ -586,17 +587,20 @@ export class TunnelClient {
             return;
           }
           // Audit F-S-2 (Task #152): identity-bind check. The Tauri shell
-          // baked the expected GitHub user id into the daemon's env at
-          // spawn time (parsed from the persisted tunnel JWT's `sub`).
-          // Reject any hello whose cloud-stamped identity disagrees so a
-          // mis-issued JWT cannot hijack this user's daemon.
+          // baked the expected user id into the daemon's env at spawn time
+          // (parsed from the persisted tunnel JWT's `sub` claim — a uuid
+          // since R-51a Task #167). Reject any hello whose cloud-stamped
+          // identity disagrees so a mis-issued JWT cannot hijack this
+          // user's daemon. R-58 (Task #182) renamed the wire field
+          // `github_id` → `user_id` so the name matches the actual value
+          // semantics.
           const expectedOwner = getExpectedOwnerId();
-          if (expectedOwner !== null && hello.identity.github_id !== expectedOwner) {
+          if (expectedOwner !== null && hello.identity.user_id !== expectedOwner) {
             this.rejectHello(
               'identity-mismatch (expected owner=' +
                 expectedOwner +
                 ' got=' +
-                hello.identity.github_id +
+                hello.identity.user_id +
                 ')',
             );
             return;

--- a/packages/daemon/test/tunnel.test.ts
+++ b/packages/daemon/test/tunnel.test.ts
@@ -924,7 +924,7 @@ describe('TunnelClient', () => {
     });
 
     it('accepts hello with identity and no token', () => {
-      const attachCalls: Array<{ sid: string; identity?: { login: string; github_id: string } }> = [];
+      const attachCalls: Array<{ sid: string; identity?: { login: string; user_id: string } }> = [];
       const client = new TunnelClient({
         url: 'wss://x',
         // daemon-side token kept for legacy callers but not consulted in trust mode.
@@ -943,16 +943,16 @@ describe('TunnelClient', () => {
         type: 'hello',
         sid: 'sess-A',
         lastSeq: 0,
-        identity: { login: 'octocat', github_id: '583231' },
+        identity: { login: 'octocat', user_id: 'a3c7ac23-2d79-4810-8c61-207179e44e91' },
       }));
 
       expect(sockets[0].closedCalls).toHaveLength(0);
       expect(attachCalls).toEqual([
-        { sid: 'sess-A', identity: { login: 'octocat', github_id: '583231' } },
+        { sid: 'sess-A', identity: { login: 'octocat', user_id: 'a3c7ac23-2d79-4810-8c61-207179e44e91' } },
       ]);
       expect(client.getBrowserIdentity('sess-A')).toEqual({
         login: 'octocat',
-        github_id: '583231',
+        user_id: 'a3c7ac23-2d79-4810-8c61-207179e44e91',
       });
       // Legacy browserToken stays null when no token rode along.
       expect(client.getBrowserToken()).toBeNull();
@@ -1018,7 +1018,7 @@ describe('TunnelClient', () => {
       sockets[0].pushText(JSON.stringify({
         type: 'hello',
         sid: 'sess-A',
-        identity: { login: 'octocat', github_id: '583231' },
+        identity: { login: 'octocat', user_id: 'a3c7ac23-2d79-4810-8c61-207179e44e91' },
       }));
 
       expect(sockets[0].closedCalls).toHaveLength(1);
@@ -1069,11 +1069,18 @@ describe('TunnelClient', () => {
   });
 
   // ---- Audit F-S-2 (Task #152): trust-tunnel identity bind ---------------
+  //
+  // R-58 (Task #182): fixtures rewritten — the wire field on `BrowserIdentity`
+  // is now `user_id` (uuid PK from cf-worker, R-51a Task #167); pre-R-58 it
+  // was called `github_id` and tests used GitHub numeric ids like '583231'.
+  // The bind check semantics are unchanged: daemon compares hello identity
+  // against CCSM_EXPECTED_OWNER_ID (also a uuid, parsed from the persisted
+  // tunnel JWT's `sub` claim).
   it('audit F-S-2: trust-tunnel rejects hello whose identity does not match CCSM_EXPECTED_OWNER_ID', () => {
     const priorTrust = process.env.CCSM_TRUST_TUNNEL;
     const priorOwner = process.env.CCSM_EXPECTED_OWNER_ID;
     process.env.CCSM_TRUST_TUNNEL = '1';
-    process.env.CCSM_EXPECTED_OWNER_ID = '583231';
+    process.env.CCSM_EXPECTED_OWNER_ID = 'a3c7ac23-2d79-4810-8c61-207179e44e91';
     try {
       const client = new TunnelClient({
         url: 'wss://example/tunnel/x',
@@ -1087,7 +1094,7 @@ describe('TunnelClient', () => {
         JSON.stringify({
           type: 'hello',
           sid: 'sess-A',
-          identity: { login: 'attacker', github_id: '999999' },
+          identity: { login: 'attacker', user_id: 'b9999999-0000-0000-0000-000000000000' },
         }),
       );
       expect(sockets[0].closedCalls).toHaveLength(1);
@@ -1106,7 +1113,7 @@ describe('TunnelClient', () => {
     const priorTrust = process.env.CCSM_TRUST_TUNNEL;
     const priorOwner = process.env.CCSM_EXPECTED_OWNER_ID;
     process.env.CCSM_TRUST_TUNNEL = '1';
-    process.env.CCSM_EXPECTED_OWNER_ID = '583231';
+    process.env.CCSM_EXPECTED_OWNER_ID = 'a3c7ac23-2d79-4810-8c61-207179e44e91';
     try {
       const client = new TunnelClient({
         url: 'wss://example/tunnel/x',
@@ -1119,7 +1126,7 @@ describe('TunnelClient', () => {
       sockets[0].pushText(
         JSON.stringify({
           type: 'hello',
-          identity: { login: 'octocat', github_id: '583231' },
+          identity: { login: 'octocat', user_id: 'a3c7ac23-2d79-4810-8c61-207179e44e91' },
         }),
       );
       expect(sockets[0].closedCalls).toHaveLength(0);
@@ -1148,7 +1155,7 @@ describe('TunnelClient', () => {
       sockets[0].pushText(
         JSON.stringify({
           type: 'hello',
-          identity: { login: 'anyone', github_id: '11' },
+          identity: { login: 'anyone', user_id: 'c0000000-1111-2222-3333-444444444444' },
         }),
       );
       expect(sockets[0].closedCalls).toHaveLength(0);
@@ -1156,6 +1163,45 @@ describe('TunnelClient', () => {
       if (priorTrust === undefined) delete process.env.CCSM_TRUST_TUNNEL;
       else process.env.CCSM_TRUST_TUNNEL = priorTrust;
       if (priorOwner !== undefined) process.env.CCSM_EXPECTED_OWNER_ID = priorOwner;
+    }
+  });
+
+  // R-58 (Task #182): parseHello must REJECT a hello using the legacy
+  // `github_id` wire field — the schema migration is a hard cut, not a
+  // double-field tolerance. Without this, a stale browser bundle could
+  // smuggle a non-conforming identity past the daemon and we'd never know
+  // until production. parseIdentity returns null → parseHello rejects the
+  // identity, and since the identity branch is required in trust mode,
+  // the daemon closes 1008.
+  it('R-58: trust-tunnel rejects hello using legacy `github_id` field name', () => {
+    const priorTrust = process.env.CCSM_TRUST_TUNNEL;
+    const priorOwner = process.env.CCSM_EXPECTED_OWNER_ID;
+    process.env.CCSM_TRUST_TUNNEL = '1';
+    process.env.CCSM_EXPECTED_OWNER_ID = 'a3c7ac23-2d79-4810-8c61-207179e44e91';
+    try {
+      const client = new TunnelClient({
+        url: 'wss://example/tunnel/x',
+        token: 'tok',
+        onFrame: () => {},
+        wsFactory: factory,
+      });
+      client.start();
+      sockets[0].open();
+      sockets[0].pushText(
+        JSON.stringify({
+          type: 'hello',
+          sid: 'sess-A',
+          // Legacy field name — must NOT be accepted.
+          identity: { login: 'octocat', github_id: 'a3c7ac23-2d79-4810-8c61-207179e44e91' },
+        }),
+      );
+      expect(sockets[0].closedCalls).toHaveLength(1);
+      expect(sockets[0].closedCalls[0].code).toBe(1008);
+    } finally {
+      if (priorTrust === undefined) delete process.env.CCSM_TRUST_TUNNEL;
+      else process.env.CCSM_TRUST_TUNNEL = priorTrust;
+      if (priorOwner === undefined) delete process.env.CCSM_EXPECTED_OWNER_ID;
+      else process.env.CCSM_EXPECTED_OWNER_ID = priorOwner;
     }
   });
 });

--- a/packages/frontend-tauri/src-tauri/src/auth.rs
+++ b/packages/frontend-tauri/src-tauri/src/auth.rs
@@ -1035,6 +1035,84 @@ mod tests {
         assert_eq!(parse_jwt_sub_unverified(&jwt), Some("1".to_string()));
     }
 
+    /// R-58 (Task #182): the JWT `sub` claim is now a uuid (R-51a Task #167)
+    /// rather than a GitHub numeric id. parse_jwt_sub_unverified must
+    /// return the uuid string verbatim — no shape assumption — so
+    /// daemon_mgr can feed it into both `CCSM_EXPECTED_OWNER_ID` (env)
+    /// and `daemon_state::Identity.user_id` (in-process state).
+    #[test]
+    fn parse_jwt_sub_extracts_uuid_sub_r58() {
+        let header = "eyJhbGciOiJIUzI1NiJ9";
+        // base64url of {"sub":"a3c7ac23-2d79-4810-8c61-207179e44e91","login":"octocat"}
+        // computed with: echo -n '<json>' | base64 -w0 | tr '+/' '-_' | tr -d '='
+        let json_bytes = br#"{"sub":"a3c7ac23-2d79-4810-8c61-207179e44e91","login":"octocat"}"#;
+        let payload = base64url_encode_for_test(json_bytes);
+        let jwt = format!("{}.{}.sig", header, payload);
+        assert_eq!(
+            parse_jwt_sub_unverified(&jwt),
+            Some("a3c7ac23-2d79-4810-8c61-207179e44e91".to_string()),
+            "R-58: parse must surface uuid sub verbatim (no field-name assumption)"
+        );
+    }
+
+    /// R-58 (Task #182): full identity-bind chain — given a JWT with a
+    /// uuid `sub` claim (as cf-worker mints in R-51a), the daemon-state
+    /// `Identity` constructed from it must serialize with the wire key
+    /// `user_id`, not `github_id`. This anchors the SPA contract change
+    /// against future serde rename slips.
+    #[test]
+    fn identity_from_uuid_sub_serializes_as_user_id_r58() {
+        let header = "eyJhbGciOiJIUzI1NiJ9";
+        let json_bytes = br#"{"sub":"a3c7ac23-2d79-4810-8c61-207179e44e91"}"#;
+        let payload = base64url_encode_for_test(json_bytes);
+        let jwt = format!("{}.{}.sig", header, payload);
+        let user_id =
+            parse_jwt_sub_unverified(&jwt).expect("R-58: uuid sub must parse");
+        let identity = crate::daemon_state::Identity { user_id };
+        let json = serde_json::to_string(&identity).expect("serialize");
+        assert_eq!(
+            json,
+            r#"{"user_id":"a3c7ac23-2d79-4810-8c61-207179e44e91"}"#,
+            "R-58: Identity must serialize as user_id (renamed from github_id)"
+        );
+    }
+
+    /// Minimal base64url encoder used only by the R-58 tests above so we
+    /// don't hand-roll payload literals each time. Mirrors the standard
+    /// base64url alphabet (RFC 4648 §5) with no padding emitted.
+    fn base64url_encode_for_test(input: &[u8]) -> String {
+        const ALPHABET: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+        let mut out = String::new();
+        let mut i = 0;
+        while i + 3 <= input.len() {
+            let b0 = input[i] as u32;
+            let b1 = input[i + 1] as u32;
+            let b2 = input[i + 2] as u32;
+            let n = (b0 << 16) | (b1 << 8) | b2;
+            out.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+            out.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+            out.push(ALPHABET[((n >> 6) & 0x3f) as usize] as char);
+            out.push(ALPHABET[(n & 0x3f) as usize] as char);
+            i += 3;
+        }
+        let rem = input.len() - i;
+        if rem == 1 {
+            let b0 = input[i] as u32;
+            let n = b0 << 16;
+            out.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+            out.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+        } else if rem == 2 {
+            let b0 = input[i] as u32;
+            let b1 = input[i + 1] as u32;
+            let n = (b0 << 16) | (b1 << 8);
+            out.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+            out.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+            out.push(ALPHABET[((n >> 6) & 0x3f) as usize] as char);
+        }
+        out
+    }
+
     // R-51b (Task #168): deep-link URL parser + PKCE state map.
 
     #[test]

--- a/packages/frontend-tauri/src-tauri/src/daemon_mgr.rs
+++ b/packages/frontend-tauri/src-tauri/src/daemon_mgr.rs
@@ -322,29 +322,44 @@ async fn run_cycle(app: &AppHandle, kill_rx: &mut mpsc::Receiver<()>) -> CycleOu
     // cloud-issued credential. Absence is fine — the daemon falls back to
     // the legacy loopback-token-only path and the cloud tunnel runs in
     // legacy mode (or is skipped, depending on CCSM_TUNNEL_DISABLE).
+    //
+    // R-58 (Task #182): also surface the (login, user_id) pair so the
+    // post-handshake `Ready { identity }` branch can fill the daemon-state
+    // identity slot (was hardcoded `None` waiting on S4-T8 — wire-up never
+    // happened; collapsing the TODO here). `user_id` is the uuid from the
+    // tunnel JWT's `sub` claim (R-51a Task #167); `parse_jwt_sub_unverified`
+    // returns None on a malformed JWT in which case we leave identity unset
+    // and the bind check is skipped (same degraded path as before).
+    let mut identity_for_ready: Option<crate::daemon_state::Identity> = None;
     if let Some(creds) = crate::auth::read_persisted_creds() {
         cmd.env("CCSM_TUNNEL_JWT", &creds.tunnel_jwt);
         cmd.env("CCSM_TUNNEL_REFRESH_TOKEN", &creds.tunnel_refresh_token);
         cmd.env("CCSM_TUNNEL_LOGIN", &creds.login);
         cmd.env("CCSM_TRUST_TUNNEL", "1");
-        // Audit F-S-2 (Task #152): bind the daemon to the GitHub user id
-        // baked into the persisted tunnel JWT. The daemon-side hello
-        // handler (tunnel.mts handleHello trust-tunnel branch) refuses
-        // any cloud-stamped identity that does not match this value, so a
+        // Audit F-S-2 (Task #152): bind the daemon to the user id baked
+        // into the persisted tunnel JWT. The daemon-side hello handler
+        // (tunnel.mts handleHello trust-tunnel branch) refuses any
+        // cloud-stamped identity that does not match this value, so a
         // mis-issued JWT for some other user cannot hijack the tunnel.
         // Absence (malformed JWT) leaves the env unset and the daemon
         // skips the bind check — degraded but not fail-open since hello
         // identity is still checked against trust-tunnel's existing
         // "must carry identity" gate.
-        if let Some(owner_id) = crate::auth::parse_jwt_sub_unverified(&creds.tunnel_jwt) {
-            cmd.env("CCSM_EXPECTED_OWNER_ID", &owner_id);
+        //
+        // R-58 (Task #182): the env name `CCSM_EXPECTED_OWNER_ID` is kept
+        // for back-compat (lockstep daemon + Tauri deploy required to
+        // rename); the value is a uuid since R-51a, not a GitHub numeric
+        // id. See daemon/src/tunnel.mts `getExpectedOwnerId` doc.
+        if let Some(user_id) = crate::auth::parse_jwt_sub_unverified(&creds.tunnel_jwt) {
+            cmd.env("CCSM_EXPECTED_OWNER_ID", &user_id);
             eprintln!(
-                "[daemon-mgr] injecting tunnel JWT for login={} owner_id={} (trust-tunnel mode)",
-                creds.login, owner_id,
+                "[daemon-mgr] injecting tunnel JWT for login={} user_id={} (trust-tunnel mode)",
+                creds.login, user_id,
             );
+            identity_for_ready = Some(crate::daemon_state::Identity { user_id });
         } else {
             eprintln!(
-                "[daemon-mgr] injecting tunnel JWT for login={} (trust-tunnel mode; owner_id parse failed, identity-bind disabled)",
+                "[daemon-mgr] injecting tunnel JWT for login={} (trust-tunnel mode; user_id parse failed, identity-bind disabled)",
                 creds.login,
             );
         }
@@ -458,7 +473,13 @@ async fn run_cycle(app: &AppHandle, kill_rx: &mut mpsc::Receiver<()>) -> CycleOu
                 DaemonPhase::Ready {
                     port: hs.port,
                     token: hs.token.clone(),
-                    identity: None, // S4-T8 will populate after auth.
+                    // R-58 (Task #182): identity now populated from the
+                    // persisted tunnel JWT's `sub` claim (computed above
+                    // alongside CCSM_EXPECTED_OWNER_ID injection). Pre-R-58
+                    // this was hardcoded `None` waiting on S4-T8 which
+                    // never wired it up, so daemon-state.identity stayed
+                    // null in production despite the bind check working.
+                    identity: identity_for_ready.clone(),
                     // R-50 (Task #164): tunnel sub-state defaults to Pending
                     // here. If the stderr observer already saw "tunnel:
                     // connected" before this commit, the store's

--- a/packages/shared/src/tunnel-frame.ts
+++ b/packages/shared/src/tunnel-frame.ts
@@ -41,12 +41,20 @@ export const WS_SUBPROTOCOL_PREFIX = 'ccsm.';
  * paths still ride the per-browser bearer token in `HelloFrame.token` and
  * leave `identity` undefined.
  *
- * `login` is the GitHub login (handle); `github_id` is the numeric GitHub
- * user id rendered as a string so we don't lose precision on the wire.
+ * `login` is the GitHub login (handle); `user_id` is the cloud-side user
+ * PK (a uuid string, R-51a Task #167 — replaced the pre-R-51 github numeric
+ * id with `crypto.randomUUID()` so future providers like Google can link to
+ * the same user via verified email). The wire field was called `github_id`
+ * pre-R-58 (Task #182); kept the daemon expecting numeric ids while the
+ * cf-worker had already moved to uuids, with both sides happening to agree
+ * (uuid==uuid) but the field name lying about its contents. R-58 renamed it
+ * to `user_id` to match the actual value semantics; identity-bind still
+ * works the same (daemon compares against `CCSM_EXPECTED_OWNER_ID` parsed
+ * from the tunnel JWT's `sub` claim — also a uuid since R-51a).
  */
 export interface BrowserIdentity {
   login: string;
-  github_id: string;
+  user_id: string;
 }
 
 /**

--- a/tools/cloud-e2e/specs/cross-user-isolation.spec.ts
+++ b/tools/cloud-e2e/specs/cross-user-isolation.spec.ts
@@ -72,7 +72,7 @@ function encodeSidEnvelope(sid: string, payload: Uint8Array): Uint8Array {
 interface HelloFrame {
   token: string;
   sid: string;
-  identity?: { login: string; github_id: string };
+  identity?: { login: string; user_id: string };
 }
 
 interface DaemonHandle {
@@ -145,9 +145,9 @@ async function connectDaemon(opts: {
     if (obj.type === 'hello' && typeof obj.token === 'string' && typeof obj.sid === 'string') {
       const frame: HelloFrame = { token: obj.token, sid: obj.sid };
       if (obj.identity && typeof obj.identity === 'object') {
-        const id = obj.identity as { login?: unknown; github_id?: unknown };
-        if (typeof id.login === 'string' && typeof id.github_id === 'string') {
-          frame.identity = { login: id.login, github_id: id.github_id };
+        const id = obj.identity as { login?: unknown; user_id?: unknown };
+        if (typeof id.login === 'string' && typeof id.user_id === 'string') {
+          frame.identity = { login: id.login, user_id: id.user_id };
         }
       }
       const waiter = helloWaiters.shift();
@@ -367,9 +367,9 @@ test.describe('cross-user TunnelDO isolation (S4-T9, Task #135)', () => {
         //    X-CCSM-Identity-* headers and the DO echoes them in hello.
         expect(aliceHello.sid).toBe(aliceSid);
         expect(aliceHello.identity?.login, 'alice hello carries login=alice').toBe('alice');
-        expect(aliceHello.identity?.github_id, 'alice hello carries github_id=gh-1').toBe('gh-1');
+        expect(aliceHello.identity?.user_id, 'alice hello carries user_id=gh-1').toBe('gh-1');
         expect(bobHello.identity?.login, 'bob hello carries login=bob').toBe('bob');
-        expect(bobHello.identity?.github_id, 'bob hello carries github_id=gh-2').toBe('gh-2');
+        expect(bobHello.identity?.user_id, 'bob hello carries user_id=gh-2').toBe('gh-2');
 
         // 6. PTY-data isolation: alice daemon emits a unique payload bound
         //    to alice's sid; the DO must route it to alice's browser ONLY.


### PR DESCRIPTION
Fixes #182. R-58 dev investigation surfaced two coupled defects flagged in R-55 forensics:

```
[daemon-mgr] injecting tunnel JWT for login=Jiahui-Gu owner_id=a3c7ac23-2d79-4810-8c61-207179e44e91 (trust-tunnel mode)
[daemon-state] phase=ready ... "identity":null ...
```

## Phase 1 evidence (research-only, confirmed in pool-1 grep)

1. **R-44 designed for github numeric id**: `daemon/src/tunnel.mts:594` checks `hello.identity.github_id !== expectedOwner`; fixtures at `tunnel.test.ts:946/1090/1122` all use `'583231'`; R-44 commit `0bc32b9c` message says "GitHub user id parsed from JWT sub claim".
2. **R-51a swapped sub to a uuid**: `cf-worker/src/auth/oauthLinker.ts:265` mints `crypto.randomUUID()`; `deviceFlow.ts:279` and `desktopOauth.ts:414` both set `claims.sub = userId`; line 276 comment says explicitly "claims.sub = uuid (was github_id pre-R-51)".
3. **uuid propagated via the wire header**: `cf-worker/src/index.ts:170` passes `claims.sub` (uuid) into `withIdentityHeaders`; `tunnel-do.ts:362` builds `{ login, github_id: idGithub }` — field name **lies**, value is a uuid.
4. **daemon expectedOwner is also a uuid**: `daemon_mgr.rs:339` parses tunnel JWT's `sub` (uuid post-R-51a) into `CCSM_EXPECTED_OWNER_ID`. Identity-bind compared uuid==uuid and **silently worked** in production, just with a misleading field name.
5. **`daemon-state.identity = null` is independent**: `daemon_mgr.rs:461` hardcoded `identity: None, // S4-T8 will populate after auth.` — the TODO never landed. Unrelated to schema, but lumped under this task.

## Why B (not A or C)

- **A** (inject github numeric id into `CCSM_EXPECTED_OWNER_ID`): `PersistedTunnelCreds` has no `github_id` field today (only `tunnel_jwt / tunnel_refresh_token / login`). Adding one means extending the cf-worker response with a field R-51a deliberately removed from the user PK. Reverts the R-51a design direction.
- **C** (dual-stuff uuid + github_id into JWT / hello): redundant fields; daemon would still need to pick one for cross-user isolation, and picking `github_id` works around the R-51a uuid-PK invariant. Hits the "no compat-layer glue" rule.
- **B** (chosen): rename the wire field `github_id` → `user_id` to match the value (a uuid). Daemon and DO stay aligned; bind check semantics unchanged; field name no longer lies. Also fixes the line 461 TODO since the uuid is already parsed two lines above.

## Changes

- `packages/shared/src/tunnel-frame.ts`: `BrowserIdentity.github_id` → `user_id` with R-58 history note.
- `packages/daemon/src/tunnel.mts`: `parseIdentity` requires `user_id` (rejects legacy `github_id`); `handleHello` bind check + log uses `user_id`; `getExpectedOwnerId` doc updated.
- `packages/cf-worker/src/tunnel-do.ts`: header read variable renamed `idGithub` → `idUserId`; `BrowserIdentity` build sets `user_id`.
- `packages/cf-worker/src/index.ts`: `withIdentityHeaders` param renamed `github_id` → `user_id` (HTTP header name `X-CCSM-Identity-Id` kept stable on the wire — renaming would need lockstep DO+worker deploy).
- `packages/frontend-tauri/src-tauri/src/daemon_mgr.rs:461` TODO collapsed: identity now `Some(Identity { user_id })` from the same `parse_jwt_sub_unverified` already computed for `CCSM_EXPECTED_OWNER_ID` env injection.
- Tests:
  - `daemon/test/tunnel.test.ts`: all `github_id: '583231'` fixtures → `user_id: '<uuid>'`; new `R-58: trust-tunnel rejects hello using legacy github_id field name` (hard schema cut, no double-tolerance).
  - `cf-worker/test/tunnel-do.test.ts`: new `R-58: hello frame echoes X-CCSM-Identity-* under identity.user_id` covers the full `X-CCSM-Identity-Id` header → `BrowserIdentity.user_id` chain and asserts `github_id` is absent.
  - `frontend-tauri/src-tauri/src/auth.rs`: `parse_jwt_sub_extracts_uuid_sub_r58` (uuid passes through verbatim) + `identity_from_uuid_sub_serializes_as_user_id_r58` (full chain: parsed sub → `Identity { user_id }` → JSON `{"user_id":"<uuid>"}`).
  - `tools/cloud-e2e/specs/cross-user-isolation.spec.ts`: HelloFrame interface + parser + assertions all use `user_id`.
  - `cf-worker/test/middleware.test.ts`: `getUserDoIdName` test title updated.

## Local checks (host: Windows, mode: full)
- lint: pre-existing baseline-red on 5 unrelated files (`packages/daemon/test/persist.test.ts`, `packages/frontend-tauri/test/PhaseSwitch.test.tsx`, `packages/frontend-web/test/oauth-callback-page.test.ts`, `packages/ui/test/BootstrapRefresh.test.tsx`, `tools/cloud-e2e/specs/two-tab-pairing.spec.ts`). Verified by `git diff origin/working -- <each>` returning empty — not introduced here.
- typecheck: ✓ (all 8 workspaces clean after `pnpm --filter @ccsm/shared @ccsm/core @ccsm/ui build` to publish .d.ts).
- build: ✓ (all packages green).
- vitest (full path, all packages):
  - cf-worker: 204 / 204 pass (includes new R-58 tunnel-do test)
  - daemon: 188 pass + 1 skipped (includes R-58 + reworked F-S-2 fixtures)
  - ui: 68 / 68
  - frontend-web: 46 / 46
  - frontend-tauri: 35 / 35
  - core / shared / smoke: pass / no tests
- cargo check --lib: ✓ (2 pre-existing deprecation warnings on `tauri_plugin_shell::Shell::open`, not introduced here).
- cargo test --lib: 33 / 33 pass (includes both R-58 tests `parse_jwt_sub_extracts_uuid_sub_r58` + `identity_from_uuid_sub_serializes_as_user_id_r58`).

## References
- R-44 / Task #152 PR #1227 (commit `0bc32b9c`) — `CCSM_EXPECTED_OWNER_ID` + identity-bind introduced.
- R-51a / Task #167 PR #1234 (commit `f57a4259`) — UserDO uuid-PK schema rebuild; `claims.sub` moved from github_id to uuid.
- S4-T8 (Task #141) — was supposed to wire daemon-state identity; line 461 TODO collapsed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)