### PR TITLE
feat(terminal): Ctrl/Cmd+click link opens in system browser

### DIFF
--- a/electron/ipc/__tests__/utilityIpc.test.ts
+++ b/electron/ipc/__tests__/utilityIpc.test.ts
@@ -3,9 +3,12 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
+const openExternalMock = vi.fn(async (_url: string) => undefined);
+
 vi.mock('electron', () => ({
   BrowserWindow: { fromWebContents: () => null },
   dialog: { showOpenDialog: async () => ({ canceled: true, filePaths: [] }) },
+  shell: { openExternal: (url: string) => openExternalMock(url) },
 }));
 vi.mock('../../import-scanner', () => ({
   scanImportableSessions: async () => [],
@@ -15,7 +18,11 @@ vi.mock('../../prefs/userCwds', () => ({
   pushUserCwd: (p: string) => [p, os.homedir()],
 }));
 
-import { probePaths } from '../utilityIpc';
+import {
+  probePaths,
+  isAllowedExternalUrl,
+  registerUtilityIpc,
+} from '../utilityIpc';
 
 let tmpDir = '';
 
@@ -67,5 +74,127 @@ describe('probePaths', () => {
     expect(probePaths([tmpDir])[tmpDir]).toBe(true);
     fs.rmSync(tmpDir, { recursive: true, force: true });
     expect(probePaths([tmpDir])[tmpDir]).toBe(false);
+  });
+});
+
+describe('isAllowedExternalUrl (scheme whitelist for ccsm:openExternal)', () => {
+  it('accepts https URLs', () => {
+    expect(isAllowedExternalUrl('https://example.com')).toBe(true);
+    expect(isAllowedExternalUrl('https://example.com/path?q=1#frag')).toBe(true);
+  });
+
+  it('accepts http URLs (intranet / dev links printed by tools)', () => {
+    expect(isAllowedExternalUrl('http://example.com')).toBe(true);
+    expect(isAllowedExternalUrl('http://localhost:3000/x')).toBe(true);
+  });
+
+  it('is case-insensitive on the scheme', () => {
+    expect(isAllowedExternalUrl('HTTPS://example.com')).toBe(true);
+    expect(isAllowedExternalUrl('Http://example.com')).toBe(true);
+  });
+
+  it('rejects file:// URLs (local file disclosure)', () => {
+    expect(isAllowedExternalUrl('file:///etc/passwd')).toBe(false);
+    expect(isAllowedExternalUrl('file://C:/Windows/System32/drivers/etc/hosts')).toBe(false);
+  });
+
+  it('rejects javascript: URLs (XSS / RCE via shell)', () => {
+    expect(isAllowedExternalUrl('javascript:alert(1)')).toBe(false);
+    expect(isAllowedExternalUrl('JaVaScRiPt:alert(1)')).toBe(false);
+  });
+
+  it('rejects data: URLs', () => {
+    expect(isAllowedExternalUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+  });
+
+  it('rejects vbscript: URLs', () => {
+    expect(isAllowedExternalUrl('vbscript:msgbox(1)')).toBe(false);
+  });
+
+  it('rejects other custom protocols (mailto, ms-settings, ssh, etc.)', () => {
+    expect(isAllowedExternalUrl('mailto:a@b.com')).toBe(false);
+    expect(isAllowedExternalUrl('ms-settings:network')).toBe(false);
+    expect(isAllowedExternalUrl('ssh://user@host')).toBe(false);
+    expect(isAllowedExternalUrl('ftp://example.com')).toBe(false);
+  });
+
+  it('rejects scheme-relative and protocol-confused inputs', () => {
+    expect(isAllowedExternalUrl('//example.com')).toBe(false);
+    expect(isAllowedExternalUrl('example.com')).toBe(false);
+    expect(isAllowedExternalUrl(' https://example.com')).toBe(false);
+  });
+
+  it('rejects non-string inputs', () => {
+    expect(isAllowedExternalUrl(undefined)).toBe(false);
+    expect(isAllowedExternalUrl(null)).toBe(false);
+    expect(isAllowedExternalUrl(42)).toBe(false);
+    expect(isAllowedExternalUrl({ url: 'https://x' })).toBe(false);
+    expect(isAllowedExternalUrl(['https://x'])).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isAllowedExternalUrl('')).toBe(false);
+  });
+});
+
+describe('ccsm:openExternal IPC handler', () => {
+  type Handler = (e: unknown, ...args: unknown[]) => unknown;
+  let handler: Handler;
+
+  beforeEach(() => {
+    openExternalMock.mockClear();
+    const handlers = new Map<string, Handler>();
+    const ipcMain = {
+      handle: (ch: string, fn: Handler) => handlers.set(ch, fn),
+      on: (ch: string, fn: Handler) => handlers.set(ch, fn),
+    } as unknown as Electron.IpcMain;
+    registerUtilityIpc({ ipcMain });
+    handler = handlers.get('ccsm:openExternal')!;
+    expect(handler).toBeDefined();
+  });
+
+  it('forwards http(s) URLs to shell.openExternal and returns true', async () => {
+    const r1 = await handler({}, 'https://example.com');
+    const r2 = await handler({}, 'http://localhost:8080/x');
+    expect(r1).toBe(true);
+    expect(r2).toBe(true);
+    expect(openExternalMock).toHaveBeenCalledTimes(2);
+    expect(openExternalMock).toHaveBeenNthCalledWith(1, 'https://example.com');
+    expect(openExternalMock).toHaveBeenNthCalledWith(2, 'http://localhost:8080/x');
+  });
+
+  it('rejects file:// without calling shell.openExternal', async () => {
+    const r = await handler({}, 'file:///etc/passwd');
+    expect(r).toBe(false);
+    expect(openExternalMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects javascript: without calling shell.openExternal', async () => {
+    const r = await handler({}, 'javascript:alert(1)');
+    expect(r).toBe(false);
+    expect(openExternalMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects data: without calling shell.openExternal', async () => {
+    const r = await handler({}, 'data:text/html,x');
+    expect(r).toBe(false);
+    expect(openExternalMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-string inputs without calling shell.openExternal', async () => {
+    expect(await handler({}, 42)).toBe(false);
+    expect(await handler({}, null)).toBe(false);
+    expect(await handler({}, undefined)).toBe(false);
+    expect(await handler({}, { url: 'https://x' })).toBe(false);
+    expect(openExternalMock).not.toHaveBeenCalled();
+  });
+
+  it('returns false (does not throw) when shell.openExternal rejects', async () => {
+    openExternalMock.mockRejectedValueOnce(new Error('boom'));
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const r = await handler({}, 'https://example.com');
+    expect(r).toBe(false);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
   });
 });

--- a/electron/ipc/utilityIpc.ts
+++ b/electron/ipc/utilityIpc.ts
@@ -13,7 +13,7 @@
 // internal; main.ts only needs the `prime()` hook to kick the eager load.
 
 import type { IpcMain } from 'electron';
-import { BrowserWindow, dialog } from 'electron';
+import { BrowserWindow, dialog, shell } from 'electron';
 import * as fs from 'fs';
 import * as os from 'os';
 import {
@@ -101,6 +101,22 @@ export function primeImportableCache(): void {
   void refreshImportableCache();
 }
 
+/**
+ * Scheme whitelist for `ccsm:openExternal`. Renderer feeds URIs detected
+ * by xterm's WebLinksAddon — i.e. arbitrary strings printed by whatever
+ * the PTY is running. The IPC handler MUST refuse anything outside
+ * `http://` / `https://` so a malicious TUI cannot trick the user's
+ * Ctrl/Cmd-click into launching `file://`, `javascript:`, `data:`,
+ * `vbscript:` (or any other shell-handled scheme) via `shell.openExternal`.
+ *
+ * Exported for direct unit testing so the security gate is exercised
+ * without spinning up the IPC layer or mocking `electron.shell`.
+ */
+export function isAllowedExternalUrl(url: unknown): url is string {
+  if (typeof url !== 'string') return false;
+  return /^https?:\/\//i.test(url);
+}
+
 export function registerUtilityIpc(deps: UtilityIpcDeps): void {
   const { ipcMain } = deps;
 
@@ -167,4 +183,25 @@ export function registerUtilityIpc(deps: UtilityIpcDeps): void {
     // auto-spawn).
     probePaths(inputPaths),
   );
+
+  // Ctrl/Cmd-click handoff from xterm's WebLinksAddon to the OS browser.
+  // Background: the renderer's BrowserWindow has `setWindowOpenHandler`
+  // returning `{action:'deny'}` (see electron/window/createWindow.ts), so
+  // a plain `window.open(uri)` — WebLinksAddon's default — is silently
+  // dropped. The renderer now gates on modifier key and routes through
+  // this channel; we still apply a strict scheme whitelist here because
+  // the URI originates from arbitrary PTY output and IPC payloads are
+  // untrusted by definition. Anything outside http(s) (file://, javascript:,
+  // data:, vbscript:, custom protocol handlers, ...) is rejected before
+  // touching `shell.openExternal`.
+  ipcMain.handle('ccsm:openExternal', async (_e, url: unknown) => {
+    if (!isAllowedExternalUrl(url)) return false;
+    try {
+      await shell.openExternal(url);
+      return true;
+    } catch (err) {
+      console.warn('[main] ccsm:openExternal failed', err);
+      return false;
+    }
+  });
 }

--- a/electron/preload/bridges/ccsmCore.ts
+++ b/electron/preload/bridges/ccsmCore.ts
@@ -106,6 +106,19 @@ const api = {
   pathsExist: (paths: string[]): Promise<Record<string, boolean>> =>
     ipcRenderer.invoke('paths:exist', paths),
 
+  /**
+   * Open an external URL in the user's default browser. Backs the
+   * Ctrl/Cmd-click handler installed on xterm's WebLinksAddon — the only
+   * production caller. The main process enforces a strict http(s) scheme
+   * whitelist (see `electron/ipc/utilityIpc.ts:isAllowedExternalUrl`) so
+   * malicious PTY output cannot smuggle `file://` / `javascript:` /
+   * `data:` URIs through `shell.openExternal`. Returns `true` when the OS
+   * accepted the open, `false` when the URL was rejected by the whitelist
+   * or `shell.openExternal` threw.
+   */
+  openExternal: (url: string): Promise<boolean> =>
+    ipcRenderer.invoke('ccsm:openExternal', url),
+
   updatesStatus: (): Promise<UpdateStatus> => ipcRenderer.invoke('updates:status'),
   updatesCheck: (): Promise<UpdateStatus> => ipcRenderer.invoke('updates:check'),
   updatesDownload: (): Promise<{ ok: true } | { ok: false; reason: string }> =>

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -77,6 +77,16 @@ declare global {
        */
       pathsExist: (paths: string[]) => Promise<Record<string, boolean>>;
 
+      /**
+       * Open an external URL in the user's default browser via the main
+       * process's `shell.openExternal`. The IPC handler enforces a strict
+       * http(s) scheme whitelist, so callers can pass arbitrary URIs
+       * harvested from PTY output (xterm WebLinksAddon) without
+       * pre-validating: anything non-http(s) resolves to `false` with no
+       * side effect. Production caller: Ctrl/Cmd-click on a terminal link.
+       */
+      openExternal: (url: string) => Promise<boolean>;
+
       updatesStatus: () => Promise<UpdateStatus>;
       updatesCheck: () => Promise<UpdateStatus>;
       updatesDownload: () => Promise<{ ok: true } | { ok: false; reason: string }>;

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -116,7 +116,27 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
   fit = new FitAddon();
   term.loadAddon(fit);
   try {
-    term.loadAddon(new WebLinksAddon());
+    // Ctrl-click (Win/Linux) / Cmd-click (macOS) opens the link in the
+    // user's default browser; plain clicks are deliberately a no-op.
+    //
+    // Why the modifier gate: matches the Windows Terminal / VS Code
+    // convention so muscle memory carries over, and avoids hijacking
+    // accidental clicks on URL-shaped output (paths, ANSI escapes that
+    // look like links, etc.) from claude's TUI.
+    //
+    // Why route through preload (not WebLinksAddon's default `window.open`):
+    // the BrowserWindow installs a `setWindowOpenHandler` returning
+    // `{action:'deny'}` to block popups, which silently swallows the
+    // default behaviour. `window.ccsm.openExternal` hands the URI to the
+    // main process, which applies a strict http(s) scheme whitelist
+    // before calling `shell.openExternal` (see utilityIpc.ts).
+    term.loadAddon(
+      new WebLinksAddon((event, uri) => {
+        if (event.ctrlKey || event.metaKey) {
+          window.ccsm?.openExternal?.(uri);
+        }
+      }),
+    );
   } catch (e) {
     console.warn('[TerminalPane] web-links addon failed', e);
   }

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -4,7 +4,7 @@ import { renderHook } from '@testing-library/react';
 // Mock xterm constructors BEFORE importing the hook so the singleton
 // uses the spies. Use vi.hoisted because vi.mock factories run before
 // any top-level `const`.
-const { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, terminalCtor } =
+const { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, terminalCtor, webLinksCtor } =
   vi.hoisted(() => {
     const openSpy = vi.fn();
     const loadAddonSpy = vi.fn();
@@ -22,12 +22,15 @@ const { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandler
         _core: { _parent: null },
       };
     });
-    return { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, terminalCtor };
+    const webLinksCtor = vi.fn(function () {
+      return {};
+    });
+    return { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, terminalCtor, webLinksCtor };
   });
 
 vi.mock('@xterm/xterm', () => ({ Terminal: terminalCtor }));
 vi.mock('@xterm/addon-fit', () => ({ FitAddon: vi.fn(function () { return { fit: vi.fn() }; }) }));
-vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: webLinksCtor }));
 vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: vi.fn(function () { return {}; }) }));
 vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: vi.fn(function () { return {}; }) }));
 vi.mock('@xterm/addon-canvas', () => ({ CanvasAddon: vi.fn(function () { return {}; }) }));
@@ -44,6 +47,7 @@ describe('useXtermSingleton', () => {
     terminalCtor.mockClear();
     openSpy.mockClear();
     loadAddonSpy.mockClear();
+    webLinksCtor.mockClear();
   });
 
   afterEach(() => {
@@ -78,5 +82,64 @@ describe('useXtermSingleton', () => {
     const ref = { current: null };
     renderHook(() => useXtermSingleton(ref));
     expect(terminalCtor).not.toHaveBeenCalled();
+  });
+
+  describe('WebLinksAddon Ctrl/Cmd-click handler', () => {
+    // The handler is the first ctor arg to `new WebLinksAddon(handler)`.
+    // We extract it from the mock to exercise the modifier-gate without
+    // touching the live xterm DOM.
+    function getHandler(): (ev: { ctrlKey?: boolean; metaKey?: boolean }, uri: string) => void {
+      const host = document.createElement('div');
+      renderHook(() => useXtermSingleton({ current: host }));
+      expect(webLinksCtor).toHaveBeenCalledTimes(1);
+      const handler = webLinksCtor.mock.calls[0][0];
+      expect(typeof handler).toBe('function');
+      return handler as (ev: { ctrlKey?: boolean; metaKey?: boolean }, uri: string) => void;
+    }
+
+    beforeEach(() => {
+      // Install a fresh openExternal spy on window.ccsm for each case.
+      (window as unknown as { ccsm: { openExternal: ReturnType<typeof vi.fn> } }).ccsm = {
+        openExternal: vi.fn(),
+      };
+    });
+
+    afterEach(() => {
+      delete (window as unknown as { ccsm?: unknown }).ccsm;
+    });
+
+    it('opens external on Ctrl+click (Windows/Linux convention)', () => {
+      const handler = getHandler();
+      handler({ ctrlKey: true, metaKey: false }, 'https://example.com');
+      const spy = (window as unknown as { ccsm: { openExternal: ReturnType<typeof vi.fn> } })
+        .ccsm.openExternal;
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith('https://example.com');
+    });
+
+    it('opens external on Cmd+click (macOS convention)', () => {
+      const handler = getHandler();
+      handler({ ctrlKey: false, metaKey: true }, 'https://example.com/path');
+      const spy = (window as unknown as { ccsm: { openExternal: ReturnType<typeof vi.fn> } })
+        .ccsm.openExternal;
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith('https://example.com/path');
+    });
+
+    it('does NOT open external on plain click (no modifier)', () => {
+      const handler = getHandler();
+      handler({ ctrlKey: false, metaKey: false }, 'https://example.com');
+      const spy = (window as unknown as { ccsm: { openExternal: ReturnType<typeof vi.fn> } })
+        .ccsm.openExternal;
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('does not throw when window.ccsm bridge is unavailable', () => {
+      const handler = getHandler();
+      delete (window as unknown as { ccsm?: unknown }).ccsm;
+      expect(() =>
+        handler({ ctrlKey: true, metaKey: false }, 'https://example.com'),
+      ).not.toThrow();
+    });
   });
 });


### PR DESCRIPTION
## What

Wire xterm's `WebLinksAddon` to a modifier-gated handler so users can open detected URLs from the terminal in their default browser.

- **Before**: clicking a URL in the terminal does nothing. `WebLinksAddon` is loaded without a custom handler, so it defaults to `window.open(uri)`. The renderer's `BrowserWindow` installs `setWindowOpenHandler(() => ({ action: 'deny' }))` (electron/window/createWindow.ts:203), which silently swallows the call. Hover highlights work, click is dead.
- **After**: Ctrl+click (Windows/Linux) or Cmd+click (macOS) routes the URI through a new `ccsm:openExternal` IPC, which validates and forwards it to `shell.openExternal`. Plain clicks remain deliberately inert to avoid hijacking accidental clicks on URL-shaped output. Matches Windows Terminal / VS Code convention.

## Security

The IPC handler enforces a strict scheme whitelist (`isAllowedExternalUrl`) — only `http://` and `https://` are accepted. Anything else (`file://`, `javascript:`, `data:`, `vbscript:`, `mailto:`, `ssh://`, `ms-settings:`, scheme-relative `//host`, leading whitespace, non-string payloads) is rejected before `shell.openExternal` is called. URIs originate from arbitrary PTY output and must be treated as untrusted at the IPC boundary regardless of any renderer-side filtering xterm performs.

## Files

- `electron/ipc/utilityIpc.ts` — register `ccsm:openExternal`; export pure `isAllowedExternalUrl` for direct unit testing
- `electron/preload/bridges/ccsmCore.ts` — expose `window.ccsm.openExternal(url)` on the existing core bridge
- `src/global.d.ts` — type declaration on the `window.ccsm` surface
- `src/terminal/xtermSingleton.ts:119` — install modifier-gated handler on `new WebLinksAddon(...)`
- `electron/ipc/__tests__/utilityIpc.test.ts` — whitelist + handler tests
- `tests/terminal/useXtermSingleton.test.tsx` — Ctrl/Cmd-click renderer tests

## Tests

30/30 green locally on Windows for the two affected test files:

- `isAllowedExternalUrl` (11): http / https accepted; case-insensitive scheme; rejects `file://`, `javascript:`, `data:`, `vbscript:`, `mailto:`, `ms-settings:`, `ssh://`, `ftp://`, scheme-relative `//host`, bare hostname, leading-whitespace, empty string, non-string inputs.
- `ccsm:openExternal` handler (6): http(s) forwards to `shell.openExternal` and returns `true`; `file://` / `javascript:` / `data:` rejected without invoking shell; non-string rejected; `shell.openExternal` throw is swallowed (returns `false`, no propagation).
- WebLinksAddon handler (4): Ctrl+click invokes `window.ccsm.openExternal(uri)`; Cmd+click likewise; plain click does NOT invoke; missing `window.ccsm` bridge does not throw.

`npm run typecheck` and `npm run lint` both pass (0 errors).

Note: 21 unrelated test failures locally are all `better-sqlite3` `NODE_MODULE_VERSION` mismatch in this worktree's `node_modules` (built against Electron's Node ABI, run under system Node) — not introduced by this PR; CI's `npm ci` against the matching runtime is unaffected. None of the changed files touch the db layer.

## Relation to PR #1243

Physically non-conflicting. PR #1243 (`fix/paste-duplication-v021`) edits `xtermSingleton.ts` lines 159-209 (the `attachCustomKeyEventHandler` clipboard path). This PR edits line 119 (`new WebLinksAddon(...)`). Independent ship order.

## Test plan

- [ ] CI green (lint + typecheck + vitest)
- [ ] Manual smoke: print `https://example.com` to a session, hover (underline appears), Ctrl-click on Windows / Cmd-click on macOS → default browser opens to that URL
- [ ] Manual smoke: plain click on the same link → no action (intentional)
- [ ] Manual smoke: print `file:///etc/passwd` and `javascript:alert(1)` to a session, Ctrl-click → nothing happens, no shell.openExternal invocation