### PR TITLE
ci(release): fix mac build "not a file" by not exporting empty CSC vars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,19 +135,41 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Package (macOS)
-        if: matrix.platform == 'mac'
+      # Two mutually-exclusive macOS package steps. We must NOT export
+      # CSC_LINK / CSC_KEY_PASSWORD at all when secrets are missing —
+      # GitHub Actions materializes a missing secret as an empty string
+      # (not unset), and electron-builder 26.x treats CSC_LINK="" as a
+      # certificate path, calls path.resolve(cwd, "") which yields the
+      # workspace dir, then fs.stat fails with "<workspace> not a file"
+      # right after the log line "empty password will be used for code
+      # signing  reason=CSC_KEY_PASSWORD is not defined".
+      # See v0.2.1 release run #25785568643 for the failure trace.
+      - name: Package (macOS, signed)
+        if: matrix.platform == 'mac' && steps.secrets.outputs.signed == 'true'
         run: npx electron-builder --mac --publish never
         env:
+          DEBUG: electron-builder
+          DEBUG_COLORS: 'false'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          # Skip notarization if Apple creds missing — electron-builder
-          # reads these env vars and falls back to unsigned when empty.
-          CSC_IDENTITY_AUTO_DISCOVERY: ${{ steps.secrets.outputs.signed == 'true' && 'true' || 'false' }}
+          CSC_IDENTITY_AUTO_DISCOVERY: 'true'
+
+      - name: Package (macOS, unsigned)
+        if: matrix.platform == 'mac' && steps.secrets.outputs.signed != 'true'
+        # Deliberately do NOT export CSC_LINK / CSC_KEY_PASSWORD here —
+        # leaving them unset lets electron-builder take the pure-unsigned
+        # code path. CSC_IDENTITY_AUTO_DISCOVERY=false suppresses keychain
+        # lookup on the runner.
+        run: npx electron-builder --mac --publish never
+        env:
+          DEBUG: electron-builder
+          DEBUG_COLORS: 'false'
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false'
 
       - name: Warn on unsigned Windows build
         if: matrix.platform == 'win' && steps.secrets.outputs.signed != 'true'


### PR DESCRIPTION
## Root cause

The v0.2.1 release CI mac job (run #25785568643) fails with:

```
  • empty password will be used for code signing  reason=CSC_KEY_PASSWORD is not defined
  ⨯ /Users/runner/work/ccsm/ccsm not a file
```

`/Users/runner/work/ccsm/ccsm` is `$GITHUB_WORKSPACE` — a directory.

GitHub Actions materializes a **missing** secret as the **empty string** (not unset). The previous step did:

```yaml
env:
  CSC_LINK: ${{ secrets.CSC_LINK }}        # → ""
  CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}  # → ""
```

electron-builder 26.x sees `CSC_LINK=""`, treats it as a certificate path, does `path.resolve(cwd, "")` which collapses to `cwd`, then `fs.stat` fails because the workspace is a directory — hence `⨯ <workspace> not a file`. `CSC_IDENTITY_AUTO_DISCOVERY=false` was set but that only suppresses keychain lookup; it doesn't stop electron-builder from inspecting `CSC_LINK`.

Windows passes because the win signing path tolerates empty `CSC_LINK` differently (no `fs.stat` on cwd).

## Fix

Split the macOS package step into two mutually exclusive variants:

- `Package (macOS, signed)` runs only when all signing secrets are present — exports `CSC_LINK` / `CSC_KEY_PASSWORD` / Apple creds.
- `Package (macOS, unsigned)` runs otherwise and **deliberately does not export** `CSC_LINK` / `CSC_KEY_PASSWORD`, so electron-builder takes the pure unsigned code path. `CSC_IDENTITY_AUTO_DISCOVERY=false` is kept to suppress keychain lookup on the runner.

This is plan (c) from the task brief (avoid the bad signing input) rather than plan (d) (drop dmg target). Plan (d) is held in reserve if signing-path issues resurface.

`DEBUG=electron-builder` is kept on both mac branches so the next failure (if any) prints the full signing trace inline — cheap, only on release workflow.

No product code changed. No Windows / Linux changes.

## Verification gap

PR CI (`ci.yml`) runs lint + typecheck + test + e2e, but **does not invoke `electron-builder --mac`** — so PR green proves we didn't break lint/types/tests, but does **not** prove the release mac job is fixed.

To actually verify, the **manager** needs to either:

1. Push a dry-run tag like `v0.0.0-dryrun-mac-fix1` (release.yml supports `workflow_dispatch` for this — but note: `on.push.tags: v*` will trigger on tag push too, and the `Verify tag matches package.json version` step is conditioned to skip on `workflow_dispatch` only, so a real `v0.0.0-dryrun-*` tag push would fail that step. Easiest is `gh workflow run release.yml` via `workflow_dispatch` after merge.), **or**
2. Cut a patch tag `v0.2.2` once `package.json` is bumped.

## Risk

- Low. The change only affects the mac signing env. Worst case the unsigned mac build still fails, in which case the `DEBUG=electron-builder` output will pinpoint the next step. No risk to win / linux artifacts.

## Test plan

- [ ] PR CI green (lint, typecheck, unit, e2e)
- [ ] Manager triggers release.yml via `workflow_dispatch` after merge to verify mac job produces `.dmg` + `.zip` artifacts
- [ ] Once mac job green, remove `DEBUG: electron-builder` envs in a follow-up (optional cleanup)