### PR TITLE
fix(terminal): host-level paste listener (0->1 times)

### DIFF
--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -162,6 +162,43 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
 
   term.open(host);
 
+  // v0.2.2 paste fix: host-level capture-phase paste listener.
+  //
+  // Background: PR #1243 removed a custom Ctrl+V handler that was sending
+  // pastes twice (once via direct pty.write, once via xterm's built-in
+  // textarea paste → onData pipeline). The fix correctly delegates to
+  // xterm's built-in pipeline — BUT that pipeline only fires when the
+  // browser dispatches the native `paste` event to xterm's hidden helper
+  // textarea, which requires that textarea to have focus. In practice
+  // users frequently click on the surrounding host wrapper / sidebar /
+  // anywhere that drains focus from the helper textarea, so the native
+  // paste event lands on `host` (or an ancestor) and xterm never sees
+  // it → 0 pastes (v0.2.1 user report).
+  //
+  // Fix: install a capture-phase paste listener on the host element
+  // itself and route the clipboard text through `term.paste(text)`. This
+  //   - preserves the single canonical data path (term.paste →
+  //     prepareTextForTerminal → onData → usePtyAttach → pty.write), so
+  //     bracketed-paste wrapping and CR/LF normalization stay intact;
+  //   - does NOT depend on which descendant of host owns focus;
+  //   - uses capture phase + stopPropagation so xterm's own textarea /
+  //     element paste listeners cannot also fire on the same event
+  //     (prevents regression to the v0.2.0 double-paste bug);
+  //   - preventDefault keeps the browser from inserting the pasted text
+  //     into any contenteditable / input that might be focused inside
+  //     the host subtree.
+  host.addEventListener(
+    'paste',
+    (ev) => {
+      const text = ev.clipboardData?.getData('text/plain');
+      if (!text) return;
+      ev.preventDefault();
+      ev.stopPropagation();
+      term?.paste(text);
+    },
+    true,
+  );
+
   // ttyd-style: auto-copy on selection change. Works in alt-screen apps
   // (claude/Ink) when user holds Shift to bypass mouse tracking and
   // drags. Use Electron's clipboard via preload because navigator.clipboard

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -10,6 +10,7 @@ const {
   onSelectionChangeSpy,
   attachCustomKeyEventHandlerSpy,
   getSelectionSpy,
+  pasteSpy,
   terminalCtor,
   webLinksCtor,
 } = vi.hoisted(() => {
@@ -18,6 +19,7 @@ const {
   const onSelectionChangeSpy = vi.fn();
   const attachCustomKeyEventHandlerSpy = vi.fn();
   const getSelectionSpy = vi.fn(() => '');
+  const pasteSpy = vi.fn();
   // vitest v3+ requires `function`/`class` (not arrow) for mocks invoked
   // with `new` — otherwise tinyspy throws "is not a constructor".
   const terminalCtor = vi.fn(function () {
@@ -27,6 +29,7 @@ const {
       onSelectionChange: onSelectionChangeSpy,
       attachCustomKeyEventHandler: attachCustomKeyEventHandlerSpy,
       getSelection: getSelectionSpy,
+      paste: pasteSpy,
       unicode: { activeVersion: '6' },
       _core: { _parent: null },
     };
@@ -40,6 +43,7 @@ const {
     onSelectionChangeSpy,
     attachCustomKeyEventHandlerSpy,
     getSelectionSpy,
+    pasteSpy,
     terminalCtor,
     webLinksCtor,
   };
@@ -69,6 +73,7 @@ describe('useXtermSingleton', () => {
     attachCustomKeyEventHandlerSpy.mockClear();
     getSelectionSpy.mockClear();
     getSelectionSpy.mockReturnValue('');
+    pasteSpy.mockClear();
   });
 
   afterEach(() => {
@@ -279,6 +284,70 @@ describe('useXtermSingleton', () => {
       const result = handler(ev);
       expect(writeTextSpy).toHaveBeenCalledWith('selected text');
       expect(result).toBe(false);
+    });
+  });
+
+  describe('host-level paste listener (v0.2.2 paste-zero-times fix)', () => {
+    // Regression coverage for the v0.2.1 user report: Ctrl+V paste fired
+    // 0 times. Root cause: xterm's built-in paste pipeline only fires
+    // when the hidden helper textarea has focus; in practice focus is
+    // often elsewhere in the host wrapper, so the native `paste` event
+    // never reached xterm. Fix: capture-phase paste listener on the host
+    // element that routes through `term.paste(text)`.
+
+    function mountAndGetHost() {
+      const host = document.createElement('div');
+      // Attach to document so dispatched events bubble through the real
+      // event flow (capture listeners run regardless of attachment, but
+      // we mirror prod conditions).
+      document.body.appendChild(host);
+      const ref = { current: host };
+      renderHook(() => useXtermSingleton(ref));
+      return host;
+    }
+
+    function makePasteEvent(text: string | null) {
+      // jsdom's ClipboardEvent constructor doesn't accept clipboardData
+      // in init dict, so synthesize via Event + assign a stub. The
+      // production listener only reads `ev.clipboardData?.getData(...)`,
+      // `ev.preventDefault`, and `ev.stopPropagation`.
+      const ev = new Event('paste', { bubbles: true, cancelable: true });
+      Object.defineProperty(ev, 'clipboardData', {
+        value: text === null
+          ? null
+          : { getData: vi.fn((_type: string) => text) },
+      });
+      return ev;
+    }
+
+    it('routes paste through term.paste once and prevents default', () => {
+      const host = mountAndGetHost();
+      const ev = makePasteEvent('hello world');
+      const preventSpy = vi.spyOn(ev, 'preventDefault');
+      const stopSpy = vi.spyOn(ev, 'stopPropagation');
+
+      host.dispatchEvent(ev);
+
+      expect(pasteSpy).toHaveBeenCalledTimes(1);
+      expect(pasteSpy).toHaveBeenCalledWith('hello world');
+      expect(preventSpy).toHaveBeenCalledTimes(1);
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+
+      document.body.removeChild(host);
+    });
+
+    it('does not call term.paste when clipboard text is empty', () => {
+      const host = mountAndGetHost();
+      const ev = makePasteEvent('');
+      const preventSpy = vi.spyOn(ev, 'preventDefault');
+
+      host.dispatchEvent(ev);
+
+      expect(pasteSpy).not.toHaveBeenCalled();
+      // No-op path: don't preventDefault so other handlers can decide.
+      expect(preventSpy).not.toHaveBeenCalled();
+
+      document.body.removeChild(host);
     });
   });
 });


### PR DESCRIPTION
## User report (v0.2.1 installed build)

Ctrl+V paste fires **0 times** — expected 1, was 2 before PR #1243.

## Root cause hypotheses (static analysis, Explore subagent)

PR #1243 correctly removed the custom Ctrl+V handler (which had been writing pasted text to the PTY in addition to xterm's built-in textarea paste pipeline, causing v0.2.0 double-paste). The remaining built-in pipeline is:

```
native `paste` on helper textarea
  -> xterm onPaste()
  -> term.paste(text)
  -> prepareTextForTerminal (CR/LF normalize + bracketed-paste wrap)
  -> term.onData listener (installed by usePtyAttach.ts)
  -> ccsmPty.input(sid, data) -> pty.write
```

H1-H4 (any of these can produce 0 pastes):
- **H2 focus** — helper textarea only receives native `paste` when focused. Users frequently click the host wrapper / sidebar / drag-select within the terminal pane, draining focus away from the textarea. Most likely cause.
- **H1 bracketed-paste** — Claude's TUI may not render `ESC[200~ ... ESC[201~` framing visibly. Less likely (would still be "1 paste, just invisible") but listed for completeness.
- **H3 addon side effect** — ClipboardAddon installs `oncopy/oncut/onpaste` on `term.textarea`, but only after `term.open()`. If addon load races with focus, paste can fall through.
- **H4 canvas DOM** — CanvasAddon overlays the terminal viewport; in some focus paths the helper textarea ends up under the canvas and pointer/focus events route oddly.

## Fix (architecture-layer, not glue)

Install a **capture-phase** `paste` listener on the `host` element (the same `div` the user actually clicks). On paste:

1. Read `ev.clipboardData.getData('text/plain')`.
2. `preventDefault()` + `stopPropagation()` (capture phase) — guarantees xterm's textarea/element paste listeners cannot also fire on the same event. No regression to v0.2.0 double paste.
3. Call `term.paste(text)` — re-enters the **same canonical pipeline** (`term.paste` -> `prepareTextForTerminal` -> `onData` -> `usePtyAttach` -> `pty.write`). Bracketed-paste wrapping and CR/LF normalization preserved.

Why this is root-cause-level, not glue:
- Single paste data path retained — no parallel `pty.write` like the deleted Ctrl+V handler had.
- Does not depend on which descendant of `host` owns focus — covers H2 directly.
- Capture phase + stopPropagation defends against H3 (addon textarea listener) and H4 (canvas focus weirdness).
- If H1 (bracketed-paste) turns out to be the real cause, `term.paste()` behaves identically to the pre-existing pipeline, so this PR doesn't make it worse — a future mode toggle can be added orthogonally.

## What this PR does NOT touch

- `attachCustomKeyEventHandler` Ctrl+C / Ctrl+Shift+C copy branches (kept verbatim).
- `usePtyAttach.ts` — paste reaches it automatically via the existing `onData` listener.
- `ClipboardAddon` load — still loaded.
- `release.yml` / `build-icon.cjs` / any build infra.
- The v0.2.1 tag is not retagged.

## Test coverage

`tests/terminal/useXtermSingleton.test.tsx` gains 2 regression tests:

- **routes paste through term.paste once and prevents default** — dispatches a synthesized `paste` event on `host` with `clipboardData.getData('text/plain') = 'hello world'`. Asserts `term.paste` called once with `'hello world'`, `preventDefault` and `stopPropagation` each called once.
- **does not call term.paste when clipboard text is empty** — empty-string clipboard short-circuits, no `term.paste`, no `preventDefault` (lets other handlers decide).

Existing 12 tests untouched and still pass (14/14 total).

## Local validation (Windows)

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (91 pre-existing warnings unchanged)
- `npx vitest run tests/terminal/useXtermSingleton.test.tsx` — 14/14 pass

## Files changed

- `src/terminal/xtermSingleton.ts` — +37 lines (listener + extended comment block)
- `tests/terminal/useXtermSingleton.test.tsx` — +69 lines (2 new tests + paste spy plumbing)