### PR TITLE
fix(terminal): Ctrl+V pastes exactly once (real v0.2.0 → v0.2.3 fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ release/
 .dogfood-userdata/
 .dogfood-userdata-happy/
 .dogfood-userdata-ttyd-debug/
+.dev-userdata/
 docs/screenshots/dogfood-current-ui/
 docs/screenshots/dogfood-happy-path/
 *.exe

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -38,6 +38,18 @@ export function applyAppMenuLocale(): void {
   // around).
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const i18n = require('../i18n') as typeof import('../i18n');
+  // Paste is intentionally OMITTED from this menu. Electron's `role: 'paste'`
+  // resolves the Ctrl/Cmd+V accelerator by calling `webContents.paste()`,
+  // which only works against a focused contentEditable/textarea via the
+  // OS-level paste pathway. For the terminal pane, focus may sit on the
+  // xterm helper textarea, the screen canvas, or the host wrapper, and the
+  // OS-paste path is a no-op (or worse, silently inserts into the helper
+  // textarea instead of the PTY). The terminal pane installs its own
+  // capture-phase Ctrl/Cmd+V handler that routes through `ccsmPty.input` —
+  // see `src/terminal/xtermSingleton.ts`. Letting the menu accelerator
+  // through means it never reaches DOM keydown at all (the menu consumes
+  // it first); removing the menu entry lets the keydown propagate
+  // normally to the renderer.
   const accelMenu = Menu.buildFromTemplate([
     {
       label: i18n.tMenu('edit'),
@@ -47,7 +59,6 @@ export function applyAppMenuLocale(): void {
         { type: 'separator' },
         { role: 'cut' },
         { role: 'copy' },
-        { role: 'paste' },
         { role: 'selectAll' },
       ],
     },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,6 +66,8 @@ export default [
         PointerEvent: 'readonly',
         FocusEvent: 'readonly',
         DragEvent: 'readonly',
+        ClipboardEvent: 'readonly',
+        DataTransfer: 'readonly',
         File: 'readonly',
         FileList: 'readonly',
         FileReader: 'readonly',

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "dev": "concurrently -k -n web,app -c blue,magenta \"npm:dev:web\" \"npm:dev:app\"",
     "dev:web": "webpack serve --config webpack.config.js --mode development",
-    "dev:app": "wait-on http://localhost:4100 && tsc -p tsconfig.electron.json && electron .",
+    "dev:app": "wait-on http://localhost:4100 && tsc -p tsconfig.electron.json && node scripts/dev-electron.mjs",
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "build": "npm run clean && tsc -p tsconfig.electron.json && webpack --mode production && node -e \"const fs=require('fs');const p='dist/renderer/bundle.js';const t=Date.now()/1000;fs.utimesSync(p,t,t)\"",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.electron.json",

--- a/scripts/dev-electron.mjs
+++ b/scripts/dev-electron.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// Dev-only wrapper around `electron .`. Two pieces of friction it removes:
+//
+//   1. Single-instance lock.  ccsm's prod build calls
+//      `app.requestSingleInstanceLock()` at module load so duplicate desktop-
+//      icon double-clicks don't fork zombies. When you're using your installed
+//      ccsm to develop ccsm, that lock also blocks `npm run dev`. The lock
+//      already has an opt-out (`CCSM_E2E_NO_SINGLE_INSTANCE=1`, originally
+//      added for parallel E2E probes); this wrapper sets it.
+//
+//   2. userData collision.  Electron derives `app.getPath('userData')` from
+//      `productName`, which is "CCSM" in both prod and dev. Without an
+//      override, dev runs would read/write the same SQLite DB and prefs as
+//      your installed ccsm — risky even after exit (WAL recovery, schema
+//      migrations). We point the dev instance at `.dev-userdata/` inside the
+//      worktree via Electron's `--user-data-dir` switch.
+//
+// Cross-platform: spawning Node with explicit arg/env propagation works on
+// Windows without `cross-env`. Stdio is inherited so logs and Ctrl-C behave
+// exactly like running `electron .` directly.
+
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { mkdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+const userDataDir = resolve(repoRoot, '.dev-userdata');
+mkdirSync(userDataDir, { recursive: true });
+
+const electronBinary = createRequire(import.meta.url)('electron');
+
+const child = spawn(
+  electronBinary,
+  [`--user-data-dir=${userDataDir}`, repoRoot],
+  {
+    cwd: repoRoot,
+    stdio: 'inherit',
+    env: { ...process.env, CCSM_E2E_NO_SINGLE_INSTANCE: '1' },
+  },
+);
+
+child.on('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  else process.exit(code ?? 0);
+});

--- a/scripts/probe-paste-double-fire.mjs
+++ b/scripts/probe-paste-double-fire.mjs
@@ -1,0 +1,224 @@
+// Paste-double-fire diagnostic probe.
+//
+// Question this answers: when Ctrl+V is pressed in the terminal pane, which
+// code paths reach `window.ccsmPty.input`? The user reports pasting "hello"
+// produces "hellohello" in the PTY — exactly two calls. We need to know
+// WHICH two, because the fix in xtermSingleton.ts is supposed to converge
+// every paste source onto a single `ccsmPty.input(sid, text)` call.
+//
+// Strategy:
+//   1. Launch ccsm isolated + seed a session, wait for terminal ready.
+//   2. In the renderer, monkey-patch `window.ccsmPty.input` to count calls
+//      and capture each caller's stack — non-destructive: the original is
+//      still invoked so the PTY behaves normally.
+//   3. Stub `window.ccsmPty.clipboard.readText` to deterministically return
+//      a known sentinel string ("ccsm-paste-probe-hello"). This decouples
+//      the test from the OS clipboard.
+//   4. Trigger paste via TWO routes:
+//        (a) Direct keyboard event on the xterm element via Playwright's
+//            keyboard API. This drives our `attachCustomKeyEventHandler`
+//            Ctrl+V branch in xtermSingleton.ts — that's path P1.
+//        (b) Synthesize a real DOM `ClipboardEvent` on xterm's helper
+//            textarea. This is what the browser's native paste-event
+//            dispatch looks like — that's path P2 (host capture listener)
+//            and P3 (xterm built-in paste pipeline).
+//      We run both serially so we can attribute calls to a route.
+//   5. Print the call log: count, text content per call, and a few frames
+//      of stack so we can see whether the call came from our keydown
+//      handler, our host capture listener, the xterm built-in pipeline,
+//      or anywhere else.
+//
+// Why this is enough to diagnose: if (a) alone causes >1 call, the bug is
+// inside our keydown path (which is supposed to inject once + set a flag
+// that suppresses the follow-up paste event). If (b) alone causes >1 call,
+// the bug is that our host capture listener isn't stopping xterm's own
+// listeners on textarea/element. Either way we'll see WHERE the duplicate
+// fires come from in the stack traces.
+
+import {
+  createIsolatedClaudeDir,
+  launchCcsmIsolated,
+  seedSession,
+  waitForTerminalReady,
+  dismissFirstRunModals,
+} from './probe-utils-real-cli.mjs';
+
+const SENTINEL = 'ccsm-paste-probe-hello';
+
+async function main() {
+  const { tempDir } = await createIsolatedClaudeDir();
+  console.log('[probe] tempDir=', tempDir);
+
+  const { electronApp, win } = await launchCcsmIsolated({ tempDir });
+
+  try {
+    // Wait for claude-availability probe + mount.
+    await win.waitForFunction(
+      () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+      null,
+      { timeout: 30000 },
+    );
+
+    const { sid } = await seedSession(win, { name: 'paste-probe', cwd: tempDir });
+    if (!sid) throw new Error('seedSession returned empty sid');
+    console.log('[probe] seeded sid=', sid);
+
+    await new Promise((r) => setTimeout(r, 4000));
+    await waitForTerminalReady(win, sid, { timeout: 60000 });
+    await dismissFirstRunModals(win);
+
+    // Install diagnostics. `window.ccsmPty` is frozen by contextBridge,
+    // so we cannot reliably monkey-patch ccsmPty.input from the renderer.
+    // Instead instrument the main-process IPC handler — same call site,
+    // strictly above the preload boundary, robust against frozen objects.
+    await electronApp.evaluate(({ ipcMain }) => {
+      const g = globalThis;
+      g.__pasteProbeCalls = [];
+      // ipcMain stores invoke handlers in an internal map. The public API
+      // is removeHandler + handle, but we don't have a reference to the
+      // original handler. We mutate the internal map directly to wrap it.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const internal = ipcMain;
+      const handlers = internal._invokeHandlers;
+      if (!handlers || !handlers.get('pty:input')) {
+        g.__pasteProbeError = 'no existing pty:input handler';
+        return;
+      }
+      const orig = handlers.get('pty:input');
+      handlers.set('pty:input', async (event, ...args) => {
+        const [sid, data] = args;
+        g.__pasteProbeCalls.push({ sid, data, ts: Date.now() });
+        return orig(event, ...args);
+      });
+      g.__pasteProbeReady = true;
+    });
+    const ipcReady = await electronApp.evaluate(() => ({
+      ready: globalThis.__pasteProbeReady === true,
+      error: globalThis.__pasteProbeError || null,
+    }));
+    console.log('[probe] ipcMain patch:', ipcReady);
+    if (!ipcReady.ready) throw new Error('failed to patch ipcMain.handle');
+
+    // Try stubbing the renderer-side readText too, in case it's mutable.
+    const stubMode = await win.evaluate((sentinel) => {
+      try {
+        window.ccsmPty.clipboard.readText = () => sentinel;
+        return 'direct-ok';
+      } catch (_) {
+        try {
+          Object.defineProperty(window.ccsmPty.clipboard, 'readText', {
+            value: () => sentinel,
+            configurable: true,
+          });
+          return 'defineProperty-ok';
+        } catch (_) {
+          return 'failed-frozen';
+        }
+      }
+    }, SENTINEL);
+    console.log('[probe] readText stub:', stubMode);
+
+    // Sanity.
+    const sanity = await win.evaluate(() => ({
+      hasTerm: !!window.__ccsmTerm,
+      hasXterm: !!document.querySelector('.xterm'),
+      hasHelper: !!document.querySelector('.xterm-helper-textarea'),
+    }));
+    console.log('[probe] sanity:', sanity);
+
+    const resetProbe = () => electronApp.evaluate(() => {
+      globalThis.__pasteProbeCalls.length = 0;
+    });
+    const readProbe = () =>
+      electronApp.evaluate(() => globalThis.__pasteProbeCalls.slice());
+
+    // Write SENTINEL to the OS clipboard so the browser's native paste
+    // pipeline (event.clipboardData) sees the same string as our stubbed
+    // ccsmPty.clipboard.readText. Use Electron's main-process clipboard
+    // API since the renderer's navigator.clipboard requires user-activation.
+    await electronApp.evaluate(({ clipboard }, text) => {
+      clipboard.writeText(text);
+    }, SENTINEL);
+    console.log('[probe] wrote SENTINEL to OS clipboard');
+
+    // --- Route A: synthesize Ctrl+V keydown directly on the xterm element.
+    //
+    // We dispatch a real KeyboardEvent on the xterm helper textarea, which
+    // is what xterm's internal listeners are attached to. xterm forwards
+    // keydown to its `_customKeyEventHandler`, exercising our P1 branch in
+    // xtermSingleton.ts. Note: this is a synthetic event — it does NOT
+    // trigger the browser's native paste pipeline (which only fires for
+    // real OS clipboard operations), so it isolates P1 cleanly.
+    console.log('\n[probe] === Route A: Playwright keyboard Ctrl+V on focused textarea ===');
+    await resetProbe();
+    await win.evaluate(() => {
+      const ta = document.querySelector('.xterm-helper-textarea');
+      if (ta) ta.focus();
+    });
+    await win.keyboard.down('Control');
+    await win.keyboard.press('KeyV');
+    await win.keyboard.up('Control');
+    await new Promise((r) => setTimeout(r, 800));
+    const routeA = await readProbe();
+    console.log(`[probe] route A: pty:input invoked ${routeA.length} time(s):`);
+    routeA.forEach((c, i) => {
+      console.log(`  [${i}] data=${JSON.stringify(c.data).slice(0, 100)}`);
+    });
+
+    console.log('\n[probe] === Route B: synthetic paste ClipboardEvent ===');
+    await resetProbe();
+    await win.evaluate((sentinel) => {
+      const xtermEl = document.querySelector('.xterm');
+      if (!xtermEl) throw new Error('.xterm not found');
+      const target = document.querySelector('.xterm-helper-textarea') || xtermEl;
+      const dt = new DataTransfer();
+      dt.setData('text/plain', sentinel);
+      const evt = new ClipboardEvent('paste', {
+        clipboardData: dt,
+        bubbles: true,
+        cancelable: true,
+      });
+      target.dispatchEvent(evt);
+    }, SENTINEL);
+    await new Promise((r) => setTimeout(r, 800));
+    const routeB = await readProbe();
+    console.log(`[probe] route B: pty:input invoked ${routeB.length} time(s):`);
+    routeB.forEach((c, i) => {
+      console.log(`  [${i}] data=${JSON.stringify(c.data).slice(0, 100)}`);
+    });
+
+    console.log('\n[probe] === Route C: combined keydown + paste event in same tick ===');
+    await resetProbe();
+    await win.evaluate((sentinel) => {
+      const ta = document.querySelector('.xterm-helper-textarea');
+      if (!ta) throw new Error('xterm-helper-textarea not found');
+      ta.focus();
+      ta.dispatchEvent(new KeyboardEvent('keydown', {
+        key: 'v', code: 'KeyV', ctrlKey: true, bubbles: true, cancelable: true,
+      }));
+      const dt = new DataTransfer();
+      dt.setData('text/plain', sentinel);
+      ta.dispatchEvent(new ClipboardEvent('paste', {
+        clipboardData: dt, bubbles: true, cancelable: true,
+      }));
+    }, SENTINEL);
+    await new Promise((r) => setTimeout(r, 800));
+    const routeC = await readProbe();
+    console.log(`[probe] route C: pty:input invoked ${routeC.length} time(s):`);
+    routeC.forEach((c, i) => {
+      console.log(`  [${i}] data=${JSON.stringify(c.data).slice(0, 100)}`);
+    });
+
+    console.log('\n[probe] === summary ===');
+    console.log(`route A (real keyboard): ${routeA.length} call(s)`);
+    console.log(`route B (paste-event):   ${routeB.length} call(s)`);
+    console.log(`route C (combined):      ${routeC.length} call(s)`);
+  } finally {
+    try { await electronApp.close(); } catch (_) { /* ignore */ }
+  }
+}
+
+main().catch((e) => {
+  console.error('[probe] failed:', e);
+  process.exit(1);
+});

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -162,43 +162,6 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
 
   term.open(host);
 
-  // v0.2.2 paste fix: host-level capture-phase paste listener.
-  //
-  // Background: PR #1243 removed a custom Ctrl+V handler that was sending
-  // pastes twice (once via direct pty.write, once via xterm's built-in
-  // textarea paste → onData pipeline). The fix correctly delegates to
-  // xterm's built-in pipeline — BUT that pipeline only fires when the
-  // browser dispatches the native `paste` event to xterm's hidden helper
-  // textarea, which requires that textarea to have focus. In practice
-  // users frequently click on the surrounding host wrapper / sidebar /
-  // anywhere that drains focus from the helper textarea, so the native
-  // paste event lands on `host` (or an ancestor) and xterm never sees
-  // it → 0 pastes (v0.2.1 user report).
-  //
-  // Fix: install a capture-phase paste listener on the host element
-  // itself and route the clipboard text through `term.paste(text)`. This
-  //   - preserves the single canonical data path (term.paste →
-  //     prepareTextForTerminal → onData → usePtyAttach → pty.write), so
-  //     bracketed-paste wrapping and CR/LF normalization stay intact;
-  //   - does NOT depend on which descendant of host owns focus;
-  //   - uses capture phase + stopPropagation so xterm's own textarea /
-  //     element paste listeners cannot also fire on the same event
-  //     (prevents regression to the v0.2.0 double-paste bug);
-  //   - preventDefault keeps the browser from inserting the pasted text
-  //     into any contenteditable / input that might be focused inside
-  //     the host subtree.
-  host.addEventListener(
-    'paste',
-    (ev) => {
-      const text = ev.clipboardData?.getData('text/plain');
-      if (!text) return;
-      ev.preventDefault();
-      ev.stopPropagation();
-      term?.paste(text);
-    },
-    true,
-  );
-
   // ttyd-style: auto-copy on selection change. Works in alt-screen apps
   // (claude/Ink) when user holds Shift to bypass mouse tracking and
   // drags. Use Electron's clipboard via preload because navigator.clipboard

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -248,16 +248,15 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
   });
 
   const pasteFromClipboard = (): void => {
-    // Mark the keyboard-driven branch so the capture-phase paste
-    // listener below knows to discard the native paste event the
-    // browser is about to dispatch — otherwise we'd inject twice.
     keyboardPasteHandled = true;
-    // Auto-clear on the next microtask so that if the browser does
-    // NOT dispatch a follow-up paste event (focus on a non-editable
-    // descendant — canvas / div), a future paste from any source
-    // isn't permanently suppressed. Paste dispatch is synchronous
-    // relative to keydown handling, so it lands before microtasks.
-    queueMicrotask(() => { keyboardPasteHandled = false; });
+    // Reset the flag on a macrotask (NOT a microtask). The browser dispatches
+    // the follow-up native `paste` event after our keydown handler returns
+    // but before the next task tick — microtasks fire BEFORE the native
+    // paste, leaving the flag false when the capture listener runs and
+    // causing a second inject (the v0.2.0 double-paste comes back). A
+    // setTimeout 0 task lands AFTER the native paste dispatch, so the
+    // capture listener sees the flag and suppresses.
+    setTimeout(() => { keyboardPasteHandled = false; }, 0);
     try {
       const text = window.ccsmPty?.clipboard?.readText();
       if (text && activeSid) window.ccsmPty.input(activeSid, text);

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -179,21 +179,14 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
     }
   });
 
-  // Copy keyboard shortcuts (Windows Terminal style):
-  //   Ctrl+C        → if selection, copy; else fall through to SIGINT
-  //   Ctrl+Shift+C  → explicit always-copy
-  //
-  // Paste is intentionally NOT handled here. xterm.js has a built-in paste
-  // pipeline (textarea `paste` event → `term.paste()` → `onData` → main
-  // process `pty.write`) which is already wired by `usePtyAttach`. A
-  // previous custom Ctrl+V / Ctrl+Shift+V handler here ran in addition to
-  // the built-in pipeline — returning `false` only suppresses xterm's
-  // keydown→data dispatch, not the browser's native `paste` clipboard
-  // event — so every paste was sent twice. Delegating to xterm's built-in
-  // pipeline gives us a single, canonical paste path.
+  // Copy/paste keyboard shortcuts (Windows Terminal style):
+  //   Ctrl+C  → if selection, copy; else fall through to SIGINT
+  //   Ctrl+V  → paste
+  //   Ctrl+Shift+C / Ctrl+Shift+V → explicit always-clipboard
   term.attachCustomKeyEventHandler((ev) => {
     if (ev.type !== 'keydown') return true;
     const isC = ev.key === 'C' || ev.key === 'c';
+    const isV = ev.key === 'V' || ev.key === 'v';
 
     if (ev.ctrlKey && !ev.shiftKey && !ev.altKey && isC) {
       const sel = term?.getSelection();
@@ -207,6 +200,15 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
       }
       return true;
     }
+    if (ev.ctrlKey && !ev.shiftKey && !ev.altKey && isV) {
+      try {
+        const text = window.ccsmPty?.clipboard?.readText();
+        if (text && activeSid) window.ccsmPty.input(activeSid, text);
+      } catch {
+        // ignore clipboard failures — paste is best-effort.
+      }
+      return false;
+    }
     if (ev.ctrlKey && ev.shiftKey && isC) {
       const sel = term?.getSelection();
       if (sel) {
@@ -215,6 +217,15 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
         } catch {
           // ignore clipboard failures — selection still highlights.
         }
+      }
+      return false;
+    }
+    if (ev.ctrlKey && ev.shiftKey && isV) {
+      try {
+        const text = window.ccsmPty?.clipboard?.readText();
+        if (text && activeSid) window.ccsmPty.input(activeSid, text);
+      } catch {
+        // ignore clipboard failures — paste is best-effort.
       }
       return false;
     }

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -29,6 +29,12 @@ let fit: FitAddon | null = null;
 let activeSid: string | null = null;
 let unsubscribeData: (() => void) | null = null;
 let inputDisposable: { dispose: () => void } | null = null;
+// Handoff flag between the Ctrl/Cmd+V keydown hook and the capture-phase
+// `paste` listener. Module-level (not closed over `ensureTerminal`) so a
+// keydown that was attached against an earlier Terminal instance still
+// suppresses the native paste event reaching the current host element.
+// See the paste-path block inside `ensureTerminal` for details.
+let keyboardPasteHandled = false;
 // L4 PR-D (#866): callback installed by `usePtyAttach` once it has wired the
 // snapshot/dedupe-by-seq flow. Invoked by `useTerminalResize` AFTER pushing
 // a new size to the headless mirror so the visible xterm can re-render
@@ -162,6 +168,68 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
 
   term.open(host);
 
+  // Single canonical paste path.
+  //
+  // xterm.js exposes two competing entry points for paste:
+  //   (1) an `attachCustomKeyEventHandler` keydown hook
+  //   (2) a built-in `paste` DOM-event pipeline (`handlePasteEvent` →
+  //       `coreService.triggerDataEvent` → `onData`), wired to BOTH
+  //       `this.textarea` and `this.element`.
+  //
+  // Electron adds a third: `role: 'paste'` in any application menu
+  // resolves Ctrl/Cmd+V via `webContents.paste()` (OS-level), which
+  // bypasses the DOM entirely. (We've removed that role from the
+  // hidden accelerator menu in `electron/lifecycle/appLifecycle.ts`,
+  // but it can still arrive from the right-click context menu.)
+  //
+  // Letting two of these fire concurrently is what caused v0.2.0's
+  // double-paste; disabling the keydown hook (v0.2.1) instead left
+  // paste depending on which descendant of host happened to be
+  // focused, manifesting as zero pastes when focus was on the screen
+  // canvas. Both failure modes have the same root cause: we were
+  // riding xterm's internals instead of owning the user intent.
+  //
+  // Fix: own the user intent. Treat the terminal pane as a single
+  // atomic unit, like a native CLI terminal. Every "user wants to
+  // paste" signal — Ctrl/Cmd+V keydown, Ctrl/Cmd+Shift+V keydown,
+  // bracketed `paste` DOM events — converges on one call:
+  //
+  //   ccsmPty.input(activeSid, clipboard.readText())
+  //
+  // Implementation: install a capture-phase `paste` listener on the
+  // host wrapper that swallows xterm's built-in pipeline before it
+  // can call `triggerDataEvent`, and route Ctrl/Cmd+V via the
+  // keydown hook below (returning `false` to also stop xterm from
+  // translating the keystroke into a 0x16 SYN byte).
+  //
+  // The capture listener also routes `paste` events that did NOT
+  // originate from our keydown hook (right-click → Paste, Shift+Insert,
+  // OS-level `webContents.paste()` via context menu) into the same
+  // canonical sink, so every paste source converges.
+  //
+  // Subtlety: when the user types Ctrl+V, the keydown hook reads the
+  // clipboard and injects synchronously. Some browsers / Electron
+  // versions then dispatch a native `paste` event a moment later;
+  // the keydown handler sets `keyboardPasteHandled` so this listener
+  // discards that follow-up event and we paste exactly once.
+  const onPasteCapture = (e: ClipboardEvent): void => {
+    e.stopImmediatePropagation();
+    e.preventDefault();
+    if (keyboardPasteHandled) {
+      keyboardPasteHandled = false;
+      return;
+    }
+    const text = e.clipboardData?.getData('text/plain');
+    if (text && activeSid) {
+      try {
+        window.ccsmPty.input(activeSid, text);
+      } catch {
+        // best-effort — write can fail if PTY isn't attached.
+      }
+    }
+  };
+  host.addEventListener('paste', onPasteCapture, { capture: true });
+
   // ttyd-style: auto-copy on selection change. Works in alt-screen apps
   // (claude/Ink) when user holds Shift to bypass mouse tracking and
   // drags. Use Electron's clipboard via preload because navigator.clipboard
@@ -179,16 +247,38 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
     }
   });
 
+  const pasteFromClipboard = (): void => {
+    // Mark the keyboard-driven branch so the capture-phase paste
+    // listener below knows to discard the native paste event the
+    // browser is about to dispatch — otherwise we'd inject twice.
+    keyboardPasteHandled = true;
+    // Auto-clear on the next microtask so that if the browser does
+    // NOT dispatch a follow-up paste event (focus on a non-editable
+    // descendant — canvas / div), a future paste from any source
+    // isn't permanently suppressed. Paste dispatch is synchronous
+    // relative to keydown handling, so it lands before microtasks.
+    queueMicrotask(() => { keyboardPasteHandled = false; });
+    try {
+      const text = window.ccsmPty?.clipboard?.readText();
+      if (text && activeSid) window.ccsmPty.input(activeSid, text);
+    } catch {
+      // best-effort — clipboard read can fail under permission edge cases.
+    }
+  };
+
   // Copy/paste keyboard shortcuts (Windows Terminal style):
   //   Ctrl+C  → if selection, copy; else fall through to SIGINT
-  //   Ctrl+V  → paste
+  //   Ctrl+V  → paste (single canonical path, see above)
   //   Ctrl+Shift+C / Ctrl+Shift+V → explicit always-clipboard
+  // On macOS the same handler matches Cmd via `metaKey`.
   term.attachCustomKeyEventHandler((ev) => {
     if (ev.type !== 'keydown') return true;
+    const mod = ev.ctrlKey || ev.metaKey;
+    if (!mod || ev.altKey) return true;
     const isC = ev.key === 'C' || ev.key === 'c';
     const isV = ev.key === 'V' || ev.key === 'v';
 
-    if (ev.ctrlKey && !ev.shiftKey && !ev.altKey && isC) {
+    if (!ev.shiftKey && isC) {
       const sel = term?.getSelection();
       if (sel) {
         try {
@@ -200,16 +290,11 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
       }
       return true;
     }
-    if (ev.ctrlKey && !ev.shiftKey && !ev.altKey && isV) {
-      try {
-        const text = window.ccsmPty?.clipboard?.readText();
-        if (text && activeSid) window.ccsmPty.input(activeSid, text);
-      } catch {
-        // ignore clipboard failures — paste is best-effort.
-      }
+    if (!ev.shiftKey && isV) {
+      pasteFromClipboard();
       return false;
     }
-    if (ev.ctrlKey && ev.shiftKey && isC) {
+    if (ev.shiftKey && isC) {
       const sel = term?.getSelection();
       if (sel) {
         try {
@@ -220,13 +305,8 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
       }
       return false;
     }
-    if (ev.ctrlKey && ev.shiftKey && isV) {
-      try {
-        const text = window.ccsmPty?.clipboard?.readText();
-        if (text && activeSid) window.ccsmPty.input(activeSid, text);
-      } catch {
-        // ignore clipboard failures — paste is best-effort.
-      }
+    if (ev.shiftKey && isV) {
+      pasteFromClipboard();
       return false;
     }
     return true;
@@ -256,6 +336,7 @@ export function __resetSingletonForTests(): void {
   unsubscribeData = null;
   inputDisposable = null;
   snapshotReplay = null;
+  keyboardPasteHandled = false;
   if (typeof window !== 'undefined') {
     delete window.__ccsmTerm;
   }

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -10,7 +10,6 @@ const {
   onSelectionChangeSpy,
   attachCustomKeyEventHandlerSpy,
   getSelectionSpy,
-  pasteSpy,
   terminalCtor,
   webLinksCtor,
 } = vi.hoisted(() => {
@@ -19,7 +18,6 @@ const {
   const onSelectionChangeSpy = vi.fn();
   const attachCustomKeyEventHandlerSpy = vi.fn();
   const getSelectionSpy = vi.fn(() => '');
-  const pasteSpy = vi.fn();
   // vitest v3+ requires `function`/`class` (not arrow) for mocks invoked
   // with `new` — otherwise tinyspy throws "is not a constructor".
   const terminalCtor = vi.fn(function () {
@@ -29,7 +27,6 @@ const {
       onSelectionChange: onSelectionChangeSpy,
       attachCustomKeyEventHandler: attachCustomKeyEventHandlerSpy,
       getSelection: getSelectionSpy,
-      paste: pasteSpy,
       unicode: { activeVersion: '6' },
       _core: { _parent: null },
     };
@@ -43,7 +40,6 @@ const {
     onSelectionChangeSpy,
     attachCustomKeyEventHandlerSpy,
     getSelectionSpy,
-    pasteSpy,
     terminalCtor,
     webLinksCtor,
   };
@@ -73,7 +69,6 @@ describe('useXtermSingleton', () => {
     attachCustomKeyEventHandlerSpy.mockClear();
     getSelectionSpy.mockClear();
     getSelectionSpy.mockReturnValue('');
-    pasteSpy.mockClear();
   });
 
   afterEach(() => {
@@ -284,70 +279,6 @@ describe('useXtermSingleton', () => {
       const result = handler(ev);
       expect(writeTextSpy).toHaveBeenCalledWith('selected text');
       expect(result).toBe(false);
-    });
-  });
-
-  describe('host-level paste listener (v0.2.2 paste-zero-times fix)', () => {
-    // Regression coverage for the v0.2.1 user report: Ctrl+V paste fired
-    // 0 times. Root cause: xterm's built-in paste pipeline only fires
-    // when the hidden helper textarea has focus; in practice focus is
-    // often elsewhere in the host wrapper, so the native `paste` event
-    // never reached xterm. Fix: capture-phase paste listener on the host
-    // element that routes through `term.paste(text)`.
-
-    function mountAndGetHost() {
-      const host = document.createElement('div');
-      // Attach to document so dispatched events bubble through the real
-      // event flow (capture listeners run regardless of attachment, but
-      // we mirror prod conditions).
-      document.body.appendChild(host);
-      const ref = { current: host };
-      renderHook(() => useXtermSingleton(ref));
-      return host;
-    }
-
-    function makePasteEvent(text: string | null) {
-      // jsdom's ClipboardEvent constructor doesn't accept clipboardData
-      // in init dict, so synthesize via Event + assign a stub. The
-      // production listener only reads `ev.clipboardData?.getData(...)`,
-      // `ev.preventDefault`, and `ev.stopPropagation`.
-      const ev = new Event('paste', { bubbles: true, cancelable: true });
-      Object.defineProperty(ev, 'clipboardData', {
-        value: text === null
-          ? null
-          : { getData: vi.fn((_type: string) => text) },
-      });
-      return ev;
-    }
-
-    it('routes paste through term.paste once and prevents default', () => {
-      const host = mountAndGetHost();
-      const ev = makePasteEvent('hello world');
-      const preventSpy = vi.spyOn(ev, 'preventDefault');
-      const stopSpy = vi.spyOn(ev, 'stopPropagation');
-
-      host.dispatchEvent(ev);
-
-      expect(pasteSpy).toHaveBeenCalledTimes(1);
-      expect(pasteSpy).toHaveBeenCalledWith('hello world');
-      expect(preventSpy).toHaveBeenCalledTimes(1);
-      expect(stopSpy).toHaveBeenCalledTimes(1);
-
-      document.body.removeChild(host);
-    });
-
-    it('does not call term.paste when clipboard text is empty', () => {
-      const host = mountAndGetHost();
-      const ev = makePasteEvent('');
-      const preventSpy = vi.spyOn(ev, 'preventDefault');
-
-      host.dispatchEvent(ev);
-
-      expect(pasteSpy).not.toHaveBeenCalled();
-      // No-op path: don't preventDefault so other handlers can decide.
-      expect(preventSpy).not.toHaveBeenCalled();
-
-      document.body.removeChild(host);
     });
   });
 });

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -4,46 +4,29 @@ import { renderHook } from '@testing-library/react';
 // Mock xterm constructors BEFORE importing the hook so the singleton
 // uses the spies. Use vi.hoisted because vi.mock factories run before
 // any top-level `const`.
-const {
-  openSpy,
-  loadAddonSpy,
-  onSelectionChangeSpy,
-  attachCustomKeyEventHandlerSpy,
-  getSelectionSpy,
-  terminalCtor,
-  webLinksCtor,
-} = vi.hoisted(() => {
-  const openSpy = vi.fn();
-  const loadAddonSpy = vi.fn();
-  const onSelectionChangeSpy = vi.fn();
-  const attachCustomKeyEventHandlerSpy = vi.fn();
-  const getSelectionSpy = vi.fn(() => '');
-  // vitest v3+ requires `function`/`class` (not arrow) for mocks invoked
-  // with `new` — otherwise tinyspy throws "is not a constructor".
-  const terminalCtor = vi.fn(function () {
-    return {
-      open: openSpy,
-      loadAddon: loadAddonSpy,
-      onSelectionChange: onSelectionChangeSpy,
-      attachCustomKeyEventHandler: attachCustomKeyEventHandlerSpy,
-      getSelection: getSelectionSpy,
-      unicode: { activeVersion: '6' },
-      _core: { _parent: null },
-    };
+const { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, terminalCtor, webLinksCtor } =
+  vi.hoisted(() => {
+    const openSpy = vi.fn();
+    const loadAddonSpy = vi.fn();
+    const onSelectionChangeSpy = vi.fn();
+    const attachCustomKeyEventHandlerSpy = vi.fn();
+    // vitest v3+ requires `function`/`class` (not arrow) for mocks invoked
+    // with `new` — otherwise tinyspy throws "is not a constructor".
+    const terminalCtor = vi.fn(function () {
+      return {
+        open: openSpy,
+        loadAddon: loadAddonSpy,
+        onSelectionChange: onSelectionChangeSpy,
+        attachCustomKeyEventHandler: attachCustomKeyEventHandlerSpy,
+        unicode: { activeVersion: '6' },
+        _core: { _parent: null },
+      };
+    });
+    const webLinksCtor = vi.fn(function () {
+      return {};
+    });
+    return { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, terminalCtor, webLinksCtor };
   });
-  const webLinksCtor = vi.fn(function () {
-    return {};
-  });
-  return {
-    openSpy,
-    loadAddonSpy,
-    onSelectionChangeSpy,
-    attachCustomKeyEventHandlerSpy,
-    getSelectionSpy,
-    terminalCtor,
-    webLinksCtor,
-  };
-});
 
 vi.mock('@xterm/xterm', () => ({ Terminal: terminalCtor }));
 vi.mock('@xterm/addon-fit', () => ({ FitAddon: vi.fn(function () { return { fit: vi.fn() }; }) }));
@@ -56,7 +39,6 @@ import { useXtermSingleton } from '../../src/terminal/useXtermSingleton';
 import {
   __resetSingletonForTests,
   getTerm,
-  setActiveSid,
 } from '../../src/terminal/xtermSingleton';
 
 describe('useXtermSingleton', () => {
@@ -66,9 +48,6 @@ describe('useXtermSingleton', () => {
     openSpy.mockClear();
     loadAddonSpy.mockClear();
     webLinksCtor.mockClear();
-    attachCustomKeyEventHandlerSpy.mockClear();
-    getSelectionSpy.mockClear();
-    getSelectionSpy.mockReturnValue('');
   });
 
   afterEach(() => {
@@ -161,124 +140,6 @@ describe('useXtermSingleton', () => {
       expect(() =>
         handler({ ctrlKey: true, metaKey: false }, 'https://example.com'),
       ).not.toThrow();
-    });
-  });
-
-  describe('custom key event handler — paste duplication fix', () => {
-    // Regression coverage for the paste-duplication bug: the custom
-    // handler previously had Ctrl+V / Ctrl+Shift+V branches that wrote
-    // pasted text to the PTY directly while xterm's built-in textarea
-    // paste pipeline (term.paste → onData → pty.write) ALSO fired,
-    // causing paste to be sent twice. The fix removes those branches
-    // so paste flows exclusively through xterm's built-in pipeline.
-
-    function installHandler() {
-      const host = document.createElement('div');
-      const ref = { current: host };
-      renderHook(() => useXtermSingleton(ref));
-      const handler = attachCustomKeyEventHandlerSpy.mock.calls[0][0] as (
-        ev: Partial<KeyboardEvent>,
-      ) => boolean;
-      return handler;
-    }
-
-    let inputSpy: ReturnType<typeof vi.fn>;
-    let writeTextSpy: ReturnType<typeof vi.fn>;
-    let readTextSpy: ReturnType<typeof vi.fn>;
-
-    beforeEach(() => {
-      inputSpy = vi.fn();
-      writeTextSpy = vi.fn();
-      readTextSpy = vi.fn(() => 'clipboard-text');
-      (window as unknown as { ccsmPty: unknown }).ccsmPty = {
-        input: inputSpy,
-        clipboard: { readText: readTextSpy, writeText: writeTextSpy },
-      };
-      setActiveSid('sid-1');
-    });
-
-    afterEach(() => {
-      setActiveSid(null);
-      delete (window as unknown as { ccsmPty?: unknown }).ccsmPty;
-    });
-
-    it('returns true on Ctrl+V keydown (defers to xterm built-in paste pipeline)', () => {
-      const handler = installHandler();
-      const ev = {
-        type: 'keydown' as const,
-        key: 'v',
-        ctrlKey: true,
-        shiftKey: false,
-        altKey: false,
-      };
-      const result = handler(ev);
-      // Must return true so xterm core does NOT short-circuit; the
-      // browser's native `paste` clipboard event reaches xterm's
-      // textarea listener and flows through term.paste() → onData.
-      expect(result).toBe(true);
-      // Custom PTY write path is removed — must not be invoked here.
-      expect(inputSpy).not.toHaveBeenCalled();
-      expect(readTextSpy).not.toHaveBeenCalled();
-    });
-
-    it('returns true on Ctrl+Shift+V keydown (defers to xterm built-in paste pipeline)', () => {
-      const handler = installHandler();
-      const ev = {
-        type: 'keydown' as const,
-        key: 'V',
-        ctrlKey: true,
-        shiftKey: true,
-        altKey: false,
-      };
-      const result = handler(ev);
-      expect(result).toBe(true);
-      expect(inputSpy).not.toHaveBeenCalled();
-      expect(readTextSpy).not.toHaveBeenCalled();
-    });
-
-    it('Ctrl+C with selection copies to clipboard and returns false', () => {
-      getSelectionSpy.mockReturnValue('selected text');
-      const handler = installHandler();
-      const ev = {
-        type: 'keydown' as const,
-        key: 'c',
-        ctrlKey: true,
-        shiftKey: false,
-        altKey: false,
-      };
-      const result = handler(ev);
-      expect(writeTextSpy).toHaveBeenCalledWith('selected text');
-      expect(result).toBe(false);
-    });
-
-    it('Ctrl+C without selection returns true (falls through to SIGINT)', () => {
-      getSelectionSpy.mockReturnValue('');
-      const handler = installHandler();
-      const ev = {
-        type: 'keydown' as const,
-        key: 'c',
-        ctrlKey: true,
-        shiftKey: false,
-        altKey: false,
-      };
-      const result = handler(ev);
-      expect(writeTextSpy).not.toHaveBeenCalled();
-      expect(result).toBe(true);
-    });
-
-    it('Ctrl+Shift+C with selection always copies and returns false', () => {
-      getSelectionSpy.mockReturnValue('selected text');
-      const handler = installHandler();
-      const ev = {
-        type: 'keydown' as const,
-        key: 'C',
-        ctrlKey: true,
-        shiftKey: true,
-        altKey: false,
-      };
-      const result = handler(ev);
-      expect(writeTextSpy).toHaveBeenCalledWith('selected text');
-      expect(result).toBe(false);
     });
   });
 });

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -39,6 +39,7 @@ import { useXtermSingleton } from '../../src/terminal/useXtermSingleton';
 import {
   __resetSingletonForTests,
   getTerm,
+  setActiveSid,
 } from '../../src/terminal/xtermSingleton';
 
 describe('useXtermSingleton', () => {
@@ -140,6 +141,130 @@ describe('useXtermSingleton', () => {
       expect(() =>
         handler({ ctrlKey: true, metaKey: false }, 'https://example.com'),
       ).not.toThrow();
+    });
+  });
+
+  // Paste behaviour — the core regression test for v0.2.0 double-paste
+  // and v0.2.1/v0.2.2 zero-paste. Both prior fixes had unit tests that
+  // passed; both failed in the real app. These tests exercise the actual
+  // wiring: the keydown hook installed via `attachCustomKeyEventHandler`,
+  // the capture-phase paste listener installed on the host element, and
+  // the handoff flag that prevents double-injection.
+  describe('paste behaviour', () => {
+    let inputSpy: ReturnType<typeof vi.fn>;
+    let readTextSpy: ReturnType<typeof vi.fn>;
+    let host: HTMLDivElement;
+
+    function getKeyHandler(): (ev: {
+      type: string;
+      key: string;
+      ctrlKey?: boolean;
+      metaKey?: boolean;
+      shiftKey?: boolean;
+      altKey?: boolean;
+    }) => boolean {
+      const handler = attachCustomKeyEventHandlerSpy.mock.calls[0][0];
+      expect(typeof handler).toBe('function');
+      return handler;
+    }
+
+    beforeEach(() => {
+      inputSpy = vi.fn();
+      readTextSpy = vi.fn().mockReturnValue('hello');
+      (window as unknown as { ccsmPty: unknown }).ccsmPty = {
+        input: inputSpy,
+        clipboard: {
+          readText: readTextSpy,
+          writeText: vi.fn(),
+        },
+      };
+      // The hook receives a real DOM node so the capture-phase paste
+      // listener it installs is exercised by real events.
+      host = document.createElement('div');
+      document.body.appendChild(host);
+      renderHook(() => useXtermSingleton({ current: host }));
+      // setActiveSid is module-internal; the hook leaves activeSid at
+      // null until usePtyAttach wires it. Set it directly via the
+      // exported setter so the paste path is reachable.
+      setActiveSid('sid-1');
+    });
+
+    afterEach(() => {
+      document.body.removeChild(host);
+      delete (window as unknown as { ccsmPty?: unknown }).ccsmPty;
+    });
+
+    function makePasteEvent(text: string): ClipboardEvent {
+      // jsdom doesn't implement DataTransfer; we synthesize a minimal
+      // ClipboardEvent + clipboardData shim sufficient for the handler.
+      const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+      Object.defineProperty(evt, 'clipboardData', {
+        value: { getData: (type: string) => (type === 'text/plain' ? text : '') },
+      });
+      return evt;
+    }
+
+    it('Ctrl+V keydown injects clipboard text exactly once', () => {
+      const handler = getKeyHandler();
+      const ret = handler({ type: 'keydown', key: 'v', ctrlKey: true });
+      expect(ret).toBe(false);
+      expect(readTextSpy).toHaveBeenCalledTimes(1);
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+      expect(inputSpy).toHaveBeenCalledWith('sid-1', 'hello');
+    });
+
+    it('Cmd+V keydown injects clipboard text exactly once (macOS)', () => {
+      const handler = getKeyHandler();
+      const ret = handler({ type: 'keydown', key: 'v', metaKey: true });
+      expect(ret).toBe(false);
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+      expect(inputSpy).toHaveBeenCalledWith('sid-1', 'hello');
+    });
+
+    it('keydown-driven paste suppresses the follow-up native paste event', () => {
+      const handler = getKeyHandler();
+      handler({ type: 'keydown', key: 'v', ctrlKey: true });
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+
+      // The browser's native paste event arrives after our synchronous
+      // keydown handling. It must be swallowed, not turned into a second
+      // ccsmPty.input call.
+      const evt = makePasteEvent('hello');
+      host.dispatchEvent(evt);
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('right-click / context-menu paste (no preceding keydown) injects once', () => {
+      const evt = makePasteEvent('world');
+      host.dispatchEvent(evt);
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+      expect(inputSpy).toHaveBeenCalledWith('sid-1', 'world');
+      // xterm's built-in paste pipeline must not see the event.
+      expect(evt.defaultPrevented).toBe(true);
+    });
+
+    it('handoff flag clears so a later non-keyboard paste is not silently dropped', async () => {
+      const handler = getKeyHandler();
+      // Keyboard paste with NO follow-up native event (e.g. focus on
+      // canvas — browser doesn't dispatch paste to non-editable nodes).
+      handler({ type: 'keydown', key: 'v', ctrlKey: true });
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+
+      // Wait a microtask for the auto-reset.
+      await Promise.resolve();
+
+      // A later paste from a different source must still be delivered.
+      const evt = makePasteEvent('later');
+      host.dispatchEvent(evt);
+      expect(inputSpy).toHaveBeenCalledTimes(2);
+      expect(inputSpy).toHaveBeenLastCalledWith('sid-1', 'later');
+    });
+
+    it('Ctrl+V is a no-op when no active session', () => {
+      setActiveSid(null);
+      const handler = getKeyHandler();
+      handler({ type: 'keydown', key: 'v', ctrlKey: true });
+      expect(inputSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -250,8 +250,12 @@ describe('useXtermSingleton', () => {
       handler({ type: 'keydown', key: 'v', ctrlKey: true });
       expect(inputSpy).toHaveBeenCalledTimes(1);
 
-      // Wait a microtask for the auto-reset.
-      await Promise.resolve();
+      // Wait for the macrotask that resets the flag. We use setTimeout 0
+      // (not queueMicrotask) because the browser's native paste event
+      // arrives AFTER microtasks but BEFORE the next task tick, so a
+      // microtask reset would race the suppression. A real timer tick
+      // has to elapse for the reset to fire.
+      await new Promise((r) => setTimeout(r, 10));
 
       // A later paste from a different source must still be delivered.
       const evt = makePasteEvent('later');


### PR DESCRIPTION
## Summary
- v0.2.0 sent paste twice (custom Ctrl+V handler + xterm built-in pipeline both fired).
- v0.2.1 / v0.2.2 \"fixes\" both regressed to zero pastes — both based on wrong commit-message hypothesis (\"helper textarea isn't focused\") that did not match the actual cause.
- This PR reverts #1243 + #1249 back to v0.2.0 paste behavior, then re-fixes properly: treat the terminal pane as a single atomic unit with one canonical sink (\`ccsmPty.input\`), and remove Electron's accelerator-menu \`role:'paste'\` (which was actually intercepting Ctrl+V via \`webContents.paste()\` and bypassing the DOM entirely).
- Adds \`scripts/probe-paste-double-fire.mjs\` — Playwright-driven regression guard that counts \`pty:input\` IPC calls under real Ctrl+V; would have caught both prior failed fixes.

## Why v0.2.1 and v0.2.2 unit tests passed but the app broke

The unit tests mocked the entire xterm \`Terminal\` constructor — no real DOM, no real focus state, no real paste event dispatch. They asserted that a spy was called, not that paste actually reached the PTY. This PR adds real-DOM jsdom paste tests in \`tests/terminal/useXtermSingleton.test.tsx\` and the Playwright probe for the OS-clipboard path.

## Root cause (full)

There are **four** layers that can fire \`pty.write\` for a single Ctrl+V:
1. xterm.js keydown hook (\`attachCustomKeyEventHandler\`) → custom path → \`ccsmPty.input\`
2. xterm.js built-in paste pipeline (\`paste\` event on textarea/element → \`handlePasteEvent\` → \`triggerDataEvent\` → \`onData\` → \`ccsmPty.input\`)
3. Electron menu \`role: 'paste'\` → \`webContents.paste()\` (OS-level, bypasses DOM)
4. Browser-native \`paste\` event timing: dispatched **after** keydown handler returns but on the **next task tick**, not as a microtask

v0.2.0 hit (1)+(2) = 2 pastes. v0.2.1/v0.2.2 hit (3) silent no-op = 0 pastes. My first attempt in this PR (commit dc52a5ac) had a timing bug at layer (4) — a \`queueMicrotask\` flag-reset drained before the native paste arrived, so suppression failed → 2 pastes returned. Fixed in db9e7abf by switching to \`setTimeout(0)\`.

## Probe results

Real Playwright Ctrl+V on a seeded terminal session, patching \`ipcMain._invokeHandlers['pty:input']\` to count:

| Route | Before fix | After fix |
|---|---|---|
| Real Chromium Ctrl+V keydown | 2 | 1 |
| Synthetic \`paste\` ClipboardEvent | 1 | 1 |
| Combined keydown + paste | 1 | 1 |

## Test plan
- [x] \`npm test\` — 1303 passing, 21 pre-existing failures unrelated to this branch (electron-load-smoke needs \`dist/\`, db-hardening unrelated)
- [x] \`npm run typecheck\` — clean
- [x] \`node scripts/probe-paste-double-fire.mjs\` — all 3 routes = 1 call
- [x] Real-app dogfood by author: copy \"hello\", Ctrl+V → \"hello\" (was \"hellohello\")
- [ ] Reviewer reverse-verification (stash → re-run probe → expect Route A=2)

## Additional drive-by

\`chore(dev): isolate dev electron from installed ccsm\` (fa2f9fff): \`npm run dev\` now uses \`scripts/dev-electron.mjs\` wrapper that sets \`CCSM_E2E_NO_SINGLE_INSTANCE=1\` and \`--user-data-dir=.dev-userdata\`. Removes the friction of \"single-instance lock blocks dev when prod is open\" + \"dev and prod share the same SQLite DB\". This was needed to even reproduce the bug during this fix session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)