### PR TITLE
ci: nightly promote working → main + tag release

### DIFF
--- a/.github/workflows/daily-promote-release.yml
+++ b/.github/workflows/daily-promote-release.yml
@@ -1,0 +1,367 @@
+name: daily promote + release
+
+# Nightly automation: fast-forward working → main (via a real PR so
+# `check-source` runs), then tag the version in package.json on main if
+# that tag doesn't already exist. The tag push triggers release.yml.
+#
+# Design notes (locked decisions):
+#   1. We never invent a version. The tag is always `v$(package.json.version)`.
+#      Bumping package.json on `working` is the explicit "I want to release"
+#      signal. If the tag already exists, the workflow is a no-op for the
+#      release step.
+#   2. main has branch protection requiring the `check-source` status, which
+#      only fires on PRs from `working`. So we open a real PR and merge it
+#      via API. GitHub does NOT trigger required checks on PRs opened by
+#      GITHUB_TOKEN, so a `RELEASE_TOKEN` PAT is required in practice.
+#   3. CI workflows (ci.yml, e2e.yml) only trigger on `pull_request`, so the
+#      merge commit on `working` / `main` never has check-runs directly
+#      attached. We walk back via /commits/{sha}/pulls to find the PR that
+#      produced each tip and gate on that PR head SHA's check-runs.
+#
+# To disable temporarily: comment out the `schedule:` block below. Manual
+# runs still work via `workflow_dispatch`.
+#
+# To skip a single nightly: include `[skip-release]` in the working HEAD
+# commit message. Gates still run; promote + tag are skipped.
+
+on:
+  schedule:
+    # 18:00 UTC = 02:00 Beijing
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: daily-promote-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+  checks: read
+  statuses: read
+
+jobs:
+  promote-and-release:
+    name: promote working → main + tag
+    runs-on: ubuntu-latest
+    env:
+      OWNER: ${{ github.repository_owner }}
+      REPO: ${{ github.event.repository.name }}
+      # Prefer RELEASE_TOKEN (PAT) so the auto-opened PR fires required
+      # checks. Fall back to GITHUB_TOKEN for the read-only gates.
+      GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # We need RELEASE_TOKEN here too so the tag push later triggers
+          # release.yml (tags pushed by GITHUB_TOKEN don't trigger workflows).
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Verify RELEASE_TOKEN is configured
+        run: |
+          if [ -z "${{ secrets.RELEASE_TOKEN }}" ]; then
+            echo "::error title=RELEASE_TOKEN missing::This workflow requires a PAT named RELEASE_TOKEN. GITHUB_TOKEN cannot trigger required checks on auto-opened PRs, and tags pushed with GITHUB_TOKEN do not trigger release.yml. Create a fine-grained PAT with: contents:write + pull-requests:write on this repo, store as RELEASE_TOKEN secret."
+            exit 1
+          fi
+          echo "RELEASE_TOKEN present" >> "$GITHUB_STEP_SUMMARY"
+
+      # ---------------------------------------------------------------
+      # Gate 1: blocker labels
+      # ---------------------------------------------------------------
+      - name: Gate — blocker labels
+        id: blockers
+        run: |
+          set -euo pipefail
+          issues=$(gh issue list --repo "$OWNER/$REPO" --label blocker --state open --json number,title)
+          prs=$(gh pr list    --repo "$OWNER/$REPO" --label blocker --state open --json number,title)
+          n_issues=$(echo "$issues" | jq 'length')
+          n_prs=$(echo    "$prs"    | jq 'length')
+          total=$((n_issues + n_prs))
+          if [ "$total" -gt 0 ]; then
+            echo "blocked=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Gate: blockers — BLOCKED";
+              echo "$total open item(s) labeled \`blocker\`. Skipping run.";
+              echo '```json';
+              echo "issues: $issues";
+              echo "prs:    $prs";
+              echo '```';
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "blocked by $total items, skipping"
+          else
+            echo "blocked=false" >> "$GITHUB_OUTPUT"
+            echo "### Gate: blockers — OK (0 open)" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # All subsequent steps short-circuit when blocked. We use a per-step
+      # `if:` rather than `exit 0` so the run is visibly green-skip, not
+      # green-noop-but-claimed-done.
+
+      # ---------------------------------------------------------------
+      # Resolve tips
+      # ---------------------------------------------------------------
+      - name: Resolve working + main tips
+        id: tips
+        if: steps.blockers.outputs.blocked == 'false'
+        run: |
+          set -euo pipefail
+          working_sha=$(gh api "repos/$OWNER/$REPO/git/refs/heads/working" --jq '.object.sha')
+          main_sha=$(   gh api "repos/$OWNER/$REPO/git/refs/heads/main"    --jq '.object.sha')
+          echo "working_sha=$working_sha" >> "$GITHUB_OUTPUT"
+          echo "main_sha=$main_sha"       >> "$GITHUB_OUTPUT"
+          {
+            echo "### Tips";
+            echo "- working: \`$working_sha\`";
+            echo "- main:    \`$main_sha\`";
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      # ---------------------------------------------------------------
+      # Gates 2 + 3: CI green on working + main (via PR walkback)
+      # ---------------------------------------------------------------
+      # check_ci_via_pr.sh logic, inlined:
+      #   1. Look up PR(s) associated with the given commit SHA.
+      #   2. If none → fail loud ("no associated PR, refusing to promote").
+      #   3. Take the first (most recent) PR's head.sha and inspect its
+      #      check-runs. Pass iff every check-run conclusion is in
+      #      {success, neutral, skipped}. Anything else (failure, cancelled,
+      #      timed_out, action_required, stale, or status != completed) →
+      #      fail this gate.
+      - name: Gate — CI green on working tip
+        if: steps.blockers.outputs.blocked == 'false'
+        env:
+          SHA: ${{ steps.tips.outputs.working_sha }}
+          LABEL: working
+        run: |
+          set -euo pipefail
+          bash .github/workflows/scripts/check-ci-via-pr.sh "$SHA" "$LABEL"
+
+      - name: Gate — CI green on main tip
+        if: steps.blockers.outputs.blocked == 'false'
+        env:
+          SHA: ${{ steps.tips.outputs.main_sha }}
+          LABEL: main
+        run: |
+          set -euo pipefail
+          bash .github/workflows/scripts/check-ci-via-pr.sh "$SHA" "$LABEL"
+
+      # ---------------------------------------------------------------
+      # Skip-release detection
+      # ---------------------------------------------------------------
+      - name: Detect [skip-release] on working HEAD
+        id: skip
+        if: steps.blockers.outputs.blocked == 'false'
+        env:
+          SHA: ${{ steps.tips.outputs.working_sha }}
+        run: |
+          set -euo pipefail
+          msg=$(gh api "repos/$OWNER/$REPO/commits/$SHA" --jq '.commit.message')
+          if echo "$msg" | grep -qF '[skip-release]'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "### Skip-release flag detected on working HEAD — promote + tag will be skipped." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # ---------------------------------------------------------------
+      # Decide whether promote is needed
+      # ---------------------------------------------------------------
+      - name: Compare working vs main
+        id: cmp
+        if: steps.blockers.outputs.blocked == 'false' && steps.skip.outputs.skip == 'false'
+        env:
+          WORKING_SHA: ${{ steps.tips.outputs.working_sha }}
+          MAIN_SHA:    ${{ steps.tips.outputs.main_sha }}
+        run: |
+          set -euo pipefail
+          if [ "$WORKING_SHA" = "$MAIN_SHA" ]; then
+            echo "need_promote=false" >> "$GITHUB_OUTPUT"
+            echo "### Promote: not needed (working == main)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "need_promote=true" >> "$GITHUB_OUTPUT"
+            echo "### Promote: needed" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # ---------------------------------------------------------------
+      # Promote: open PR, wait for check-source, merge
+      # ---------------------------------------------------------------
+      - name: Open promote PR (working → main)
+        id: open_pr
+        if: steps.blockers.outputs.blocked == 'false' && steps.skip.outputs.skip == 'false' && steps.cmp.outputs.need_promote == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          WORKING_SHA: ${{ steps.tips.outputs.working_sha }}
+          MAIN_SHA:    ${{ steps.tips.outputs.main_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # Reuse an existing open PR working→main if present, else create.
+          existing=$(gh pr list --repo "$OWNER/$REPO" --base main --head working --state open --json number,url --jq '.[0]')
+          if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+            n=$(echo "$existing" | jq -r '.number')
+            url=$(echo "$existing" | jq -r '.url')
+            echo "Reusing existing PR #$n"
+          else
+            commits=$(git log --oneline "$MAIN_SHA..$WORKING_SHA" | head -50)
+            body_file=$(mktemp)
+            {
+              echo "Automated nightly promote.";
+              echo "";
+              echo "- Run: $RUN_URL";
+              echo "- working tip: \`$WORKING_SHA\`";
+              echo "- main tip:    \`$MAIN_SHA\`";
+              echo "";
+              echo "### Commits being promoted";
+              echo '```';
+              echo "$commits";
+              echo '```';
+            } > "$body_file"
+            url=$(gh pr create \
+              --repo "$OWNER/$REPO" \
+              --base main \
+              --head working \
+              --title "chore: promote working → main" \
+              --body-file "$body_file")
+            n=$(basename "$url")
+            echo "Opened PR #$n"
+          fi
+          echo "pr_number=$n"  >> "$GITHUB_OUTPUT"
+          echo "pr_url=$url"   >> "$GITHUB_OUTPUT"
+          echo "### Promote PR: [#$n]($url)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Wait for check-source on promote PR
+        if: steps.blockers.outputs.blocked == 'false' && steps.skip.outputs.skip == 'false' && steps.cmp.outputs.need_promote == 'true'
+        env:
+          PR_NUMBER: ${{ steps.open_pr.outputs.pr_number }}
+          TIMEOUT_SECONDS: '1200'  # 20 min
+        run: |
+          set -euo pipefail
+          # Get the PR head SHA, then poll its check-runs for "check-source".
+          head_sha=$(gh api "repos/$OWNER/$REPO/pulls/$PR_NUMBER" --jq '.head.sha')
+          echo "PR #$PR_NUMBER head: $head_sha"
+          deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+          while :; do
+            run=$(gh api "repos/$OWNER/$REPO/commits/$head_sha/check-runs?check_name=check-source" \
+              --jq '.check_runs[0] | {status, conclusion}')
+            status=$(echo "$run" | jq -r '.status // empty')
+            conclusion=$(echo "$run" | jq -r '.conclusion // empty')
+            echo "check-source: status=$status conclusion=$conclusion"
+            if [ "$status" = "completed" ]; then
+              case "$conclusion" in
+                success|neutral|skipped)
+                  echo "### check-source: PASS ($conclusion)" >> "$GITHUB_STEP_SUMMARY"
+                  exit 0
+                  ;;
+                *)
+                  echo "::error::check-source completed with conclusion=$conclusion"
+                  exit 1
+                  ;;
+              esac
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::Timed out waiting for check-source after ${TIMEOUT_SECONDS}s"
+              exit 1
+            fi
+            sleep 20
+          done
+
+      - name: Merge promote PR
+        id: merge_pr
+        if: steps.blockers.outputs.blocked == 'false' && steps.skip.outputs.skip == 'false' && steps.cmp.outputs.need_promote == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          PR_NUMBER: ${{ steps.open_pr.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          # Use --merge (true merge commit) per locked decision: preserve
+          # commit history. This matches the existing manual flow (see
+          # recent PR #1251 "release: catch main up").
+          gh pr merge "$PR_NUMBER" --repo "$OWNER/$REPO" --merge
+          new_main=$(gh api "repos/$OWNER/$REPO/git/refs/heads/main" --jq '.object.sha')
+          echo "new_main=$new_main" >> "$GITHUB_OUTPUT"
+          echo "### Merged: main is now \`$new_main\`" >> "$GITHUB_STEP_SUMMARY"
+
+      # ---------------------------------------------------------------
+      # Re-check CI on the new main tip (the merge commit itself has no
+      # checks, so walkback applies the same way).
+      # ---------------------------------------------------------------
+      - name: Wait + re-check CI on new main
+        if: steps.blockers.outputs.blocked == 'false' && steps.skip.outputs.skip == 'false' && steps.cmp.outputs.need_promote == 'true'
+        env:
+          NEW_MAIN: ${{ steps.merge_pr.outputs.new_main }}
+          TIMEOUT_SECONDS: '1800'  # 30 min
+        run: |
+          set -euo pipefail
+          deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
+          while :; do
+            # Find PR for this merge commit.
+            pr_head=$(gh api "repos/$OWNER/$REPO/commits/$NEW_MAIN/pulls" --jq '.[0].head.sha // empty')
+            if [ -z "$pr_head" ]; then
+              echo "PR association not yet indexed; waiting..."
+            else
+              # Pull all check-runs; require all completed and all in {success,neutral,skipped}.
+              runs=$(gh api --paginate "repos/$OWNER/$REPO/commits/$pr_head/check-runs" --jq '.check_runs[] | {name, status, conclusion}')
+              if [ -z "$runs" ]; then
+                echo "No check-runs yet on $pr_head; waiting..."
+              else
+                pending=$(echo "$runs" | jq -s '[.[] | select(.status != "completed")] | length')
+                bad=$(    echo "$runs" | jq -s '[.[] | select(.status == "completed") | select(.conclusion as $c | ["success","neutral","skipped"] | index($c) | not)] | length')
+                if [ "$bad" -gt 0 ]; then
+                  echo "::error::main CI has $bad failed check(s) on $pr_head"
+                  echo "$runs" | jq -s '.[] | select(.conclusion as $c | ["success","neutral","skipped"] | index($c) | not)'
+                  exit 1
+                fi
+                if [ "$pending" -eq 0 ]; then
+                  echo "### main CI: all checks green on \`$pr_head\`" >> "$GITHUB_STEP_SUMMARY"
+                  exit 0
+                fi
+                echo "$pending check(s) still pending; waiting..."
+              fi
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "::error::Timed out waiting for main CI after ${TIMEOUT_SECONDS}s"
+              exit 1
+            fi
+            sleep 30
+          done
+
+      # ---------------------------------------------------------------
+      # Release: tag v<package.json.version> on main if missing
+      # ---------------------------------------------------------------
+      - name: Tag release if package.json version is new
+        if: steps.blockers.outputs.blocked == 'false' && steps.skip.outputs.skip == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        run: |
+          set -euo pipefail
+          # Sync local main to remote.
+          git fetch origin main --tags --quiet
+          main_sha=$(gh api "repos/$OWNER/$REPO/git/refs/heads/main" --jq '.object.sha')
+          version=$(git show "$main_sha:package.json" | jq -r '.version')
+          tag="v$version"
+          echo "main: $main_sha  package.json.version: $version  tag: $tag"
+
+          if gh api "repos/$OWNER/$REPO/git/ref/tags/$tag" >/dev/null 2>&1; then
+            {
+              echo "### Release: nothing to release";
+              echo "Tag \`$tag\` already exists. Bump \`package.json\` on \`working\` to cut a new release.";
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          # Create an annotated tag object via API on the main SHA.
+          tag_obj=$(gh api -X POST "repos/$OWNER/$REPO/git/tags" \
+            -f tag="$tag" \
+            -f message="Release $tag" \
+            -f object="$main_sha" \
+            -f type=commit \
+            --jq '.sha')
+          gh api -X POST "repos/$OWNER/$REPO/git/refs" \
+            -f ref="refs/tags/$tag" \
+            -f sha="$tag_obj" >/dev/null
+          {
+            echo "### Release: tagged \`$tag\` on \`$main_sha\`";
+            echo "release.yml will run next.";
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/scripts/check-ci-via-pr.sh
+++ b/.github/workflows/scripts/check-ci-via-pr.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# check-ci-via-pr.sh — gate "CI green at commit SHA" by walking back to the
+# PR that produced that commit, then inspecting the PR head SHA's
+# check-runs. Required because ci.yml / e2e.yml only trigger on
+# pull_request, so the merge commit on working/main itself never has
+# check-runs directly attached.
+#
+# Usage: check-ci-via-pr.sh <commit-sha> <label-for-summary>
+#
+# Pass iff every check-run on the PR head is completed AND conclusion in
+# {success, neutral, skipped}. Anything else (failure, cancelled,
+# timed_out, action_required, stale, or status != completed) → exit 1.
+#
+# If the commit has no associated PR, exit 1 with a clear message — per
+# locked decision: "refuse to promote" rather than silently passing.
+#
+# Env: OWNER, REPO, GH_TOKEN must be set by the caller.
+
+set -euo pipefail
+
+sha="${1:?sha required}"
+label="${2:?label required}"
+
+if [ -z "${OWNER:-}" ] || [ -z "${REPO:-}" ]; then
+  echo "::error::OWNER and REPO env vars required"
+  exit 2
+fi
+
+echo "Gate CI for $label at $sha"
+
+# /commits/{sha}/pulls returns PRs whose head OR merge_commit_sha matches.
+# We take the first; for a merge commit on working/main, that's the PR
+# that produced this commit.
+pr_json=$(gh api "repos/$OWNER/$REPO/commits/$sha/pulls" --jq '.[0] // empty')
+
+if [ -z "$pr_json" ]; then
+  {
+    echo "### Gate: CI on $label — REFUSE";
+    echo "Commit \`$sha\` has no associated PR. Refusing to promote (someone pushed directly to the branch).";
+  } >> "$GITHUB_STEP_SUMMARY"
+  echo "::error::No PR associated with $sha on $label — refusing to promote"
+  exit 1
+fi
+
+pr_number=$(echo "$pr_json" | jq -r '.number')
+pr_head=$(  echo "$pr_json" | jq -r '.head.sha')
+echo "Associated PR #$pr_number, head $pr_head"
+
+# Pull all check-runs (paginated) for the PR head SHA.
+runs=$(gh api --paginate "repos/$OWNER/$REPO/commits/$pr_head/check-runs" \
+  --jq '.check_runs[] | {name, status, conclusion}')
+
+if [ -z "$runs" ]; then
+  {
+    echo "### Gate: CI on $label — FAIL";
+    echo "No check-runs found on PR #$pr_number head \`$pr_head\`.";
+  } >> "$GITHUB_STEP_SUMMARY"
+  echo "::error::No check-runs on $pr_head"
+  exit 1
+fi
+
+# Anything not completed, or completed with a conclusion not in the pass
+# set, fails the gate.
+bad=$(echo "$runs" | jq -s '
+  [ .[]
+    | select( (.status != "completed")
+           or ( .conclusion as $c
+                | (["success","neutral","skipped"] | index($c)) | not ) )
+  ]
+')
+bad_count=$(echo "$bad" | jq 'length')
+
+if [ "$bad_count" -gt 0 ]; then
+  {
+    echo "### Gate: CI on $label — FAIL";
+    echo "PR #$pr_number head \`$pr_head\` has $bad_count bad check-run(s):";
+    echo '```json';
+    echo "$bad" | jq '.';
+    echo '```';
+  } >> "$GITHUB_STEP_SUMMARY"
+  echo "::error::CI gate failed on $label (PR #$pr_number)"
+  echo "$bad" | jq '.'
+  exit 1
+fi
+
+total=$(echo "$runs" | jq -s 'length')
+{
+  echo "### Gate: CI on $label — OK";
+  echo "PR #$pr_number head \`$pr_head\`: all $total check-run(s) passed.";
+} >> "$GITHUB_STEP_SUMMARY"
+echo "OK: $total check-runs all green on $label"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/daily-promote-release.yml`: a nightly automation that fast-forwards `working` → `main` (via a real PR, so `check-source` runs) and tags the version in `package.json` on `main` if that tag doesn't already exist. Tag push triggers the existing `release.yml`.

Runs at **18:00 UTC = 02:00 Beijing**, plus `workflow_dispatch` for manual runs.

## Locked design decisions

1. **Tag from `package.json`, never invent.** The workflow reads `main:package.json.version` and tags `v<version>`. If that tag already exists → no-op release. Bumping `package.json` on `working` is the explicit "cut a release" signal. No auto-bump, no `release.yml` change (its `tag == pkg.version` guard stays intact).
2. **Promote via real PR.** `main` branch protection requires `check-source`, which only fires on PRs from `working`. The workflow opens `chore: promote working → main`, polls for `check-source` (≤20 min), then `gh pr merge --merge` (preserve history, matches existing manual flow like PR #1251).
3. **CI gate via PR walkback.** `ci.yml`/`e2e.yml` only trigger on `pull_request`, so merge commits on `working`/`main` have zero check-runs. The gate looks up `/commits/{sha}/pulls` to find the originating PR, then checks that PR's head SHA's check-runs. Pass set: `{success, neutral, skipped}`. No associated PR → refuse to promote (loud failure).

## Gate order

1. blocker-label scan → hit = exit 0 (skip, **not** failure)
2. CI green on working (walkback)
3. CI green on main (walkback)
4. `[skip-release]` in working HEAD → skip steps 5–7
5. If `working == main` → skip promote, jump to step 7
6. Open PR → wait for `check-source` → merge
7. Re-poll all check-runs on new main (≤30 min); any failure → abort, don't tag
8. Tag `v<pkg.version>` if missing, else no-op

## Required setup: `RELEASE_TOKEN` secret

`GITHUB_TOKEN` is insufficient because:
- PRs opened by `GITHUB_TOKEN` don't trigger required workflows → `check-source` would never run.
- Tags pushed by `GITHUB_TOKEN` don't trigger workflows → `release.yml` would never run.

Create a fine-grained PAT on `Jiahui-Gu/ccsm` with `Contents: write` + `Pull requests: write`, store as repo secret `RELEASE_TOKEN`. The workflow fails fast with a clear message if it's missing.

## How to disable / control

- **Disable temporarily:** comment out the `schedule:` block. `workflow_dispatch` still works.
- **Disable for one night:** include `[skip-release]` in the working HEAD commit message. Gates still run; promote + tag are skipped.
- **Manual trigger:** `gh workflow run daily-promote-release.yml` (or the Actions UI).
- **Pause for blockers:** label any open issue/PR with `blocker`. Workflow logs and exits 0.

## Dry-run findings (against current repo state)

- working tip `e03a3700` → walks back to PR #1252, head `77012fb5`, check-runs: 6 success + 1 failure (`e2e (ubuntu-latest)`). **Gate would correctly fail today** because the most recent merged PR has a red e2e job.
- main tip `b0f9b488` → walks back to PR #1251.
- `main:package.json.version` = `0.2.3`; tag `v0.2.3` exists → release step would no-op.

## Test plan

- [ ] Add `RELEASE_TOKEN` secret to the repo before the first scheduled run.
- [ ] After merge, trigger once manually: `gh workflow run daily-promote-release.yml`.
- [ ] Verify the run: blocker gate logs `0 open`, walkback resolves to PR #1252, gate fails on the e2e red (expected — needs the e2e flake resolved first).
- [ ] After e2e is green on a future working tip, re-trigger and watch a full happy-path run (promote PR opens, `check-source` passes, merge succeeds, re-check polls main, then no-op tag because no version bump).
- [ ] Bump `package.json` on `working` and verify next nightly cuts a real tag.