### PR TITLE
fix(close-dialog): in-app modal replaces native Windows confirm

### DIFF
--- a/electron/i18n.ts
+++ b/electron/i18n.ts
@@ -41,6 +41,7 @@ type CloseDialogCatalog = {
   detail: string;
   tray: string;
   quit: string;
+  cancel: string;
   dontAskAgain: string;
 };
 
@@ -133,6 +134,7 @@ const closeDialogCatalogs: Record<SupportedLanguage, CloseDialogCatalog> = {
       'Minimize to tray keeps ccsm running so notifications and background sessions stay active.',
     tray: 'Minimize to tray',
     quit: 'Quit',
+    cancel: 'Cancel',
     dontAskAgain: "Don't ask again"
   },
   zh: {
@@ -141,6 +143,7 @@ const closeDialogCatalogs: Record<SupportedLanguage, CloseDialogCatalog> = {
       '最小化到托盘会让 ccsm 继续运行，通知和后台会话保持活跃。',
     tray: '最小化到托盘',
     quit: '退出',
+    cancel: '取消',
     dontAskAgain: '不再询问'
   }
 };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -142,6 +142,7 @@ function createWindow(): BrowserWindow {
     setIsQuitting: (v) => {
       isQuitting = v;
     },
+    ipcMain,
   });
 }
 

--- a/electron/preload/bridges/ccsmCore.ts
+++ b/electron/preload/bridges/ccsmCore.ts
@@ -162,6 +162,65 @@ const api = {
       ipcRenderer.on('window:afterShow', wrap);
       return () => ipcRenderer.removeListener('window:afterShow', wrap);
     },
+    /**
+     * Main fires `window:askCloseAction` when the user clicks the window X
+     * (or Ctrl+W / menu Close) AND their close-action preference is 'ask'.
+     * Renderer opens the in-app CloseActionDialog with the supplied labels
+     * (translated on main, passed through to keep the renderer i18n catalog
+     * free of duplicate strings) and the request id, then calls
+     * `resolveCloseAction` with the user's choice. Replaces the native
+     * `dialog.showMessageBox` window (#1253).
+     *
+     * If no resolveCloseAction call arrives within 10s, main falls back to
+     * hide-to-tray without persisting a pref. See `CLOSE_ASK_TIMEOUT_MS`.
+     */
+    onAskCloseAction: (
+      handler: (payload: {
+        requestId: string;
+        labels: {
+          message: string;
+          detail: string;
+          tray: string;
+          quit: string;
+          cancel: string;
+          dontAskAgain: string;
+        };
+      }) => void,
+    ): (() => void) => {
+      const wrap = (
+        _e: IpcRendererEvent,
+        payload: {
+          requestId: string;
+          labels: {
+            message: string;
+            detail: string;
+            tray: string;
+            quit: string;
+            cancel: string;
+            dontAskAgain: string;
+          };
+        },
+      ) => handler(payload);
+      ipcRenderer.on('window:askCloseAction', wrap);
+      return () => ipcRenderer.removeListener('window:askCloseAction', wrap);
+    },
+    /**
+     * Renderer's reply to the latest `window:askCloseAction` ping. The
+     * requestId pairs the reply with main's in-flight ask so a stale
+     * reply from a previous (timed-out) ask is ignored. `'cancel'` never
+     * persists, even when `dontAskAgain` is true — see
+     * `decideCloseAction` in electron/window/createWindow.ts.
+     *
+     * Uses `send` (one-way) rather than `invoke` because main does not
+     * need to ack; main acts on the choice unilaterally.
+     */
+    resolveCloseAction: (payload: {
+      requestId: string;
+      choice: 'tray' | 'quit' | 'cancel';
+      dontAskAgain: boolean;
+    }): void => {
+      ipcRenderer.send('window:resolveCloseAction', payload);
+    },
     platform: process.platform
   },
 };

--- a/electron/window/__tests__/createWindow.test.ts
+++ b/electron/window/__tests__/createWindow.test.ts
@@ -15,7 +15,7 @@ vi.mock('electron', () => {
   return { Menu };
 });
 
-import { installContextMenu, isAllowedNavigation } from '../createWindow';
+import { installContextMenu, isAllowedNavigation, decideCloseAction } from '../createWindow';
 
 interface ContextMenuParams {
   selectionText: string;
@@ -182,5 +182,61 @@ describe('isAllowedNavigation (#804 risk #7)', () => {
   it('blocks other protocols (javascript:, data:)', () => {
     expect(isAllowedNavigation('javascript:alert(1)', '4100')).toBe(false);
     expect(isAllowedNavigation('data:text/html,<script>x</script>', '4100')).toBe(false);
+  });
+});
+
+// #1253: the in-app close dialog routes the user's choice back to main as
+// `{choice, dontAskAgain}`. `decideCloseAction` is the pure mapping
+// from that response → {action, persist}. Locked semantics:
+//   * 'cancel' NEVER persists, even when dontAskAgain is checked —
+//     cancelling must never trap the user into a pref they can't undo.
+//   * 'tray' / 'quit' + dontAskAgain → persist that choice as the new
+//     close-action preference.
+describe('decideCloseAction (#1253)', () => {
+  it('tray + dontAskAgain off → tray action, no persist', () => {
+    expect(decideCloseAction({ choice: 'tray', dontAskAgain: false })).toEqual({
+      action: 'tray',
+      persist: null,
+    });
+  });
+
+  it('tray + dontAskAgain on → tray action, persist tray', () => {
+    expect(decideCloseAction({ choice: 'tray', dontAskAgain: true })).toEqual({
+      action: 'tray',
+      persist: 'tray',
+    });
+  });
+
+  it('quit + dontAskAgain off → quit action, no persist', () => {
+    expect(decideCloseAction({ choice: 'quit', dontAskAgain: false })).toEqual({
+      action: 'quit',
+      persist: null,
+    });
+  });
+
+  it('quit + dontAskAgain on → quit action, persist quit', () => {
+    expect(decideCloseAction({ choice: 'quit', dontAskAgain: true })).toEqual({
+      action: 'quit',
+      persist: 'quit',
+    });
+  });
+
+  it('cancel + dontAskAgain off → cancel action, no persist', () => {
+    expect(decideCloseAction({ choice: 'cancel', dontAskAgain: false })).toEqual({
+      action: 'cancel',
+      persist: null,
+    });
+  });
+
+  it('cancel + dontAskAgain ON → cancel action, STILL no persist', () => {
+    // The "never trap the user" rule. A user who hits Cancel and ticks
+    // the box at the same time has given contradictory signals; we
+    // discard the tick. Persisting 'cancel' would be meaningless anyway
+    // (no such close-pref value), but the broader policy also forbids
+    // persisting any pref on the cancel path.
+    expect(decideCloseAction({ choice: 'cancel', dontAskAgain: true })).toEqual({
+      action: 'cancel',
+      persist: null,
+    });
   });
 });

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -25,16 +25,18 @@ import {
   BrowserWindow,
   Menu,
   app,
-  dialog,
   type MenuItemConstructorOptions,
+  type IpcMain,
 } from 'electron';
 import * as path from 'path';
+import { randomUUID } from 'crypto';
 import { buildAppIcon } from '../branding/icon';
 import {
   type CloseAction,
   getCloseAction,
   setCloseAction,
 } from '../prefs/closeAction';
+import { tCloseDialog } from '../i18n';
 
 export interface CreateWindowDeps {
   /** True iff we should load the webpack-dev-server URL instead of the
@@ -53,6 +55,11 @@ export interface CreateWindowDeps {
   /** Flip `isQuitting` to true when the user picks "quit" in the
    *  close-action dialog or sets the persisted preference to 'quit'. */
   setIsQuitting: (v: boolean) => void;
+  /** Shared `ipcMain`. createWindow registers the `window:resolveCloseAction`
+   *  handler here so the renderer's in-app close dialog can route its
+   *  choice back to the window that asked. Same instance the rest of
+   *  electron/ipc/* uses. */
+  ipcMain: IpcMain;
 }
 
 // Pure decider for the `will-navigate` allowlist (#804 risk #7). Allows the
@@ -98,6 +105,51 @@ export function installContextMenu(win: BrowserWindow): void {
     menu.popup({ window: win });
   });
 }
+
+// Pure decider for the close-action dialog response. Given the user's
+// choice + dontAskAgain checkbox, returns:
+//   - `action`: what main should DO right now ('tray' | 'quit' | 'cancel').
+//   - `persist`: which preference (if any) to persist via setCloseAction.
+//
+// Locked semantics (#1253):
+//   * cancel NEVER persists, even when dontAskAgain is checked. Persisting
+//     'cancel' is meaningless (there's no 'cancel' close-pref), and we
+//     refuse to trap the user — if they cancel + tick the box, treat the
+//     tick as discarded.
+//   * tray/quit + dontAskAgain → persist that choice as the new pref.
+//   * tray/quit alone → no persistence; act once.
+// Pure so it can be unit-tested without booting Electron.
+export type CloseDialogChoice = 'tray' | 'quit' | 'cancel';
+
+export interface CloseDialogResponse {
+  choice: CloseDialogChoice;
+  dontAskAgain: boolean;
+}
+
+export interface CloseDialogDecision {
+  action: CloseDialogChoice;
+  persist: CloseAction | null;
+}
+
+export function decideCloseAction(
+  response: CloseDialogResponse,
+): CloseDialogDecision {
+  if (response.choice === 'cancel') {
+    return { action: 'cancel', persist: null };
+  }
+  return {
+    action: response.choice,
+    persist: response.dontAskAgain ? response.choice : null,
+  };
+}
+
+// Default fallback when the renderer never responds to a
+// `window:askCloseAction` request (renderer hung, dialog crashed, IPC
+// dropped). Locked to 'tray' on every platform: it's the non-destructive
+// option (user can quit explicitly via tray menu) and matches the macOS
+// default. Never persists. 10s window matches generous human reaction
+// time without leaving the close X feeling completely dead.
+export const CLOSE_ASK_TIMEOUT_MS = 10_000;
 
 export function createWindow(deps: CreateWindowDeps): BrowserWindow {
   // E2E hidden mode: when CCSM_E2E_HIDDEN=1 the window is created
@@ -268,9 +320,11 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
   //   'quit' → don't preventDefault; let the window close, fall through to
   //            window-all-closed → before-quit → app exit.
   //   'tray' → preventDefault + fade-to-hide (the original behaviour).
-  //   'ask'  → preventDefault + native dialog with a "Don't ask again"
-  //            checkbox; on confirm we persist the choice via setCloseAction
-  //            so the next click goes straight to that branch.
+  //   'ask'  → preventDefault + in-app modal (rendered by the renderer's
+  //            CloseActionDialog) over IPC. The user picks tray / quit /
+  //            cancel + optional "Don't ask again"; renderer answers via
+  //            `window:resolveCloseAction`. Replaces the ugly native
+  //            `dialog.showMessageBox` (#1253).
   // The `isQuitting` short-circuit at the top stays so explicit quit paths
   // (tray menu Quit, app.before-quit safety net, electron-builder updater)
   // bypass everything.
@@ -298,6 +352,54 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
       win.hide();
     }, HIDE_FADE_MS);
   };
+
+  // In-flight close-ask request. While a request is pending, subsequent
+  // `win.on('close')` fires are coalesced — we don't open a second dialog
+  // on top of the first. Cleared on resolve / timeout / window destroy.
+  let pendingAsk: {
+    requestId: string;
+    timer: NodeJS.Timeout;
+  } | null = null;
+
+  // Apply the renderer's decision (or the timeout fallback). Centralised
+  // so the IPC handler and the timeout path share one branching tree.
+  const applyCloseDecision = (response: CloseDialogResponse) => {
+    const decision = decideCloseAction(response);
+    if (decision.persist) setCloseAction(decision.persist);
+    if (decision.action === 'tray') {
+      fadeThenHide();
+      return;
+    }
+    if (decision.action === 'quit') {
+      deps.setIsQuitting(true);
+      app.quit();
+      return;
+    }
+    // 'cancel' — nothing to do. The window stays open because
+    // `e.preventDefault()` already ran.
+  };
+
+  // Renderer reply handler. Registered once per window; the requestId in
+  // the payload pairs it with the in-flight request so stale replies from
+  // a previous (timed-out) ask are ignored.
+  const resolveHandler = (
+    _e: unknown,
+    payload: { requestId: string; choice: CloseDialogChoice; dontAskAgain: boolean },
+  ) => {
+    if (!pendingAsk || pendingAsk.requestId !== payload.requestId) return;
+    clearTimeout(pendingAsk.timer);
+    pendingAsk = null;
+    applyCloseDecision({ choice: payload.choice, dontAskAgain: payload.dontAskAgain });
+  };
+  deps.ipcMain.on('window:resolveCloseAction', resolveHandler);
+  win.on('closed', () => {
+    deps.ipcMain.removeListener('window:resolveCloseAction', resolveHandler);
+    if (pendingAsk) {
+      clearTimeout(pendingAsk.timer);
+      pendingAsk = null;
+    }
+  });
+
   win.on('close', (e) => {
     if (deps.getIsQuitting()) return;
     const pref = getCloseAction();
@@ -310,41 +412,47 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
       fadeThenHide();
       return;
     }
-    // pref === 'ask': prompt once. Showing the dialog is async, but
-    // preventDefault has already kept the window alive; we run the dialog
-    // and act on the user's choice in the resolved promise.
-    void (async () => {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const i18n = require('../i18n') as typeof import('../i18n');
-      let result: { response: number; checkboxChecked: boolean };
-      try {
-        result = await dialog.showMessageBox(win, {
-          type: 'question',
-          buttons: [i18n.tCloseDialog('tray'), i18n.tCloseDialog('quit')],
-          defaultId: 0,
-          cancelId: 0,
-          message: i18n.tCloseDialog('message'),
-          detail: i18n.tCloseDialog('detail'),
-          checkboxLabel: i18n.tCloseDialog('dontAskAgain'),
-          checkboxChecked: false,
+    // pref === 'ask': open the in-app dialog over IPC. If a request is
+    // already in flight, coalesce — don't stack dialogs.
+    if (pendingAsk) return;
+    const requestId = randomUUID();
+    const timer = setTimeout(() => {
+      if (!pendingAsk || pendingAsk.requestId !== requestId) return;
+      pendingAsk = null;
+      console.warn(
+        '[main] close-action dialog timed out; falling back to tray',
+      );
+      applyCloseDecision({ choice: 'tray', dontAskAgain: false });
+    }, CLOSE_ASK_TIMEOUT_MS);
+    pendingAsk = { requestId, timer };
+    try {
+      if (!win.webContents.isDestroyed()) {
+        win.webContents.send('window:askCloseAction', {
+          requestId,
+          labels: {
+            message: tCloseDialog('message'),
+            detail: tCloseDialog('detail'),
+            tray: tCloseDialog('tray'),
+            quit: tCloseDialog('quit'),
+            cancel: tCloseDialog('cancel'),
+            dontAskAgain: tCloseDialog('dontAskAgain'),
+          },
         });
-      } catch (err) {
-        console.warn(
-          '[main] close-action dialog failed; falling back to tray',
-          err,
-        );
-        fadeThenHide();
-        return;
-      }
-      const choice: CloseAction = result.response === 0 ? 'tray' : 'quit';
-      if (result.checkboxChecked) setCloseAction(choice);
-      if (choice === 'tray') {
-        fadeThenHide();
       } else {
-        deps.setIsQuitting(true);
-        app.quit();
+        // Renderer is gone — fall straight to tray with no persistence.
+        clearTimeout(timer);
+        pendingAsk = null;
+        applyCloseDecision({ choice: 'tray', dontAskAgain: false });
       }
-    })();
+    } catch (err) {
+      clearTimeout(timer);
+      pendingAsk = null;
+      console.warn(
+        '[main] close-action dialog send failed; falling back to tray',
+        err,
+      );
+      applyCloseDecision({ choice: 'tray', dontAskAgain: false });
+    }
   });
 
   // After the window is shown again (tray click, dock click on macOS) the

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,11 @@ import { ImportDialog } from './components/ImportDialog';
 import { ShortcutOverlay } from './components/ShortcutOverlay';
 import { DragRegion, WindowControls } from './components/WindowControls';
 import { InstallerCorruptBanner } from './components/InstallerCorruptBanner';
+import {
+  CloseActionDialog,
+  type CloseActionLabels,
+  type CloseDialogChoice,
+} from './components/CloseActionDialog';
 import { useStore } from './stores/store';
 import { initI18n } from './i18n';
 import { useTranslation } from './i18n/useTranslation';
@@ -94,6 +99,31 @@ export default function App() {
   const [paletteOpen, setPaletteOpen] = React.useState(false);
   const [importOpen, setImportOpen] = React.useState(false);
   const [shortcutsOpen, setShortcutsOpen] = React.useState(false);
+
+  // In-app close dialog (#1253): main emits `window:askCloseAction`
+  // when the user clicks the X with pref='ask'. We open
+  // CloseActionDialog, then reply via `resolveCloseAction`. Labels come
+  // from the IPC payload (translated on main) so the renderer i18n
+  // catalog doesn't duplicate the strings.
+  const [closeAsk, setCloseAsk] = React.useState<{
+    open: boolean;
+    requestId: string;
+    labels: CloseActionLabels;
+  } | null>(null);
+  useEffect(() => {
+    const bridge = window.ccsm?.window;
+    if (!bridge?.onAskCloseAction) return;
+    return bridge.onAskCloseAction((payload) => {
+      // Coalesce: if a dialog is already open, ignore the new request.
+      // Main has its own pending-ask gate so this is belt-and-suspenders,
+      // but if it ever drifts the user shouldn't see two stacked dialogs.
+      setCloseAsk((prev) =>
+        prev?.open
+          ? prev
+          : { open: true, requestId: payload.requestId, labels: payload.labels }
+      );
+    });
+  }, []);
 
   // ---- Extracted effect hooks (Task #732 Phase B + Task #758 Phase C) ----
   // Theme application — reactive to user choice + (when system) OS scheme.
@@ -308,12 +338,40 @@ export default function App() {
   // blank white window during sqlite hydration. See AppSkeleton (#584).
   // The first-run/empty CTA branch below is reserved for when we're
   // CERTAIN there are no persisted sessions (i.e. hydrated === true).
+  //
+  // Both return branches mount <CloseActionDialog/> because Ctrl+W / menu
+  // Close can fire during the hydrate window — we still need to answer
+  // main with SOME choice so its pending-ask gate clears.
+  const handleCloseResolve = React.useCallback(
+    (result: { choice: CloseDialogChoice; dontAskAgain: boolean }) => {
+      const ask = closeAsk;
+      if (!ask) return;
+      window.ccsm?.window?.resolveCloseAction?.({
+        requestId: ask.requestId,
+        choice: result.choice,
+        dontAskAgain: result.dontAskAgain,
+      });
+    },
+    [closeAsk]
+  );
+  const closeActionDialog = (
+    <CloseActionDialog
+      open={!!closeAsk?.open}
+      onOpenChange={(next) => {
+        setCloseAsk((prev) => (prev ? { ...prev, open: next } : prev));
+      }}
+      labels={closeAsk?.labels ?? null}
+      onResolve={handleCloseResolve}
+    />
+  );
+
   if (!active && !hydrated) {
     return (
       <TooltipProvider delayDuration={400} skipDelayDuration={100}>
         <ToastProvider>
           <AppEffectsBridge />
           <AppSkeleton />
+          {closeActionDialog}
         </ToastProvider>
       </TooltipProvider>
     );
@@ -387,6 +445,7 @@ export default function App() {
           onFocusGroup={focusGroup}
         />
         <ShortcutOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
+        {closeActionDialog}
       </ToastProvider>
     </TooltipProvider>
   );

--- a/src/components/CloseActionDialog.tsx
+++ b/src/components/CloseActionDialog.tsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useId, useRef, useState } from 'react';
+import { Dialog, DialogContent, DialogBody, DialogFooter } from './ui/Dialog';
+import { Button } from './ui/Button';
+
+/**
+ * In-app replacement (#1253) for the previous native
+ * `dialog.showMessageBox` shown the first time the user clicks the
+ * window X with their close-pref still on 'ask'. Three buttons +
+ * "Don't ask again" checkbox, exactly mirroring the old semantics.
+ *
+ * Strings arrive in `labels` from main (translated via `tCloseDialog`)
+ * rather than from the renderer i18n catalog, to avoid duplicating
+ * close-dialog copy in two locales and keep main as the single source
+ * of truth for OS-language-sensitive surfaces.
+ *
+ * Choice contract (locked, see `decideCloseAction`):
+ *   - 'tray'   → hide window; persist 'tray' iff dontAskAgain.
+ *   - 'quit'   → app.quit;    persist 'quit' iff dontAskAgain.
+ *   - 'cancel' → no-op;       NEVER persists, even when dontAskAgain
+ *                is checked. Cancelling must never trap the user.
+ *
+ * Every dismiss path (Esc, outside click, X button) is treated as
+ * 'cancel'. We must always answer main with SOME choice so main can
+ * clear its pending-ask state and the user's next click on the X
+ * isn't silently swallowed by the in-flight gate.
+ */
+export type CloseDialogChoice = 'tray' | 'quit' | 'cancel';
+
+export interface CloseActionLabels {
+  message: string;
+  detail: string;
+  tray: string;
+  quit: string;
+  cancel: string;
+  dontAskAgain: string;
+}
+
+export interface CloseActionDialogProps {
+  open: boolean;
+  /** Caller-driven; we call onResolve THEN onOpenChange(false). */
+  onOpenChange: (next: boolean) => void;
+  labels: CloseActionLabels | null;
+  /**
+   * Fires exactly once per open with the user's choice. The caller is
+   * responsible for forwarding the choice to main via
+   * `window.ccsm.window.resolveCloseAction`.
+   */
+  onResolve: (result: { choice: CloseDialogChoice; dontAskAgain: boolean }) => void;
+}
+
+export function CloseActionDialog({
+  open,
+  onOpenChange,
+  labels,
+  onResolve,
+}: CloseActionDialogProps) {
+  const [dontAskAgain, setDontAskAgain] = useState(false);
+  const checkboxId = useId();
+  // Default focus lands on the safer "Minimize to tray" button — quitting
+  // is the destructive option, and Enter on a freshly-shown dialog
+  // shouldn't kill the app.
+  const trayRef = useRef<HTMLButtonElement>(null);
+  // Distinguish a "user picked something" close from an Esc/X/outside
+  // close so we only fire onResolve once per open.
+  const resolvedRef = useRef(false);
+
+  useEffect(() => {
+    if (!open) return;
+    resolvedRef.current = false;
+    setDontAskAgain(false);
+    // Delay focus so the dialog entrance animation lands before the focus
+    // ring snaps in — matches ConfirmDialog's timing.
+    const t = window.setTimeout(() => trayRef.current?.focus(), 150);
+    return () => window.clearTimeout(t);
+  }, [open]);
+
+  const pick = (choice: CloseDialogChoice) => {
+    if (resolvedRef.current) return;
+    resolvedRef.current = true;
+    // 'cancel' never persists, even when the checkbox is on. Surface the
+    // raw user input here; the main-side decider enforces the policy.
+    onResolve({ choice, dontAskAgain });
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !resolvedRef.current) {
+          // Esc / X / outside click — treat as Cancel so main clears its
+          // pending-ask gate and the user can click X again.
+          resolvedRef.current = true;
+          onResolve({ choice: 'cancel', dontAskAgain });
+        }
+        onOpenChange(next);
+      }}
+    >
+      <DialogContent
+        title={labels?.message ?? ''}
+        description={labels?.detail ?? ''}
+        width="460px"
+        data-testid="close-action-dialog"
+      >
+        <DialogBody>
+          <label
+            className="flex items-center gap-2 text-chrome text-fg-secondary select-none cursor-pointer"
+            htmlFor={checkboxId}
+          >
+            <input
+              id={checkboxId}
+              type="checkbox"
+              className="size-3.5 accent-[var(--color-accent)] cursor-pointer"
+              checked={dontAskAgain}
+              onChange={(e) => setDontAskAgain(e.target.checked)}
+              data-testid="close-action-dontask"
+            />
+            <span>{labels?.dontAskAgain ?? ''}</span>
+          </label>
+        </DialogBody>
+        <DialogFooter>
+          <Button
+            variant="ghost"
+            size="md"
+            onClick={() => pick('cancel')}
+            data-testid="close-action-cancel"
+          >
+            {labels?.cancel ?? ''}
+          </Button>
+          <Button
+            variant="danger"
+            size="md"
+            onClick={() => pick('quit')}
+            data-testid="close-action-quit"
+          >
+            {labels?.quit ?? ''}
+          </Button>
+          <Button
+            ref={trayRef}
+            variant="primary"
+            size="md"
+            onClick={() => pick('tray')}
+            data-testid="close-action-tray"
+          >
+            {labels?.tray ?? ''}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -104,6 +104,24 @@ declare global {
         onMaximizedChanged: (handler: (max: boolean) => void) => () => void;
         onBeforeHide: (handler: (info: { durationMs: number }) => void) => () => void;
         onAfterShow: (handler: () => void) => () => void;
+        onAskCloseAction: (
+          handler: (payload: {
+            requestId: string;
+            labels: {
+              message: string;
+              detail: string;
+              tray: string;
+              quit: string;
+              cancel: string;
+              dontAskAgain: string;
+            };
+          }) => void
+        ) => () => void;
+        resolveCloseAction: (payload: {
+          requestId: string;
+          choice: 'tray' | 'quit' | 'cancel';
+          dontAskAgain: boolean;
+        }) => void;
         platform: 'aix' | 'android' | 'darwin' | 'freebsd' | 'haiku' | 'linux' | 'openbsd' | 'sunos' | 'win32' | 'cygwin' | 'netbsd';
       };
     };

--- a/tests/components/CloseActionDialog.test.tsx
+++ b/tests/components/CloseActionDialog.test.tsx
@@ -1,0 +1,158 @@
+// UT for src/components/CloseActionDialog.tsx (#1253) — the in-app
+// replacement for the native close confirmation. Covers the
+// resolve-payload contract that the component file documents:
+//   * Tray / Quit / Cancel each fire onResolve with their respective
+//     choice + the current dontAskAgain state.
+//   * Cancel via Esc / outside click / X also routes to onResolve as
+//     'cancel' so main can clear its pending-ask gate (otherwise
+//     subsequent X clicks would be silently swallowed).
+//   * onResolve fires AT MOST ONCE per open — the dialog must not
+//     double-answer main.
+//   * dontAskAgain checkbox value rides along with every choice; the
+//     POLICY that 'cancel' never persists is enforced on the main
+//     side (`decideCloseAction`), not here — this component just
+//     forwards raw user input.
+import React from 'react';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, act } from '@testing-library/react';
+import {
+  CloseActionDialog,
+  type CloseActionLabels,
+} from '../../src/components/CloseActionDialog';
+
+afterEach(() => cleanup());
+
+const LABELS: CloseActionLabels = {
+  message: 'Close ccsm?',
+  detail: 'Minimize to tray keeps ccsm running.',
+  tray: 'Minimize to tray',
+  quit: 'Quit',
+  cancel: 'Cancel',
+  dontAskAgain: "Don't ask again",
+};
+
+function setup(
+  override: Partial<React.ComponentProps<typeof CloseActionDialog>> = {}
+) {
+  const onOpenChange = vi.fn(function (_o: boolean) {});
+  const onResolve = vi.fn(function (_r: {
+    choice: 'tray' | 'quit' | 'cancel';
+    dontAskAgain: boolean;
+  }) {});
+  const utils = render(
+    <CloseActionDialog
+      open
+      onOpenChange={onOpenChange}
+      labels={LABELS}
+      onResolve={onResolve}
+      {...override}
+    />
+  );
+  return { ...utils, onOpenChange, onResolve };
+}
+
+describe('<CloseActionDialog /> (#1253)', () => {
+  it('renders message, detail, three buttons, and the checkbox', () => {
+    setup();
+    expect(screen.getByText(LABELS.message)).toBeInTheDocument();
+    expect(screen.getByText(LABELS.detail)).toBeInTheDocument();
+    expect(screen.getByTestId('close-action-tray')).toHaveTextContent(LABELS.tray);
+    expect(screen.getByTestId('close-action-quit')).toHaveTextContent(LABELS.quit);
+    expect(screen.getByTestId('close-action-cancel')).toHaveTextContent(LABELS.cancel);
+    expect(screen.getByTestId('close-action-dontask')).not.toBeChecked();
+  });
+
+  it('tray button resolves with { choice: tray, dontAskAgain: false } by default', () => {
+    const { onResolve, onOpenChange } = setup();
+    fireEvent.click(screen.getByTestId('close-action-tray'));
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onResolve).toHaveBeenLastCalledWith({ choice: 'tray', dontAskAgain: false });
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('quit button resolves with choice=quit', () => {
+    const { onResolve } = setup();
+    fireEvent.click(screen.getByTestId('close-action-quit'));
+    expect(onResolve).toHaveBeenLastCalledWith({ choice: 'quit', dontAskAgain: false });
+  });
+
+  it('cancel button resolves with choice=cancel', () => {
+    const { onResolve } = setup();
+    fireEvent.click(screen.getByTestId('close-action-cancel'));
+    expect(onResolve).toHaveBeenLastCalledWith({ choice: 'cancel', dontAskAgain: false });
+  });
+
+  it('checking "don\'t ask again" rides along with the chosen action', () => {
+    const { onResolve } = setup();
+    fireEvent.click(screen.getByTestId('close-action-dontask'));
+    fireEvent.click(screen.getByTestId('close-action-quit'));
+    expect(onResolve).toHaveBeenLastCalledWith({ choice: 'quit', dontAskAgain: true });
+  });
+
+  it('cancel + dontAskAgain forwards the raw user input (policy enforced elsewhere)', () => {
+    // The component does NOT enforce "cancel never persists" — that lives
+    // in `decideCloseAction` on main. The dialog forwards both signals
+    // verbatim so a future UI change (e.g. disable the checkbox when
+    // cancel is focused) doesn't accidentally drift the contract.
+    const { onResolve } = setup();
+    fireEvent.click(screen.getByTestId('close-action-dontask'));
+    fireEvent.click(screen.getByTestId('close-action-cancel'));
+    expect(onResolve).toHaveBeenLastCalledWith({ choice: 'cancel', dontAskAgain: true });
+  });
+
+  it('onResolve fires at most once per open even with rapid double-clicks', () => {
+    const { onResolve } = setup();
+    const tray = screen.getByTestId('close-action-tray');
+    fireEvent.click(tray);
+    fireEvent.click(tray);
+    fireEvent.click(screen.getByTestId('close-action-quit'));
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onResolve).toHaveBeenLastCalledWith({ choice: 'tray', dontAskAgain: false });
+  });
+
+  it('closing via the X button routes through onResolve as cancel', () => {
+    // Radix's <DialogClose> at the top-right triggers onOpenChange(false)
+    // without a choice click — we must still answer main so its pending
+    // ask gate clears. The component synthesizes a `'cancel'` reply on
+    // any unresolved dismiss.
+    const { onResolve, onOpenChange } = setup();
+    // Find the dialog close (X) — the only IconButton with aria-label
+    // 'Close' / 'close' rendered by DialogContent. Use the i18n's actual
+    // resolved label via getAllByRole; the X is the only button OUTSIDE
+    // our three testids.
+    const closeButtons = screen
+      .getAllByRole('button')
+      .filter((b) => !b.getAttribute('data-testid')?.startsWith('close-action-'));
+    expect(closeButtons.length).toBeGreaterThan(0);
+    fireEvent.click(closeButtons[0]);
+    // Radix forwards the click → onOpenChange(false). The dialog wraps
+    // that path with a synthetic cancel resolve.
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onResolve).toHaveBeenLastCalledWith({ choice: 'cancel', dontAskAgain: false });
+  });
+
+  it('dismiss after a button click does NOT double-resolve', () => {
+    // After a tray click resolves, the parent flips `open` to false via
+    // onOpenChange. The subsequent unmount must NOT fire a second
+    // cancel reply on top of the legitimate tray one.
+    const onResolve = vi.fn();
+    function Harness() {
+      const [open, setOpen] = React.useState(true);
+      return (
+        <CloseActionDialog
+          open={open}
+          onOpenChange={setOpen}
+          labels={LABELS}
+          onResolve={onResolve}
+        />
+      );
+    }
+    render(<Harness />);
+    act(() => {
+      fireEvent.click(screen.getByTestId('close-action-tray'));
+    });
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onResolve).toHaveBeenLastCalledWith({ choice: 'tray', dontAskAgain: false });
+  });
+});


### PR DESCRIPTION
## Summary

- Replace native `dialog.showMessageBox` on close X with an in-app modal built on the existing `Dialog` primitive — semantics unchanged (Minimize to tray / Quit / Cancel + ``Don't ask again``).
- Main owns lifecycle, renderer owns UI: `win.on('close')` `preventDefault`s and emits `window:askCloseAction` with a request-id + translated labels; renderer answers via `window:resolveCloseAction`. Pending-ask coalesced so a double Ctrl+W doesn't stack two dialogs. 10s timeout → hide-to-tray fallback.
- Cancel NEVER persists a pref, even with ``Don't ask again`` ticked — never trap the user.
- Pure `decideCloseAction` extracted + unit-tested. Renderer dispatch contract tested in `tests/components/CloseActionDialog.test.tsx`.

## Files

- `electron/window/createWindow.ts` — IPC roundtrip + pure decider + timeout
- `electron/ipc` flow — registered on shared `ipcMain` via new `deps.ipcMain`; main.ts passes it through
- `electron/preload/bridges/ccsmCore.ts` — `onAskCloseAction` + `resolveCloseAction`
- `electron/i18n.ts` — add `cancel` key
- `src/components/CloseActionDialog.tsx` — new dialog (3 buttons + checkbox)
- `src/App.tsx` — IPC listener + dialog render (mounted in both hydrate and post-hydrate trees so Ctrl+W during hydrate still resolves)
- `src/global.d.ts` — extend `window.ccsm.window` types

## Test plan

- [x] `node_modules/.bin/vitest run electron/window/__tests__/createWindow.test.ts tests/components/CloseActionDialog.test.tsx` — 27/27 pass
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (warnings pre-existing)
- [x] `npm test` — 1320 pass; only failures are the pre-existing `db-hardening` Windows sqlite NODE_MODULE_VERSION mismatch (per task instructions: ignore)
- [x] Probe: weakened `decideCloseAction` to never persist → 2 of the new decider tests fail. Restored. Tests pass again.

## Screenshots

> **No screenshots — this environment is headless.** Capture before/after on Windows 11 before merge. The before state is the system-styled Windows confirmation dialog with two buttons + native checkbox; the after state should be a dark in-app Dialog at the center of the window, rounded corners, three Apple-styled Buttons (Cancel ghost, Quit danger, Minimize to tray primary), with a styled checkbox on the left of the footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)