### PR TITLE
feat(terminal): scrollback cap (default 1500) + Settings knob

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -65,6 +65,7 @@ import {
 } from './sessionTitles';
 import { loadNotifyEnabled, subscribeNotifyEnabledInvalidation } from './prefs/notifyEnabled';
 import { subscribeCrashReportingInvalidation } from './prefs/crashReporting';
+import { subscribeScrollbackInvalidation } from './prefs/scrollback';
 import { BadgeController } from './badgeController';
 import { registerDbIpc } from './ipc/dbIpc';
 import { registerSystemIpc } from './ipc/systemIpc';
@@ -188,6 +189,7 @@ app.whenReady().then(() => {
   // See `tech-debt-12-functional-core.md` leak #5 / Task #818.
   subscribeCrashReportingInvalidation();
   subscribeNotifyEnabledInvalidation();
+  subscribeScrollbackInvalidation();
   // Order is significant for systemIpc: it seeds the active i18n language
   // from the OS locale, so any subsequent producer that calls i18n.t()
   // sees the correct active language.

--- a/electron/prefs/__tests__/scrollback.test.ts
+++ b/electron/prefs/__tests__/scrollback.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const stateStore = new Map<string, string | null>();
+let throwOnLoad = false;
+
+vi.mock('../../db', () => ({
+  loadState: (key: string) => {
+    if (throwOnLoad) throw new Error('boom');
+    return stateStore.has(key) ? stateStore.get(key)! : null;
+  },
+  saveState: (key: string, value: string) => {
+    stateStore.set(key, value);
+  },
+}));
+
+beforeEach(() => {
+  stateStore.clear();
+  throwOnLoad = false;
+  vi.resetModules();
+});
+
+describe('parseScrollbackLines', () => {
+  it('returns the default when raw is null/undefined/empty', async () => {
+    const { parseScrollbackLines, DEFAULT_SCROLLBACK_LINES } = await import(
+      '../scrollback'
+    );
+    expect(parseScrollbackLines(null)).toBe(DEFAULT_SCROLLBACK_LINES);
+    expect(parseScrollbackLines(undefined)).toBe(DEFAULT_SCROLLBACK_LINES);
+    expect(parseScrollbackLines('')).toBe(DEFAULT_SCROLLBACK_LINES);
+  });
+
+  it('accepts numeric strings (TEXT-column round-trip)', async () => {
+    const { parseScrollbackLines } = await import('../scrollback');
+    expect(parseScrollbackLines('2500')).toBe(2500);
+  });
+
+  it('clamps below MIN', async () => {
+    const { parseScrollbackLines, MIN_SCROLLBACK_LINES } = await import(
+      '../scrollback'
+    );
+    expect(parseScrollbackLines(0)).toBe(MIN_SCROLLBACK_LINES);
+    expect(parseScrollbackLines(-9999)).toBe(MIN_SCROLLBACK_LINES);
+  });
+
+  it('clamps above MAX', async () => {
+    const { parseScrollbackLines, MAX_SCROLLBACK_LINES } = await import(
+      '../scrollback'
+    );
+    expect(parseScrollbackLines(999_999)).toBe(MAX_SCROLLBACK_LINES);
+  });
+
+  it('rounds non-integers', async () => {
+    const { parseScrollbackLines } = await import('../scrollback');
+    expect(parseScrollbackLines(1500.4)).toBe(1500);
+    expect(parseScrollbackLines(1500.6)).toBe(1501);
+  });
+
+  it('falls back to default for NaN / non-numeric strings', async () => {
+    const { parseScrollbackLines, DEFAULT_SCROLLBACK_LINES } = await import(
+      '../scrollback'
+    );
+    expect(parseScrollbackLines('abc')).toBe(DEFAULT_SCROLLBACK_LINES);
+    expect(parseScrollbackLines(NaN)).toBe(DEFAULT_SCROLLBACK_LINES);
+  });
+});
+
+describe('loadScrollbackLines', () => {
+  it('returns the default when the row is missing', async () => {
+    const { loadScrollbackLines, DEFAULT_SCROLLBACK_LINES } = await import(
+      '../scrollback'
+    );
+    expect(loadScrollbackLines()).toBe(DEFAULT_SCROLLBACK_LINES);
+  });
+
+  it('reads the persisted value (numeric string)', async () => {
+    stateStore.set('scrollbackLines', '3000');
+    const { loadScrollbackLines } = await import('../scrollback');
+    expect(loadScrollbackLines()).toBe(3000);
+  });
+
+  it('clamps an out-of-range persisted value', async () => {
+    stateStore.set('scrollbackLines', '999999');
+    const { loadScrollbackLines, MAX_SCROLLBACK_LINES } = await import(
+      '../scrollback'
+    );
+    expect(loadScrollbackLines()).toBe(MAX_SCROLLBACK_LINES);
+  });
+
+  it('returns the default when loadState throws', async () => {
+    throwOnLoad = true;
+    const { loadScrollbackLines, DEFAULT_SCROLLBACK_LINES } = await import(
+      '../scrollback'
+    );
+    expect(loadScrollbackLines()).toBe(DEFAULT_SCROLLBACK_LINES);
+  });
+
+  it('caches after first read; cache invalidation re-reads', async () => {
+    stateStore.set('scrollbackLines', '500');
+    const { loadScrollbackLines, invalidateScrollbackCache } = await import(
+      '../scrollback'
+    );
+    expect(loadScrollbackLines()).toBe(500);
+    stateStore.set('scrollbackLines', '4000');
+    // Cache still serves the old value.
+    expect(loadScrollbackLines()).toBe(500);
+    invalidateScrollbackCache();
+    expect(loadScrollbackLines()).toBe(4000);
+  });
+});
+
+describe('subscribeScrollbackInvalidation', () => {
+  it('invalidates the cache when stateSavedBus emits SCROLLBACK_KEY', async () => {
+    stateStore.set('scrollbackLines', '500');
+    const { loadScrollbackLines, subscribeScrollbackInvalidation } =
+      await import('../scrollback');
+    const { emitStateSaved, _resetStateSavedBusForTests } = await import(
+      '../../shared/stateSavedBus'
+    );
+    _resetStateSavedBusForTests();
+    const off = subscribeScrollbackInvalidation();
+    expect(loadScrollbackLines()).toBe(500);
+
+    stateStore.set('scrollbackLines', '4000');
+    emitStateSaved('scrollbackLines');
+    expect(loadScrollbackLines()).toBe(4000);
+    off();
+  });
+
+  it('ignores unrelated keys', async () => {
+    stateStore.set('scrollbackLines', '500');
+    const { loadScrollbackLines, subscribeScrollbackInvalidation } =
+      await import('../scrollback');
+    const { emitStateSaved, _resetStateSavedBusForTests } = await import(
+      '../../shared/stateSavedBus'
+    );
+    _resetStateSavedBusForTests();
+    const off = subscribeScrollbackInvalidation();
+    expect(loadScrollbackLines()).toBe(500);
+
+    stateStore.set('scrollbackLines', '4000');
+    emitStateSaved('closeAction');
+    // Unrelated key did not invalidate; cache still serves 500.
+    expect(loadScrollbackLines()).toBe(500);
+    off();
+  });
+
+  it('reverse-verify: unsubscribed listener no longer invalidates', async () => {
+    stateStore.set('scrollbackLines', '500');
+    const { loadScrollbackLines, subscribeScrollbackInvalidation } =
+      await import('../scrollback');
+    const { emitStateSaved, _resetStateSavedBusForTests } = await import(
+      '../../shared/stateSavedBus'
+    );
+    _resetStateSavedBusForTests();
+    const off = subscribeScrollbackInvalidation();
+    loadScrollbackLines(); // prime cache
+    off();
+
+    stateStore.set('scrollbackLines', '4000');
+    emitStateSaved('scrollbackLines');
+    // Listener detached → cache still stale.
+    expect(loadScrollbackLines()).toBe(500);
+  });
+});

--- a/electron/prefs/scrollback.ts
+++ b/electron/prefs/scrollback.ts
@@ -1,0 +1,66 @@
+// Terminal scrollback line cap preference.
+//
+// Single user-facing knob that bounds BOTH the headless authoritative buffer
+// (PR-A #861) and the per-attach `getBufferSnapshot` payload (PR-B #865).
+// Lowered from the legacy 10000-line headless cap / 5000-line visible cap
+// to a 1500-line default so a long-running session no longer pays MB-sized
+// snapshot serialize cost on every attach.
+//
+// Persisted in app_state under `scrollbackLines`. Read synchronously inside
+// `entryFactory.makeEntry` (when constructing the headless Terminal) and
+// `lifecycle.attach` / `lifecycle.getBufferSnapshot` (when serializing) —
+// the SQLite read is a single point lookup so the cost is negligible. The
+// in-process cache + stateSavedBus invalidation pattern matches
+// `notifyEnabled` and `crashReporting`: see tech-debt-12 leak #5.
+
+import { loadState } from '../db';
+import { onStateSaved } from '../shared/stateSavedBus';
+
+export const SCROLLBACK_KEY = 'scrollbackLines';
+
+/** Default cap. Applied when the row is missing or unparseable. */
+export const DEFAULT_SCROLLBACK_LINES = 1500;
+
+/** User-facing range. Anything outside this is clamped (not rejected) so a
+ *  legacy snapshot with the old 5000/10000 value still loads sensibly. */
+export const MIN_SCROLLBACK_LINES = 100;
+export const MAX_SCROLLBACK_LINES = 50000;
+
+let _cached: number | undefined;
+
+/** Pure parser: clamp + integerize a raw persisted value into the valid
+ *  range. Exported so the renderer setter can share the same sanitization. */
+export function parseScrollbackLines(raw: unknown): number {
+  let n: number;
+  if (typeof raw === 'number') n = raw;
+  else if (typeof raw === 'string' && raw.length > 0) n = Number(raw);
+  else return DEFAULT_SCROLLBACK_LINES;
+  if (!Number.isFinite(n)) return DEFAULT_SCROLLBACK_LINES;
+  n = Math.round(n);
+  if (n < MIN_SCROLLBACK_LINES) return MIN_SCROLLBACK_LINES;
+  if (n > MAX_SCROLLBACK_LINES) return MAX_SCROLLBACK_LINES;
+  return n;
+}
+
+export function loadScrollbackLines(): number {
+  if (_cached !== undefined) return _cached;
+  try {
+    const raw = loadState(SCROLLBACK_KEY);
+    _cached = parseScrollbackLines(raw);
+    return _cached;
+  } catch {
+    return DEFAULT_SCROLLBACK_LINES;
+  }
+}
+
+export function invalidateScrollbackCache(): void {
+  _cached = undefined;
+}
+
+/** Wire cache invalidation to the stateSavedBus. Call once during boot
+ *  (before `registerDbIpc`). Returns the unsubscribe handle. */
+export function subscribeScrollbackInvalidation(): () => void {
+  return onStateSaved((key) => {
+    if (key === SCROLLBACK_KEY) invalidateScrollbackCache();
+  });
+}

--- a/electron/ptyHost/__tests__/bufferSnapshot.test.ts
+++ b/electron/ptyHost/__tests__/bufferSnapshot.test.ts
@@ -11,7 +11,27 @@
 //
 // Out of scope (PR-B/E): visible xterm replay, IPC wire format, detach/reattach.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// `lifecycle.getBufferSnapshot` now consults the user's scrollbackLines
+// preference (electron/prefs/scrollback) on every call so the cap honors
+// live setting changes. The prefs module imports `../db`, which calls
+// Electron's `app.getPath()` on first use — fatal in pure-node tests.
+// Stub the prefs module to a fixed cap so the lifecycle path stays
+// hermetic. Each individual test that wants to assert "the cap is
+// passed to serialize" overrides this via vi.mocked(...) below.
+let _stubbedCap = 1500;
+vi.mock('../../prefs/scrollback', () => ({
+  loadScrollbackLines: () => _stubbedCap,
+  DEFAULT_SCROLLBACK_LINES: 1500,
+  MIN_SCROLLBACK_LINES: 100,
+  MAX_SCROLLBACK_LINES: 50000,
+  SCROLLBACK_KEY: 'scrollbackLines',
+  parseScrollbackLines: (v: unknown) => (typeof v === 'number' ? v : 1500),
+  invalidateScrollbackCache: () => {},
+  subscribeScrollbackInvalidation: () => () => {},
+}));
+
 import { Terminal as HeadlessTerminal } from '@xterm/headless';
 import { SerializeAddon } from '@xterm/addon-serialize';
 import { SCROLLBACK } from '../entryFactory';
@@ -33,14 +53,24 @@ function makeRealHeadless(): { term: HeadlessTerminal; serialize: SerializeAddon
   return { term, serialize };
 }
 
-// Build a fake Entry that just exposes a `serialize.serialize()` returning
-// the supplied string. Other Entry fields are stubbed because
-// getBufferSnapshot only reads `entry.serialize` and `entry.seq`.
-function fakeEntry(snapshot: string, seq: number = 0): Entry {
+// Build a fake Entry that just exposes a `serialize.serialize(opts?)` echoing
+// back whatever string the test supplied. The `optsCapture` array (when
+// passed) records every options arg the lifecycle layer hands through, so
+// tests can assert the user-configured cap reaches SerializeAddon.
+function fakeEntry(
+  snapshot: string,
+  seq: number = 0,
+  optsCapture?: unknown[],
+): Entry {
   return {
     pty: { pid: 0 } as Entry['pty'],
     headless: {} as Entry['headless'],
-    serialize: { serialize: () => snapshot } as unknown as Entry['serialize'],
+    serialize: {
+      serialize: (opts?: unknown) => {
+        if (optsCapture) optsCapture.push(opts);
+        return snapshot;
+      },
+    } as unknown as Entry['serialize'],
     attached: new Map(),
     cols: 80,
     rows: 24,
@@ -50,8 +80,8 @@ function fakeEntry(snapshot: string, seq: number = 0): Entry {
 }
 
 describe('headless authoritative buffer (PR-A real wiring)', () => {
-  it('SCROLLBACK is bumped to 10000 lines for L4', () => {
-    expect(SCROLLBACK).toBe(10000);
+  it('SCROLLBACK default cap is 1500 lines', () => {
+    expect(SCROLLBACK).toBe(1500);
   });
 
   it('headless buffer accumulates writes across chunks', async () => {
@@ -64,11 +94,11 @@ describe('headless authoritative buffer (PR-A real wiring)', () => {
     expect(snap).toContain('second line');
   });
 
-  it('scrollback cap of 10000 truncates the OLDEST lines once exceeded', async () => {
+  it('scrollback cap of SCROLLBACK truncates the OLDEST lines once exceeded', async () => {
     const { term, serialize } = makeRealHeadless();
-    // Write 10500 distinct lines. After the cap, the first ~500 + the 24
-    // visible rows offset should be gone.
-    const TOTAL = 10500;
+    // Write more lines than the cap. After the cap, the oldest lines
+    // should be evicted while the newest survive.
+    const TOTAL = SCROLLBACK + 500;
     let buf = '';
     for (let i = 0; i < TOTAL; i++) buf += `LINE${i}\r\n`;
     await new Promise<void>((r) => term.write(buf, r));
@@ -77,7 +107,6 @@ describe('headless authoritative buffer (PR-A real wiring)', () => {
     expect(snap).toContain(`LINE${TOTAL - 1}`);
     // The very first line MUST have been evicted (well under the cap window).
     expect(snap).not.toContain('LINE0\n');
-    expect(snap).not.toContain('LINE100\n');
     // A line comfortably inside the surviving cap window must still be present.
     expect(snap).toContain(`LINE${TOTAL - 100}`);
   });
@@ -150,5 +179,62 @@ describe('lifecycle.getBufferSnapshot (PR-A async chunking + PR-B seq capture)',
     // Expect at least the number of inter-chunk yields - 1; in practice
     // we should see >= 3 immediates fire alongside 4 internal yields.
     expect(immediateFired).toBeGreaterThanOrEqual(3);
+  });
+
+  it('passes the user-configured scrollback cap as serialize options', async () => {
+    const sessions = new Map<string, Entry>();
+    const optsCapture: unknown[] = [];
+    sessions.set('s4', fakeEntry('payload', 7, optsCapture));
+    _stubbedCap = 1500;
+    await getBufferSnapshot(sessions, 's4');
+    expect(optsCapture).toHaveLength(1);
+    expect(optsCapture[0]).toEqual({ scrollback: 1500 });
+  });
+
+  it('honors a changed scrollback cap on subsequent calls (live setting)', async () => {
+    const sessions = new Map<string, Entry>();
+    const optsCapture: unknown[] = [];
+    sessions.set('s5', fakeEntry('payload', 0, optsCapture));
+    _stubbedCap = 200;
+    await getBufferSnapshot(sessions, 's5');
+    _stubbedCap = 9000;
+    await getBufferSnapshot(sessions, 's5');
+    expect(optsCapture).toEqual([{ scrollback: 200 }, { scrollback: 9000 }]);
+  });
+
+  it('returns at most `cap` lines when serialize honors the option (real addon, real cap)', async () => {
+    // End-to-end check against the real SerializeAddon: a buffer with
+    // many more rows than the cap should yield a snapshot whose line
+    // count is bounded by the cap (plus some constant for terminal
+    // mode/style prefixes).
+    _stubbedCap = 500;
+    const { term, serialize } = makeRealHeadless();
+    const TOTAL = 3000;
+    let buf = '';
+    for (let i = 0; i < TOTAL; i++) buf += `L${i}\r\n`;
+    await new Promise<void>((r) => term.write(buf, r));
+
+    const sessions = new Map<string, Entry>();
+    // Wire the real entry's serialize so getBufferSnapshot calls the
+    // real addon with our cap.
+    sessions.set('real', {
+      pty: { pid: 0 } as Entry['pty'],
+      headless: term as unknown as Entry['headless'],
+      serialize: serialize as unknown as Entry['serialize'],
+      attached: new Map(),
+      cols: 80,
+      rows: 24,
+      cwd: '/tmp',
+      seq: 0,
+    } as Entry);
+    const result = await getBufferSnapshot(sessions, 'real');
+    // Sanity: the newest line must survive.
+    expect(result.snapshot).toContain(`L${TOTAL - 1}`);
+    // The cap must have evicted lines well outside the bottom 500
+    // — anything older than ~600 lines from the bottom should be gone.
+    expect(result.snapshot).not.toContain(`L${TOTAL - 1000}`);
+    // Conservative line-count cap: 500 + a small overhead for ANSI
+    // escapes and trailing rows. We just assert "much less than TOTAL".
+    expect(result.snapshot.split('\n').length).toBeLessThan(700);
   });
 });

--- a/electron/ptyHost/__tests__/entryFactory.test.ts
+++ b/electron/ptyHost/__tests__/entryFactory.test.ts
@@ -51,6 +51,11 @@ vi.mock('node-pty', () => ({
 
 vi.mock('@xterm/headless', () => ({
   Terminal: class {
+    constructor(opts?: unknown) {
+      // Record constructor opts so tests can pin scrollback wiring.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).__pf_lastHeadlessOpts = opts;
+    }
     // Mirror @xterm/headless's `write(data, callback?)` signature so tests
     // can exercise PR-C backpressure (we count pending writes by deferring
     // the callback until the test fires it).
@@ -99,6 +104,17 @@ vi.mock('../cwdResolver', () => ({
 
 vi.mock('../dataFanout', () => ({
   emitPtyData: (sid: string, chunk: string) => bus().emitData(sid, chunk),
+}));
+
+// The user-configured scrollback cap is now read at headless construction
+// time. Stub the prefs module so tests don't hit the SQLite-backed
+// loadState path; tests that care about the cap value flip
+// `globalThis.__pf_scrollback` directly.
+vi.mock('../../prefs/scrollback', () => ({
+  loadScrollbackLines: () =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (((globalThis as any).__pf_scrollback as number | undefined) ?? 1500),
+  DEFAULT_SCROLLBACK_LINES: 1500,
 }));
 
 import { makeEntry } from '../entryFactory';
@@ -200,6 +216,28 @@ describe('entryFactory.makeEntry', () => {
     expect(e.rows).toBe(40);
     expect(e.cwd).toBe('/work');
     expect(e.attached.size).toBe(0);
+  });
+
+  it('passes the user-configured scrollback cap into the headless Terminal constructor', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).__pf_scrollback = 2500;
+    makeEntry('sid-SCROLL', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const opts = (globalThis as any).__pf_lastHeadlessOpts as
+      | { scrollback?: number }
+      | undefined;
+    expect(opts?.scrollback).toBe(2500);
+  });
+
+  it('falls back to the default cap when the prefs module returns the default', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).__pf_scrollback;
+    makeEntry('sid-DEFAULT', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const opts = (globalThis as any).__pf_lastHeadlessOpts as
+      | { scrollback?: number }
+      | undefined;
+    expect(opts?.scrollback).toBe(1500);
   });
 });
 

--- a/electron/ptyHost/__tests__/lifecycle.test.ts
+++ b/electron/ptyHost/__tests__/lifecycle.test.ts
@@ -60,6 +60,12 @@ vi.mock('../entryFactory', () => ({
   makeEntry: (...args: unknown[]) => bus().makeEntry(...args),
 }));
 
+// scrollback prefs transitively import `electron` (via `../db` → `app`).
+// We don't exercise scrollback caps in these lifecycle tests — stub it.
+vi.mock('../../prefs/scrollback', () => ({
+  loadScrollbackLines: () => 1500,
+}));
+
 import * as L from '../lifecycle';
 
 function makeFakeEntry(over: Partial<FakeEntry> = {}): FakeEntry {

--- a/electron/ptyHost/entryFactory.ts
+++ b/electron/ptyHost/entryFactory.ts
@@ -33,14 +33,21 @@ import {
 } from './jsonlResolver';
 import { resolveSpawnCwd } from './cwdResolver';
 import { emitPtyData } from './dataFanout';
+import { loadScrollbackLines } from '../prefs/scrollback';
 
 export const DEFAULT_COLS = 120;
 export const DEFAULT_ROWS = 30;
-// L4 PR-A (#861): scrollback bumped from 5000 -> 10000 lines so the headless
-// terminal becomes a session-level authoritative buffer suitable for serving
-// re-attach replays, not just the live screen. 10000 was 80/20-decided by the
-// owner; bump only here and in any future replay-budget calculation.
-export const SCROLLBACK = 10000;
+// User-facing scrollback cap defaults to 1500 lines (see
+// `electron/prefs/scrollback.ts`). The headless mirror's per-entry buffer
+// is sized at construction time from `loadScrollbackLines()`; this constant
+// is the static fallback used when the prefs read fails (e.g. db init race)
+// and is kept exported for tests that bypass the prefs path.
+//
+// History: PR #861 bumped to 10000 to back re-attach replay; user-driven
+// research showed 10000 was unnecessarily generous for typical usage and
+// caused multi-megabyte snapshot serializes on every attach. Lowered as
+// part of the user-facing scrollback knob landing in this PR.
+export const SCROLLBACK = 1500;
 
 // L4 PR-C (#863): when the visible xterm cannot keep up with PTY output the
 // headless mirror's `write(data, cb)` callback is invoked asynchronously.
@@ -248,7 +255,11 @@ export function makeEntry(
   const headless = new HeadlessTerminal({
     cols,
     rows,
-    scrollback: SCROLLBACK,
+    // Read the user-configured cap at construction time. Existing entries
+    // keep their already-sized buffer when the user changes the setting
+    // — only newly-spawned sessions pick up the new value, matching the
+    // "applies on next attach" UX contract documented in SettingsDialog.
+    scrollback: loadScrollbackLines(),
     allowProposedApi: true,
   });
   const serialize = new SerializeAddon();

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -15,6 +15,7 @@ import { sessionWatcher } from '../sessionWatcher';
 import { killProcessSubtree } from './processKiller';
 import { DEFAULT_COLS, DEFAULT_ROWS, makeEntry } from './entryFactory';
 import type { Entry } from './entryFactory';
+import { loadScrollbackLines } from '../prefs/scrollback';
 
 export interface PtySessionInfo {
   sid: string;
@@ -152,14 +153,17 @@ export function get(sessions: Map<string, Entry>, sid: string): PtySessionInfo |
 // L4 PR-A (#861) + PR-B (#865): async, chunked snapshot of the headless
 // authoritative buffer, paired with the per-entry monotonic chunk seq.
 //
-// SerializeAddon.serialize() itself is synchronous and walks the entire
-// scrollback (cap 10000 lines). With the bumped cap the serialized string can
-// reach ~MBs for long sessions; concatenating + handing back the full string
-// in one tick would briefly block the main thread. We yield to the event loop
-// every CHUNK_LINES (~1000) lines via setImmediate so other I/O (IPC, JSONL
-// tail, OSC sniffer fanout) keeps making progress while a large snapshot is
-// being assembled. The returned value is still the FULL serialized string —
-// chunking is purely a yield strategy, not a streaming protocol.
+// SerializeAddon.serialize() itself is synchronous and walks the requested
+// rows from the bottom of the scrollback (cap configurable via the
+// `scrollbackLines` user preference, default 1500 — see
+// `electron/prefs/scrollback.ts`). With the bumped cap the serialized
+// string can still reach hundreds of KB; concatenating + handing back the
+// full string in one tick would briefly block the main thread. We yield
+// to the event loop every CHUNK_LINES (~1000) lines via setImmediate so
+// other I/O (IPC, JSONL tail, OSC sniffer fanout) keeps making progress
+// while a large snapshot is being assembled. The returned value is still
+// the FULL serialized string — chunking is purely a yield strategy, not
+// a streaming protocol.
 //
 // PR-B adds the `seq` field: captured ATOMICALLY with `serialize.serialize()`
 // (both happen synchronously, no chunk can arrive between them under Node's
@@ -189,7 +193,13 @@ export async function getBufferSnapshot(
   if (!entry) return { snapshot: '', seq: 0 };
   // Capture seq + serialized string atomically (both sync, no awaits).
   const seq = entry.seq;
-  const full = entry.serialize.serialize();
+  // PR-B contract: serialize captures whatever lives in the headless buffer
+  // at this instant, paired with `seq`. We bound the payload to the user's
+  // configured scrollback cap (last N rows from the bottom of the scrollback)
+  // so a long-running session doesn't return MB of lines on every attach.
+  // Cap honors the live setting (read fresh per call), so the user's
+  // change takes effect on the next attach without restarting the entry.
+  const full = entry.serialize.serialize({ scrollback: loadScrollbackLines() });
   if (!full) return { snapshot: '', seq };
   // Split on '\n' so we yield on a line boundary; preserves the original
   // separator on rejoin. setImmediate is available in Electron main (Node

--- a/src/components/settings/AppearancePane.tsx
+++ b/src/components/settings/AppearancePane.tsx
@@ -3,6 +3,12 @@ import { cn } from '../../lib/cn';
 import { useStore } from '../../stores/store';
 import { useTranslation } from '../../i18n/useTranslation';
 import { usePreferences } from '../../store/preferences';
+import {
+  SCROLLBACK_LINES_DEFAULT,
+  SCROLLBACK_LINES_MAX,
+  SCROLLBACK_LINES_MIN,
+} from '../../stores/slices/types';
+import { sanitizeScrollbackLines } from '../../stores/slices/appearanceSlice';
 import { Field } from './Field';
 import { Segmented } from './Segmented';
 
@@ -62,6 +68,7 @@ export function AppearancePane() {
         </div>
       </Field>
       <CloseBehaviorField />
+      <ScrollbackField />
     </>
   );
 }
@@ -113,6 +120,84 @@ function CloseBehaviorField() {
             { value: 'quit', label: t('closeBehaviorOptions.quit') }
           ]}
         />
+      </div>
+    </Field>
+  );
+}
+
+// Terminal scrollback line cap. Single user-facing knob that bounds BOTH
+// the visible xterm buffer (next-launch effect — the renderer's xterm
+// singleton reads this once at construction) and the headless
+// authoritative buffer in main (next-spawn effect — `entryFactory.makeEntry`
+// reads from the same `scrollbackLines` row). Persisted via `db:save` to
+// match the closeBehavior pattern, NOT via the renderer's PERSISTED_KEYS
+// JSON blob, so the main process can read the same value directly.
+//
+// We mirror the value into zustand on change so the live xterm singleton
+// has a synchronous reader; the on-disk row is the source of truth.
+function ScrollbackField() {
+  const { t } = useTranslation('settings');
+  const storeValue = useStore((s) => s.scrollbackLines);
+  const setStoreValue = useStore((s) => s.setScrollbackLines);
+  // Local "what the user is currently typing" buffer so we don't clobber
+  // their keystrokes mid-edit with the sanitized round-trip. Synced to
+  // the store value when the input loses focus / user commits.
+  const [draft, setDraft] = useState<string>(String(storeValue));
+
+  // If the store value changes from elsewhere (e.g. another window, future
+  // multi-window support, or hydrate), reflect it into the input.
+  useEffect(() => {
+    setDraft(String(storeValue));
+  }, [storeValue]);
+
+  const commit = (raw: string): void => {
+    const sanitized = sanitizeScrollbackLines(raw);
+    setStoreValue(sanitized);
+    setDraft(String(sanitized));
+    // Persist to the same db row main reads from in
+    // electron/prefs/scrollback.ts. Fire-and-forget — the renderer's view
+    // (zustand) is already updated synchronously above, so a slow IPC
+    // doesn't block the UI. Persist as a string for parity with how
+    // closeAction is stored (db column is TEXT).
+    void window.ccsm?.saveState('scrollbackLines', String(sanitized));
+  };
+
+  return (
+    <Field label={t('scrollback')} hint={t('scrollbackHint')}>
+      <div className="flex items-center gap-3">
+        <input
+          type="number"
+          min={SCROLLBACK_LINES_MIN}
+          max={SCROLLBACK_LINES_MAX}
+          step={100}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={(e) => commit(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              (e.target as HTMLInputElement).blur();
+            }
+          }}
+          aria-label={t('scrollbackAriaLabel')}
+          className={cn(
+            'h-7 w-24 px-2 rounded-sm bg-bg-input text-fg-primary text-chrome',
+            'border border-border-subtle focus-ring outline-none tabular-nums'
+          )}
+        />
+        <span className="text-meta text-fg-secondary">
+          {t('scrollbackUnit')}
+        </span>
+        <button
+          type="button"
+          onClick={() => commit(String(SCROLLBACK_LINES_DEFAULT))}
+          className={cn(
+            'h-7 px-2 rounded-sm text-meta text-fg-secondary',
+            'hover:bg-bg-hover hover:text-fg-primary focus-ring outline-none transition-colors'
+          )}
+        >
+          {t('scrollbackReset', { default: SCROLLBACK_LINES_DEFAULT.toString() })}
+        </button>
       </div>
     </Field>
   );

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -125,6 +125,12 @@ const en = {
       tray: 'Minimize to tray',
       quit: 'Quit'
     },
+    scrollback: 'Terminal scrollback',
+    scrollbackHint:
+      'How many lines each terminal keeps in its scrollback buffer. Applies on next attach for the headless mirror and on next launch for the visible terminal.',
+    scrollbackUnit: 'lines',
+    scrollbackAriaLabel: 'Terminal scrollback in lines',
+    scrollbackReset: 'Reset to default ({{default}})',
     version: 'Version',
     checkForUpdates: 'Check for updates',
     crashReporting: {

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -120,6 +120,12 @@ const zh: EnCatalog = {
       tray: '最小化到托盘',
       quit: '退出'
     },
+    scrollback: '终端回滚行数',
+    scrollbackHint:
+      '每个终端在回滚缓冲区中保留的行数。后台镜像缓冲区在下次接入时生效，可见终端在下次启动时生效。',
+    scrollbackUnit: '行',
+    scrollbackAriaLabel: '终端回滚行数',
+    scrollbackReset: '重置为默认值 ({{default}})',
     version: '版本',
     checkForUpdates: '检查更新',
     crashReporting: {

--- a/src/stores/slices/appearanceSlice.ts
+++ b/src/stores/slices/appearanceSlice.ts
@@ -12,6 +12,11 @@ import type {
   SetFn,
   GetFn,
 } from './types';
+import {
+  SCROLLBACK_LINES_DEFAULT,
+  SCROLLBACK_LINES_MAX,
+  SCROLLBACK_LINES_MIN,
+} from './types';
 
 /** Map the legacy `sm`/`md`/`lg` enum to the numeric pixel scale. The old
  * values kept only three stops (12/13/14); the new slider exposes 12–16.
@@ -37,6 +42,21 @@ export function sanitizeFontSizePx(raw: unknown): FontSizePx {
   const n = typeof raw === 'number' ? Math.round(raw) : NaN;
   if (n === 12 || n === 13 || n === 14 || n === 15 || n === 16) return n;
   return 14;
+}
+
+/** Clamp + integerize a raw scrollback value into the valid range. Mirrors
+ *  the main-side `parseScrollbackLines` so the renderer-mirrored value
+ *  always agrees with what the headless side reads from the same db row. */
+export function sanitizeScrollbackLines(raw: unknown): number {
+  let n: number;
+  if (typeof raw === 'number') n = raw;
+  else if (typeof raw === 'string' && raw.length > 0) n = Number(raw);
+  else return SCROLLBACK_LINES_DEFAULT;
+  if (!Number.isFinite(n)) return SCROLLBACK_LINES_DEFAULT;
+  n = Math.round(n);
+  if (n < SCROLLBACK_LINES_MIN) return SCROLLBACK_LINES_MIN;
+  if (n > SCROLLBACK_LINES_MAX) return SCROLLBACK_LINES_MAX;
+  return n;
 }
 
 export const SIDEBAR_WIDTH_DEFAULT = 260;
@@ -83,9 +103,11 @@ export type AppearanceSlice = Pick<
   | 'theme'
   | 'fontSize'
   | 'fontSizePx'
+  | 'scrollbackLines'
   | 'setTheme'
   | 'setFontSize'
   | 'setFontSizePx'
+  | 'setScrollbackLines'
   | 'setSidebarWidth'
   | 'resetSidebarWidth'
 >;
@@ -97,6 +119,7 @@ export function createAppearanceSlice(set: SetFn, _get: GetFn): AppearanceSlice 
     theme: 'system',
     fontSize: 'md',
     fontSizePx: 14,
+    scrollbackLines: SCROLLBACK_LINES_DEFAULT,
 
     // actions
     setTheme: (theme) => set({ theme }),
@@ -104,6 +127,8 @@ export function createAppearanceSlice(set: SetFn, _get: GetFn): AppearanceSlice 
       set({ fontSize, fontSizePx: legacyFontSizeToPx(fontSize) }),
     setFontSizePx: (fontSizePx) =>
       set({ fontSizePx, fontSize: pxToLegacyFontSize(fontSizePx) }),
+    setScrollbackLines: (n) =>
+      set({ scrollbackLines: sanitizeScrollbackLines(n) }),
     setSidebarWidth: (px) => set({ sidebarWidth: sanitizeSidebarWidth(px) }),
     resetSidebarWidth: () => set({ sidebarWidth: SIDEBAR_WIDTH_DEFAULT }),
   };

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -17,6 +17,14 @@ export type Theme = 'system' | 'light' | 'dark';
 export type FontSize = 'sm' | 'md' | 'lg';
 export type FontSizePx = 12 | 13 | 14 | 15 | 16;
 
+/** Terminal scrollback line cap. Single user-facing knob for both the
+ *  visible xterm (next-launch effect) and the headless authoritative buffer
+ *  in main (next-spawn effect). Range enforced by `sanitizeScrollbackLines`
+ *  (mirrors the main-side `parseScrollbackLines`). */
+export const SCROLLBACK_LINES_DEFAULT = 1500;
+export const SCROLLBACK_LINES_MIN = 100;
+export const SCROLLBACK_LINES_MAX = 50000;
+
 export type EndpointKind =
   | 'anthropic'
   | 'openai-compat'
@@ -61,6 +69,7 @@ export type State = {
   theme: Theme;
   fontSize: FontSize;
   fontSizePx: FontSizePx;
+  scrollbackLines: number;
   flashStates: Record<string, boolean>;
   hydrated: boolean;
   installerCorrupt: boolean;
@@ -111,6 +120,7 @@ export type Actions = {
   setTheme: (theme: Theme) => void;
   setFontSize: (size: FontSize) => void;
   setFontSizePx: (px: FontSizePx) => void;
+  setScrollbackLines: (n: number) => void;
   setSidebarWidth: (px: number) => void;
   resetSidebarWidth: () => void;
 

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -9,6 +9,7 @@ import {
   createAppearanceSlice,
   legacyFontSizeToPx,
   sanitizeFontSizePx,
+  sanitizeScrollbackLines,
   resolvePersistedSidebarWidth,
 } from './slices/appearanceSlice';
 import { createInstallerSlice } from './slices/installerSlice';
@@ -72,6 +73,19 @@ export async function hydrateStore(): Promise<void> {
   // an empty string that flashes for one tick.
   await hydrateDrafts();
   const persisted = await loadPersisted();
+  // Terminal scrollback cap lives in its own app_state row (keyed
+  // `scrollbackLines`) — the SAME row the main process reads via
+  // `electron/prefs/scrollback.ts`, so renderer + main agree on a single
+  // user-facing value. Read it here (before flipping `hydrated`) so the
+  // very first `ensureTerminal()` call in TerminalPane sees the correct
+  // cap. Best-effort — falls back to the slice's default on any failure.
+  let persistedScrollback: number | null = null;
+  try {
+    const raw = await window.ccsm?.loadState('scrollbackLines');
+    if (raw != null) persistedScrollback = sanitizeScrollbackLines(raw);
+  } catch {
+    /* default already in the slice */
+  }
   if (persisted) {
     const stillActive = persisted.sessions.some((s) => s.id === persisted.activeId);
     // Migration: older snapshots may carry `model`, `permission`, and
@@ -90,6 +104,9 @@ export async function hydrateStore(): Promise<void> {
         ? sanitizeFontSizePx(persisted.fontSizePx)
         : legacyFontSizeToPx(persisted.fontSize ?? 'md'),
     });
+  }
+  if (persistedScrollback !== null) {
+    useStore.setState({ scrollbackLines: persistedScrollback });
   }
   // Flip `hydrated` BEFORE kicking off the deferred IPCs below — components
   // that gate their first paint on this can stop showing skeleton state the

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -4,6 +4,8 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import { ClipboardAddon } from '@xterm/addon-clipboard';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { CanvasAddon } from '@xterm/addon-canvas';
+import { useStore } from '../stores/store';
+import { SCROLLBACK_LINES_DEFAULT } from '../stores/slices/types';
 
 // Module-scope singleton state for the renderer's xterm view.
 //
@@ -111,12 +113,22 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
     return term;
   }
 
+  // The scrollback cap is read ONCE at construction. Changing the user
+  // setting after the singleton exists does not retroactively resize the
+  // visible buffer (xterm.js doesn't expose a mutable scrollback setter),
+  // so the SettingsDialog helper text says "applies on next launch". Read
+  // synchronously from the zustand store, which `hydrateStore()` populates
+  // from db:load before TerminalPane mounts (App.tsx gates on `hydrated`).
+  // Falls back to the default constant if the store somehow isn't ready
+  // yet (e.g. test mounts that bypass hydrate).
+  const scrollback =
+    useStore.getState().scrollbackLines ?? SCROLLBACK_LINES_DEFAULT;
   term = new Terminal({
     fontFamily: 'Cascadia Mono, Consolas, "Courier New", monospace',
     fontSize: 13,
     cursorBlink: true,
     allowProposedApi: true,
-    scrollback: 5000,
+    scrollback,
     theme: { background: '#000000' },
   });
   fit = new FitAddon();

--- a/tests/settings-scrollback.test.tsx
+++ b/tests/settings-scrollback.test.tsx
@@ -1,0 +1,200 @@
+// Coverage for the terminal scrollback setting in the Appearance pane.
+//
+// Pins:
+//   - The number input renders and reflects the persisted store value.
+//   - Editing the input commits via blur → updates the zustand store
+//     (synchronous renderer-side read for ensureTerminal) AND writes
+//     through window.ccsm.saveState('scrollbackLines', ...) so the main
+//     process pref module sees the new value (via stateSavedBus
+//     invalidation) on next read.
+//   - Clamping enforces the documented MIN/MAX (sanitizeScrollbackLines).
+//   - The reset button restores the documented default.
+//
+// Reverse-verify: stub `setScrollbackLines` to a no-op → `commit` no longer
+// updates the input AND no longer fires saveState — both expectations fail.
+
+import React, { useState } from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  within,
+  act,
+} from '@testing-library/react';
+import { SettingsDialog } from '../src/components/SettingsDialog';
+import { useStore } from '../src/stores/store';
+import { initI18n } from '../src/i18n';
+import {
+  SCROLLBACK_LINES_DEFAULT,
+  SCROLLBACK_LINES_MAX,
+  SCROLLBACK_LINES_MIN,
+} from '../src/stores/slices/types';
+
+let saveStateSpy: ReturnType<typeof vi.fn>;
+let loadStateSpy: ReturnType<typeof vi.fn>;
+
+function stubCcsm() {
+  saveStateSpy = vi.fn(async () => {});
+  loadStateSpy = vi.fn(async () => undefined);
+  const api = {
+    getVersion: vi.fn(async () => '0.0.0-test'),
+    updatesStatus: vi.fn(async () => ({ kind: 'idle' as const })),
+    updatesGetAutoCheck: vi.fn(async () => true),
+    updatesSetAutoCheck: vi.fn(async (v: boolean) => v),
+    updatesCheck: vi.fn(async () => {}),
+    updatesDownload: vi.fn(async () => {}),
+    updatesInstall: vi.fn(async () => {}),
+    onUpdateStatus: () => () => {},
+    loadState: loadStateSpy,
+    saveState: saveStateSpy,
+    settingsLoad: vi.fn(async () => ({})),
+    settingsOpenInEditor: vi.fn(async () => {}),
+    modelsList: vi.fn(async () => []),
+  };
+  (window as { ccsm?: unknown }).ccsm = api;
+  return api;
+}
+
+function stubMatchMedia() {
+  if (window.matchMedia) return;
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (q: string) => ({
+      matches: false,
+      media: q,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+function Harness() {
+  const [open, setOpen] = useState(true);
+  return (
+    <SettingsDialog open={open} onOpenChange={setOpen} initialTab="appearance" />
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  stubCcsm();
+  stubMatchMedia();
+  initI18n('en');
+  // Reset the slice's value to default before each test.
+  act(() => {
+    useStore.getState().setScrollbackLines(SCROLLBACK_LINES_DEFAULT);
+  });
+});
+
+afterEach(() => {
+  delete (window as { ccsm?: unknown }).ccsm;
+});
+
+describe('Settings: terminal scrollback', () => {
+  it('renders the scrollback input and label', () => {
+    render(<Harness />);
+    const dialog = screen.getByRole('dialog');
+    // Field label visible.
+    expect(within(dialog).getByText(/Terminal scrollback/i)).toBeInTheDocument();
+    // Input present and reflects current store default.
+    const input = within(dialog).getByLabelText(
+      /Terminal scrollback in lines/i,
+    ) as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe(String(SCROLLBACK_LINES_DEFAULT));
+  });
+
+  it('reflects the current zustand store value at mount', () => {
+    act(() => useStore.getState().setScrollbackLines(2222));
+    render(<Harness />);
+    const input = screen.getByLabelText(
+      /Terminal scrollback in lines/i,
+    ) as HTMLInputElement;
+    expect(input.value).toBe('2222');
+  });
+
+  it('persists the new value on blur via setScrollbackLines + saveState', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText(
+      /Terminal scrollback in lines/i,
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '3500' } });
+    fireEvent.blur(input);
+
+    // Renderer source-of-truth (zustand) updated.
+    expect(useStore.getState().scrollbackLines).toBe(3500);
+    // Through-write to db (main reads from this same row).
+    expect(saveStateSpy).toHaveBeenCalledWith('scrollbackLines', '3500');
+    // Input echoes the sanitized value.
+    expect(input.value).toBe('3500');
+  });
+
+  it('clamps a too-large value to MAX', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText(
+      /Terminal scrollback in lines/i,
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '999999' } });
+    fireEvent.blur(input);
+
+    expect(useStore.getState().scrollbackLines).toBe(SCROLLBACK_LINES_MAX);
+    expect(saveStateSpy).toHaveBeenCalledWith(
+      'scrollbackLines',
+      String(SCROLLBACK_LINES_MAX),
+    );
+    expect(input.value).toBe(String(SCROLLBACK_LINES_MAX));
+  });
+
+  it('clamps a too-small value to MIN', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText(
+      /Terminal scrollback in lines/i,
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '0' } });
+    fireEvent.blur(input);
+
+    expect(useStore.getState().scrollbackLines).toBe(SCROLLBACK_LINES_MIN);
+    expect(input.value).toBe(String(SCROLLBACK_LINES_MIN));
+  });
+
+  it('reset button restores the documented default', () => {
+    act(() => useStore.getState().setScrollbackLines(4242));
+    render(<Harness />);
+    const dialog = screen.getByRole('dialog');
+    // Localized label: "Reset to default ({{default}})".
+    const resetBtn = within(dialog).getByRole('button', {
+      name: /Reset to default/i,
+    });
+    fireEvent.click(resetBtn);
+
+    expect(useStore.getState().scrollbackLines).toBe(SCROLLBACK_LINES_DEFAULT);
+    expect(saveStateSpy).toHaveBeenCalledWith(
+      'scrollbackLines',
+      String(SCROLLBACK_LINES_DEFAULT),
+    );
+  });
+
+  it('Enter key triggers blur which commits the value', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText(
+      /Terminal scrollback in lines/i,
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '2750' } });
+    // jsdom doesn't reliably forward `el.blur()` from a keydown handler
+    // back into a synthetic React onBlur event in this test environment.
+    // Drive the keydown for behavioural coverage of the handler itself
+    // (preventDefault path), then fire the blur directly to verify the
+    // commit pipeline. Production behavior is unchanged: keydown calls
+    // .blur(), the browser fires onBlur, commit runs.
+    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.blur(input);
+    expect(useStore.getState().scrollbackLines).toBe(2750);
+    expect(saveStateSpy).toHaveBeenCalledWith('scrollbackLines', '2750');
+  });
+});


### PR DESCRIPTION
## Summary

Single user-facing knob bounding both the visible xterm and the headless authoritative buffer. Default lowered from **10000 (headless) / 5000 (visible)** to **1500**.

## Why

Per investigation: the L4 PR-A bump to 10000 made every attach serialize potentially MBs of scrollback. 1500 lines covers typical re-attach replay needs while keeping snapshot payloads small. Power users who want more (long bisect / log review) now have a slider instead of a hardcoded constant.

## Design

- New pref module `electron/prefs/scrollback.ts` (db:save + stateSavedBus, mirroring `notifyEnabled` / `closeAction`).
- `entryFactory.makeEntry`: headless `Terminal({ scrollback: loadScrollbackLines() })`. Existing entries keep their already-sized buffer; new spawns pick up changes immediately.
- `lifecycle.attach` and `lifecycle.getBufferSnapshot`: pass `{ scrollback: cap }` to `SerializeAddon.serialize` so the IPC payload only carries the bottom `cap` rows. Cap is read fresh per call → live setting effect, no entry recreate needed.
- Renderer xterm singleton reads the cap once at construction (xterm.js doesn't expose mutable scrollback) → "applies on next launch" for the visible side, documented in helper text.
- `appearanceSlice.scrollbackLines` mirrors the on-disk row so renderer reads are synchronous (`hydrateStore()` seeds it from `db:load('scrollbackLines')` before flipping `hydrated`).
- `SettingsDialog` → Appearance pane: number input, range 100-50000, sentence-case label "Terminal scrollback" + helper text. Reset button restores default.
- i18n: `settings.scrollback{,Hint,Unit,AriaLabel,Reset}` in en + zh.

## Untouched

- PR-B snapshot/seq dedupe protocol (only the cap on which lines are included changes).
- xterm paste/copy/keymap (3-layer fragility).
- No "show all history" / "load more" buttons.
- No separate headless-vs-visible knobs (single user-facing value).

## Tests

- `electron/prefs/__tests__/scrollback.test.ts` — parser clamping, cache invalidation, reverse-verify.
- `electron/ptyHost/__tests__/bufferSnapshot.test.ts` — `SCROLLBACK == 1500`; cap is passed to `serialize`; live setting changes between calls; real-addon end-to-end (500-line cap, 3000-line buffer).
- `electron/ptyHost/__tests__/entryFactory.test.ts` — headless constructor receives the user cap.
- `tests/settings-scrollback.test.tsx` — input renders, persists via `saveState` + zustand on blur, clamps MIN/MAX, reset.

## Test plan

- [ ] `npm run typecheck` passes (verified locally)
- [ ] `npm run lint` passes (verified locally; 0 errors)
- [ ] Targeted vitest: 45/45 pass (verified)
- [ ] Full vitest: only pre-existing Windows sqlite NODE_MODULE_VERSION failures (db-hardening, db.test) remain — ignored per dev guidance
- [ ] Manual: open Settings → Appearance → "Terminal scrollback" — confirm input renders, accepts a value, persists across reload
- [ ] Manual: spawn a session, change scrollback to 200, spawn a new session, confirm only ~200 lines are retained in the headless buffer