### PR TITLE
feat(notify): debounce-style "ring the last waiting" toast

### DIFF
--- a/electron/notify/__tests__/runStateTracker.test.ts
+++ b/electron/notify/__tests__/runStateTracker.test.ts
@@ -1,24 +1,33 @@
-import { describe, it, expect } from 'vitest';
-import { createRunStateTracker } from '../runStateTracker';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRunStateTracker, RING_DEBOUNCE_MS } from '../runStateTracker';
 import { decide, DEDUPE_MS, SHORT_TASK_MS } from '../notifyDecider';
+import type { Decision } from '../notifyDecider';
 
 const NOW = 1_700_000_000_000;
 
 describe('runStateTracker — pure decider', () => {
-  it('running → idle: fires a decision (Rule 5 unfocused branch)', () => {
-    const t = createRunStateTracker(decide);
+  it('running → idle: fires a decision (Rule 5 unfocused branch); toast is deferred', () => {
+    const fires: Decision[] = [];
+    const t = createRunStateTracker(decide, {
+      onDeferredToast: (d) => fires.push(d),
+    });
     t.setFocused(false); // Rule 5: not focused → toast + flash
     expect(t.onTitle('s1', 'running', NOW)).toBeNull();
     expect(t._internals().runStartTs.get('s1')).toBe(NOW);
     const dec = t.onTitle('s1', 'idle', NOW + 1_000);
     expect(dec).not.toBeNull();
     expect(dec?.sid).toBe('s1');
-    expect(dec?.toast).toBe(true);
+    // Toast is debounced — immediate decision carries flash only.
+    expect(dec?.toast).toBe(false);
     expect(dec?.flash).toBe(true);
     // runStartTs cleared after non-running title
     expect(t._internals().runStartTs.has('s1')).toBe(false);
-    // lastFiredTs recorded
+    // lastFiredTs recorded (for the flash)
     expect(t._internals().lastFiredTs.get('s1')).toBe(NOW + 1_000);
+    // A pending deferred toast is scheduled.
+    expect(t._internals().pendingToastSids).toEqual(['s1']);
+    expect(fires).toEqual([]);
+    t.dispose();
   });
 
   it('dedupes back-to-back idle titles within DEDUPE_MS', () => {
@@ -31,6 +40,7 @@ describe('runStateTracker — pure decider', () => {
     t.onTitle('s1', 'running', NOW + 200);
     const second = t.onTitle('s1', 'idle', NOW + 100 + DEDUPE_MS - 1);
     expect(second).toBeNull();
+    t.dispose();
   });
 
   it('mute window prevents toast (Rule 7) but flash still fires', () => {
@@ -42,15 +52,26 @@ describe('runStateTracker — pure decider', () => {
     expect(dec).not.toBeNull();
     expect(dec?.toast).toBe(false);
     expect(dec?.flash).toBe(true);
+    // Muted sids must not even schedule a deferred toast (the timer would
+    // be re-suppressed at fire-time anyway, so keep the pending-set tidy).
+    expect(t._internals().pendingToastSids).toEqual([]);
+    t.dispose();
   });
 
   it('expired mute (untilTs in the past) no longer suppresses toast', () => {
-    const t = createRunStateTracker(decide);
+    const fires: Decision[] = [];
+    const t = createRunStateTracker(decide, {
+      onDeferredToast: (d) => fires.push(d),
+    });
     t.setFocused(false);
     t.setMuted('s1', NOW - 1); // already expired
     t.onTitle('s1', 'running', NOW);
     const dec = t.onTitle('s1', 'idle', NOW + 1_000);
-    expect(dec?.toast).toBe(true);
+    // Immediate is flash-only (toast deferred); pending toast exists.
+    expect(dec?.toast).toBe(false);
+    expect(dec?.flash).toBe(true);
+    expect(t._internals().pendingToastSids).toEqual(['s1']);
+    t.dispose();
   });
 
   it('setMuted(null) clears the mute', () => {
@@ -60,7 +81,11 @@ describe('runStateTracker — pure decider', () => {
     t.setMuted('s1', null);
     t.onTitle('s1', 'running', NOW);
     const dec = t.onTitle('s1', 'idle', NOW + 1_000);
-    expect(dec?.toast).toBe(true);
+    // Immediate flash fires; toast is deferred.
+    expect(dec?.toast).toBe(false);
+    expect(dec?.flash).toBe(true);
+    expect(t._internals().pendingToastSids).toEqual(['s1']);
+    t.dispose();
   });
 
   it('forgetSid clears all per-sid state', () => {
@@ -85,10 +110,15 @@ describe('runStateTracker — pure decider', () => {
     expect(after.mutedSids.has('s1')).toBe(false);
     expect(after.lastFiredTs.has('s1')).toBe(false);
     expect(after.lastUserInputTs.has('s1')).toBe(false);
+    expect(after.pendingToastSids).toEqual([]);
+    t.dispose();
   });
 
   it('multiple sids tracked independently', () => {
-    const t = createRunStateTracker(decide);
+    const fires: Decision[] = [];
+    const t = createRunStateTracker(decide, {
+      onDeferredToast: (d) => fires.push(d),
+    });
     t.setFocused(false);
     t.onTitle('s1', 'running', NOW);
     t.onTitle('s2', 'running', NOW + 500);
@@ -106,6 +136,7 @@ describe('runStateTracker — pure decider', () => {
     // Forgetting s1 doesn't touch s2
     t.forgetSid('s1');
     expect(t._internals().lastFiredTs.has('s2')).toBe(true);
+    t.dispose();
   });
 
   it('classification "unknown" is a no-op', () => {
@@ -114,6 +145,7 @@ describe('runStateTracker — pure decider', () => {
     expect(t.onTitle('s1', 'unknown', NOW)).toBeNull();
     expect(t._internals().runStartTs.has('s1')).toBe(false);
     expect(t._internals().lastFiredTs.has('s1')).toBe(false);
+    t.dispose();
   });
 
   it('Rule 1: user-input within 60s suppresses fire', () => {
@@ -124,10 +156,14 @@ describe('runStateTracker — pure decider', () => {
     // Idle 1s later — Rule 1 mute window still active
     const dec = t.onTitle('s1', 'idle', NOW + 1_000);
     expect(dec).toBeNull();
+    t.dispose();
   });
 
   it('Rule 2 vs Rule 3: foreground active sid splits on SHORT_TASK_MS', () => {
-    const t = createRunStateTracker(decide);
+    const fires: Decision[] = [];
+    const t = createRunStateTracker(decide, {
+      onDeferredToast: (d) => fires.push(d),
+    });
     t.setFocused(true);
     t.setActiveSid('s1');
 
@@ -137,24 +173,33 @@ describe('runStateTracker — pure decider', () => {
     expect(shortDec).not.toBeNull();
     expect(shortDec?.toast).toBe(false);
     expect(shortDec?.flash).toBe(true);
+    // Rule 2 doesn't toast → no deferred timer scheduled.
+    expect(t._internals().pendingToastSids).toEqual([]);
 
-    // Wait past dedupe, then long task — Rule 3: toast + flash
+    // Wait past dedupe, then long task — Rule 3: toast + flash.
+    // Toast is debounced, so the immediate Decision still carries flash only;
+    // the toast surfaces via the deferred callback.
     const t2 = NOW + DEDUPE_MS + 10_000;
     t.onTitle('s1', 'running', t2);
     const longDec = t.onTitle('s1', 'idle', t2 + SHORT_TASK_MS + 1_000);
     expect(longDec).not.toBeNull();
-    expect(longDec?.toast).toBe(true);
+    expect(longDec?.toast).toBe(false);
     expect(longDec?.flash).toBe(true);
+    expect(t._internals().pendingToastSids).toEqual(['s1']);
+    t.dispose();
   });
 
-  it('Rule 4: foreground but viewing a different sid → toast + flash', () => {
+  it('Rule 4: foreground but viewing a different sid → toast + flash (toast deferred)', () => {
     const t = createRunStateTracker(decide);
     t.setFocused(true);
     t.setActiveSid('s2'); // viewing s2
     t.onTitle('s1', 'running', NOW);
     const dec = t.onTitle('s1', 'idle', NOW + 1_000);
-    expect(dec?.toast).toBe(true);
+    // Toast debounced; immediate is flash-only.
+    expect(dec?.toast).toBe(false);
     expect(dec?.flash).toBe(true);
+    expect(t._internals().pendingToastSids).toEqual(['s1']);
+    t.dispose();
   });
 
   it('runStartTs is cleared after every non-running title (even when no decision fires)', () => {
@@ -166,6 +211,7 @@ describe('runStateTracker — pure decider', () => {
     const dec = t.onTitle('s1', 'idle', NOW + 1_000);
     expect(dec).toBeNull();
     expect(t._internals().runStartTs.has('s1')).toBe(false);
+    t.dispose();
   });
 
   // ---------------------------------------------------------------------------
@@ -196,6 +242,7 @@ describe('runStateTracker — pure decider', () => {
     // No mutation: lastFiredTs must stay empty (the bug also poisoned the
     // 5s dedupe window with a phantom fire).
     expect(t._internals().lastFiredTs.has('s1')).toBe(false);
+    t.dispose();
   });
 
   it('Task #767: does not fire when first title for a sid is "waiting"', () => {
@@ -205,6 +252,7 @@ describe('runStateTracker — pure decider', () => {
     const dec = t.onTitle('s1', 'waiting', NOW);
     expect(dec).toBeNull();
     expect(t._internals().lastFiredTs.has('s1')).toBe(false);
+    t.dispose();
   });
 
   it('Task #767 regression guard: still fires on idle AFTER a running title', () => {
@@ -223,6 +271,7 @@ describe('runStateTracker — pure decider', () => {
     expect(dec).not.toBeNull();
     expect(dec?.toast).toBe(false);
     expect(dec?.flash).toBe(true);
+    t.dispose();
   });
 
   it('Task #767: forgetSid resets the hasObservedRunning gate', () => {
@@ -242,5 +291,200 @@ describe('runStateTracker — pure decider', () => {
     // lifetime).
     const dec2 = t.onTitle('s1', 'idle', NOW + 10_000);
     expect(dec2).toBeNull();
+    t.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// "Ring the last waiting" debounce (toast-spam fix).
+//
+// Real-world burst: agent runs a long task with several mid-task permission
+// prompts. Each prompt = a 'waiting' title; user answers in-app, agent
+// resumes (next 'running'), next prompt arrives ~5s later. Pre-debounce
+// the user got 3-5 toasts back-to-back. Post-debounce, each waiting
+// (re)starts a RING_DEBOUNCE_MS timer; only the LAST waiting (i.e. the one
+// where the agent actually gets stuck) fires a toast.
+// ---------------------------------------------------------------------------
+describe('runStateTracker — ring-last debounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function newTracker(): { tracker: ReturnType<typeof createRunStateTracker>; fires: Decision[] } {
+    const fires: Decision[] = [];
+    const tracker = createRunStateTracker(decide, {
+      onDeferredToast: (d) => fires.push(d),
+      // nowFn defaults to Date.now which vi.useFakeTimers also patches.
+    });
+    return { tracker, fires };
+  }
+
+  it('edge case 1: quick waiting (title flips out before debounce) → no toast', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false); // Rule 5 path → would-toast
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    expect(tracker._internals().pendingToastSids).toEqual(['s1']);
+    // User answers in-app: agent resumes BEFORE the debounce window closes.
+    vi.advanceTimersByTime(2_000);
+    tracker.onTitle('s1', 'running', NOW + 3_000);
+    expect(tracker._internals().pendingToastSids).toEqual([]);
+    // Advance well past the original deadline — no toast fires.
+    vi.advanceTimersByTime(RING_DEBOUNCE_MS + 1_000);
+    expect(fires).toEqual([]);
+    tracker.dispose();
+  });
+
+  it('edge case 2: single sustained waiting → exactly one toast at +RING_DEBOUNCE_MS', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    // Advance past the debounce window — toast fires.
+    vi.advanceTimersByTime(RING_DEBOUNCE_MS + 10);
+    expect(fires.length).toBe(1);
+    expect(fires[0]!.toast).toBe(true);
+    expect(fires[0]!.flash).toBe(false);
+    expect(fires[0]!.sid).toBe('s1');
+    expect(tracker._internals().pendingToastSids).toEqual([]);
+    tracker.dispose();
+  });
+
+  it('edge case 3: long task with 3 quick prompts then sustained → exactly one toast', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    // Initial run starts at NOW.
+    tracker.onTitle('s1', 'running', NOW);
+    // Prompt #1 at +5s; user answers in 2s (running at +7s).
+    vi.advanceTimersByTime(5_000);
+    tracker.onTitle('s1', 'idle', NOW + 5_000);
+    vi.advanceTimersByTime(2_000); // timer not yet exhausted
+    tracker.onTitle('s1', 'running', NOW + 7_000);
+    expect(fires).toEqual([]);
+    // Prompt #2 at +12s; user answers in 3s.
+    vi.advanceTimersByTime(5_000);
+    tracker.onTitle('s1', 'idle', NOW + 12_000);
+    vi.advanceTimersByTime(3_000);
+    tracker.onTitle('s1', 'running', NOW + 15_000);
+    expect(fires).toEqual([]);
+    // Prompt #3 at +20s; this one sticks (user is away).
+    vi.advanceTimersByTime(5_000);
+    tracker.onTitle('s1', 'idle', NOW + 20_000);
+    // Advance the full debounce window.
+    vi.advanceTimersByTime(RING_DEBOUNCE_MS + 10);
+    expect(fires.length).toBe(1);
+    expect(fires[0]!.sid).toBe('s1');
+    tracker.dispose();
+  });
+
+  it('edge case 4a: Rule 1 (user-input) still suppresses at fire-time', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    // 2s into the wait, user touches the sid (e.g. presses Enter from inside
+    // ccsm to take an action). The timer is still pending; at fire-time the
+    // user-init window is active and suppresses the toast.
+    vi.advanceTimersByTime(2_000);
+    tracker.markUserInput('s1', NOW + 3_000);
+    vi.advanceTimersByTime(RING_DEBOUNCE_MS); // fires at NOW + 9_000
+    expect(fires).toEqual([]);
+    tracker.dispose();
+  });
+
+  it('edge case 4b: Rule 7 (per-sid mute) still suppresses at fire-time', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    expect(tracker._internals().pendingToastSids).toEqual(['s1']);
+    // Mute the sid during the wait — fire-time re-check suppresses.
+    vi.advanceTimersByTime(2_000);
+    tracker.setMuted('s1', Number.POSITIVE_INFINITY);
+    vi.advanceTimersByTime(RING_DEBOUNCE_MS);
+    expect(fires).toEqual([]);
+    tracker.dispose();
+  });
+
+  it('edge case 5: multiple sids run independent timers', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s2', 'running', NOW + 100);
+    // s1 starts waiting at +1s → deadline NOW+9_000.
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    // s2 starts waiting at +3s → deadline NOW+11_000.
+    vi.advanceTimersByTime(2_000);
+    tracker.onTitle('s2', 'idle', NOW + 3_000);
+    expect(tracker._internals().pendingToastSids.sort()).toEqual(['s1', 's2']);
+    // Advance to NOW+9_010 — only s1 fires.
+    vi.advanceTimersByTime(6_010);
+    expect(fires.length).toBe(1);
+    expect(fires[0]!.sid).toBe('s1');
+    expect(tracker._internals().pendingToastSids).toEqual(['s2']);
+    // Advance to NOW+11_010 — s2 fires too.
+    vi.advanceTimersByTime(2_000);
+    expect(fires.length).toBe(2);
+    expect(fires[1]!.sid).toBe('s2');
+    tracker.dispose();
+  });
+
+  it('forgetSid cancels any pending deferred toast', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    expect(tracker._internals().pendingToastSids).toEqual(['s1']);
+    tracker.forgetSid('s1');
+    expect(tracker._internals().pendingToastSids).toEqual([]);
+    vi.advanceTimersByTime(RING_DEBOUNCE_MS + 1_000);
+    expect(fires).toEqual([]);
+    tracker.dispose();
+  });
+
+  it('dispose cancels all pending deferred toasts', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    tracker.onTitle('s2', 'running', NOW + 100);
+    tracker.onTitle('s2', 'idle', NOW + 1_100);
+    expect(tracker._internals().pendingToastSids.length).toBe(2);
+    tracker.dispose();
+    expect(tracker._internals().pendingToastSids).toEqual([]);
+    vi.advanceTimersByTime(RING_DEBOUNCE_MS + 1_000);
+    expect(fires).toEqual([]);
+  });
+
+  it('two bursts past dedupe: the LAST waiting wins (timer pushed out by each fresh idle)', () => {
+    // Burst pattern with running flips between idles. Each fresh idle past
+    // the 5s dedupe window pushes the deadline out — only the final waiting
+    // (no follow-up running) actually rings.
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    // Idle #1 at +1s.
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    // 6s later (past the 5s dedupe), agent resumes briefly.
+    vi.advanceTimersByTime(6_000); // now NOW+7_000
+    tracker.onTitle('s1', 'running', NOW + 7_000);
+    // No fire yet — running cancelled the pending timer.
+    expect(fires).toEqual([]);
+    expect(tracker._internals().pendingToastSids).toEqual([]);
+    // Idle #2 at +8s; this one sticks.
+    vi.advanceTimersByTime(1_000); // now NOW+8_000
+    tracker.onTitle('s1', 'idle', NOW + 8_000);
+    // Deadline now NOW+16_000. Advance to NOW+15_500 — not fired yet.
+    vi.advanceTimersByTime(7_500);
+    expect(fires).toEqual([]);
+    // Past the deadline.
+    vi.advanceTimersByTime(1_000);
+    expect(fires.length).toBe(1);
+    expect(fires[0]!.sid).toBe('s1');
+    tracker.dispose();
   });
 });

--- a/electron/notify/runStateTracker.ts
+++ b/electron/notify/runStateTracker.ts
@@ -29,9 +29,48 @@
 //   * `forgetSid(sid)` clears every per-sid map entry in one shot
 //                      (mirrors pipeline.forgetSid for the state it owns).
 
-import type { Ctx, Decision, Event } from './notifyDecider';
+import { USER_INIT_MUTE_MS, type Ctx, type Decision, type Event } from './notifyDecider';
 
 export type TitleClassification = 'idle' | 'running' | 'waiting' | 'unknown';
+
+/**
+ * "Ring the last waiting" debounce window.
+ *
+ * Real-world burst pattern: a long agent task issues several quick
+ * permission / question prompts back-to-back (waiting → user answers in-app
+ * → running → waiting → …). Pre-debounce, each waiting fired its own toast,
+ * giving the user 3-5 OS notifications for a single task. Post-debounce,
+ * each waiting (re)starts a 8s timer; if the title flips back to running
+ * before 8s elapses (because the user answered in-app, or the CLI moved on
+ * on its own), the timer is cancelled and no toast fires. Only the FINAL,
+ * still-waiting prompt that has settled for 8s rings.
+ *
+ * Trade-off: a single long-waiting prompt is now delayed by 8s vs. fire-
+ * immediately. We accept the slight latency in exchange for the burst-
+ * collapse — toast spam is the louder complaint. Tune via PR if needed.
+ *
+ * The flash (sidebar halo) still fires IMMEDIATELY on each waiting — only
+ * the OS toast is debounced. The user gets instant in-app feedback;
+ * the OS-level interrupt is reserved for genuinely stuck waits.
+ */
+export const RING_DEBOUNCE_MS = 8_000;
+
+export interface RunStateTrackerOptions {
+  /** Override the debounce window (test only). Defaults to RING_DEBOUNCE_MS. */
+  ringDebounceMs?: number;
+  /** Wall-clock provider for deferred-toast fire-time re-evaluation. Defaults
+   *  to Date.now. Tests inject a mock to advance time deterministically. */
+  nowFn?: () => number;
+  /** setTimeout / clearTimeout overrides. Default to globalThis. Tests using
+   *  vi.useFakeTimers() can rely on the defaults, but explicit injection is
+   *  available if a test needs a hand-rolled scheduler. */
+  setTimeoutFn?: (cb: () => void, ms: number) => unknown;
+  clearTimeoutFn?: (handle: unknown) => void;
+  /** Sink callback for a deferred toast that survived the debounce window.
+   *  Receives a Decision with `toast:true, flash:false` (flash already fired
+   *  on the immediate path when the debounce started). */
+  onDeferredToast?: (decision: Decision) => void;
+}
 
 export interface RunStateTracker {
   /** Producer entry — feed a classified title for `sid` at `nowTs`.
@@ -48,6 +87,8 @@ export interface RunStateTracker {
   /** Mute `sid` until `untilTs` (use `Infinity` for sticky). Pass
    *  `null` to clear. */
   setMuted(sid: string, untilTs: number | null): void;
+  /** Cancel all pending deferred toasts (test / shutdown cleanup). */
+  dispose(): void;
   /** Test-only — read internal maps for assertion. */
   _internals(): {
     runStartTs: Map<string, number>;
@@ -56,17 +97,34 @@ export interface RunStateTracker {
     lastUserInputTs: Map<string, number>;
     focused: boolean;
     activeSid: string | null;
+    /** sids with an outstanding deferred-toast timer. */
+    pendingToastSids: string[];
   };
 }
 
 export function createRunStateTracker(
   decide: (event: Event, ctx: Ctx) => Decision | null,
+  options: RunStateTrackerOptions = {},
 ): RunStateTracker {
+  const ringDebounceMs = options.ringDebounceMs ?? RING_DEBOUNCE_MS;
+  const nowFn = options.nowFn ?? Date.now;
+  const setTimeoutFn =
+    options.setTimeoutFn ?? ((cb: () => void, ms: number) => setTimeout(cb, ms));
+  const clearTimeoutFn =
+    options.clearTimeoutFn ?? ((h: unknown) => clearTimeout(h as ReturnType<typeof setTimeout>));
+  const onDeferredToast = options.onDeferredToast;
+
   const runStartTs = new Map<string, number>();
   /** Map<sid, untilTs> — entry present + nowTs < untilTs ⇒ sid is muted. */
   const mutedSids = new Map<string, number>();
   const lastFiredTs = new Map<string, number>();
   const lastUserInputTs = new Map<string, number>();
+  /** Per-sid outstanding deferred-toast timer handle. Cancelled on:
+   *    - 'running' classification (task resumed → no ring)
+   *    - forgetSid (session teardown)
+   *    - dispose (pipeline / process shutdown)
+   *  Reset on each new waiting signal (debounce semantics — ring the LAST). */
+  const pendingToastTimers = new Map<string, unknown>();
   /**
    * Per-sid gate (Task #767): true once we have observed a 'running' title
    * for this sid in the current process lifetime. The decider's Rule 2
@@ -94,6 +152,51 @@ export function createRunStateTracker(
     return out;
   }
 
+  function isMutedNow(sid: string, nowTs: number): boolean {
+    const until = mutedSids.get(sid);
+    return until !== undefined && nowTs < until;
+  }
+
+  function cancelPendingToast(sid: string): void {
+    const t = pendingToastTimers.get(sid);
+    if (t !== undefined) {
+      clearTimeoutFn(t);
+      pendingToastTimers.delete(sid);
+    }
+  }
+
+  /**
+   * Schedule (or reset) the deferred-toast timer for `sid`.
+   *
+   * Each fresh waiting signal pushes the fire deadline out to NOW +
+   * ringDebounceMs. Burst-collapse: rapid running ↔ waiting flips never
+   * exhaust the timer; only sustained waiting does.
+   */
+  function schedulePendingToast(sid: string): void {
+    cancelPendingToast(sid);
+    const handle = setTimeoutFn(() => {
+      pendingToastTimers.delete(sid);
+      if (!onDeferredToast) return;
+      // Re-evaluate at fire-time. We deliberately do NOT re-run the full
+      // decider here — runStartTs has been cleared (so Rule 2 would fire
+      // flash-only and Rule 3 would never fire). Instead, re-check the
+      // two dynamic suppressors that may have flipped during the wait:
+      //   1. Rule 1 user-init mute (user touched this sid in last 60s)
+      //   2. Rule 7 per-sid mute
+      // Global mute is enforced one layer up in pipeline.ts (the pipeline
+      // never feeds idle through to the tracker when global mute is on, so
+      // a deferred fire on a globally-muted sid cannot happen unless the
+      // mute toggled on AFTER schedule — acceptable, pipeline owns it).
+      const fireTs = nowFn();
+      const lastInput = lastUserInputTs.get(sid);
+      if (lastInput !== undefined && fireTs - lastInput < USER_INIT_MUTE_MS) return;
+      if (isMutedNow(sid, fireTs)) return;
+      lastFiredTs.set(sid, fireTs);
+      onDeferredToast({ toast: true, flash: false, sid });
+    }, ringDebounceMs);
+    pendingToastTimers.set(sid, handle);
+  }
+
   return {
     onTitle(sid, classification, nowTs) {
       if (classification === 'unknown') return null;
@@ -101,6 +204,9 @@ export function createRunStateTracker(
       if (classification === 'running') {
         if (!runStartTs.has(sid)) runStartTs.set(sid, nowTs);
         hasObservedRunning.add(sid);
+        // Cancel any pending deferred toast — the task moved on, the user
+        // (or the CLI) already handled the previous waiting signal.
+        cancelPendingToast(sid);
         return null;
       }
 
@@ -129,16 +235,41 @@ export function createRunStateTracker(
         now: nowTs,
       };
       const event: Event = { type: 'osc-title', sid, title: 'waiting', ts: nowTs };
-      const decision = decide(event, ctx);
+      const immediate = decide(event, ctx);
 
       // Mirror pipeline behaviour: always clear runStartTs after a
       // non-running title so the next run starts a fresh elapsed clock.
       runStartTs.delete(sid);
 
-      if (decision !== null) {
-        lastFiredTs.set(sid, nowTs);
+      // Debounce-style "ring the LAST waiting": any waiting signal that
+      // would otherwise toast (re)starts the deferred-toast timer.
+      // We trigger the schedule when EITHER:
+      //   - decide() returned toast:true (the original "yes, toast" path), OR
+      //   - decide() returned null AND a deferred toast is already pending
+      //     (a follow-up waiting inside a burst — even if the immediate
+      //     decision was suppressed by 5s dedupe, we still want the timer
+      //     pushed out so the LAST waiting wins).
+      // We do NOT schedule when the sid is currently muted (no point
+      // firing later either — re-eval at fire-time would suppress anyway,
+      // and avoiding the timer keeps the pending-set tidy).
+      const shouldDefer =
+        !isMutedNow(sid, nowTs) &&
+        ((immediate !== null && immediate.toast) || pendingToastTimers.has(sid));
+      if (shouldDefer) {
+        schedulePendingToast(sid);
       }
-      return decision;
+
+      if (immediate !== null) {
+        lastFiredTs.set(sid, nowTs);
+        if (immediate.toast) {
+          // Strip the toast from the immediate fan-out — it will fire (or
+          // not) via the deferred path. Flash still fires immediately so
+          // the in-app halo is instant.
+          return { toast: false, flash: immediate.flash, sid };
+        }
+        return immediate;
+      }
+      return null;
     },
     forgetSid(sid) {
       runStartTs.delete(sid);
@@ -146,6 +277,7 @@ export function createRunStateTracker(
       lastFiredTs.delete(sid);
       lastUserInputTs.delete(sid);
       hasObservedRunning.delete(sid);
+      cancelPendingToast(sid);
     },
     setFocused(next) {
       focused = next;
@@ -160,6 +292,10 @@ export function createRunStateTracker(
       if (untilTs === null) mutedSids.delete(sid);
       else mutedSids.set(sid, untilTs);
     },
+    dispose() {
+      for (const handle of pendingToastTimers.values()) clearTimeoutFn(handle);
+      pendingToastTimers.clear();
+    },
     _internals() {
       return {
         runStartTs,
@@ -168,6 +304,7 @@ export function createRunStateTracker(
         lastUserInputTs,
         focused,
         activeSid,
+        pendingToastSids: Array.from(pendingToastTimers.keys()),
       };
     },
   };

--- a/electron/notify/sinks/__tests__/pipeline.test.ts
+++ b/electron/notify/sinks/__tests__/pipeline.test.ts
@@ -59,32 +59,43 @@ describe('installNotifyPipeline (Task #743 orchestrator)', () => {
   });
 
   it('running -> idle (unfocused) feeds a toast + flash via the sinks', () => {
-    const { win, sends } = makeStubWin();
-    const onNotified = vi.fn();
-    const pipeline = installNotifyPipeline({
-      getMainWindow: () => win as never,
-      isGlobalMutedFn: () => false,
-      getNameFn: () => 'Test',
-      onNotified,
-    });
-    pipeline.setFocused(false); // Rule 5
+    vi.useFakeTimers();
+    try {
+      const { win, sends } = makeStubWin();
+      const onNotified = vi.fn();
+      const pipeline = installNotifyPipeline({
+        getMainWindow: () => win as never,
+        isGlobalMutedFn: () => false,
+        getNameFn: () => 'Test',
+        onNotified,
+      });
+      pipeline.setFocused(false); // Rule 5
 
-    pipeline.feedChunk('s1', osc(RUNNING_TITLE));
-    pipeline.feedChunk('s1', osc(IDLE_TITLE));
+      pipeline.feedChunk('s1', osc(RUNNING_TITLE));
+      pipeline.feedChunk('s1', osc(IDLE_TITLE));
 
-    // Toast sink fired (test-hook impl writes to globalThis log).
-    const log = (globalThis as { __ccsmNotifyLog?: Array<{ sid: string }> }).__ccsmNotifyLog;
-    expect(log).toBeDefined();
-    expect(log!.length).toBe(1);
-    expect(log![0]!.sid).toBe('s1');
-    expect(onNotified).toHaveBeenCalledWith('s1');
+      // Flash sink fired immediately (sidebar halo is instant).
+      const flashSends = sends.filter((s) => s.channel === 'notify:flash');
+      expect(flashSends.length).toBe(1);
+      expect(flashSends[0]!.payload).toEqual({ sid: 's1', on: true });
 
-    // Flash sink fired notify:flash IPC.
-    const flashSends = sends.filter((s) => s.channel === 'notify:flash');
-    expect(flashSends.length).toBe(1);
-    expect(flashSends[0]!.payload).toEqual({ sid: 's1', on: true });
+      // Toast is DEBOUNCED — nothing yet.
+      const log0 = (globalThis as { __ccsmNotifyLog?: Array<{ sid: string }> }).__ccsmNotifyLog;
+      expect(log0 ?? []).toEqual([]);
+      expect(onNotified).not.toHaveBeenCalled();
 
-    pipeline.dispose();
+      // Advance past the ring-debounce window — toast fires.
+      vi.advanceTimersByTime(10_000);
+      const log = (globalThis as { __ccsmNotifyLog?: Array<{ sid: string }> }).__ccsmNotifyLog;
+      expect(log).toBeDefined();
+      expect(log!.length).toBe(1);
+      expect(log![0]!.sid).toBe('s1');
+      expect(onNotified).toHaveBeenCalledWith('s1');
+
+      pipeline.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('global mute short-circuits BEFORE the tracker runs (no decision, no fire)', () => {
@@ -143,25 +154,33 @@ describe('installNotifyPipeline (Task #743 orchestrator)', () => {
   });
 
   it('setMuted suppresses toast for the sid (Rule 7) but a different sid still fires', () => {
-    const { win } = makeStubWin();
-    const onNotified = vi.fn();
-    const pipeline = installNotifyPipeline({
-      getMainWindow: () => win as never,
-      isGlobalMutedFn: () => false,
-      onNotified,
-    });
-    pipeline.setFocused(false);
-    pipeline.setMuted('s1', true);
+    vi.useFakeTimers();
+    try {
+      const { win } = makeStubWin();
+      const onNotified = vi.fn();
+      const pipeline = installNotifyPipeline({
+        getMainWindow: () => win as never,
+        isGlobalMutedFn: () => false,
+        onNotified,
+      });
+      pipeline.setFocused(false);
+      pipeline.setMuted('s1', true);
 
-    pipeline.feedChunk('s1', osc(RUNNING_TITLE));
-    pipeline.feedChunk('s1', osc(IDLE_TITLE));
-    expect(onNotified).not.toHaveBeenCalledWith('s1');
+      pipeline.feedChunk('s1', osc(RUNNING_TITLE));
+      pipeline.feedChunk('s1', osc(IDLE_TITLE));
 
-    // A non-muted sid still fires through the same pipeline.
-    pipeline.feedChunk('s2', osc(RUNNING_TITLE));
-    pipeline.feedChunk('s2', osc(IDLE_TITLE));
-    expect(onNotified).toHaveBeenCalledWith('s2');
-    pipeline.dispose();
+      // A non-muted sid still fires through the same pipeline.
+      pipeline.feedChunk('s2', osc(RUNNING_TITLE));
+      pipeline.feedChunk('s2', osc(IDLE_TITLE));
+
+      // s2's toast is debounced — drain the timer.
+      vi.advanceTimersByTime(10_000);
+      expect(onNotified).not.toHaveBeenCalledWith('s1');
+      expect(onNotified).toHaveBeenCalledWith('s2');
+      pipeline.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('projectCtx surfaces tracker focused/active state for inspectors', () => {

--- a/electron/notify/sinks/pipeline.ts
+++ b/electron/notify/sinks/pipeline.ts
@@ -84,7 +84,17 @@ export function installNotifyPipeline(opts: NotifyPipelineOptions): NotifyPipeli
     onNotified: opts.onNotified,
   });
   const flash = createFlashSink({ getMainWindow: opts.getMainWindow });
-  const tracker = createRunStateTracker(decide);
+  // Deferred-toast wiring (Task: "ring the last waiting"). The tracker
+  // strips toast:true from its synchronous return and instead schedules a
+  // RING_DEBOUNCE_MS timer per sid; on timer fire (no 'running' arrived
+  // in the meantime), it calls back here to ring exactly once. The
+  // `onNotified` badge bump still fires via toastSink.apply, so unread
+  // counts stay consistent regardless of which path the toast took.
+  const tracker = createRunStateTracker(decide, {
+    onDeferredToast: (decision) => {
+      toast.apply(decision);
+    },
+  });
 
   // Diagnostics for e2e probes — counts what each layer sees so we can tell
   // whether failure is "no PTY data", "no OSC titles", "titles seen but
@@ -207,6 +217,11 @@ export function installNotifyPipeline(opts: NotifyPipelineOptions): NotifyPipeli
       // pipeline disposal — visible as a slow-growing handle count in
       // long-running tests / HMR reloads.
       flash.dispose();
+      // Cancel any outstanding deferred-toast timers held by the tracker.
+      // Same leak class as flashSink timers — without this, a still-pending
+      // ring would fire after the pipeline (and its sinks) are torn down,
+      // attempting to toast against a destroyed BrowserWindow.
+      tracker.dispose();
     },
     _internals() {
       return { ctx: projectCtx(), sniffer, tracker, toast, flash, diag };


### PR DESCRIPTION
## Problem

When an agent runs a long-running task with several quick mid-task
permission/question prompts, ccsm currently fires a separate Windows
toast for each waiting transition. User feedback: ring only the LAST
one (after the burst settles).

ccsm has no way to distinguish "auto-allowed" from "needs input" — it
only sees OSC titles. Each waiting title is a real CLI prompt, but in
practice users answer the first N quickly from inside ccsm. The toast
spam is the noisy half of that exchange.

## Design

When a waiting signal arrives for a sid:
1. (Re)start an 8s deferred-toast timer for that sid.
2. On `running`: cancel the timer (task moved on, no ring).
3. When the timer fires: re-check Rule 1 (user-init mute) and Rule 7
   (per-sid mute) at fire-time, then ring.

Flash (sidebar halo) still fires IMMEDIATELY on each waiting — only
the OS-level toast is debounced.

`RING_DEBOUNCE_MS = 8000` is hardcoded. Settings tuning is a 1-line PR
if dogfood reveals the value is wrong.

## Before / after burst behaviour

```
Sequence: running → idle → running → idle → running → idle (sticks)
          (5s)     (3s)    (4s)     (3s)    (∞)

Before: 3 toasts (each idle past 5s dedupe).
After:  1 toast at LAST_idle + 8s (the only one still waiting at fire-time).
```

## Trade-off (documented in code)

Single sustained waiting is now delayed by 8s vs. fire-immediately.
Burst-collapse is the louder complaint, so we accept the latency.

## Edge cases tested

1. Quick waiting (title flips out before 8s) → no toast.
2. Single sustained waiting → exactly one toast at +8s.
3. Long task with 3 quick prompts then sustained → exactly one toast.
4. Rule 1 user-init mute + Rule 7 per-sid mute still suppress at
   fire-time (re-checked when the timer fires, not just on schedule).
5. Multiple sids run independent timers; each rings on its own clock.
6. forgetSid / pipeline.dispose cancel pending timers (no late toasts
   after session teardown / app shutdown).

## Verification

- `npm run typecheck` — clean.
- `npm run lint` — 0 errors on changed files (pre-existing warnings
  elsewhere unchanged).
- `npx vitest run electron/notify` — 134/134 pass (11 files), including
  all 5 design edge cases plus 4 supporting cases (forget/dispose/
  ring-last burst).

## Files changed

- `electron/notify/runStateTracker.ts` — per-sid pending-toast timer,
  schedule on idle, cancel on running/forget/dispose.
- `electron/notify/sinks/pipeline.ts` — wire `onDeferredToast` →
  `toast.apply`; call `tracker.dispose()` in pipeline `dispose`.
- Test updates + new ring-last debounce describe block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)