### PR TITLE
fix(release): allowlist required checks in CI gate to ignore self-pollution

### DIFF
--- a/.github/workflows/daily-promote-release.yml
+++ b/.github/workflows/daily-promote-release.yml
@@ -64,6 +64,23 @@ jobs:
       # Prefer RELEASE_TOKEN (PAT) so the auto-opened PR fires required
       # checks. Fall back to GITHUB_TOKEN for the read-only gates.
       GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+      # Allowlist of CI check-run names that gates require to be green on
+      # the PR head SHA. Newline-separated so names with spaces work.
+      # CRITICAL: this list MUST exclude the names of any check-run this
+      # workflow itself registers (e.g. "promote working → main + tag"),
+      # otherwise the gate self-poisons — the in-progress / historical-
+      # failed runs of this workflow attach check-runs to the same PR head
+      # and would fail the gate. See: failing run 26205515547.
+      # When adding a new required CI check, append it here.
+      EXPECTED_CHECKS: |
+        e2e (macos-latest)
+        e2e (ubuntu-latest)
+        e2e (windows-latest)
+        lint + typecheck + test (macos-latest)
+        lint + typecheck + test (ubuntu-latest)
+        lint + typecheck + test (windows-latest)
+        no-silent-drops
+        check-source
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -307,6 +324,8 @@ jobs:
           TIMEOUT_SECONDS: '1800'  # 30 min
         run: |
           set -euo pipefail
+          # Render allowlist as JSON array for jq.
+          expected_json=$(printf '%s\n' "$EXPECTED_CHECKS" | jq -R . | jq -s '[.[] | select(length > 0)]')
           deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
           while :; do
             # Find PR for this merge commit.
@@ -314,24 +333,42 @@ jobs:
             if [ -z "$pr_head" ]; then
               echo "PR association not yet indexed; waiting..."
             else
-              # Pull all check-runs; require all completed and all in {success,neutral,skipped}.
-              runs=$(gh api --paginate "repos/$OWNER/$REPO/commits/$pr_head/check-runs" --jq '.check_runs[] | {name, status, conclusion}')
-              if [ -z "$runs" ]; then
-                echo "No check-runs yet on $pr_head; waiting..."
-              else
-                pending=$(echo "$runs" | jq -s '[.[] | select(.status != "completed")] | length')
-                bad=$(    echo "$runs" | jq -s '[.[] | select(.status == "completed") | select(.conclusion as $c | ["success","neutral","skipped"] | index($c) | not)] | length')
-                if [ "$bad" -gt 0 ]; then
-                  echo "::error::main CI has $bad failed check(s) on $pr_head"
-                  echo "$runs" | jq -s '.[] | select(.conclusion as $c | ["success","neutral","skipped"] | index($c) | not)'
-                  exit 1
-                fi
-                if [ "$pending" -eq 0 ]; then
-                  echo "### main CI: all checks green on \`$pr_head\`" >> "$GITHUB_STEP_SUMMARY"
-                  exit 0
-                fi
-                echo "$pending check(s) still pending; waiting..."
+              # Pull all check-runs, then filter to allowlist (ignore this
+              # workflow's own check-run + any other unrelated runs that
+              # happen to land on the same PR head SHA).
+              all=$(gh api --paginate "repos/$OWNER/$REPO/commits/$pr_head/check-runs" \
+                --jq '.check_runs[] | {name, status, conclusion, completed_at, id}' | jq -s '.')
+              # For each expected name pick the latest matching run (re-run dedup).
+              selected=$(jq -n --argjson runs "$all" --argjson expected "$expected_json" '
+                $expected
+                | map(. as $name
+                      | { name: $name,
+                          run: ( $runs
+                                 | map(select(.name == $name))
+                                 | sort_by([(.completed_at // ""), (.id // 0)])
+                                 | last ) })
+              ')
+              missing=$(echo "$selected" | jq '[.[] | select(.run == null) | .name]')
+              missing_count=$(echo "$missing" | jq 'length')
+              pending=$(echo "$selected" | jq '[.[] | select(.run != null) | select(.run.status != "completed")] | length')
+              bad=$(echo "$selected" | jq '
+                [ .[]
+                  | select(.run != null)
+                  | select(.run.status == "completed")
+                  | select(.run.conclusion as $c | (["success","neutral","skipped"] | index($c)) | not)
+                  | { name: .name, conclusion: .run.conclusion } ]
+              ')
+              bad_count=$(echo "$bad" | jq 'length')
+              if [ "$bad_count" -gt 0 ]; then
+                echo "::error::main CI has $bad_count failed required check(s) on $pr_head"
+                echo "$bad" | jq '.'
+                exit 1
               fi
+              if [ "$missing_count" -eq 0 ] && [ "$pending" -eq 0 ]; then
+                echo "### main CI: all required checks green on \`$pr_head\`" >> "$GITHUB_STEP_SUMMARY"
+                exit 0
+              fi
+              echo "$pending pending, $missing_count missing required check(s); waiting..."
             fi
             if [ "$(date +%s)" -ge "$deadline" ]; then
               echo "::error::Timed out waiting for main CI after ${TIMEOUT_SECONDS}s"

--- a/.github/workflows/scripts/check-ci-via-pr.sh
+++ b/.github/workflows/scripts/check-ci-via-pr.sh
@@ -7,14 +7,23 @@
 #
 # Usage: check-ci-via-pr.sh <commit-sha> <label-for-summary>
 #
-# Pass iff every check-run on the PR head is completed AND conclusion in
-# {success, neutral, skipped}. Anything else (failure, cancelled,
-# timed_out, action_required, stale, or status != completed) → exit 1.
+# Required env: OWNER, REPO, GH_TOKEN, EXPECTED_CHECKS.
+#
+# EXPECTED_CHECKS is a newline-separated allowlist of check-run names that
+# MUST all be present and green. Newline-separated (not space) so names
+# containing spaces (e.g. "lint + typecheck + test (macos-latest)") work
+# without quoting gymnastics. Anything outside the allowlist is ignored —
+# critical, because the promote-release workflow registers its own
+# check-run ("promote working → main + tag") on the same PR head SHA and
+# would otherwise self-poison this gate.
+#
+# Pass iff every name in EXPECTED_CHECKS has a check-run that is completed
+# AND conclusion in {success, neutral, skipped}. Missing names → fail
+# loud. Names appearing multiple times (re-runs) → use the latest by
+# completed_at then id.
 #
 # If the commit has no associated PR, exit 1 with a clear message — per
 # locked decision: "refuse to promote" rather than silently passing.
-#
-# Env: OWNER, REPO, GH_TOKEN must be set by the caller.
 
 set -euo pipefail
 
@@ -26,7 +35,17 @@ if [ -z "${OWNER:-}" ] || [ -z "${REPO:-}" ]; then
   exit 2
 fi
 
+if [ -z "${EXPECTED_CHECKS:-}" ]; then
+  echo "::error::EXPECTED_CHECKS env var required (newline-separated check-run names)"
+  exit 2
+fi
+
 echo "Gate CI for $label at $sha"
+
+# Render expected list for logs / step summary.
+expected_json=$(printf '%s\n' "$EXPECTED_CHECKS" | jq -R . | jq -s '[.[] | select(length > 0)]')
+echo "Expected checks:"
+echo "$expected_json" | jq -r '.[]'
 
 # /commits/{sha}/pulls returns PRs whose head OR merge_commit_sha matches.
 # We take the first; for a merge commit on working/main, that's the PR
@@ -46,9 +65,10 @@ pr_number=$(echo "$pr_json" | jq -r '.number')
 pr_head=$(  echo "$pr_json" | jq -r '.head.sha')
 echo "Associated PR #$pr_number, head $pr_head"
 
-# Pull all check-runs (paginated) for the PR head SHA.
+# Pull all check-runs (paginated) for the PR head SHA. Keep full objects
+# so we can sort by completed_at / id for re-run dedup.
 runs=$(gh api --paginate "repos/$OWNER/$REPO/commits/$pr_head/check-runs" \
-  --jq '.check_runs[] | {name, status, conclusion}')
+  --jq '.check_runs[] | {name, status, conclusion, completed_at, id}')
 
 if [ -z "$runs" ]; then
   {
@@ -59,33 +79,86 @@ if [ -z "$runs" ]; then
   exit 1
 fi
 
-# Anything not completed, or completed with a conclusion not in the pass
-# set, fails the gate.
-bad=$(echo "$runs" | jq -s '
-  [ .[]
-    | select( (.status != "completed")
-           or ( .conclusion as $c
-                | (["success","neutral","skipped"] | index($c)) | not ) )
-  ]
-')
-bad_count=$(echo "$bad" | jq 'length')
+# Filter to allowlist, then for each expected name pick the latest
+# (completed_at desc, id desc) check-run. Result is a JSON array of
+# {name, run} pairs; run is null when nothing matched.
+all_runs_json=$(echo "$runs" | jq -s '.')
+selected=$(jq -n \
+  --argjson runs "$all_runs_json" \
+  --argjson expected "$expected_json" \
+  '
+  $expected
+  | map(. as $name
+        | { name: $name,
+            run: ( $runs
+                   | map(select(.name == $name))
+                   | sort_by([(.completed_at // ""), (.id // 0)])
+                   | last ) })
+  ')
 
-if [ "$bad_count" -gt 0 ]; then
+# Build lists of missing + bad.
+missing=$(echo "$selected" | jq '[.[] | select(.run == null) | .name]')
+bad=$(    echo "$selected" | jq '
+  [ .[]
+    | select(.run != null)
+    | select( (.run.status != "completed")
+           or ( .run.conclusion as $c
+                | (["success","neutral","skipped"] | index($c)) | not ) )
+    | { name: .name,
+        status: .run.status,
+        conclusion: .run.conclusion } ]
+')
+missing_count=$(echo "$missing" | jq 'length')
+bad_count=$(    echo "$bad"     | jq 'length')
+
+# Always log expected vs got for debuggability when the allowlist drifts.
+got_filtered=$(echo "$all_runs_json" | jq --argjson e "$expected_json" '[.[] | select(.name as $n | $e | index($n))] | map(.name) | unique')
+got_all=$(     echo "$all_runs_json" | jq '[.[].name] | unique')
+echo "Got (in allowlist):   $(echo "$got_filtered" | jq -c '.')"
+echo "Got (all on PR head): $(echo "$got_all"      | jq -c '.')"
+
+if [ "$missing_count" -gt 0 ] || [ "$bad_count" -gt 0 ]; then
   {
     echo "### Gate: CI on $label — FAIL";
-    echo "PR #$pr_number head \`$pr_head\` has $bad_count bad check-run(s):";
+    echo "PR #$pr_number head \`$pr_head\`.";
+    if [ "$missing_count" -gt 0 ]; then
+      echo "";
+      echo "Missing required check(s):";
+      echo '```json';
+      echo "$missing" | jq '.';
+      echo '```';
+    fi
+    if [ "$bad_count" -gt 0 ]; then
+      echo "";
+      echo "Failed/incomplete check(s):";
+      echo '```json';
+      echo "$bad" | jq '.';
+      echo '```';
+    fi
+    echo "";
+    echo "Expected:";
     echo '```json';
-    echo "$bad" | jq '.';
+    echo "$expected_json" | jq '.';
+    echo '```';
+    echo "Got (all check-runs on PR head, for debugging):";
+    echo '```json';
+    echo "$got_all" | jq '.';
     echo '```';
   } >> "$GITHUB_STEP_SUMMARY"
-  echo "::error::CI gate failed on $label (PR #$pr_number)"
-  echo "$bad" | jq '.'
+  if [ "$missing_count" -gt 0 ]; then
+    echo "::error::CI gate failed on $label (PR #$pr_number): $missing_count missing required check(s)"
+    echo "$missing" | jq '.'
+  fi
+  if [ "$bad_count" -gt 0 ]; then
+    echo "::error::CI gate failed on $label (PR #$pr_number): $bad_count bad check(s)"
+    echo "$bad" | jq '.'
+  fi
   exit 1
 fi
 
-total=$(echo "$runs" | jq -s 'length')
+total=$(echo "$selected" | jq 'length')
 {
   echo "### Gate: CI on $label — OK";
-  echo "PR #$pr_number head \`$pr_head\`: all $total check-run(s) passed.";
+  echo "PR #$pr_number head \`$pr_head\`: all $total required check-run(s) passed.";
 } >> "$GITHUB_STEP_SUMMARY"
-echo "OK: $total check-runs all green on $label"
+echo "OK: $total required check-runs all green on $label"


### PR DESCRIPTION
## Symptom

`daily-promote-release.yml`'s "re-check CI on new main" gate fails on PR heads where every real CI job is green. Failing reference: https://github.com/Jiahui-Gu/ccsm/actions/runs/26205515547 — the gate sees 3 bad check-runs and refuses to tag, even though the 8 real CI checks (`e2e × 3`, `lint + typecheck + test × 3`, `no-silent-drops`, `check-source`) are all success.

## Root cause: self-pollution

The walkback (`/commits/{merge_sha}/pulls` → PR head SHA → `/commits/{pr_head}/check-runs`) returns *every* check-run on that SHA. That includes the `promote working → main + tag` check-run that **this same workflow** registers when it runs. Live runs are `in_progress`; historical failed dispatches leave `failure` entries on the same SHA forever. The gate had no filter, so it counted those self-registered failures and aborted promotion.

Local snapshot of PR #1265 head (current main HEAD's PR): 11 check-runs total — 8 real CI all `success`, 3 `promote working → main + tag` all `failure`.

## Fix: explicit allowlist

Add a required `EXPECTED_CHECKS` env var (newline-separated, so names with spaces don't need quoting). The script filters check-runs to that allowlist *before* any pass/fail evaluation — anything outside the list (including this workflow's own check-run, and any unrelated future check-runs) is ignored. Missing required names now fail loud with a clear "missing required check" error and an "expected vs got" dump.

The same inlined logic in the "Wait + re-check CI on new main" step is patched the same way. Re-runs are handled by picking the latest matching check-run by `(completed_at, id)` for each expected name.

Why env var rather than positional arg: names like `lint + typecheck + test (macos-latest)` contain spaces and parentheses; newline-separated env var avoids quoting hell and keeps the call sites simple.

## Local simulation

Replicated the jq selection logic in Python against the live API for main HEAD `1bd47dfbd98dde2d970aa8af5fc607892bc520e8` (PR #1265, head `e0eb623f8985d109fc59f1cf1218c3c37aa6159b`):

```
PR #1265, head e0eb623f8985d109fc59f1cf1218c3c37aa6159b
Total check-runs on PR head: 11
All names: ['check-source', 'e2e (macos-latest)', 'e2e (ubuntu-latest)', 'e2e (windows-latest)',
            'lint + typecheck + test (macos-latest)', 'lint + typecheck + test (ubuntu-latest)',
            'lint + typecheck + test (windows-latest)', 'no-silent-drops',
            'promote working → main + tag']
Missing: []
Bad: []
Result: PASS
```

Without the filter the same SHA would FAIL (3 self-pollution `failure` entries). With it, gate passes.

## Files changed

- `.github/workflows/scripts/check-ci-via-pr.sh` — require `EXPECTED_CHECKS`, allowlist-filter then evaluate, latest-per-name dedup, log expected-vs-got.
- `.github/workflows/daily-promote-release.yml` — declare `EXPECTED_CHECKS` at job env (8 real CI names); update inlined re-check step to use the same allowlist.

## Not touched

- `release.yml`
- the `Wait for check-source on promote PR` step (it already targets `check-source` by name via API filter)
- "no associated PR → refuse" branch
- waiting / polling logic (only the evaluation is changed)
- version / package.json

## Bootstrap note

Per the workflow file's own header comment, cron schedules from the default branch (`main`). After this lands on `working` and is promoted to `main`, one manual `workflow_dispatch` is needed for cron to start picking up the fixed file.