### PR TITLE
fix(dev): quit app on window close in npm run dev (Task #11)

### DIFF
--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -402,6 +402,19 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
 
   win.on('close', (e) => {
     if (deps.getIsQuitting()) return;
+    // Dev-loop escape hatch (Task #11): `scripts/dev-electron.mjs` sets
+    // CCSM_DEV_QUIT_ON_CLOSE=1 so closing the window during `npm run dev`
+    // fully quits the app instead of going tray-resident. Without this,
+    // the Electron main proc lingered in the tray AND its sibling
+    // webpack-dev-server (concurrently `dev:web`, port 4100) kept
+    // running because concurrently's `-k` only reaps when one child
+    // exits — every restart needed a manual taskkill. Scoped to the dev
+    // wrapper's env so production, manual `electron .`, and e2e probes
+    // still get the real close-to-tray choreography below.
+    if (process.env.CCSM_DEV_QUIT_ON_CLOSE === '1') {
+      deps.setIsQuitting(true);
+      return;
+    }
     const pref = getCloseAction();
     if (pref === 'quit') {
       deps.setIsQuitting(true);

--- a/scripts/dev-electron.mjs
+++ b/scripts/dev-electron.mjs
@@ -38,7 +38,21 @@ const child = spawn(
   {
     cwd: repoRoot,
     stdio: 'inherit',
-    env: { ...process.env, CCSM_E2E_NO_SINGLE_INSTANCE: '1' },
+    env: {
+      ...process.env,
+      CCSM_E2E_NO_SINGLE_INSTANCE: '1',
+      // Dev-loop ergonomics (Task #11): closing the main window during
+      // `npm run dev` should fully quit the Electron app instead of
+      // going production tray-resident, so concurrently's `-k` reaps
+      // the sibling `dev:web` (webpack-dev-server on :4100). Without
+      // this, closing the window leaves the Electron main proc alive
+      // in the tray AND keeps webpack-dev-server holding port 4100 —
+      // every restart needed a manual taskkill. Scoped to this wrapper
+      // so manual `electron .` runs and e2e probes still get the real
+      // close-to-tray choreography. Read by
+      // `electron/window/createWindow.ts`.
+      CCSM_DEV_QUIT_ON_CLOSE: '1',
+    },
   },
 );
 


### PR DESCRIPTION
## Symptom
After \`npm run dev\`, closing the main window leaves two zombie processes:
- Electron main proc (in tray)
- \`node\` running webpack-dev-server on port 4100

Every dev restart needs a manual \`taskkill\` / \`lsof | kill\`.

## Root cause (Layer 1)
Not a child-process leak. Production ccsm is tray-resident by design:
\`win.on('close')\` calls \`e.preventDefault()\` and fades to tray, so
\`window-all-closed\` never fires and \`app.quit()\` is never called. In
\`npm run dev\`, concurrently runs \`dev:web\` (webpack-dev-server) +
\`dev:app\` (Electron). \`concurrently -k\` only kills siblings when one
child exits — but Electron never exits, so dev-server keeps running.

## Fix (Layer 2)
- \`scripts/dev-electron.mjs\` sets \`CCSM_DEV_QUIT_ON_CLOSE=1\` in the
  spawned Electron's env.
- \`electron/window/createWindow.ts\` close handler short-circuits on that
  env: flip \`isQuitting\`, let the close fall through. That triggers
  \`window-all-closed\` -> \`app.quit()\` -> Electron exits -> concurrently
  \`-k\` reaps webpack-dev-server.

No new deps, no spawn-tree surgery, no detached-children. Scoped via env
so:
- Production (env unset, app packaged) -> close-to-tray unchanged.
- Manual \`electron .\` against unpackaged checkout (env unset) -> close-to-tray unchanged.
- E2E probes (env unset; spawn Electron directly, not via dev wrapper) -> unchanged.
- Only \`npm run dev\` -> dev-electron wrapper opts in.

## Files
- \`scripts/dev-electron.mjs\` — inject \`CCSM_DEV_QUIT_ON_CLOSE=1\`.
- \`electron/window/createWindow.ts\` — close handler env short-circuit.

## Reviewer needs to verify on their box (I cannot run \`npm run dev\` locally)
1. \`npm run dev\` -> wait for window.
2. Close the window with the X button.
3. Confirm: no \`electron\` process; \`netstat\`/\`lsof\` shows port 4100 free; concurrently log shows both \`web\` and \`app\` exited.
4. Sanity check tray behavior is **unchanged** in a packaged build (run \`npm run make:win:dev\` or use an installed CCSM): close X still fades to tray, tray Quit still works.
5. Sanity check e2e: \`npm run probe:e2e\` still passes (probes don't go via the dev wrapper, so the env should never be set there).

## Layer 1 stance
This is a real dev-loop UX bug, not a phantom. The fix is dev-only by
construction (env var only set by the dev wrapper script). I considered
spawning webpack-dev-server as a child of Electron and killing it on
\`before-quit\`, but that conflates concerns and changes the dev
architecture for what's a 2-line semantic tweak.