### PR TITLE
fix(cli): scroll-to-bottom button always visible

### DIFF
--- a/src/components/ScrollToBottomButton.tsx
+++ b/src/components/ScrollToBottomButton.tsx
@@ -1,14 +1,16 @@
-import { AnimatePresence, motion } from 'framer-motion';
 import { ArrowDown } from 'lucide-react';
 import { useTranslation } from '../i18n/useTranslation';
 
 // Floating "jump to bottom" affordance for the terminal viewport.
 // Mounted inside the TerminalPane's relative wrapper so it absolutely
-// positions over the bottom-right corner of the xterm host. Only
-// renders when the user has scrolled up (atBottom === false); fades
-// itself out the moment they hit bottom again (either by clicking
-// this button or by xterm's own behaviour after Page Down / scroll
-// wheel down).
+// positions over the bottom-right corner of the xterm host.
+//
+// Always rendered while the terminal is in the `ready` state — the
+// previous `atBottom`-gated visibility was flaky in practice (xterm's
+// onScroll/onLineFeed signals can miss edges, leaving the button hidden
+// when the user has scrolled up). Clicking while already at bottom is a
+// no-op (xterm's scrollToBottom is idempotent), so always-on costs us
+// nothing behaviourally.
 //
 // Sits above xterm's canvas (z-10) so it stays clickable — the canvas
 // renderer stacks its own absolutely-positioned canvases inside the
@@ -16,47 +18,34 @@ import { useTranslation } from '../i18n/useTranslation';
 //
 // Visual: 32px circle, IconButton's `raised` aesthetic (matches the
 // other elevated controls in the app) with the lucide ArrowDown glyph.
-// Framer-motion handles fade + 4px translate for entry/exit so the
-// button feels like it slid up from the corner rather than popping.
 export function ScrollToBottomButton({
-  visible,
   onClick,
 }: {
-  visible: boolean;
   onClick: () => void;
 }) {
   const { t } = useTranslation();
   return (
-    <AnimatePresence>
-      {visible ? (
-        <motion.button
-          type="button"
-          onClick={onClick}
-          aria-label={t('terminal.scrollToBottom')}
-          title={t('terminal.scrollToBottom')}
-          initial={{ opacity: 0, y: 4 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: 4 }}
-          transition={{ duration: 0.15, ease: [0.32, 0.72, 0, 1] }}
-          whileTap={{ scale: 0.94 }}
-          data-scroll-to-bottom
-          className={[
-            'absolute bottom-4 right-4 z-10',
-            'inline-grid place-items-center',
-            'h-8 w-8 rounded-full',
-            'text-fg-secondary',
-            'bg-[oklch(0.32_0.003_240)] border border-[oklch(0.42_0.003_240)]',
-            'shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.10),0_2px_8px_0_oklch(0_0_0_/_0.45)]',
-            'hover:bg-[oklch(0.38_0.003_240)] hover:text-fg-primary hover:border-[oklch(0.50_0.003_240)]',
-            'active:bg-[oklch(0.30_0.003_240)]',
-            'focus-visible:outline-none focus-visible:shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.10),0_2px_8px_0_oklch(0_0_0_/_0.45),0_0_0_2px_oklch(1_0_0_/_0.18)]',
-            'transition-[background-color,border-color,color] duration-150',
-          ].join(' ')}
-        >
-          <ArrowDown size={16} strokeWidth={2} />
-        </motion.button>
-      ) : null}
-    </AnimatePresence>
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={t('terminal.scrollToBottom')}
+      title={t('terminal.scrollToBottom')}
+      data-scroll-to-bottom
+      className={[
+        'absolute bottom-4 right-4 z-10',
+        'inline-grid place-items-center',
+        'h-8 w-8 rounded-full',
+        'text-fg-secondary',
+        'bg-[oklch(0.32_0.003_240)] border border-[oklch(0.42_0.003_240)]',
+        'shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.10),0_2px_8px_0_oklch(0_0_0_/_0.45)]',
+        'hover:bg-[oklch(0.38_0.003_240)] hover:text-fg-primary hover:border-[oklch(0.50_0.003_240)]',
+        'active:bg-[oklch(0.30_0.003_240)] active:scale-[0.94]',
+        'focus-visible:outline-none focus-visible:shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.10),0_2px_8px_0_oklch(0_0_0_/_0.45),0_0_0_2px_oklch(1_0_0_/_0.18)]',
+        'transition-[background-color,border-color,color,transform] duration-150',
+      ].join(' ')}
+    >
+      <ArrowDown size={16} strokeWidth={2} />
+    </button>
   );
 }
 

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -32,7 +32,10 @@ export function TerminalPane({ sessionId, cwd }: Props) {
   useXtermSingleton(hostRef);
   useTerminalResize(hostRef);
   const { state, onRetry } = usePtyAttach(sessionId, cwd);
-  const { atBottom, scrollToBottom } = useAtBottom(sessionId);
+  // `atBottom` is intentionally unused — the button is always visible while
+  // ready (see ScrollToBottomButton). We keep the hook subscribed so the
+  // detection logic (and its tests) stay live for future use.
+  const { scrollToBottom } = useAtBottom(sessionId);
 
   return (
     <div
@@ -44,9 +47,12 @@ export function TerminalPane({ sessionId, cwd }: Props) {
       <Overlay state={state} onRetry={onRetry} t={t} />
       {/* Hide the jump-to-bottom affordance while an overlay (attaching /
           error / exit) is up — those cover the viewport and the button
-          would be meaningless. */}
+          would be meaningless. While ready, the button is always visible:
+          clicking it when already at bottom is a no-op (xterm's
+          scrollToBottom is idempotent), and conditional visibility based
+          on the atBottom signal proved flaky in practice. */}
       {state.kind === 'ready' ? (
-        <ScrollToBottomButton visible={!atBottom} onClick={scrollToBottom} />
+        <ScrollToBottomButton onClick={scrollToBottom} />
       ) : null}
     </div>
   );


### PR DESCRIPTION
## Why

User report: the scroll-to-bottom button (added in #1255) sometimes does not appear when the user has scrolled up. User explicitly asked to make it always visible rather than debug the underlying detection issue.

> CLI 区右下角的"滚到底"按钮有时候不出现 ... 直接要求常驻显示

## Choice: always 100% visible (no opacity dimming)

Considered dimming the button to ~30% when `atBottom` is true and full opacity otherwise, but rejected: opacity dimming still depends on the same `atBottom` signal that's the suspected root cause of flakiness — if the signal misfires, dim does too. Always-on removes the dependency entirely. Clicking when already at bottom is a no-op (xterm's `scrollToBottom` is idempotent).

## Changes

- ` + "`src/components/ScrollToBottomButton.tsx`" + `: drop ` + "`visible`" + ` prop + ` + "`AnimatePresence`" + ` wrapper. Button always renders. Tap feedback moved from framer-motion ` + "`whileTap`" + ` to CSS ` + "`active:scale-[0.94]`" + ` so we can drop the motion wrapper.
- ` + "`src/components/TerminalPane.tsx`" + `: stop destructuring ` + "`atBottom`" + `; still mount ` + "`useAtBottom`" + ` so its detection logic + tests stay live (per scope guidance, not removing the hook in this PR).
- ` + "`useAtBottom`" + ` and its tests: untouched.

## Verification

- ` + "`npm run lint`" + ` — 0 errors (warnings pre-existing).
- ` + "`npm run typecheck`" + ` — clean.
- ` + "`npm run test`" + ` — 1376 passed. Pre-existing failures in ` + "`electron-load-smoke.test.ts`" + ` and ` + "`db-hardening.test.ts`" + ` are environmental (missing ` + "`dist/electron`" + ` build + better-sqlite3 ` + "`NODE_MODULE_VERSION`" + ` mismatch on this machine), unrelated to this change.
- ` + "`useAtBottom`" + ` test suite (8 tests) passes — hook unchanged.

## E2E

` + "`grep -r scroll-to-bottom scripts/ tests/`" + ` — no e2e or probe relies on visibility being conditional. No e2e adjustments needed.