### PR TITLE
perf(sidebar): keep session refs stable on JSONL state tick

### DIFF
--- a/src/app-effects/useSessionNameBridge.ts
+++ b/src/app-effects/useSessionNameBridge.ts
@@ -19,24 +19,42 @@ interface SessionLike {
  * `sessionNamesFromRenderer` map doesn't grow unbounded across the app
  * lifetime as sessions are created and deleted (#613, follow-up to #509).
  *
+ * Perf: the effect's dep is `sessions`, whose array reference changes on
+ * every session-runtime store patch (state toggle, title backfill, cwd
+ * redirect, etc.) — including hot paths like waiting<->idle on JSONL
+ * chunks. Without per-sid diffing we'd fire one IPC per session per chunk
+ * even though no name changed. The `prevNamesRef` map below makes the
+ * common case (no name changed) a free pass — IPC fires only for the
+ * actual delta (added sid, renamed sid, deleted sid).
+ *
  * Extracted from App.tsx for SRP under Task #758 Phase C.
  */
 export function useSessionNameBridge(sessions: ReadonlyArray<SessionLike>): void {
-  const prevSidsRef = useRef<Set<string>>(new Set());
+  const prevNamesRef = useRef<Map<string, string | null>>(new Map());
   useEffect(() => {
     type Bridge = { setName: (sid: string, name: string | null) => void };
     const bridge = (window as unknown as { ccsmSession?: Bridge }).ccsmSession;
     if (!bridge || typeof bridge.setName !== 'function') return;
-    const currentSids = new Set<string>();
+    const prev = prevNamesRef.current;
+    const next = new Map<string, string | null>();
     for (const sess of sessions) {
-      bridge.setName(sess.id, sess.name ?? null);
-      currentSids.add(sess.id);
+      const name = sess.name ?? null;
+      next.set(sess.id, name);
+      // Only IPC when the name (per sid) actually changed — covers mount
+      // (sid absent from prev) and rename (sid present, name differs).
+      // Pure state-toggle store updates re-run this effect with every
+      // sess.name unchanged, so we short-circuit those without any IPC.
+      if (!prev.has(sess.id) || prev.get(sess.id) !== name) {
+        bridge.setName(sess.id, name);
+      }
     }
-    for (const staleSid of prevSidsRef.current) {
-      if (!currentSids.has(staleSid)) {
+    // Clear any sid that disappeared since the previous render so main's
+    // map doesn't leak across the app lifetime.
+    for (const [staleSid] of prev) {
+      if (!next.has(staleSid)) {
         bridge.setName(staleSid, null);
       }
     }
-    prevSidsRef.current = currentSids;
+    prevNamesRef.current = next;
   }, [sessions]);
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -55,6 +55,36 @@ export function Sidebar({ onCreateSession, onCreateSessionWithCwd, onOpenSetting
   // re-renders triggered by unrelated store mutations.
   const normal = useMemo(() => groups.filter((g) => g.kind === 'normal'), [groups]);
   const archived = useMemo(() => groups.filter((g) => g.kind === 'archive'), [groups]);
+  // Perf: bucket sessions by groupId ONCE per `sessions` ref change instead
+  // of calling `sessions.filter(s => s.groupId === g.id)` inline per GroupRow
+  // per render. The inline filter produced a fresh array reference for every
+  // GroupRow on every parent render, defeating React.memo on GroupRow /
+  // SessionRow and causing the entire sidebar tree (dnd-kit + framer-motion)
+  // to re-render whenever any session toggled state (e.g. waiting<->idle on
+  // every JSONL stream chunk). The store-side mutators
+  // (`_applySessionState`, `_applyExternalTitle`, `_applyCwdRedirect`,
+  // `sessionCrudSlice.*`) all preserve untouched session refs via per-element
+  // map / slice, so as long as we don't break that here, each GroupRow's
+  // `sessions` prop ref stays stable when its own bucket didn't change.
+  const sessionsByGroup = useMemo(() => {
+    const map = new Map<string, Session[]>();
+    for (const s of sessions) {
+      let bucket = map.get(s.groupId);
+      if (!bucket) {
+        bucket = [];
+        map.set(s.groupId, bucket);
+      }
+      bucket.push(s);
+    }
+    return map;
+  }, [sessions]);
+  // Shared empty-array sentinel so the "group with no sessions" common case
+  // is also fully ref-stable across renders.
+  const emptySessions = useMemo<Session[]>(() => [], []);
+  const getSessionsForGroup = React.useCallback(
+    (gid: string): Session[] => sessionsByGroup.get(gid) ?? emptySessions,
+    [sessionsByGroup, emptySessions]
+  );
   // J2: track the most recently created group so its <GroupRow> mounts in
   // inline-rename mode. Cleared after the next render cycle so toggling rename
   // off (or remounting) doesn't accidentally re-trigger it.
@@ -220,13 +250,13 @@ export function Sidebar({ onCreateSession, onCreateSessionWithCwd, onOpenSetting
               <GroupRow
                 key={g.id}
                 group={g}
-                sessions={sessions.filter((s) => s.groupId === g.id)}
+                sessions={getSessionsForGroup(g.id)}
                 activeSessionId={activeSessionId}
                 focused={focusedGroupId === g.id}
                 anyGroupFocused={focusedGroupId !== null}
                 autoRename={justCreatedGroupId === g.id}
                 onSelectSession={onSelectSession}
-                onFocus={() => onFocusGroup(g.id)}
+                onFocusGroup={onFocusGroup}
                 normalGroups={normal}
               />
             ))}
@@ -237,7 +267,7 @@ export function Sidebar({ onCreateSession, onCreateSessionWithCwd, onOpenSetting
           <ArchivedSection
             archivedGroups={archived}
             normalGroups={normal}
-            sessions={sessions}
+            getSessionsForGroup={getSessionsForGroup}
             activeSessionId={activeSessionId}
             focusedGroupId={focusedGroupId}
             onSelectSession={onSelectSession}

--- a/src/components/sidebar/ArchivedSection.tsx
+++ b/src/components/sidebar/ArchivedSection.tsx
@@ -14,10 +14,16 @@ import { GroupRow } from './GroupRow';
 // J14: archived groups are a "viewer" surface — DnD onto archived headers is
 // rejected upstream in useSidebarDnd. The archived rows here intentionally
 // don't render their own SortableContext (no empty-drop targets either).
+//
+// Perf: receives a `getSessionsForGroup` lookup from <Sidebar> rather than a
+// flat `sessions` array we'd have to .filter() per row. The parent bucket is
+// built once per `sessions` ref change, so each archived GroupRow's
+// `sessions` prop ref stays stable when its own bucket didn't change —
+// preserving React.memo on GroupRow / SessionRow.
 export function ArchivedSection({
   archivedGroups,
   normalGroups,
-  sessions,
+  getSessionsForGroup,
   activeSessionId,
   focusedGroupId,
   onSelectSession,
@@ -25,7 +31,7 @@ export function ArchivedSection({
 }: {
   archivedGroups: Group[];
   normalGroups: Group[];
-  sessions: Session[];
+  getSessionsForGroup: (groupId: string) => Session[];
   activeSessionId: string;
   focusedGroupId: string | null;
   onSelectSession: (id: string) => void;
@@ -65,12 +71,12 @@ export function ArchivedSection({
             <GroupRow
               key={g.id}
               group={g}
-              sessions={sessions.filter((s) => s.groupId === g.id)}
+              sessions={getSessionsForGroup(g.id)}
               activeSessionId={activeSessionId}
               focused={focusedGroupId === g.id}
               anyGroupFocused={focusedGroupId !== null}
               onSelectSession={onSelectSession}
-              onFocus={() => onFocusGroup(g.id)}
+              onFocusGroup={onFocusGroup}
               normalGroups={normalGroups}
             />
           ))}

--- a/src/components/sidebar/GroupRow.tsx
+++ b/src/components/sidebar/GroupRow.tsx
@@ -29,7 +29,7 @@ import type { Group, Session } from '../../types';
 import { headerDroppableId } from './dnd';
 import { SessionRow } from './SessionRow';
 
-export function GroupRow({
+function GroupRowImpl({
   group,
   sessions,
   activeSessionId,
@@ -37,7 +37,7 @@ export function GroupRow({
   anyGroupFocused,
   autoRename,
   onSelectSession,
-  onFocus,
+  onFocusGroup,
   normalGroups
 }: {
   group: Group;
@@ -50,7 +50,10 @@ export function GroupRow({
    *  group without an extra click. Cleared by the parent once consumed. */
   autoRename?: boolean;
   onSelectSession: (id: string) => void;
-  onFocus: () => void;
+  /** Receives this group's id when the row gets focus. id-passing (vs. a
+   *  pre-bound `() => void`) keeps the prop reference stable across parent
+   *  re-renders so React.memo can short-circuit unrelated GroupRows. */
+  onFocusGroup: (id: string) => void;
   /** Pre-filtered list of normal (non-archive) groups, hoisted to the parent
    *  Sidebar so we don't recompute per SessionRow per render. */
   normalGroups: Group[];
@@ -127,7 +130,7 @@ export function GroupRow({
             )}
             <button
               onClick={() => {
-                onFocus();
+                onFocusGroup(group.id);
                 if (!renaming) setGroupCollapsed(group.id, !collapsed);
               }}
               onKeyDown={(e) => {
@@ -256,7 +259,7 @@ export function GroupRow({
               session={s}
               active={s.id === activeSessionId}
               selected={!anyGroupFocused && s.id === activeSessionId}
-              onSelect={() => onSelectSession(s.id)}
+              onSelectSession={onSelectSession}
               normalGroups={normalGroups}
             />
           ))}
@@ -289,3 +292,11 @@ export function GroupRow({
     </div>
   );
 }
+
+// Memoize so a parent re-render driven by an unrelated store mutation (e.g.
+// another group's session toggling waiting<->idle on a JSONL chunk) doesn't
+// also re-render this group's body. Relies on the parent Sidebar handing us
+// a stable `sessions` array reference via its bucketed
+// `getSessionsForGroup` lookup — see Sidebar.tsx. Default shallow-equals is
+// correct here: every prop is either a primitive or a ref-stable object.
+export const GroupRow = React.memo(GroupRowImpl);

--- a/src/components/sidebar/SessionRow.tsx
+++ b/src/components/sidebar/SessionRow.tsx
@@ -24,17 +24,20 @@ import {
 } from '../../lib/motion';
 import type { Group, Session } from '../../types';
 
-export function SessionRow({
+function SessionRowImpl({
   session,
   active,
   selected,
-  onSelect,
+  onSelectSession,
   normalGroups
 }: {
   session: Session;
   active: boolean;
   selected: boolean;
-  onSelect: () => void;
+  /** Receives this row's session id. id-passing (vs. a pre-bound `() => void`)
+   *  keeps the prop reference stable across parent re-renders so React.memo
+   *  can short-circuit when only an unrelated session changed. */
+  onSelectSession: (id: string) => void;
   normalGroups: Group[];
 }) {
   const { t } = useTranslation();
@@ -134,12 +137,12 @@ export function SessionRow({
           aria-selected={selected}
           tabIndex={renaming ? -1 : selected ? 0 : -1}
           data-session-id={session.id}
-          onClick={onSelect}
+          onClick={() => onSelectSession(session.id)}
           onContextMenu={() => {
             // J4b: right-click selects the row first, matching standard GUI
             // behavior where the context menu acts on "this row" — and the
             // user expects "this row" to be visually highlighted.
-            onSelect();
+            onSelectSession(session.id);
           }}
           onKeyDown={(e) => {
             // Only handle keys when the <li> itself is the focused element.
@@ -157,7 +160,7 @@ export function SessionRow({
             }
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault();
-              onSelect();
+              onSelectSession(session.id);
             }
           }}
           title={
@@ -314,3 +317,15 @@ export function SessionRow({
     </ContextMenu>
   );
 }
+
+// Memoize so a parent re-render driven by another session's state toggle
+// (e.g. waiting<->idle on a JSONL chunk for a different row) does not
+// re-render this row. SessionRow is the hot row — it mounts dnd-kit's
+// useSortable + framer-motion's <motion.li>, so a churning re-render here
+// dominated the streaming-flicker cost flagged by the perf audit. Relies on
+// stable parent props: `session` ref-stable thanks to the store's per-element
+// patch (sessionRuntimeSlice / sessionTitleBackfillSlice / sessionCrudSlice
+// all use slice/map with per-id patch), `normalGroups` ref-stable via the
+// parent's useMemo, and `onSelectSession` ref-stable now that the parent
+// passes the id-accepting store action through unchanged.
+export const SessionRow = React.memo(SessionRowImpl);

--- a/tests/app-effects/useSessionNameBridge.test.tsx
+++ b/tests/app-effects/useSessionNameBridge.test.tsx
@@ -25,7 +25,7 @@ describe('useSessionNameBridge', () => {
     expect(setName).toHaveBeenCalledWith('s2', null);
   });
 
-  it('emits null clear for sids that disappear between renders', () => {
+  it('emits null clear for sids that disappear between renders, without re-emitting unchanged names', () => {
     const { rerender } = renderHook(
       ({ list }: { list: Array<{ id: string; name?: string | null }> }) =>
         useSessionNameBridge(list),
@@ -40,9 +40,48 @@ describe('useSessionNameBridge', () => {
     );
     setName.mockClear();
     rerender({ list: [{ id: 's1', name: 'Alpha' }] });
-    // s1 re-emitted, s2 cleared.
-    expect(setName).toHaveBeenCalledWith('s1', 'Alpha');
+    // s2 cleared. s1 is NOT re-emitted because its name didn't change —
+    // re-emitting on every render would fire one IPC per session per JSONL
+    // state toggle, which is the perf regression this diff guards against.
     expect(setName).toHaveBeenCalledWith('s2', null);
+    expect(setName).not.toHaveBeenCalledWith('s1', 'Alpha');
+  });
+
+  it('only IPCs for sids whose name actually changed', () => {
+    const { rerender } = renderHook(
+      ({ list }: { list: Array<{ id: string; name?: string | null }> }) =>
+        useSessionNameBridge(list),
+      {
+        initialProps: {
+          list: [
+            { id: 's1', name: 'Alpha' },
+            { id: 's2', name: 'Beta' },
+          ],
+        },
+      }
+    );
+    setName.mockClear();
+    // Rerender with a NEW array reference but identical contents — this is
+    // the hot path when the store toggles a different session's `state`
+    // field. Zero IPCs expected.
+    rerender({
+      list: [
+        { id: 's1', name: 'Alpha' },
+        { id: 's2', name: 'Beta' },
+      ],
+    });
+    expect(setName).not.toHaveBeenCalled();
+
+    // Rename s2 only — exactly one IPC, for s2.
+    setName.mockClear();
+    rerender({
+      list: [
+        { id: 's1', name: 'Alpha' },
+        { id: 's2', name: 'Beta renamed' },
+      ],
+    });
+    expect(setName).toHaveBeenCalledTimes(1);
+    expect(setName).toHaveBeenCalledWith('s2', 'Beta renamed');
   });
 
   it('is a no-op when the bridge is missing', () => {

--- a/tests/sidebar/ArchivedSection.test.tsx
+++ b/tests/sidebar/ArchivedSection.test.tsx
@@ -20,13 +20,27 @@ function renderArchived(props: {
   normalGroups?: Group[];
   sessions?: Session[];
 }) {
+  const sessions = props.sessions ?? [];
+  // Mirror the bucketing the parent <Sidebar> does so the component's new
+  // getSessionsForGroup API matches its production contract.
+  const byGroup = new Map<string, Session[]>();
+  for (const s of sessions) {
+    let bucket = byGroup.get(s.groupId);
+    if (!bucket) {
+      bucket = [];
+      byGroup.set(s.groupId, bucket);
+    }
+    bucket.push(s);
+  }
+  const EMPTY: Session[] = [];
+  const getSessionsForGroup = (gid: string) => byGroup.get(gid) ?? EMPTY;
   return render(
     <ToastProvider>
       <DndContext>
         <ArchivedSection
           archivedGroups={props.archivedGroups}
           normalGroups={props.normalGroups ?? []}
-          sessions={props.sessions ?? []}
+          getSessionsForGroup={getSessionsForGroup}
           activeSessionId=""
           focusedGroupId={null}
           onSelectSession={() => {}}

--- a/tests/sidebar/GroupRow.test.tsx
+++ b/tests/sidebar/GroupRow.test.tsx
@@ -30,7 +30,7 @@ describe('<GroupRow /> (extracted)', () => {
             focused={false}
             anyGroupFocused={false}
             onSelectSession={() => {}}
-            onFocus={() => {}}
+            onFocusGroup={() => {}}
             normalGroups={[group]}
           />
         </DndContext>

--- a/tests/sidebar/SessionRow.test.tsx
+++ b/tests/sidebar/SessionRow.test.tsx
@@ -40,7 +40,7 @@ describe('<SessionRow /> (extracted)', () => {
                 session={session}
                 active={opts.active ?? false}
                 selected={opts.selected ?? false}
-                onSelect={() => {}}
+                onSelectSession={() => {}}
                 normalGroups={[group]}
               />
             </ul>

--- a/tests/sidebar/session-row-dot-selection.test.tsx
+++ b/tests/sidebar/session-row-dot-selection.test.tsx
@@ -54,7 +54,7 @@ describe('<SessionRow /> selection dot — only on active row (#784)', () => {
                   session={s}
                   active={s.id === activeId}
                   selected={s.id === activeId}
-                  onSelect={() => {}}
+                  onSelectSession={() => {}}
                   normalGroups={[group]}
                 />
               ))}

--- a/tests/sidebar/session-row-name.test.tsx
+++ b/tests/sidebar/session-row-name.test.tsx
@@ -43,7 +43,7 @@ describe('<SessionRow /> renders store.name, not id (#788)', () => {
                 session={session}
                 active={false}
                 selected={false}
-                onSelect={() => {}}
+                onSelectSession={() => {}}
                 normalGroups={[group]}
               />
             </ul>

--- a/tests/stores/slices/sessionRuntimeSlice.test.ts
+++ b/tests/stores/slices/sessionRuntimeSlice.test.ts
@@ -82,4 +82,36 @@ describe('sessionRuntimeSlice', () => {
     h.runtime._setFlash('a', false);
     expect(h.state().flashStates['a']).toBeUndefined();
   });
+
+  // Ref-stability regression guards for the sidebar perf path. The Sidebar
+  // buckets sessions by groupId via useMemo([sessions]) and relies on
+  // React.memo on GroupRow / SessionRow to short-circuit unrelated rows
+  // when a single session's `state` toggles (waiting<->idle on JSONL
+  // chunks). Both rely on the slice patching ONLY the changed session and
+  // preserving every other session's reference via per-element map. If
+  // that property regresses, the sidebar streaming-flicker bug returns.
+  it('_applySessionState is a noop (same sessions ref) when state is unchanged', () => {
+    const sessions = [mkSession('a', 'g1', { state: 'idle' })];
+    const h = harness({ sessions, activeId: 'b' });
+    const before = h.state().sessions;
+    h.runtime._applySessionState('a', 'idle');
+    // Same array ref — no subscriber notification, no persist scheduled.
+    expect(h.state().sessions).toBe(before);
+  });
+
+  it('_applySessionState preserves untouched session refs on real change', () => {
+    const a = mkSession('a', 'g1', { state: 'idle' });
+    const b = mkSession('b', 'g1', { state: 'idle' });
+    const c = mkSession('c', 'g2', { state: 'idle' });
+    const h = harness({ sessions: [a, b, c], activeId: 'x' });
+    h.runtime._applySessionState('b', 'waiting');
+    const next = h.state().sessions;
+    // `b` was patched — new object ref.
+    expect(next[1]).not.toBe(b);
+    expect(next[1].state).toBe('waiting');
+    // `a` and `c` were untouched — same ref so React.memo on SessionRow
+    // can short-circuit.
+    expect(next[0]).toBe(a);
+    expect(next[2]).toBe(c);
+  });
 });


### PR DESCRIPTION
## Why

Perf audit (task #16) flagged H1+H2+H3 as same-root. User-felt symptom:
**streaming Claude output makes the sidebar pulse / lag** — every JSONL
chunk toggles a session's `state` (waiting<->idle), and that single
store patch was cascading into a full sidebar re-render, a queued
persist snapshot, and one IPC per session on the name bridge.

## Root cause

Per-render reference instability **downstream** of the store, not the
store itself:

- `Sidebar.tsx:223` called `sessions.filter(s => s.groupId === g.id)`
  inline per GroupRow per render. Every parent render produced a fresh
  array reference for every group, so any future React.memo would have
  been defeated. dnd-kit's `useSortable` + framer-motion on SessionRow
  made this the dominant cost (H1).
- `ArchivedSection.tsx:68` had the same inline filter.
- `useSessionNameBridge.ts` looped every session and fired
  `bridge.setName(sid, name)` on every effect run — the doc string
  claimed it diffed, but the implementation didn't. A state toggle on
  one session re-IPC'd all N sessions' names (H3).

Store-side mutators (`_applySessionState`, `_applyExternalTitle`,
`_applyCwdRedirect`, `sessionCrudSlice.*`) already preserve untouched
session refs via per-element map/slice and already short-circuit on
noop, so **no store changes were needed** for H2 — persist subscribes
on PERSISTED_KEYS ref-equality and the `sessions` array ref is only
rebuilt on a real change. Added regression tests guarding that
property so it doesn't silently regress.

## Layer-1 decision

A + B from the manager spec, but **B-only ended up being the actual
fix** — the store already had the A property (already verified by the
new ref-stability tests). The downstream fixes (B) are what closes the
gap.

## Files

- `src/components/Sidebar.tsx` — bucket sessions by groupId once via
  `useMemo`; expose stable `getSessionsForGroup` lookup to children.
- `src/components/sidebar/ArchivedSection.tsx` — accept
  `getSessionsForGroup` instead of a flat `sessions` array; mirror the
  same lookup pattern.
- `src/components/sidebar/GroupRow.tsx` — React.memo wrapper; switch
  prop `onFocus: () => void` to `onFocusGroup: (id) => void` so the
  parent can pass a ref-stable store action through unchanged.
- `src/components/sidebar/SessionRow.tsx` — React.memo wrapper; switch
  prop `onSelect: () => void` to `onSelectSession: (id) => void` for
  the same ref-stability reason.
- `src/app-effects/useSessionNameBridge.ts` — actually diff by
  sid+name against a `prevNamesRef` Map; IPC only on real change.

## Tests

- `tests/stores/slices/sessionRuntimeSlice.test.ts` — two new
  regression guards:
  1. `_applySessionState` noop preserves the `sessions` array ref.
  2. On real change, untouched session refs are preserved.
- `tests/app-effects/useSessionNameBridge.test.tsx` — updated existing
  case + new case asserting **zero IPCs** when the array ref changes
  but names don't, and exactly-one IPC for a single rename.
- `tests/sidebar/*.test.tsx` — updated mounting harnesses for the
  renamed callback props and the new ArchivedSection signature.

## Verification

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no new issues on changed files (baseline noise
      unchanged; 14056 pre-existing errors out of scope)
- [x] `npm run test` — 1397 passed. 3 pre-existing failures in
      `electron/__tests__/db-hardening.test.ts` are env-only
      (better-sqlite3 NODE_MODULE_VERSION mismatch), unrelated to this
      diff. All sidebar / store / bridge tests pass (58/58 on
      affected files).

## Dogfood verification (manager)

Static analysis can't catch "did the lag actually go away"; needs the
manager to verify subjectively:

1. `npm run dev`
2. Open 3+ sessions across at least 2 groups.
3. Run a long claude prompt in one of them to drive a stream
   (anything that keeps `waiting` flipping for ~10+ seconds).
4. Watch the sidebar: rows in **other** sessions should not visibly
   redraw. The active row's pulse should still animate normally; rows
   should not flicker as a side effect of the stream.
5. Expand the Archived section; the same property should hold there.
6. Rename a session via the context menu → name should propagate
   immediately to OS notifications (sanity-check that the bridge diff
   still emits on real changes).