### PR TITLE
fix(release): prefer completed over in-progress when deduping check-runs

### DIFF
--- a/.github/workflows/scripts/check-ci-via-pr.sh
+++ b/.github/workflows/scripts/check-ci-via-pr.sh
@@ -80,8 +80,14 @@ if [ -z "$runs" ]; then
 fi
 
 # Filter to allowlist, then for each expected name pick the latest
-# (completed_at desc, id desc) check-run. Result is a JSON array of
-# {name, run} pairs; run is null when nothing matched.
+# completed check-run when one exists, otherwise fall back to the
+# latest in-progress run. We sort by (status == "completed") first so
+# that completed runs land at the tail of the array (true > false in
+# jq sort_by ascending), guaranteeing that `last` prefers a completed
+# run over a stale in-progress rerun whose completed_at is still null.
+# Within the same status tier we keep the original (completed_at, id)
+# ordering. Result is a JSON array of {name, run} pairs; run is null
+# when nothing matched.
 all_runs_json=$(echo "$runs" | jq -s '.')
 selected=$(jq -n \
   --argjson runs "$all_runs_json" \
@@ -92,7 +98,7 @@ selected=$(jq -n \
         | { name: $name,
             run: ( $runs
                    | map(select(.name == $name))
-                   | sort_by([(.completed_at // ""), (.id // 0)])
+                   | sort_by([(.status == "completed"), (.completed_at // ""), (.id // 0)])
                    | last ) })
   ')
 


### PR DESCRIPTION
## What

In `.github/workflows/scripts/check-ci-via-pr.sh`, the latest-per-name selection sorts check-runs by `(.completed_at // ""), (.id // 0)` and takes `last`. Add `(.status == "completed")` as the primary sort key so completed runs land at the tail (jq sorts ascending; `false < true`), and `last` deterministically prefers a completed run over a concurrent in-progress rerun.

## Why (latent bug)

Per PR #1266 reviewer report (H1 latent bug): when EXPECTED_CHECKS contains a name with both a completed run and an in-progress rerun on the same PR head SHA, the gate must never assert on a check whose status/conclusion is not final.

The current sort happens to do the right thing in the common case because `null // ""` maps in-progress completed_at to `""`, which lexicographically precedes any real ISO timestamp. But the contract is not explicit: if a completed run also carries a null `completed_at` (defensive / edge), the tiebreaker falls through to `id`, and an in-progress rerun with a higher id wins — a false-pass on an unfinished check.

## Local simulation

Synthetic JSON, two records same name:

- **Common case** — completed (real `completed_at`) + in_progress (`completed_at: null`): both old and new pick the completed run.
- **Edge case** — both have `completed_at: null`, in_progress has higher id:
  - **Old:** picks the in_progress run (id 999) — false pass.
  - **New:** picks the completed run (id 100) — correct.

## Reachability

The current call site is not reachable in a way that triggers the bug (the gate inspects a static PR head SHA and does not rerun checks itself). This does not unblock any failing release; it tightens the contract so future call sites can rely on it.

## Test plan

- [ ] CI green (only `.github/` touched)

Closes task #18.