### PR TITLE
perf(sidebar): memo ArchivedSection + comment memo-chain contract

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,6 +85,12 @@ export default function App() {
   // persisted snapshot lands.
   const hydrated = useStore((s) => s.hydrated);
 
+  // Hold these as direct Zustand action refs (not inline arrows) so the
+  // Sidebar -> GroupRow / SessionRow / ArchivedSection React.memo chain
+  // stays effective — any inline `() => store.selectSession(id)` here
+  // would generate a new function identity per render and force every
+  // memoized row to re-render on every state tick (e.g. JSONL chunks
+  // toggling a single session's waiting<->idle). See PR #1269.
   const selectSession = useStore((s) => s.selectSession);
   const focusGroup = useStore((s) => s.focusGroup);
   const applyExternalTitle = useStore((s) => s._applyExternalTitle);

--- a/src/components/sidebar/ArchivedSection.tsx
+++ b/src/components/sidebar/ArchivedSection.tsx
@@ -20,7 +20,7 @@ import { GroupRow } from './GroupRow';
 // built once per `sessions` ref change, so each archived GroupRow's
 // `sessions` prop ref stays stable when its own bucket didn't change —
 // preserving React.memo on GroupRow / SessionRow.
-export function ArchivedSection({
+function ArchivedSectionImpl({
   archivedGroups,
   normalGroups,
   getSessionsForGroup,
@@ -85,3 +85,13 @@ export function ArchivedSection({
     </>
   );
 }
+
+// Memoize for symmetry with GroupRow / SessionRow so a Sidebar re-render
+// driven by an unrelated store mutation (e.g. a session state toggle on a
+// non-archived row) doesn't re-render the archived block. All props are
+// ref-stable upstream: `archivedGroups` / `normalGroups` come from
+// useMemo'd partitions of `groups`, `getSessionsForGroup` is useCallback'd,
+// `activeSessionId` / `focusedGroupId` are primitives, and
+// `onSelectSession` / `onFocusGroup` are direct Zustand action refs passed
+// through App.tsx unchanged. See PR #1269.
+export const ArchivedSection = React.memo(ArchivedSectionImpl);


### PR DESCRIPTION
## Summary

Follow-up to PR #1269 (task #20): pick up the two L-level reviewer nits
flagged on that PR. Both are pure sidebar memo hygiene and ship together.

1. **`src/components/sidebar/ArchivedSection.tsx`** — wrap in `React.memo`
   for symmetry with `GroupRow` / `SessionRow`. The child rows are
   already memoized so wall-clock impact is small, but without a memo
   boundary on `ArchivedSection` itself, the parent function re-runs on
   every Sidebar re-render (e.g. an unrelated session's state toggle on
   a JSONL chunk), even when nothing in the archived block changed.
   All props are ref-stable upstream:
   - `archivedGroups` / `normalGroups` — `useMemo`'d partitions of `groups`
   - `getSessionsForGroup` — `useCallback`'d in Sidebar
   - `activeSessionId` / `focusedGroupId` — primitives
   - `onSelectSession` / `onFocusGroup` — direct Zustand action refs
     passed through `App.tsx` unchanged

   So `React.memo`'s default shallow compare is the right tool.

2. **`src/App.tsx`** — add a 6-line comment block above the
   `selectSession` / `focusGroup` Zustand selectors explaining why they
   must be held as direct action refs and never inlined as arrows. An
   inline `() => store.selectSession(id)` here would generate a new
   function identity per render and force every memoized row to
   re-render on every state tick, defeating PR #1269 and the memo
   added in change (1).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean on touched files (`ArchivedSection.tsx`, `App.tsx`)
- [x] `npm test` — pre-existing native-module mismatch failures
      (better-sqlite3 NODE_MODULE_VERSION on local box) unrelated; CI
      will run on a clean toolchain
- [ ] Dogfood: archive a group, toggle the archived block open, then
      trigger a JSONL state tick on a non-archived session — confirm
      via React DevTools profiler that the archived block does not
      re-render