### PR TITLE
perf(resolveClaude): async lookup so cold start doesn't block main event loop

### DIFF
--- a/electron/ptyHost/__tests__/claudeResolver.test.ts
+++ b/electron/ptyHost/__tests__/claudeResolver.test.ts
@@ -5,10 +5,17 @@
 // and the failure-mode contract (returns null when both lookups fail — never
 // the literal string "claude" — so the IPC channel can surface a clean
 // `available: false` for the renderer's ClaudeMissingGuide).
+//
+// Resolver is async (#PERF: original spawnSync blocked the main process
+// event loop on Windows cold start). Tests await each call and the
+// `spawn` mock returns an EventEmitter-like child whose stdout pushes
+// scripted bytes then emits `exit` with a scripted code on the next tick.
 
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Hoisted module-level state the spawnSync mock reads. Tests rewrite
+// Hoisted module-level state the spawn mock reads. Tests rewrite
 // `__bus` between cases; the mock factory captures `globalThis` lazily.
 interface SpawnCall {
   cmd: string;
@@ -25,22 +32,36 @@ function bus(): SpawnFakeBus {
 }
 
 vi.mock('node:child_process', () => {
-  const spawnSync = (cmd: string, args: readonly string[]) => {
+  const spawn = (cmd: string, args: readonly string[]) => {
     const b = bus();
     b.calls.push({ cmd, args });
-    if (b.shouldThrow) throw new Error('spawnSync EPERM');
+    if (b.shouldThrow) throw new Error('spawn EPERM');
     const key = `${cmd} ${args.join(' ')}`;
-    const r = b.results.get(key);
-    if (r) return { status: r.status, stdout: r.stdout, stderr: '' };
-    return { status: 1, stdout: '', stderr: '' };
+    const r = b.results.get(key) ?? { status: 1, stdout: '' };
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: Readable;
+    };
+    const stdout = new Readable({ read() {} });
+    child.stdout = stdout;
+    // Push data on next microtask so the resolver's `'data'` listener
+    // (attached synchronously after spawn returns) receives it. Emit
+    // `exit` on the FOLLOWING tick — after the readable has drained the
+    // pushed buffer to the listener — so the resolver doesn't snapshot
+    // an empty stdout buffer before the data event fires.
+    queueMicrotask(() => {
+      if (r.stdout) stdout.push(Buffer.from(r.stdout, 'utf8'));
+      stdout.push(null);
+      setImmediate(() => child.emit('exit', r.status));
+    });
+    return child;
   };
   return {
-    default: { spawnSync },
-    spawnSync,
+    default: { spawn },
+    spawn,
   };
 });
 
-// Import AFTER vi.mock so the resolver picks up the mocked spawnSync.
+// Import AFTER vi.mock so the resolver picks up the mocked spawn.
 import { __resetClaudeResolverForTest, resolveClaude } from '../claudeResolver';
 
 const ORIGINAL_PLATFORM = process.platform;
@@ -70,93 +91,103 @@ afterEach(() => {
 describe('resolveClaude on Windows', () => {
   beforeEach(() => setPlatform('win32'));
 
-  it('returns the path from `where claude.cmd` when present', () => {
+  it('returns the path from `where claude.cmd` when present', async () => {
     bus().results.set('where claude.cmd', {
       status: 0,
       stdout: 'C:\\Users\\u\\AppData\\Roaming\\npm\\claude.cmd\r\n',
     });
-    expect(resolveClaude()).toBe('C:\\Users\\u\\AppData\\Roaming\\npm\\claude.cmd');
+    expect(await resolveClaude()).toBe('C:\\Users\\u\\AppData\\Roaming\\npm\\claude.cmd');
     expect(bus().calls.map((c) => c.args[0])).toEqual(['claude.cmd']);
   });
 
-  it('falls back to `where claude` when claude.cmd lookup fails', () => {
+  it('falls back to `where claude` when claude.cmd lookup fails', async () => {
     bus().results.set('where claude.cmd', { status: 1, stdout: '' });
     bus().results.set('where claude', {
       status: 0,
       stdout: 'C:\\tools\\claude\n',
     });
-    expect(resolveClaude()).toBe('C:\\tools\\claude');
+    expect(await resolveClaude()).toBe('C:\\tools\\claude');
     expect(bus().calls.map((c) => c.args[0])).toEqual(['claude.cmd', 'claude']);
   });
 
-  it('returns null (never the literal "claude") when both lookups fail', () => {
-    expect(resolveClaude()).toBeNull();
+  it('returns null (never the literal "claude") when both lookups fail', async () => {
+    expect(await resolveClaude()).toBeNull();
     expect(bus().calls).toHaveLength(2);
   });
 
-  it('takes the FIRST line of multi-line where output (PATH may have dupes)', () => {
+  it('takes the FIRST line of multi-line where output (PATH may have dupes)', async () => {
     bus().results.set('where claude.cmd', {
       status: 0,
       stdout: 'C:\\first\\claude.cmd\r\nC:\\second\\claude.cmd\r\n',
     });
-    expect(resolveClaude()).toBe('C:\\first\\claude.cmd');
+    expect(await resolveClaude()).toBe('C:\\first\\claude.cmd');
   });
 
-  it('treats blank-stdout success as not-found (status==0 but no path)', () => {
+  it('treats blank-stdout success as not-found (status==0 but no path)', async () => {
     bus().results.set('where claude.cmd', { status: 0, stdout: '\r\n  \r\n' });
     bus().results.set('where claude', { status: 0, stdout: 'C:\\fallback\\claude' });
-    expect(resolveClaude()).toBe('C:\\fallback\\claude');
+    expect(await resolveClaude()).toBe('C:\\fallback\\claude');
   });
 });
 
 describe('resolveClaude on POSIX', () => {
   beforeEach(() => setPlatform('linux'));
 
-  it('uses `which claude` (single lookup)', () => {
+  it('uses `which claude` (single lookup)', async () => {
     bus().results.set('which claude', { status: 0, stdout: '/usr/local/bin/claude\n' });
-    expect(resolveClaude()).toBe('/usr/local/bin/claude');
+    expect(await resolveClaude()).toBe('/usr/local/bin/claude');
     expect(bus().calls).toEqual([{ cmd: 'which', args: ['claude'] }]);
   });
 
-  it('returns null when `which claude` fails', () => {
-    expect(resolveClaude()).toBeNull();
+  it('returns null when `which claude` fails', async () => {
+    expect(await resolveClaude()).toBeNull();
     expect(bus().calls).toHaveLength(1);
   });
 
-  it('returns null when spawnSync itself throws', () => {
+  it('returns null when spawn itself throws', async () => {
     bus().shouldThrow = true;
-    expect(resolveClaude()).toBeNull();
+    expect(await resolveClaude()).toBeNull();
   });
 });
 
 describe('resolveClaude caching', () => {
   beforeEach(() => setPlatform('linux'));
 
-  it('caches the resolved path — second call does not re-spawn', () => {
+  it('caches the resolved path — second call does not re-spawn', async () => {
     bus().results.set('which claude', { status: 0, stdout: '/bin/claude\n' });
-    expect(resolveClaude()).toBe('/bin/claude');
-    expect(resolveClaude()).toBe('/bin/claude');
+    expect(await resolveClaude()).toBe('/bin/claude');
+    expect(await resolveClaude()).toBe('/bin/claude');
     expect(bus().calls).toHaveLength(1);
   });
 
-  it('caches the null result — second call does not re-spawn', () => {
-    expect(resolveClaude()).toBeNull();
-    expect(resolveClaude()).toBeNull();
+  it('caches the null result — second call does not re-spawn', async () => {
+    expect(await resolveClaude()).toBeNull();
+    expect(await resolveClaude()).toBeNull();
     expect(bus().calls).toHaveLength(1);
   });
 
-  it('force:true bypasses the cache (re-check button on ClaudeMissingGuide)', () => {
-    expect(resolveClaude()).toBeNull();
+  it('force:true bypasses the cache (re-check button on ClaudeMissingGuide)', async () => {
+    expect(await resolveClaude()).toBeNull();
     bus().results.set('which claude', { status: 0, stdout: '/bin/claude\n' });
-    expect(resolveClaude({ force: true })).toBe('/bin/claude');
+    expect(await resolveClaude({ force: true })).toBe('/bin/claude');
     expect(bus().calls).toHaveLength(2);
   });
 
-  it('__resetClaudeResolverForTest clears the cache', () => {
+  it('__resetClaudeResolverForTest clears the cache', async () => {
     bus().results.set('which claude', { status: 0, stdout: '/bin/claude\n' });
-    expect(resolveClaude()).toBe('/bin/claude');
+    expect(await resolveClaude()).toBe('/bin/claude');
     __resetClaudeResolverForTest();
     bus().results.clear();
-    expect(resolveClaude()).toBeNull();
+    expect(await resolveClaude()).toBeNull();
+  });
+
+  it('dedups concurrent first-callers into a single in-flight spawn', async () => {
+    bus().results.set('which claude', { status: 0, stdout: '/bin/claude\n' });
+    // Fire two callers BEFORE awaiting — both should share the same
+    // in-flight Promise rather than each spawning their own `where`.
+    const [a, b] = await Promise.all([resolveClaude(), resolveClaude()]);
+    expect(a).toBe('/bin/claude');
+    expect(b).toBe('/bin/claude');
+    expect(bus().calls).toHaveLength(1);
   });
 });

--- a/electron/ptyHost/__tests__/ipcRegistrar.test.ts
+++ b/electron/ptyHost/__tests__/ipcRegistrar.test.ts
@@ -203,18 +203,18 @@ describe('pty:input / resize / kill / get pass-through', () => {
 // ─── pty:spawn — claude resolution + spawn delegation + cwd-redirect ──────
 
 describe('pty:spawn', () => {
-  it('returns {ok:false, error:claude_not_found} when resolveClaude returns null', () => {
+  it('returns {ok:false, error:claude_not_found} when resolveClaude returns null', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue(null);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    expect(ipc.handlers.get('pty:spawn')!({}, 'sid', '/work')).toEqual({
+    expect(await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work')).toEqual({
       ok: false,
       error: 'claude_not_found',
     });
   });
 
-  it('returns {ok:true, ...info} on success and forwards args to spawnPtySession', () => {
+  it('returns {ok:true, ...info} on success and forwards args to spawnPtySession', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     const deps = makeDeps({
@@ -222,7 +222,7 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    const out = ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
+    const out = await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
     expect(out).toEqual({ ok: true, sid: 'sid', pid: 1, cols: 80, rows: 24, cwd: '/picked' });
     const call = (deps.spawnPtySession as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[0]).toBe('sid');
@@ -237,7 +237,7 @@ describe('pty:spawn', () => {
   // (PR-D #866) reflows both the headless source-of-truth buffer and the
   // visible xterm to the real container. The IPC handler therefore no
   // longer parses or threads cols/rows into spawnPtySession opts.
-  it('does not forward cols/rows to spawnPtySession (#867 — PR-D resize+replay covers #852)', () => {
+  it('does not forward cols/rows to spawnPtySession (#867 — PR-D resize+replay covers #852)', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     const deps = makeDeps({
@@ -248,7 +248,7 @@ describe('pty:spawn', () => {
     // Even if a (legacy) renderer were to send the third opts argument,
     // the IPC handler ignores it — the only opt threaded into the
     // lifecycle is onCwdRedirect (#603).
-    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work', { cols: 134, rows: 51 });
+    await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work', { cols: 134, rows: 51 });
     const call = (deps.spawnPtySession as ReturnType<typeof vi.fn>).mock.calls[0];
     const opts = call[3] as { cols?: number; rows?: number; onCwdRedirect?: unknown };
     expect(opts.cols).toBeUndefined();
@@ -256,7 +256,7 @@ describe('pty:spawn', () => {
     expect(typeof opts.onCwdRedirect).toBe('function');
   });
 
-  it('omits opts argument entirely from `pty:spawn` (post-#867)', () => {
+  it('omits opts argument entirely from `pty:spawn` (post-#867)', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     const deps = makeDeps({
@@ -264,7 +264,7 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
+    await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
     const call = (deps.spawnPtySession as ReturnType<typeof vi.fn>).mock.calls[0];
     const opts = call[3] as { cols?: number; rows?: number; onCwdRedirect?: unknown };
     expect(opts.cols).toBeUndefined();
@@ -272,7 +272,7 @@ describe('pty:spawn', () => {
     expect(typeof opts.onCwdRedirect).toBe('function');
   });
 
-  it('returns {ok:false, error:spawn_failed:...} when spawnPtySession throws', () => {
+  it('returns {ok:false, error:spawn_failed:...} when spawnPtySession throws', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     const deps = makeDeps({
@@ -280,12 +280,12 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    const out = ipc.handlers.get('pty:spawn')!({}, 'sid', '/work') as { ok: boolean; error: string };
+    const out = (await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work')) as { ok: boolean; error: string };
     expect(out.ok).toBe(false);
     expect(out.error).toMatch(/^spawn_failed: ENOENT$/);
   });
 
-  it('onCwdRedirect callback sends session:cwdRedirected to the main window', () => {
+  it('onCwdRedirect callback sends session:cwdRedirected to the main window', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     const wc = makeWc(1);
@@ -301,13 +301,13 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
+    await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
     expect(captured).not.toBeNull();
     captured!('/new/cwd');
     expect(wc.send).toHaveBeenCalledWith('session:cwdRedirected', { sid: 'sid', newCwd: '/new/cwd' });
   });
 
-  it('onCwdRedirect is a no-op when main window is null', () => {
+  it('onCwdRedirect is a no-op when main window is null', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     let captured: ((newCwd: string) => void) | null = null;
@@ -320,11 +320,11 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
+    await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
     expect(() => captured!('/new')).not.toThrow();
   });
 
-  it('onCwdRedirect swallows wc.send throws (renderer gone)', () => {
+  it('onCwdRedirect swallows wc.send throws (renderer gone)', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     const wc = makeWc(1, { sendThrows: true });
@@ -340,7 +340,7 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
+    await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
     expect(() => captured!('/new')).not.toThrow();
   });
 });
@@ -430,45 +430,45 @@ describe('pty:detach', () => {
 // ─── pty:checkClaudeAvailable ─────────────────────────────────────────────
 
 describe('pty:checkClaudeAvailable', () => {
-  it('returns {available:true, path} when resolveClaude succeeds', () => {
+  it('returns {available:true, path} when resolveClaude succeeds', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    expect(ipc.handlers.get('pty:checkClaudeAvailable')!({}, undefined)).toEqual({
+    expect(await ipc.handlers.get('pty:checkClaudeAvailable')!({}, undefined)).toEqual({
       available: true,
       path: '/bin/claude',
     });
   });
 
-  it('returns {available:false} when resolveClaude returns null', () => {
+  it('returns {available:false} when resolveClaude returns null', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue(null);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    expect(ipc.handlers.get('pty:checkClaudeAvailable')!({}, undefined)).toEqual({
+    expect(await ipc.handlers.get('pty:checkClaudeAvailable')!({}, undefined)).toEqual({
       available: false,
     });
   });
 
-  it('passes {force:true} through to resolveClaude when opts.force === true', () => {
+  it('passes {force:true} through to resolveClaude when opts.force === true', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    ipc.handlers.get('pty:checkClaudeAvailable')!({}, { force: true });
+    await ipc.handlers.get('pty:checkClaudeAvailable')!({}, { force: true });
     expect(bus().resolveClaude).toHaveBeenCalledWith({ force: true });
   });
 
-  it('does NOT pass force when opts is malformed (string / number / null / no force key)', () => {
+  it('does NOT pass force when opts is malformed (string / number / null / no force key)', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    ipc.handlers.get('pty:checkClaudeAvailable')!({}, 'not-an-object');
-    ipc.handlers.get('pty:checkClaudeAvailable')!({}, null);
-    ipc.handlers.get('pty:checkClaudeAvailable')!({}, {});
-    ipc.handlers.get('pty:checkClaudeAvailable')!({}, { force: 'yes' });
+    await ipc.handlers.get('pty:checkClaudeAvailable')!({}, 'not-an-object');
+    await ipc.handlers.get('pty:checkClaudeAvailable')!({}, null);
+    await ipc.handlers.get('pty:checkClaudeAvailable')!({}, {});
+    await ipc.handlers.get('pty:checkClaudeAvailable')!({}, { force: 'yes' });
     for (const call of bus().resolveClaude.mock.calls) {
       expect(call[0]).toEqual({ force: false });
     }

--- a/electron/ptyHost/claudeResolver.ts
+++ b/electron/ptyHost/claudeResolver.ts
@@ -26,35 +26,75 @@
 // bypass the cache (the renderer's "Re-check" button on ClaudeMissingGuide
 // uses this so the user can install claude in a separate terminal and
 // recover in-place without restarting the app).
+//
+// Async since #PERF: the original `spawnSync` blocked the main process
+// event loop for 50-200ms on Windows during cold start (first
+// `pty:checkClaudeAvailable` from App.tsx + first `pty:spawn`), causing
+// a visible "window hang" stutter. Both callers are `ipcMain.handle`
+// handlers that already await Promise returns, so flipping to async is
+// free at the call site. A module-level in-flight Promise dedups
+// concurrent first-callers so two simultaneous IPCs don't double-spawn
+// `where`.
 
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 
 let cached: string | null | undefined; // undefined = never tried
+let inFlight: Promise<string | null> | null = null;
 
-function tryWhere(name: string): string | null {
+function whereAsync(name: string): Promise<string | null> {
   const cmd = process.platform === 'win32' ? 'where' : 'which';
-  try {
-    const r = spawnSync(cmd, [name], { encoding: 'utf8', windowsHide: true });
-    if (r.status !== 0) return null;
-    const first = r.stdout.split(/\r?\n/).find((l) => l.trim().length > 0);
-    return first ? first.trim() : null;
-  } catch {
-    return null;
-  }
+  return new Promise((resolve) => {
+    let stdout = '';
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(cmd, [name], { windowsHide: true });
+    } catch {
+      resolve(null);
+      return;
+    }
+    child.stdout?.on('data', (b: Buffer) => {
+      stdout += b.toString('utf8');
+    });
+    child.on('error', () => resolve(null));
+    child.on('exit', (code) => {
+      if (code !== 0) {
+        resolve(null);
+        return;
+      }
+      const first = stdout.split(/\r?\n/).find((l) => l.trim().length > 0);
+      resolve(first ? first.trim() : null);
+    });
+  });
 }
 
-export function resolveClaude({ force = false }: { force?: boolean } = {}): string | null {
-  if (!force && cached !== undefined) return cached;
+async function doResolve(): Promise<string | null> {
   if (process.platform === 'win32') {
-    cached = tryWhere('claude.cmd') ?? tryWhere('claude');
-  } else {
-    cached = tryWhere('claude');
+    return (await whereAsync('claude.cmd')) ?? (await whereAsync('claude'));
   }
-  return cached;
+  return whereAsync('claude');
+}
+
+export function resolveClaude({ force = false }: { force?: boolean } = {}): Promise<string | null> {
+  if (!force && cached !== undefined) return Promise.resolve(cached);
+  // Concurrent-caller dedup: while the first lookup is in flight, hand
+  // the same Promise to every additional caller. Without this, an N-wide
+  // burst of `pty:checkClaudeAvailable` + `pty:spawn` on cold start
+  // would spawn N copies of `where` instead of one.
+  if (!force && inFlight) return inFlight;
+  inFlight = doResolve()
+    .then((result) => {
+      cached = result;
+      return result;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+  return inFlight;
 }
 
 // Test seam — used by harness-real-cli's ttyd cases to force a fresh
 // lookup between cases. Production code never invokes this.
 export function __resetClaudeResolverForTest(): void {
   cached = undefined;
+  inFlight = null;
 }

--- a/electron/ptyHost/ipcRegistrar.ts
+++ b/electron/ptyHost/ipcRegistrar.ts
@@ -87,8 +87,8 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
 
   ipcMain.handle('pty:list', () => deps.listPtySessions());
 
-  ipcMain.handle('pty:spawn', (_event, sid: string, cwd: string) => {
-    const claudePath = resolveClaude();
+  ipcMain.handle('pty:spawn', async (_event, sid: string, cwd: string) => {
+    const claudePath = await resolveClaude();
     if (!claudePath) {
       return { ok: false, error: 'claude_not_found' };
     }
@@ -182,10 +182,10 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
   // `force: true` bypasses the resolver's success-cache so the user can
   // install claude in another terminal and recover in-place via the
   // ClaudeMissingGuide "Re-check" button without restarting the app.
-  ipcMain.handle('pty:checkClaudeAvailable', (_event, opts: unknown) => {
+  ipcMain.handle('pty:checkClaudeAvailable', async (_event, opts: unknown) => {
     const force =
       typeof opts === 'object' && opts !== null && (opts as { force?: unknown }).force === true;
-    const p = resolveClaude({ force });
+    const p = await resolveClaude({ force });
     return p ? { available: true as const, path: p } : { available: false as const };
   });
 }


### PR DESCRIPTION
## Symptom

On Windows cold start, the app's first window shows a visible 50-200ms stutter before the renderer becomes interactive.

## Root cause

`electron/ptyHost/claudeResolver.ts` uses `spawnSync('where claude.cmd')` (then optionally `where claude` fallback) inside the main process. `where.exe` walks the user PATH on first invocation and routinely takes 50-200ms. Because this runs synchronously on the main process, the entire Electron event loop stalls — UI, IPC, GPU, all paused.

The two callers are both `ipcMain.handle` handlers:

- `pty:checkClaudeAvailable` — fired by `App.tsx` on mount as a startup probe
- `pty:spawn` — fired the first time the user opens a session

`ipcMain.handle` already awaits Promise returns, so the sync call was a free self-inflicted hang, not one forced by the IPC contract. Cache means only the first call pays (a hit returns immediately) — but the first call IS the cold-start path the user feels.

## Fix

Switch `resolveClaude` to `Promise<string | null>` using `child_process.spawn` + an `'exit'` listener. Both callers gain a single `await`. The success / null / `force: true` cache contract is unchanged; the cache stores resolved primitives (not Promises), so post-cache hits are still effectively zero-cost.

Added a module-level **in-flight Promise dedup**: while the first lookup is pending, additional callers share the same Promise rather than each spawning their own `where`. Without this, an N-wide burst of cold-start IPCs (checkAvailable + first spawn) would double-spawn `where` — sync didn't have this risk because it never yielded.

## Callers touched

| Caller | File | Change |
|---|---|---|
| `pty:spawn` | `electron/ptyHost/ipcRegistrar.ts:90` | handler → `async`, `await resolveClaude()` |
| `pty:checkClaudeAvailable` | `electron/ptyHost/ipcRegistrar.ts:185` | handler → `async`, `await resolveClaude({force})` |

Both already returned Promise-shaped IPC results — no renderer-side change needed.

## Test plan

- [x] `npm run lint` — clean (only pre-existing warnings in other files)
- [x] `npm run typecheck` — clean
- [x] `npx vitest run electron/ptyHost/__tests__/claudeResolver.test.ts electron/ptyHost/__tests__/ipcRegistrar.test.ts` — 42/42 pass
- [x] `npm run test` — 1398 / 1401 pass; 3 failures in `db-hardening.test.ts` are unrelated (better-sqlite3 NODE_MODULE_VERSION mismatch in local node version, not touched by this PR)
- [x] Added `dedups concurrent first-callers into a single in-flight spawn` test that pins the dedup contract
- [ ] Dogfood: cold-start install, watch for the "window hang" — should be gone or significantly reduced
- [ ] Dogfood: ClaudeMissingGuide "Re-check" button still works (force:true cache bypass preserved)