### PR TITLE
fix(terminal): tame wheel overscroll on precision input devices

### DIFF
--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -135,14 +135,20 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
     // (~17px at our 13px font), so a Windows precision-mouse / touchpad
     // notch reporting `deltaY` in the 100–400px range with the default
     // sensitivity of 1 lands the user 6–25 lines down per notch — "a
-    // light flick scrolls to the middle of the page" (see #user-report
-    // 2026-05-21). 0.5 brings a ~120px notch back to ~3 lines, matching
-    // a native CLI terminal's feel without making intentional fast scrolls
-    // sluggish (the Alt modifier still gives 5x for long jumps).
+    // light flick scrolls to the middle of the page" reported in dogfood.
+    // 0.5 brings a ~120px notch back to ~3 lines, matching a native CLI
+    // terminal's feel without making intentional fast scrolls sluggish
+    // (the Alt modifier still gives 5x for long jumps).
+    //
+    // 0.5 is also safe for low-deltaY trackpads: xterm's Viewport keeps a
+    // `_wheelPartialScroll %= 1` accumulator (Viewport.ts:360-362) that
+    // carries the sub-row remainder across wheel events, so a trackpad
+    // emitting `deltaY` in the 4–10px range still scrolls smoothly — the
+    // partial line just lands on the next event instead of being dropped.
     //
     // `fastScrollSensitivity` and `fastScrollModifier` are pinned to their
-    // current xterm defaults explicitly so an upstream default change can't
-    // resurface this bug; if a future xterm starts treating
+    // current xterm defaults explicitly — manager-pinned to defend against
+    // upstream default drift; if a future xterm starts treating
     // `fastScrollModifier: 'alt'` as default-fast, the runaway scroll
     // returns silently.
     scrollSensitivity: 0.5,

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -130,6 +130,24 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
     allowProposedApi: true,
     scrollback,
     theme: { background: '#000000' },
+    // Wheel-scroll tuning. xterm's `Viewport.getLinesScrolled` multiplies
+    // `event.deltaY` by `scrollSensitivity` BEFORE dividing by row height
+    // (~17px at our 13px font), so a Windows precision-mouse / touchpad
+    // notch reporting `deltaY` in the 100–400px range with the default
+    // sensitivity of 1 lands the user 6–25 lines down per notch — "a
+    // light flick scrolls to the middle of the page" (see #user-report
+    // 2026-05-21). 0.5 brings a ~120px notch back to ~3 lines, matching
+    // a native CLI terminal's feel without making intentional fast scrolls
+    // sluggish (the Alt modifier still gives 5x for long jumps).
+    //
+    // `fastScrollSensitivity` and `fastScrollModifier` are pinned to their
+    // current xterm defaults explicitly so an upstream default change can't
+    // resurface this bug; if a future xterm starts treating
+    // `fastScrollModifier: 'alt'` as default-fast, the runaway scroll
+    // returns silently.
+    scrollSensitivity: 0.5,
+    fastScrollSensitivity: 5,
+    fastScrollModifier: 'alt',
   });
   fit = new FitAddon();
   term.loadAddon(fit);

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -68,6 +68,27 @@ describe('useXtermSingleton', () => {
     expect(window.__ccsmTerm).toBe(getTerm());
   });
 
+  // Wheel-scroll tuning regression guard. xterm's `Viewport.getLinesScrolled`
+  // multiplies `event.deltaY` by `scrollSensitivity` before dividing by row
+  // height; without these explicit values, a Windows precision-mouse notch
+  // reporting `deltaY` ~120-400px lands the user 6-25 lines down per notch
+  // ("light flick scrolls to middle of page"). A future refactor that drops
+  // any of these three options silently resurrects the bug — pin them in a
+  // test so the constructor contract is enforced.
+  it('constructs Terminal with explicit wheel-scroll tuning', () => {
+    const host = document.createElement('div');
+    renderHook(() => useXtermSingleton({ current: host }));
+    expect(terminalCtor).toHaveBeenCalledTimes(1);
+    const opts = terminalCtor.mock.calls[0][0] as {
+      scrollSensitivity?: number;
+      fastScrollSensitivity?: number;
+      fastScrollModifier?: string;
+    };
+    expect(opts.scrollSensitivity).toBe(0.5);
+    expect(opts.fastScrollSensitivity).toBe(5);
+    expect(opts.fastScrollModifier).toBe('alt');
+  });
+
   it('reuses the singleton across remounts (does NOT recreate)', () => {
     const host = document.createElement('div');
     const ref = { current: host };


### PR DESCRIPTION
## 现象

> "CLI 区往上轻轻一滚滚轮，直接滚到页面中间了"

单次 wheel notch 滚动距离过大，CLI 视口几乎是页面级跳转。

## Layer-1 根因

`src/terminal/xtermSingleton.ts:126-133`，Terminal 构造没传 `scrollSensitivity` / `fastScrollSensitivity` / `fastScrollModifier`，全部走 xterm 默认。全代码库 grep `wheel|deltaY|scrollLines|scrollSensitivity|fastScroll` 零匹配——没有自定义 wheel handler、没有重复 listener。

读 `node_modules/@xterm/xterm/src/browser/Viewport.ts:349-378`：

```ts
public getLinesScrolled(ev: WheelEvent): number {
  let amount = this._applyScrollModifier(ev.deltaY, ev);  // deltaY * scrollSensitivity
  if (ev.deltaMode === WheelEvent.DOM_DELTA_PIXEL) {
    amount /= this._currentRowHeight;                      // 再除以 ~17px
    ...
  }
}
```

xterm 在 `DOM_DELTA_PIXEL` 模式下先乘 `scrollSensitivity` 再除 `rowHeight`。Windows 精密鼠标 / 触摸板 / Chromium OS 加速滚动开启时，一次 notch `deltaY` 可达 100–400px。在默认 `scrollSensitivity=1` 下：

- 120px notch → 120/17 ≈ 7 行/notch
- 400px notch → 400/17 ≈ 23 行/notch

这就是"轻轻一滚滚到中间"的来源。

## 修法

`src/terminal/xtermSingleton.ts` 显式传三个参数：

```ts
scrollSensitivity: 0.5,         // 120px notch → ~3.5 lines, 匹配原生 CLI 手感
fastScrollSensitivity: 5,       // pin to xterm default
fastScrollModifier: 'alt',      // pin to xterm default, 防上游默认变化
```

`0.5` 把高 deltaY 设备拉回 1-3 行/notch；Alt 修饰键仍可触发 5x 加速跳转，长跳不会变慢。

### 为什么 0.5 对低 deltaY 触摸板也是安全的

xterm 的 `Viewport.getLinesScrolled` 在算出小数行数后会通过 `this._wheelPartialScroll %= 1` 累加器（`Viewport.ts:360-362`）把 sub-row 余数跨 wheel 事件累计起来，不会丢。低 deltaY 设备（比如 macOS 惯性滚动一次只发 4–10px）即使在 `scrollSensitivity=0.5` 下单次事件不足 1 行，余数会累积到下一次事件，最终仍然滚动顺畅，不会卡顿或卡帧。

## Dogfood

1. `npm run dev` 启动
2. 打开 CLI 区
3. 鼠标滚轮轻滚一格 → 应位移约 1-3 行（不是跳到页面中间）
4. 按住 Alt + 滚轮 → 大跨度跳转仍正常（约 5x）

## 验证

- npm run lint：本文件 0 error
- npm run typecheck：通过
- npm test：3 个失败全部是 `db-hardening.test.ts` better-sqlite3 native ABI 不匹配，与本 PR 无关
- 新增 unit test `tests/terminal/useXtermSingleton.test.tsx > constructs Terminal with explicit wheel-scroll tuning`：断言三个 wheel 参数被显式传给 Terminal 构造函数，防止未来 refactor 静默丢弃

🤖 Generated with [Claude Code](https://claude.com/claude-code)