### PR TITLE
fix(session-title): first-write-wins for OSC title to stop flicker

### DIFF
--- a/src/stores/slices/sessionTitleBackfillSlice.ts
+++ b/src/stores/slices/sessionTitleBackfillSlice.ts
@@ -4,9 +4,14 @@
 //
 // Owned actions:
 //   `_applyExternalTitle` — patch a session's `name` from an external
-//      source (SDK title bridge IPC, or `_backfillTitles` below). Stable
-//      no-op if the name already matches so we don't churn the persisted
-//      snapshot or trigger unnecessary re-renders.
+//      source (SDK title bridge IPC, or `_backfillTitles` below).
+//      First-write-wins: only overwrites the default placeholder
+//      (`'New session'` etc.). Once a session has a real name (auto
+//      from the first turn's OSC title, backfilled summary, or user
+//      rename) subsequent external titles are dropped — claude TUI
+//      rewrites the window title every prompt, so without this guard
+//      the session name flickers turn-to-turn. Stable no-op if the
+//      name already matches.
 //   `_backfillTitles` — one-shot post-hydrate pass that pulls
 //      per-project summaries from the SDK and renames any sessions still
 //      stuck on a default name (`'New session'` etc.).
@@ -37,8 +42,7 @@ export function createSessionTitleBackfillSlice(
       // fire `title-changed` with the pre-rename summary; without this
       // guard the user's name flicks back. Clear the guard once we observe
       // an external title equal to the desired name — that proves the
-      // round-trip landed and future external changes (e.g. claude
-      // `/title`) should apply normally.
+      // round-trip landed.
       const desired = getPendingManualRename(sid);
       if (desired !== undefined) {
         if (title !== desired) return;
@@ -47,7 +51,18 @@ export function createSessionTitleBackfillSlice(
       set((s) => {
         const idx = s.sessions.findIndex((x) => x.id === sid);
         if (idx === -1) return s;
-        if (s.sessions[idx]!.name === title) return s;
+        const cur = s.sessions[idx]!.name;
+        if (cur === title) return s;
+        // First-write-wins on auto naming. The OSC title sniffer in
+        // ptyHost emits a fresh title every time the user types a new
+        // prompt (claude TUI rewrites the window title each turn);
+        // before this guard the session name flickered between turns
+        // and any user rename downstream of the initial backfill could
+        // be clobbered by the next turn. Only allow external titles to
+        // overwrite the *default* placeholder; once the row carries a
+        // real name (auto-named on the first turn, or user-renamed via
+        // `renameSession`) external titles are dropped.
+        if (!BACKFILL_DEFAULT_NAMES.has(cur)) return s;
         const next = s.sessions.slice();
         next[idx] = { ...next[idx]!, name: title };
         return { ...s, sessions: next };

--- a/tests/stores/slices/sessionTitleBackfillSlice.test.ts
+++ b/tests/stores/slices/sessionTitleBackfillSlice.test.ts
@@ -51,9 +51,9 @@ describe('sessionTitleBackfillSlice', () => {
     _resetPendingManualRenamesForTests();
   });
 
-  it('_applyExternalTitle patches matching session, no-op for unknowns', () => {
+  it('_applyExternalTitle patches matching default-named session, no-op for unknowns', () => {
     const h = harness({
-      sessions: [mkSession('a', 'g1', { name: 'old' })],
+      sessions: [mkSession('a', 'g1', { name: 'New session' })],
     });
     h.titles._applyExternalTitle('a', 'new');
     expect(h.state().sessions[0].name).toBe('new');
@@ -66,6 +66,28 @@ describe('sessionTitleBackfillSlice', () => {
     const before = h.state().sessions;
     h.titles._applyExternalTitle('a', 'same');
     expect(h.state().sessions).toBe(before);
+  });
+
+  it('_applyExternalTitle is a no-op once the session has a non-default name', () => {
+    // claude TUI re-emits the OSC title every prompt; before the
+    // first-write-wins guard the session name flickered between turns.
+    // Only the default placeholder ('New session' / '新会话') is
+    // overwritable — anything else is treated as authoritative.
+    const h = harness({
+      sessions: [mkSession('a', 'g1', { name: 'first turn summary' })],
+    });
+    const before = h.state().sessions;
+    h.titles._applyExternalTitle('a', 'second turn rewrites the title');
+    expect(h.state().sessions).toBe(before);
+    expect(h.state().sessions[0].name).toBe('first turn summary');
+  });
+
+  it('_applyExternalTitle overwrites the legacy zh default placeholder', () => {
+    const h = harness({
+      sessions: [mkSession('a', 'g1', { name: '新会话' })],
+    });
+    h.titles._applyExternalTitle('a', 'auto-named');
+    expect(h.state().sessions[0].name).toBe('auto-named');
   });
 
   it('_backfillTitles is a no-op when no bridge is present', async () => {
@@ -89,7 +111,7 @@ describe('sessionTitleBackfillSlice', () => {
     expect(h.state().sessions[0].name).toBe('My label');
   });
 
-  it('_applyExternalTitle clears the guard and applies once the SDK round-trips', () => {
+  it('_applyExternalTitle clears the guard on round-trip then ignores later OSC titles', () => {
     const h = harness({
       sessions: [mkSession('a', 'g1', { name: 'My label' })],
     });
@@ -97,8 +119,10 @@ describe('sessionTitleBackfillSlice', () => {
     // First the JSONL rewrite lands: external title matches desired -> guard clears.
     h.titles._applyExternalTitle('a', 'My label');
     expect(h.state().sessions[0].name).toBe('My label');
-    // Later the user (or claude `/title`) legitimately changes it again.
+    // Later claude TUI re-emits the OSC title for a new prompt. The
+    // session already has a non-default name (user-renamed), so the
+    // first-write-wins guard drops the patch — the user's label sticks.
     h.titles._applyExternalTitle('a', 'Renamed by claude');
-    expect(h.state().sessions[0].name).toBe('Renamed by claude');
+    expect(h.state().sessions[0].name).toBe('My label');
   });
 });


### PR DESCRIPTION
## User report

> session 的名字，我不 rename 的情况下，会随着聊天一直变

ccsm treats Claude TUI's OSC 0/2 window-title as the session display name. Claude rewrites that title every time the user submits a new prompt, so the renderer's `_applyExternalTitle` overwrote `session.name` on every turn. Result: the sidebar name jumps around, and a non-default name set by an earlier turn (or the boot-time backfill) gets clobbered the moment claude emits the next prompt's summary.

## Layer-1 root cause

Path: `electron/ptyHost/oscTitleSniffer.ts` → `session:title` IPC → `src/app-effects/useSessionTitleBridge.ts` → `_applyExternalTitle` in `src/stores/slices/sessionTitleBackfillSlice.ts`.

Old `_applyExternalTitle` had only one guard — `pendingManualRenames` — which protects a user rename only between the click and the SDK round-trip. Once the round-trip cleared the guard, the next OSC title for the same sid happily overwrote the user's chosen name (the existing test `'clears the guard and applies once the SDK round-trips'` actually pinned this incorrect behavior).

There was no guard against the much more common case: an auto-named session getting its name rewritten on every prompt.

## Fix (option A — minimal)

`_applyExternalTitle` now drops the patch when the row's current name is not in `BACKFILL_DEFAULT_NAMES` (`'New session'` / `'新会话'`). First-write-wins:

- Empty / default-named session → first OSC title auto-names it (unchanged)
- Boot-time `_backfillTitles` → still works (it already pre-filtered to default names before calling `_applyExternalTitle`, and it only ever runs while names are still default)
- Auto-named session → subsequent OSC titles are dropped → no more turn-by-turn flicker
- User-renamed session → name is non-default → OSC titles are dropped → user rename sticks even after the manual-rename guard clears

Picked A over adding a `nameSource` field because the existing default-name set is already exported (`BACKFILL_DEFAULT_NAMES`) and the only edge case A doesn't cover ("user renames *back to* 'New session' wanting auto-naming to resume") is one nobody actually does.

## Files changed

- `src/stores/slices/sessionTitleBackfillSlice.ts` — guard added, doc-comment updated
- `tests/stores/slices/sessionTitleBackfillSlice.test.ts` — pinned the new behavior

## Test coverage

- Default name (`'New session'`) + first OSC title → overwrites
- Legacy zh default (`'新会话'`) + OSC title → overwrites
- Non-default name + later OSC title → no-op (reference-stable, the new flicker guard)
- Manual rename round-trip clears guard, then later OSC titles are dropped (replaces the old test that pinned the buggy overwrite)
- Same name → no-op (existing)
- Unknown sid → no-op (existing)

7/7 in this file pass. Full suite: 1400/1403 (3 unrelated `better-sqlite3` ABI failures from a local Node mismatch — environmental, not on CI).

`npm run typecheck` clean.

## Dogfood steps

1. Create a fresh session
2. Send a prompt → name auto-fills from the first OSC title
3. Send 2-3 more prompts → name should NOT change between turns
4. Manually rename the session via the sidebar
5. Send another prompt → renamed label sticks, claude's new title is ignored