### PR TITLE
fix(sidebar): default new-session cwd to home, not last-used

### DIFF
--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -6,10 +6,9 @@
 //   2. switch-session-keeps-chat     — UX F: session A↔B switch reuses pty, scrollback intact
 //   3. cwd-projects-claude           — UX E: real cwd flows into claude's JSONL hash
 //   4. import-resume                 — UX H: import existing JSONL, claude --resume restores
-//   5. default-cwd-from-userCwds-lru — task #551: new-session cwd defaults to LRU head
-//   6. new-session-focus-cli         — UX C': button focus does not double-fire
-//   7. pty-pid-stable-across-switch  — direct-xterm: pty pid stable across A→B→A switch
-//   8. reopen-resume                 — UX G: close ccsm, reopen, click session, --resume restores
+//   5. new-session-focus-cli         — UX C': button focus does not double-fire
+//   6. pty-pid-stable-across-switch  — direct-xterm: pty pid stable across A→B→A switch
+//   7. reopen-resume                 — UX G: close ccsm, reopen, click session, --resume restores
 //
 // Sharing strategy:
 //   * Cases 1–6 share ONE Electron launch + ONE isolated tempDir. Each case
@@ -1863,119 +1862,6 @@ async function caseImportLandsInFocusedGroup({ win, tempDir }) {
 }
 
 // ============================================================================
-// Case: default-cwd-from-userCwds-lru (task #551)
-//
-// New session creation must default the cwd to the user's most-recently
-// used cwd from the ccsm-owned `userCwds` LRU (head of the list), with
-// a fallback to `userHome` only when the LRU is empty.
-//
-// Reproduces the bug from PR #392's "default cwd is always home" policy:
-// the user re-picks the same project on every new session because the
-// LRU is consulted only by the picker, never by the default.
-//
-// Steps:
-//   1. Read userHome from the renderer.
-//   2. Push a synthetic non-home cwd into the LRU via `window.ccsm.userCwds.push`.
-//   3. Wait for `lastUsedCwd` to reflect the new head in the store.
-//   4. Call `createSession()` with NO opts.cwd — the new session's cwd
-//      MUST equal the pushed path, NOT userHome.
-//   5. Soft-cleanup: delete the new session so subsequent cases see a
-//      clean shared launch.
-// ============================================================================
-
-async function caseDefaultCwdFromUserCwdsLru({ electronApp: _e, win, tempDir }) {
-  // Boot probe must have resolved (renderer needs userCwds IPC + store).
-  await win.waitForFunction(
-    () => !document.querySelector('[data-testid="claude-availability-probing"]'),
-    null,
-    { timeout: 30000 },
-  );
-
-  // Synthetic project dir distinct from tempDir so we don't collide with
-  // earlier cases that may have pushed tempDir already.
-  const projectDir = path.join(tempDir, 'lru-project-' + Math.random().toString(36).slice(2, 8));
-  mkdirSync(projectDir, { recursive: true });
-  const normalizedExpected = projectDir.replace(/[\\/]+$/, '');
-
-  // Push the cwd through the real IPC. The renderer-side `lastUsedCwd`
-  // cache is normally updated by store mutators (createSession /
-  // setSessionCwd / importSession) that wrap the push call; pushing the
-  // raw IPC bypasses those wrappers, so we mirror what `hydrateStore`
-  // does at boot — read the LRU back via `userCwds.get` and seed
-  // `lastUsedCwd` from the head. This matches the real path for the
-  // first `+` click of every fresh launch.
-  const pushed = await win.evaluate(async (p) => {
-    const api = window.ccsm;
-    if (!api?.userCwds?.push || !api?.userCwds?.get) {
-      return { ok: false, reason: 'userCwds IPC unavailable' };
-    }
-    await api.userCwds.push(p);
-    const list = await api.userCwds.get();
-    const head = Array.isArray(list) && list.length > 0 ? list[0] : null;
-    if (head) {
-      window.__ccsmStore.setState({ lastUsedCwd: head });
-    }
-    return { ok: true, head };
-  }, projectDir);
-  if (!pushed.ok) throw new Error(`userCwds.push failed: ${pushed.reason}`);
-
-  // Wait briefly for the setState to flush. The check polls instead of
-  // relying on react-batching timing.
-  await win.waitForFunction(
-    (expected) => {
-      const st = window.__ccsmStore?.getState?.();
-      return !!st && (st.lastUsedCwd || '').replace(/[\\/]+$/, '') === expected;
-    },
-    normalizedExpected,
-    { timeout: 5000 },
-  );
-
-  // Snapshot pre-create state for the failure message.
-  const before = await win.evaluate(() => {
-    const st = window.__ccsmStore.getState();
-    return {
-      lastUsedCwd: st.lastUsedCwd,
-      userHome: st.userHome,
-      sessionCount: st.sessions.length,
-    };
-  });
-
-  // Create the new session WITHOUT specifying cwd — this is the defaulted
-  // path the bug is about. Read back the active session's cwd.
-  const result = await win.evaluate(() => {
-    const useStore = window.__ccsmStore;
-    const { createSession } = useStore.getState();
-    createSession({ name: 'lru-default-probe' });
-    const st = useStore.getState();
-    const active = st.sessions.find((s) => s.id === st.activeId);
-    return { sid: st.activeId, cwd: active?.cwd ?? null };
-  });
-
-  const actual = (result.cwd || '').replace(/[\\/]+$/, '');
-  if (actual !== normalizedExpected) {
-    throw new Error(
-      `default cwd did not honor userCwds LRU.\n` +
-        `  expected (LRU head): ${normalizedExpected}\n` +
-        `  actual (session.cwd): ${result.cwd}\n` +
-        `  store.lastUsedCwd:   ${before.lastUsedCwd}\n` +
-        `  store.userHome:      ${before.userHome}`,
-    );
-  }
-
-  // Negative: actual MUST NOT equal userHome (the regressed default).
-  if (before.userHome && actual === before.userHome.replace(/[\\/]+$/, '')) {
-    throw new Error(`default cwd fell back to userHome (${before.userHome}) despite non-empty LRU`);
-  }
-
-  // Cleanup so subsequent cases see no extra session row.
-  await win.evaluate((sid) => {
-    const useStore = window.__ccsmStore;
-    const { deleteSession } = useStore.getState();
-    deleteSession?.(sid);
-  }, result.sid);
-}
-
-// ============================================================================
 // Case: new-session-focus-cli — clicking "New Session" must transfer focus
 // AWAY from the trigger button so a subsequent Enter goes to the CLI, not
 // to the still-focused button (which would re-fire and spawn yet another
@@ -2506,8 +2392,10 @@ async function _waitBoot(win) {
 }
 
 async function _seedRecentCwd(win, projectDir) {
-  // Push the cwd through the real IPC and mirror lastUsedCwd, matching the
-  // boot path used by hydrateStore. See caseDefaultCwdFromUserCwdsLru.
+  // Push the cwd into the ccsm-owned `userCwds` LRU. The LRU feeds the
+  // chevron popover's "Recent" column — NOT the new-session default.
+  // Per PR #392 spec, the default cwd is always `userHome`; the chevron
+  // covers the "open in another recent project" case.
   mkdirSync(projectDir, { recursive: true });
   const result = await win.evaluate(async (p) => {
     const api = window.ccsm;
@@ -2517,7 +2405,6 @@ async function _seedRecentCwd(win, projectDir) {
     await api.userCwds.push(p);
     const list = await api.userCwds.get();
     const head = Array.isArray(list) && list.length > 0 ? list[0] : null;
-    if (head) window.__ccsmStore.setState({ lastUsedCwd: head });
     return { ok: true, head };
   }, projectDir);
   if (!result.ok) throw new Error(`userCwds.push failed: ${result.reason}`);
@@ -2557,13 +2444,18 @@ async function _seedGroup(win, name) {
 }
 
 // Case: cwd-picker-top-default
-//   Click the top `+` (NOT the chevron). Asserts the new session uses the
-//   LRU default cwd (lastUsedCwd), proving that the `+` half is unaffected
-//   by the chevron addition.
+//   Click the top `+` (NOT the chevron). Asserts the new session uses
+//   `userHome` as the default cwd, even when the userCwds LRU has a
+//   non-home head. Per PR #392 spec ("default cwd is home, no fallback
+//   chains") — the chevron popover is the explicit path for picking a
+//   recent project; the bare `+` must always land at home.
 async function caseCwdPickerTopDefault({ win, tempDir }) {
   await _waitBoot(win);
+  // Seed the LRU with a non-home cwd. The default MUST ignore it.
   const projectDir = path.join(tempDir, 'cwd-pick-top-default-' + Math.random().toString(36).slice(2, 8));
-  const expected = _norm(await _seedRecentCwd(win, projectDir));
+  await _seedRecentCwd(win, projectDir);
+  const userHome = _norm(await win.evaluate(() => window.__ccsmStore.getState().userHome));
+  if (!userHome) throw new Error('userHome not seeded yet — boot probe race');
 
   const before = await _sessionCount(win);
   // The top "+" lives inside [data-sidebar-newsession-cluster] as the
@@ -2579,8 +2471,10 @@ async function caseCwdPickerTopDefault({ win, tempDir }) {
   const after = await _sessionCount(win);
   if (after - before !== 1) throw new Error(`expected 1 new session, got delta=${after - before}`);
   const actual = _norm(await _activeCwd(win));
-  if (actual !== expected) {
-    throw new Error(`top + did not honor LRU default. expected=${expected} actual=${actual}`);
+  if (actual !== userHome) {
+    throw new Error(
+      `top + did not default to userHome.\n  expected (userHome): ${userHome}\n  actual (session.cwd): ${actual}\n  (LRU head was ${_norm(projectDir)} — must be ignored by the default)`,
+    );
   }
   await _deleteActive(win);
 }
@@ -3448,7 +3342,6 @@ const CASE_REGISTRY = [
   { name: 'caseSpacesInCwdSpawnsCorrectly', group: 'shared', run: caseSpacesInCwdSpawnsCorrectly },
   { name: 'import-resume',               group: 'shared', run: caseImportResume },
   { name: 'import-lands-in-focused-group', group: 'shared', run: caseImportLandsInFocusedGroup },
-  { name: 'default-cwd-from-userCwds-lru', group: 'shared', run: caseDefaultCwdFromUserCwdsLru },
   { name: 'new-session-focus-cli',       group: 'shared', run: caseNewSessionFocusCli },
   { name: 'pty-pid-stable-across-switch',group: 'shared', run: casePtyPidStableAcrossSwitch },
   { name: 'cwd-picker-top-default',      group: 'shared', run: caseCwdPickerTopDefault },

--- a/scripts/screenshot-552-chevron-picker.mjs
+++ b/scripts/screenshot-552-chevron-picker.mjs
@@ -31,9 +31,6 @@ async function seedRecent(win, p) {
   await win.evaluate(async (path_) => {
     const api = window.ccsm;
     if (api?.userCwds?.push) await api.userCwds.push(path_);
-    const list = await api.userCwds.get();
-    const head = Array.isArray(list) && list.length > 0 ? list[0] : null;
-    if (head) window.__ccsmStore.setState({ lastUsedCwd: head });
   }, p);
 }
 

--- a/src/stores/slices/sessionCrudSlice.ts
+++ b/src/stores/slices/sessionCrudSlice.ts
@@ -1,6 +1,5 @@
 // Session CRUD slice: create / import / delete / restore / move /
-// rename / changeCwd / setSessionModel + active selection + LRU cwd
-// seed.
+// rename / changeCwd / setSessionModel + active selection.
 //
 // `ensureUsableGroup` is colocated here because the only callers are
 // session creation/import — it picks (or synthesizes) a target group so
@@ -131,7 +130,6 @@ export type SessionCrudSlice = Pick<
   | 'focusedGroupId'
   | 'userHome'
   | 'claudeSettingsDefaultModel'
-  | 'lastUsedCwd'
   | 'selectSession'
   | 'focusGroup'
   | 'createSession'
@@ -154,7 +152,6 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
     focusedGroupId: null,
     userHome: '',
     claudeSettingsDefaultModel: null,
-    lastUsedCwd: null,
 
     selectSession: (id) => {
       set((s) => ({
@@ -180,7 +177,6 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
         activeId,
         userHome,
         claudeSettingsDefaultModel,
-        lastUsedCwd,
       } = get();
       const activeGroupId = sessions.find((s) => s.id === activeId)?.groupId;
       const preferred = resolvePreferredGroup(
@@ -193,7 +189,11 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
       const targetGroupId = ensured.groupId;
       const baseGroups = ensured.groups;
       const id = newSessionId();
-      const defaultCwd = lastUsedCwd ?? userHome ?? '';
+      // Default cwd is `os.homedir()` always — no fallback chain. Per
+      // PR #392 spec ("default cwd is home, no fallback chains"). The
+      // chevron popover next to the `+` covers the "open in another
+      // recent project" case so the default doesn't need to guess.
+      const defaultCwd = userHome ?? '';
       let initialModel = '';
       if (!initialModel) initialModel = claudeSettingsDefaultModel ?? '';
       const newSession: Session = {
@@ -219,14 +219,7 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
       const finalCwd = newSession.cwd;
       if (finalCwd && userHome && finalCwd !== userHome) {
         const api = window.ccsm;
-        void api?.userCwds?.push(finalCwd)
-          .then((list) => {
-            if (Array.isArray(list) && list.length > 0) {
-              set({ lastUsedCwd: list[0] ?? null });
-            }
-          })
-          .catch(() => {});
-        if (finalCwd !== lastUsedCwd) set({ lastUsedCwd: finalCwd });
+        void api?.userCwds?.push(finalCwd).catch(() => {});
       }
     },
 
@@ -310,14 +303,7 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
       const userHome = get().userHome;
       if (cwd && userHome && cwd !== userHome) {
         const api = window.ccsm;
-        void api?.userCwds?.push(cwd)
-          .then((list) => {
-            if (Array.isArray(list) && list.length > 0) {
-              set({ lastUsedCwd: list[0] ?? null });
-            }
-          })
-          .catch(() => {});
-        if (cwd !== get().lastUsedCwd) set({ lastUsedCwd: cwd });
+        void api?.userCwds?.push(cwd).catch(() => {});
       }
       return id;
     },
@@ -446,14 +432,7 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
       const userHome = get().userHome;
       if (cwd && cwd !== userHome) {
         const api = window.ccsm;
-        void api?.userCwds?.push(cwd)
-          .then((list) => {
-            if (Array.isArray(list) && list.length > 0) {
-              set({ lastUsedCwd: list[0] ?? null });
-            }
-          })
-          .catch(() => {});
-        if (cwd !== get().lastUsedCwd) set({ lastUsedCwd: cwd });
+        void api?.userCwds?.push(cwd).catch(() => {});
       }
     },
 

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -74,7 +74,6 @@ export type State = {
   hydrated: boolean;
   installerCorrupt: boolean;
   openPopoverId: string | null;
-  lastUsedCwd: string | null;
   disconnectedSessions: Record<
     string,
     { kind: 'clean' | 'crashed'; code: number | null; signal: string | number | null; at: number }

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -167,22 +167,6 @@ export async function hydrateStore(): Promise<void> {
           claudeSettingsDefaultModel: typeof defaultModel === 'string' ? defaultModel : null,
         });
       }
-      // Seed `lastUsedCwd` from the ccsm-owned `userCwds` LRU so the very
-      // first `+` click after launch already lands in the user's most
-      // recent project. Without this, the first session of every boot
-      // would silently fall back to home and re-train the picker. Skip
-      // when the only entry is `userHome` — that's the empty-LRU sentinel
-      // (`getUserCwds()` always appends home), which means "no real
-      // pick", so we leave `lastUsedCwd` null and let createSession use
-      // userHome via the explicit fallback.
-      if (api?.userCwds?.get) {
-        const list = await api.userCwds.get().catch(() => [] as string[]);
-        const head = Array.isArray(list) && list.length > 0 ? list[0] : null;
-        const home = useStore.getState().userHome;
-        if (head && head !== home) {
-          useStore.setState({ lastUsedCwd: head });
-        }
-      }
     } catch {
       /* IPC unavailable — boot continues with empty defaults */
     }

--- a/tests/stores/slices/sessionCrudSlice.test.ts
+++ b/tests/stores/slices/sessionCrudSlice.test.ts
@@ -57,7 +57,6 @@ describe('sessionCrudSlice', () => {
     expect(s.sessions).toEqual([]);
     expect(s.activeId).toBe('');
     expect(s.focusedGroupId).toBeNull();
-    expect(s.lastUsedCwd).toBeNull();
     expect(s.userHome).toBe('');
     expect(s.claudeSettingsDefaultModel).toBeNull();
   });
@@ -100,18 +99,18 @@ describe('sessionCrudSlice', () => {
     expect(h.state().sessions[0].groupId).toMatch(/^g-/);
   });
 
-  it('createSession defaults cwd to lastUsedCwd, then userHome', () => {
+  it('createSession defaults cwd to userHome (no fallback chain, per PR #392 spec)', () => {
     const h = harness({
       groups: defaultGroups,
-      lastUsedCwd: '/recent',
       userHome: '/home/u',
     });
     h.sessions.createSession(null);
-    expect(h.state().sessions[0].cwd).toBe('/recent');
+    expect(h.state().sessions[0].cwd).toBe('/home/u');
 
-    const h2 = harness({ groups: defaultGroups, userHome: '/home/u' });
+    // No userHome → empty string, never falls back to anything else.
+    const h2 = harness({ groups: defaultGroups });
     h2.sessions.createSession(null);
-    expect(h2.state().sessions[0].cwd).toBe('/home/u');
+    expect(h2.state().sessions[0].cwd).toBe('');
   });
 
   it('createSession seeds initial model from claudeSettingsDefaultModel', () => {


### PR DESCRIPTION
## Bug

Clicking the bare ``+`` ("New session") in the sidebar lands the new session in the **last-used cwd** instead of ``os.homedir()``. Reported verbatim: "直接点 New session 不指定目录的时候应该 new 在根目录" — root = home, per locked spec.

## Spec reference

PR #392 (a3c2b9cf) — *fix(session): default cwd is home, default model is settings.json — no fallback chains*:

> Default cwd = ``os.homedir()`` always. No derivation from CLI history, no inheritance from sibling sessions in the focused group, no ``recentProjects[0]`` fallback. The historyRecentCwds → recentProjects → groupRecentCwd cascade silently hijacked the default from stale state.

## Where the regression came from

PR #551 (cc6a325f) — *fix(session): default new-session cwd to last-used (userCwds LRU head) (#551) (#478)* — explicitly reversed the PR #392 policy:

> Reverses PR #392's "default cwd is always home" policy. The user re-picked the same project on every new session because the LRU was consulted only by the StatusBar picker, never by the default.

That motivation is **superseded** by the chevron (▾) popover added next to ``+`` (PR #552 / ``cwd-picker-top-chevron``). The chevron is now the explicit "open in another recent project" entry — so the bare ``+`` no longer needs to guess. The right division of labor is:

- ``+``: deterministic, always lands in ``userHome`` (this PR)
- ``▾``: explicit picker, honors LRU + Browse… (already shipped, untouched here)

## Changes

- ``src/stores/slices/sessionCrudSlice.ts`` — drop the ``lastUsedCwd`` field and its readers/writers. ``createSession`` now defaults to ``userHome ?? ''``. The ``userCwds`` LRU pushes are kept (StatusBar + chevron popover still read from it via IPC); only the renderer-side mirror is removed.
- ``src/stores/slices/types.ts`` — remove ``lastUsedCwd`` from ``State``.
- ``src/stores/store.ts`` — remove the boot-time ``userCwds[0] → lastUsedCwd`` seed (PR #551's other half; orphaned once nothing reads it).
- ``tests/stores/slices/sessionCrudSlice.test.ts`` — replace the *"defaults to lastUsedCwd, then userHome"* test with *"defaults cwd to userHome (no fallback chain, per PR #392 spec)"*; also covers the no-``userHome`` ⇒ empty-string negative.
- ``scripts/harness-real-cli.mjs`` —
  - **Delete** ``caseDefaultCwdFromUserCwdsLru``: its assertion *is* the regression we're reverting.
  - **Update** ``caseCwdPickerTopDefault`` to assert *"+ defaults to userHome even when LRU has a non-home head"* — the explicit negative.
  - Strip the renderer-side ``lastUsedCwd`` mirror from ``_seedRecentCwd``; the IPC push alone now suffices.
- ``scripts/screenshot-552-chevron-picker.mjs`` — same: drop the ``lastUsedCwd`` mirror from ``seedRecent``.

## Out of scope (intentionally untouched)

- Chevron path (``createSession({ cwd })``) — explicit user pick, still honors whatever the popover commits.
- ``electron/ptyHost/cwdResolver.ts`` — last-resort PTY-side homedir fallback; orthogonal safety net, not a default-source.

## Verification

- ``npm run typecheck`` — clean.
- ``npm run lint`` — 0 errors (warnings all pre-existing).
- ``npm test -- sessionCrudSlice`` — 21/21 pass, including the new ``createSession defaults cwd to userHome`` case.

### Test plan for reviewer (real-machine dogfood)

- [ ] ``npm run build && npm run dev``
- [ ] In the running app, ``changeCwd`` on the active session to a non-home dir (so ``userCwds`` LRU has a non-home head)
- [ ] **Quit and relaunch ccsm** (critical — simulates next-launch boot path: PR #551's seed used to fire here)
- [ ] Click the bare ``+`` (NOT the chevron) → new session ``cwd`` MUST be ``$HOME``, not the previously-used dir
- [ ] Click the ``▾`` next to ``+`` → popover opens, recent dirs visible → pick one → that session uses the picked dir (proves chevron path is unaffected)
- [ ] Run E2E: ``node scripts/harness-real-cli.mjs --only=cwd-picker-top-default`` and ``--only=cwd-picker-top-chevron``

🤖 Generated with [Claude Code](https://claude.com/claude-code)