### PR TITLE
feat(sidebar): right-click reload session

### DIFF
--- a/electron/ptyHost/__tests__/ipcRegistrar.test.ts
+++ b/electron/ptyHost/__tests__/ipcRegistrar.test.ts
@@ -87,7 +87,7 @@ function makeDeps(over: Partial<PtyIpcDeps> = {}): PtyIpcDeps {
     spawnPtySession: vi.fn(() => ({ sid: 's', pid: 1, cols: 80, rows: 24, cwd: '/' })),
     inputPtySession: vi.fn(),
     resizePtySession: vi.fn(),
-    killPtySession: vi.fn(() => true),
+    killPtySession: vi.fn(async () => true),
     getPtySession: vi.fn(() => null),
     getBufferSnapshot: vi.fn(async () => ({ snapshot: '', seq: 0 })),
     ...over,
@@ -181,12 +181,12 @@ describe('pty:input / resize / kill / get pass-through', () => {
     expect(deps.resizePtySession).toHaveBeenCalledWith('sid', 100, 30);
   });
 
-  it('kill returns the deps result', () => {
+  it('kill returns the deps result', async () => {
     const ipc = makeFakeIpc();
-    const deps = makeDeps({ killPtySession: vi.fn(() => false) });
+    const deps = makeDeps({ killPtySession: vi.fn(async () => false) });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    expect(ipc.handlers.get('pty:kill')!({}, 'sid')).toBe(false);
+    await expect(ipc.handlers.get('pty:kill')!({}, 'sid')).resolves.toBe(false);
     expect(deps.killPtySession).toHaveBeenCalledWith('sid');
   });
 

--- a/electron/ptyHost/__tests__/lifecycle.test.ts
+++ b/electron/ptyHost/__tests__/lifecycle.test.ts
@@ -12,6 +12,9 @@ interface FakePty {
   write: ReturnType<typeof vi.fn>;
   resize: ReturnType<typeof vi.fn>;
   kill: ReturnType<typeof vi.fn>;
+  onExit: (cb: () => void) => { dispose: () => void };
+  /** Test helper — fire the registered onExit listener. */
+  __fireExit?: () => void;
   killShouldThrow?: boolean;
   writeShouldThrow?: boolean;
   resizeShouldThrow?: boolean;
@@ -68,14 +71,34 @@ vi.mock('../../prefs/scrollback', () => ({
 
 import * as L from '../lifecycle';
 
+function makeFakePty(over: Partial<FakePty> = {}): FakePty {
+  // Multi-listener onExit (mirrors node-pty's IEvent contract — see
+  // node-pty.d.ts: `readonly onExit: IEvent<...>`). The lifecycle race fix
+  // (#1277 review) registers a listener inside `kill()` to await entry
+  // removal; entryFactory also registers one for the cleanup pump. Both
+  // must fire on a single exit event.
+  const listeners = new Set<() => void>();
+  const pty: FakePty = {
+    pid: 1234,
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    onExit: (cb: () => void) => {
+      listeners.add(cb);
+      return { dispose: () => listeners.delete(cb) };
+    },
+    __fireExit: () => {
+      // Snapshot listeners — a listener may dispose itself when fired.
+      for (const cb of [...listeners]) cb();
+    },
+    ...over,
+  };
+  return pty;
+}
+
 function makeFakeEntry(over: Partial<FakeEntry> = {}): FakeEntry {
   return {
-    pty: {
-      pid: 1234,
-      write: vi.fn(),
-      resize: vi.fn(),
-      kill: vi.fn(),
-    },
+    pty: makeFakePty(),
     headless: { resize: vi.fn() },
     serialize: { serialize: () => 'snapshot' },
     attached: new Map(),
@@ -108,7 +131,7 @@ afterEach(() => {
 describe('lifecycle.spawn', () => {
   it('inserts a new Entry into the map and returns its info', () => {
     const sessions = new Map<string, FakeEntry>();
-    const entry = makeFakeEntry({ pty: { pid: 9, write: vi.fn(), resize: vi.fn(), kill: vi.fn() }, cwd: '/picked' });
+    const entry = makeFakeEntry({ pty: makeFakePty({ pid: 9 }), cwd: '/picked' });
     bus().makeEntry.mockReturnValue(entry);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -140,7 +163,7 @@ describe('lifecycle.spawn', () => {
 
   it('is idempotent — second spawn for the same sid returns existing Entry, no makeEntry call', () => {
     const sessions = new Map<string, FakeEntry>();
-    const entry = makeFakeEntry({ pty: { pid: 99, write: vi.fn(), resize: vi.fn(), kill: vi.fn() } });
+    const entry = makeFakeEntry({ pty: makeFakePty({ pid: 99 }) });
     sessions.set('sid-A', entry);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -177,8 +200,8 @@ describe('lifecycle.spawn', () => {
 describe('lifecycle.list and get', () => {
   it('list returns one info per entry', () => {
     const sessions = new Map<string, FakeEntry>();
-    sessions.set('a', makeFakeEntry({ cwd: '/a', pty: { pid: 1, write: vi.fn(), resize: vi.fn(), kill: vi.fn() } }));
-    sessions.set('b', makeFakeEntry({ cwd: '/b', pty: { pid: 2, write: vi.fn(), resize: vi.fn(), kill: vi.fn() } }));
+    sessions.set('a', makeFakeEntry({ cwd: '/a', pty: makeFakePty({ pid: 1 }) }));
+    sessions.set('b', makeFakeEntry({ cwd: '/b', pty: makeFakePty({ pid: 2 }) }));
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const out = L.list(sessions as any);
@@ -195,7 +218,7 @@ describe('lifecycle.list and get', () => {
 
   it('get returns the info for an existing entry', () => {
     const sessions = new Map<string, FakeEntry>();
-    sessions.set('s', makeFakeEntry({ cwd: '/c', pty: { pid: 7, write: vi.fn(), resize: vi.fn(), kill: vi.fn() } }));
+    sessions.set('s', makeFakeEntry({ cwd: '/c', pty: makeFakePty({ pid: 7 }) }));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(L.get(sessions as any, 's')).toEqual({ sid: 's', pid: 7, cols: 80, rows: 24, cwd: '/c' });
   });
@@ -215,7 +238,7 @@ describe('lifecycle.attach and detach', () => {
     sessions.set('s', makeFakeEntry({
       cols: 99,
       rows: 33,
-      pty: { pid: 55, write: vi.fn(), resize: vi.fn(), kill: vi.fn() },
+      pty: makeFakePty({ pid: 55 }),
       serialize: { serialize: serializeSpy },
     }));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -317,53 +340,159 @@ describe('lifecycle.resize', () => {
 // ─── kill / killAll ───────────────────────────────────────────────────────
 
 describe('lifecycle.kill', () => {
-  it('returns false for an unknown sid (no side effects)', () => {
+  it('resolves to false for an unknown sid (no side effects)', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(L.kill(new Map() as any, 'ghost')).toBe(false);
+    await expect(L.kill(new Map() as any, 'ghost')).resolves.toBe(false);
     expect(bus().killCalls).toEqual([]);
     expect(bus().watcherStopCalls).toEqual([]);
   });
 
-  it('captures pid BEFORE pty.kill (binding may zero pid post-kill)', () => {
+  it('captures pid BEFORE pty.kill (binding may zero pid post-kill)', async () => {
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
     entry.pty.pid = 4242;
-    // simulate the binding zeroing pid on kill
-    entry.pty.kill = vi.fn(() => { entry.pty.pid = 0; });
+    // simulate the binding zeroing pid on kill, then firing onExit (the
+    // production race-fix path: kill() awaits onExit before resolving).
+    entry.pty.kill = vi.fn(() => { entry.pty.pid = 0; entry.pty.__fireExit!(); });
     sessions.set('s', entry);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(L.kill(sessions as any, 's')).toBe(true);
+    await expect(L.kill(sessions as any, 's')).resolves.toBe(true);
     expect(bus().killCalls).toEqual([4242]);
   });
 
-  it('always invokes killProcessSubtree even if pty.kill throws', () => {
+  it('always invokes killProcessSubtree even if pty.kill throws', async () => {
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
     entry.pty.pid = 7;
     entry.pty.kill = vi.fn(() => { throw new Error('already dead'); });
     sessions.set('s', entry);
+    // pty.kill threw, no onExit fired → resolves false via timeout
+    vi.useFakeTimers();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(L.kill(sessions as any, 's')).toBe(true);
+    const p = L.kill(sessions as any, 's');
     expect(bus().killCalls).toEqual([7]);
+    await vi.advanceTimersByTimeAsync(L.KILL_EXIT_TIMEOUT_MS + 10);
+    await expect(p).resolves.toBe(false);
+    vi.useRealTimers();
   });
 
-  it('always invokes sessionWatcher.stopWatching (belt-and-braces, swallows throws)', () => {
+  it('always invokes sessionWatcher.stopWatching (belt-and-braces, swallows throws)', async () => {
     const sessions = new Map<string, FakeEntry>();
-    sessions.set('s', makeFakeEntry());
+    const entry = makeFakeEntry();
+    // Fire onExit synchronously inside kill so the promise resolves promptly.
+    entry.pty.kill = vi.fn(() => entry.pty.__fireExit!());
+    sessions.set('s', entry);
     bus().watcherStopShouldThrow = true;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(() => L.kill(sessions as any, 's')).not.toThrow();
+    await expect(L.kill(sessions as any, 's')).resolves.toBe(true);
     expect(bus().watcherStopCalls).toEqual(['s']);
+  });
+
+  // ─── #1277 review race fix ─────────────────────────────────────────────
+
+  it('awaits pty.onExit before resolving — renderer-attach race fix', async () => {
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    entry.pty.pid = 100;
+    // pty.kill() does NOT auto-fire onExit (the production node-pty contract:
+    // kill dispatches a signal; onExit fires when the OS reaps the process).
+    entry.pty.kill = vi.fn();
+    sessions.set('s', entry);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p = L.kill(sessions as any, 's');
+    // pty.kill + processKiller already ran synchronously (kill signal dispatched).
+    expect(entry.pty.kill).toHaveBeenCalled();
+    expect(bus().killCalls).toEqual([100]);
+
+    // But the promise must NOT have resolved yet — the renderer awaits this
+    // before bumping reloadNonce, and the entry hasn't been removed.
+    let resolved: boolean | 'pending' = 'pending';
+    void p.then((v) => { resolved = v; });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe('pending');
+
+    // Fire the OS-reap event. Now the kill promise should resolve.
+    entry.pty.__fireExit!();
+    await expect(p).resolves.toBe(true);
+  });
+
+  it('falls back to a 3s timeout when pty.onExit never fires (wedged kill)', async () => {
+    vi.useFakeTimers();
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    entry.pty.pid = 200;
+    // Simulates a wedged pty: kill signal dispatched but the process never
+    // exits (onExit silent). Without the timeout the renderer would hang
+    // forever on `await ccsmPty.kill(sid)`.
+    entry.pty.kill = vi.fn();
+    sessions.set('s', entry);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p = L.kill(sessions as any, 's');
+    let resolved: boolean | 'pending' = 'pending';
+    void p.then((v) => { resolved = v; });
+
+    // Advance just under the timeout — still pending.
+    await vi.advanceTimersByTimeAsync(L.KILL_EXIT_TIMEOUT_MS - 100);
+    expect(resolved).toBe('pending');
+
+    // Cross the timeout — resolves false (entry-removed signal not observed),
+    // letting the renderer's reloadNonce path proceed instead of hanging.
+    await vi.advanceTimersByTimeAsync(200);
+    await expect(p).resolves.toBe(false);
+    vi.useRealTimers();
+  });
+
+  it('dedupes concurrent kills for the same sid — second call shares the first promise', async () => {
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    entry.pty.pid = 300;
+    entry.pty.kill = vi.fn();
+    sessions.set('s', entry);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p1 = L.kill(sessions as any, 's');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p2 = L.kill(sessions as any, 's');
+    // Same promise — second call is a no-op short-circuit, no extra
+    // pty.kill / processKiller / stopWatching invocations.
+    expect(p1).toBe(p2);
+    expect(entry.pty.kill).toHaveBeenCalledTimes(1);
+    expect(bus().killCalls).toEqual([300]);
+    expect(bus().watcherStopCalls).toEqual(['s']);
+
+    // Drain.
+    entry.pty.__fireExit!();
+    await expect(p1).resolves.toBe(true);
+  });
+
+  it('a fresh kill after the previous one completes is NOT deduped', async () => {
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    entry.pty.pid = 400;
+    entry.pty.kill = vi.fn(() => entry.pty.__fireExit!());
+    sessions.set('s', entry);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await L.kill(sessions as any, 's');
+    // Re-add the entry (simulating spawn-on-null fallback creating a new pty
+    // for the same sid) and kill again — this must NOT short-circuit.
+    sessions.set('s', entry);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await L.kill(sessions as any, 's');
+    expect(entry.pty.kill).toHaveBeenCalledTimes(2);
   });
 });
 
 describe('lifecycle.killAll', () => {
   it('kills every entry via the kill op', () => {
     const sessions = new Map<string, FakeEntry>();
-    sessions.set('a', makeFakeEntry({ pty: { pid: 1, write: vi.fn(), resize: vi.fn(), kill: vi.fn() } }));
-    sessions.set('b', makeFakeEntry({ pty: { pid: 2, write: vi.fn(), resize: vi.fn(), kill: vi.fn() } }));
-    sessions.set('c', makeFakeEntry({ pty: { pid: 3, write: vi.fn(), resize: vi.fn(), kill: vi.fn() } }));
+    sessions.set('a', makeFakeEntry({ pty: makeFakePty({ pid: 1 }) }));
+    sessions.set('b', makeFakeEntry({ pty: makeFakePty({ pid: 2 }) }));
+    sessions.set('c', makeFakeEntry({ pty: makeFakePty({ pid: 3 }) }));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     L.killAll(sessions as any);
     expect(bus().killCalls.sort()).toEqual([1, 2, 3]);

--- a/electron/ptyHost/index.ts
+++ b/electron/ptyHost/index.ts
@@ -81,7 +81,7 @@ export const inputPtySession = (sid: string, data: string): void =>
 export const resizePtySession = (sid: string, cols: number, rows: number): void =>
   L.resize(sessions, sid, cols, rows);
 
-export const killPtySession = (sid: string): boolean => L.kill(sessions, sid);
+export const killPtySession = (sid: string): Promise<boolean> => L.kill(sessions, sid);
 
 export const getPtySession = (sid: string): L.PtySessionInfo | null =>
   L.get(sessions, sid);

--- a/electron/ptyHost/ipcRegistrar.ts
+++ b/electron/ptyHost/ipcRegistrar.ts
@@ -35,7 +35,7 @@ export interface PtyIpcDeps {
   ) => PtySessionInfo;
   inputPtySession: (sid: string, data: string) => void;
   resizePtySession: (sid: string, cols: number, rows: number) => void;
-  killPtySession: (sid: string) => boolean;
+  killPtySession: (sid: string) => Promise<boolean>;
   getPtySession: (sid: string) => PtySessionInfo | null;
   /** L4 PR-B (#865): async chunked snapshot + capture seq. Routed through
    *  the deps surface (rather than direct module import) so the registrar
@@ -163,7 +163,14 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
     deps.resizePtySession(sid, cols, rows);
   });
 
-  ipcMain.handle('pty:kill', (_event, sid: string) => deps.killPtySession(sid));
+  // Race fix (#1277 review): killPtySession returns a Promise that resolves
+  // only after pty.onExit fires (entry removed from sessions Map) or
+  // KILL_EXIT_TIMEOUT_MS elapses. ipcMain.handle awaits the return so the
+  // renderer's `await ccsmPty.kill(sid)` does NOT resolve until the entry
+  // is gone — a subsequent `pty:attach` is then guaranteed to see null and
+  // walk the spawn-on-null fallback rather than registering as a viewer of
+  // a dying pty.
+  ipcMain.handle('pty:kill', async (_event, sid: string) => deps.killPtySession(sid));
 
   ipcMain.handle('pty:get', (_event, sid: string) => deps.getPtySession(sid));
 

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -122,15 +122,89 @@ export function resize(
   }
 }
 
-export function kill(sessions: Map<string, Entry>, sid: string): boolean {
+// Max wait for pty.onExit to fire after kill() before we give up and resolve
+// the kill promise anyway. The renderer awaits `kill(sid)` before bumping
+// reloadNonce; if the pty is wedged we still want the renderer to fall through
+// to the spawn-on-null fallback rather than hanging the UI. 3s comfortably
+// covers ConPTY teardown + processKiller subtree walk on slow Windows boxes
+// while staying short enough that a stuck kill doesn't feel broken.
+export const KILL_EXIT_TIMEOUT_MS = 3000;
+
+// Dedupe re-entrant kills for the same sid (e.g. user spam-clicks Reload).
+// Keyed by `sessions` Map so multiple registries (tests) don't collide.
+const pendingKills: WeakMap<Map<string, Entry>, Map<string, Promise<boolean>>> =
+  new WeakMap();
+
+function getPendingKills(sessions: Map<string, Entry>): Map<string, Promise<boolean>> {
+  let m = pendingKills.get(sessions);
+  if (!m) {
+    m = new Map();
+    pendingKills.set(sessions, m);
+  }
+  return m;
+}
+
+export function kill(sessions: Map<string, Entry>, sid: string): Promise<boolean> {
+  const inflight = getPendingKills(sessions).get(sid);
+  if (inflight) return inflight;
+
   const entry = sessions.get(sid);
-  if (!entry) return false;
+  if (!entry) return Promise.resolve(false);
+
   // Capture pid BEFORE pty.kill() — the binding may zero it after kill.
   const pid = entry.pty.pid;
+
+  // Race fix (#1277 review): pty.kill() returns synchronously but the entry
+  // is removed from `sessions` only when the onExit pump in entryFactory
+  // fires (async). Without awaiting that, a renderer doing
+  // `await ccsmPty.kill(sid)` then re-attaching can land on the dying entry,
+  // skip the spawn-on-null fallback, and end up registered to a dead pty
+  // that immediately fires pty:exit → user sees a crash overlay. Hold the
+  // kill IPC open until either onExit fires (entry removed, headless
+  // disposed, watchers stopped) or KILL_EXIT_TIMEOUT_MS elapses.
+  //
+  // We register the promise in `pendingKills` BEFORE side effects so a
+  // concurrent caller dedupes correctly; we delete the slot inside `settle`
+  // AFTER `resolve()`. Order matters: with a sync `pty.kill()` mock that
+  // fires `onExit` immediately, settle runs inside the Promise executor,
+  // so the slot must already exist when settle fires (otherwise the slot
+  // delete is a no-op then a stale `set` re-inserts a resolved promise,
+  // and the next `kill()` for the same sid short-circuits forever).
+  let resolveOuter!: (v: boolean) => void;
+  const promise = new Promise<boolean>((r) => { resolveOuter = r; });
+  getPendingKills(sessions).set(sid, promise);
+
+  let settled = false;
+  let exitDisposable: { dispose(): void } | undefined;
+  const settle = (v: boolean) => {
+    if (settled) return;
+    settled = true;
+    // Best-effort dispose of the listener; if the binding's onExit already
+    // fired and disposed itself this is a no-op.
+    try { exitDisposable?.dispose(); } catch { /* ignore */ }
+    clearTimeout(timer);
+    // Free the dedup slot BEFORE resolving so anything `await kill()`s
+    // and immediately calls `kill()` again (e.g. spawn-on-null then
+    // user-driven reload) gets a fresh kill, not a no-op short-circuit.
+    if (getPendingKills(sessions).get(sid) === promise) {
+      getPendingKills(sessions).delete(sid);
+    }
+    resolveOuter(v);
+  };
+
+  try {
+    exitDisposable = entry.pty.onExit(() => settle(true));
+  } catch {
+    /* onExit registration failed (already-exited binding) — fall through;
+       the timeout will resolve us, and processKiller below still runs. */
+  }
+
+  const timer = setTimeout(() => settle(false), KILL_EXIT_TIMEOUT_MS);
+
   try {
     entry.pty.kill();
   } catch {
-    /* already dead */
+    /* already dead — onExit may or may not fire; timeout covers us */
   }
   // ConPTY's kill only terminates the cmd.exe / OpenConsole wrapper; on Windows
   // the claude.exe child (and its grandchildren) survive as orphans. On
@@ -141,7 +215,8 @@ export function kill(sessions: Map<string, Entry>, sid: string): boolean {
   // pty.kill that races with onExit can't leak the fs.watch handle.
   // sessionWatcher.stopWatching is idempotent.
   try { sessionWatcher.stopWatching(sid); } catch { /* never throws */ }
-  return true;
+
+  return promise;
 }
 
 export function get(sessions: Map<string, Entry>, sid: string): PtySessionInfo | null {
@@ -219,9 +294,12 @@ export async function getBufferSnapshot(
 }
 
 // Kill every running pty. Call from app `before-quit` so renderer-side
-// claude processes don't leak past Electron exit.
+// claude processes don't leak past Electron exit. Fire-and-forget — we don't
+// block app teardown on the per-pty onExit/timeout dance; the kill signal +
+// processKiller subtree walk dispatch synchronously inside `kill()` before
+// the awaited onExit, which is what actually reaps the children.
 export function killAll(sessions: Map<string, Entry>): void {
   for (const sid of [...sessions.keys()]) {
-    kill(sessions, sid);
+    void kill(sessions, sid);
   }
 }

--- a/scripts/probe-session-reload.mjs
+++ b/scripts/probe-session-reload.mjs
@@ -1,0 +1,144 @@
+// Right-click "Reload session" diagnostic probe.
+//
+// Question this answers: when the user invokes `reloadSession(sid)` from
+// the sidebar's right-click menu, does the renderer correctly:
+//   1. kill the running pty (observable as a `pty:kill` IPC call), and
+//   2. re-spawn a fresh pty for the same sid (observable as a NEW pid),
+// while preserving the visible xterm host (same sid wired up after the
+// reload — claude transcript continuation is the SDK's responsibility,
+// out of scope here).
+//
+// Strategy:
+//   1. Launch ccsm isolated + seed a session, wait for terminal ready.
+//   2. Capture the pid of the spawned pty (read via `ccsmPty.get(sid)`
+//      from the renderer; the main-process bridge already exposes pid).
+//   3. Patch the `pty:kill` ipcMain handler to count invocations
+//      (mirrors probe-paste-double-fire's pattern — `ccsmPty` is frozen
+//      so we can't monkey-patch from the renderer).
+//   4. Drive the store action: `useStore.getState().reloadSession(sid)`.
+//   5. Wait for the attach effect to settle (poll `pty.get(sid)` until
+//      pid changes from the pre-reload pid).
+//   6. Assert: kill was called once, new pid differs from old pid, host
+//      element still present with same data-active-sid.
+//
+// This is a workshop probe — it requires `npm run build` + a working
+// claude binary. CI does NOT run it; reviewer runs locally to validate
+// the reload path end-to-end.
+
+import {
+  createIsolatedClaudeDir,
+  launchCcsmIsolated,
+  seedSession,
+  waitForTerminalReady,
+  dismissFirstRunModals,
+} from './probe-utils-real-cli.mjs';
+
+async function main() {
+  const { tempDir } = await createIsolatedClaudeDir();
+  console.log('[probe] tempDir=', tempDir);
+
+  const { electronApp, win } = await launchCcsmIsolated({ tempDir });
+
+  try {
+    await win.waitForFunction(
+      () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+      null,
+      { timeout: 30000 },
+    );
+
+    const { sid } = await seedSession(win, { name: 'reload-probe', cwd: tempDir });
+    if (!sid) throw new Error('seedSession returned empty sid');
+    console.log('[probe] seeded sid=', sid);
+
+    await new Promise((r) => setTimeout(r, 4000));
+    await waitForTerminalReady(win, sid, { timeout: 60000 });
+    await dismissFirstRunModals(win);
+
+    // Patch pty:kill to count calls.
+    await electronApp.evaluate(({ ipcMain }) => {
+      const g = globalThis;
+      g.__reloadProbeKills = [];
+      const internal = ipcMain;
+      const handlers = internal._invokeHandlers;
+      const orig = handlers.get('pty:kill');
+      if (!orig) {
+        g.__reloadProbeError = 'no existing pty:kill handler';
+        return;
+      }
+      handlers.set('pty:kill', async (event, ...args) => {
+        const [killedSid] = args;
+        g.__reloadProbeKills.push({ sid: killedSid, ts: Date.now() });
+        return orig(event, ...args);
+      });
+      g.__reloadProbeReady = true;
+    });
+    const ipcReady = await electronApp.evaluate(() => ({
+      ready: globalThis.__reloadProbeReady === true,
+      error: globalThis.__reloadProbeError || null,
+    }));
+    console.log('[probe] ipcMain patch:', ipcReady);
+    if (!ipcReady.ready) throw new Error('failed to patch ipcMain.handle for pty:kill');
+
+    // Capture pre-reload pid.
+    const preInfo = await win.evaluate(async (s) => {
+      return await window.ccsmPty.get(s);
+    }, sid);
+    console.log('[probe] pre-reload info:', preInfo);
+    if (!preInfo || typeof preInfo.pid !== 'number') {
+      throw new Error('no pid for sid before reload — pty not running?');
+    }
+    const prePid = preInfo.pid;
+
+    // Drive the action.
+    await win.evaluate((s) => {
+      const useStore = window.__ccsmStore;
+      if (!useStore) throw new Error('window.__ccsmStore not ready');
+      const { reloadSession } = useStore.getState();
+      void reloadSession(s);
+    }, sid);
+
+    // Wait for the attach effect to spawn a new pty (different pid).
+    const start = Date.now();
+    let postInfo = null;
+    while (Date.now() - start < 30000) {
+      postInfo = await win
+        .evaluate(async (s) => await window.ccsmPty.get(s), sid)
+        .catch(() => null);
+      if (postInfo && typeof postInfo.pid === 'number' && postInfo.pid !== prePid) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    console.log('[probe] post-reload info:', postInfo);
+
+    const kills = await electronApp.evaluate(() => globalThis.__reloadProbeKills.slice());
+    console.log(`[probe] pty:kill invoked ${kills.length} time(s):`, kills);
+
+    // Verify the host element is still rendered for this sid.
+    const hostStillPresent = await win.evaluate(
+      (s) => !!document.querySelector(`[data-terminal-host][data-active-sid="${s}"]`),
+      sid,
+    );
+    console.log('[probe] host element present after reload:', hostStillPresent);
+
+    console.log('\n[probe] === summary ===');
+    console.log(`pre-reload pid:     ${prePid}`);
+    console.log(`post-reload pid:    ${postInfo?.pid ?? '(none)'}`);
+    console.log(`pty:kill calls:     ${kills.length}`);
+    console.log(`host preserved:     ${hostStillPresent}`);
+
+    const ok =
+      kills.length >= 1 &&
+      postInfo &&
+      typeof postInfo.pid === 'number' &&
+      postInfo.pid !== prePid &&
+      hostStillPresent;
+    console.log(`\n[probe] result:     ${ok ? 'PASS' : 'FAIL'}`);
+    if (!ok) process.exitCode = 1;
+  } finally {
+    try { await electronApp.close(); } catch (_) { /* ignore */ }
+  }
+}
+
+main().catch((e) => {
+  console.error('[probe] failed:', e);
+  process.exit(1);
+});

--- a/src/components/sidebar/SessionRow.tsx
+++ b/src/components/sidebar/SessionRow.tsx
@@ -64,6 +64,7 @@ function SessionRowImpl({
   const createGroup = useStore((s) => s.createGroup);
   const archiveSession = useStore((s) => s.archiveSession);
   const unarchiveSession = useStore((s) => s.unarchiveSession);
+  const reloadSession = useStore((s) => s.reloadSession);
   // The session is archived (lives in an archive container) iff its
   // parent group has `kind === 'archive'`. We detect it via the prop
   // `normalGroups` indirectly: archived sessions are rendered through
@@ -115,6 +116,18 @@ function SessionRowImpl({
         action: { label: t('common.undo'), onClick: () => restoreSession(snap) }
       });
     }
+  };
+  // J7: right-click "Reload session" — kills the current pty and lets the
+  // attach effect re-spawn it (env / config refresh). No confirm: the
+  // operation is non-destructive (claude resumes the same transcript via
+  // the JSONL resolver) and the toast gives the user feedback during the
+  // ~1-2s blank window between kill and re-attach.
+  const performReload = () => {
+    void reloadSession(session.id);
+    toast.push({
+      kind: 'info',
+      title: t('sidebar.reloadingSessionToast', { name: session.name }),
+    });
   };
   return (
     <ContextMenu>
@@ -303,6 +316,9 @@ function SessionRowImpl({
           );
         })()}
         <ContextMenuSeparator />
+        <ContextMenuItem onSelect={performReload}>
+          {t('sidebar.reloadSession')}
+        </ContextMenuItem>
         <ContextMenuItem
           onSelect={() =>
             isArchived ? unarchiveSession(session.id) : archiveSession(session.id)

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -52,6 +52,8 @@ const en = {
     unarchiveGroup: 'Unarchive group',
     archiveSession: 'Archive',
     unarchiveSession: 'Unarchive',
+    reloadSession: 'Reload session',
+    reloadingSessionToast: 'Reloading "{{name}}"…',
     deleteGroupEllipsis: 'Delete group…',
     deleteGroup: 'Delete group',
     deleteGroupConfirmTitle: 'Delete "{{name}}"?',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -52,6 +52,8 @@ const zh: EnCatalog = {
     unarchiveGroup: '取消归档',
     archiveSession: '归档',
     unarchiveSession: '取消归档',
+    reloadSession: '重启会话',
+    reloadingSessionToast: '正在重启"{{name}}"…',
     deleteGroupEllipsis: '删除分组…',
     deleteGroup: '删除分组',
     deleteGroupConfirmTitle: '确认删除"{{name}}"？',

--- a/src/stores/slices/sessionRuntimeSlice.ts
+++ b/src/stores/slices/sessionRuntimeSlice.ts
@@ -23,11 +23,13 @@ export type SessionRuntimeSlice = Pick<
   RootStore,
   | 'flashStates'
   | 'disconnectedSessions'
+  | 'reloadNonce'
   | '_applySessionState'
   | '_setFlash'
   | '_applyCwdRedirect'
   | '_applyPtyExit'
   | '_clearPtyExit'
+  | 'reloadSession'
 >;
 
 export function createSessionRuntimeSlice(
@@ -39,6 +41,7 @@ export function createSessionRuntimeSlice(
     // initial state
     flashStates: {},
     disconnectedSessions: {},
+    reloadNonce: {},
 
     _applySessionState: (sid, state) => {
       set((s) => {
@@ -94,6 +97,37 @@ export function createSessionRuntimeSlice(
         const next = { ...s.disconnectedSessions };
         delete next[sid];
         return { disconnectedSessions: next };
+      });
+    },
+
+    reloadSession: async (sid) => {
+      // Kill the current pty (best-effort — it may already be exiting,
+      // in which case `kill` resolves with `ok: false` which we ignore).
+      // The renderer's preload bridge swallows IPC errors via `.catch()`
+      // pattern at other call sites; we mirror that here.
+      try {
+        await window.ccsmPty?.kill(sid);
+      } catch {
+        /* renderer started without preload (tests) — no-op */
+      }
+      // Drop any stale exit-classification entry from the previous pty
+      // so the sidebar red dot doesn't linger across the reload window
+      // (the new pty's attach effect will also clearPtyExit on success,
+      // but doing it eagerly here avoids a brief flash for crashed-then-
+      // reload-to-recover sequences).
+      set((s) => {
+        const nextDisc = s.disconnectedSessions[sid]
+          ? (() => {
+              const next = { ...s.disconnectedSessions };
+              delete next[sid];
+              return next;
+            })()
+          : s.disconnectedSessions;
+        const cur = s.reloadNonce[sid] ?? 0;
+        return {
+          disconnectedSessions: nextDisc,
+          reloadNonce: { ...s.reloadNonce, [sid]: cur + 1 },
+        };
       });
     },
   };

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -78,6 +78,13 @@ export type State = {
     string,
     { kind: 'clean' | 'crashed'; code: number | null; signal: string | number | null; at: number }
   >;
+  /**
+   * Per-session counter bumped by `reloadSession()` to force the
+   * `usePtyAttach` effect to re-run for an unchanged sid (kill the
+   * current pty, then re-spawn via the existing spawn-on-null fallback).
+   * Not persisted — purely a transient nudge for the attach hook.
+   */
+  reloadNonce: Record<string, number>;
 };
 
 export type Actions = {
@@ -102,6 +109,13 @@ export type Actions = {
     payload: { code: number | null; signal: string | number | null }
   ) => void;
   _clearPtyExit: (sid: string) => void;
+  /**
+   * Right-click "Reload session" — kill the current pty and bump the
+   * per-session reload nonce so the `usePtyAttach` effect re-runs and
+   * spawns a fresh pty (via the existing spawn-on-null fallback).
+   * Used to pick up env / config changes that require a new claude process.
+   */
+  reloadSession: (sid: string) => Promise<void>;
   _backfillTitles: () => Promise<void>;
   deleteSession: (id: string) => SessionSnapshot | null;
   restoreSession: (snapshot: SessionSnapshot) => void;

--- a/src/terminal/usePtyAttach.ts
+++ b/src/terminal/usePtyAttach.ts
@@ -60,6 +60,11 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
   const requestedSidRef = useRef<string>(sessionId);
   // Bumped by Retry to force the attach effect to re-run for the same sid.
   const [attachNonce, setAttachNonce] = useState(0);
+  // Right-click "Reload session" — the slice action `reloadSession` kills
+  // the pty and bumps this nonce, which we read here so the attach effect
+  // re-runs and walks the spawn-on-null fallback for a fresh pty. Same
+  // re-attach semantics as Retry, just with an external trigger.
+  const reloadNonce = useStore((s) => s.reloadNonce?.[sessionId] ?? 0);
 
   // Attach effect: on sessionId change (or Retry), detach the previous
   // session, reset the terminal, attach the new one, and wire data flow.
@@ -442,7 +447,10 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
       }
     };
     // attachNonce is intentional: bumping it re-runs the attach for Retry.
-  }, [sessionId, attachNonce, cwd]);
+    // reloadNonce is intentional: bumping it (via `reloadSession` after a
+    // pty.kill) re-runs the attach so the spawn-on-null fallback brings
+    // up a fresh pty for the same sid (env / config refresh).
+  }, [sessionId, attachNonce, reloadNonce, cwd]);
 
   // pty:exit subscription for the active session → flip to exit state with
   // a classification (clean vs crashed) shared with the store via

--- a/tests/stores/slices/sessionRuntimeSlice.test.ts
+++ b/tests/stores/slices/sessionRuntimeSlice.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createSessionRuntimeSlice } from '../../../src/stores/slices/sessionRuntimeSlice';
 import type { RootStore } from '../../../src/stores/slices/types';
 import type { Session } from '../../../src/types';
@@ -113,5 +113,54 @@ describe('sessionRuntimeSlice', () => {
     // can short-circuit.
     expect(next[0]).toBe(a);
     expect(next[2]).toBe(c);
+  });
+
+  describe('reloadSession', () => {
+    let killSpy: ReturnType<typeof vi.fn>;
+    let prevPty: unknown;
+    beforeEach(() => {
+      killSpy = vi.fn().mockResolvedValue({ ok: true, killed: true });
+      prevPty = (window as unknown as { ccsmPty?: unknown }).ccsmPty;
+      (window as unknown as { ccsmPty: unknown }).ccsmPty = { kill: killSpy };
+    });
+    afterEach(() => {
+      (window as unknown as { ccsmPty: unknown }).ccsmPty = prevPty;
+    });
+
+    it('initial reloadNonce is empty', () => {
+      const h = harness();
+      expect(h.state().reloadNonce).toEqual({});
+    });
+
+    it('kills pty and bumps the per-session reloadNonce', async () => {
+      const h = harness({ sessions: [mkSession('a', 'g1')] });
+      await h.runtime.reloadSession('a');
+      expect(killSpy).toHaveBeenCalledWith('a');
+      expect(h.state().reloadNonce['a']).toBe(1);
+      await h.runtime.reloadSession('a');
+      expect(h.state().reloadNonce['a']).toBe(2);
+    });
+
+    it('clears any stale disconnect entry on reload', async () => {
+      const h = harness({ sessions: [mkSession('a', 'g1')] });
+      h.runtime._applyPtyExit('a', { code: 1, signal: null });
+      expect(h.state().disconnectedSessions['a'].kind).toBe('crashed');
+      await h.runtime.reloadSession('a');
+      expect(h.state().disconnectedSessions['a']).toBeUndefined();
+    });
+
+    it('swallows kill IPC errors so the nonce still bumps', async () => {
+      killSpy.mockRejectedValueOnce(new Error('not running'));
+      const h = harness({ sessions: [mkSession('a', 'g1')] });
+      await h.runtime.reloadSession('a');
+      expect(h.state().reloadNonce['a']).toBe(1);
+    });
+
+    it('tolerates ccsmPty being undefined (test env)', async () => {
+      (window as unknown as { ccsmPty: unknown }).ccsmPty = undefined;
+      const h = harness({ sessions: [mkSession('a', 'g1')] });
+      await h.runtime.reloadSession('a');
+      expect(h.state().reloadNonce['a']).toBe(1);
+    });
   });
 });


### PR DESCRIPTION
## Problem

User reports that some changes (env vars, claude config edits, prompt customizations, etc.) only take effect on a freshly-started claude process — but ccsm has no UI affordance to restart a session's pty without losing the session identity (id, name, cwd, group, transcript).

## Solution — approach A (no new IPC)

Reuse the existing primitives that already cover kill + respawn:

- `window.ccsmPty.kill(sid)` — already exposed (used by `deleteSession`)
- `usePtyAttach`'s spawn-on-null fallback — when the attach effect re-runs and `pty.attach` returns null, it falls through to `pty.spawn` then re-attaches

Wire them together via a new per-session `reloadNonce` in `sessionRuntimeSlice`:

1. Right-click ▸ Reload session → `reloadSession(sid)` action
2. Action `await`s `pty.kill(sid)`, then bumps `reloadNonce[sid]`
3. `usePtyAttach` reads `reloadNonce[sid]` and includes it in the attach-effect deps array → effect re-runs → spawn-on-null fallback brings up a fresh pty
4. Same path as the existing Retry button (which also re-runs the attach effect via an internal nonce), just externally triggered

claude transcript continuation is the SDK's job — the JSONL resolver picks the existing transcript via `--resume`, so the user sees the same conversation history when the process comes back up.

## Behavior decisions

- **No confirm dialog** — non-destructive (transcript preserved). Matches the J4 pattern of replacing modal confirms with reversible UX.
- **Lightweight info toast** — "Reloading <name>…" — provides feedback during the ~1-2s blank window between kill and re-attach (otherwise the user sees an unexplained xterm flash).
- **Always shown** — archived sessions can be reloaded too. The action only operates on the pty, which is decoupled from archive state.
- **Eager crash-dot clear** — drops any stale `disconnectedSessions[sid]` entry on reload start so the sidebar red dot doesn't linger across the reload window. The new pty's successful attach also clears it (`_clearPtyExit` in usePtyAttach), but the eager clear avoids a flash on the crashed-then-reload-to-recover path.
- **Right-click selects the row** — `SessionRow.tsx:154` calls `onSelectSession(session.id)` from `onContextMenu`, so opening the menu on an unfocused row focuses it first. Earlier PR description claimed focus was preserved — that was wrong; the focus DOES move to the right-clicked row, which is the conventional desktop behavior.
- **Tolerates kill failure** — IPC errors are swallowed (the pty may already be exiting); the nonce still bumps so the attach effect always re-runs.

## Race fix (reviewer round 2)

Reviewer caught a real race in the kill → re-attach handoff:

1. `lifecycle.kill()` called `pty.kill()` synchronously and returned `true`.
2. Entry removal from the `sessions` Map only happens later, inside `entryFactory`'s `p.onExit` pump.
3. Renderer `await ccsmPty.kill(sid)` resolves at signal-dispatch time, before the entry is gone.
4. `reloadNonce` bumps → attach effect re-runs → `pty:attach` finds the still-present dying entry and returns its `(cols, rows, pid)` instead of `null`.
5. Spawn-on-null fallback does NOT trigger. Renderer registers as a viewer of the dead pty, then the pending `pty:exit` fires → user sees the crash overlay and has to click Retry.

**Fix** (~90 LOC, contained in `electron/ptyHost/lifecycle.ts`): `kill()` now returns `Promise<boolean>` that resolves only after `pty.onExit` fires (entry removed, headless disposed, watcher stopped) OR after `KILL_EXIT_TIMEOUT_MS` (3s) elapses for a wedged pty. The renderer's existing `await ccsmPty.kill(sid)` now guarantees the next `pty:attach` sees null and walks the spawn-on-null fallback.

Implementation notes:
- Dedupe `WeakMap<sessions, Map<sid, Promise>>` so concurrent kills for the same sid share one promise (single `pty.kill` / `processKiller` / `stopWatching` per kill cycle).
- Slot is registered BEFORE side effects so a sync-fire onExit mock can settle without leaving a stale resolved promise pinned for the next caller.
- 3s timeout falls back to `resolve(false)` — wedged pty can't hang the renderer; `reloadNonce` still bumps, spawn-on-null still recovers.
- `ipcMain.handle('pty:kill')` already awaits the return; renderer's `reloadSession` already awaits `ccsmPty.kill` — no caller-side changes.
- `killAll` keeps fire-and-forget semantics (the synchronous kill signal + `processKiller` walk are what reap children on app teardown; awaiting onExit per pty would just stall before-quit).

## Diff scope

Original feature: 127 LOC across 7 files.
Race fix: +90 LOC in `electron/ptyHost/lifecycle.ts`, +1 line type adjust in `index.ts` and `ipcRegistrar.ts`, new + updated tests.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 errors; pre-existing warnings unchanged)
- [x] `tests/stores/slices/sessionRuntimeSlice.test.ts` — 5 test cases for `reloadSession` (kill called, nonce bumps, disconnect entry cleared, kill-error tolerated, missing-bridge OK)
- [x] `tests/terminal/usePtyAttach.test.tsx` — defensive nonce read keeps existing 9 cases passing
- [x] `tests/i18n-key-parity.test.ts` — both keys added to en + zh, parity preserved
- [x] **Race fix** — `electron/ptyHost/__tests__/lifecycle.test.ts`: existing kill suite migrated to async; new cases pin the contract:
  - awaits `pty.onExit` before resolving (mock onExit silent → promise pending until `__fireExit`)
  - 3s timeout fallback when onExit never fires (fake timers)
  - dedupes concurrent kills for the same sid
  - re-entry after settle is NOT deduped
- [x] Full `npx vitest run`: 1392 pass; 21 pre-existing failures (electron-load-smoke needs `npm run build` first; db-hardening hits a better-sqlite3 NODE_MODULE_VERSION mismatch in this env) also fail on the base commit — unrelated.
- [ ] Reviewer optional: `scripts/probe-session-reload.mjs` — workshop probe that launches isolated ccsm + seeds a session + drives `reloadSession` and asserts the pty pid changes while the host element with the same `data-active-sid` is preserved (requires `npm run build` + working claude binary). Not run in this session on Windows — the new unit tests pin the race-fix contract end-to-end at the lifecycle layer.

## Two pre-existing failing test files (unchanged by this PR)

`tests/electron-load-smoke.test.ts` (needs `npm run build` first — its own assertion message says so) and `electron/__tests__/db-hardening.test.ts` (native module). Verified failing on baseline before any changes via `git stash` round-trip.