### PR TITLE
feat(installer): silent updater (NSIS oneClick) for VSCode-style restart-to-update UX

### DIFF
--- a/electron/__tests__/updater.test.ts
+++ b/electron/__tests__/updater.test.ts
@@ -201,7 +201,7 @@ describe('updater: IPC wiring', () => {
     expect(sendsFor('updates:status')).toContainEqual({ kind: 'error', message: 'boom' });
   });
 
-  it('updates:install calls quitAndInstall with visible installer + relaunch', async () => {
+  it('updates:install calls quitAndInstall silently + relaunch', async () => {
     // Defense-in-depth gate (#TBD): updates:install refuses unless
     // lastStatus is `downloaded`. Drive the broadcast first so the
     // handler can proceed.
@@ -211,7 +211,9 @@ describe('updater: IPC wiring', () => {
     expect(res).toEqual({ ok: true });
     // quitAndInstall is scheduled via setImmediate — flush it.
     await new Promise((r) => setImmediate(r));
-    expect(quitAndInstallCalls).toEqual([{ isSilent: false, isForceRunAfter: true }]);
+    // isSilent=true pairs with NSIS oneClick=true to give a VSCode-style
+    // restart-and-done UX — no installer wizard, no progress popup.
+    expect(quitAndInstallCalls).toEqual([{ isSilent: true, isForceRunAfter: true }]);
   });
 
   it('updates:install refuses when no download has completed', () => {

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -174,9 +174,11 @@ export function installUpdaterIpc(): void {
     if (lastStatus.kind !== 'downloaded') {
       return { ok: false as const, reason: 'not-ready' as const };
     }
-    // quitAndInstall: (isSilent, isForceRunAfter). We want a visible installer
-    // on Windows (isSilent=false) and to relaunch after install on all OSes.
-    setImmediate(() => autoUpdater.quitAndInstall(false, true));
+    // quitAndInstall: (isSilent, isForceRunAfter). With NSIS oneClick=true the
+    // installer runs without UI; pair with isSilent=true so electron-updater
+    // doesn't pop a redundant progress window. isForceRunAfter=true relaunches
+    // CCSM after install on all OSes — VSCode-style restart-to-update.
+    setImmediate(() => autoUpdater.quitAndInstall(true, true));
     return { ok: true as const };
   });
 

--- a/package.json
+++ b/package.json
@@ -152,10 +152,8 @@
       "artifactName": "${productName}-Setup-${version}-${arch}.${ext}"
     },
     "nsis": {
-      "oneClick": false,
+      "oneClick": true,
       "perMachine": false,
-      "allowToChangeInstallationDirectory": true,
-      "allowElevation": true,
       "deleteAppDataOnUninstall": false,
       "createDesktopShortcut": true,
       "createStartMenuShortcut": true,


### PR DESCRIPTION
## User report

> vscode 或者 edge 更新就是重启一下就行了，我们更新为什么还要走一遍安装程序，我们能做到他们那样吗

## Layer-1 finding

The whole electron-updater pipeline was already wired up — `electron-updater` dependency, main-process IPC, 4h auto-check, `autoDownload` + `autoInstallOnAppQuit`, renderer toast bridge, `latest.yml` + blockmap on GitHub Releases, `perMachine=false` so installs land in `%LocalAppData%\Programs\CCSM\` without elevation.

The **only** thing keeping it from feeling like VSCode was the NSIS installer running a full wizard on every update. Flip the switch.

## Changes (3 files)

1. **`package.json` build.nsis**:
   - `oneClick: false` → `oneClick: true`
   - dropped `allowToChangeInstallationDirectory` (meaningless in oneClick)
   - dropped `allowElevation` (user-local install needs no elevation)
   - kept `perMachine: false`, shortcut + uninstall settings unchanged

2. **`electron/updater.ts`**: `quitAndInstall(false, true)` → `quitAndInstall(true, true)`. `isSilent=true` pairs with `oneClick=true` so electron-updater doesn't pop a redundant progress popup on top of the silent installer.

3. **`electron/__tests__/updater.test.ts`**: updated assertion to `{ isSilent: true, isForceRunAfter: true }`.

## What this changes for users

- **Update flow**: download finishes → user clicks "Install now" (or app quit triggers `autoInstallOnAppQuit`) → app quits → installer runs in the background with no UI → app relaunches. VSCode/Slack/Discord-style.
- **First install**: a brief NSIS progress bar flashes (a few seconds) then the app auto-launches — no wizard pages, no choices. Same as VSCode/Slack/Discord first-run UX. Silent update is inseparable from silent install.
- **Existing v0.2.x users — one-time transition cost on the first auto-update to this release**: the *currently-installed* uninstaller on every existing v0.2.4 machine is the pre-oneClick assisted/wizard variant. electron-updater's uninstall-then-install handoff will flash that old wizard **once**. Subsequent updates (v0.2.5 → v0.2.6 onward) are truly silent. No data loss (`deleteAppDataOnUninstall: false` retained, `%AppData%/CCSM/` preserved). Release notes for v0.2.5 should call this out so users aren't surprised.

## Verification done in this PR

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (pre-existing 97 warnings unchanged)
- [x] `npx vitest run electron/__tests__/updater.test.ts` — 15/15 pass
- [x] `npm run make:win` produces:
  - `release/CCSM-Setup-0.2.4-x64.exe` (173 MB, in line with prior releases)
  - `release/latest.yml` (electron-updater feed, well-formed)
  - `release/CCSM-Setup-0.2.4-x64.exe.blockmap` (differential updates)
  - electron-builder log confirms `oneClick=true perMachine=false`

## Reviewer real-machine checklist

Per manager direction, this worker did **not** install the new exe over the user's working CCSM. Reviewer please run on a clean(-ish) Windows machine or VM:

- [ ] Double-click the new `CCSM-Setup-0.2.4-x64.exe` from a fresh state — no wizard pages should appear, app installs silently and launches itself.
- [ ] Bump `package.json` version to 0.2.5, `npm run make:win` again, double-click the second installer — should also be UI-less, app relaunches on the new version, user data in `%AppData%/CCSM/` preserved.
- [ ] Confirm shortcut still appears on Desktop + Start Menu (`createDesktopShortcut`/`createStartMenuShortcut` retained).
- [ ] Confirm uninstall still works via "Add or Remove Programs".

## Out of scope (tracked separately)

- Windows code-signing (the existing `release.yml` "unsigned Windows build" warning) is orthogonal and not addressed here. SmartScreen behavior is unchanged by this PR.
- macOS dmg / Linux AppImage updater paths are untouched.
