### PR TITLE
feat(sidebar): right-click copy session (claude --fork-session)

### DIFF
--- a/electron/preload/bridges/ccsmPty.ts
+++ b/electron/preload/bridges/ccsmPty.ts
@@ -30,8 +30,10 @@ const ptyExitListeners = new Set<(e: PtyExitPayload) => void>();
 
 const ccsmPty = {
   list: (): Promise<unknown> => ipcRenderer.invoke('pty:list'),
-  spawn: (sid: string, cwd: string): Promise<unknown> =>
-    ipcRenderer.invoke('pty:spawn', sid, cwd),
+  spawn: (sid: string, cwd: string, forkSourceSid?: string): Promise<unknown> =>
+    forkSourceSid === undefined
+      ? ipcRenderer.invoke('pty:spawn', sid, cwd)
+      : ipcRenderer.invoke('pty:spawn', sid, cwd, forkSourceSid),
   attach: (sid: string): Promise<unknown> => ipcRenderer.invoke('pty:attach', sid),
   detach: (sid: string): Promise<void> => ipcRenderer.invoke('pty:detach', sid),
   input: (sid: string, data: string): Promise<void> =>

--- a/electron/ptyHost/__tests__/entryFactory.test.ts
+++ b/electron/ptyHost/__tests__/entryFactory.test.ts
@@ -239,6 +239,57 @@ describe('entryFactory.makeEntry', () => {
       | undefined;
     expect(opts?.scrollback).toBe(1500);
   });
+
+  // Right-click "Copy session" path: when the renderer mints a fresh sid
+  // (no JSONL on disk yet) AND passes a `forkSourceSid`, makeEntry must
+  // spawn `claude --resume <src> --fork-session --session-id <new>` so the
+  // CLI duplicates the source's transcript natively. The bare new-session
+  // path (`['--session-id', sid]`) would lose the source context entirely.
+  it('forks via --resume + --fork-session + --session-id when forkSourceSid is set and no JSONL exists', () => {
+    bus().sourceJsonl = null;
+    makeEntry(
+      'sid-NEW',
+      '/work',
+      '/bin/claude',
+      80,
+      24,
+      { onExit: vi.fn() },
+      'sid-SOURCE',
+    );
+    const args = bus().ptySpawn.mock.calls[0][1] as string[];
+    expect(args).toEqual([
+      '--resume',
+      'sid-SOURCE',
+      '--fork-session',
+      '--session-id',
+      'sid-NEW',
+    ]);
+    // No import-resume copy expected — sourceJsonl is null so the existing
+    // `ensureResumeJsonlAtSpawnCwd` branch is skipped (correct: claude
+    // CLI handles the transcript copy itself with --fork-session).
+    expect(bus().ensureJsonl).not.toHaveBeenCalled();
+  });
+
+  // Defensive: once the forked session has booted at least once, its own
+  // JSONL exists at `<newSid>.jsonl`. A re-spawn (Retry, app relaunch)
+  // must NOT re-issue --fork-session — that would copy the transcript a
+  // SECOND time. Falling through to the normal `--resume <new>` path is
+  // the right behavior. We model this by setting sourceJsonl truthy
+  // (i.e. findJsonlForSid found the new sid's jsonl).
+  it('skips --fork-session and resumes the new sid directly when the new sid already has a JSONL', () => {
+    bus().sourceJsonl = '/proj/sid-NEW.jsonl';
+    makeEntry(
+      'sid-NEW',
+      '/work',
+      '/bin/claude',
+      80,
+      24,
+      { onExit: vi.fn() },
+      'sid-SOURCE',
+    );
+    const args = bus().ptySpawn.mock.calls[0][1] as string[];
+    expect(args).toEqual(['--resume', 'sid-NEW']);
+  });
 });
 
 // L4 PR-C (#863): the onData handler is now an extracted, named

--- a/electron/ptyHost/entryFactory.ts
+++ b/electron/ptyHost/entryFactory.ts
@@ -210,11 +210,32 @@ export function makeEntry(
   cols: number,
   rows: number,
   deps: MakeEntryDeps,
+  forkSourceSid?: string,
 ): Entry {
   const claudeSid = toClaudeSid(sid);
   const sourceJsonl = findJsonlForSid(claudeSid);
-  const flag = sourceJsonl ? '--resume' : '--session-id';
-  const args = [flag, claudeSid];
+
+  // `--fork-session` path: the renderer is creating a new session that should
+  // boot with another (source) session's full transcript context but write to
+  // its own JSONL. Claude CLI handles the duplication natively — we hand it
+  // BOTH the source sid (`--resume`) AND the desired new sid (`--session-id`)
+  // along with `--fork-session`, and it copies the transcript on first write.
+  // The new sid's JSONL DOES NOT EXIST YET (since we just minted it in the
+  // renderer), so the normal `findJsonlForSid` branch below would route us
+  // into a `--session-id`-only spawn that reuses the bare new id — losing
+  // the parent context. Handle fork explicitly first, before the resume/
+  // session-id picker; once the fork finishes the first turn, the new JSONL
+  // exists and any subsequent re-spawn (e.g. user kills + retries) will fall
+  // through `findJsonlForSid` → `--resume` like any other ccsm-tracked
+  // session, no special-casing needed downstream.
+  let args: string[];
+  if (forkSourceSid && !sourceJsonl) {
+    const sourceClaudeSid = toClaudeSid(forkSourceSid);
+    args = ['--resume', sourceClaudeSid, '--fork-session', '--session-id', claudeSid];
+  } else {
+    const flag = sourceJsonl ? '--resume' : '--session-id';
+    args = [flag, claudeSid];
+  }
 
   const spawnCwd = resolveSpawnCwd(cwd);
 

--- a/electron/ptyHost/ipcRegistrar.ts
+++ b/electron/ptyHost/ipcRegistrar.ts
@@ -31,7 +31,12 @@ export interface PtyIpcDeps {
     sid: string,
     cwd: string,
     claudePath: string,
-    opts?: { cols?: number; rows?: number; onCwdRedirect?: (newCwd: string) => void },
+    opts?: {
+      cols?: number;
+      rows?: number;
+      onCwdRedirect?: (newCwd: string) => void;
+      forkSourceSid?: string;
+    },
   ) => PtySessionInfo;
   inputPtySession: (sid: string, data: string) => void;
   resizePtySession: (sid: string, cols: number, rows: number) => void;
@@ -87,11 +92,19 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
 
   ipcMain.handle('pty:list', () => deps.listPtySessions());
 
-  ipcMain.handle('pty:spawn', async (_event, sid: string, cwd: string) => {
+  ipcMain.handle('pty:spawn', async (_event, sid: string, cwd: string, forkSourceSid?: string) => {
     const claudePath = await resolveClaude();
     if (!claudePath) {
       return { ok: false, error: 'claude_not_found' };
     }
+    // Defense-in-depth: only accept a string (and in the same shape as `sid`
+    // — `toClaudeSid` will throw on anything that doesn't pass `VALID_SID_RE`,
+    // so a malformed value here surfaces as `spawn_failed:` rather than
+    // landing as raw argv text). Anything else (number, object, array,
+    // undefined → rest-arg behavior) is dropped to undefined.
+    const fork = typeof forkSourceSid === 'string' && forkSourceSid.length > 0
+      ? forkSourceSid
+      : undefined;
     // L4 PR-F (#867): the renderer no longer forwards initial cols/rows.
     // The PTY launches at the lifecycle defaults (DEFAULT_COLS/ROWS) and
     // the renderer's post-attach `pty:resize` (with snapshot replay,
@@ -103,6 +116,7 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
     // redundant; it has been removed.
     try {
       const info = deps.spawnPtySession(sid, cwd, claudePath, {
+        forkSourceSid: fork,
         // Import-resume cwd-redirect (#603 reviewer Layer-1 fix). When the
         // copy helper relocates the JSONL into the spawn cwd's projectDir,
         // the renderer's `session.cwd` (still pointing at the original

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -52,16 +52,33 @@ export function spawn(
   sid: string,
   cwd: string,
   claudePath: string,
-  opts?: { cols?: number; rows?: number; onCwdRedirect?: (newCwd: string) => void },
+  opts?: {
+    cols?: number;
+    rows?: number;
+    onCwdRedirect?: (newCwd: string) => void;
+    /** When set, spawn args include `--resume <forkSourceSid> --fork-session
+     *  --session-id <sid>` so the new session boots with the source's
+     *  transcript but writes a fresh JSONL keyed to `sid`. Threaded through
+     *  to `makeEntry` — see entryFactory.ts for the flag-picker. */
+    forkSourceSid?: string;
+  },
 ): PtySessionInfo {
   const existing = sessions.get(sid);
   if (existing) return infoFromEntry(sid, existing);
   const cols = opts?.cols ?? DEFAULT_COLS;
   const rows = opts?.rows ?? DEFAULT_ROWS;
-  const entry = makeEntry(sid, cwd, claudePath, cols, rows, {
-    onExit: (s) => { sessions.delete(s); },
-    onCwdRedirect: opts?.onCwdRedirect,
-  });
+  const entry = makeEntry(
+    sid,
+    cwd,
+    claudePath,
+    cols,
+    rows,
+    {
+      onExit: (s) => { sessions.delete(s); },
+      onCwdRedirect: opts?.onCwdRedirect,
+    },
+    opts?.forkSourceSid,
+  );
   sessions.set(sid, entry);
   return infoFromEntry(sid, entry);
 }

--- a/src/components/sidebar/SessionRow.tsx
+++ b/src/components/sidebar/SessionRow.tsx
@@ -65,6 +65,21 @@ function SessionRowImpl({
   const archiveSession = useStore((s) => s.archiveSession);
   const unarchiveSession = useStore((s) => s.unarchiveSession);
   const reloadSession = useStore((s) => s.reloadSession);
+  const copySession = useStore((s) => s.copySession);
+  // `copySession` arms `pendingRenameId` so the freshly-minted row enters
+  // inline rename without a follow-up click. Read the flag here and, when
+  // it matches this row's id, auto-toggle `renaming` on mount, then clear
+  // the flag so a re-mount (e.g. group collapse/expand) doesn't loop. We
+  // intentionally watch only the matching-id signal (boolean) — subscribing
+  // to the raw string would re-render every row on any pendingRenameId
+  // change, including unrelated copy operations.
+  const wantsRename = useStore((s) => s.pendingRenameId === session.id);
+  const consumePendingRename = useStore((s) => s.consumePendingRename);
+  useEffect(() => {
+    if (!wantsRename) return;
+    setRenaming(true);
+    consumePendingRename(session.id);
+  }, [wantsRename, session.id, consumePendingRename]);
   // The session is archived (lives in an archive container) iff its
   // parent group has `kind === 'archive'`. We detect it via the prop
   // `normalGroups` indirectly: archived sessions are rendered through
@@ -282,6 +297,7 @@ function SessionRowImpl({
         onCloseAutoFocus={(e) => e.preventDefault()}
       >
         <ContextMenuItem onSelect={() => setRenaming(true)}>{t('common.rename')}</ContextMenuItem>
+        <ContextMenuItem onSelect={() => copySession(session.id)}>{t('sidebar.copySession')}</ContextMenuItem>
         {(() => {
           // Exclude the session's current group from the destination list so
           // users can only move TO another group (#612). The submenu is

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -54,6 +54,7 @@ const en = {
     unarchiveSession: 'Unarchive',
     reloadSession: 'Reload session',
     reloadingSessionToast: 'Reloading "{{name}}"…',
+    copySession: 'Copy session',
     deleteGroupEllipsis: 'Delete group…',
     deleteGroup: 'Delete group',
     deleteGroupConfirmTitle: 'Delete "{{name}}"?',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -54,6 +54,7 @@ const zh: EnCatalog = {
     unarchiveSession: '取消归档',
     reloadSession: '重启会话',
     reloadingSessionToast: '正在重启"{{name}}"…',
+    copySession: '复制会话',
     deleteGroupEllipsis: '删除分组…',
     deleteGroup: '删除分组',
     deleteGroupConfirmTitle: '确认删除"{{name}}"？',

--- a/src/pty.d.ts
+++ b/src/pty.d.ts
@@ -64,7 +64,11 @@ export type CheckClaudeAvailableResult =
 
 export interface CcsmPtyApi {
   list(): Promise<PtySessionInfo[]>;
-  spawn(sid: string, cwd: string): Promise<SpawnResult>;
+  /** When `forkSourceSid` is set, main spawns
+   *  `claude --resume <forkSourceSid> --fork-session --session-id <sid>` so the
+   *  new pty boots with the source session's full transcript context but
+   *  writes to its own JSONL. Used by the right-click "Copy session" flow. */
+  spawn(sid: string, cwd: string, forkSourceSid?: string): Promise<SpawnResult>;
   attach(sid: string): Promise<AttachResult | null>;
   detach(sid: string): Promise<void>;
   input(sid: string, data: string): Promise<void>;

--- a/src/stores/slices/sessionCrudSlice.ts
+++ b/src/stores/slices/sessionCrudSlice.ts
@@ -142,6 +142,10 @@ export type SessionCrudSlice = Pick<
   | 'setSessionModel'
   | 'archiveSession'
   | 'unarchiveSession'
+  | 'pendingRenameId'
+  | 'pendingForkSource'
+  | 'copySession'
+  | 'consumePendingRename'
 >;
 
 export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice {
@@ -152,6 +156,8 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
     focusedGroupId: null,
     userHome: '',
     claudeSettingsDefaultModel: null,
+    pendingRenameId: null,
+    pendingForkSource: {},
 
     selectSession: (id) => {
       set((s) => ({
@@ -542,6 +548,60 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
         const nextActive = s.activeId === '' ? sessionId : s.activeId;
         return { groups, sessions, activeId: nextActive };
       });
+    },
+
+    copySession: (sourceId) => {
+      const cur = get();
+      const source = cur.sessions.find((x) => x.id === sourceId);
+      if (!source) return null;
+      const newId = newSessionId();
+      // Place the copy in the same group as the source. If the source lives
+      // in an archive container we still honor that — user can unarchive
+      // afterwards. cwd/model/groupId/agentType all sourced from the
+      // original; archivedAt is intentionally NOT carried over so a copy
+      // never inherits a stale archive timestamp.
+      const copy: Session = {
+        id: newId,
+        name: `${source.name} (copy)`,
+        state: 'idle',
+        cwd: source.cwd,
+        model: source.model,
+        groupId: source.groupId,
+        agentType: source.agentType,
+        // Inherit cwdMissing — the directory state is independent of which
+        // session points at it; if it's missing for the source it's missing
+        // for the copy too.
+        ...(source.cwdMissing ? { cwdMissing: true as const } : {}),
+      };
+      // Insert the copy directly after the source so the new row appears
+      // adjacent to its origin (matches Finder "Duplicate" behavior). The
+      // sidebar renders sessions in order; so list-position == sidebar
+      // position. activeId flips to the new id; pendingRenameId arms
+      // inline rename for the matching <SessionRow>; pendingForkSource
+      // carries the source's claude UUID so the very first `pty.spawn`
+      // for newId becomes a `--resume <src> --fork-session --session-id
+      // <new>` invocation in main.
+      set((s) => {
+        const idx = s.sessions.findIndex((x) => x.id === sourceId);
+        const insertAt = idx === -1 ? 0 : idx + 1;
+        const sessions = [
+          ...s.sessions.slice(0, insertAt),
+          copy,
+          ...s.sessions.slice(insertAt),
+        ];
+        return {
+          sessions,
+          activeId: newId,
+          focusedGroupId: null,
+          pendingRenameId: newId,
+          pendingForkSource: { ...s.pendingForkSource, [newId]: sourceId },
+        };
+      });
+      return newId;
+    },
+
+    consumePendingRename: (sessionId) => {
+      set((s) => (s.pendingRenameId === sessionId ? { pendingRenameId: null } : {}));
     },
   };
 }

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -85,6 +85,19 @@ export type State = {
    * Not persisted — purely a transient nudge for the attach hook.
    */
   reloadNonce: Record<string, number>;
+  /** Transient UI signal: when a session is freshly copied (`copySession`),
+   *  this holds its id so the matching `<SessionRow>` mounts directly into
+   *  inline-rename mode. Cleared by the row after it consumes the flag, or
+   *  by any subsequent `selectSession` to a different id. */
+  pendingRenameId: string | null;
+  /** Map newSid → source ccsm sid for sessions created via `copySession`.
+   *  `usePtyAttach` reads it on the very first `pty.spawn` for a given sid
+   *  and threads the source through to main so the spawn args become
+   *  `--resume <srcUuid> --fork-session --session-id <newUuid>`. The entry
+   *  is cleared the moment the spawn IPC is dispatched so subsequent
+   *  re-attach / Retry paths fall back to the normal `--session-id` flow
+   *  (the JSONL exists by then so `--resume` will pick it up). */
+  pendingForkSource: Record<string, string>;
 };
 
 export type Actions = {
@@ -128,6 +141,18 @@ export type Actions = {
   setSessionModel: (sessionId: string, model: ModelId) => void;
   archiveSession: (sessionId: string) => void;
   unarchiveSession: (sessionId: string) => void;
+  /** Right-click "Copy session" — fork a session in place. Creates a new
+   *  Session row with the source's group/cwd/model, name `<source> (copy)`,
+   *  selects it, sets `pendingRenameId` so the new row enters inline rename,
+   *  and registers the source in `pendingForkSource` so the renderer's
+   *  `pty.spawn(newSid, …)` IPC carries `forkSourceSid` and main spawns
+   *  `claude --resume <srcUuid> --fork-session --session-id <newUuid>` —
+   *  i.e. the new session boots with the source's full transcript context
+   *  but writes to its own JSONL. Returns the new session id (or null when
+   *  the source isn't found). */
+  copySession: (sourceId: string) => string | null;
+  /** Clear `pendingRenameId` once a SessionRow has consumed it. */
+  consumePendingRename: (sessionId: string) => void;
 
   // appearance
   setTheme: (theme: Theme) => void;

--- a/src/terminal/usePtyAttach.ts
+++ b/src/terminal/usePtyAttach.ts
@@ -161,9 +161,34 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
           | { cols: number; rows: number; pid: number }
           | null;
         if (!res) {
-          const spawnResult = (await pty.spawn(sessionId, cwd ?? '')) as
+          // Right-click "Copy session" → `copySession` registers the source
+          // sid in `pendingForkSource[newSid]`. Read it BEFORE we hand off
+          // to the spawn IPC; main turns it into `--resume <src>
+          // --fork-session --session-id <new>` so the new pty boots with
+          // the source's transcript context. Pass `undefined` for the
+          // common (non-fork) path so `pty.spawn`'s 3rd arg stays absent
+          // over the wire (matches the pre-fork IPC shape exactly when no
+          // copy is in flight).
+          const forkSourceSid =
+            useStore.getState().pendingForkSource[sessionId] ?? undefined;
+          const spawnResult = (await pty.spawn(sessionId, cwd ?? '', forkSourceSid)) as
             | { ok: true; sid: string; pid: number; cols: number; rows: number }
             | { ok: false; error: string };
+          // Clear the fork marker regardless of spawn outcome. On success
+          // the JSONL now exists, so any subsequent re-spawn (Retry, new
+          // session row mount) takes the normal `--resume` branch in
+          // `entryFactory`. On failure we don't want to re-fire `--fork-
+          // session` against a CLI that just rejected it — Retry should
+          // attempt a clean `--session-id` spawn so the user isn't stuck
+          // in a fork loop.
+          if (forkSourceSid) {
+            useStore.setState((s) => {
+              if (!s.pendingForkSource[sessionId]) return {};
+              const next = { ...s.pendingForkSource };
+              delete next[sessionId];
+              return { pendingForkSource: next };
+            });
+          }
           if (!spawnResult || spawnResult.ok === false) {
             const reason =
               spawnResult && spawnResult.ok === false ? spawnResult.error : 'spawn_failed';

--- a/tests/stores/slices/sessionCrudSlice.test.ts
+++ b/tests/stores/slices/sessionCrudSlice.test.ts
@@ -307,4 +307,76 @@ describe('sessionCrudSlice', () => {
       expect(h.state().sessions).toEqual([]);
     });
   });
+
+  describe('copySession', () => {
+    it('returns null when source does not exist', () => {
+      const h = harness({
+        sessions: [],
+        groups: [{ id: 'g1', name: 'g1', collapsed: false, kind: 'normal' }],
+      });
+      expect(h.sessions.copySession('nope')).toBeNull();
+    });
+
+    it('inserts a `<name> (copy)` row immediately after the source, inheriting cwd/model/group', () => {
+      const h = harness({
+        sessions: [
+          mkSession('a', 'g1', { name: 'before', cwd: '/x' }),
+          mkSession('src', 'g1', { name: 'fork me', cwd: '/picked', model: 'opus' }),
+          mkSession('z', 'g1', { name: 'after' }),
+        ],
+        groups: [{ id: 'g1', name: 'g1', collapsed: false, kind: 'normal' }],
+        pendingForkSource: {},
+      });
+      const newId = h.sessions.copySession('src');
+      expect(newId).toBeTruthy();
+      const ids = h.state().sessions.map((s) => s.id);
+      // Position: directly after `src`, NOT at top — preserves the user's
+      // mental model of "duplicate this row, right here".
+      expect(ids).toEqual(['a', 'src', newId!, 'z']);
+      const copy = h.state().sessions.find((s) => s.id === newId)!;
+      expect(copy.name).toBe('fork me (copy)');
+      expect(copy.cwd).toBe('/picked');
+      expect(copy.model).toBe('opus');
+      expect(copy.groupId).toBe('g1');
+      // The original is untouched — same name, same model.
+      expect(h.state().sessions.find((s) => s.id === 'src')!.name).toBe('fork me');
+    });
+
+    it('flips activeId to the new session, arms pendingRenameId, and registers pendingForkSource', () => {
+      const h = harness({
+        sessions: [mkSession('src', 'g1')],
+        groups: [{ id: 'g1', name: 'g1', collapsed: false, kind: 'normal' }],
+        activeId: 'src',
+        pendingForkSource: {},
+        pendingRenameId: null,
+      });
+      const newId = h.sessions.copySession('src')!;
+      expect(h.state().activeId).toBe(newId);
+      expect(h.state().pendingRenameId).toBe(newId);
+      expect(h.state().pendingForkSource).toEqual({ [newId]: 'src' });
+    });
+
+    it('does NOT carry archivedAt onto the copy (a fresh row is never archived in time)', () => {
+      const h = harness({
+        sessions: [mkSession('src', 'g1', { archivedAt: 12345 })],
+        groups: [{ id: 'g1', name: 'g1', collapsed: false, kind: 'normal' }],
+        pendingForkSource: {},
+      });
+      const newId = h.sessions.copySession('src')!;
+      const copy = h.state().sessions.find((s) => s.id === newId)!;
+      expect(copy.archivedAt).toBeUndefined();
+    });
+
+    it('consumePendingRename only clears when ids match (idempotent)', () => {
+      const h = harness({
+        sessions: [mkSession('a', 'g1')],
+        groups: [{ id: 'g1', name: 'g1', collapsed: false, kind: 'normal' }],
+        pendingRenameId: 'a',
+      });
+      h.sessions.consumePendingRename('b');
+      expect(h.state().pendingRenameId).toBe('a'); // mismatched id — no-op
+      h.sessions.consumePendingRename('a');
+      expect(h.state().pendingRenameId).toBeNull();
+    });
+  });
 });

--- a/tests/terminal/usePtyAttach.test.tsx
+++ b/tests/terminal/usePtyAttach.test.tsx
@@ -57,11 +57,35 @@ vi.mock('../../src/terminal/xtermSingleton', async () => {
   };
 });
 
-// Mock store — _clearPtyExit is the only piece usePtyAttach reads.
+// Mock store — _clearPtyExit is the only piece usePtyAttach reads via the
+// hook selector. The fork-on-spawn path (right-click "Copy session") also
+// reaches into `useStore.getState().pendingForkSource[sid]` and calls
+// `useStore.setState((s) => …)` to clear the entry post-spawn, so the mock
+// must expose getState/setState statics on the same callable. Tests that
+// need to seed a fork source push into `mockStoreState.pendingForkSource`.
 const clearPtyExitSpy = vi.fn();
-vi.mock('../../src/stores/store', () => ({
-  useStore: (selector: (s: any) => any) => selector({ _clearPtyExit: clearPtyExitSpy }),
-}));
+const mockStoreState: { pendingForkSource: Record<string, string> } = {
+  pendingForkSource: {},
+};
+vi.mock('../../src/stores/store', () => {
+  const useStore = ((selector: (s: any) => any) =>
+    selector({ _clearPtyExit: clearPtyExitSpy, ...mockStoreState })) as any;
+  useStore.getState = () => ({ _clearPtyExit: clearPtyExitSpy, ...mockStoreState });
+  useStore.setState = (
+    patch:
+      | { pendingForkSource?: Record<string, string> }
+      | ((s: typeof mockStoreState) => { pendingForkSource?: Record<string, string> } | {}),
+  ) => {
+    const next =
+      typeof patch === 'function'
+        ? patch({ ...mockStoreState })
+        : patch;
+    if (next && 'pendingForkSource' in next && next.pendingForkSource) {
+      mockStoreState.pendingForkSource = next.pendingForkSource;
+    }
+  };
+  return { useStore };
+});
 
 import { usePtyAttach } from '../../src/terminal/usePtyAttach';
 import {
@@ -140,6 +164,7 @@ describe('usePtyAttach', () => {
     proposeDimensionsSpy.mockClear();
     proposeDimensionsSpy.mockReturnValue({ cols: 134, rows: 51 });
     clearPtyExitSpy.mockClear();
+    mockStoreState.pendingForkSource = {};
   });
 
   afterEach(() => {
@@ -204,11 +229,36 @@ describe('usePtyAttach', () => {
     renderHook(() => usePtyAttach('sid-C', '/cwd'));
     await flushAll();
 
-    expect(spies.spawn).toHaveBeenCalledWith('sid-C', '/cwd');
+    expect(spies.spawn).toHaveBeenCalledWith('sid-C', '/cwd', undefined);
     expect(spies.attach).toHaveBeenCalledTimes(2);
     // L4 PR-B (#865): the visible terminal paints the getBufferSnapshot
     // string, NOT the legacy attach.snapshot.
     expect(writeSpy).toHaveBeenCalledWith('after-spawn');
+  });
+
+  // Right-click "Copy session" → `copySession` registers `pendingForkSource[
+  // newSid] = sourceSid`. usePtyAttach's spawn-on-null-attach fallback must
+  // read it and pass `sourceSid` as the 3rd arg of `pty.spawn`, then clear
+  // the entry so a subsequent Retry doesn't re-fire `--fork-session` against
+  // an already-forked sid.
+  it('forwards pendingForkSource[sid] as the 3rd spawn arg, then clears it post-spawn', async () => {
+    let calls = 0;
+    const { bridge, spies } = makePtyBridge({ snapshot: { snapshot: 'forked', seq: 0 } });
+    spies.attach.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 1) return null;
+      return { snapshot: 'ignored', cols: 80, rows: 24, pid: 1 };
+    });
+    (window as any).ccsmPty = bridge;
+    mockStoreState.pendingForkSource = { 'sid-FORK': 'sid-SOURCE' };
+
+    renderHook(() => usePtyAttach('sid-FORK', '/cwd'));
+    await flushAll();
+
+    expect(spies.spawn).toHaveBeenCalledWith('sid-FORK', '/cwd', 'sid-SOURCE');
+    // Post-spawn: pendingForkSource entry for this sid is gone, so a
+    // hypothetical re-spawn (Retry) wouldn't accidentally re-fork.
+    expect(mockStoreState.pendingForkSource['sid-FORK']).toBeUndefined();
   });
 
   // L4 PR-F (#867) — the spawn-time cols/rows hack added for #852 has been
@@ -232,8 +282,12 @@ describe('usePtyAttach', () => {
     renderHook(() => usePtyAttach('sid-867', '/cwd'));
     await flushAll();
 
-    // Spawn is called with sid + cwd ONLY — no opts argument.
-    expect(spies.spawn).toHaveBeenCalledWith('sid-867', '/cwd');
+    // Spawn is called with sid + cwd + an explicit `undefined` 3rd arg
+    // (forkSourceSid). The 3rd arg is only set on the right-click "Copy
+    // session" fork path; for the normal spawn-on-null-attach fallback it
+    // must be undefined so main takes the standard `--session-id <sid>`
+    // branch in `entryFactory.makeEntry`.
+    expect(spies.spawn).toHaveBeenCalledWith('sid-867', '/cwd', undefined);
     // FitAddon.proposeDimensions is no longer called pre-spawn.
     expect(proposeDimensionsSpy).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## User request
> 加个功能, 右键 session fork 一份, 体感就像是复制了一份一模一样的 session, 用于同样上下文, 我要分两个 agent 做事之类的, 可以叫 copy

## What

Right-click any session row → **Copy session** (between Rename and Move to group). One click duplicates the session in place:
- new row inserted directly after the source
- name = `<source name> (copy)`, auto-enters inline rename
- cwd / model / group inherited from source
- focus flips to the new session
- the new pty boots with the **source's full transcript context** but writes its own JSONL

## How — claude CLI flag combo (verified live first)

Used `claude --fork-session` — exists natively in the installed CLI:
```
--fork-session  When resuming, create a new session ID instead of reusing the original (use with --resume or --continue)
```

**Live probe (path A confirmed):**
```bash
claude --resume <SOURCE_SID> --fork-session --session-id <NEW_SID> -p "say hi briefly"
# exit=0
# new jsonl written at ~/.claude/projects/<key>/<NEW_SID>.jsonl
#   size ≈ source + new turn (transcript copied)
# source jsonl mtime UNCHANGED (untouched)
```
All three flags coexist cleanly. No need for path B (auto-detect new sid from stdout / file mtime).

## Implementation (~200 LOC source + ~190 test)

**Renderer:**
- `sessionCrudSlice.copySession(sourceId)` mints a new sid, inserts after source, flips `activeId`, arms two transient store fields:
  - `pendingRenameId` → consumed by `SessionRow` to auto-enter inline rename
  - `pendingForkSource[newSid] = sourceSid` → consumed by `usePtyAttach` on the very first `pty.spawn`, cleared post-spawn so any later Retry falls back to the standard `--resume <new>` branch
- `SessionRow.tsx` — new `ContextMenuItem` + `useEffect` watching `pendingRenameId`

**Main:**
- `entryFactory.makeEntry` takes an optional 7th `forkSourceSid?`. When set AND no jsonl exists for the new sid:
  ```
  args = [--resume, <srcUuid>, --fork-session, --session-id, <newUuid>]
  ```
  Otherwise falls through to the pre-existing `[--resume|--session-id, <sid>]` flag picker. Re-spawn after a fork (Retry, app restart) does NOT re-fork — the new sid's jsonl exists by then so `--resume <new>` is correct.
- `lifecycle.spawn` / `ipcRegistrar` `pty:spawn` handler / preload `ccsmPty.spawn` / `pty.d.ts` all thread the optional arg through. Absent on the non-fork path so existing wire shape is preserved (only the test mocks needed updates for the now-explicit `undefined` 3rd arg).

**i18n:** `sidebar.copySession` added to en (`Copy session`) + zh (`复制会话`). These are the only two locales today.

**UX (manager-locked):**
- Menu position: right after Rename ("derive new" cluster)
- New session name: `<source> (copy)`, auto-enters inline rename
- group / cwd / model = source's
- archived sessions are also copyable (copy lands in same group as source; `archivedAt` is intentionally NOT inherited so the row never boots stale-archived)
- focus flips to the new session
- no toast, no keyboard shortcut in v1

## Tests

- **`entryFactory.test.ts`** (+2): fork branch produces the 5-flag argv; re-spawn after fork falls back to plain `--resume <new>`.
- **`sessionCrudSlice.test.ts`** (+5): copySession insert position, name suffix, cwd/model/group inheritance, side effects on `activeId` / `pendingRenameId` / `pendingForkSource`, `archivedAt` not carried over, `consumePendingRename` idempotency.
- **`usePtyAttach.test.tsx`** (+1, 2 modified): existing assertions updated for the explicit `undefined` 3rd spawn arg; new test pins the fork-arg forwarding + post-spawn `pendingForkSource` clear.

## Verification

- `npx tsc --noEmit` — clean
- `npx eslint <changed files>` — 0 errors (only pre-existing warnings)
- `npx vitest run` — 1349/1370 pass; the 21 failures are all in `tests/electron-load-smoke` (requires prior `npm run build`) and `electron/__tests__/db-hardening` (`better-sqlite3` native build artifacts) — same files already failed before this change

## Test plan

- [ ] Right-click a session that has had at least a few turns with claude → click "Copy session"
- [ ] New row appears immediately after source, name `<original> (copy)`, inline rename input is focused
- [ ] Type a new name + Enter → renamed
- [ ] New pty attaches; claude shows the source's prior context (e.g. `/resume` indicator or recap)
- [ ] Send a new message in the copy → it streams independently
- [ ] `ls ~/.claude/projects/<projectKey>/` shows two distinct `<sid>.jsonl` files (source + copy)
- [ ] Source session is unaffected (mtime preserved, can still be opened, original transcript intact)
- [ ] Copy an archived session → new row lands in source's group (the archive container, since that's where the source is)
- [ ] Kill the forked pty + Retry → spawns with `--resume <newSid>` (no second fork), context still intact

## Coordination note

PR #1277 (right-click Reload) is not yet merged into base. This PR adds Copy session right after Rename; when #1277 lands, the rebase will need a manual merge of the `ContextMenuItem` list. Copy belongs adjacent to Rename ("derive new" cluster), so the resolution should be clean.