### PR TITLE
chore(claude-resolver): add timeout to whereAsync to prevent indefinite hang

### DIFF
--- a/electron/ptyHost/__tests__/claudeResolver.test.ts
+++ b/electron/ptyHost/__tests__/claudeResolver.test.ts
@@ -25,6 +25,8 @@ interface SpawnFakeBus {
   results: Map<string, { status: number; stdout: string }>;
   calls: SpawnCall[];
   shouldThrow: boolean;
+  hang: boolean;
+  killed: number;
 }
 function bus(): SpawnFakeBus {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,9 +42,17 @@ vi.mock('node:child_process', () => {
     const r = b.results.get(key) ?? { status: 1, stdout: '' };
     const child = new EventEmitter() as EventEmitter & {
       stdout: Readable;
+      kill: () => void;
     };
     const stdout = new Readable({ read() {} });
     child.stdout = stdout;
+    child.kill = () => {
+      b.killed += 1;
+    };
+    // When `hang` is set, simulate a stuck `where`/`which`: never push
+    // data, never emit exit. The resolver's timeout is the only way the
+    // promise can settle. Used by the where_timeout test.
+    if (b.hang) return child;
     // Push data on next microtask so the resolver's `'data'` listener
     // (attached synchronously after spawn returns) receives it. Emit
     // `exit` on the FOLLOWING tick — after the readable has drained the
@@ -62,7 +72,7 @@ vi.mock('node:child_process', () => {
 });
 
 // Import AFTER vi.mock so the resolver picks up the mocked spawn.
-import { __resetClaudeResolverForTest, resolveClaude } from '../claudeResolver';
+import { __resetClaudeResolverForTest, resolveClaude, whereAsync } from '../claudeResolver';
 
 const ORIGINAL_PLATFORM = process.platform;
 
@@ -76,6 +86,8 @@ beforeEach(() => {
     results: new Map(),
     calls: [],
     shouldThrow: false,
+    hang: false,
+    killed: 0,
   } satisfies SpawnFakeBus;
   __resetClaudeResolverForTest();
 });
@@ -189,5 +201,43 @@ describe('resolveClaude caching', () => {
     expect(a).toBe('/bin/claude');
     expect(b).toBe('/bin/claude');
     expect(bus().calls).toHaveLength(1);
+  });
+});
+
+describe('whereAsync timeout', () => {
+  // Pins the 5s hard cap on a single `where`/`which` invocation. A
+  // broken PATH / slow shell / AV interception used to hang the lookup
+  // forever; without rejection the IPC handler stays pending and the
+  // renderer's spinner never resolves.
+  beforeEach(() => {
+    setPlatform('linux');
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('rejects with where_timeout error after 5s when the child never exits', async () => {
+    bus().hang = true;
+    const promise = whereAsync('claude');
+    // Attach catch synchronously so an early rejection isn't unhandled.
+    const settled = promise.catch((e: Error) => e);
+    await vi.advanceTimersByTimeAsync(5000);
+    const err = await settled;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/^where_timeout: /);
+    expect((err as Error).message).toContain('5000ms');
+    // Resolver must kill the stuck child so the FD/handle isn't leaked.
+    expect(bus().killed).toBe(1);
+  });
+
+  it('resolveClaude collapses where_timeout to null (UI shows ClaudeMissingGuide, not undefined cwd)', async () => {
+    bus().hang = true;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const promise = resolveClaude();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(await promise).toBeNull();
+    expect(warn).toHaveBeenCalledWith('[claudeResolver]', expect.stringMatching(/^where_timeout:/));
+    warn.mockRestore();
   });
 });

--- a/electron/ptyHost/claudeResolver.ts
+++ b/electron/ptyHost/claudeResolver.ts
@@ -41,9 +41,18 @@ import { spawn } from 'node:child_process';
 let cached: string | null | undefined; // undefined = never tried
 let inFlight: Promise<string | null> | null = null;
 
-function whereAsync(name: string): Promise<string | null> {
+// Hard cap on a single `where`/`which` invocation. A broken PATH, slow
+// shell startup, or AV interception can hang the lookup indefinitely;
+// without a timeout the whole resolveClaude promise never settles and
+// the IPC handler stays pending forever (renderer spinner stuck).
+const WHERE_TIMEOUT_MS = 5000;
+
+// Exported for the timeout unit test (asserts the rejection shape). Not
+// part of the module's public API — production callers go through
+// `resolveClaude`.
+export function whereAsync(name: string): Promise<string | null> {
   const cmd = process.platform === 'win32' ? 'where' : 'which';
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     let stdout = '';
     let child: ReturnType<typeof spawn>;
     try {
@@ -52,11 +61,23 @@ function whereAsync(name: string): Promise<string | null> {
       resolve(null);
       return;
     }
+    const timer = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        /* ignore */
+      }
+      reject(new Error(`where_timeout: '${cmd} ${name}' did not complete in ${WHERE_TIMEOUT_MS}ms`));
+    }, WHERE_TIMEOUT_MS);
     child.stdout?.on('data', (b: Buffer) => {
       stdout += b.toString('utf8');
     });
-    child.on('error', () => resolve(null));
+    child.on('error', () => {
+      clearTimeout(timer);
+      resolve(null);
+    });
     child.on('exit', (code) => {
+      clearTimeout(timer);
       if (code !== 0) {
         resolve(null);
         return;
@@ -68,10 +89,20 @@ function whereAsync(name: string): Promise<string | null> {
 }
 
 async function doResolve(): Promise<string | null> {
-  if (process.platform === 'win32') {
-    return (await whereAsync('claude.cmd')) ?? (await whereAsync('claude'));
+  // Catch where_timeout at the boundary: collapse to null so the IPC
+  // contract stays the same (renderer surfaces ClaudeMissingGuide rather
+  // than seeing an unhandled rejection / silent fallback to undefined
+  // cwd). The warning lets diagnosis trace a hang back to a stuck
+  // `where`/`which` rather than a "claude not installed" misdiagnosis.
+  try {
+    if (process.platform === 'win32') {
+      return (await whereAsync('claude.cmd')) ?? (await whereAsync('claude'));
+    }
+    return await whereAsync('claude');
+  } catch (err) {
+    console.warn('[claudeResolver]', (err as Error).message);
+    return null;
   }
-  return whereAsync('claude');
 }
 
 export function resolveClaude({ force = false }: { force?: boolean } = {}): Promise<string | null> {


### PR DESCRIPTION
## Summary

Followup to PR #1272 (reviewer non-blocking suggestion). `whereAsync` had no timeout — a broken PATH, slow shell startup, or AV interception could hang `where claude` / `which claude` forever. Without a timeout the `resolveClaude` Promise never settles and the IPC handler stays pending, leaving the renderer spinner stuck.

- Cap each `where`/`which` invocation at 5s. On timeout, `child.kill()` and `reject(new Error('where_timeout: ...'))`.
- `doResolve` catches `where_timeout` and collapses to `null` so the existing IPC contract is preserved (renderer surfaces `ClaudeMissingGuide` rather than seeing an unhandled rejection or silent fallback to undefined cwd).
- `console.warn` on timeout so a hang isn't misdiagnosed as "claude not installed".

## Test plan

- [x] `npx vitest run electron/ptyHost/__tests__/claudeResolver.test.ts` — 15 pass (13 existing + 2 new)
  - `whereAsync` rejects with `where_timeout: ...` after 5s when child never exits, and kills the stuck child
  - `resolveClaude` collapses `where_timeout` to `null` and logs `[claudeResolver] where_timeout: ...`
- [x] `npm run typecheck` — passes
- [x] `npx eslint` on changed files — 0 errors
- [ ] CI green