### PR TITLE
test(preload): cover IPC bridge surface (batch 1, 0% -> 80%+)

### DIFF
--- a/electron/preload/bridges/__tests__/ccsmCore.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmCore.test.ts
@@ -1,0 +1,283 @@
+// Pins the `window.ccsm` preload bridge surface. Each entry in the IPC
+// surface is a renderer-visible API that callers (src/stores/persist.ts,
+// src/stores/drafts.ts, the StatusBar cwd popover, the in-app updater
+// dialog, the CloseActionDialog, etc.) bind to early at boot. Silent
+// removal or rename of any key would brick those callers with no compiler
+// signal — the preload runs in its own isolated module graph that's only
+// linked at runtime via `contextBridge.exposeInMainWorld`. These tests
+// freeze the shape and the IPC channel mapping so a future refactor must
+// touch this file too. Channel names are a wire contract with the main
+// process (`electron/ipc/*Ipc.ts` handlers); rename one without updating
+// the matching handler and the renderer call hangs forever waiting for
+// `invoke` to resolve.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { exposeSpy, invokeSpy, sendSpy, onSpy, removeListenerSpy } = vi.hoisted(() => ({
+  exposeSpy: vi.fn(),
+  invokeSpy: vi.fn(),
+  sendSpy: vi.fn(),
+  onSpy: vi.fn(),
+  removeListenerSpy: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: exposeSpy },
+  ipcRenderer: {
+    invoke: invokeSpy,
+    send: sendSpy,
+    on: onSpy,
+    removeListener: removeListenerSpy,
+  },
+}));
+
+import { installCcsmCoreBridge } from '../ccsmCore';
+
+type AnyApi = Record<string, unknown>;
+
+function getApi(): AnyApi {
+  expect(exposeSpy).toHaveBeenCalled();
+  const last = exposeSpy.mock.calls[exposeSpy.mock.calls.length - 1];
+  expect(last[0]).toBe('ccsm');
+  return last[1] as AnyApi;
+}
+
+describe('ccsmCore preload bridge', () => {
+  beforeEach(() => {
+    exposeSpy.mockClear();
+    invokeSpy.mockReset();
+    invokeSpy.mockResolvedValue(undefined);
+    sendSpy.mockReset();
+    onSpy.mockReset();
+    removeListenerSpy.mockReset();
+    installCcsmCoreBridge();
+  });
+
+  it('exposes a stable top-level key set under "ccsm"', () => {
+    const api = getApi();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'defaultModel',
+        'getVersion',
+        'i18n',
+        'loadState',
+        'onUpdateDownloaded',
+        'onUpdateStatus',
+        'openExternal',
+        'pathsExist',
+        'pickCwd',
+        'recentCwds',
+        'saveState',
+        'scanImportable',
+        'updatesCheck',
+        'updatesDownload',
+        'updatesGetAutoCheck',
+        'updatesInstall',
+        'updatesSetAutoCheck',
+        'updatesStatus',
+        'userCwds',
+        'userHome',
+        'window',
+      ].sort(),
+    );
+  });
+
+  it('nests i18n / userCwds / window with their own stable keys', () => {
+    const api = getApi();
+    expect(Object.keys(api.i18n as AnyApi).sort()).toEqual(
+      ['getSystemLocale', 'setLanguage'].sort(),
+    );
+    expect(Object.keys(api.userCwds as AnyApi).sort()).toEqual(
+      ['get', 'push'].sort(),
+    );
+    expect(Object.keys(api.window as AnyApi).sort()).toEqual(
+      [
+        'close',
+        'isMaximized',
+        'minimize',
+        'onAfterShow',
+        'onAskCloseAction',
+        'onBeforeHide',
+        'onMaximizedChanged',
+        'platform',
+        'resolveCloseAction',
+        'toggleMaximize',
+      ].sort(),
+    );
+  });
+
+  it.each<[string, string, unknown[]]>([
+    ['loadState', 'db:load', ['some.key']],
+    ['getVersion', 'app:getVersion', []],
+    ['scanImportable', 'import:scan', []],
+    ['recentCwds', 'import:recentCwds', []],
+    ['userHome', 'app:userHome', []],
+    ['pickCwd', 'cwd:pick', [undefined]],
+    ['defaultModel', 'settings:defaultModel', []],
+    ['pathsExist', 'paths:exist', [['/a', '/b']]],
+    ['openExternal', 'ccsm:openExternal', ['https://example.com']],
+    ['updatesStatus', 'updates:status', []],
+    ['updatesCheck', 'updates:check', []],
+    ['updatesDownload', 'updates:download', []],
+    ['updatesInstall', 'updates:install', []],
+    ['updatesGetAutoCheck', 'updates:getAutoCheck', []],
+    ['updatesSetAutoCheck', 'updates:setAutoCheck', [true]],
+  ])('forwards %s -> ipcRenderer.invoke("%s", ...)', async (m, chan, args) => {
+    const api = getApi();
+    const fn = api[m] as (...a: unknown[]) => Promise<unknown>;
+    await fn(...args);
+    if (m === 'pickCwd') {
+      // Bridge wraps the optional defaultPath in an object literal.
+      expect(invokeSpy).toHaveBeenCalledWith(chan, { defaultPath: args[0] });
+    } else {
+      expect(invokeSpy).toHaveBeenCalledWith(chan, ...args);
+    }
+  });
+
+  it('saveState unwraps {ok:true} silently', async () => {
+    invokeSpy.mockResolvedValueOnce({ ok: true });
+    const api = getApi();
+    await expect(
+      (api.saveState as (k: string, v: string) => Promise<void>)('k', 'v'),
+    ).resolves.toBeUndefined();
+    expect(invokeSpy).toHaveBeenCalledWith('db:save', 'k', 'v');
+  });
+
+  it('saveState rethrows on {ok:false} so .catch handlers fire', async () => {
+    invokeSpy.mockResolvedValueOnce({ ok: false, error: 'disk-full' });
+    const api = getApi();
+    await expect(
+      (api.saveState as (k: string, v: string) => Promise<void>)('k', 'v'),
+    ).rejects.toThrow('disk-full');
+  });
+
+  it('i18n.getSystemLocale invokes ccsm:get-system-locale', async () => {
+    const api = getApi();
+    await (api.i18n as { getSystemLocale: () => Promise<unknown> }).getSystemLocale();
+    expect(invokeSpy).toHaveBeenCalledWith('ccsm:get-system-locale');
+  });
+
+  it('i18n.setLanguage sends one-way ccsm:set-language', () => {
+    const api = getApi();
+    (api.i18n as { setLanguage: (l: 'en' | 'zh') => void }).setLanguage('zh');
+    expect(sendSpy).toHaveBeenCalledWith('ccsm:set-language', 'zh');
+  });
+
+  it('userCwds.get / push forward to app:userCwds:* channels', async () => {
+    const api = getApi();
+    const u = api.userCwds as {
+      get: () => Promise<unknown>;
+      push: (p: string) => Promise<unknown>;
+    };
+    await u.get();
+    expect(invokeSpy).toHaveBeenCalledWith('app:userCwds:get');
+    await u.push('/tmp/x');
+    expect(invokeSpy).toHaveBeenCalledWith('app:userCwds:push', '/tmp/x');
+  });
+
+  it.each<[string, string, unknown[]]>([
+    ['minimize', 'window:minimize', []],
+    ['toggleMaximize', 'window:toggleMaximize', []],
+    ['close', 'window:close', []],
+    ['isMaximized', 'window:isMaximized', []],
+  ])('window.%s invokes "%s"', async (m, chan, args) => {
+    const api = getApi();
+    const w = api.window as Record<string, (...a: unknown[]) => Promise<unknown>>;
+    await w[m](...args);
+    expect(invokeSpy).toHaveBeenCalledWith(chan, ...args);
+  });
+
+  it('window.resolveCloseAction sends one-way window:resolveCloseAction', () => {
+    const api = getApi();
+    const payload = {
+      requestId: 'req-1',
+      choice: 'tray' as const,
+      dontAskAgain: false,
+    };
+    (
+      api.window as { resolveCloseAction: (p: typeof payload) => void }
+    ).resolveCloseAction(payload);
+    expect(sendSpy).toHaveBeenCalledWith('window:resolveCloseAction', payload);
+  });
+
+  it('window.platform mirrors process.platform', () => {
+    const api = getApi();
+    expect((api.window as { platform: string }).platform).toBe(process.platform);
+  });
+
+  // ---- Listener registration & unsubscribe round-trip --------------------
+  // Each `on*` call must (a) register an ipcRenderer listener on the right
+  // channel and (b) hand back an unsubscribe that calls removeListener with
+  // the EXACT SAME wrap function reference. Mismatching identities would
+  // make the unsubscribe a silent no-op and leak a handler on every dialog
+  // open / window-state change.
+  it.each<[string, string]>([
+    ['onUpdateStatus', 'updates:status'],
+    ['onUpdateDownloaded', 'update:downloaded'],
+  ])('%s registers and cleanly unsubscribes on "%s"', (m, chan) => {
+    const api = getApi();
+    const cb = vi.fn();
+    const off = (api[m] as (cb: unknown) => () => void)(cb);
+    expect(onSpy).toHaveBeenCalled();
+    const matching = onSpy.mock.calls.find((c) => c[0] === chan);
+    expect(matching).toBeDefined();
+    const wrap = matching![1];
+    off();
+    expect(removeListenerSpy).toHaveBeenCalledWith(chan, wrap);
+  });
+
+  it.each<[string, string]>([
+    ['onMaximizedChanged', 'window:maximizedChanged'],
+    ['onBeforeHide', 'window:beforeHide'],
+    ['onAfterShow', 'window:afterShow'],
+    ['onAskCloseAction', 'window:askCloseAction'],
+  ])('window.%s registers and unsubscribes on "%s"', (m, chan) => {
+    const api = getApi();
+    const w = api.window as Record<string, (cb: unknown) => () => void>;
+    const cb = vi.fn();
+    const off = w[m](cb);
+    const matching = onSpy.mock.calls.find((c) => c[0] === chan);
+    expect(matching).toBeDefined();
+    const wrap = matching![1];
+    off();
+    expect(removeListenerSpy).toHaveBeenCalledWith(chan, wrap);
+  });
+
+  it('onUpdateStatus wrap forwards payload through to user handler', () => {
+    const api = getApi();
+    const cb = vi.fn();
+    (api.onUpdateStatus as (cb: unknown) => () => void)(cb);
+    const wrap = onSpy.mock.calls.find((c) => c[0] === 'updates:status')![1] as (
+      e: unknown,
+      p: unknown,
+    ) => void;
+    wrap({}, { kind: 'idle' });
+    expect(cb).toHaveBeenCalledWith({ kind: 'idle' });
+  });
+
+  it('window.onAskCloseAction wrap forwards labels payload', () => {
+    const api = getApi();
+    const cb = vi.fn();
+    (
+      api.window as {
+        onAskCloseAction: (cb: unknown) => () => void;
+      }
+    ).onAskCloseAction(cb);
+    const wrap = onSpy.mock.calls.find(
+      (c) => c[0] === 'window:askCloseAction',
+    )![1] as (e: unknown, p: unknown) => void;
+    const payload = {
+      requestId: 'req-2',
+      labels: {
+        message: 'm',
+        detail: 'd',
+        tray: 't',
+        quit: 'q',
+        cancel: 'c',
+        dontAskAgain: 'a',
+      },
+    };
+    wrap({}, payload);
+    expect(cb).toHaveBeenCalledWith(payload);
+  });
+});

--- a/electron/preload/bridges/__tests__/ccsmNotify.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmNotify.test.ts
@@ -1,0 +1,100 @@
+// Pins the `window.ccsmNotify` preload bridge — small surface (one fan-out
+// + one one-way send), but the IPC channel names are wire contracts with
+// `electron/notify/sinks/flashSink.ts` and the decider's Rule 1 input
+// mute. Renaming either side without the other silently breaks the
+// AgentIcon flash halo or the 60s post-input toast suppression.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { exposeSpy, sendSpy, onSpy, removeListenerSpy } = vi.hoisted(() => ({
+  exposeSpy: vi.fn(),
+  sendSpy: vi.fn(),
+  onSpy: vi.fn(),
+  removeListenerSpy: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: exposeSpy },
+  ipcRenderer: {
+    invoke: vi.fn(),
+    send: sendSpy,
+    on: onSpy,
+    removeListener: removeListenerSpy,
+  },
+}));
+
+import { installCcsmNotifyBridge } from '../ccsmNotify';
+
+type AnyApi = Record<string, unknown>;
+
+function lastApi(): AnyApi {
+  const last = exposeSpy.mock.calls[exposeSpy.mock.calls.length - 1];
+  expect(last[0]).toBe('ccsmNotify');
+  return last[1] as AnyApi;
+}
+
+describe('ccsmNotify preload bridge', () => {
+  beforeEach(() => {
+    exposeSpy.mockClear();
+    sendSpy.mockReset();
+    onSpy.mockReset();
+    removeListenerSpy.mockReset();
+    installCcsmNotifyBridge();
+  });
+
+  it('exposes a stable key set under "ccsmNotify"', () => {
+    const api = lastApi();
+    expect(Object.keys(api).sort()).toEqual(['markUserInput', 'onFlash'].sort());
+  });
+
+  it('install registers exactly one fan-out on "notify:flash"', () => {
+    const calls = onSpy.mock.calls.map((c) => c[0]);
+    expect(calls).toEqual(['notify:flash']);
+  });
+
+  it('onFlash fan-out delivers payload, unsubscribe stops delivery', () => {
+    const api = lastApi();
+    const cb = vi.fn();
+    const off = (api.onFlash as (cb: unknown) => () => void)(cb);
+    const dispatch = onSpy.mock.calls.find((c) => c[0] === 'notify:flash')![1] as (
+      e: unknown,
+      p: unknown,
+    ) => void;
+    dispatch({}, { sid: 's1', on: true });
+    expect(cb).toHaveBeenCalledWith({ sid: 's1', on: true });
+    off();
+    dispatch({}, { sid: 's1', on: false });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('throwing onFlash listener does not abort siblings', () => {
+    const api = lastApi();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const bad = vi.fn(() => {
+      throw new Error('x');
+    });
+    const good = vi.fn();
+    (api.onFlash as (cb: unknown) => () => void)(bad);
+    (api.onFlash as (cb: unknown) => () => void)(good);
+    const dispatch = onSpy.mock.calls.find((c) => c[0] === 'notify:flash')![1] as (
+      e: unknown,
+      p: unknown,
+    ) => void;
+    dispatch({}, { sid: 's', on: true });
+    expect(bad).toHaveBeenCalled();
+    expect(good).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('markUserInput sends one-way notify:userInput', () => {
+    const api = lastApi();
+    (api.markUserInput as (sid: string) => void)('s-42');
+    expect(sendSpy).toHaveBeenCalledWith('notify:userInput', 's-42');
+  });
+
+  it('markUserInput("") is a no-op (does NOT send)', () => {
+    const api = lastApi();
+    (api.markUserInput as (sid: string) => void)('');
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+});

--- a/electron/preload/bridges/__tests__/ccsmPty.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmPty.test.ts
@@ -1,0 +1,182 @@
+// Pins the `window.ccsmPty` preload bridge surface. This bridge fronts the
+// in-process node-pty host (replaces ttyd) plus folds the CLI-availability
+// probe and clipboard. `onData` / `onExit` use the same listener-set
+// fan-out as ccsmSession so every TerminalPane mount doesn't leak a fresh
+// ipcRenderer handler on the shared `pty:data` / `pty:exit` channels —
+// that's the whole reason the bridge exists in this shape.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  exposeSpy,
+  invokeSpy,
+  onSpy,
+  removeListenerSpy,
+  clipboardReadSpy,
+  clipboardWriteSpy,
+} = vi.hoisted(() => ({
+  exposeSpy: vi.fn(),
+  invokeSpy: vi.fn(),
+  onSpy: vi.fn(),
+  removeListenerSpy: vi.fn(),
+  clipboardReadSpy: vi.fn(() => 'clip-text'),
+  clipboardWriteSpy: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: exposeSpy },
+  ipcRenderer: {
+    invoke: invokeSpy,
+    send: vi.fn(),
+    on: onSpy,
+    removeListener: removeListenerSpy,
+  },
+  clipboard: {
+    readText: () => clipboardReadSpy(),
+    writeText: (t: string) => clipboardWriteSpy(t),
+  },
+}));
+
+import { installCcsmPtyBridge } from '../ccsmPty';
+
+type AnyApi = Record<string, unknown>;
+
+function lastApi(): AnyApi {
+  const last = exposeSpy.mock.calls[exposeSpy.mock.calls.length - 1];
+  expect(last[0]).toBe('ccsmPty');
+  return last[1] as AnyApi;
+}
+
+describe('ccsmPty preload bridge', () => {
+  beforeEach(() => {
+    exposeSpy.mockClear();
+    invokeSpy.mockReset();
+    invokeSpy.mockResolvedValue(undefined);
+    onSpy.mockReset();
+    removeListenerSpy.mockReset();
+    clipboardReadSpy.mockClear();
+    clipboardWriteSpy.mockClear();
+    installCcsmPtyBridge();
+  });
+
+  it('exposes a stable key set under "ccsmPty"', () => {
+    const api = lastApi();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'attach',
+        'checkClaudeAvailable',
+        'clipboard',
+        'detach',
+        'get',
+        'getBufferSnapshot',
+        'input',
+        'kill',
+        'list',
+        'onData',
+        'onExit',
+        'resize',
+        'spawn',
+      ].sort(),
+    );
+    expect(Object.keys(api.clipboard as AnyApi).sort()).toEqual(
+      ['readText', 'writeText'].sort(),
+    );
+  });
+
+  it('install registers fan-outs for "pty:data" and "pty:exit"', () => {
+    const channels = onSpy.mock.calls.map((c) => c[0]).sort();
+    expect(channels).toEqual(['pty:data', 'pty:exit'].sort());
+  });
+
+  it.each<[string, string, unknown[]]>([
+    ['list', 'pty:list', []],
+    ['spawn', 'pty:spawn', ['s1', '/cwd']],
+    ['attach', 'pty:attach', ['s1']],
+    ['detach', 'pty:detach', ['s1']],
+    ['input', 'pty:input', ['s1', 'hello']],
+    ['resize', 'pty:resize', ['s1', 80, 24]],
+    ['kill', 'pty:kill', ['s1']],
+    ['get', 'pty:get', ['s1']],
+    ['getBufferSnapshot', 'pty:getBufferSnapshot', ['s1']],
+  ])('forwards %s -> ipcRenderer.invoke("%s", ...)', async (m, chan, args) => {
+    const api = lastApi();
+    await (api[m] as (...a: unknown[]) => Promise<unknown>)(...args);
+    expect(invokeSpy).toHaveBeenCalledWith(chan, ...args);
+  });
+
+  it('checkClaudeAvailable defaults its opts to {}', async () => {
+    const api = lastApi();
+    await (api.checkClaudeAvailable as (o?: unknown) => Promise<unknown>)();
+    expect(invokeSpy).toHaveBeenCalledWith('pty:checkClaudeAvailable', {});
+  });
+
+  it('checkClaudeAvailable forwards explicit opts', async () => {
+    const api = lastApi();
+    await (
+      api.checkClaudeAvailable as (o?: { force?: boolean }) => Promise<unknown>
+    )({ force: true });
+    expect(invokeSpy).toHaveBeenCalledWith('pty:checkClaudeAvailable', {
+      force: true,
+    });
+  });
+
+  it('clipboard.readText / writeText delegate to electron.clipboard', () => {
+    const api = lastApi();
+    const c = api.clipboard as { readText: () => string; writeText: (s: string) => void };
+    expect(c.readText()).toBe('clip-text');
+    expect(clipboardReadSpy).toHaveBeenCalledTimes(1);
+    c.writeText('hi');
+    expect(clipboardWriteSpy).toHaveBeenCalledWith('hi');
+  });
+
+  it('onData fan-out delivers payload, unsubscribe stops delivery', () => {
+    const api = lastApi();
+    const cb = vi.fn();
+    const off = (api.onData as (cb: unknown) => () => void)(cb);
+    const dispatch = onSpy.mock.calls.find((c) => c[0] === 'pty:data')![1] as (
+      e: unknown,
+      p: unknown,
+    ) => void;
+    const payload = { sid: 's1', chunk: 'abc', seq: 7 };
+    dispatch({}, payload);
+    expect(cb).toHaveBeenCalledWith(payload);
+    off();
+    dispatch({}, payload);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('onExit fan-out delivers payload, unsubscribe stops delivery', () => {
+    const api = lastApi();
+    const cb = vi.fn();
+    const off = (api.onExit as (cb: unknown) => () => void)(cb);
+    const dispatch = onSpy.mock.calls.find((c) => c[0] === 'pty:exit')![1] as (
+      e: unknown,
+      p: unknown,
+    ) => void;
+    const payload = { sessionId: 's1', code: 0, signal: null };
+    dispatch({}, payload);
+    expect(cb).toHaveBeenCalledWith(payload);
+    off();
+    dispatch({}, payload);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('throwing onData listener does not abort siblings', () => {
+    const api = lastApi();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const bad = vi.fn(() => {
+      throw new Error('x');
+    });
+    const good = vi.fn();
+    (api.onData as (cb: unknown) => () => void)(bad);
+    (api.onData as (cb: unknown) => () => void)(good);
+    const dispatch = onSpy.mock.calls.find((c) => c[0] === 'pty:data')![1] as (
+      e: unknown,
+      p: unknown,
+    ) => void;
+    dispatch({}, { sid: 's', chunk: '', seq: 0 });
+    expect(bad).toHaveBeenCalled();
+    expect(good).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/electron/preload/bridges/__tests__/ccsmSession.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmSession.test.ts
@@ -1,0 +1,162 @@
+// Pins the `window.ccsmSession` preload bridge surface. This bridge owns
+// 4 listener-set fan-outs (state / activate / title / cwdRedirected) — the
+// install function registers ONE ipcRenderer.on per channel and dispatches
+// to the renderer-side Set, so multiple subscribers (Sidebar, notify integration,
+// store hydration) don't each leak a handler on the shared channel. We
+// verify (a) exposed shape, (b) one-way setters forward to the right channel,
+// and (c) each fan-out actually delivers the payload to a registered cb
+// AND that the returned unsubscribe drops it from the Set so subsequent
+// pushes don't re-fire.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { exposeSpy, sendSpy, onSpy, removeListenerSpy } = vi.hoisted(() => ({
+  exposeSpy: vi.fn(),
+  sendSpy: vi.fn(),
+  onSpy: vi.fn(),
+  removeListenerSpy: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: exposeSpy },
+  ipcRenderer: {
+    invoke: vi.fn(),
+    send: sendSpy,
+    on: onSpy,
+    removeListener: removeListenerSpy,
+  },
+}));
+
+import { installCcsmSessionBridge } from '../ccsmSession';
+
+type AnyApi = Record<string, unknown>;
+
+function lastApi(): AnyApi {
+  const last = exposeSpy.mock.calls[exposeSpy.mock.calls.length - 1];
+  expect(last[0]).toBe('ccsmSession');
+  return last[1] as AnyApi;
+}
+
+function findRegisteredHandler(chan: string): (e: unknown, payload: unknown) => void {
+  const match = onSpy.mock.calls.find((c) => c[0] === chan);
+  expect(match, `no ipcRenderer.on registration for ${chan}`).toBeDefined();
+  return match![1] as (e: unknown, payload: unknown) => void;
+}
+
+describe('ccsmSession preload bridge', () => {
+  beforeEach(() => {
+    exposeSpy.mockClear();
+    sendSpy.mockReset();
+    onSpy.mockReset();
+    removeListenerSpy.mockReset();
+    installCcsmSessionBridge();
+  });
+
+  it('exposes a stable key set under "ccsmSession"', () => {
+    const api = lastApi();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'onActivate',
+        'onCwdRedirected',
+        'onState',
+        'onTitle',
+        'setActive',
+        'setName',
+      ].sort(),
+    );
+  });
+
+  it('install registers exactly the 4 fan-out channels on ipcRenderer', () => {
+    const channels = onSpy.mock.calls.map((c) => c[0]).sort();
+    expect(channels).toEqual(
+      [
+        'session:state',
+        'session:title',
+        'session:cwdRedirected',
+        'session:activate',
+      ].sort(),
+    );
+  });
+
+  it.each<[string, string, unknown]>([
+    ['onState', 'session:state', { sid: 's1', state: 'running' }],
+    ['onActivate', 'session:activate', { sid: 's1' }],
+    ['onTitle', 'session:title', { sid: 's1', title: 'hi' }],
+    [
+      'onCwdRedirected',
+      'session:cwdRedirected',
+      { sid: 's1', newCwd: '/new/cwd' },
+    ],
+  ])('%s subscribes to %s fan-out and unsubscribe stops delivery', (m, chan, payload) => {
+    const api = lastApi();
+    const cb = vi.fn();
+    const off = (api[m] as (cb: unknown) => () => void)(cb);
+
+    const dispatch = findRegisteredHandler(chan);
+    dispatch({}, payload);
+    expect(cb).toHaveBeenCalledWith(payload);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    off();
+    dispatch({}, payload);
+    // After unsubscribe, no further deliveries.
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('multiple subscribers all receive the same payload (fan-out)', () => {
+    const api = lastApi();
+    const cbA = vi.fn();
+    const cbB = vi.fn();
+    (api.onState as (cb: unknown) => () => void)(cbA);
+    (api.onState as (cb: unknown) => () => void)(cbB);
+    const dispatch = findRegisteredHandler('session:state');
+    dispatch({}, { sid: 's2', state: 'idle' });
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(1);
+  });
+
+  it('a throwing listener does not abort delivery to siblings', () => {
+    const api = lastApi();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const bad = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const good = vi.fn();
+    (api.onState as (cb: unknown) => () => void)(bad);
+    (api.onState as (cb: unknown) => () => void)(good);
+    findRegisteredHandler('session:state')({}, { sid: 's', state: 'idle' });
+    expect(bad).toHaveBeenCalled();
+    expect(good).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('setActive sends "session:setActive" with sid (or empty string for null)', () => {
+    const api = lastApi();
+    const fn = api.setActive as (s: string | null) => void;
+    fn('s-123');
+    expect(sendSpy).toHaveBeenCalledWith('session:setActive', 's-123');
+    fn(null);
+    expect(sendSpy).toHaveBeenCalledWith('session:setActive', '');
+  });
+
+  it('setName sends "session:setName" with normalized null name', () => {
+    const api = lastApi();
+    const fn = api.setName as (sid: string, n: string | null) => void;
+    fn('s-1', 'Friendly');
+    expect(sendSpy).toHaveBeenCalledWith('session:setName', {
+      sid: 's-1',
+      name: 'Friendly',
+    });
+    fn('s-1', null);
+    expect(sendSpy).toHaveBeenCalledWith('session:setName', {
+      sid: 's-1',
+      name: '',
+    });
+  });
+
+  it('setName with empty sid is a no-op (does NOT send)', () => {
+    const api = lastApi();
+    (api.setName as (sid: string, n: string | null) => void)('', 'x');
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+});

--- a/electron/preload/bridges/__tests__/ccsmSessionTitles.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmSessionTitles.test.ts
@@ -1,0 +1,74 @@
+// Pins the `window.ccsmSessionTitles` preload bridge. Pure invoke
+// pass-through to the main-process sessionTitles module — the substrate
+// (per-sid serialization, 2s TTL, ENOENT classification, pending-rename
+// queue) all lives on main. The renderer surface is small but every
+// channel is a wire contract with `electron/sessionTitles/index.ts`
+// handlers; rename one without the other and the renderer rename action
+// hangs forever.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { exposeSpy, invokeSpy } = vi.hoisted(() => ({
+  exposeSpy: vi.fn(),
+  invokeSpy: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: exposeSpy },
+  ipcRenderer: {
+    invoke: invokeSpy,
+    send: vi.fn(),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  },
+}));
+
+import { installCcsmSessionTitlesBridge } from '../ccsmSessionTitles';
+
+type AnyApi = Record<string, unknown>;
+
+function lastApi(): AnyApi {
+  const last = exposeSpy.mock.calls[exposeSpy.mock.calls.length - 1];
+  expect(last[0]).toBe('ccsmSessionTitles');
+  return last[1] as AnyApi;
+}
+
+describe('ccsmSessionTitles preload bridge', () => {
+  beforeEach(() => {
+    exposeSpy.mockClear();
+    invokeSpy.mockReset();
+    invokeSpy.mockResolvedValue(undefined);
+    installCcsmSessionTitlesBridge();
+  });
+
+  it('exposes a stable key set under "ccsmSessionTitles"', () => {
+    const api = lastApi();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'enqueuePending',
+        'flushPending',
+        'get',
+        'listForProject',
+        'rename',
+      ].sort(),
+    );
+  });
+
+  it.each<[string, string, unknown[]]>([
+    ['get', 'sessionTitles:get', ['sid-1', '/some/dir']],
+    ['get', 'sessionTitles:get', ['sid-1', undefined]],
+    ['rename', 'sessionTitles:rename', ['sid-1', 'New Title', '/d']],
+    ['rename', 'sessionTitles:rename', ['sid-1', 'New Title', undefined]],
+    ['listForProject', 'sessionTitles:listForProject', ['proj-key']],
+    [
+      'enqueuePending',
+      'sessionTitles:enqueuePending',
+      ['sid-1', 'Title', '/d'],
+    ],
+    ['flushPending', 'sessionTitles:flushPending', ['sid-1']],
+  ])('forwards %s -> ipcRenderer.invoke("%s", ...)', async (m, chan, args) => {
+    const api = lastApi();
+    await (api[m] as (...a: unknown[]) => Promise<unknown>)(...args);
+    expect(invokeSpy).toHaveBeenLastCalledWith(chan, ...args);
+  });
+});

--- a/electron/preload/bridges/__tests__/index.test.ts
+++ b/electron/preload/bridges/__tests__/index.test.ts
@@ -1,0 +1,53 @@
+// Pins the preload entry point. The 5 `install*` calls are independent
+// (order is preserved for diff clarity, not correctness) — but if a
+// future refactor drops one of them, the corresponding `window.ccsm*`
+// surface goes silently missing in the renderer with no compiler signal.
+// The Sentry preload import must also stay first so error capture is
+// armed before any bridge runs (its initializer hooks into webContents).
+
+import { describe, it, expect, vi } from 'vitest';
+
+const {
+  installCore,
+  installPty,
+  installSession,
+  installNotify,
+  installSessionTitles,
+  sentryLoaded,
+} = vi.hoisted(() => ({
+  installCore: vi.fn(),
+  installPty: vi.fn(),
+  installSession: vi.fn(),
+  installNotify: vi.fn(),
+  installSessionTitles: vi.fn(),
+  sentryLoaded: vi.fn(),
+}));
+
+vi.mock('@sentry/electron/preload', () => {
+  sentryLoaded();
+  return {};
+});
+vi.mock('../ccsmCore', () => ({ installCcsmCoreBridge: installCore }));
+vi.mock('../ccsmPty', () => ({ installCcsmPtyBridge: installPty }));
+vi.mock('../ccsmSession', () => ({
+  installCcsmSessionBridge: installSession,
+}));
+vi.mock('../ccsmNotify', () => ({
+  installCcsmNotifyBridge: installNotify,
+}));
+vi.mock('../ccsmSessionTitles', () => ({
+  installCcsmSessionTitlesBridge: installSessionTitles,
+}));
+
+describe('preload/index entry point', () => {
+  it('loads sentry/preload and invokes every install function exactly once', async () => {
+    await import('../../index');
+
+    expect(sentryLoaded).toHaveBeenCalledTimes(1);
+    expect(installCore).toHaveBeenCalledTimes(1);
+    expect(installPty).toHaveBeenCalledTimes(1);
+    expect(installSession).toHaveBeenCalledTimes(1);
+    expect(installNotify).toHaveBeenCalledTimes(1);
+    expect(installSessionTitles).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Test-coverage batch 1: brings the 6 files under `electron/preload/` from **0% to 96%+ lines** (147 implementation LOC + 1 entry point, now pinned by 79 unit tests).

Why these first: the manager's coverage triage flagged the preload bridges as the highest-ROI gap — they sit on every IPC entry from the renderer, but had zero tests, so any silent rename of an `ipcRenderer.invoke` channel or an `exposeInMainWorld` key would brick the renderer at runtime with no compile signal.

## What each test pins

- **Exposed key set** per `window.ccsm*` namespace — deleting a method by accident fires a test
- **`ipcRenderer.invoke` / `send` channel + arg passthrough** for every method (wire contract with `electron/ipc/*Ipc.ts` handlers)
- **Listener-set fan-outs** (ccsmSession state/title/activate/cwdRedirected, ccsmPty data/exit, ccsmNotify flash):
  - payload delivery to subscribed callback
  - multi-subscriber fan-out (the whole reason the bridge owns a Set instead of registering one `ipcRenderer.on` per caller)
  - throwing listener doesn't abort delivery to siblings
  - returned unsubscribe stops further delivery
- **Direct `ipcRenderer.on` / `removeListener` round-trip** for ccsmCore's `onUpdateStatus` / `onUpdateDownloaded` / window-event handlers — verifies the wrap-function identity matches so unsubscribe is not a silent no-op
- **`saveState` re-throw on `{ok:false}`** so persist callers' `.catch(onPersistError)` actually fires (a resolved `{ok:false}` would otherwise slip past and produce silent data loss)
- **`preload/index.ts` entry point** installs every bridge exactly once and loads `@sentry/electron/preload` first

## Coverage delta (`electron/preload/bridges/`)

| File | Lines | Funcs | Branches |
|---|---|---|---|
| ccsmCore.ts | 0% -> 97.95% | 0% -> 90.9% | -> 100% |
| ccsmPty.ts | 0% -> 96.87% | 0% -> 100% | -> 100% |
| ccsmSession.ts | 0% -> 92.68% | 0% -> 100% | -> 100% |
| ccsmNotify.ts | 0% -> **100%** | 0% -> 100% | -> 100% |
| ccsmSessionTitles.ts | 0% -> **100%** | 0% -> 100% | -> 100% |
| preload/index.ts | 0% -> **100%** | 0% -> 100% | -> 100% |
| **`preload/bridges/` (dir)** | **0% -> 96.47%** | **0% -> 95.5%** | **-> 100%** |

Project-wide lines: 73.6% -> **75.07%** (per `coverage/coverage-summary.json`).

## Scope discipline

- Diff is test-only — **zero changes to any bridge source file**.
- Uses the existing `vi.mock('electron', ...)` pattern already established in `electron/notify/sinks/__tests__/badgeSink.test.ts` and 14 others; `vi.hoisted` is used so the spy refs survive the mock-factory hoist.
- No new dev-deps.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run electron/preload/bridges/__tests__` — 79/79 pass
- [x] Full `npm test` — only pre-existing env failures (`electron-load-smoke` needs a `npm run build` first; `db-hardening` hits the better-sqlite3 NODE_MODULE_VERSION mismatch on this worktree). Neither touches the changed files.
- [x] `npx vitest run --coverage` — preload/bridges 0% -> 96.47% lines confirmed via `coverage-summary.json`