### PR TITLE
test(import): cover ImportDialog UI + import-scanner edge cases (batch 4)

### DIFF
--- a/electron/__tests__/import-scanner.test.ts
+++ b/electron/__tests__/import-scanner.test.ts
@@ -1,0 +1,444 @@
+// UT for electron/import-scanner.ts — exercises the JSONL → ScannableSession
+// pipeline using a real on-disk fixture tree under a per-test tmp dir.
+//
+// Coverage targets the import flow's data contract:
+//   1. Missing `~/.claude/projects` → empty result, no throw
+//   2. Malformed JSONL lines → skipped (not fatal)
+//   3. Empty / metadata-less transcripts → dropped (resolve(null) path)
+//   4. Sidechain/sub-agent transcripts → filtered out
+//   5. Sort order — newest mtime first
+//   6. ccsm/agentory temp-cwd noise filter
+//   7. Title fallback: aiTitle > firstUserText > "(untitled session)"
+//   8. <command-...> wrapped first user lines do NOT become titles
+//   9. parseHead pure helper edge cases
+//  10. deriveRecentCwds: frequency-then-recency ranking + `~` skip
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  scanImportableSessions,
+  parseHead,
+  deriveRecentCwds,
+  isCCSMTempCwd,
+  isSidechainFrame,
+} from '../import-scanner';
+
+let tmpRoot: string;
+let projectsDir: string;
+let savedEnv: string | undefined;
+
+function mkProject(projectKey: string): string {
+  const dir = path.join(projectsDir, projectKey);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeJsonl(file: string, lines: Array<unknown | string>) {
+  const body = lines
+    .map((l) => (typeof l === 'string' ? l : JSON.stringify(l)))
+    .join('\n');
+  fs.writeFileSync(file, body);
+}
+
+function setMtime(file: string, ms: number) {
+  const t = ms / 1000;
+  fs.utimesSync(file, t, t);
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-import-scanner-test-'));
+  projectsDir = path.join(tmpRoot, 'projects');
+  fs.mkdirSync(projectsDir, { recursive: true });
+  savedEnv = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = tmpRoot;
+});
+
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+  else process.env.CLAUDE_CONFIG_DIR = savedEnv;
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe('scanImportableSessions', () => {
+  it('returns [] (does not throw) when the projects dir is missing', async () => {
+    fs.rmSync(projectsDir, { recursive: true, force: true });
+    const out = await scanImportableSessions();
+    expect(out).toEqual([]);
+  });
+
+  it('returns [] when the projects dir is empty', async () => {
+    const out = await scanImportableSessions();
+    expect(out).toEqual([]);
+  });
+
+  it('returns [] when only non-jsonl files are present', async () => {
+    const dir = mkProject('-Users-foo-proj');
+    fs.writeFileSync(path.join(dir, 'README.md'), 'hi');
+    const out = await scanImportableSessions();
+    expect(out).toEqual([]);
+  });
+
+  it('extracts cwd, title, mtime, projectDir from a well-formed transcript', async () => {
+    const dir = mkProject('-Users-foo-proj');
+    const file = path.join(dir, 'sess-A.jsonl');
+    writeJsonl(file, [
+      { cwd: '/Users/foo/proj', type: 'meta' },
+      { type: 'user', message: { content: 'hello world' } },
+      { type: 'ai-title', aiTitle: 'Greeting' },
+      { type: 'assistant', message: { model: 'claude-3-5-sonnet' } },
+    ]);
+    setMtime(file, 1_700_000_000_000);
+
+    const out = await scanImportableSessions();
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      sessionId: 'sess-A',
+      cwd: '/Users/foo/proj',
+      title: 'Greeting', // aiTitle wins
+      projectDir: '-Users-foo-proj',
+      model: 'claude-3-5-sonnet',
+    });
+    expect(out[0].mtime).toBeGreaterThan(0);
+  });
+
+  it('falls back to first user text when no aiTitle frame is present', async () => {
+    const dir = mkProject('-tmp-foo');
+    const file = path.join(dir, 'sess-B.jsonl');
+    writeJsonl(file, [
+      { cwd: '/Users/foo/work', type: 'meta' },
+      { type: 'user', message: { content: 'do the thing please' } },
+    ]);
+    const out = await scanImportableSessions();
+    expect(out).toHaveLength(1);
+    expect(out[0].title).toBe('do the thing please');
+  });
+
+  it('skips <command-...> wrapped user lines when picking a title fallback', async () => {
+    const dir = mkProject('-tmp-foo2');
+    const file = path.join(dir, 'sess-C.jsonl');
+    writeJsonl(file, [
+      { cwd: '/Users/foo/work', type: 'meta' },
+      { type: 'user', message: { content: '<command-name>compact</command-name>' } },
+      { type: 'user', message: { content: 'real prompt here' } },
+    ]);
+    const out = await scanImportableSessions();
+    expect(out[0].title).toBe('real prompt here');
+  });
+
+  it('uses "(untitled session)" when only cwd is present', async () => {
+    const dir = mkProject('-Users-foo-empty');
+    const file = path.join(dir, 'sess-D.jsonl');
+    writeJsonl(file, [{ cwd: '/Users/foo/empty', type: 'meta' }]);
+    const out = await scanImportableSessions();
+    expect(out).toHaveLength(1);
+    expect(out[0].title).toBe('(untitled session)');
+  });
+
+  it('drops a transcript whose head has no cwd, title, user-text, or model', async () => {
+    const dir = mkProject('-Users-foo-junk');
+    const file = path.join(dir, 'sess-E.jsonl');
+    writeJsonl(file, [{ type: 'meta', extra: 1 }]);
+    const out = await scanImportableSessions();
+    expect(out).toEqual([]);
+  });
+
+  it('drops sub-agent (sidechain) transcripts', async () => {
+    const dir = mkProject('-Users-foo-side');
+    const file = path.join(dir, 'sess-F.jsonl');
+    writeJsonl(file, [
+      { isSidechain: true, cwd: '/Users/foo/side' },
+      { type: 'user', message: { content: 'inside subagent' } },
+    ]);
+    const out = await scanImportableSessions();
+    expect(out).toEqual([]);
+  });
+
+  it('drops transcripts whose first frame has a non-empty parentUuid', async () => {
+    const dir = mkProject('-Users-foo-side2');
+    const file = path.join(dir, 'sess-G.jsonl');
+    writeJsonl(file, [
+      { parentUuid: 'parent-1', cwd: '/Users/foo/side2', type: 'meta' },
+    ]);
+    const out = await scanImportableSessions();
+    expect(out).toEqual([]);
+  });
+
+  it('skips malformed JSON lines but still returns subsequent valid frames', async () => {
+    const dir = mkProject('-Users-foo-mal');
+    const file = path.join(dir, 'sess-H.jsonl');
+    // Mix of garbage + valid lines. The garbage line must NOT abort parsing.
+    writeJsonl(file, [
+      'this-is-not-json{{{',
+      { cwd: '/Users/foo/mal', type: 'meta' },
+      'another}garbage',
+      { type: 'user', message: { content: 'survived parsing' } },
+    ]);
+    const out = await scanImportableSessions();
+    expect(out).toHaveLength(1);
+    expect(out[0].cwd).toBe('/Users/foo/mal');
+    expect(out[0].title).toBe('survived parsing');
+  });
+
+  it('drops empty (0-byte) jsonl files without throwing', async () => {
+    const dir = mkProject('-Users-foo-empty2');
+    fs.writeFileSync(path.join(dir, 'sess-I.jsonl'), '');
+    // Plus one valid sibling to confirm the empty file is silently skipped
+    // and the valid one still surfaces.
+    const ok = path.join(dir, 'sess-J.jsonl');
+    writeJsonl(ok, [
+      { cwd: '/Users/foo/empty2', type: 'meta' },
+      { type: 'ai-title', aiTitle: 'Valid' },
+    ]);
+    const out = await scanImportableSessions();
+    expect(out).toHaveLength(1);
+    expect(out[0].sessionId).toBe('sess-J');
+  });
+
+  it('filters out our own ccsm-* / agentory-* temp-dir cwds', async () => {
+    const dir = mkProject('-tmp-noise');
+    const noisy = path.join(dir, 'sess-K.jsonl');
+    writeJsonl(noisy, [
+      { cwd: `${os.tmpdir()}/ccsm-spawn-abc`, type: 'meta' },
+      { type: 'ai-title', aiTitle: 'Noise' },
+    ]);
+    const real = path.join(dir, 'sess-L.jsonl');
+    writeJsonl(real, [
+      { cwd: '/Users/foo/realwork', type: 'meta' },
+      { type: 'ai-title', aiTitle: 'Real' },
+    ]);
+    const out = await scanImportableSessions();
+    const titles = out.map((s) => s.title).sort();
+    expect(titles).toEqual(['Real']);
+  });
+
+  it('sorts results by mtime desc (newest first)', async () => {
+    const dir = mkProject('-Users-foo-sort');
+    const a = path.join(dir, 'old.jsonl');
+    const b = path.join(dir, 'new.jsonl');
+    writeJsonl(a, [
+      { cwd: '/Users/foo/sort', type: 'meta' },
+      { type: 'ai-title', aiTitle: 'old' },
+    ]);
+    writeJsonl(b, [
+      { cwd: '/Users/foo/sort', type: 'meta' },
+      { type: 'ai-title', aiTitle: 'new' },
+    ]);
+    setMtime(a, 1_600_000_000_000);
+    setMtime(b, 1_700_000_000_000);
+
+    const out = await scanImportableSessions();
+    expect(out.map((s) => s.sessionId)).toEqual(['new', 'old']);
+  });
+
+  it('walks across multiple project directories', async () => {
+    const d1 = mkProject('-Users-foo-p1');
+    const d2 = mkProject('-Users-foo-p2');
+    writeJsonl(path.join(d1, 'a.jsonl'), [
+      { cwd: '/Users/foo/p1', type: 'meta' },
+      { type: 'ai-title', aiTitle: 'p1' },
+    ]);
+    writeJsonl(path.join(d2, 'b.jsonl'), [
+      { cwd: '/Users/foo/p2', type: 'meta' },
+      { type: 'ai-title', aiTitle: 'p2' },
+    ]);
+    const out = await scanImportableSessions();
+    expect(out.map((s) => s.projectDir).sort()).toEqual([
+      '-Users-foo-p1',
+      '-Users-foo-p2',
+    ]);
+  });
+
+  it('honors a runtime CLAUDE_CONFIG_DIR mutation between calls', async () => {
+    // First call: original tmpRoot, populated.
+    const d = mkProject('-Users-foo-run1');
+    writeJsonl(path.join(d, 'a.jsonl'), [
+      { cwd: '/Users/foo/run1', type: 'meta' },
+      { type: 'ai-title', aiTitle: 'r1' },
+    ]);
+    const first = await scanImportableSessions();
+    expect(first).toHaveLength(1);
+
+    // Second call: redirect to an empty tmp.
+    const altRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-import-scanner-alt-'));
+    try {
+      process.env.CLAUDE_CONFIG_DIR = altRoot;
+      const second = await scanImportableSessions();
+      expect(second).toEqual([]);
+    } finally {
+      process.env.CLAUDE_CONFIG_DIR = tmpRoot; // restore for afterEach
+      fs.rmSync(altRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('parseHead', () => {
+  it('returns null on a head with no useful fields', () => {
+    expect(parseHead([JSON.stringify({ type: 'noise' })])).toBeNull();
+  });
+
+  it('returns null on a sidechain first frame', () => {
+    expect(
+      parseHead([
+        JSON.stringify({ isSidechain: true, cwd: '/x' }),
+        JSON.stringify({ type: 'user', message: { content: 'hi' } }),
+      ])
+    ).toBeNull();
+  });
+
+  it('skips malformed lines and continues', () => {
+    const head = parseHead([
+      'garbage',
+      JSON.stringify({ cwd: '/x' }),
+      JSON.stringify({ type: 'ai-title', aiTitle: 'T' }),
+    ]);
+    expect(head).toEqual({ cwd: '/x', title: 'T', model: null });
+  });
+
+  it('uses "~" as cwd fallback when none was found but other fields exist', () => {
+    const head = parseHead([JSON.stringify({ type: 'ai-title', aiTitle: 'T' })]);
+    expect(head).toEqual({ cwd: '~', title: 'T', model: null });
+  });
+
+  it('extracts model from message.model on assistant frames', () => {
+    const head = parseHead([
+      JSON.stringify({ cwd: '/x' }),
+      JSON.stringify({ type: 'assistant', message: { model: 'opus' } }),
+    ]);
+    expect(head?.model).toBe('opus');
+  });
+
+  it('accepts top-level `model` as a fallback', () => {
+    const head = parseHead([
+      JSON.stringify({ cwd: '/x', model: 'sonnet' }),
+    ]);
+    expect(head?.model).toBe('sonnet');
+  });
+
+  it('extracts user text from array-content messages', () => {
+    const head = parseHead([
+      JSON.stringify({ cwd: '/x' }),
+      JSON.stringify({
+        type: 'user',
+        message: { content: [{ type: 'text', text: 'array form' }] },
+      }),
+    ]);
+    expect(head?.title).toBe('array form');
+  });
+
+  it('truncates long titles', () => {
+    const long = 'x'.repeat(200);
+    const head = parseHead([
+      JSON.stringify({ cwd: '/x' }),
+      JSON.stringify({ type: 'user', message: { content: long } }),
+    ]);
+    expect(head?.title.length).toBeLessThanOrEqual(80);
+    expect(head?.title.endsWith('…')).toBe(true);
+  });
+});
+
+describe('isSidechainFrame', () => {
+  it('flags frames with isSidechain:true', () => {
+    expect(isSidechainFrame({ isSidechain: true })).toBe(true);
+  });
+  it('flags frames with non-empty parentUuid', () => {
+    expect(isSidechainFrame({ parentUuid: 'p' })).toBe(true);
+  });
+  it('does NOT flag normal frames with parentUuid:null', () => {
+    expect(isSidechainFrame({ parentUuid: null })).toBe(false);
+  });
+  it('does NOT flag non-objects', () => {
+    expect(isSidechainFrame(null)).toBe(false);
+    expect(isSidechainFrame('x')).toBe(false);
+  });
+});
+
+describe('isCCSMTempCwd', () => {
+  it('matches a ccsm-prefixed segment under os.tmpdir()', () => {
+    expect(isCCSMTempCwd(path.join(os.tmpdir(), 'ccsm-A1', 'sub'))).toBe(true);
+  });
+  it('matches the legacy agentory-* prefix', () => {
+    expect(isCCSMTempCwd(path.join(os.tmpdir(), 'agentory-X', 'q'))).toBe(true);
+  });
+  it('matches /tmp/ccsm-* even when os.tmpdir() differs (macOS aliasing)', () => {
+    expect(isCCSMTempCwd('/tmp/ccsm-foo/bar')).toBe(true);
+  });
+  it('matches /var/folders/.../ccsm-* prefix', () => {
+    expect(isCCSMTempCwd('/var/folders/aa/bb/T/ccsm-foo')).toBe(true);
+  });
+  it('matches Windows AppData\\Local\\Temp\\ccsm-* (case-insensitive)', () => {
+    expect(
+      isCCSMTempCwd('C:/Users/me/AppData/Local/Temp/ccsm-foo')
+    ).toBe(true);
+    expect(
+      isCCSMTempCwd('C:\\Users\\me\\AppData\\Local\\Temp\\ccsm-foo')
+    ).toBe(true);
+  });
+  it('does not match a user-named path that contains "agentory"', () => {
+    expect(isCCSMTempCwd('/Users/me/projects/my-agentory-fork')).toBe(false);
+  });
+  it('does not match a normal cwd outside any temp root', () => {
+    expect(isCCSMTempCwd('/Users/me/proj')).toBe(false);
+  });
+  it('returns false for empty / non-string inputs', () => {
+    expect(isCCSMTempCwd('')).toBe(false);
+    // @ts-expect-error — exercising the runtime guard
+    expect(isCCSMTempCwd(undefined)).toBe(false);
+  });
+});
+
+describe('deriveRecentCwds', () => {
+  it('returns [] for empty input', () => {
+    expect(deriveRecentCwds([])).toEqual([]);
+  });
+
+  it('drops "~" placeholder cwds', () => {
+    expect(
+      deriveRecentCwds([
+        { cwd: '~', mtime: 5 },
+        { cwd: '~', mtime: 4 },
+      ])
+    ).toEqual([]);
+  });
+
+  it('ranks by frequency in the recent window, ties broken by recency', () => {
+    const out = deriveRecentCwds([
+      { cwd: '/a', mtime: 10 },
+      { cwd: '/a', mtime: 9 },
+      { cwd: '/a', mtime: 8 },
+      { cwd: '/b', mtime: 7 },
+      { cwd: '/b', mtime: 6 },
+      { cwd: '/c', mtime: 5 },
+    ]);
+    expect(out).toEqual(['/a', '/b', '/c']);
+  });
+
+  it('respects the windowSize bound — older entries do not contribute', () => {
+    // window=2: only the two newest contribute. /a wins 2-0 over /b even
+    // though /b dominates the long tail.
+    const out = deriveRecentCwds(
+      [
+        { cwd: '/a', mtime: 10 },
+        { cwd: '/a', mtime: 9 },
+        { cwd: '/b', mtime: 8 },
+        { cwd: '/b', mtime: 7 },
+        { cwd: '/b', mtime: 6 },
+      ],
+      10,
+      2
+    );
+    expect(out).toEqual(['/a']);
+  });
+
+  it('respects the max bound', () => {
+    const sessions = Array.from({ length: 5 }, (_, i) => ({
+      cwd: `/p${i}`,
+      mtime: 100 - i,
+    }));
+    expect(deriveRecentCwds(sessions, 2)).toEqual(['/p0', '/p1']);
+  });
+});

--- a/tests/components/ImportDialog.test.tsx
+++ b/tests/components/ImportDialog.test.tsx
@@ -1,0 +1,400 @@
+// UT for src/components/ImportDialog.tsx — covers the multi-step picker UI
+// that wraps electron/import-scanner.ts output. Mocks the store and
+// `window.ccsm.scanImportable` so the file exercises pure dialog state +
+// the importSession action contract.
+//
+// Coverage targets the import-flow data contract:
+//   1. Loading state while scan promise is pending
+//   2. Empty / error scanner result → empty-state copy
+//   3. Toggling rows, toggling whole buckets, select-all / deselect-all
+//   4. Bucket collapse / expand
+//   5. Selecting a row → enables the primary button + updates the count
+//   6. Submit → fans out one importSession() call per picked row, passing
+//      cwd / title / projectDir / resumeSessionId verbatim
+//   7. Submit → routes into focused group when one is selected
+//   8. Submit → creates the "Imported" group when none focused + bucket missing
+//   9. Submit → closes the dialog via onOpenChange(false)
+//  10. Already-known sessions are filtered out before display
+import React from 'react';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, act, within } from '@testing-library/react';
+import { ImportDialog } from '../../src/components/ImportDialog';
+
+// ---- Store mock -----------------------------------------------------------
+// ImportDialog reads via `useStore((s) => s.field)` — we mock the hook to
+// pull from a shared mutable state container so each test can preset
+// fixtures (sessions, groups, focusedGroupId) and then introspect the
+// action calls the component fires.
+
+type ScannableRow = {
+  sessionId: string;
+  cwd: string;
+  title: string;
+  mtime: number;
+  projectDir: string;
+  model: string | null;
+};
+
+type StoreShape = {
+  sessions: Array<{ id: string }>;
+  groups: Array<{ id: string; name: string; kind: 'normal' | 'archive' }>;
+  focusedGroupId: string | null;
+  importSession: ReturnType<typeof vi.fn>;
+  createGroup: ReturnType<typeof vi.fn>;
+  renameGroup: ReturnType<typeof vi.fn>;
+};
+
+const storeState: StoreShape = {
+  sessions: [],
+  groups: [],
+  focusedGroupId: null,
+  importSession: vi.fn(),
+  createGroup: vi.fn(),
+  renameGroup: vi.fn(),
+};
+
+vi.mock('../../src/stores/store', () => ({
+  useStore: <T,>(selector: (s: StoreShape) => T): T => selector(storeState),
+}));
+
+// ---- Bridge mock ----------------------------------------------------------
+function installBridge(scan: () => Promise<ScannableRow[]>) {
+  const api = { scanImportable: vi.fn(scan) };
+  (window as unknown as { ccsm: unknown }).ccsm = api;
+  return api;
+}
+
+function deferredScan(): { promise: Promise<ScannableRow[]>; resolve: (r: ScannableRow[]) => void; reject: (e: unknown) => void } {
+  let resolve!: (r: ScannableRow[]) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<ScannableRow[]>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function row(over: Partial<ScannableRow> = {}): ScannableRow {
+  return {
+    sessionId: over.sessionId ?? 'sid-' + Math.random().toString(36).slice(2, 8),
+    cwd: over.cwd ?? '/Users/foo/proj',
+    title: over.title ?? 'Some title',
+    mtime: over.mtime ?? Date.now(),
+    projectDir: over.projectDir ?? '-Users-foo-proj',
+    model: over.model ?? null,
+  };
+}
+
+beforeEach(() => {
+  storeState.sessions = [];
+  storeState.groups = [];
+  storeState.focusedGroupId = null;
+  storeState.importSession = vi.fn();
+  storeState.createGroup = vi.fn(() => 'g-created');
+  storeState.renameGroup = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  delete (window as unknown as { ccsm?: unknown }).ccsm;
+});
+
+// ---- Helpers --------------------------------------------------------------
+async function renderOpen(rows: ScannableRow[]) {
+  installBridge(() => Promise.resolve(rows));
+  const onOpenChange = vi.fn();
+  await act(async () => {
+    render(<ImportDialog open onOpenChange={onOpenChange} />);
+    // Flush the scan promise.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { onOpenChange };
+}
+
+describe('<ImportDialog />', () => {
+  it('shows the loading copy while the scan promise is pending', async () => {
+    const d = deferredScan();
+    installBridge(() => d.promise);
+    render(<ImportDialog open onOpenChange={vi.fn()} />);
+    // Synchronous: useEffect kicks off the scan, loading=true is set
+    // before the promise resolves. The mocked-i18n 'en' bundle uses
+    // 'Scanning…' for this key.
+    expect(screen.getByText(/Scanning/i)).toBeInTheDocument();
+
+    await act(async () => {
+      d.resolve([]);
+      await Promise.resolve();
+    });
+  });
+
+  it('shows the empty-state copy when the scanner returns no rows', async () => {
+    await renderOpen([]);
+    expect(screen.getByText(/No importable transcripts/i)).toBeInTheDocument();
+    expect(screen.getByText('~/.claude/projects/')).toBeInTheDocument();
+  });
+
+  it('shows the empty-state copy when the scanner promise rejects', async () => {
+    installBridge(() => Promise.reject(new Error('boom')));
+    await act(async () => {
+      render(<ImportDialog open onOpenChange={vi.fn()} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText(/No importable transcripts/i)).toBeInTheDocument();
+  });
+
+  it('renders one row per scanned session with cwd and title visible', async () => {
+    await renderOpen([
+      row({ sessionId: 's1', title: 'First', cwd: '/work/a' }),
+      row({ sessionId: 's2', title: 'Second', cwd: '/work/b' }),
+    ]);
+    expect(screen.getByText('First')).toBeInTheDocument();
+    expect(screen.getByText('Second')).toBeInTheDocument();
+    expect(screen.getByText(/\/work\/a/)).toBeInTheDocument();
+    expect(screen.getByText(/\/work\/b/)).toBeInTheDocument();
+  });
+
+  it('filters out sessions already known to the store', async () => {
+    storeState.sessions = [{ id: 'already-here' }];
+    await renderOpen([
+      row({ sessionId: 'already-here', title: 'Dup' }),
+      row({ sessionId: 'fresh', title: 'New one' }),
+    ]);
+    expect(screen.queryByText('Dup')).not.toBeInTheDocument();
+    expect(screen.getByText('New one')).toBeInTheDocument();
+  });
+
+  it('Select-all checks every row and the count flips to N', async () => {
+    await renderOpen([
+      row({ sessionId: 's1', title: 'one' }),
+      row({ sessionId: 's2', title: 'two' }),
+      row({ sessionId: 's3', title: 'three' }),
+    ]);
+    expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
+    const selectAll = screen.getByRole('button', { name: /select all/i });
+    fireEvent.click(selectAll);
+    expect(screen.getByText(/3 selected/i)).toBeInTheDocument();
+    // Button flips to deselect all.
+    expect(screen.getByRole('button', { name: /deselect all/i })).toBeInTheDocument();
+  });
+
+  it('Deselect-all clears the selection after a full-select', async () => {
+    await renderOpen([
+      row({ sessionId: 's1', title: 'one' }),
+      row({ sessionId: 's2', title: 'two' }),
+    ]);
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    expect(screen.getByText(/2 selected/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /deselect all/i }));
+    expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
+  });
+
+  it('clicking a row toggles its selection', async () => {
+    await renderOpen([row({ sessionId: 's1', title: 'pick me' })]);
+    const li = screen.getByText('pick me').closest('li')!;
+    fireEvent.click(li);
+    expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+    fireEvent.click(li);
+    expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
+  });
+
+  it('the bucket "select group" button picks every row in that bucket', async () => {
+    // Two rows in the same bucket (Today) -> one bucket button "Select group".
+    await renderOpen([
+      row({ sessionId: 's1', title: 'a' }),
+      row({ sessionId: 's2', title: 'b' }),
+    ]);
+    const btn = screen.getByRole('button', { name: /^select group$/i });
+    fireEvent.click(btn);
+    expect(screen.getByText(/2 selected/i)).toBeInTheDocument();
+    // After full bucket selection the button label flips.
+    expect(screen.getByRole('button', { name: /^deselect group$/i })).toBeInTheDocument();
+  });
+
+  it('collapsing a bucket hides its rows', async () => {
+    await renderOpen([row({ sessionId: 's1', title: 'hide me' })]);
+    expect(screen.getByText('hide me')).toBeInTheDocument();
+    const collapseBtn = screen.getByRole('button', { name: /collapse/i });
+    fireEvent.click(collapseBtn);
+    expect(screen.queryByText('hide me')).not.toBeInTheDocument();
+    // Expand label appears in its place.
+    expect(screen.getByRole('button', { name: /expand/i })).toBeInTheDocument();
+  });
+
+  it('primary action is disabled when nothing is selected', async () => {
+    await renderOpen([row({ sessionId: 's1', title: 'x' })]);
+    const importBtn = screen.getByRole('button', { name: /^Import 0$/ });
+    expect((importBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('submit fans out one importSession call per selected row with the full payload', async () => {
+    const { onOpenChange } = await renderOpen([
+      row({
+        sessionId: 'sid-A',
+        title: 'titleA',
+        cwd: '/work/a',
+        projectDir: '-work-a',
+      }),
+      row({
+        sessionId: 'sid-B',
+        title: 'titleB',
+        cwd: '/work/b',
+        projectDir: '-work-b',
+      }),
+    ]);
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    const importBtn = screen.getByRole('button', { name: /^Import 2$/ });
+    await act(async () => {
+      fireEvent.click(importBtn);
+      await Promise.resolve();
+    });
+    expect(storeState.importSession).toHaveBeenCalledTimes(2);
+    // Each call payload must carry through cwd / title / projectDir /
+    // resumeSessionId verbatim — this is the contract reviewer locks down.
+    const calls = storeState.importSession.mock.calls.map((c) => c[0]);
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'titleA',
+          cwd: '/work/a',
+          projectDir: '-work-a',
+          resumeSessionId: 'sid-A',
+        }),
+        expect.objectContaining({
+          name: 'titleB',
+          cwd: '/work/b',
+          projectDir: '-work-b',
+          resumeSessionId: 'sid-B',
+        }),
+      ])
+    );
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('routes imports into the focused group when one is selected', async () => {
+    storeState.groups = [
+      { id: 'g-focused', name: 'My Group', kind: 'normal' },
+      { id: 'g-other', name: 'Imported', kind: 'normal' },
+    ];
+    storeState.focusedGroupId = 'g-focused';
+    await renderOpen([row({ sessionId: 's1', title: 'x' })]);
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Import 1$/ }));
+      await Promise.resolve();
+    });
+    expect(storeState.importSession).toHaveBeenCalledWith(
+      expect.objectContaining({ groupId: 'g-focused' })
+    );
+    expect(storeState.createGroup).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the existing "Imported" bucket when no group is focused', async () => {
+    storeState.groups = [
+      { id: 'g-bucket', name: 'Imported', kind: 'normal' },
+      { id: 'g-other', name: 'Other', kind: 'normal' },
+    ];
+    storeState.focusedGroupId = null;
+    await renderOpen([row({ sessionId: 's1', title: 'x' })]);
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Import 1$/ }));
+      await Promise.resolve();
+    });
+    expect(storeState.importSession).toHaveBeenCalledWith(
+      expect.objectContaining({ groupId: 'g-bucket' })
+    );
+    expect(storeState.createGroup).not.toHaveBeenCalled();
+  });
+
+  it('creates an "Imported" group when none exists and nothing is focused', async () => {
+    storeState.groups = []; // no Imported bucket, no focus
+    storeState.focusedGroupId = null;
+    storeState.createGroup = vi.fn(() => 'g-newly-made');
+    await renderOpen([row({ sessionId: 's1', title: 'x' })]);
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Import 1$/ }));
+      await Promise.resolve();
+    });
+    expect(storeState.createGroup).toHaveBeenCalledWith('Imported');
+    expect(storeState.importSession).toHaveBeenCalledWith(
+      expect.objectContaining({ groupId: 'g-newly-made' })
+    );
+  });
+
+  it('ignores a focused archive group (only normal groups receive imports)', async () => {
+    storeState.groups = [
+      { id: 'g-arch', name: 'Old', kind: 'archive' },
+      { id: 'g-bucket', name: 'Imported', kind: 'normal' },
+    ];
+    storeState.focusedGroupId = 'g-arch';
+    await renderOpen([row({ sessionId: 's1', title: 'x' })]);
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Import 1$/ }));
+      await Promise.resolve();
+    });
+    expect(storeState.importSession).toHaveBeenCalledWith(
+      expect.objectContaining({ groupId: 'g-bucket' })
+    );
+  });
+
+  it('submit is a no-op when window.ccsm is missing', async () => {
+    // Render with a bridge so we get past loading, then yank it.
+    await renderOpen([row({ sessionId: 's1', title: 'x' })]);
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    delete (window as unknown as { ccsm?: unknown }).ccsm;
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Import 1$/ }));
+      await Promise.resolve();
+    });
+    expect(storeState.importSession).not.toHaveBeenCalled();
+  });
+
+  it('open=false does not trigger a scan', async () => {
+    const api = installBridge(() => Promise.resolve([]));
+    render(<ImportDialog open={false} onOpenChange={vi.fn()} />);
+    expect(api.scanImportable).not.toHaveBeenCalled();
+  });
+
+  it('re-opening (open false → true) clears stale selection and re-scans', async () => {
+    const rows = [row({ sessionId: 's1', title: 'first' })];
+    const api = installBridge(() => Promise.resolve(rows));
+    function Harness() {
+      const [open, setOpen] = React.useState(true);
+      return (
+        <>
+          <button data-testid="reopen" onClick={() => setOpen((v) => !v)}>x</button>
+          <ImportDialog open={open} onOpenChange={setOpen} />
+        </>
+      );
+    }
+    await act(async () => {
+      render(<Harness />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(api.scanImportable).toHaveBeenCalledTimes(1);
+    // Select everything, then close + reopen.
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reopen')); // close
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reopen')); // reopen
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(api.scanImportable).toHaveBeenCalledTimes(2);
+    // Selection reset.
+    expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
+  });
+});
+
+// `within` is unused above but pulled in as an extension point — explicit
+// import keeps the lint rule happy if a future test needs scoped queries.
+void within;


### PR DESCRIPTION
## Summary

Test-coverage batch 4 — pairs `src/components/ImportDialog.tsx` (was 28% lines / 9% branches) with `electron/import-scanner.ts` (was 53%). Dialog input is scanner output, so testing the two together locks down the cross-process data contract instead of letting each side drift behind ad-hoc mocks.

No source-file changes.

## Coverage delta

| File | Before (lines / branches) | After (lines / branches) |
|---|---|---|
| `src/components/ImportDialog.tsx` | 28% / 9% | 97.56% / 88.67% |
| `electron/import-scanner.ts` | 53% / — | 96.81% (stmts) / 89.94% |

## Scanner cases (41 tests, `electron/__tests__/import-scanner.test.ts`)

Backed by an on-disk fixture tree under a per-test tmp dir + `CLAUDE_CONFIG_DIR` override (real `fs.promises.readdir` / `createReadStream` paths exercised, not mocked):

1. missing `~/.claude/projects` → `[]`, no throw
2. malformed JSONL lines skipped, valid frames continue parsing
3. empty / metadata-less / sidechain (`isSidechain: true`) / `parentUuid` transcripts dropped
4. mtime-desc ordering across multiple project directories
5. `ccsm-*` / `agentory-*` temp-dir noise filter (incl. macOS `/var/folders/`, Windows `AppData\Local\Temp`, legacy `/tmp` aliases)
6. title fallback chain: `aiTitle` > `firstUserText` > `(untitled session)`
7. `<command-…>` wrapped user lines never become titles
8. runtime `CLAUDE_CONFIG_DIR` mutation honored between calls (#812 regression)
9. `parseHead` + `isSidechainFrame` + `isCCSMTempCwd` + `deriveRecentCwds` units (frequency-then-recency ranking, `~` placeholder skip, `windowSize` / `max` bounds)

## Dialog cases (19 tests, `tests/components/ImportDialog.test.tsx`)

Mocks `useStore` (selector form) + `window.ccsm.scanImportable` so the component runs against the same payload shape the scanner emits:

1. loading copy while scan promise is pending
2. empty state when scanner returns `[]`
3. empty state when scanner rejects
4. already-known sessions filtered out before display
5. row/bucket/select-all/deselect toggles + collapse/expand
6. primary action disabled while nothing selected
7. submit fans out one `importSession()` per selected row carrying `cwd` / `title` / `projectDir` / `resumeSessionId` verbatim (the contract reviewer locks down)
8. focused-group routing → uses focused group id
9. no focus + existing `Imported` group → reuses bucket, no `createGroup`
10. no focus + no bucket → `createGroup('Imported')` + uses new id
11. archive-kind focused group ignored, falls back to `Imported`
12. missing `window.ccsm` makes submit a no-op
13. `open=false` skips scan; close→reopen clears stale selection + re-scans

## Test plan

- [x] `npm run typecheck` clean
- [x] New scanner suite: 41/41 pass
- [x] New dialog suite: 19/19 pass
- [x] Full vitest suite: all pre-existing pass; the 21 failures (`tests/electron-load-smoke.test.ts` + `electron/__tests__/db-hardening.test.ts`) are pre-existing on `origin/working` (better-sqlite3 native module / missing build) and unrelated to this PR
- [x] Coverage thresholds: both target files now well over the 60% / 50% project thresholds