### PR TITLE
test(store/db): cover hydrate + sqlite recovery paths (batch 5)

### DIFF
--- a/electron/__tests__/db.test.ts
+++ b/electron/__tests__/db.test.ts
@@ -1,8 +1,26 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
 import Database from 'better-sqlite3';
+
+// Wrap fs so the corruption-recovery test can pin that `electron/db.ts`
+// actually calls `unlinkSync` on the `-wal` / `-shm` sidecar paths.
+//
+// `vi.spyOn(fs, 'unlinkSync')` fails — the ESM namespace is frozen. The
+// `Module._cache` hack doesn't work either, because Vitest runs modules
+// inside its own loader (no shared CJS cache). The robust path is
+// `vi.mock('fs', …)` with `importActual`: every importer (test + production)
+// gets the same wrapper, which by default delegates to the real impl so
+// other tests' `mkdtempSync` / `writeFileSync` / etc. keep working. Tests
+// that need to assert the call shape override the wrapper.
+const unlinkSpy = vi.hoisted(() => ({ fn: undefined as unknown as ReturnType<typeof vi.fn> }));
+vi.mock('fs', async () => {
+  const actual = (await vi.importActual('fs')) as typeof import('fs');
+  const wrapped = vi.fn(actual.unlinkSync);
+  unlinkSpy.fn = wrapped;
+  return { ...actual, default: actual, unlinkSync: wrapped };
+});
 
 // `initDb` asks electron for the userData dir. Point it at a per-test tmp dir
 // so real app data isn't touched and each test gets a fresh database.
@@ -141,36 +159,80 @@ describe('db: legacy-table cleanup', () => {
 });
 
 describe('db: corruption recovery sidecar cleanup', () => {
-  it('removes leftover -wal / -shm sidecar files when backing up a corrupt main db', async () => {
+  it('calls fs.unlinkSync on the -wal and -shm sidecars during corruption recovery', async () => {
     const mod = await freshDb();
     mod.closeDb();
 
     const file = path.join(tmpDir, 'ccsm.db');
     // Garbage main file — quick_check will report corruption inside
-    // ensureHealthyDb.
+    // ensureHealthyDb and trigger the sidecar-cleanup branch.
     fs.writeFileSync(file, Buffer.from('not a sqlite database'));
-    // Stale WAL / SHM left over from a previous crashed process. If they
-    // survived into the rebuilt db, SQLite could try to replay a journal
-    // pointing at the renamed main file.
-    fs.writeFileSync(file + '-wal', Buffer.from('stale-wal-bytes-marker'));
-    fs.writeFileSync(file + '-shm', Buffer.from('stale-shm-bytes-marker'));
+
+    // The vi.mock('fs') wrapper above delegates to the real unlinkSync by
+    // default (vi.fn(actual.unlinkSync)). Just clear the call log before
+    // initDb so we only capture calls made during corruption recovery.
+    unlinkSpy.fn.mockClear();
 
     const err = vi.spyOn(console, 'error').mockImplementation(() => {});
-    expect(() => mod.initDb()).not.toThrow();
-    err.mockRestore();
+    try {
+      expect(() => mod.initDb()).not.toThrow();
+    } finally {
+      err.mockRestore();
+    }
 
-    // Assert the stale bytes are no longer present on disk — the rebuilt
-    // db's own WAL/SHM may exist after WAL-mode init, but they won't carry
-    // our stale marker text.
-    if (fs.existsSync(file + '-wal')) {
-      const walBytes = fs.readFileSync(file + '-wal');
-      expect(walBytes.includes(Buffer.from('stale-wal-bytes-marker'))).toBe(false);
-    }
-    if (fs.existsSync(file + '-shm')) {
-      const shmBytes = fs.readFileSync(file + '-shm');
-      expect(shmBytes.includes(Buffer.from('stale-shm-bytes-marker'))).toBe(false);
-    }
+    const paths = unlinkSpy.fn.mock.calls.map((c) => String(c[0]));
+    // Pinning the syscall, not the on-disk after-state. Reverse-verifies
+    // against deletion of the `for (const ext of ['-wal','-shm'])` cleanup
+    // loop in electron/db.ts.
+    expect(paths).toContain(file + '-wal');
+    expect(paths).toContain(file + '-shm');
   });
+
+  it('swallows ENOENT from sidecar unlinkSync (sidecars may not exist)', async () => {
+    // Common case: corrupt main file with no leftover sidecars. The unlink
+    // loop must tolerate ENOENT silently — otherwise corruption recovery
+    // would crash on the most common shape of the bug it's supposed to fix.
+    const mod = await freshDb();
+    mod.closeDb();
+
+    const file = path.join(tmpDir, 'ccsm.db');
+    fs.writeFileSync(file, Buffer.from('not a sqlite database'));
+
+    // Override the wrapper to throw ENOENT for sidecar paths; let other
+    // unlink calls (e.g. the unlink fallback in the backup-rename branch)
+    // proceed via the real implementation.
+    const realFs = (await vi.importActual('fs')) as typeof import('fs');
+    unlinkSpy.fn.mockImplementation((p: fs.PathLike) => {
+      const s = String(p);
+      if (s.endsWith('-wal') || s.endsWith('-shm')) {
+        const e = new Error('ENOENT') as NodeJS.ErrnoException;
+        e.code = 'ENOENT';
+        throw e;
+      }
+      return realFs.unlinkSync(p);
+    });
+
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => mod.initDb()).not.toThrow();
+    } finally {
+      err.mockRestore();
+    }
+
+    const attempted = unlinkSpy.fn.mock.calls.map((c) => String(c[0]));
+    expect(attempted).toContain(file + '-wal');
+    expect(attempted).toContain(file + '-shm');
+  });
+});
+
+afterEach(async () => {
+  // Restore the default delegate-to-real-fs behaviour after any test that
+  // overrode it via mockImplementation. mockReset would clear the default,
+  // breaking the first test in this describe; mockClear keeps the impl but
+  // wipes the call log.
+  const realFs = (await vi.importActual('fs')) as typeof import('fs');
+  unlinkSpy.fn.mockImplementation(realFs.unlinkSync);
+  unlinkSpy.fn.mockClear();
 });
 
 describe('db: __setDbForTests injection', () => {

--- a/electron/__tests__/db.test.ts
+++ b/electron/__tests__/db.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
+import Database from 'better-sqlite3';
 
 // `initDb` asks electron for the userData dir. Point it at a per-test tmp dir
 // so real app data isn't touched and each test gets a fresh database.
@@ -24,15 +25,208 @@ beforeEach(async () => {
   await freshDb();
 });
 
-describe('db: surface', () => {
-  // Both the `messages` table (PR-H, replaced by JSONL loader) and the
-  // `claudeBinPath` helpers (PR-I, the wizard that wrote them is gone)
-  // were deleted, taking their bespoke test suites with them. The
-  // remaining `loadState` / `saveState` + integrity-check + schema
-  // versioning are exercised by `db-hardening.test.ts`. We keep a
-  // placeholder here so the test runner still discovers the file and
-  // future db features have an obvious place to land.
-  it('placeholder', () => {
-    expect(true).toBe(true);
+// Complements `db-hardening.test.ts` (which covers corruption recovery, fresh
+// user_version stamp, prepared-statement cache reuse, db:save validator, and
+// preload re-throw). The tests below pick up the remaining branches: load
+// misses, upsert semantics, close+reopen, schema downgrade warning, legacy-
+// table drop, WAL/SHM sidecar cleanup, getDb passthrough, and the
+// `__setDbForTests` injection seam.
+
+describe('db: loadState / saveState round-trips', () => {
+  it('loadState returns null for an unknown key on a fresh db', async () => {
+    const { initDb, loadState } = await freshDb();
+    initDb();
+    expect(loadState('never-written')).toBeNull();
+  });
+
+  it('saveState upserts: second write replaces the value rather than colliding on PRIMARY KEY', async () => {
+    const { initDb, saveState, loadState } = await freshDb();
+    initDb();
+    saveState('k', 'v1');
+    saveState('k', 'v2');
+    saveState('k', 'v3');
+    expect(loadState('k')).toBe('v3');
+  });
+
+  it('preserves data across closeDb() + initDb() reopen of the same file', async () => {
+    const mod = await freshDb();
+    mod.initDb();
+    mod.saveState('persisted', 'hello');
+    mod.closeDb();
+    // The on-disk file under tmpDir is unchanged; reopening yields the same
+    // app_state row.
+    mod.initDb();
+    expect(mod.loadState('persisted')).toBe('hello');
+  });
+
+  it('initDb is idempotent — repeated calls return the same handle', async () => {
+    const { initDb } = await freshDb();
+    const h1 = initDb();
+    const h2 = initDb();
+    expect(h1).toBe(h2);
+  });
+
+  it('getDb returns the same instance as initDb()', async () => {
+    const { initDb, getDb } = await freshDb();
+    const a = initDb();
+    const b = getDb();
+    expect(a).toBe(b);
+  });
+});
+
+describe('db: schema versioning branches', () => {
+  it('logs a warning and proceeds when on-disk user_version > app SCHEMA_VERSION (downgrade)', async () => {
+    const mod = await freshDb();
+    // Pre-seed the canonical db file with a future-version user_version stamp.
+    const file = path.join(tmpDir, 'ccsm.db');
+    const seed = new Database(file);
+    seed.pragma('user_version = 99');
+    seed.close();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handle = mod.initDb();
+    // Boot must not refuse — we proceed and log a breadcrumb.
+    expect(handle).toBeTruthy();
+    expect(warn).toHaveBeenCalled();
+    const msg = warn.mock.calls[0]?.[0] ?? '';
+    expect(String(msg)).toMatch(/newer than app/);
+    warn.mockRestore();
+  });
+
+  it('keeps an existing matching user_version untouched (no migrate, no warn)', async () => {
+    const mod = await freshDb();
+    const file = path.join(tmpDir, 'ccsm.db');
+    const seed = new Database(file);
+    seed.pragma('user_version = 1'); // matches SCHEMA_VERSION
+    seed.close();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handle = mod.initDb();
+    const v = handle.pragma('user_version', { simple: true }) as number;
+    expect(v).toBe(1);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('db: legacy-table cleanup', () => {
+  it('drops endpoints / endpoint_models / messages tables on init when present', async () => {
+    const mod = await freshDb();
+    // Pre-seed a db with the legacy tables AND content. initDb() must drop
+    // them silently — they're tables the current app no longer reads.
+    const file = path.join(tmpDir, 'ccsm.db');
+    const seed = new Database(file);
+    seed.exec(`
+      CREATE TABLE endpoints (id INTEGER PRIMARY KEY, name TEXT);
+      CREATE TABLE endpoint_models (id INTEGER PRIMARY KEY, endpoint_id INTEGER);
+      CREATE TABLE messages (id INTEGER PRIMARY KEY, body TEXT);
+      INSERT INTO endpoints (name) VALUES ('legacy');
+      INSERT INTO messages (body) VALUES ('old message');
+    `);
+    seed.close();
+
+    const handle = mod.initDb();
+    const remaining = handle
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('endpoints','endpoint_models','messages')"
+      )
+      .all() as { name: string }[];
+    expect(remaining).toEqual([]);
+    // The app_state table created by SCHEMA_SQL must still be there.
+    const appState = handle
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='app_state'")
+      .all();
+    expect(appState.length).toBe(1);
+  });
+});
+
+describe('db: corruption recovery sidecar cleanup', () => {
+  it('removes leftover -wal / -shm sidecar files when backing up a corrupt main db', async () => {
+    const mod = await freshDb();
+    mod.closeDb();
+
+    const file = path.join(tmpDir, 'ccsm.db');
+    // Garbage main file — quick_check will report corruption inside
+    // ensureHealthyDb.
+    fs.writeFileSync(file, Buffer.from('not a sqlite database'));
+    // Stale WAL / SHM left over from a previous crashed process. If they
+    // survived into the rebuilt db, SQLite could try to replay a journal
+    // pointing at the renamed main file.
+    fs.writeFileSync(file + '-wal', Buffer.from('stale-wal-bytes-marker'));
+    fs.writeFileSync(file + '-shm', Buffer.from('stale-shm-bytes-marker'));
+
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => mod.initDb()).not.toThrow();
+    err.mockRestore();
+
+    // Assert the stale bytes are no longer present on disk — the rebuilt
+    // db's own WAL/SHM may exist after WAL-mode init, but they won't carry
+    // our stale marker text.
+    if (fs.existsSync(file + '-wal')) {
+      const walBytes = fs.readFileSync(file + '-wal');
+      expect(walBytes.includes(Buffer.from('stale-wal-bytes-marker'))).toBe(false);
+    }
+    if (fs.existsSync(file + '-shm')) {
+      const shmBytes = fs.readFileSync(file + '-shm');
+      expect(shmBytes.includes(Buffer.from('stale-shm-bytes-marker'))).toBe(false);
+    }
+  });
+});
+
+describe('db: __setDbForTests injection', () => {
+  it('swaps in an in-memory handle and re-runs the schema bootstrap', async () => {
+    const mod = await freshDb();
+    const mem = new Database(':memory:');
+    mod.__setDbForTests(mem);
+
+    // app_state must be created by __setDbForTests's SCHEMA_SQL execution.
+    const row = mem
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='app_state'")
+      .get();
+    expect(row).toBeTruthy();
+
+    // saveState / loadState route through the injected handle.
+    mod.saveState('mem-key', 'mem-val');
+    expect(mod.loadState('mem-key')).toBe('mem-val');
+
+    // Resetting to null releases the override — next init opens a real file.
+    mod.__setDbForTests(null);
+    const real = mod.initDb();
+    expect(real).not.toBe(mem);
+    // Persistent file is empty — the in-memory write didn't leak across.
+    expect(mod.loadState('mem-key')).toBeNull();
+  });
+
+  it('resets the prepared-statement cache on injection so the new handle compiles its own', async () => {
+    const mod = await freshDb();
+    // Warm the cache against the real db.
+    mod.initDb();
+    mod.saveState('warm', 'a');
+    expect(mod.loadState('warm')).toBe('a');
+
+    // Swap to a fresh in-memory db. If the cache wasn't reset, the next
+    // saveState() would call .run() on a Statement bound to the now-closed
+    // file handle and throw.
+    mod.closeDb();
+    const mem = new Database(':memory:');
+    mod.__setDbForTests(mem);
+    expect(() => mod.saveState('warm', 'b')).not.toThrow();
+    expect(mod.loadState('warm')).toBe('b');
+  });
+});
+
+describe('db: closeDb hygiene', () => {
+  it('closeDb is safe to call when db was never opened', async () => {
+    const mod = await freshDb();
+    mod.closeDb();
+    expect(() => mod.closeDb()).not.toThrow();
+  });
+
+  it('forces a re-init on the next initDb call after close', async () => {
+    const mod = await freshDb();
+    const a = mod.initDb();
+    mod.closeDb();
+    const b = mod.initDb();
+    expect(a).not.toBe(b);
   });
 });

--- a/tests/stores/store.test.ts
+++ b/tests/stores/store.test.ts
@@ -1,0 +1,336 @@
+// Tests for `hydrateStore()` in src/stores/store.ts.
+//
+// The module wires up a one-shot boot sequence (drafts + main snapshot +
+// scrollback + deferred IPCs + persist subscriber). It owns a
+// module-singleton `hydrated` flag, so each test path re-imports the module
+// via `vi.resetModules()` to get a clean run. Where `hydrateStore` touches
+// `loadPersisted` / `hydrateDrafts` / `schedulePersist`, we mock those
+// modules so we can drive the persisted shape from the test (rather than
+// stubbing real IDB / IPC plumbing).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { PersistedState } from '../../src/stores/persist';
+
+type CcsmShape = {
+  loadState?: ReturnType<typeof vi.fn>;
+  saveState?: ReturnType<typeof vi.fn>;
+  userHome?: ReturnType<typeof vi.fn>;
+  defaultModel?: ReturnType<typeof vi.fn>;
+  pathsExist?: ReturnType<typeof vi.fn>;
+};
+
+function installCcsm(overrides: CcsmShape = {}): CcsmShape {
+  const ccsm: CcsmShape = {
+    loadState: overrides.loadState ?? vi.fn(async () => null),
+    saveState: overrides.saveState ?? vi.fn(async () => undefined),
+    userHome: overrides.userHome ?? vi.fn(async () => '/home/tester'),
+    defaultModel: overrides.defaultModel ?? vi.fn(async () => 'claude-3-5-sonnet'),
+    pathsExist: overrides.pathsExist ?? vi.fn(async (paths: string[]) =>
+      Object.fromEntries(paths.map((p) => [p, true]))
+    ),
+  };
+  (window as unknown as { ccsm: CcsmShape }).ccsm = ccsm;
+  return ccsm;
+}
+
+function clearWindowExtras() {
+  delete (window as unknown as { ccsm?: unknown }).ccsm;
+  delete (window as unknown as { __ccsmHydrationTrace?: unknown }).__ccsmHydrationTrace;
+  delete (window as unknown as { __ccsmDrafts?: unknown }).__ccsmDrafts;
+}
+
+// Re-import store + persist + drafts after a resetModules so the
+// module-level singleton state (`hydrated`, `cache`, subscribers) starts
+// clean. Returns the freshly-loaded module bundle.
+async function freshStore() {
+  vi.resetModules();
+  const persist = await import('../../src/stores/persist');
+  const drafts = await import('../../src/stores/drafts');
+  const store = await import('../../src/stores/store');
+  return { persist, drafts, store };
+}
+
+beforeEach(() => {
+  clearWindowExtras();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  clearWindowExtras();
+});
+
+describe('hydrateStore: persisted snapshot load', () => {
+  it('starts hydrated=false and flips to true after hydrateStore resolves', async () => {
+    installCcsm();
+    const { store } = await freshStore();
+    expect(store.useStore.getState().hydrated).toBe(false);
+    await store.hydrateStore();
+    expect(store.useStore.getState().hydrated).toBe(true);
+  });
+
+  it('applies persisted sessions/groups/theme/font from the main snapshot', async () => {
+    const snap: PersistedState = {
+      version: 1,
+      sessions: [
+        // Just enough to satisfy `sessions.some(s => s.id === activeId)`.
+        // The slice doesn't reach into Session internals during hydrate.
+        { id: 's-1', name: 'one', cwd: '/x', model: 'claude-3-5-sonnet' } as unknown as PersistedState['sessions'][number],
+        { id: 's-2', name: 'two', cwd: '/y', model: 'claude-3-5-sonnet' } as unknown as PersistedState['sessions'][number],
+      ],
+      groups: [],
+      activeId: 's-2',
+      sidebarWidth: 320,
+      theme: 'dark',
+      fontSize: 'lg',
+      fontSizePx: 16,
+    };
+    installCcsm({
+      loadState: vi.fn(async (key: string) => {
+        if (key === 'main') return JSON.stringify(snap);
+        return null;
+      }),
+    });
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    const s = store.useStore.getState();
+    expect(s.sessions.map((x) => x.id)).toEqual(['s-1', 's-2']);
+    expect(s.activeId).toBe('s-2');
+    expect(s.theme).toBe('dark');
+    expect(s.fontSizePx).toBe(16);
+    expect(s.sidebarWidth).toBe(320);
+    expect(s.hydrated).toBe(true);
+  });
+
+  it('falls back to first session id when persisted activeId no longer exists', async () => {
+    const snap: PersistedState = {
+      version: 1,
+      sessions: [
+        { id: 's-1', name: 'one', cwd: '/x', model: 'm' } as unknown as PersistedState['sessions'][number],
+      ],
+      groups: [],
+      // activeId points to a session that's been deleted between runs.
+      activeId: 's-deleted',
+    };
+    installCcsm({
+      loadState: vi.fn(async (key: string) =>
+        key === 'main' ? JSON.stringify(snap) : null
+      ),
+    });
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    expect(store.useStore.getState().activeId).toBe('s-1');
+  });
+
+  it('returns gracefully when no persisted snapshot exists (fresh install)', async () => {
+    installCcsm();
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    const s = store.useStore.getState();
+    expect(s.hydrated).toBe(true);
+    expect(s.sessions).toEqual([]);
+    // Defaults from appearanceSlice survive untouched.
+    expect(s.theme).toBe('system');
+  });
+
+  it('is idempotent — calling twice does not re-apply persisted state', async () => {
+    const loadState = vi.fn(async () => null);
+    installCcsm({ loadState });
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    const callsAfterFirst = loadState.mock.calls.length;
+    await store.hydrateStore();
+    expect(loadState.mock.calls.length).toBe(callsAfterFirst);
+  });
+});
+
+describe('hydrateStore: scrollback key', () => {
+  it('applies a persisted scrollback line cap when present', async () => {
+    installCcsm({
+      loadState: vi.fn(async (key: string) => {
+        if (key === 'scrollbackLines') return '4096';
+        return null;
+      }),
+    });
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    expect(store.useStore.getState().scrollbackLines).toBe(4096);
+  });
+
+  it('keeps the slice default when scrollback load throws', async () => {
+    installCcsm({
+      loadState: vi.fn(async (key: string) => {
+        if (key === 'scrollbackLines') throw new Error('idb gone');
+        return null;
+      }),
+    });
+    const { store } = await freshStore();
+    await expect(store.hydrateStore()).resolves.toBeUndefined();
+    // Default from createAppearanceSlice — never overwritten on load failure.
+    expect(store.useStore.getState().scrollbackLines).toBe(1500);
+  });
+});
+
+describe('hydrateStore: drafts integration', () => {
+  it('awaits hydrateDrafts before flipping hydrated', async () => {
+    // Resolve order: drafts load (loadState('drafts')) must complete before
+    // hydrated flips. We assert ordering by tracking the moment each fires.
+    const order: string[] = [];
+    installCcsm({
+      loadState: vi.fn(async (key: string) => {
+        order.push(`load:${key}`);
+        return null;
+      }),
+    });
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    order.push('done');
+    // loadState('drafts') is called from hydrateDrafts() which runs first,
+    // then loadState('main') from loadPersisted(), then loadState('scrollbackLines').
+    expect(order[0]).toBe('load:drafts');
+    expect(order).toContain('load:main');
+    expect(order).toContain('load:scrollbackLines');
+    expect(order[order.length - 1]).toBe('done');
+  });
+
+  it('hydrate continues when a corrupt drafts blob is present', async () => {
+    installCcsm({
+      loadState: vi.fn(async (key: string) => {
+        if (key === 'drafts') return '{not json';
+        return null;
+      }),
+    });
+    const { store } = await freshStore();
+    await expect(store.hydrateStore()).resolves.toBeUndefined();
+    expect(store.useStore.getState().hydrated).toBe(true);
+  });
+});
+
+describe('hydrateStore: persist subscriber wiring', () => {
+  it('writes a curated snapshot through saveState when persisted state changes', async () => {
+    const saveState = vi.fn(async () => undefined);
+    installCcsm({ saveState });
+    vi.useFakeTimers();
+    try {
+      const { store } = await freshStore();
+      await store.hydrateStore();
+      // Trigger a mutation on a persisted field. theme is in PERSISTED_KEYS.
+      store.useStore.setState({ theme: 'dark' });
+      // schedulePersist's 250ms debounce + microtask drain.
+      await vi.advanceTimersByTimeAsync(300);
+      expect(saveState).toHaveBeenCalled();
+      const calls = saveState.mock.calls.filter((c) => c[0] === 'main');
+      expect(calls.length).toBeGreaterThan(0);
+      const lastBlob = JSON.parse(calls[calls.length - 1][1] as string);
+      expect(lastBlob).toHaveProperty('version', 1);
+      expect(lastBlob.theme).toBe('dark');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does NOT write when only non-persisted state mutates (early bail)', async () => {
+    const saveState = vi.fn(async () => undefined);
+    installCcsm({ saveState });
+    vi.useFakeTimers();
+    try {
+      const { store } = await freshStore();
+      await store.hydrateStore();
+      // The subscriber unconditionally writes the FIRST snapshot (prevSnap is
+      // null on the first mutation), so drain that baseline write before
+      // asserting the early-bail behaviour on subsequent mutations.
+      store.useStore.setState({ theme: 'light' });
+      await vi.advanceTimersByTimeAsync(300);
+      saveState.mockClear();
+      // `flashStates` is in State but NOT in PERSISTED_KEYS — the
+      // reference-equality comparator over PERSISTED_KEYS should early-bail.
+      store.useStore.setState({ flashStates: { 's-1': true } });
+      await vi.advanceTimersByTimeAsync(300);
+      expect(saveState).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('hydrateStore: deferred boot IPCs', () => {
+  it('seeds userHome + claudeSettingsDefaultModel from main after first paint', async () => {
+    const userHome = vi.fn(async () => '/home/me');
+    const defaultModel = vi.fn(async () => 'claude-haiku');
+    installCcsm({ userHome, defaultModel });
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    // The deferred IPC is fire-and-forget; drain pending promises.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(userHome).toHaveBeenCalled();
+    expect(defaultModel).toHaveBeenCalled();
+    const s = store.useStore.getState();
+    expect(s.userHome).toBe('/home/me');
+    expect(s.claudeSettingsDefaultModel).toBe('claude-haiku');
+  });
+
+  it('tags sessions whose cwd no longer exists via pathsExist', async () => {
+    const snap: PersistedState = {
+      version: 1,
+      sessions: [
+        { id: 's-1', name: 'one', cwd: '/exists', model: 'm' } as unknown as PersistedState['sessions'][number],
+        { id: 's-2', name: 'two', cwd: '/gone', model: 'm' } as unknown as PersistedState['sessions'][number],
+      ],
+      groups: [],
+      activeId: 's-1',
+    };
+    installCcsm({
+      loadState: vi.fn(async (k: string) => (k === 'main' ? JSON.stringify(snap) : null)),
+      pathsExist: vi.fn(async () => ({ '/exists': true, '/gone': false })),
+    });
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    // Drain deferred microtasks.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    const sessions = store.useStore.getState().sessions;
+    const tagged = sessions.find((s) => s.id === 's-2') as { cwdMissing?: boolean };
+    const healthy = sessions.find((s) => s.id === 's-1') as { cwdMissing?: boolean };
+    expect(tagged.cwdMissing).toBe(true);
+    expect(healthy.cwdMissing).toBeUndefined();
+  });
+
+  it('swallows pathsExist errors without blowing up hydrate', async () => {
+    const snap: PersistedState = {
+      version: 1,
+      sessions: [
+        { id: 's-1', name: 'one', cwd: '/x', model: 'm' } as unknown as PersistedState['sessions'][number],
+      ],
+      groups: [],
+      activeId: 's-1',
+    };
+    installCcsm({
+      loadState: vi.fn(async (k: string) => (k === 'main' ? JSON.stringify(snap) : null)),
+      pathsExist: vi.fn(async () => {
+        throw new Error('ipc dropped');
+      }),
+    });
+    const { store } = await freshStore();
+    await expect(store.hydrateStore()).resolves.toBeUndefined();
+    await new Promise((r) => setTimeout(r, 0));
+    // Sessions remain untouched — no cwdMissing tag.
+    const session = store.useStore.getState().sessions[0] as { cwdMissing?: boolean };
+    expect(session.cwdMissing).toBeUndefined();
+  });
+});
+
+describe('hydrateStore: trace bookkeeping', () => {
+  it('writes hydrateStartedAt / hydrateDoneAt onto window.__ccsmHydrationTrace', async () => {
+    installCcsm();
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    const trace = (window as unknown as {
+      __ccsmHydrationTrace?: { hydrateStartedAt?: number; hydrateDoneAt?: number };
+    }).__ccsmHydrationTrace;
+    expect(trace).toBeTruthy();
+    expect(typeof trace?.hydrateStartedAt).toBe('number');
+    expect(typeof trace?.hydrateDoneAt).toBe('number');
+    expect((trace!.hydrateDoneAt as number)).toBeGreaterThanOrEqual(
+      trace!.hydrateStartedAt as number
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Coverage batch 5 — fills the gap on two boot-critical modules manager flagged from coverage triage:

- **src/stores/store.ts**: line% **9 → 95.58**, branch% **0 → 81.81**
- **electron/db.ts**: line% **35 → 92.64**, branch% **10 → 90.00**

No source files touched. Existing `db-hardening.test.ts` placeholder for `db.test.ts` was replaced with real tests (db-hardening covers a separate slice of branches; the two files are complementary).

## What's covered

### `tests/stores/store.test.ts` (new, 15 tests)

`hydrateStore()` boot sequence:
1. `hydrated` flips false → true through the awaited path
2. Persisted snapshot applied: sessions / groups / theme / fontSize / sidebarWidth
3. Fallback when `activeId` no longer matches any session (stale persisted id)
4. Fresh-install path (no main snapshot) — defaults survive
5. Idempotent — second call doesn't re-read IDB
6. `scrollbackLines` key applied when present
7. Scrollback load error leaves slice default intact
8. `hydrateDrafts` ordering — runs before `hydrated` flips
9. Corrupt drafts blob doesn't blow up hydrate
10. Persist subscriber writes a curated snapshot through `saveState` on persisted-field mutation
11. Persist subscriber early-bails on non-persisted (`flashStates`) mutation
12. Deferred `userHome` + `defaultModel` seeding from main IPC
13. `pathsExist` tags vanished cwds with `cwdMissing`
14. `pathsExist` error is swallowed without blocking hydrate
15. `window.__ccsmHydrationTrace` populated with start/done timestamps

Each test uses `vi.resetModules()` + dynamic import to reset the module-level `hydrated` singleton between cases.

### `electron/__tests__/db.test.ts` (extended from placeholder, 13 tests)

- `loadState` miss returns null on a fresh db
- `saveState` upsert: 3x writes of same key keeps last value (no PK conflict)
- close + reopen preserves rows in the file
- `initDb` is idempotent (same handle on repeated calls)
- `getDb` matches `initDb`
- Downgrade: on-disk `user_version > SCHEMA_VERSION` logs warning + proceeds
- Matching `user_version`: no migrate, no warn
- Legacy `endpoints` / `endpoint_models` / `messages` tables dropped on init; `app_state` survives
- Corruption recovery clears stale `-wal` / `-shm` sidecar markers
- `__setDbForTests` injection runs schema bootstrap + reroutes save/load
- `__setDbForTests` resets prepared-statement cache so the new handle compiles its own
- `closeDb` safe on never-opened db
- `closeDb` + next `initDb` returns a fresh handle (no stale singleton)

## Pre-flight note

Manager flagged that `db-hardening.test.ts` was failing with NODE_MODULE_VERSION 145 vs 127 ABI mismatch in worker preflight. Root cause was empty `node_modules/` in the fresh worktree (npm install never ran). After `npm install` + `npm rebuild better-sqlite3`, all db tests pass cleanly.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npx vitest run tests/stores/ tests/drafts.test.ts tests/persist-shape.test.ts electron/__tests__/db.test.ts electron/__tests__/db-hardening.test.ts` — 126/126 pass
- [x] `npx vitest run --coverage` confirms store.ts 95.58% / db.ts 92.64%
- [x] No source files (`src/stores/store.ts`, `electron/db.ts`) modified

Note: the only repo-wide failure on `npm test` is `tests/electron-load-smoke.test.ts` which requires `npm run build` to have produced `dist/electron/*.js` first — unrelated to this PR and pre-existing on `working`.