### PR TITLE
docs(preload): clarify install order is cosmetic, not load-bearing

### DIFF
--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -2,9 +2,11 @@
 // `path.join(__dirname, '..', 'preload', 'index.js')` (resolves to
 // `dist/electron/preload/index.js` post-tsc). Splits into 5 single-concern
 // bridges (#769, SRP wave-2 PR-A) — each bridge owns its own listener
-// sets, IPC channels, and exposed type. The order of `install*` calls is
-// not load-bearing (each bridge is independent), but kept in the original
-// preload.ts order for diff clarity.
+// sets, IPC channels, and exposed type. Call order below is cosmetic
+// (each `install*` is independent and load-safe — just `ipcRenderer.on`
+// registrations + `contextBridge.exposeInMainWorld`), kept in the
+// original preload.ts order for diff clarity. The Sentry import sits at
+// the top by convention, not because the bridges can throw on load.
 
 import '@sentry/electron/preload';
 


### PR DESCRIPTION
Tightens the doc-comment in `electron/preload/index.ts` after PR #1284 reviewer flagged a contradiction: the source said "order is not load-bearing" but a recent PR body claimed Sentry-first was required to capture bridge load-time throws.

Read all 5 `install*Bridge` functions — they only do `ipcRenderer.on` registrations + `contextBridge.exposeInMainWorld`, neither of which can realistically throw at load time. Picked the simpler truth: order is cosmetic, Sentry sits at the top by convention. No test added because there's nothing real to assert.