### PR TITLE
test(lifecycle): restore Module.prototype.require patch in afterAll

### DIFF
--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 import type { App } from 'electron';
 
 // Mock electron — appLifecycle.ts top-level imports `Menu`, which would
@@ -18,7 +18,10 @@ vi.mock('electron', () => {
 // intercepts ESM `import`, NOT Node-native CJS require — and Node's CJS
 // resolver can't find the .ts source on its own. Patch the CJS require
 // to short-circuit any '../i18n' lookup with our deterministic stub.
-// Restored in afterAll-equivalent below if we ever need it.
+// MUST be restored in afterAll: vitest's default per-file isolation hides
+// the leak today, but if anyone flips to `pool: 'threads'` + `isolate: false`
+// an un-restored patch would bleed into sibling test files (e.g. anything
+// that itself does `require('../i18n')`) and surface as mysterious failures.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const Module = require('node:module') as typeof import('node:module');
 const ModuleProto = (Module as unknown as { prototype: { require: (id: string) => unknown } })
@@ -30,6 +33,10 @@ ModuleProto.require = function patchedRequire(this: NodeJS.Module, id: string) {
   }
   return originalRequire.call(this, id);
 };
+
+afterAll(() => {
+  ModuleProto.require = originalRequire;
+});
 
 import { Menu } from 'electron';
 import {


### PR DESCRIPTION
## Summary

`electron/lifecycle/__tests__/appLifecycle.test.ts` monkey-patches `Module.prototype.require` at file top-level to intercept the production CJS dynamic `require('../i18n')` (used in `appLifecycle.ts` to dodge a circular import). Before this PR the patch was never restored.

Today vitest's default per-file isolation hides this — each test file gets its own module graph, so the un-restored patch dies with the worker. But if anyone later flips to `pool: 'threads'` + `isolate: false` (a common perf tweak), the patch would bleed into sibling test files that load via CJS `require`, including the other two production sites at `electron/ipc/systemIpc.ts` and `electron/tray/createTray.ts`, and surface as mysterious "wrong i18n result" failures.

Fix: cache the original `Module.prototype.require` in the top-level const we already had, and restore it in `afterAll`. Five lines.

## Verification

- `npx vitest run electron/lifecycle/__tests__/` — 20 passed
- `npx vitest run electron/lifecycle/__tests__/appLifecycle.test.ts electron/lifecycle/__tests__/singleInstance.test.ts --no-isolate --pool=threads` — 20 passed (the exact configuration the leak would impact)
- `npm run typecheck` — clean
- `npx eslint electron/lifecycle/__tests__/appLifecycle.test.ts` — clean

## Follow-up (not this PR)

`appLifecycle.ts` could take `i18n` as a dep (same pattern as the other `LifecycleDeps` fields), eliminating the need for any CJS-require patch in the test. Larger change — also applies to `systemIpc.ts` and `createTray.ts` — out of scope for this hygiene fix.