### PR TITLE
chore(ci): enforce coverage thresholds in CI (task #43)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,20 +89,17 @@ jobs:
       - name: Test
         run: npm test
 
-      # Tech-debt R6 (Task #802) — coverage roll-out. Run only on Linux to
-      # keep the matrix lean (coverage instrumentation roughly doubles
-      # wall-clock; one OS is enough for the lcov artifact). Threshold
-      # misses do NOT fail CI yet — this is the initial roll-out; we wrap
-      # with `continue-on-error: true` to keep CI green during the bake-in
-      # period. Bump and enforce in a follow-up once we've watched a few
-      # PRs.
+      # Tech-debt R6 (Task #802 / Task #43) — coverage gate. Runs only on
+      # Linux to keep the matrix lean (coverage instrumentation roughly
+      # doubles wall-clock; one OS is enough for the lcov artifact and
+      # the gate). Threshold misses now fail CI — see vitest.config.ts
+      # for the configured floors and PR #(this) for the rationale.
       - name: Coverage
         if: matrix.os == 'ubuntu-latest'
         run: npm run coverage
-        continue-on-error: true
 
       - name: Upload coverage artifact
-        if: matrix.os == 'ubuntu-latest'
+        if: always() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-lcov

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,17 +30,33 @@ export default defineConfig({
         'tests/**',
         'scripts/**',
         'dist/**',
+        // Procedural / bootstrap files (Task #43) — pure wiring with no
+        // branching logic, not meaningfully unit-testable. Covered by e2e
+        // smoke + manual dogfood. Excluding lifts headline `lines` from
+        // ~79% to ~83.6% on the same suite. See PR body for justification.
+        'electron/main.ts',
+        'electron/testHooks.ts',
+        'electron/db-validate.ts',
+        'electron/agent/read-default-model.ts',
+        'electron/branding/icon.ts',
+        'electron/sentry/init.ts',
+        'electron/tray/createTray.ts',
+        'electron/ipc/*Ipc.ts',
+        'electron/notify/badge.ts',
+        'src/index.tsx',
+        'src/components/ScrollToBottomButton.tsx',
       ],
-      // Initial roll-out — start lenient. Adjusted to current actuals
-      // (see PR #802 body for measured numbers). Bump in follow-up tasks
-      // as suites grow. Thresholds are NOT enforced in CI yet — the CI
-      // job runs `npm run coverage` to produce lcov.info as an artifact
-      // but does not fail on threshold misses for this initial roll-out.
+      // Task #43 — gate is now enforced in CI. Thresholds set ~5pp below
+      // measured post-exclusion baseline (lines ~83.6%, statements ~81%,
+      // functions ~81%, branches ~73%) so normal week-to-week churn
+      // doesn't flake the gate, while regressions of >5pp are caught.
+      // Raise these as suites grow; never lower without a written
+      // justification in the PR body.
       thresholds: {
-        lines: 60,
-        functions: 60,
-        branches: 50,
-        statements: 60,
+        lines: 78,
+        functions: 76,
+        branches: 68,
+        statements: 76,
       },
     },
   },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
         // Procedural / bootstrap files (Task #43) — pure wiring with no
         // branching logic, not meaningfully unit-testable. Covered by e2e
         // smoke + manual dogfood. Excluding lifts headline `lines` from
-        // ~79% to ~83.6% on the same suite. See PR body for justification.
+        // ~79% to ~87.1% on the same suite. See PR body for justification.
         'electron/main.ts',
         'electron/testHooks.ts',
         'electron/db-validate.ts',
@@ -41,15 +41,16 @@ export default defineConfig({
         'electron/branding/icon.ts',
         'electron/sentry/init.ts',
         'electron/tray/createTray.ts',
-        'electron/ipc/*Ipc.ts',
+        'electron/ipc/systemIpc.ts',
+        'electron/ipc/windowIpc.ts',
         'electron/notify/badge.ts',
         'src/index.tsx',
         'src/components/ScrollToBottomButton.tsx',
       ],
-      // Task #43 — gate is now enforced in CI. Thresholds set ~5pp below
-      // measured post-exclusion baseline (lines ~83.6%, statements ~81%,
-      // functions ~81%, branches ~73%) so normal week-to-week churn
-      // doesn't flake the gate, while regressions of >5pp are caught.
+      // Task #43 — gate is now enforced in CI. Thresholds set ~8pp below
+      // measured post-exclusion baseline (lines 87.08%, statements 84.60%,
+      // functions 84.52%, branches 76.28%) so normal week-to-week churn
+      // doesn't flake the gate, while regressions of >8pp are caught.
       // Raise these as suites grow; never lower without a written
       // justification in the PR body.
       thresholds: {


### PR DESCRIPTION
## Summary

Wires the coverage gate so vitest threshold misses fail CI, and trims 12 procedural files from the coverage denominator so the gate measures meaningful test surface area.

Closes task #43.

## Baseline (working @ 392d311e, 1597 tests passing post-exclusion)

Pre-exclusion (12 zero-coverage procedural files still counted):
- lines 79.01%, statements 77.17%, functions 77.32%, branches 70.86%

Post-exclusion (this PR):
- lines **87.65%**, statements **85.26%**, functions **85.58%**, branches **77.25%**

## Chosen thresholds (~5-10pp buffer below post-exclusion baseline)

| metric | baseline | threshold |
|---|---|---|
| lines | 87.65% | **78** |
| statements | 85.26% | **76** |
| functions | 85.58% | **76** |
| branches | 77.25% | **68** |

Buffer is intentionally generous on the first enforced roll-out to absorb normal week-to-week churn; raise these as suites mature.

## Excluded files (12) — all 0% by design, not unit-testable

| file | why |
|---|---|
| `electron/main.ts` | electron entry-point wiring; covered by e2e smoke |
| `electron/testHooks.ts` | test-only ipc shims, exercised by e2e harness |
| `electron/db-validate.ts` | one-shot migration/validation procedural script |
| `electron/agent/read-default-model.ts` | fs read + parse, pure i/o glue |
| `electron/branding/icon.ts` | path resolution for packaged assets |
| `electron/sentry/init.ts` | sentry sdk bootstrap; no branching logic |
| `electron/tray/createTray.ts` | electron tray construction; requires real BrowserWindow |
| `electron/ipc/systemIpc.ts` | `ipcMain.handle` wiring (matched by `electron/ipc/*Ipc.ts` glob) |
| `electron/ipc/windowIpc.ts` | `ipcMain.handle` wiring (matched by same glob) |
| `electron/notify/badge.ts` | electron BrowserWindow badge i/o (logic split into tested `badgePixels`/`badgeLabel`/`badgeController`) |
| `src/index.tsx` | react root render entrypoint |
| `src/components/ScrollToBottomButton.tsx` | trivial presentational shim |

Grepped the test tree — none of the listed files are imported by unit tests (only type-only imports of `notify/badge.ts` from `badgeController.test.ts`, which doesn't generate runtime coverage).

## CI wiring

- Removed `continue-on-error: true` from the `Coverage` step in `.github/workflows/ci.yml` (it was wrapped during the initial bake-in per #802).
- Added `if: always()` to the artifact upload so the lcov.info still uploads when the gate fails — needed for triage.
- Vitest exits non-zero on threshold violation by default, so no extra wiring required beyond removing `continue-on-error`.

## Reverse-verify proof (gate fires)

Temporarily set `lines: 99` and reran `npx vitest run --coverage`:

```
ERROR: Coverage for lines (87.65%) does not meet global threshold (99%)
EXITCODE=1
```

Restored to 78 before commit.

## Test plan

- [x] `npx vitest run --coverage` passes locally (1597/1597 tests, 85s)
- [x] Reverse-verify: forcing `lines: 99` exits 1 with explicit threshold error
- [ ] CI green on this PR (the gate exercises itself)

## Out of scope

- No source changes to lift any file's coverage.
- No codecov / badge / pr-comment tooling.