### PR TITLE
feat(terminal): native CLI-style right-click — copy on selection / paste on empty (#41)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -29,7 +29,7 @@ import { app, BrowserWindow, ipcMain, type Tray } from 'electron';
 import { initDb, closeDb } from './db';
 import { buildTrayIcon } from './branding/icon';
 import { initSentry } from './sentry/init';
-import { createWindow as createMainWindowFactory } from './window/createWindow';
+import { createWindow as createMainWindowFactory, installContextMenuSuppressIpc } from './window/createWindow';
 import { createTray, type TrayController } from './tray/createTray';
 
 // safety net — escaped main-proc rejections kill app on Node 20+ default
@@ -223,6 +223,13 @@ app.whenReady().then(() => {
   });
   registerWindowIpc({ ipcMain });
   registerUtilityIpc({ ipcMain });
+
+  // Process-wide IPC for the terminal pane's `onContextMenu` handler to
+  // ask main to skip the native context menu for one upcoming click.
+  // Registered here (alongside the other IPC handlers) rather than in
+  // `createWindow` because the channel is window-agnostic — see
+  // `installContextMenuSuppressIpc` in electron/window/createWindow.ts.
+  installContextMenuSuppressIpc(ipcMain);
 
   installUpdaterIpc();
 

--- a/electron/preload/bridges/__tests__/ccsmShell.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmShell.test.ts
@@ -1,0 +1,62 @@
+// Pins the `window.ccsmShell` preload bridge — single one-shot for
+// renderer-driven native-context-menu suppression (Task #41). The IPC
+// channel name `shell:suppressContextMenuOnce` is a wire contract with
+// `installContextMenuSuppressIpc` in electron/window/createWindow.ts;
+// renaming one side silently breaks the terminal pane's right-click
+// inline copy/paste UX (the native menu races on top).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { exposeSpy, sendSpy } = vi.hoisted(() => ({
+  exposeSpy: vi.fn(),
+  sendSpy: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: exposeSpy },
+  ipcRenderer: {
+    invoke: vi.fn(),
+    send: sendSpy,
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  },
+}));
+
+import { installCcsmShellBridge } from '../ccsmShell';
+
+type AnyApi = Record<string, unknown>;
+
+function lastApi(): AnyApi {
+  const last = exposeSpy.mock.calls[exposeSpy.mock.calls.length - 1];
+  expect(last[0]).toBe('ccsmShell');
+  return last[1] as AnyApi;
+}
+
+describe('ccsmShell preload bridge', () => {
+  beforeEach(() => {
+    exposeSpy.mockClear();
+    sendSpy.mockReset();
+    installCcsmShellBridge();
+  });
+
+  it('exposes a stable key set under "ccsmShell"', () => {
+    const api = lastApi();
+    expect(Object.keys(api).sort()).toEqual(['suppressContextMenuOnce']);
+  });
+
+  it('suppressContextMenuOnce sends one-way IPC on the canonical channel', () => {
+    const api = lastApi();
+    (api.suppressContextMenuOnce as () => void)();
+    expect(sendSpy).toHaveBeenCalledWith('shell:suppressContextMenuOnce');
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('repeated calls send one IPC each (no internal coalescing)', () => {
+    const api = lastApi();
+    (api.suppressContextMenuOnce as () => void)();
+    (api.suppressContextMenuOnce as () => void)();
+    (api.suppressContextMenuOnce as () => void)();
+    // Main side handles coalescing via its deadline; bridge stays dumb.
+    expect(sendSpy).toHaveBeenCalledTimes(3);
+  });
+});

--- a/electron/preload/bridges/__tests__/index.test.ts
+++ b/electron/preload/bridges/__tests__/index.test.ts
@@ -13,6 +13,7 @@ const {
   installSession,
   installNotify,
   installSessionTitles,
+  installShell,
   sentryLoaded,
 } = vi.hoisted(() => ({
   installCore: vi.fn(),
@@ -20,6 +21,7 @@ const {
   installSession: vi.fn(),
   installNotify: vi.fn(),
   installSessionTitles: vi.fn(),
+  installShell: vi.fn(),
   sentryLoaded: vi.fn(),
 }));
 
@@ -38,6 +40,9 @@ vi.mock('../ccsmNotify', () => ({
 vi.mock('../ccsmSessionTitles', () => ({
   installCcsmSessionTitlesBridge: installSessionTitles,
 }));
+vi.mock('../ccsmShell', () => ({
+  installCcsmShellBridge: installShell,
+}));
 
 describe('preload/index entry point', () => {
   it('loads sentry/preload and invokes every install function exactly once', async () => {
@@ -49,5 +54,6 @@ describe('preload/index entry point', () => {
     expect(installSession).toHaveBeenCalledTimes(1);
     expect(installNotify).toHaveBeenCalledTimes(1);
     expect(installSessionTitles).toHaveBeenCalledTimes(1);
+    expect(installShell).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/preload/bridges/ccsmShell.ts
+++ b/electron/preload/bridges/ccsmShell.ts
@@ -1,0 +1,35 @@
+// `window.ccsmShell` — small bridge for renderer-driven shell-level UX
+// gestures that don't fit `ccsm` (catch-all) or `ccsmPty` (terminal data).
+//
+// Currently exposes a single one-shot: `suppressContextMenuOnce()`. The
+// terminal pane calls this from its renderer-side `onContextMenu` handler
+// immediately before its `preventDefault()` returns, so that the
+// main-process `webContents.on('context-menu', ...)` listener (installed
+// per-window by `installContextMenu` in electron/window/createWindow.ts)
+// can step aside and let the renderer handle the click natively
+// (copy-on-selection / paste-on-empty) without a popover.
+//
+// Why a separate bridge: Electron's `webContents.on('context-menu')` fires
+// on every renderer right-click regardless of DOM `preventDefault()`. Without
+// this one-shot, the terminal's renderer-side handler would race the native
+// menu and lose (the OS popup appears on top of any inline action). A
+// per-IPC deadline gives main the signal it cannot get from the DOM.
+
+import { contextBridge, ipcRenderer } from 'electron';
+
+const ccsmShell = {
+  /** Tell main to skip the very next `context-menu` event on this
+   *  WebContents. One-shot — main resets the suppression as soon as the
+   *  next event arrives, OR after a short deadline (~100ms) if no event
+   *  arrives. Call this immediately BEFORE returning from a renderer
+   *  `onContextMenu` handler that handles the click itself. */
+  suppressContextMenuOnce: (): void => {
+    ipcRenderer.send('shell:suppressContextMenuOnce');
+  },
+};
+
+export type CCSMShellAPI = typeof ccsmShell;
+
+export function installCcsmShellBridge(): void {
+  contextBridge.exposeInMainWorld('ccsmShell', ccsmShell);
+}

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -13,15 +13,18 @@ import { installCcsmPtyBridge } from './bridges/ccsmPty';
 import { installCcsmSessionBridge } from './bridges/ccsmSession';
 import { installCcsmNotifyBridge } from './bridges/ccsmNotify';
 import { installCcsmSessionTitlesBridge } from './bridges/ccsmSessionTitles';
+import { installCcsmShellBridge } from './bridges/ccsmShell';
 
 installCcsmCoreBridge();
 installCcsmPtyBridge();
 installCcsmSessionBridge();
 installCcsmNotifyBridge();
 installCcsmSessionTitlesBridge();
+installCcsmShellBridge();
 
 export type { CCSMAPI } from './bridges/ccsmCore';
 export type { CCSMPtyAPI } from './bridges/ccsmPty';
 export type { CCSMSessionAPI, SessionState } from './bridges/ccsmSession';
 export type { CCSMNotifyAPI } from './bridges/ccsmNotify';
 export type { CCSMSessionTitlesAPI } from './bridges/ccsmSessionTitles';
+export type { CCSMShellAPI } from './bridges/ccsmShell';

--- a/electron/window/__tests__/createWindow.test.ts
+++ b/electron/window/__tests__/createWindow.test.ts
@@ -112,10 +112,15 @@ vi.mock('../../branding/icon', () => ({
 
 import {
   installContextMenu,
+  installContextMenuSuppressIpc,
   isAllowedNavigation,
+  isContextMenuSuppressed,
+  recordContextMenuSuppression,
   decideCloseAction,
   createWindow,
   CLOSE_ASK_TIMEOUT_MS,
+  __resetContextMenuSuppressionForTests,
+  __resetSuppressIpcForTests,
   type CreateWindowDeps,
 } from '../createWindow';
 
@@ -153,6 +158,7 @@ function makeFakeWindow() {
 describe('installContextMenu', () => {
   beforeEach(() => {
     popupCalls.length = 0;
+    __resetContextMenuSuppressionForTests();
   });
 
   it('registers a single context-menu listener on the window webContents', () => {
@@ -244,6 +250,173 @@ describe('installContextMenu', () => {
     const items = popupCalls[0].items as Array<Record<string, unknown>>;
     const paste = items.find((i) => i.role === 'paste');
     expect(paste?.enabled).toBe(false);
+  });
+
+  // ─── Task #41: terminal pane's one-shot suppression ──────────────────
+  // The terminal pane handles right-click inline (copy-on-selection /
+  // paste-on-empty, no popover). Electron fires `context-menu` on the
+  // WebContents regardless of renderer `preventDefault()`, so the pane
+  // sends `shell:suppressContextMenuOnce` immediately before its
+  // onContextMenu returns; main records a short deadline and the
+  // listener installed here consults it.
+
+  it('suppresses native menu when within suppression deadline (Task #41)', () => {
+    const fake = makeFakeWindow();
+    installContextMenu(fake.win);
+    recordContextMenuSuppression(Date.now());
+    fake.fire({
+      selectionText: 'something',
+      isEditable: false,
+      editFlags: {
+        canCut: false,
+        canCopy: true,
+        canPaste: false,
+        canSelectAll: true,
+      },
+    });
+    expect(popupCalls).toHaveLength(0);
+  });
+
+  it('the suppression is one-shot: a second right-click gets the menu', () => {
+    const fake = makeFakeWindow();
+    installContextMenu(fake.win);
+    recordContextMenuSuppression(Date.now());
+    // First click suppressed.
+    fake.fire({
+      selectionText: '',
+      isEditable: false,
+      editFlags: { canCut: false, canCopy: false, canPaste: false, canSelectAll: true },
+    });
+    // Second click — no new suppression sent — must produce a popup.
+    fake.fire({
+      selectionText: 'second',
+      isEditable: false,
+      editFlags: { canCut: false, canCopy: true, canPaste: false, canSelectAll: true },
+    });
+    expect(popupCalls).toHaveLength(1);
+  });
+
+  it('an expired suppression deadline does not block the menu', () => {
+    const fake = makeFakeWindow();
+    installContextMenu(fake.win);
+    // Record a suppression "200ms in the past" by mutating Date.now via a
+    // narrow spy — keeps the test independent of vi.useFakeTimers (which
+    // the parent describe does not enable).
+    const realNow = Date.now;
+    const stableNow = realNow();
+    Date.now = () => stableNow - 200;
+    try {
+      recordContextMenuSuppression(Date.now());
+    } finally {
+      Date.now = realNow;
+    }
+    // Now-now is 200ms past the recorded deadline — listener should
+    // proceed to popup as normal.
+    fake.fire({
+      selectionText: 'hello',
+      isEditable: false,
+      editFlags: { canCut: false, canCopy: true, canPaste: false, canSelectAll: true },
+    });
+    expect(popupCalls).toHaveLength(1);
+  });
+});
+
+// ─── Task #41: pure suppression decider + IPC wiring ────────────────────
+// Pure helpers + the IPC registration so the suppression mechanism can be
+// driven without mounting an Electron window. The deadline math is a
+// strict `<` (not `<=`) so a request recorded at T=1000 with a 100ms
+// window suppresses everything up to T=1099 inclusive and allows T=1100.
+
+describe('isContextMenuSuppressed (Task #41)', () => {
+  it('returns true when now is before the deadline', () => {
+    expect(isContextMenuSuppressed(1000, 999)).toBe(true);
+  });
+
+  it('returns false at the deadline boundary', () => {
+    expect(isContextMenuSuppressed(1000, 1000)).toBe(false);
+  });
+
+  it('returns false after the deadline', () => {
+    expect(isContextMenuSuppressed(1000, 1001)).toBe(false);
+  });
+
+  it('returns false for the default uninitialised deadline of 0', () => {
+    expect(isContextMenuSuppressed(0, 12345)).toBe(false);
+  });
+});
+
+describe('recordContextMenuSuppression (Task #41)', () => {
+  beforeEach(() => {
+    __resetContextMenuSuppressionForTests();
+  });
+
+  it('records a deadline 100ms after the supplied now', () => {
+    const deadline = recordContextMenuSuppression(1000);
+    expect(deadline).toBe(1100);
+  });
+
+  it('later calls extend (overwrite) the deadline, never shrink it relative to live now', () => {
+    expect(recordContextMenuSuppression(1000)).toBe(1100);
+    // A second call at T=1050 sets the deadline to 1150. This is the
+    // intended "renew the one-shot" behavior — a fresh request always
+    // pushes the deadline forward.
+    expect(recordContextMenuSuppression(1050)).toBe(1150);
+  });
+});
+
+describe('installContextMenuSuppressIpc (Task #41)', () => {
+  beforeEach(() => {
+    __resetSuppressIpcForTests();
+    __resetContextMenuSuppressionForTests();
+    popupCalls.length = 0;
+  });
+
+  it('registers exactly one listener on shell:suppressContextMenuOnce', () => {
+    const handlers = new Map<string, (...args: unknown[]) => void>();
+    const ipcMain = {
+      on: vi.fn((ch: string, cb: (...args: unknown[]) => void) => {
+        handlers.set(ch, cb);
+      }),
+    } as unknown as import('electron').IpcMain;
+    installContextMenuSuppressIpc(ipcMain);
+    expect(handlers.has('shell:suppressContextMenuOnce')).toBe(true);
+  });
+
+  it('the registered handler arms a suppression that blocks the next menu', () => {
+    const handlers = new Map<string, (...args: unknown[]) => void>();
+    const ipcMain = {
+      on: vi.fn((ch: string, cb: (...args: unknown[]) => void) => {
+        handlers.set(ch, cb);
+      }),
+    } as unknown as import('electron').IpcMain;
+    installContextMenuSuppressIpc(ipcMain);
+    const fake = makeFakeWindow();
+    installContextMenu(fake.win);
+    // No suppression yet — popup fires.
+    fake.fire({
+      selectionText: 'a',
+      isEditable: false,
+      editFlags: { canCut: false, canCopy: true, canPaste: false, canSelectAll: true },
+    });
+    expect(popupCalls).toHaveLength(1);
+    // Renderer asks to suppress; next popup is swallowed.
+    handlers.get('shell:suppressContextMenuOnce')!();
+    fake.fire({
+      selectionText: 'b',
+      isEditable: false,
+      editFlags: { canCut: false, canCopy: true, canPaste: false, canSelectAll: true },
+    });
+    expect(popupCalls).toHaveLength(1);
+  });
+
+  it('is idempotent — repeated installs do not double-register', () => {
+    const handlers: string[] = [];
+    const ipcMain = {
+      on: vi.fn((ch: string) => handlers.push(ch)),
+    } as unknown as import('electron').IpcMain;
+    installContextMenuSuppressIpc(ipcMain);
+    installContextMenuSuppressIpc(ipcMain);
+    expect(handlers.filter((c) => c === 'shell:suppressContextMenuOnce')).toHaveLength(1);
   });
 });
 

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -82,11 +82,86 @@ export function isAllowedNavigation(
   }
 }
 
+// One-shot suppression deadline for the native context menu. The terminal
+// pane fires `shell:suppressContextMenuOnce` from its renderer-side
+// `onContextMenu` handler immediately before calling `preventDefault()`;
+// Electron's `webContents.on('context-menu')` then fires regardless (DOM
+// preventDefault does NOT cancel the main-process event) and the listener
+// installed by `installContextMenu` consults this deadline to decide
+// whether to show the native menu or step aside.
+//
+// Module-scope (process-wide) because:
+//  * the IPC channel is one-way `send`, no per-window routing payload —
+//    keeping it process-wide matches the wire contract;
+//  * ccsm is a single-window app in practice; the BrowserWindow that
+//    fires `context-menu` is always the same one that just sent the
+//    suppress. 100ms is generous enough to absorb IPC latency on slow
+//    machines without suppressing a deliberate right-click ~100ms later.
+const SUPPRESS_CONTEXT_MENU_WINDOW_MS = 100;
+let contextMenuSuppressedUntilMs = 0;
+
+/** Pure decider — extracted for unit test. Returns true iff `nowMs` is
+ *  strictly before `deadlineMs`. */
+export function isContextMenuSuppressed(
+  deadlineMs: number,
+  nowMs: number,
+): boolean {
+  return nowMs < deadlineMs;
+}
+
+/** Record a fresh one-shot suppression starting at `nowMs`. Exported so the
+ *  IPC handler in `installContextMenuSuppressIpc` can be unit-tested
+ *  without reaching into module state. Returns the new deadline ms. */
+export function recordContextMenuSuppression(nowMs: number): number {
+  contextMenuSuppressedUntilMs = nowMs + SUPPRESS_CONTEXT_MENU_WINDOW_MS;
+  return contextMenuSuppressedUntilMs;
+}
+
+/** Test-only — reset suppression deadline so tests start from a clean
+ *  baseline. */
+export function __resetContextMenuSuppressionForTests(): void {
+  contextMenuSuppressedUntilMs = 0;
+}
+
+let suppressIpcRegistered = false;
+
+/** Register the one-shot suppression IPC handler. Idempotent — safe to call
+ *  more than once (subsequent registrations are no-ops). Called from the
+ *  `app.whenReady()` IPC wiring site, NOT from `createWindow`, because the
+ *  channel is process-wide rather than per-window. */
+export function installContextMenuSuppressIpc(ipcMain: IpcMain): void {
+  if (suppressIpcRegistered) return;
+  suppressIpcRegistered = true;
+  ipcMain.on('shell:suppressContextMenuOnce', () => {
+    recordContextMenuSuppression(Date.now());
+  });
+}
+
+/** Test-only — undo `installContextMenuSuppressIpc` so a fresh test can
+ *  re-register the handler against a fresh mock ipcMain. */
+export function __resetSuppressIpcForTests(): void {
+  suppressIpcRegistered = false;
+}
+
 // Right-click context menu for the renderer — Copy/Cut/Paste/Select All,
 // contextually enabled based on selection + editable state. Attached per
 // window in createWindow().
+//
+// The terminal pane handles its own right-click in the renderer (immediate
+// copy-on-selection / paste-on-empty, no popover) and asks main to skip
+// the native menu via `shell:suppressContextMenuOnce` immediately before
+// returning from its onContextMenu handler. Electron fires `context-menu`
+// on the WebContents regardless of DOM `preventDefault`, so the
+// suppression deadline is the only way to inhibit it from main.
 export function installContextMenu(win: BrowserWindow): void {
   win.webContents.on('context-menu', (_e, params) => {
+    if (isContextMenuSuppressed(contextMenuSuppressedUntilMs, Date.now())) {
+      // Consume the one-shot — subsequent right-clicks outside the
+      // terminal pane (which never sends `suppressContextMenuOnce`) get
+      // the native menu as normal.
+      contextMenuSuppressedUntilMs = 0;
+      return;
+    }
     const { selectionText, editFlags, isEditable } = params;
     const hasSelection = !!selectionText && selectionText.trim().length > 0;
     const items: MenuItemConstructorOptions[] = [];

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -1,10 +1,11 @@
-import { useRef } from 'react';
+import { useCallback, useRef, type MouseEvent } from 'react';
 import '@xterm/xterm/css/xterm.css';
 import { useTranslation } from '../i18n/useTranslation';
 import { useXtermSingleton } from '../terminal/useXtermSingleton';
 import { useTerminalResize } from '../terminal/useTerminalResize';
 import { usePtyAttach, type PtyAttachState } from '../terminal/usePtyAttach';
 import { useAtBottom } from '../terminal/useAtBottom';
+import { terminalCopy, terminalPaste } from '../terminal/xtermSingleton';
 import { ScrollToBottomButton } from './ScrollToBottomButton';
 
 // TerminalPane is the host shell for the singleton xterm view. The three
@@ -37,11 +38,34 @@ export function TerminalPane({ sessionId, cwd }: Props) {
   // detection logic (and its tests) stay live for future use.
   const { scrollToBottom } = useAtBottom(sessionId);
 
+  // Native CLI / terminal-emulator right-click behavior. Mirrors Windows
+  // Terminal / gnome-terminal: right-click with selection → copy (+ clear
+  // for visual feedback); right-click with no selection → paste. No
+  // popover, ever. The native context menu installed in
+  // `electron/window/createWindow.ts` would race on top by default —
+  // `ccsmShell.suppressContextMenuOnce()` tells main to skip the next
+  // popup for this WebContents (DOM `preventDefault()` alone does NOT
+  // cancel Electron's main-process `context-menu` event). Optional chain
+  // on the bridge because tests / e2e probes may not install it.
+  const onContextMenu = useCallback((e: MouseEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    try {
+      window.ccsmShell?.suppressContextMenuOnce();
+    } catch {
+      // best-effort — falling through to inline copy/paste still works,
+      // user just sees the native menu race briefly.
+    }
+    const copied = terminalCopy();
+    if (!copied) terminalPaste();
+  }, []);
+
   return (
     <div
       className="relative flex-1 w-full h-full bg-black ring-1 ring-inset ring-white/5"
       data-terminal-host
       data-active-sid={sessionId}
+      onContextMenu={onContextMenu}
     >
       <div ref={hostRef} className="absolute inset-0" />
       <Overlay state={state} onRetry={onRetry} t={t} />

--- a/src/pty.d.ts
+++ b/src/pty.d.ts
@@ -85,6 +85,14 @@ export interface CcsmPtyApi {
 declare global {
   interface Window {
     ccsmPty: CcsmPtyApi;
+    ccsmShell?: {
+      /** Tell main to skip the very next native context-menu popup. Used
+       *  by TerminalPane's `onContextMenu` handler so right-click can
+       *  copy/paste inline without a popover racing on top. See
+       *  `electron/preload/bridges/ccsmShell.ts`. Optional because tests
+       *  / e2e probes may not install the bridge. */
+      suppressContextMenuOnce(): void;
+    };
     __ccsmTerm?: import('@xterm/xterm').Terminal;
   }
 }

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -304,6 +304,9 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
   // Copy/paste keyboard shortcuts (Windows Terminal style):
   //   Ctrl+C  → if selection, copy; else fall through to SIGINT
   //   Ctrl+V  → paste (single canonical path, see above)
+  //   Ctrl+A  → select-all (xterm has no built-in; we wire it here so the
+  //             keyboard offers parity with the previous native context
+  //             menu's "Select All" item)
   //   Ctrl+Shift+C / Ctrl+Shift+V → explicit always-clipboard
   // On macOS the same handler matches Cmd via `metaKey`.
   term.attachCustomKeyEventHandler((ev) => {
@@ -312,7 +315,21 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
     if (!mod || ev.altKey) return true;
     const isC = ev.key === 'C' || ev.key === 'c';
     const isV = ev.key === 'V' || ev.key === 'v';
+    const isA = ev.key === 'A' || ev.key === 'a';
 
+    if (!ev.shiftKey && isA) {
+      // Ctrl/Cmd+A → select-all. xterm has no built-in keybinding for
+      // this, and removing the native right-click "Select All" item (in
+      // favor of native CLI right-click behavior) leaves the user with
+      // no other entry point. Returning `false` keeps xterm from also
+      // translating the keystroke into a 0x01 SOH control byte.
+      try {
+        term?.selectAll();
+      } catch {
+        // ignore — best-effort.
+      }
+      return false;
+    }
     if (!ev.shiftKey && isC) {
       const sel = term?.getSelection();
       if (sel) {
@@ -374,5 +391,60 @@ export function __resetSingletonForTests(): void {
   keyboardPasteHandled = false;
   if (typeof window !== 'undefined') {
     delete window.__ccsmTerm;
+  }
+}
+
+/**
+ * Right-click handlers — called from `TerminalPane`'s `onContextMenu` to
+ * implement native CLI/terminal behavior (Windows Terminal / gnome-terminal
+ * style): right-click with selection copies + clears, right-click without
+ * selection pastes. No popover, ever.
+ *
+ * `terminalCopy` returns `true` iff a selection existed and was copied
+ * (caller uses this to choose between copy and paste branches without
+ * having to re-read `getSelection`). `clearSelection` happens here too so
+ * the user gets visual feedback that the copy landed.
+ *
+ * `terminalPaste` routes through the same canonical paste sink as the
+ * Ctrl+V keydown hook (see `pasteFromClipboard` block above) — sets the
+ * `keyboardPasteHandled` flag so the capture-phase paste listener
+ * suppresses any follow-up native paste event, reads clipboard via
+ * `ccsmPty.clipboard.readText()`, writes via `ccsmPty.input(activeSid)`.
+ *
+ * Both are no-ops when no Terminal exists yet (pane unmounted).
+ */
+export function terminalCopy(): boolean {
+  if (!term) return false;
+  const sel = term.getSelection();
+  if (!sel) return false;
+  try {
+    window.ccsmPty?.clipboard?.writeText(sel);
+  } catch {
+    // ignore — selection still highlights, user can ctrl+c retry.
+  }
+  try {
+    term.clearSelection();
+  } catch {
+    // ignore — visual feedback is best-effort.
+  }
+  return true;
+}
+
+export function terminalPaste(): void {
+  if (!term || !activeSid) return;
+  // Reuse the same handoff flag the keydown handler uses; the capture-phase
+  // paste listener installed in `ensureTerminal` checks it to suppress a
+  // duplicate inject from any browser-dispatched follow-up `paste` event.
+  // `setTimeout(0)` (NOT `queueMicrotask`) — see comment on
+  // `pasteFromClipboard` inside ensureTerminal.
+  keyboardPasteHandled = true;
+  setTimeout(() => {
+    keyboardPasteHandled = false;
+  }, 0);
+  try {
+    const text = window.ccsmPty?.clipboard?.readText();
+    if (text) window.ccsmPty.input(activeSid, text);
+  } catch {
+    // best-effort — clipboard read can fail under permission edge cases.
   }
 }

--- a/tests/components/TerminalPane.test.tsx
+++ b/tests/components/TerminalPane.test.tsx
@@ -1,0 +1,129 @@
+// Task #41: TerminalPane's native CLI/terminal-emulator right-click
+// behavior. Replaces the global native context menu (Cut/Copy/Paste/
+// SelectAll popup installed in electron/window/createWindow.ts) with
+// immediate inline copy-on-selection / paste-on-empty, mirroring Windows
+// Terminal and gnome-terminal. The host div's `onContextMenu`:
+//   1. preventDefault + stopPropagation on the React event
+//   2. sends `ccsmShell.suppressContextMenuOnce()` so main skips the
+//      native popup (DOM preventDefault does NOT cancel Electron's
+//      main-process `context-menu` event — separate one-shot needed)
+//   3. branches on the selection: copy + clear OR paste
+//
+// All four terminal hooks are mocked to no-ops so the pane mounts
+// without instantiating xterm or attaching to a PTY — the test is
+// strictly about the right-click wiring.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+
+const { copySpy, pasteSpy } = vi.hoisted(() => ({
+  copySpy: vi.fn(),
+  pasteSpy: vi.fn(),
+}));
+
+vi.mock('../../src/terminal/useXtermSingleton', () => ({
+  useXtermSingleton: () => undefined,
+}));
+vi.mock('../../src/terminal/useTerminalResize', () => ({
+  useTerminalResize: () => undefined,
+}));
+vi.mock('../../src/terminal/usePtyAttach', () => ({
+  // Return a `ready` state so the pane doesn't render the Attaching /
+  // Error / Exit overlay layers — they're orthogonal to right-click
+  // and rendering them just adds noise.
+  usePtyAttach: () => ({ state: { kind: 'ready' }, onRetry: vi.fn() }),
+}));
+vi.mock('../../src/terminal/useAtBottom', () => ({
+  useAtBottom: () => ({ atBottom: true, scrollToBottom: vi.fn() }),
+}));
+vi.mock('../../src/terminal/xtermSingleton', () => ({
+  terminalCopy: copySpy,
+  terminalPaste: pasteSpy,
+}));
+vi.mock('../../src/i18n/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+// Skip xterm CSS import in jsdom (jsdom doesn't load CSS anyway, but the
+// import resolver still walks the path).
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
+
+import { TerminalPane } from '../../src/components/TerminalPane';
+
+interface MockShell {
+  suppressContextMenuOnce: ReturnType<typeof vi.fn>;
+}
+
+function installShellBridge(): MockShell {
+  const bridge: MockShell = { suppressContextMenuOnce: vi.fn() };
+  (window as unknown as { ccsmShell: MockShell }).ccsmShell = bridge;
+  return bridge;
+}
+
+function fireContextMenuOnHost(container: HTMLElement) {
+  const host = container.querySelector('[data-terminal-host]') as HTMLElement;
+  expect(host).not.toBeNull();
+  // `fireEvent.contextMenu` dispatches a real MouseEvent with the right
+  // type; React's onContextMenu hands the SyntheticEvent through so
+  // preventDefault on the synthetic event reaches the underlying native
+  // event via the React event pool.
+  const result = fireEvent.contextMenu(host);
+  return { host, result };
+}
+
+describe('TerminalPane right-click (Task #41)', () => {
+  beforeEach(() => {
+    copySpy.mockReset();
+    pasteSpy.mockReset();
+    delete (window as unknown as { ccsmShell?: unknown }).ccsmShell;
+  });
+
+  it('copy branch: with selection → terminalCopy, no paste, suppression sent, default prevented', () => {
+    copySpy.mockReturnValue(true);
+    const shell = installShellBridge();
+    const { container } = render(<TerminalPane sessionId="sid-1" cwd="/tmp" />);
+    const host = container.querySelector('[data-terminal-host]') as HTMLElement;
+    // `fireEvent` returns false when the event was preventDefault-ed.
+    const notPrevented = fireEvent.contextMenu(host);
+    expect(notPrevented).toBe(false);
+    expect(copySpy).toHaveBeenCalledTimes(1);
+    expect(pasteSpy).not.toHaveBeenCalled();
+    expect(shell.suppressContextMenuOnce).toHaveBeenCalledTimes(1);
+  });
+
+  it('paste branch: no selection → terminalPaste, suppression sent, default prevented', () => {
+    copySpy.mockReturnValue(false);
+    const shell = installShellBridge();
+    const { container } = render(<TerminalPane sessionId="sid-2" cwd="/tmp" />);
+    const host = container.querySelector('[data-terminal-host]') as HTMLElement;
+    const notPrevented = fireEvent.contextMenu(host);
+    expect(notPrevented).toBe(false);
+    expect(copySpy).toHaveBeenCalledTimes(1);
+    expect(pasteSpy).toHaveBeenCalledTimes(1);
+    expect(shell.suppressContextMenuOnce).toHaveBeenCalledTimes(1);
+  });
+
+  it('survives when ccsmShell bridge is missing (e2e probes / test harnesses)', () => {
+    // Bridge intentionally not installed — the optional-chain in the
+    // handler must keep the copy/paste branching alive.
+    copySpy.mockReturnValue(true);
+    const { container } = render(<TerminalPane sessionId="sid-3" cwd="/tmp" />);
+    const host = container.querySelector('[data-terminal-host]') as HTMLElement;
+    expect(() => fireEvent.contextMenu(host)).not.toThrow();
+    expect(copySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('throwing suppressContextMenuOnce does not block the inline copy/paste', () => {
+    copySpy.mockReturnValue(false);
+    const bridge: MockShell = {
+      suppressContextMenuOnce: vi.fn(() => {
+        throw new Error('IPC unavailable');
+      }),
+    };
+    (window as unknown as { ccsmShell: MockShell }).ccsmShell = bridge;
+    const { container } = render(<TerminalPane sessionId="sid-4" cwd="/tmp" />);
+    const { host } = fireContextMenuOnHost(container);
+    expect(host).toBeTruthy();
+    // Paste still ran despite the IPC throw.
+    expect(pasteSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -4,12 +4,15 @@ import { renderHook } from '@testing-library/react';
 // Mock xterm constructors BEFORE importing the hook so the singleton
 // uses the spies. Use vi.hoisted because vi.mock factories run before
 // any top-level `const`.
-const { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, terminalCtor, webLinksCtor } =
+const { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, getSelectionSpy, clearSelectionSpy, selectAllSpy, terminalCtor, webLinksCtor } =
   vi.hoisted(() => {
     const openSpy = vi.fn();
     const loadAddonSpy = vi.fn();
     const onSelectionChangeSpy = vi.fn();
     const attachCustomKeyEventHandlerSpy = vi.fn();
+    const getSelectionSpy = vi.fn(() => '');
+    const clearSelectionSpy = vi.fn();
+    const selectAllSpy = vi.fn();
     // vitest v3+ requires `function`/`class` (not arrow) for mocks invoked
     // with `new` — otherwise tinyspy throws "is not a constructor".
     const terminalCtor = vi.fn(function () {
@@ -18,6 +21,9 @@ const { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandler
         loadAddon: loadAddonSpy,
         onSelectionChange: onSelectionChangeSpy,
         attachCustomKeyEventHandler: attachCustomKeyEventHandlerSpy,
+        getSelection: getSelectionSpy,
+        clearSelection: clearSelectionSpy,
+        selectAll: selectAllSpy,
         unicode: { activeVersion: '6' },
         _core: { _parent: null },
       };
@@ -25,7 +31,7 @@ const { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandler
     const webLinksCtor = vi.fn(function () {
       return {};
     });
-    return { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, terminalCtor, webLinksCtor };
+    return { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, getSelectionSpy, clearSelectionSpy, selectAllSpy, terminalCtor, webLinksCtor };
   });
 
 vi.mock('@xterm/xterm', () => ({ Terminal: terminalCtor }));
@@ -40,6 +46,8 @@ import {
   __resetSingletonForTests,
   getTerm,
   setActiveSid,
+  terminalCopy,
+  terminalPaste,
 } from '../../src/terminal/xtermSingleton';
 
 describe('useXtermSingleton', () => {
@@ -290,6 +298,116 @@ describe('useXtermSingleton', () => {
       const handler = getKeyHandler();
       handler({ type: 'keydown', key: 'v', ctrlKey: true });
       expect(inputSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // Task #41: right-click handlers + Ctrl+A select-all. The host div's
+  // onContextMenu in TerminalPane calls these directly; we exercise them
+  // standalone to pin contract independent of the React wiring (which
+  // tests/components/TerminalPane.test.tsx covers separately with mocked
+  // singleton). Plus the new Ctrl+A keybinding so the user retains a
+  // select-all path after the native menu's "Select All" item is no
+  // longer shown for the terminal pane.
+  describe('Task #41: terminalCopy / terminalPaste / Ctrl+A', () => {
+    let inputSpy: ReturnType<typeof vi.fn>;
+    let readTextSpy: ReturnType<typeof vi.fn>;
+    let writeTextSpy: ReturnType<typeof vi.fn>;
+    let host: HTMLDivElement;
+
+    beforeEach(() => {
+      inputSpy = vi.fn();
+      readTextSpy = vi.fn().mockReturnValue('pasted-text');
+      writeTextSpy = vi.fn();
+      (window as unknown as { ccsmPty: unknown }).ccsmPty = {
+        input: inputSpy,
+        clipboard: {
+          readText: readTextSpy,
+          writeText: writeTextSpy,
+        },
+      };
+      host = document.createElement('div');
+      document.body.appendChild(host);
+      renderHook(() => useXtermSingleton({ current: host }));
+      setActiveSid('sid-rc');
+      getSelectionSpy.mockReset().mockReturnValue('');
+      clearSelectionSpy.mockReset();
+      selectAllSpy.mockReset();
+    });
+
+    afterEach(() => {
+      document.body.removeChild(host);
+      delete (window as unknown as { ccsmPty?: unknown }).ccsmPty;
+    });
+
+    it('terminalCopy returns true + writes selection + clears it when selection exists', () => {
+      getSelectionSpy.mockReturnValue('selected-text');
+      const copied = terminalCopy();
+      expect(copied).toBe(true);
+      expect(writeTextSpy).toHaveBeenCalledWith('selected-text');
+      expect(clearSelectionSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('terminalCopy returns false + no clipboard write when selection is empty', () => {
+      getSelectionSpy.mockReturnValue('');
+      const copied = terminalCopy();
+      expect(copied).toBe(false);
+      expect(writeTextSpy).not.toHaveBeenCalled();
+      expect(clearSelectionSpy).not.toHaveBeenCalled();
+    });
+
+    it('terminalPaste reads clipboard and routes through ccsmPty.input', () => {
+      terminalPaste();
+      expect(readTextSpy).toHaveBeenCalledTimes(1);
+      expect(inputSpy).toHaveBeenCalledWith('sid-rc', 'pasted-text');
+    });
+
+    it('terminalPaste arms the keyboardPasteHandled flag so a follow-up native paste is suppressed', () => {
+      terminalPaste();
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+      // Synthetic native paste from a different source — must be dropped
+      // because terminalPaste just armed the flag.
+      const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+      Object.defineProperty(evt, 'clipboardData', {
+        value: { getData: () => 'should-be-dropped' },
+      });
+      host.dispatchEvent(evt);
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('terminalPaste is a no-op when no active session', () => {
+      setActiveSid(null);
+      terminalPaste();
+      expect(inputSpy).not.toHaveBeenCalled();
+    });
+
+    it('Ctrl+A invokes term.selectAll() and returns false to stop SOH translation', () => {
+      const handler = attachCustomKeyEventHandlerSpy.mock.calls[0][0];
+      const ret = handler({ type: 'keydown', key: 'a', ctrlKey: true });
+      expect(ret).toBe(false);
+      expect(selectAllSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('Cmd+A also invokes term.selectAll() (macOS)', () => {
+      const handler = attachCustomKeyEventHandlerSpy.mock.calls[0][0];
+      const ret = handler({ type: 'keydown', key: 'a', metaKey: true });
+      expect(ret).toBe(false);
+      expect(selectAllSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('Ctrl+Shift+A does NOT select-all (shift modifier reserved for other bindings)', () => {
+      const handler = attachCustomKeyEventHandlerSpy.mock.calls[0][0];
+      const ret = handler({ type: 'keydown', key: 'A', ctrlKey: true, shiftKey: true });
+      // Shift+A is not one of our explicit shifted bindings (only C/V are);
+      // returning true keeps xterm's default handling intact.
+      expect(ret).toBe(true);
+      expect(selectAllSpy).not.toHaveBeenCalled();
+    });
+
+    it('plain "a" keydown (no modifier) is left to xterm as normal input', () => {
+      const handler = attachCustomKeyEventHandlerSpy.mock.calls[0][0];
+      const ret = handler({ type: 'keydown', key: 'a' });
+      expect(ret).toBe(true);
+      expect(selectAllSpy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary

Right-click in the terminal pane now mirrors Windows Terminal / gnome-terminal: selection present → copy + clear selection (visual feedback); no selection → paste. No popover, ever. Adds Ctrl/Cmd+A for select-all to retain the keyboard entry point the popup's "Select All" item used to provide.

The native context menu (Cut/Copy/Paste/SelectAll) installed in `electron/window/createWindow.ts` still applies to the sidebar and inputs — it's only suppressed for the terminal pane, on a per-click one-shot basis sent via a new `window.ccsmShell.suppressContextMenuOnce()` IPC.

## Layer 1 decisions

- **Scope**: only the terminal pane changes. Sidebar / editable inputs keep the existing native context menu (cut / copy / paste / select-all).
- **macOS gating**: NOT applied. User is Windows-only; gnome-terminal / Windows Terminal style is the convergent expectation. Revisit if a mac user reports the loss of the native popover.
- **Select-all preserved**: Ctrl/Cmd+A → `term.selectAll()` wired in `attachCustomKeyEventHandler`. xterm has no built-in keybinding for this, and removing the popover's "Select All" left no other entry point.
- **Paste pipeline**: `terminalPaste()` routes through the same single canonical sink the Ctrl+V keydown hook uses, per the 4-layer paste model documented in `project_xterm_paste_layers.md` (xterm keydown hook + xterm built-in paste pipeline + Electron `role:'paste'` + the keyboard→native-paste handoff timing gotcha). Reuses the existing `keyboardPasteHandled` flag with the canonical `setTimeout(0)` reset so a browser-dispatched follow-up `paste` event is suppressed instead of double-pasting.

## Implementation

- `electron/window/createWindow.ts` — process-wide suppression deadline (100ms window) consulted at the top of `installContextMenu`. Pure helpers `isContextMenuSuppressed` / `recordContextMenuSuppression` extracted for unit test. Idempotent IPC handler `installContextMenuSuppressIpc` registered alongside the other `whenReady()` handlers in `electron/main.ts`. Electron's `webContents.on('context-menu')` fires regardless of DOM `preventDefault()`, so the deadline is the only main-process signal that can inhibit the popup.
- `electron/preload/bridges/ccsmShell.ts` (new) — exposes `window.ccsmShell.suppressContextMenuOnce()`. Stays a separate bridge rather than folding into `ccsm` core because the surface is one-shot UX-gesture plumbing, not app state.
- `src/terminal/xtermSingleton.ts` — new exports `terminalCopy()` (returns whether a selection existed, writes via `ccsmPty.clipboard.writeText`, clears the selection) and `terminalPaste()` (canonical paste sink). Plus the Ctrl/Cmd+A → `selectAll()` branch in the keydown handler.
- `src/components/TerminalPane.tsx` — `onContextMenu` on the host div: preventDefault, send one-shot suppression IPC, branch on `terminalCopy()` return → copy or paste. Robust to a missing or throwing `ccsmShell` bridge (e2e probes may not install it).
- `src/pty.d.ts` — types `window.ccsmShell` as optional.

## Tests

- `electron/window/__tests__/createWindow.test.ts` — pure deciders (`isContextMenuSuppressed` boundary conditions, `recordContextMenuSuppression` deadline math), `installContextMenu` honouring the suppression deadline, **one-shot consumption** (the next right-click after a single suppression still pops up — proves no over-suppression), expired deadline does not block, IPC handler idempotency.
- `electron/preload/bridges/__tests__/ccsmShell.test.ts` (new) — bridge surface + IPC channel name pin (wire contract with main).
- `electron/preload/bridges/__tests__/index.test.ts` — extended to assert `installCcsmShellBridge` is invoked.
- `tests/components/TerminalPane.test.tsx` (new) — `onContextMenu` copy / paste branches, preventDefault on the React event, suppress-IPC fired, resilient to missing bridge + throwing bridge.
- `tests/terminal/useXtermSingleton.test.tsx` — `terminalCopy` / `terminalPaste` direct contract, follow-up native paste suppression via the shared `keyboardPasteHandled` flag, Ctrl/Cmd+A → `selectAll`, plain `a` and Ctrl+Shift+A are NOT intercepted.

Full suite: **1625 / 1625 passing**. Typecheck + lint clean (warnings pre-existing).

## Screenshots

Not captured this round — no running Electron instance available to the worker. Reviewer can pull the branch and dogfood: right-click in terminal with text selected → text should land in clipboard immediately + selection clear; right-click without selection → clipboard contents should paste into PTY immediately; no popover should appear in either case. Right-click in the sidebar should still show the native cut/copy/paste/selectAll menu (regression check).

## Test plan

- [ ] Right-click with selection → text copied to clipboard, selection cleared, no popover
- [ ] Right-click without selection → clipboard pastes into PTY, no popover
- [ ] Ctrl+A in terminal selects all visible buffer content
- [ ] Right-click in sidebar still shows the native popover (no over-suppression)
- [ ] Ctrl+V paste still works (no double-paste / zero-paste regression)
- [ ] Ctrl+C with selection still copies; Ctrl+C without selection still sends SIGINT

🤖 Generated with [Claude Code](https://claude.com/claude-code)