### PR TITLE
fix(ptyHost): evict zombie entry on KILL_EXIT_TIMEOUT_MS to unblock spawn-on-null

### DIFF
--- a/electron/ptyHost/__tests__/lifecycle.test.ts
+++ b/electron/ptyHost/__tests__/lifecycle.test.ts
@@ -446,6 +446,67 @@ describe('lifecycle.kill', () => {
     vi.useRealTimers();
   });
 
+  it('evicts the zombie entry on timeout so subsequent attach returns null (spawn-on-null unblocked)', async () => {
+    // #1277 follow-up: when KILL_EXIT_TIMEOUT_MS fires, kill() resolves false
+    // but the entry was still in the map — a subsequent pty:attach would
+    // return the zombie and bypass the spawn-on-null fallback, leaving the
+    // renderer registered on a dead pty (crash overlay → manual Retry).
+    // Fix: force SIGKILL + delete from map on timeout.
+    vi.useFakeTimers();
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    entry.pty.pid = 500;
+    // Track SIGKILL escalation — pty.kill called twice (first signal-less in
+    // production code, second with 'SIGKILL' on timeout).
+    entry.pty.kill = vi.fn();
+    sessions.set('s', entry);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p = L.kill(sessions as any, 's');
+
+    // Cross the timeout — SIGKILL escalation + zombie eviction.
+    await vi.advanceTimersByTimeAsync(L.KILL_EXIT_TIMEOUT_MS + 10);
+    await expect(p).resolves.toBe(false);
+
+    // SIGKILL escalation attempted on the wedged pty.
+    expect(entry.pty.kill).toHaveBeenCalledWith('SIGKILL');
+    // Zombie removed from registry — attach now returns null, letting the
+    // renderer's reloadNonce → spawn-on-null fallback create a fresh PTY.
+    expect(sessions.has('s')).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(L.attach(sessions as any, 's')).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it('swallows SIGKILL throws on timeout (still evicts the zombie + logs)', async () => {
+    // On Windows node-pty emulates signals; SIGKILL may throw. The timeout
+    // path must still delete the entry from the map (else the zombie blocks
+    // spawn-on-null forever) and must not propagate the throw.
+    vi.useFakeTimers();
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    entry.pty.pid = 600;
+    let calls = 0;
+    entry.pty.kill = vi.fn((signal?: string) => {
+      calls += 1;
+      // First call (signal-less production kill) succeeds; SIGKILL throws.
+      if (signal === 'SIGKILL') throw new Error('signal not supported');
+    });
+    sessions.set('s', entry);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p = L.kill(sessions as any, 's');
+    await vi.advanceTimersByTimeAsync(L.KILL_EXIT_TIMEOUT_MS + 10);
+    await expect(p).resolves.toBe(false);
+
+    expect(calls).toBe(2); // initial kill + SIGKILL escalation
+    expect(sessions.has('s')).toBe(false);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('SIGKILL also failed'),
+    );
+    vi.useRealTimers();
+  });
+
   it('dedupes concurrent kills for the same sid — second call shares the first promise', async () => {
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -216,7 +216,29 @@ export function kill(sessions: Map<string, Entry>, sid: string): Promise<boolean
        the timeout will resolve us, and processKiller below still runs. */
   }
 
-  const timer = setTimeout(() => settle(false), KILL_EXIT_TIMEOUT_MS);
+  const timer = setTimeout(() => {
+    // Wedged-pty zombie cleanup (#1277 follow-up): the 3s timeout fired
+    // before onExit, which means the cleanup pump in entryFactory never
+    // ran and `sessions` still holds this sid. If we just resolved here a
+    // subsequent `pty:attach` from the renderer's reloadNonce bump would
+    // return the zombie entry, skip the spawn-on-null fallback, and
+    // register the viewer on a dead pty → crash overlay, manual Retry.
+    //
+    // Force-evict the entry so attach returns null and the renderer gets
+    // a transparent fresh PTY. The process is still live (kill signal
+    // was sent but the OS never reaped it); attempt SIGKILL as a last
+    // resort. On Windows node-pty emulates signals so SIGKILL may be a
+    // no-op — at minimum we've logged the leak so it's visible.
+    try {
+      entry.pty.kill('SIGKILL');
+    } catch (e) {
+      console.warn(
+        `[ptyHost] kill ${sid} wedged: SIGKILL also failed (${e instanceof Error ? e.message : String(e)}); pid ${pid} may leak`,
+      );
+    }
+    if (sessions.get(sid) === entry) sessions.delete(sid);
+    settle(false);
+  }, KILL_EXIT_TIMEOUT_MS);
 
   try {
     entry.pty.kill();


### PR DESCRIPTION
## Summary

Follow-up from PR #1277 reviewer. The 3s `KILL_EXIT_TIMEOUT_MS` fallback in `kill()` resolved `false` but left the dead entry in `sessions`, so the renderer's next `pty:attach` (after the `reloadNonce` bump) got the zombie back and bypassed the spawn-on-null fallback. The viewer ended up registered on a dead pty that immediately fired `pty:exit` -> crash overlay -> user had to hit Retry manually.

## The bug

`electron/ptyHost/lifecycle.ts` `kill()`:
1. `pty.kill()` dispatched a signal but the OS never reaped the process.
2. `onExit` never fired -> the cleanup pump in `entryFactory` that calls `sessions.delete(sid)` never ran.
3. `KILL_EXIT_TIMEOUT_MS` (3s) fired, `kill()` resolved `false`.
4. Renderer awaited that, bumped `reloadNonce`, ran the attach hook.
5. `pty:attach` returned the still-present zombie entry's geometry.
6. Spawn-on-null fallback never fired. Renderer wired up listeners on a dead pty -> crash overlay.

## The fix

On timeout:
- Best-effort `entry.pty.kill('SIGKILL')` to escalate the signal. On Windows node-pty emulates signals so this may throw; caught + logged (pid leak is visible in console, but the user gets their fresh terminal).
- `sessions.delete(sid)` to evict the zombie.
- Then `resolve(false)`.

Next `pty:attach` returns null -> existing spawn-on-null fallback transparently spawns a fresh PTY. No UI changes, no IPC contract changes, no `kill()` signature change, no timeout duration change.

Picked option (a) from the reviewer's two options (best-effort SIGKILL + delete) over (b) (zombie-flag field consulted by attach) — single-file change, no new state for `attach` to consult.

## Tests

`electron/ptyHost/__tests__/lifecycle.test.ts` adds two cases to the `lifecycle.kill` block:

1. `evicts the zombie entry on timeout so subsequent attach returns null (spawn-on-null unblocked)` — pty.kill is silent, timer advances past 3s, asserts `pty.kill('SIGKILL')` was called, `sessions.has('s')` is false, and `L.attach(sessions, 's')` returns null.
2. `swallows SIGKILL throws on timeout (still evicts the zombie + logs)` — Windows path. SIGKILL throws -> entry still evicted, warn logged with "SIGKILL also failed".

## Reverse-verify trace

```
$ git stash push -- electron/ptyHost/lifecycle.ts
$ npx vitest run electron/ptyHost/__tests__/lifecycle.test.ts
 FAIL  lifecycle.kill > evicts the zombie entry on timeout
   expected pty.kill to have been called with 'SIGKILL' (called with [])
   expected sessions.has('s') to be false (was true)
   expected L.attach(sessions, 's') to be null
 FAIL  lifecycle.kill > swallows SIGKILL throws on timeout
   expected 1 to be 2  (calls counter)
 Test Files  1 failed
 Tests  2 failed | 30 passed (32)

$ git stash pop
$ npx vitest run electron/ptyHost/__tests__/lifecycle.test.ts
 Test Files  1 passed
 Tests  32 passed (32)
```

## Test plan
- [x] vitest `lifecycle.test.ts` 32/32
- [x] `tsc --noEmit` clean
- [x] `eslint` on changed files clean (only pre-existing unrelated warnings)
- [x] reverse-verified the new tests fail on un-fixed code
- [ ] e2e: not added — the wedged-pty scenario is hard to deterministically reproduce in Playwright; unit test covers the contract

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>