### PR TITLE
test(preload): cover ccsmPty fork-path spawn branch

### DIFF
--- a/electron/preload/bridges/__tests__/ccsmPty.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmPty.test.ts
@@ -104,6 +104,14 @@ describe('ccsmPty preload bridge', () => {
     expect(invokeSpy).toHaveBeenCalledWith(chan, ...args);
   });
 
+  it('spawn with forkSourceSid forwards 3 args to pty:spawn', async () => {
+    const api = lastApi();
+    await (
+      api.spawn as (sid: string, cwd: string, forkSourceSid?: string) => Promise<unknown>
+    )('s1', '/cwd', 'source-sid');
+    expect(invokeSpy).toHaveBeenCalledWith('pty:spawn', 's1', '/cwd', 'source-sid');
+  });
+
   it('checkClaudeAvailable defaults its opts to {}', async () => {
     const api = lastApi();
     await (api.checkClaudeAvailable as (o?: unknown) => Promise<unknown>)();


### PR DESCRIPTION
Per PR #1279 reviewer's suggestion: add a sibling test that exercises the 3-arg fork branch of `ccsmPty.spawn`, complementing the existing 2-arg no-fork case so both invoke shapes are pinned.