### PR TITLE
feat(terminal): auto-save pasted clipboard images and inject path (#42)

### DIFF
--- a/electron/preload/bridges/__tests__/ccsmPty.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmPty.test.ts
@@ -75,6 +75,7 @@ describe('ccsmPty preload bridge', () => {
         'onData',
         'onExit',
         'resize',
+        'saveClipboardImage',
         'spawn',
       ].sort(),
     );
@@ -98,6 +99,8 @@ describe('ccsmPty preload bridge', () => {
     ['kill', 'pty:kill', ['s1']],
     ['get', 'pty:get', ['s1']],
     ['getBufferSnapshot', 'pty:getBufferSnapshot', ['s1']],
+    // Task #42 — clipboard image autosave channel.
+    ['saveClipboardImage', 'pty:saveClipboardImage', []],
   ])('forwards %s -> ipcRenderer.invoke("%s", ...)', async (m, chan, args) => {
     const api = lastApi();
     await (api[m] as (...a: unknown[]) => Promise<unknown>)(...args);

--- a/electron/preload/bridges/ccsmPty.ts
+++ b/electron/preload/bridges/ccsmPty.ts
@@ -64,6 +64,11 @@ const ccsmPty = {
     readText: (): string => clipboard.readText(),
     writeText: (text: string): void => clipboard.writeText(text),
   },
+  // Task #42 — main-process IPC because clipboard.readImage() PNG encoding
+  // and the userData write both need the main side; renderer also doesn't
+  // get app.getPath('userData').
+  saveClipboardImage: (): Promise<string | null> =>
+    ipcRenderer.invoke('pty:saveClipboardImage'),
   checkClaudeAvailable: (opts?: { force?: boolean }): Promise<CheckClaudeAvailableResult> =>
     ipcRenderer.invoke('pty:checkClaudeAvailable', opts ?? {}),
 };

--- a/electron/ptyHost/__tests__/ipcRegistrar.test.ts
+++ b/electron/ptyHost/__tests__/ipcRegistrar.test.ts
@@ -9,15 +9,31 @@
 // ...args)` directly.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 interface RegistrarBus {
   resolveClaude: ReturnType<typeof vi.fn>;
   watcherListeners: Map<string, Array<(evt: unknown) => void>>;
+  // Task #42 — per-test overrides for the clipboard image stub. We keep
+  // these in the bus so vi.mock (hoisted) can reference them lazily
+  // without dragging state across tests.
+  clipboardReadImage: () => { isEmpty: () => boolean; toPNG: () => Buffer };
+  userDataDir: string;
 }
 function bus(): RegistrarBus {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (globalThis as any).__irBus as RegistrarBus;
 }
+
+// Task #42 — registrar now imports `app` and `clipboard` from electron at
+// module load. Provide a thin stub; per-test behaviour is steered via the
+// bus accessors so the mock factory itself stays static.
+vi.mock('electron', () => ({
+  app: { getPath: (_k: string) => bus().userDataDir },
+  clipboard: { readImage: () => bus().clipboardReadImage() },
+}));
 
 vi.mock('../claudeResolver', () => ({
   resolveClaude: (opts?: unknown) => bus().resolveClaude(opts),
@@ -99,6 +115,10 @@ beforeEach(() => {
   (globalThis as any).__irBus = {
     resolveClaude: vi.fn(),
     watcherListeners: new Map<string, Array<(evt: unknown) => void>>(),
+    // Default to an empty clipboard so the channel returns null cleanly
+    // for tests that don't touch the image branch.
+    clipboardReadImage: () => ({ isEmpty: () => true, toPNG: () => Buffer.alloc(0) }),
+    userDataDir: fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-ipcregistrar-')),
   } satisfies RegistrarBus;
 });
 
@@ -111,7 +131,7 @@ afterEach(() => {
 // ─── handler registration shape ───────────────────────────────────────────
 
 describe('registerPtyIpc handler registration', () => {
-  it('registers all nine pty:* channels (8 legacy + getBufferSnapshot)', () => {
+  it('registers all ten pty:* channels (8 legacy + getBufferSnapshot + saveClipboardImage)', () => {
     const ipc = makeFakeIpc();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
@@ -126,6 +146,7 @@ describe('registerPtyIpc handler registration', () => {
         'pty:kill',
         'pty:list',
         'pty:resize',
+        'pty:saveClipboardImage',
         'pty:spawn',
       ].sort(),
     );
@@ -472,6 +493,58 @@ describe('pty:checkClaudeAvailable', () => {
     for (const call of bus().resolveClaude.mock.calls) {
       expect(call[0]).toEqual({ force: false });
     }
+  });
+});
+
+// ─── pty:saveClipboardImage (Task #42) ────────────────────────────────────
+
+describe('pty:saveClipboardImage', () => {
+  it('writes PNG buffer under <userData>/clipboard-images/ and returns the absolute path', async () => {
+    const ipc = makeFakeIpc();
+    const pngBuf = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    bus().clipboardReadImage = () => ({ isEmpty: () => false, toPNG: () => pngBuf });
+    registerPtyIpc(ipc as unknown as Electron.IpcMain, makeDeps());
+    const out = (await ipc.handlers.get('pty:saveClipboardImage')!({})) as string;
+    expect(typeof out).toBe('string');
+    expect(path.isAbsolute(out)).toBe(true);
+    expect(out.startsWith(path.join(bus().userDataDir, 'clipboard-images'))).toBe(true);
+    expect(path.basename(out)).toMatch(/^\d{8}-\d{6}(-\d{3})?\.png$/);
+    expect(fs.readFileSync(out).equals(pngBuf)).toBe(true);
+  });
+
+  it('returns null and writes nothing when clipboard image is empty', async () => {
+    const ipc = makeFakeIpc();
+    // Default bus stub returns isEmpty=true.
+    registerPtyIpc(ipc as unknown as Electron.IpcMain, makeDeps());
+    const out = await ipc.handlers.get('pty:saveClipboardImage')!({});
+    expect(out).toBeNull();
+    const dir = path.join(bus().userDataDir, 'clipboard-images');
+    // mkdir not even attempted on the empty path; dir should not exist.
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+
+  it('appends -001 suffix when the base timestamp file already exists (collision)', async () => {
+    const ipc = makeFakeIpc();
+    const pngBuf = Buffer.from([1, 2, 3, 4]);
+    bus().clipboardReadImage = () => ({ isEmpty: () => false, toPNG: () => pngBuf });
+
+    // Freeze Date so first and second invocations produce the same base.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 4, 22, 10, 11, 12));
+
+    registerPtyIpc(ipc as unknown as Electron.IpcMain, makeDeps());
+
+    const first = (await ipc.handlers.get('pty:saveClipboardImage')!({})) as string;
+    expect(path.basename(first)).toBe('20260522-101112.png');
+
+    const second = (await ipc.handlers.get('pty:saveClipboardImage')!({})) as string;
+    expect(path.basename(second)).toBe('20260522-101112-001.png');
+
+    // Both files must exist with the expected content.
+    expect(fs.readFileSync(first).equals(pngBuf)).toBe(true);
+    expect(fs.readFileSync(second).equals(pngBuf)).toBe(true);
+
+    vi.useRealTimers();
   });
 });
 

--- a/electron/ptyHost/ipcRegistrar.ts
+++ b/electron/ptyHost/ipcRegistrar.ts
@@ -6,10 +6,41 @@
 // tangled with the IPC surface. The registrar owns no state of its own
 // beyond the one-shot `stateBridgeInstalled` guard.
 
-import type { BrowserWindow, IpcMain } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+import { app, clipboard, type BrowserWindow, type IpcMain } from 'electron';
 import { resolveClaude } from './claudeResolver';
 import { sessionWatcher } from '../sessionWatcher';
 import type { AttachResult, BufferSnapshot, PtySessionInfo } from './lifecycle';
+
+/**
+ * Task #42 — clipboard image auto-save. Filename format:
+ * `YYYYMMDD-HHMMSS[-NNN].png`. Local time (matches the user's Finder /
+ * Explorer column when they go looking for the file). The `-NNN` suffix
+ * is appended on same-second collisions; we cap retries at 999 so a
+ * runaway loop can't pin the main thread.
+ */
+function formatClipboardImageTimestamp(d: Date): string {
+  const pad = (n: number, w = 2): string => String(n).padStart(w, '0');
+  return (
+    `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}-` +
+    `${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`
+  );
+}
+
+/**
+ * Resolve a non-colliding filename inside `dir` for the given timestamp
+ * base. Uses sync existsSync because the loop must be atomic w.r.t. the
+ * subsequent write — interleaving another async tick here would race
+ * two paste-image calls landing the same second.
+ */
+function resolveClipboardImagePath(dir: string, base: string): string {
+  let file = path.join(dir, `${base}.png`);
+  for (let n = 1; n < 1000 && fs.existsSync(file); n++) {
+    file = path.join(dir, `${base}-${String(n).padStart(3, '0')}.png`);
+  }
+  return file;
+}
 
 interface SessionEntryHandle {
   pty: { pid: number };
@@ -208,5 +239,30 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
       typeof opts === 'object' && opts !== null && (opts as { force?: unknown }).force === true;
     const p = await resolveClaude({ force });
     return p ? { available: true as const, path: p } : { available: false as const };
+  });
+
+  // Task #42 — when the renderer detects a paste intent and the clipboard
+  // holds an image (e.g. user took a screenshot, dragged a PNG into the
+  // clipboard, or copied from a browser), drop it to disk under
+  // `<userData>/clipboard-images/` and return the absolute path so the
+  // renderer can inject the path into the active PTY. Claude reads files
+  // by path, so this is the canonical way to feed it a screenshot.
+  //
+  // Returns null when there is no image on the clipboard — renderer falls
+  // back to its normal text-paste path. We do NOT inspect text here, even
+  // when text is also present, because Windows readText() is unreliable
+  // when the clipboard holds an image (readImage().isEmpty() IS reliable).
+  // The renderer holds the text fallback synchronously before invoking us.
+  ipcMain.handle('pty:saveClipboardImage', async () => {
+    const img = clipboard.readImage();
+    if (img.isEmpty()) return null;
+    const buf = img.toPNG();
+    if (buf.length === 0) return null;
+    const dir = path.join(app.getPath('userData'), 'clipboard-images');
+    await fs.promises.mkdir(dir, { recursive: true });
+    const base = formatClipboardImageTimestamp(new Date());
+    const file = resolveClipboardImagePath(dir, base);
+    await fs.promises.writeFile(file, buf);
+    return file;
   });
 }

--- a/src/pty.d.ts
+++ b/src/pty.d.ts
@@ -83,6 +83,14 @@ export interface CcsmPtyApi {
     readText(): string;
     writeText(text: string): void;
   };
+  /**
+   * Task #42 — if the clipboard holds an image, save it as a PNG under
+   * `<userData>/clipboard-images/YYYYMMDD-HHMMSS[-NNN].png` and return
+   * the absolute path (native separators). Returns null if no image is
+   * present. Used by the paste path to convert pasted screenshots into
+   * file paths that claude can read.
+   */
+  saveClipboardImage(): Promise<string | null>;
   checkClaudeAvailable(opts?: { force?: boolean }): Promise<CheckClaudeAvailableResult>;
 }
 

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -97,6 +97,41 @@ export function setSnapshotReplay(fn: (() => Promise<void>) | null): void {
 }
 
 /**
+ * Task #42 — image-first paste pipeline (shared by every paste path:
+ * capture-phase DOM event in `ensureTerminal`, Ctrl/Cmd+V keydown via
+ * `pasteFromClipboard`, right-click via `terminalPaste`).
+ *
+ * Why image-first: on Windows, `clipboard.readText()` is unreliable when
+ * the clipboard also holds an image (returns empty / stale text), but
+ * `readImage().isEmpty()` IS reliable. So we ask main "is there an image"
+ * first; if yes, main writes it under `<userData>/clipboard-images/` and
+ * returns the absolute path, which we inject into the PTY. Claude reads
+ * files by path, so this turns a pasted screenshot into "claude can see
+ * the screenshot" with no extra user steps.
+ *
+ * `fallbackText` is read by the caller synchronously (clipboardData for
+ * the capture-phase listener; `clipboard.readText()` for the keyboard /
+ * right-click paths) so the text survives the async hop to main.
+ *
+ * Returns the promise so callers that need to sequence after the paste
+ * (currently only tests) can await; production paste paths fire-and-forget
+ * via `void`.
+ */
+export async function pasteIntoActivePty(fallbackText: string | undefined): Promise<void> {
+  if (!activeSid) return;
+  try {
+    const imagePath = await window.ccsmPty?.saveClipboardImage?.();
+    if (imagePath) {
+      window.ccsmPty.input(activeSid, imagePath);
+      return;
+    }
+  } catch {
+    // best-effort — fall through to text paste on IPC failure.
+  }
+  if (fallbackText) window.ccsmPty.input(activeSid, fallbackText);
+}
+
+/**
  * Create (or re-attach) the singleton Terminal against `host`. Idempotent:
  * subsequent calls reuse the cached instance and only re-`open` if React
  * remounted into a different DOM node.
@@ -248,6 +283,10 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
   // versions then dispatch a native `paste` event a moment later;
   // the keydown handler sets `keyboardPasteHandled` so this listener
   // discards that follow-up event and we paste exactly once.
+  // Task #42 — image-first paste pipeline. See `pasteIntoActivePty` at
+  // module scope: every paste path (capture-phase DOM event, Ctrl/Cmd+V
+  // keydown, right-click `terminalPaste`) funnels through that helper so
+  // pasted screenshots auto-save and inject as a path.
   const onPasteCapture = (e: ClipboardEvent): void => {
     e.stopImmediatePropagation();
     e.preventDefault();
@@ -255,14 +294,10 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
       keyboardPasteHandled = false;
       return;
     }
-    const text = e.clipboardData?.getData('text/plain');
-    if (text && activeSid) {
-      try {
-        window.ccsmPty.input(activeSid, text);
-      } catch {
-        // best-effort — write can fail if PTY isn't attached.
-      }
-    }
+    // Read text synchronously: clipboardData is only valid during the
+    // event dispatch, so we can't await before reading it.
+    const text = e.clipboardData?.getData('text/plain') ?? '';
+    void pasteIntoActivePty(text || undefined);
   };
   host.addEventListener('paste', onPasteCapture, { capture: true });
 
@@ -293,12 +328,15 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
     // setTimeout 0 task lands AFTER the native paste dispatch, so the
     // capture listener sees the flag and suppresses.
     setTimeout(() => { keyboardPasteHandled = false; }, 0);
+    let text: string | undefined;
     try {
-      const text = window.ccsmPty?.clipboard?.readText();
-      if (text && activeSid) window.ccsmPty.input(activeSid, text);
+      text = window.ccsmPty?.clipboard?.readText() || undefined;
     } catch {
       // best-effort — clipboard read can fail under permission edge cases.
     }
+    // Task #42 — route through the image-first helper so a copied
+    // screenshot lands as a file path rather than empty text.
+    void pasteIntoActivePty(text);
   };
 
   // Copy/paste keyboard shortcuts (Windows Terminal style):
@@ -441,10 +479,13 @@ export function terminalPaste(): void {
   setTimeout(() => {
     keyboardPasteHandled = false;
   }, 0);
+  let text: string | undefined;
   try {
-    const text = window.ccsmPty?.clipboard?.readText();
-    if (text) window.ccsmPty.input(activeSid, text);
+    text = window.ccsmPty?.clipboard?.readText() || undefined;
   } catch {
     // best-effort — clipboard read can fail under permission edge cases.
   }
+  // Task #42 — route through the image-first helper so right-click on a
+  // copied screenshot lands as a file path rather than empty text.
+  void pasteIntoActivePty(text);
 }

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -118,17 +118,25 @@ export function setSnapshotReplay(fn: (() => Promise<void>) | null): void {
  * via `void`.
  */
 export async function pasteIntoActivePty(fallbackText: string | undefined): Promise<void> {
-  if (!activeSid) return;
+  // N1 race fix (reviewer): snapshot `activeSid` BEFORE the async IPC hop.
+  // `saveClipboardImage` round-trips to main; the user can switch sessions
+  // during that window. Without this snapshot, the saved image path (or
+  // fallback text) would land in whichever session happens to be active
+  // when the promise resolves — i.e. the wrong one. Bind the target sid
+  // at intent time so the inject always goes to the session the user was
+  // looking at when they hit paste.
+  const sid = activeSid;
+  if (!sid) return;
   try {
     const imagePath = await window.ccsmPty?.saveClipboardImage?.();
     if (imagePath) {
-      window.ccsmPty.input(activeSid, imagePath);
+      window.ccsmPty.input(sid, imagePath);
       return;
     }
   } catch {
     // best-effort — fall through to text paste on IPC failure.
   }
-  if (fallbackText) window.ccsmPty.input(activeSid, fallbackText);
+  if (fallbackText) window.ccsmPty.input(sid, fallbackText);
 }
 
 /**

--- a/tests/fixtures/electronStub.cjs
+++ b/tests/fixtures/electronStub.cjs
@@ -147,6 +147,9 @@ const clipboard = {
   writeText: noop,
   clear: noop,
   has: () => false,
+  // Task #42 — default to an empty image so tests that hit
+  // `pty:saveClipboardImage` get null unless they override the stub.
+  readImage: () => ({ isEmpty: () => true, toPNG: () => Buffer.alloc(0) }),
 };
 const contextBridge = { exposeInMainWorld: noop };
 const webContents = { getAllWebContents: () => [], fromId: () => null };

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -45,6 +45,7 @@ import { useXtermSingleton } from '../../src/terminal/useXtermSingleton';
 import {
   __resetSingletonForTests,
   getTerm,
+  pasteIntoActivePty,
   setActiveSid,
   terminalCopy,
   terminalPaste,
@@ -443,6 +444,41 @@ describe('useXtermSingleton', () => {
       await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
       expect(inputSpy).toHaveBeenCalledWith('sid-rc', 'pasted-text');
+    });
+
+    // N1 race fix (reviewer): `saveClipboardImage` is an async IPC hop;
+    // if the user switches sessions while it's in flight, the injected
+    // text / image-path MUST land in the session that was active at
+    // paste-intent time, NOT whichever session happens to be active
+    // when the promise resolves. `pasteIntoActivePty` snapshots
+    // `activeSid` at entry to enforce this. Drive the helper directly
+    // (rather than through `terminalPaste`) so the timing is precise.
+    it('pasteIntoActivePty binds the target sid at intent time, not at promise-resolution time', async () => {
+      // Defer the resolution of saveClipboardImage until we explicitly
+      // resolve it — gives us a clean window to flip activeSid mid-flight.
+      let resolveImage: (v: string | null) => void = () => {};
+      const pending = new Promise<string | null>((r) => { resolveImage = r; });
+      (window as unknown as { ccsmPty: { saveClipboardImage: ReturnType<typeof vi.fn> } })
+        .ccsmPty.saveClipboardImage = vi.fn().mockReturnValue(pending);
+
+      setActiveSid('sid-original');
+      const pasted = pasteIntoActivePty('typed-into-original');
+
+      // Simulate the user switching sessions while we wait on the IPC.
+      setActiveSid('sid-different');
+
+      // Resolve the IPC with no image so we exercise the text-fallback
+      // branch (the more dangerous one — image path comes from main and
+      // is obviously global, but the text fallback could plausibly look
+      // session-scoped if you squint at the old code).
+      resolveImage(null);
+      await pasted;
+
+      // MUST go to the sid that was active when paste was invoked, not
+      // the sid that's active now.
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+      expect(inputSpy).toHaveBeenCalledWith('sid-original', 'typed-into-original');
+      expect(inputSpy).not.toHaveBeenCalledWith('sid-different', 'typed-into-original');
     });
 
     it('Ctrl+A invokes term.selectAll() and returns false to stop SOH translation', () => {

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -206,6 +206,10 @@ describe('useXtermSingleton', () => {
           readText: readTextSpy,
           writeText: vi.fn(),
         },
+        // Task #42 — default to "no image on clipboard" so existing
+        // text-paste assertions stay green; image-branch tests override
+        // per-case.
+        saveClipboardImage: vi.fn().mockResolvedValue(null),
       };
       // The hook receives a real DOM node so the capture-phase paste
       // listener it installs is exercised by real events.
@@ -233,26 +237,34 @@ describe('useXtermSingleton', () => {
       return evt;
     }
 
-    it('Ctrl+V keydown injects clipboard text exactly once', () => {
+    it('Ctrl+V keydown injects clipboard text exactly once', async () => {
       const handler = getKeyHandler();
       const ret = handler({ type: 'keydown', key: 'v', ctrlKey: true });
       expect(ret).toBe(false);
       expect(readTextSpy).toHaveBeenCalledTimes(1);
+      // Task #42 — paste now hops through `saveClipboardImage` first; the
+      // text injection lands on the microtask after that promise resolves.
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
       expect(inputSpy).toHaveBeenCalledWith('sid-1', 'hello');
     });
 
-    it('Cmd+V keydown injects clipboard text exactly once (macOS)', () => {
+    it('Cmd+V keydown injects clipboard text exactly once (macOS)', async () => {
       const handler = getKeyHandler();
       const ret = handler({ type: 'keydown', key: 'v', metaKey: true });
       expect(ret).toBe(false);
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
       expect(inputSpy).toHaveBeenCalledWith('sid-1', 'hello');
     });
 
-    it('keydown-driven paste suppresses the follow-up native paste event', () => {
+    it('keydown-driven paste suppresses the follow-up native paste event', async () => {
       const handler = getKeyHandler();
       handler({ type: 'keydown', key: 'v', ctrlKey: true });
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
 
       // The browser's native paste event arrives after our synchronous
@@ -260,12 +272,16 @@ describe('useXtermSingleton', () => {
       // ccsmPty.input call.
       const evt = makePasteEvent('hello');
       host.dispatchEvent(evt);
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('right-click / context-menu paste (no preceding keydown) injects once', () => {
+    it('right-click / context-menu paste (no preceding keydown) injects once', async () => {
       const evt = makePasteEvent('world');
       host.dispatchEvent(evt);
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
       expect(inputSpy).toHaveBeenCalledWith('sid-1', 'world');
       // xterm's built-in paste pipeline must not see the event.
@@ -277,6 +293,8 @@ describe('useXtermSingleton', () => {
       // Keyboard paste with NO follow-up native event (e.g. focus on
       // canvas — browser doesn't dispatch paste to non-editable nodes).
       handler({ type: 'keydown', key: 'v', ctrlKey: true });
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
 
       // Wait for the macrotask that resets the flag. We use setTimeout 0
@@ -289,14 +307,18 @@ describe('useXtermSingleton', () => {
       // A later paste from a different source must still be delivered.
       const evt = makePasteEvent('later');
       host.dispatchEvent(evt);
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(2);
       expect(inputSpy).toHaveBeenLastCalledWith('sid-1', 'later');
     });
 
-    it('Ctrl+V is a no-op when no active session', () => {
+    it('Ctrl+V is a no-op when no active session', async () => {
       setActiveSid(null);
       const handler = getKeyHandler();
       handler({ type: 'keydown', key: 'v', ctrlKey: true });
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).not.toHaveBeenCalled();
     });
   });
@@ -324,6 +346,9 @@ describe('useXtermSingleton', () => {
           readText: readTextSpy,
           writeText: writeTextSpy,
         },
+        // Task #42 — default to "no image"; image-branch test overrides
+        // per-case to assert the path-injection branch.
+        saveClipboardImage: vi.fn().mockResolvedValue(null),
       };
       host = document.createElement('div');
       document.body.appendChild(host);
@@ -355,14 +380,19 @@ describe('useXtermSingleton', () => {
       expect(clearSelectionSpy).not.toHaveBeenCalled();
     });
 
-    it('terminalPaste reads clipboard and routes through ccsmPty.input', () => {
+    it('terminalPaste reads clipboard and routes through ccsmPty.input', async () => {
       terminalPaste();
+      // Async hop via saveClipboardImage; flush microtasks before assert.
+      await Promise.resolve();
+      await Promise.resolve();
       expect(readTextSpy).toHaveBeenCalledTimes(1);
       expect(inputSpy).toHaveBeenCalledWith('sid-rc', 'pasted-text');
     });
 
-    it('terminalPaste arms the keyboardPasteHandled flag so a follow-up native paste is suppressed', () => {
+    it('terminalPaste arms the keyboardPasteHandled flag so a follow-up native paste is suppressed', async () => {
       terminalPaste();
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
       // Synthetic native paste from a different source — must be dropped
       // because terminalPaste just armed the flag.
@@ -371,13 +401,48 @@ describe('useXtermSingleton', () => {
         value: { getData: () => 'should-be-dropped' },
       });
       host.dispatchEvent(evt);
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('terminalPaste is a no-op when no active session', () => {
+    it('terminalPaste is a no-op when no active session', async () => {
       setActiveSid(null);
       terminalPaste();
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).not.toHaveBeenCalled();
+    });
+
+    // Task #42 — image-first paste branch. When `saveClipboardImage`
+    // returns a saved-file path, we MUST inject that path (not the
+    // fallback text) so claude reads the screenshot via the file path.
+    it('terminalPaste injects the saved image path when clipboard holds an image', async () => {
+      const fakePath = 'C:\\Users\\me\\AppData\\Roaming\\CCSM\\clipboard-images\\20260522-100000.png';
+      (window as unknown as { ccsmPty: { saveClipboardImage: ReturnType<typeof vi.fn> } })
+        .ccsmPty.saveClipboardImage = vi.fn().mockResolvedValue(fakePath);
+      terminalPaste();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+      expect(inputSpy).toHaveBeenCalledWith('sid-rc', fakePath);
+      // The synchronously-read text MUST NOT be injected; the image branch
+      // wins.
+      expect(inputSpy).not.toHaveBeenCalledWith('sid-rc', 'pasted-text');
+    });
+
+    // Task #42 — text fallback. When `saveClipboardImage` returns null
+    // (no image on clipboard), the previously-read text is injected as
+    // the regular paste payload. Default beforeEach stub already returns
+    // null, but spell it out for documentation.
+    it('terminalPaste falls back to text injection when no image is on clipboard', async () => {
+      (window as unknown as { ccsmPty: { saveClipboardImage: ReturnType<typeof vi.fn> } })
+        .ccsmPty.saveClipboardImage = vi.fn().mockResolvedValue(null);
+      terminalPaste();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+      expect(inputSpy).toHaveBeenCalledWith('sid-rc', 'pasted-text');
     });
 
     it('Ctrl+A invokes term.selectAll() and returns false to stop SOH translation', () => {


### PR DESCRIPTION
## User request

> ctrl+c的时候，如果粘贴板是图片，自动保存到本地一个地方，然后把地址贴上去

Semantically: when **pasting** (not literally Ctrl+C), if the clipboard holds an image, auto-save it locally and paste the file path into the terminal. Use case: drag/paste a screenshot into ccsm, claude reads it via the file path.

## Summary

- New `pty:saveClipboardImage` IPC channel — main writes `clipboard.readImage().toPNG()` under `<userData>/clipboard-images/YYYYMMDD-HHMMSS[-NNN].png` and returns the absolute path. Returns `null` when no image is on the clipboard.
- New module-scope `pasteIntoActivePty(fallbackText)` helper in `xtermSingleton.ts`; all three paste paths funnel through it:
  1. Capture-phase `paste` listener
  2. Ctrl/Cmd+V keydown via `pasteFromClipboard`
  3. Right-click via `terminalPaste` (PR #1290's export)
- **Image-first** check: on Windows `clipboard.readText()` is unreliable when an image is also present, but `readImage().isEmpty()` IS reliable. So we ask main "is there an image" first; the caller has already read the synchronous text fallback before the async hop.

## Filename / collision

`YYYYMMDD-HHMMSS.png` in local time (matches Finder/Explorer column when the user goes looking for the file). Same-second collision appends `-001..-999`; `sync existsSync` inside the resolution loop keeps the filename pick atomic w.r.t. the write.

## Out of scope (v1, deliberate)

- LRU cleanup of the images directory
- Drag-drop upload (this PR handles paste only)
- Toast confirmation
- Source-format preservation (always PNG — `NativeImage.toPNG()` is lossless from any source format)
- Multi-image clipboard
- Sentry breadcrumbs

Errors fall through to the existing text-paste path, console log only.

## Tests (8 added / updated)

**`ipcRegistrar.test.ts`** (3 new for the handler):
- happy path: PNG written, absolute path matches `^\d{8}-\d{6}(-\d{3})?\.png$`, file content matches buffer
- empty clipboard: returns null, no directory created
- collision: pre-seed first file with frozen `Date`, second invocation lands `-001` suffix

**`useXtermSingleton.test.tsx`** (2 new for the renderer + 6 existing updated):
- new: image-branch — `saveClipboardImage` stub returns path → `input` called with **path** (not text)
- new: text fallback — `saveClipboardImage` returns null → `input` called with synchronously-read text
- updated: existing paste-path tests now flush the async hop with `await Promise.resolve()`

**`ccsmPty.test.ts`** preload bridge: surface key + invoke-forwarding pinned for the new method.

**`electronStub.cjs`**: default `clipboard.readImage()` returns an empty image so any test that doesn't override stays green.

## Reverse-verify (proves test 4 catches the bug)

Commented out the image branch in `pasteIntoActivePty` and ran the image-branch test:

```
Received:
  1st vi.fn() call:
  [
    "sid-rc",
-   "C:\Users\me\AppData\Roaming\CCSM\clipboard-images\20260522-100000.png",
+   "pasted-text",
  ]
```

The test fails the way it should — it's catching the new behaviour, not a tautology. Branch restored before commit.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (warnings: 110 baseline, 110 mine — net 0 new warnings)
- [x] `npx vitest run electron/ptyHost/__tests__/ipcRegistrar.test.ts tests/terminal/useXtermSingleton.test.tsx electron/preload/bridges/__tests__/ccsmPty.test.ts` — 76/76 pass
- [x] Full `npm test`: 1653/1671 pass; 18 failures are pre-existing in `electron-load-smoke.test.ts` (requires `npm run build` first, baseline identical)
- [ ] Dogfood: paste a screenshot in a live ccsm session, verify file lands in `%AppData%/CCSM/clipboard-images/` and the path is injected