### PR TITLE
ci(nightly): drop check-source from working-tip CI gate

### DIFF
--- a/.github/workflows/daily-promote-release.yml
+++ b/.github/workflows/daily-promote-release.yml
@@ -72,6 +72,12 @@ jobs:
       # failed runs of this workflow attach check-runs to the same PR head
       # and would fail the gate. See: failing run 26205515547.
       # When adding a new required CI check, append it here.
+      # NOTE: check-source is intentionally NOT listed here. It is defined
+      # in main-source-guard.yml with `on.pull_request.branches: [main]`,
+      # so it only fires on PRs targeting `main` and never on feature →
+      # working PRs (which is what this gate inspects). The later
+      # "Wait for check-source on promote PR" step covers check-source on
+      # the working → main promote PR where it does fire.
       EXPECTED_CHECKS: |
         e2e (macos-latest)
         e2e (ubuntu-latest)
@@ -80,7 +86,6 @@ jobs:
         lint + typecheck + test (ubuntu-latest)
         lint + typecheck + test (windows-latest)
         no-silent-drops
-        check-source
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Root cause

The nightly promote workflow's `Gate — CI green on working tip` step walks back from `working`'s tip to the PR that produced it (a feature → working PR) and requires every name in `EXPECTED_CHECKS` to be present and green on that PR's head SHA. `EXPECTED_CHECKS` included `check-source`, which is defined in `.github/workflows/main-source-guard.yml` with `on.pull_request.branches: [main]`. So `check-source` never fires on feature → working PRs, and the gate always fails with `missing required check(s) "check-source"`. Latest failure: run 26249215760.

## The fix

Remove `check-source` from `EXPECTED_CHECKS` in `.github/workflows/daily-promote-release.yml` and add an inline comment explaining why it's excluded (so it doesn't get re-added by someone working through the "add new required check" instructions in the existing comment block).

## Why this is safe

`check-source` coverage on the path to `main` is preserved by the existing later step `Wait for check-source on promote PR`. That step polls check-runs on the working → main promote PR's head SHA, which IS main-targeted, so `check-source` does fire there and is enforced before merge. No path to `main` skips `check-source`.

## Bootstrap — post-merge action required

Quoting the workflow header:

> IMPORTANT — bootstrap caveat:
>   GitHub schedules cron workflows from the DEFAULT branch (main) only.
>   When this file is modified on `working`, the new version does NOT
>   start running on cron until it lands on `main`. To bootstrap a change
>   here:
>     1. Land the change on `working` (normal PR flow).
>     2. Manually trigger one run from the Actions tab or via
>        `gh workflow run daily-promote-release.yml -R <owner>/<repo>`.
>        That run will open + merge the promote PR, putting this file's
>        new version on `main`, after which cron picks it up automatically.
>   Skipping step 2 means cron continues running the OLD file from `main`
>   until something else promotes `working → main`.

So after this PR merges to `working`, run:

```
gh workflow run daily-promote-release.yml -R Jiahui-Gu/ccsm
```

to bootstrap the fix onto `main`. Subsequent cron runs will then use the new version.