### PR TITLE
fix(terminal): park viewport at bottom after attach snapshot drain

### DIFF
--- a/src/terminal/usePtyAttach.ts
+++ b/src/terminal/usePtyAttach.ts
@@ -12,6 +12,7 @@ import {
   setInputDisposable,
   setSnapshotReplay,
   getSnapshotReplay,
+  writeAndScrollToBottom,
 } from './xtermSingleton';
 
 export type PtyAttachState =
@@ -289,6 +290,12 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
           for (const b of buffered) {
             if (b.seq > snapSeq) tDrain.write(b.chunk);
           }
+          // Park the viewport at the bottom AFTER the WriteBuffer drains
+          // the snapshot + drained chunks (see writeAndScrollToBottom).
+          // Without this, attach lands the scrollbar at the top of the
+          // transcript because xterm.write is queued and a synchronous
+          // scrollToBottom() would run before baseY catches up.
+          writeAndScrollToBottom(tDrain);
         }
         buffered.length = 0;
 
@@ -346,6 +353,12 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
             for (const b of buffered) {
               if (b.seq > snapSeq) tDrain2.write(b.chunk);
             }
+            // Same rationale as the initial-attach drain above: this
+            // replay path is fired by the post-attach fit branch below
+            // (and by `useTerminalResize` after a SIGWINCH). For the
+            // attach side we want unconditional scroll-to-bottom; the
+            // resize side gates separately on the user's prior atBottom.
+            writeAndScrollToBottom(tDrain2);
           }
           buffered.length = 0;
         });
@@ -403,6 +416,19 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
                 .then(() => {
                   const replay = getSnapshotReplay();
                   return replay ? replay() : undefined;
+                })
+                .then(() => {
+                  // Post-attach fit branch: even though the replay
+                  // handler itself scrolls to bottom after its drain,
+                  // we re-assert here as a defensive rendezvous. The
+                  // replay queues writes against the live xterm and
+                  // its internal scroll happens once THAT WriteBuffer
+                  // drains; an unrelated chunk that landed between the
+                  // fit and the replay (e.g. claude reacting to the
+                  // resize) could otherwise leave baseY advanced past
+                  // viewportY again. Cheap empty-write rendezvous.
+                  const tFit = getTerm();
+                  if (tFit) writeAndScrollToBottom(tFit);
                 })
                 .catch((e) => console.warn('[TerminalPane] post-attach replay failed', e));
             }

--- a/src/terminal/useTerminalResize.ts
+++ b/src/terminal/useTerminalResize.ts
@@ -17,6 +17,16 @@ import { getTerm, getFit, getActiveSid, getSnapshotReplay } from './xtermSinglet
  * is alt-screen and does not repaint on SIGWINCH unless input
  * arrives — same root cause as #852). PTY resize still propagates so
  * subsequent claude output is sized correctly.
+ *
+ * Scroll restoration: the replay handler unconditionally parks the
+ * viewport at the bottom (the right behaviour for attach, where the
+ * user just opened a session and expects to see the live tail). For
+ * a window/pane resize that's hostile — yanking a scrolled-up viewport
+ * back to the bottom on every drag of the splitter loses the user's
+ * reading position. So we snapshot the pre-resize `atBottom` state and
+ * the absolute viewportY BEFORE the backend resize, then after the
+ * replay either let the bottom-park stand (atBottom was true) or
+ * scroll back to the saved line.
  */
 export function useTerminalResize(hostRef: RefObject<HTMLDivElement | null>): void {
   useEffect(() => {
@@ -30,6 +40,21 @@ export function useTerminalResize(hostRef: RefObject<HTMLDivElement | null>): vo
         const fit = getFit();
         const activeSid = getActiveSid();
         if (!term || !fit || !activeSid) return;
+        // Capture the pre-resize scroll state. Same atBottom rule as
+        // `useAtBottom` (gap <= 1 row tolerance covers mid-frame
+        // rounding). We also save the absolute viewportY so we can
+        // restore the exact prior line — a pure boolean isn't enough.
+        let wasAtBottom = true;
+        let savedViewportY = 0;
+        try {
+          const buf = term.buffer.active;
+          wasAtBottom = buf.baseY - buf.viewportY <= 1;
+          savedViewportY = buf.viewportY;
+        } catch {
+          // best-effort — fall back to atBottom=true so the default
+          // behaviour matches the pre-fix code (always park at bottom).
+          wasAtBottom = true;
+        }
         try {
           fit.fit();
           const { cols, rows } = term;
@@ -49,6 +74,27 @@ export function useTerminalResize(hostRef: RefObject<HTMLDivElement | null>): vo
               : Promise.resolve();
             void p
               .then(() => replay())
+              .then(() => {
+                // The replay's drain parks the viewport at the bottom
+                // unconditionally (correct for attach). For resize we
+                // only want that when the user WAS at the bottom; if
+                // they were scrolled up, restore the saved viewportY.
+                // Rendezvous via empty-write callback so the restore
+                // lands AFTER all queued writes (live chunks arriving
+                // during the replay drain would otherwise advance
+                // baseY between our scrollToLine and the next frame).
+                if (wasAtBottom) return;
+                const t2 = getTerm();
+                if (!t2) return;
+                t2.write('', () => {
+                  try {
+                    t2.scrollToLine(savedViewportY);
+                  } catch {
+                    // best-effort — if the reflow shortened the buffer,
+                    // scrollToLine on an out-of-range index is a no-op.
+                  }
+                });
+              })
               .catch((e) => console.warn('[TerminalPane] resize replay failed', e));
           }
         } catch (e) {

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -54,6 +54,40 @@ export function getTerm(): Terminal | null {
   return term;
 }
 
+/**
+ * Park the viewport at the bottom AFTER all queued writes have drained.
+ *
+ * xterm's `Terminal.write` is asynchronous: it pushes into an internal
+ * `WriteBuffer` that's flushed on the next microtask/raf. A synchronous
+ * `scrollToBottom()` immediately after `write(snapshot)` runs BEFORE the
+ * snapshot has actually advanced `baseY`, so the viewport ends up parked
+ * at the OLD bottom (which, after `term.reset()`, is row 0 — i.e. the
+ * top of the now-populated transcript). This is the bug behind "attach a
+ * session and the scrollbar lands at the middle/top of the transcript".
+ *
+ * The fix is the documented xterm idiom: pass a callback to `write`, which
+ * fires after the WriteBuffer has drained THIS chunk, and only THEN call
+ * `scrollToBottom()`. Empty-string writes are cheap (no parsing) and still
+ * cause the callback to be queued behind any prior pending writes, so we
+ * use `term.write('', cb)` as the rendezvous point regardless of how many
+ * `term.write(...)` calls preceded it.
+ *
+ * Used by `usePtyAttach` at every attach-path call site that paints into
+ * the terminal: initial snapshot + buffered drain, snapshot-replay tail,
+ * and the post-attach fit branch's replay. The resize path (in
+ * `useTerminalResize`) is gated on the user's prior atBottom state so a
+ * scrolled-up viewport isn't yanked down by a SIGWINCH.
+ */
+export function writeAndScrollToBottom(t: Terminal): void {
+  t.write('', () => {
+    try {
+      t.scrollToBottom();
+    } catch {
+      // best-effort — xterm may have been torn down between queue and drain.
+    }
+  });
+}
+
 export function getFit(): FitAddon | null {
   return fit;
 }

--- a/tests/terminal/usePtyAttach.test.tsx
+++ b/tests/terminal/usePtyAttach.test.tsx
@@ -2,7 +2,20 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
 // Spy on the Terminal so usePtyAttach can call write/reset/resize/onData/focus.
-const writeSpy = vi.fn();
+// `write` accepts an optional callback (xterm's WriteBuffer drain rendezvous)
+// which `writeAndScrollToBottom` relies on — invoke it synchronously so the
+// scrollToBottom side-effect lands during the same act() flush. Tracks the
+// ORDER of write -> scrollToBottom calls via `callLog` for the scroll-after-
+// drain assertion.
+const callLog: string[] = [];
+const scrollToBottomSpy = vi.fn(() => {
+  callLog.push('scrollToBottom');
+});
+const scrollToLineSpy = vi.fn();
+const writeSpy = vi.fn((data: string, cb?: () => void) => {
+  callLog.push(`write:${data}`);
+  if (cb) cb();
+});
 const resetSpy = vi.fn();
 const resizeSpy = vi.fn();
 const focusSpy = vi.fn();
@@ -14,7 +27,10 @@ const fakeTerm = {
   reset: resetSpy,
   resize: resizeSpy,
   focus: focusSpy,
+  scrollToBottom: scrollToBottomSpy,
+  scrollToLine: scrollToLineSpy,
   onData: onDataSpy,
+  buffer: { active: { baseY: 0, viewportY: 0 } },
   cols: 80,
   rows: 24,
 };
@@ -47,6 +63,12 @@ vi.mock('../../src/terminal/xtermSingleton', async () => {
     getSnapshotReplay: vi.fn(() => snapReplay),
     setSnapshotReplay: vi.fn((fn: (() => Promise<void>) | null) => {
       snapReplay = fn;
+    }),
+    // Mirror the real helper: `term.write('', cb)` then `cb()` scrolls.
+    // The fake `write` invokes its cb synchronously, so this also runs
+    // the scroll spy synchronously — perfect for ordering assertions.
+    writeAndScrollToBottom: vi.fn((t: any) => {
+      t.write('', () => t.scrollToBottom());
     }),
     __resetSingletonForTests: vi.fn(() => {
       activeSid = null;
@@ -158,6 +180,9 @@ describe('usePtyAttach', () => {
     resetSpy.mockClear();
     resizeSpy.mockClear();
     focusSpy.mockClear();
+    scrollToBottomSpy.mockClear();
+    scrollToLineSpy.mockClear();
+    callLog.length = 0;
     onDataSpy.mockClear();
     inputDisposableDispose.mockClear();
     fitFitSpy.mockClear();
@@ -366,5 +391,70 @@ describe('usePtyAttach', () => {
       await flush();
     });
     expect(result.current.state).toMatchObject({ kind: 'exit', exitKind: 'crashed' });
+  });
+
+  // Regression: "attach a session, scrollbar lands at the top/middle of
+  // the transcript" reported by user. Root cause: xterm's `write` is
+  // queued via WriteBuffer; a synchronous scrollToBottom() after
+  // `write(snapshot)` runs before baseY catches up to the snapshot's
+  // line count, so the viewport stays parked at the post-`reset()` line
+  // 0. Fix: park the viewport via `write('', cb)` rendezvous so the
+  // scroll happens AFTER the WriteBuffer drains the snapshot.
+  it('scrolls to bottom AFTER the snapshot write drain rendezvous fires', async () => {
+    const { bridge } = makePtyBridge({ snapshot: { snapshot: 'snap-body', seq: 0 } });
+    (window as any).ccsmPty = bridge;
+
+    renderHook(() => usePtyAttach('sid-scroll', '/tmp'));
+    await flushAll();
+
+    // Snapshot was written.
+    expect(writeSpy).toHaveBeenCalledWith('snap-body');
+    // Scroll happened at least once.
+    expect(scrollToBottomSpy).toHaveBeenCalled();
+    // Crucial ordering: the rendezvous write('') landed BEFORE its cb
+    // fired the scroll — i.e. scroll-to-bottom is NOT synchronous with
+    // the snapshot write. With the fake's synchronous-callback `write`,
+    // we expect to see `write:snap-body`, then `write:` (rendezvous),
+    // then `scrollToBottom` in the log.
+    const snapIdx = callLog.indexOf('write:snap-body');
+    const rendezvousIdx = callLog.indexOf('write:', snapIdx + 1);
+    const scrollIdx = callLog.indexOf('scrollToBottom', rendezvousIdx);
+    expect(snapIdx).toBeGreaterThanOrEqual(0);
+    expect(rendezvousIdx).toBeGreaterThan(snapIdx);
+    expect(scrollIdx).toBeGreaterThan(rendezvousIdx);
+  });
+
+  // Same scroll-to-bottom contract for the snapshot-replay path (fired
+  // by the post-attach fit branch when the container size differs from
+  // the spawn dims, and by `useTerminalResize` after a SIGWINCH). Drives
+  // the replay via the post-attach fit's container-size delta and
+  // verifies a scroll happens after the replay's snapshot write drains.
+  it('replay path scrolls to bottom after its snapshot drain (post-attach fit branch)', async () => {
+    const { bridge, spies } = makePtyBridge({ snapshot: { snapshot: 'snap-A', seq: 0 } });
+    (window as any).ccsmPty = bridge;
+    // Force a size delta so the post-attach fit branch fires the replay.
+    fitFitSpy.mockImplementation(() => {
+      fakeTerm.cols = 134;
+      fakeTerm.rows = 51;
+    });
+    // Different snapshot string for the replay so we can grep the log
+    // independently of the initial attach snapshot.
+    spies.getBufferSnapshot.mockImplementationOnce(async () => ({ snapshot: 'snap-A', seq: 0 }));
+    spies.getBufferSnapshot.mockImplementationOnce(async () => ({ snapshot: 'replayed', seq: 1 }));
+
+    try {
+      renderHook(() => usePtyAttach('sid-replay', '/tmp'));
+      await flushAll();
+
+      expect(writeSpy).toHaveBeenCalledWith('replayed');
+      const replayIdx = callLog.lastIndexOf('write:replayed');
+      const scrollIdx = callLog.indexOf('scrollToBottom', replayIdx);
+      expect(replayIdx).toBeGreaterThanOrEqual(0);
+      expect(scrollIdx).toBeGreaterThan(replayIdx);
+    } finally {
+      fakeTerm.cols = 80;
+      fakeTerm.rows = 24;
+      fitFitSpy.mockReset();
+    }
   });
 });

--- a/tests/terminal/useTerminalResize.test.tsx
+++ b/tests/terminal/useTerminalResize.test.tsx
@@ -3,7 +3,25 @@ import { renderHook } from '@testing-library/react';
 
 const fitFitSpy = vi.fn();
 const fakeFit = { fit: fitFitSpy };
-const fakeTerm = { cols: 100, rows: 30 };
+// Mutable buffer state so individual tests can set up pre-resize
+// atBottom vs scrolled-up scenarios.
+const fakeBuffer = { active: { baseY: 0, viewportY: 0 } };
+const scrollToBottomSpy = vi.fn();
+const scrollToLineSpy = vi.fn();
+// `write` invokes its drain callback synchronously so the post-write
+// scroll restoration lands in the same microtask sequence as the test's
+// awaits — mirrors the usePtyAttach test fake.
+const writeSpy = vi.fn((data: string, cb?: () => void) => {
+  if (cb) cb();
+});
+const fakeTerm = {
+  cols: 100,
+  rows: 30,
+  buffer: fakeBuffer,
+  scrollToBottom: scrollToBottomSpy,
+  scrollToLine: scrollToLineSpy,
+  write: writeSpy,
+};
 
 let snapshotReplayFn: (() => Promise<void>) | null = null;
 
@@ -56,6 +74,11 @@ describe('useTerminalResize', () => {
     fitFitSpy.mockClear();
     observeSpy.mockClear();
     disconnectSpy.mockClear();
+    scrollToBottomSpy.mockClear();
+    scrollToLineSpy.mockClear();
+    writeSpy.mockClear();
+    fakeBuffer.active.baseY = 0;
+    fakeBuffer.active.viewportY = 0;
     lastObserverCb = null;
     snapshotReplayFn = null;
     originalRO = globalThis.ResizeObserver;
@@ -132,5 +155,61 @@ describe('useTerminalResize', () => {
     vi.advanceTimersByTime(80);
     // Resize still pushed to backend; absence of replay handler is non-fatal.
     expect(resizeBridge).toHaveBeenCalledWith('sid-A', 100, 30);
+  });
+
+  // Scroll-restoration gating (fix/attach-scroll-to-bottom): the replay
+  // handler unconditionally parks the viewport at the bottom, which is
+  // the right behaviour for attach but hostile on resize when the user
+  // was scrolled up reading scrollback. The hook must snapshot
+  // `atBottom` BEFORE the backend resize and only let the bottom-park
+  // stand when it was true; otherwise it should restore the saved
+  // viewportY via `scrollToLine`.
+  it('resize when user WAS at bottom pre-resize: no scrollToLine, replay-side scroll stands', async () => {
+    const replaySpy = vi.fn(async () => {});
+    snapshotReplayFn = replaySpy;
+    // baseY === viewportY → atBottom.
+    fakeBuffer.active.baseY = 500;
+    fakeBuffer.active.viewportY = 500;
+
+    const host = document.createElement('div');
+    const ref = { current: host };
+    renderHook(() => useTerminalResize(ref));
+    lastObserverCb!([] as unknown as ResizeObserverEntry[], {} as ResizeObserver);
+    vi.advanceTimersByTime(80);
+
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(replaySpy).toHaveBeenCalledTimes(1);
+    // Pre-resize atBottom → don't restore a prior line.
+    expect(scrollToLineSpy).not.toHaveBeenCalled();
+  });
+
+  it('resize when user was scrolled UP pre-resize: scrollToLine restores saved viewportY after replay', async () => {
+    const replaySpy = vi.fn(async () => {});
+    snapshotReplayFn = replaySpy;
+    // baseY far ahead of viewportY → user scrolled up; gap > 1.
+    fakeBuffer.active.baseY = 500;
+    fakeBuffer.active.viewportY = 120;
+
+    const host = document.createElement('div');
+    const ref = { current: host };
+    renderHook(() => useTerminalResize(ref));
+    lastObserverCb!([] as unknown as ResizeObserverEntry[], {} as ResizeObserver);
+    vi.advanceTimersByTime(80);
+
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(replaySpy).toHaveBeenCalledTimes(1);
+    // The rendezvous write('') fires its cb synchronously in our fake,
+    // so scrollToLine should land with the saved pre-resize viewportY.
+    expect(scrollToLineSpy).toHaveBeenCalledWith(120);
   });
 });

--- a/tests/usePtyAttach-snapshot-replay.test.tsx
+++ b/tests/usePtyAttach-snapshot-replay.test.tsx
@@ -62,7 +62,8 @@ function newPendingSnapshot(): MockState['pendingSnapshot'] {
 
 function installMockTerminal(): void {
   const term = {
-    write: (s: string) => { M.writes.push(s); },
+    // empty writes are drain-rendezvous markers (writeAndScrollToBottom)
+    write: (s: string) => { if (s !== '') M.writes.push(s); },
     reset: () => { /* no-op for the mock */ },
     resize: (_c: number, _r: number) => { /* no-op */ },
     focus: () => { /* no-op */ },


### PR DESCRIPTION
## Bug
Attaching to a session leaves the xterm viewport at the top or middle of the transcript instead of the live tail (user report: "现在 attach 一个 session，右侧滚轮会到中间或者顶部").

## Root cause
xterm's `Terminal.write` is queued via the internal `WriteBuffer` (async drain). The attach path wrote the snapshot + buffered chunks but never called `scrollToBottom` afterwards. `term.reset()` had zeroed `viewportY`; subsequent writes advanced `baseY` past `viewportY` but xterm only auto-parks the viewport at the new bottom when it was already following. A synchronous `scrollToBottom()` right after `write(snapshot)` would have raced ahead of the drain — same root-cause class as #852.

## Fix
- Centralise the idiom in `writeAndScrollToBottom(term)` in `xtermSingleton`: `term.write('', () => term.scrollToBottom())`. The empty write queues a callback that fires AFTER this chunk drains, so the scroll lands on the post-snapshot `baseY`.
- Call the helper at 3 attach call sites in `usePtyAttach`:
  1. after the initial snapshot write + buffered drain,
  2. inside the snapshot-replay handler's drain tail,
  3. in the post-attach fit branch's replay continuation.
- In `useTerminalResize`, gate the post-replay scroll on the user's prior `atBottom`: snapshot `baseY`/`viewportY` BEFORE the backend resize, and after the replay either let the replay-side bottom-park stand (atBottom was true) or restore the saved `viewportY` via `scrollToLine` (user was reading scrollback — don't yank them down).

## Test coverage
- `usePtyAttach`: asserts `scrollToBottom` fires AFTER the snapshot `write` callback drains (ordering via call log) for both initial-attach and snapshot-replay paths.
- `useTerminalResize`: asserts atBottom-gating — `scrollToLine` is NOT called when user was at bottom pre-resize; IS called with the saved `viewportY` when user was scrolled up.

All 52 tests in `tests/terminal/` pass. `npm run typecheck` and `npm run lint` are clean.

## Note
Visual dogfood will be done by a separate worker post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)