### PR TITLE
promote: working → main (bootstrap new nightly workflow)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,20 +89,17 @@ jobs:
       - name: Test
         run: npm test
 
-      # Tech-debt R6 (Task #802) — coverage roll-out. Run only on Linux to
-      # keep the matrix lean (coverage instrumentation roughly doubles
-      # wall-clock; one OS is enough for the lcov artifact). Threshold
-      # misses do NOT fail CI yet — this is the initial roll-out; we wrap
-      # with `continue-on-error: true` to keep CI green during the bake-in
-      # period. Bump and enforce in a follow-up once we've watched a few
-      # PRs.
+      # Tech-debt R6 (Task #802 / Task #43) — coverage gate. Runs only on
+      # Linux to keep the matrix lean (coverage instrumentation roughly
+      # doubles wall-clock; one OS is enough for the lcov artifact and
+      # the gate). Threshold misses now fail CI — see vitest.config.ts
+      # for the configured floors and PR #(this) for the rationale.
       - name: Coverage
         if: matrix.os == 'ubuntu-latest'
         run: npm run coverage
-        continue-on-error: true
 
       - name: Upload coverage artifact
-        if: matrix.os == 'ubuntu-latest'
+        if: always() && matrix.os == 'ubuntu-latest'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-lcov

--- a/.github/workflows/daily-promote-release.yml
+++ b/.github/workflows/daily-promote-release.yml
@@ -64,6 +64,23 @@ jobs:
       # Prefer RELEASE_TOKEN (PAT) so the auto-opened PR fires required
       # checks. Fall back to GITHUB_TOKEN for the read-only gates.
       GH_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+      # Allowlist of CI check-run names that gates require to be green on
+      # the PR head SHA. Newline-separated so names with spaces work.
+      # CRITICAL: this list MUST exclude the names of any check-run this
+      # workflow itself registers (e.g. "promote working → main + tag"),
+      # otherwise the gate self-poisons — the in-progress / historical-
+      # failed runs of this workflow attach check-runs to the same PR head
+      # and would fail the gate. See: failing run 26205515547.
+      # When adding a new required CI check, append it here.
+      EXPECTED_CHECKS: |
+        e2e (macos-latest)
+        e2e (ubuntu-latest)
+        e2e (windows-latest)
+        lint + typecheck + test (macos-latest)
+        lint + typecheck + test (ubuntu-latest)
+        lint + typecheck + test (windows-latest)
+        no-silent-drops
+        check-source
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -307,6 +324,8 @@ jobs:
           TIMEOUT_SECONDS: '1800'  # 30 min
         run: |
           set -euo pipefail
+          # Render allowlist as JSON array for jq.
+          expected_json=$(printf '%s\n' "$EXPECTED_CHECKS" | jq -R . | jq -s '[.[] | select(length > 0)]')
           deadline=$(( $(date +%s) + TIMEOUT_SECONDS ))
           while :; do
             # Find PR for this merge commit.
@@ -314,24 +333,42 @@ jobs:
             if [ -z "$pr_head" ]; then
               echo "PR association not yet indexed; waiting..."
             else
-              # Pull all check-runs; require all completed and all in {success,neutral,skipped}.
-              runs=$(gh api --paginate "repos/$OWNER/$REPO/commits/$pr_head/check-runs" --jq '.check_runs[] | {name, status, conclusion}')
-              if [ -z "$runs" ]; then
-                echo "No check-runs yet on $pr_head; waiting..."
-              else
-                pending=$(echo "$runs" | jq -s '[.[] | select(.status != "completed")] | length')
-                bad=$(    echo "$runs" | jq -s '[.[] | select(.status == "completed") | select(.conclusion as $c | ["success","neutral","skipped"] | index($c) | not)] | length')
-                if [ "$bad" -gt 0 ]; then
-                  echo "::error::main CI has $bad failed check(s) on $pr_head"
-                  echo "$runs" | jq -s '.[] | select(.conclusion as $c | ["success","neutral","skipped"] | index($c) | not)'
-                  exit 1
-                fi
-                if [ "$pending" -eq 0 ]; then
-                  echo "### main CI: all checks green on \`$pr_head\`" >> "$GITHUB_STEP_SUMMARY"
-                  exit 0
-                fi
-                echo "$pending check(s) still pending; waiting..."
+              # Pull all check-runs, then filter to allowlist (ignore this
+              # workflow's own check-run + any other unrelated runs that
+              # happen to land on the same PR head SHA).
+              all=$(gh api --paginate "repos/$OWNER/$REPO/commits/$pr_head/check-runs" \
+                --jq '.check_runs[] | {name, status, conclusion, completed_at, id}' | jq -s '.')
+              # For each expected name pick the latest matching run (re-run dedup).
+              selected=$(jq -n --argjson runs "$all" --argjson expected "$expected_json" '
+                $expected
+                | map(. as $name
+                      | { name: $name,
+                          run: ( $runs
+                                 | map(select(.name == $name))
+                                 | sort_by([(.completed_at // ""), (.id // 0)])
+                                 | last ) })
+              ')
+              missing=$(echo "$selected" | jq '[.[] | select(.run == null) | .name]')
+              missing_count=$(echo "$missing" | jq 'length')
+              pending=$(echo "$selected" | jq '[.[] | select(.run != null) | select(.run.status != "completed")] | length')
+              bad=$(echo "$selected" | jq '
+                [ .[]
+                  | select(.run != null)
+                  | select(.run.status == "completed")
+                  | select(.run.conclusion as $c | (["success","neutral","skipped"] | index($c)) | not)
+                  | { name: .name, conclusion: .run.conclusion } ]
+              ')
+              bad_count=$(echo "$bad" | jq 'length')
+              if [ "$bad_count" -gt 0 ]; then
+                echo "::error::main CI has $bad_count failed required check(s) on $pr_head"
+                echo "$bad" | jq '.'
+                exit 1
               fi
+              if [ "$missing_count" -eq 0 ] && [ "$pending" -eq 0 ]; then
+                echo "### main CI: all required checks green on \`$pr_head\`" >> "$GITHUB_STEP_SUMMARY"
+                exit 0
+              fi
+              echo "$pending pending, $missing_count missing required check(s); waiting..."
             fi
             if [ "$(date +%s)" -ge "$deadline" ]; then
               echo "::error::Timed out waiting for main CI after ${TIMEOUT_SECONDS}s"

--- a/.github/workflows/daily-promote-release.yml
+++ b/.github/workflows/daily-promote-release.yml
@@ -72,6 +72,12 @@ jobs:
       # failed runs of this workflow attach check-runs to the same PR head
       # and would fail the gate. See: failing run 26205515547.
       # When adding a new required CI check, append it here.
+      # NOTE: check-source is intentionally NOT listed here. It is defined
+      # in main-source-guard.yml with `on.pull_request.branches: [main]`,
+      # so it only fires on PRs targeting `main` and never on feature →
+      # working PRs (which is what this gate inspects). The later
+      # "Wait for check-source on promote PR" step covers check-source on
+      # the working → main promote PR where it does fire.
       EXPECTED_CHECKS: |
         e2e (macos-latest)
         e2e (ubuntu-latest)
@@ -80,7 +86,6 @@ jobs:
         lint + typecheck + test (ubuntu-latest)
         lint + typecheck + test (windows-latest)
         no-silent-drops
-        check-source
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scripts/check-ci-via-pr.sh
+++ b/.github/workflows/scripts/check-ci-via-pr.sh
@@ -7,14 +7,23 @@
 #
 # Usage: check-ci-via-pr.sh <commit-sha> <label-for-summary>
 #
-# Pass iff every check-run on the PR head is completed AND conclusion in
-# {success, neutral, skipped}. Anything else (failure, cancelled,
-# timed_out, action_required, stale, or status != completed) → exit 1.
+# Required env: OWNER, REPO, GH_TOKEN, EXPECTED_CHECKS.
+#
+# EXPECTED_CHECKS is a newline-separated allowlist of check-run names that
+# MUST all be present and green. Newline-separated (not space) so names
+# containing spaces (e.g. "lint + typecheck + test (macos-latest)") work
+# without quoting gymnastics. Anything outside the allowlist is ignored —
+# critical, because the promote-release workflow registers its own
+# check-run ("promote working → main + tag") on the same PR head SHA and
+# would otherwise self-poison this gate.
+#
+# Pass iff every name in EXPECTED_CHECKS has a check-run that is completed
+# AND conclusion in {success, neutral, skipped}. Missing names → fail
+# loud. Names appearing multiple times (re-runs) → use the latest by
+# completed_at then id.
 #
 # If the commit has no associated PR, exit 1 with a clear message — per
 # locked decision: "refuse to promote" rather than silently passing.
-#
-# Env: OWNER, REPO, GH_TOKEN must be set by the caller.
 
 set -euo pipefail
 
@@ -26,7 +35,17 @@ if [ -z "${OWNER:-}" ] || [ -z "${REPO:-}" ]; then
   exit 2
 fi
 
+if [ -z "${EXPECTED_CHECKS:-}" ]; then
+  echo "::error::EXPECTED_CHECKS env var required (newline-separated check-run names)"
+  exit 2
+fi
+
 echo "Gate CI for $label at $sha"
+
+# Render expected list for logs / step summary.
+expected_json=$(printf '%s\n' "$EXPECTED_CHECKS" | jq -R . | jq -s '[.[] | select(length > 0)]')
+echo "Expected checks:"
+echo "$expected_json" | jq -r '.[]'
 
 # /commits/{sha}/pulls returns PRs whose head OR merge_commit_sha matches.
 # We take the first; for a merge commit on working/main, that's the PR
@@ -46,9 +65,10 @@ pr_number=$(echo "$pr_json" | jq -r '.number')
 pr_head=$(  echo "$pr_json" | jq -r '.head.sha')
 echo "Associated PR #$pr_number, head $pr_head"
 
-# Pull all check-runs (paginated) for the PR head SHA.
+# Pull all check-runs (paginated) for the PR head SHA. Keep full objects
+# so we can sort by completed_at / id for re-run dedup.
 runs=$(gh api --paginate "repos/$OWNER/$REPO/commits/$pr_head/check-runs" \
-  --jq '.check_runs[] | {name, status, conclusion}')
+  --jq '.check_runs[] | {name, status, conclusion, completed_at, id}')
 
 if [ -z "$runs" ]; then
   {
@@ -59,33 +79,86 @@ if [ -z "$runs" ]; then
   exit 1
 fi
 
-# Anything not completed, or completed with a conclusion not in the pass
-# set, fails the gate.
-bad=$(echo "$runs" | jq -s '
-  [ .[]
-    | select( (.status != "completed")
-           or ( .conclusion as $c
-                | (["success","neutral","skipped"] | index($c)) | not ) )
-  ]
-')
-bad_count=$(echo "$bad" | jq 'length')
+# Filter to allowlist, then for each expected name pick the latest
+# (completed_at desc, id desc) check-run. Result is a JSON array of
+# {name, run} pairs; run is null when nothing matched.
+all_runs_json=$(echo "$runs" | jq -s '.')
+selected=$(jq -n \
+  --argjson runs "$all_runs_json" \
+  --argjson expected "$expected_json" \
+  '
+  $expected
+  | map(. as $name
+        | { name: $name,
+            run: ( $runs
+                   | map(select(.name == $name))
+                   | sort_by([(.completed_at // ""), (.id // 0)])
+                   | last ) })
+  ')
 
-if [ "$bad_count" -gt 0 ]; then
+# Build lists of missing + bad.
+missing=$(echo "$selected" | jq '[.[] | select(.run == null) | .name]')
+bad=$(    echo "$selected" | jq '
+  [ .[]
+    | select(.run != null)
+    | select( (.run.status != "completed")
+           or ( .run.conclusion as $c
+                | (["success","neutral","skipped"] | index($c)) | not ) )
+    | { name: .name,
+        status: .run.status,
+        conclusion: .run.conclusion } ]
+')
+missing_count=$(echo "$missing" | jq 'length')
+bad_count=$(    echo "$bad"     | jq 'length')
+
+# Always log expected vs got for debuggability when the allowlist drifts.
+got_filtered=$(echo "$all_runs_json" | jq --argjson e "$expected_json" '[.[] | select(.name as $n | $e | index($n))] | map(.name) | unique')
+got_all=$(     echo "$all_runs_json" | jq '[.[].name] | unique')
+echo "Got (in allowlist):   $(echo "$got_filtered" | jq -c '.')"
+echo "Got (all on PR head): $(echo "$got_all"      | jq -c '.')"
+
+if [ "$missing_count" -gt 0 ] || [ "$bad_count" -gt 0 ]; then
   {
     echo "### Gate: CI on $label — FAIL";
-    echo "PR #$pr_number head \`$pr_head\` has $bad_count bad check-run(s):";
+    echo "PR #$pr_number head \`$pr_head\`.";
+    if [ "$missing_count" -gt 0 ]; then
+      echo "";
+      echo "Missing required check(s):";
+      echo '```json';
+      echo "$missing" | jq '.';
+      echo '```';
+    fi
+    if [ "$bad_count" -gt 0 ]; then
+      echo "";
+      echo "Failed/incomplete check(s):";
+      echo '```json';
+      echo "$bad" | jq '.';
+      echo '```';
+    fi
+    echo "";
+    echo "Expected:";
     echo '```json';
-    echo "$bad" | jq '.';
+    echo "$expected_json" | jq '.';
+    echo '```';
+    echo "Got (all check-runs on PR head, for debugging):";
+    echo '```json';
+    echo "$got_all" | jq '.';
     echo '```';
   } >> "$GITHUB_STEP_SUMMARY"
-  echo "::error::CI gate failed on $label (PR #$pr_number)"
-  echo "$bad" | jq '.'
+  if [ "$missing_count" -gt 0 ]; then
+    echo "::error::CI gate failed on $label (PR #$pr_number): $missing_count missing required check(s)"
+    echo "$missing" | jq '.'
+  fi
+  if [ "$bad_count" -gt 0 ]; then
+    echo "::error::CI gate failed on $label (PR #$pr_number): $bad_count bad check(s)"
+    echo "$bad" | jq '.'
+  fi
   exit 1
 fi
 
-total=$(echo "$runs" | jq -s 'length')
+total=$(echo "$selected" | jq 'length')
 {
   echo "### Gate: CI on $label — OK";
-  echo "PR #$pr_number head \`$pr_head\`: all $total check-run(s) passed.";
+  echo "PR #$pr_number head \`$pr_head\`: all $total required check-run(s) passed.";
 } >> "$GITHUB_STEP_SUMMARY"
-echo "OK: $total check-runs all green on $label"
+echo "OK: $total required check-runs all green on $label"

--- a/.github/workflows/scripts/check-ci-via-pr.sh
+++ b/.github/workflows/scripts/check-ci-via-pr.sh
@@ -80,8 +80,14 @@ if [ -z "$runs" ]; then
 fi
 
 # Filter to allowlist, then for each expected name pick the latest
-# (completed_at desc, id desc) check-run. Result is a JSON array of
-# {name, run} pairs; run is null when nothing matched.
+# completed check-run when one exists, otherwise fall back to the
+# latest in-progress run. We sort by (status == "completed") first so
+# that completed runs land at the tail of the array (true > false in
+# jq sort_by ascending), guaranteeing that `last` prefers a completed
+# run over a stale in-progress rerun whose completed_at is still null.
+# Within the same status tier we keep the original (completed_at, id)
+# ordering. Result is a JSON array of {name, run} pairs; run is null
+# when nothing matched.
 all_runs_json=$(echo "$runs" | jq -s '.')
 selected=$(jq -n \
   --argjson runs "$all_runs_json" \
@@ -92,7 +98,7 @@ selected=$(jq -n \
         | { name: $name,
             run: ( $runs
                    | map(select(.name == $name))
-                   | sort_by([(.completed_at // ""), (.id // 0)])
+                   | sort_by([(.status == "completed"), (.completed_at // ""), (.id // 0)])
                    | last ) })
   ')
 

--- a/electron/__tests__/db.test.ts
+++ b/electron/__tests__/db.test.ts
@@ -1,7 +1,26 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
+import Database from 'better-sqlite3';
+
+// Wrap fs so the corruption-recovery test can pin that `electron/db.ts`
+// actually calls `unlinkSync` on the `-wal` / `-shm` sidecar paths.
+//
+// `vi.spyOn(fs, 'unlinkSync')` fails — the ESM namespace is frozen. The
+// `Module._cache` hack doesn't work either, because Vitest runs modules
+// inside its own loader (no shared CJS cache). The robust path is
+// `vi.mock('fs', …)` with `importActual`: every importer (test + production)
+// gets the same wrapper, which by default delegates to the real impl so
+// other tests' `mkdtempSync` / `writeFileSync` / etc. keep working. Tests
+// that need to assert the call shape override the wrapper.
+const unlinkSpy = vi.hoisted(() => ({ fn: undefined as unknown as ReturnType<typeof vi.fn> }));
+vi.mock('fs', async () => {
+  const actual = (await vi.importActual('fs')) as typeof import('fs');
+  const wrapped = vi.fn(actual.unlinkSync);
+  unlinkSpy.fn = wrapped;
+  return { ...actual, default: actual, unlinkSync: wrapped };
+});
 
 // `initDb` asks electron for the userData dir. Point it at a per-test tmp dir
 // so real app data isn't touched and each test gets a fresh database.
@@ -24,15 +43,252 @@ beforeEach(async () => {
   await freshDb();
 });
 
-describe('db: surface', () => {
-  // Both the `messages` table (PR-H, replaced by JSONL loader) and the
-  // `claudeBinPath` helpers (PR-I, the wizard that wrote them is gone)
-  // were deleted, taking their bespoke test suites with them. The
-  // remaining `loadState` / `saveState` + integrity-check + schema
-  // versioning are exercised by `db-hardening.test.ts`. We keep a
-  // placeholder here so the test runner still discovers the file and
-  // future db features have an obvious place to land.
-  it('placeholder', () => {
-    expect(true).toBe(true);
+// Complements `db-hardening.test.ts` (which covers corruption recovery, fresh
+// user_version stamp, prepared-statement cache reuse, db:save validator, and
+// preload re-throw). The tests below pick up the remaining branches: load
+// misses, upsert semantics, close+reopen, schema downgrade warning, legacy-
+// table drop, WAL/SHM sidecar cleanup, getDb passthrough, and the
+// `__setDbForTests` injection seam.
+
+describe('db: loadState / saveState round-trips', () => {
+  it('loadState returns null for an unknown key on a fresh db', async () => {
+    const { initDb, loadState } = await freshDb();
+    initDb();
+    expect(loadState('never-written')).toBeNull();
+  });
+
+  it('saveState upserts: second write replaces the value rather than colliding on PRIMARY KEY', async () => {
+    const { initDb, saveState, loadState } = await freshDb();
+    initDb();
+    saveState('k', 'v1');
+    saveState('k', 'v2');
+    saveState('k', 'v3');
+    expect(loadState('k')).toBe('v3');
+  });
+
+  it('preserves data across closeDb() + initDb() reopen of the same file', async () => {
+    const mod = await freshDb();
+    mod.initDb();
+    mod.saveState('persisted', 'hello');
+    mod.closeDb();
+    // The on-disk file under tmpDir is unchanged; reopening yields the same
+    // app_state row.
+    mod.initDb();
+    expect(mod.loadState('persisted')).toBe('hello');
+  });
+
+  it('initDb is idempotent — repeated calls return the same handle', async () => {
+    const { initDb } = await freshDb();
+    const h1 = initDb();
+    const h2 = initDb();
+    expect(h1).toBe(h2);
+  });
+
+  it('getDb returns the same instance as initDb()', async () => {
+    const { initDb, getDb } = await freshDb();
+    const a = initDb();
+    const b = getDb();
+    expect(a).toBe(b);
+  });
+});
+
+describe('db: schema versioning branches', () => {
+  it('logs a warning and proceeds when on-disk user_version > app SCHEMA_VERSION (downgrade)', async () => {
+    const mod = await freshDb();
+    // Pre-seed the canonical db file with a future-version user_version stamp.
+    const file = path.join(tmpDir, 'ccsm.db');
+    const seed = new Database(file);
+    seed.pragma('user_version = 99');
+    seed.close();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handle = mod.initDb();
+    // Boot must not refuse — we proceed and log a breadcrumb.
+    expect(handle).toBeTruthy();
+    expect(warn).toHaveBeenCalled();
+    const msg = warn.mock.calls[0]?.[0] ?? '';
+    expect(String(msg)).toMatch(/newer than app/);
+    warn.mockRestore();
+  });
+
+  it('keeps an existing matching user_version untouched (no migrate, no warn)', async () => {
+    const mod = await freshDb();
+    const file = path.join(tmpDir, 'ccsm.db');
+    const seed = new Database(file);
+    seed.pragma('user_version = 1'); // matches SCHEMA_VERSION
+    seed.close();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const handle = mod.initDb();
+    const v = handle.pragma('user_version', { simple: true }) as number;
+    expect(v).toBe(1);
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+
+describe('db: legacy-table cleanup', () => {
+  it('drops endpoints / endpoint_models / messages tables on init when present', async () => {
+    const mod = await freshDb();
+    // Pre-seed a db with the legacy tables AND content. initDb() must drop
+    // them silently — they're tables the current app no longer reads.
+    const file = path.join(tmpDir, 'ccsm.db');
+    const seed = new Database(file);
+    seed.exec(`
+      CREATE TABLE endpoints (id INTEGER PRIMARY KEY, name TEXT);
+      CREATE TABLE endpoint_models (id INTEGER PRIMARY KEY, endpoint_id INTEGER);
+      CREATE TABLE messages (id INTEGER PRIMARY KEY, body TEXT);
+      INSERT INTO endpoints (name) VALUES ('legacy');
+      INSERT INTO messages (body) VALUES ('old message');
+    `);
+    seed.close();
+
+    const handle = mod.initDb();
+    const remaining = handle
+      .prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name IN ('endpoints','endpoint_models','messages')"
+      )
+      .all() as { name: string }[];
+    expect(remaining).toEqual([]);
+    // The app_state table created by SCHEMA_SQL must still be there.
+    const appState = handle
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='app_state'")
+      .all();
+    expect(appState.length).toBe(1);
+  });
+});
+
+describe('db: corruption recovery sidecar cleanup', () => {
+  it('calls fs.unlinkSync on the -wal and -shm sidecars during corruption recovery', async () => {
+    const mod = await freshDb();
+    mod.closeDb();
+
+    const file = path.join(tmpDir, 'ccsm.db');
+    // Garbage main file — quick_check will report corruption inside
+    // ensureHealthyDb and trigger the sidecar-cleanup branch.
+    fs.writeFileSync(file, Buffer.from('not a sqlite database'));
+
+    // The vi.mock('fs') wrapper above delegates to the real unlinkSync by
+    // default (vi.fn(actual.unlinkSync)). Just clear the call log before
+    // initDb so we only capture calls made during corruption recovery.
+    unlinkSpy.fn.mockClear();
+
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => mod.initDb()).not.toThrow();
+    } finally {
+      err.mockRestore();
+    }
+
+    const paths = unlinkSpy.fn.mock.calls.map((c) => String(c[0]));
+    // Pinning the syscall, not the on-disk after-state. Reverse-verifies
+    // against deletion of the `for (const ext of ['-wal','-shm'])` cleanup
+    // loop in electron/db.ts.
+    expect(paths).toContain(file + '-wal');
+    expect(paths).toContain(file + '-shm');
+  });
+
+  it('swallows ENOENT from sidecar unlinkSync (sidecars may not exist)', async () => {
+    // Common case: corrupt main file with no leftover sidecars. The unlink
+    // loop must tolerate ENOENT silently — otherwise corruption recovery
+    // would crash on the most common shape of the bug it's supposed to fix.
+    const mod = await freshDb();
+    mod.closeDb();
+
+    const file = path.join(tmpDir, 'ccsm.db');
+    fs.writeFileSync(file, Buffer.from('not a sqlite database'));
+
+    // Override the wrapper to throw ENOENT for sidecar paths; let other
+    // unlink calls (e.g. the unlink fallback in the backup-rename branch)
+    // proceed via the real implementation.
+    const realFs = (await vi.importActual('fs')) as typeof import('fs');
+    unlinkSpy.fn.mockImplementation((p: fs.PathLike) => {
+      const s = String(p);
+      if (s.endsWith('-wal') || s.endsWith('-shm')) {
+        const e = new Error('ENOENT') as NodeJS.ErrnoException;
+        e.code = 'ENOENT';
+        throw e;
+      }
+      return realFs.unlinkSync(p);
+    });
+
+    const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => mod.initDb()).not.toThrow();
+    } finally {
+      err.mockRestore();
+    }
+
+    const attempted = unlinkSpy.fn.mock.calls.map((c) => String(c[0]));
+    expect(attempted).toContain(file + '-wal');
+    expect(attempted).toContain(file + '-shm');
+  });
+});
+
+afterEach(async () => {
+  // Restore the default delegate-to-real-fs behaviour after any test that
+  // overrode it via mockImplementation. mockReset would clear the default,
+  // breaking the first test in this describe; mockClear keeps the impl but
+  // wipes the call log.
+  const realFs = (await vi.importActual('fs')) as typeof import('fs');
+  unlinkSpy.fn.mockImplementation(realFs.unlinkSync);
+  unlinkSpy.fn.mockClear();
+});
+
+describe('db: __setDbForTests injection', () => {
+  it('swaps in an in-memory handle and re-runs the schema bootstrap', async () => {
+    const mod = await freshDb();
+    const mem = new Database(':memory:');
+    mod.__setDbForTests(mem);
+
+    // app_state must be created by __setDbForTests's SCHEMA_SQL execution.
+    const row = mem
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='app_state'")
+      .get();
+    expect(row).toBeTruthy();
+
+    // saveState / loadState route through the injected handle.
+    mod.saveState('mem-key', 'mem-val');
+    expect(mod.loadState('mem-key')).toBe('mem-val');
+
+    // Resetting to null releases the override — next init opens a real file.
+    mod.__setDbForTests(null);
+    const real = mod.initDb();
+    expect(real).not.toBe(mem);
+    // Persistent file is empty — the in-memory write didn't leak across.
+    expect(mod.loadState('mem-key')).toBeNull();
+  });
+
+  it('resets the prepared-statement cache on injection so the new handle compiles its own', async () => {
+    const mod = await freshDb();
+    // Warm the cache against the real db.
+    mod.initDb();
+    mod.saveState('warm', 'a');
+    expect(mod.loadState('warm')).toBe('a');
+
+    // Swap to a fresh in-memory db. If the cache wasn't reset, the next
+    // saveState() would call .run() on a Statement bound to the now-closed
+    // file handle and throw.
+    mod.closeDb();
+    const mem = new Database(':memory:');
+    mod.__setDbForTests(mem);
+    expect(() => mod.saveState('warm', 'b')).not.toThrow();
+    expect(mod.loadState('warm')).toBe('b');
+  });
+});
+
+describe('db: closeDb hygiene', () => {
+  it('closeDb is safe to call when db was never opened', async () => {
+    const mod = await freshDb();
+    mod.closeDb();
+    expect(() => mod.closeDb()).not.toThrow();
+  });
+
+  it('forces a re-init on the next initDb call after close', async () => {
+    const mod = await freshDb();
+    const a = mod.initDb();
+    mod.closeDb();
+    const b = mod.initDb();
+    expect(a).not.toBe(b);
   });
 });

--- a/electron/__tests__/import-scanner.test.ts
+++ b/electron/__tests__/import-scanner.test.ts
@@ -1,0 +1,444 @@
+// UT for electron/import-scanner.ts — exercises the JSONL → ScannableSession
+// pipeline using a real on-disk fixture tree under a per-test tmp dir.
+//
+// Coverage targets the import flow's data contract:
+//   1. Missing `~/.claude/projects` → empty result, no throw
+//   2. Malformed JSONL lines → skipped (not fatal)
+//   3. Empty / metadata-less transcripts → dropped (resolve(null) path)
+//   4. Sidechain/sub-agent transcripts → filtered out
+//   5. Sort order — newest mtime first
+//   6. ccsm/agentory temp-cwd noise filter
+//   7. Title fallback: aiTitle > firstUserText > "(untitled session)"
+//   8. <command-...> wrapped first user lines do NOT become titles
+//   9. parseHead pure helper edge cases
+//  10. deriveRecentCwds: frequency-then-recency ranking + `~` skip
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  scanImportableSessions,
+  parseHead,
+  deriveRecentCwds,
+  isCCSMTempCwd,
+  isSidechainFrame,
+} from '../import-scanner';
+
+let tmpRoot: string;
+let projectsDir: string;
+let savedEnv: string | undefined;
+
+function mkProject(projectKey: string): string {
+  const dir = path.join(projectsDir, projectKey);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeJsonl(file: string, lines: Array<unknown | string>) {
+  const body = lines
+    .map((l) => (typeof l === 'string' ? l : JSON.stringify(l)))
+    .join('\n');
+  fs.writeFileSync(file, body);
+}
+
+function setMtime(file: string, ms: number) {
+  const t = ms / 1000;
+  fs.utimesSync(file, t, t);
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-import-scanner-test-'));
+  projectsDir = path.join(tmpRoot, 'projects');
+  fs.mkdirSync(projectsDir, { recursive: true });
+  savedEnv = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = tmpRoot;
+});
+
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+  else process.env.CLAUDE_CONFIG_DIR = savedEnv;
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  } catch {
+    /* best-effort */
+  }
+});
+
+describe('scanImportableSessions', () => {
+  it('returns [] (does not throw) when the projects dir is missing', async () => {
+    fs.rmSync(projectsDir, { recursive: true, force: true });
+    const out = await scanImportableSessions();
+    expect(out).toEqual([]);
+  });
+
+  it('returns [] when the projects dir is empty', async () => {
+    const out = await scanImportableSessions();
+    expect(out).toEqual([]);
+  });
+
+  it('returns [] when only non-jsonl files are present', async () => {
+    const dir = mkProject('-Users-foo-proj');
+    fs.writeFileSync(path.join(dir, 'README.md'), 'hi');
+    const out = await scanImportableSessions();
+    expect(out).toEqual([]);
+  });
+
+  it('extracts cwd, title, mtime, projectDir from a well-formed transcript', async () => {
+    const dir = mkProject('-Users-foo-proj');
+    const file = path.join(dir, 'sess-A.jsonl');
+    writeJsonl(file, [
+      { cwd: '/Users/foo/proj', type: 'meta' },
+      { type: 'user', message: { content: 'hello world' } },
+      { type: 'ai-title', aiTitle: 'Greeting' },
+      { type: 'assistant', message: { model: 'claude-3-5-sonnet' } },
+    ]);
+    setMtime(file, 1_700_000_000_000);
+
+    const out = await scanImportableSessions();
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      sessionId: 'sess-A',
+      cwd: '/Users/foo/proj',
+      title: 'Greeting', // aiTitle wins
+      projectDir: '-Users-foo-proj',
+      model: 'claude-3-5-sonnet',
+    });
+    expect(out[0].mtime).toBeGreaterThan(0);
+  });
+
+  it('falls back to first user text when no aiTitle frame is present', async () => {
+    const dir = mkProject('-tmp-foo');
+    const file = path.join(dir, 'sess-B.jsonl');
+    writeJsonl(file, [
+      { cwd: '/Users/foo/work', type: 'meta' },
+      { type: 'user', message: { content: 'do the thing please' } },
+    ]);
+    const out = await scanImportableSessions();
+    expect(out).toHaveLength(1);
+    expect(out[0].title).toBe('do the thing please');
+  });
+
+  it('skips <command-...> wrapped user lines when picking a title fallback', async () => {
+    const dir = mkProject('-tmp-foo2');
+    const file = path.join(dir, 'sess-C.jsonl');
+    writeJsonl(file, [
+      { cwd: '/Users/foo/work', type: 'meta' },
+      { type: 'user', message: { content: '<command-name>compact</command-name>' } },
+      { type: 'user', message: { content: 'real prompt here' } },
+    ]);
+    const out = await scanImportableSessions();
+    expect(out[0].title).toBe('real prompt here');
+  });
+
+  it('uses "(untitled session)" when only cwd is present', async () => {
+    const dir = mkProject('-Users-foo-empty');
+    const file = path.join(dir, 'sess-D.jsonl');
+    writeJsonl(file, [{ cwd: '/Users/foo/empty', type: 'meta' }]);
+    const out = await scanImportableSessions();
+    expect(out).toHaveLength(1);
+    expect(out[0].title).toBe('(untitled session)');
+  });
+
+  it('drops a transcript whose head has no cwd, title, user-text, or model', async () => {
+    const dir = mkProject('-Users-foo-junk');
+    const file = path.join(dir, 'sess-E.jsonl');
+    writeJsonl(file, [{ type: 'meta', extra: 1 }]);
+    const out = await scanImportableSessions();
+    expect(out).toEqual([]);
+  });
+
+  it('drops sub-agent (sidechain) transcripts', async () => {
+    const dir = mkProject('-Users-foo-side');
+    const file = path.join(dir, 'sess-F.jsonl');
+    writeJsonl(file, [
+      { isSidechain: true, cwd: '/Users/foo/side' },
+      { type: 'user', message: { content: 'inside subagent' } },
+    ]);
+    const out = await scanImportableSessions();
+    expect(out).toEqual([]);
+  });
+
+  it('drops transcripts whose first frame has a non-empty parentUuid', async () => {
+    const dir = mkProject('-Users-foo-side2');
+    const file = path.join(dir, 'sess-G.jsonl');
+    writeJsonl(file, [
+      { parentUuid: 'parent-1', cwd: '/Users/foo/side2', type: 'meta' },
+    ]);
+    const out = await scanImportableSessions();
+    expect(out).toEqual([]);
+  });
+
+  it('skips malformed JSON lines but still returns subsequent valid frames', async () => {
+    const dir = mkProject('-Users-foo-mal');
+    const file = path.join(dir, 'sess-H.jsonl');
+    // Mix of garbage + valid lines. The garbage line must NOT abort parsing.
+    writeJsonl(file, [
+      'this-is-not-json{{{',
+      { cwd: '/Users/foo/mal', type: 'meta' },
+      'another}garbage',
+      { type: 'user', message: { content: 'survived parsing' } },
+    ]);
+    const out = await scanImportableSessions();
+    expect(out).toHaveLength(1);
+    expect(out[0].cwd).toBe('/Users/foo/mal');
+    expect(out[0].title).toBe('survived parsing');
+  });
+
+  it('drops empty (0-byte) jsonl files without throwing', async () => {
+    const dir = mkProject('-Users-foo-empty2');
+    fs.writeFileSync(path.join(dir, 'sess-I.jsonl'), '');
+    // Plus one valid sibling to confirm the empty file is silently skipped
+    // and the valid one still surfaces.
+    const ok = path.join(dir, 'sess-J.jsonl');
+    writeJsonl(ok, [
+      { cwd: '/Users/foo/empty2', type: 'meta' },
+      { type: 'ai-title', aiTitle: 'Valid' },
+    ]);
+    const out = await scanImportableSessions();
+    expect(out).toHaveLength(1);
+    expect(out[0].sessionId).toBe('sess-J');
+  });
+
+  it('filters out our own ccsm-* / agentory-* temp-dir cwds', async () => {
+    const dir = mkProject('-tmp-noise');
+    const noisy = path.join(dir, 'sess-K.jsonl');
+    writeJsonl(noisy, [
+      { cwd: `${os.tmpdir()}/ccsm-spawn-abc`, type: 'meta' },
+      { type: 'ai-title', aiTitle: 'Noise' },
+    ]);
+    const real = path.join(dir, 'sess-L.jsonl');
+    writeJsonl(real, [
+      { cwd: '/Users/foo/realwork', type: 'meta' },
+      { type: 'ai-title', aiTitle: 'Real' },
+    ]);
+    const out = await scanImportableSessions();
+    const titles = out.map((s) => s.title).sort();
+    expect(titles).toEqual(['Real']);
+  });
+
+  it('sorts results by mtime desc (newest first)', async () => {
+    const dir = mkProject('-Users-foo-sort');
+    const a = path.join(dir, 'old.jsonl');
+    const b = path.join(dir, 'new.jsonl');
+    writeJsonl(a, [
+      { cwd: '/Users/foo/sort', type: 'meta' },
+      { type: 'ai-title', aiTitle: 'old' },
+    ]);
+    writeJsonl(b, [
+      { cwd: '/Users/foo/sort', type: 'meta' },
+      { type: 'ai-title', aiTitle: 'new' },
+    ]);
+    setMtime(a, 1_600_000_000_000);
+    setMtime(b, 1_700_000_000_000);
+
+    const out = await scanImportableSessions();
+    expect(out.map((s) => s.sessionId)).toEqual(['new', 'old']);
+  });
+
+  it('walks across multiple project directories', async () => {
+    const d1 = mkProject('-Users-foo-p1');
+    const d2 = mkProject('-Users-foo-p2');
+    writeJsonl(path.join(d1, 'a.jsonl'), [
+      { cwd: '/Users/foo/p1', type: 'meta' },
+      { type: 'ai-title', aiTitle: 'p1' },
+    ]);
+    writeJsonl(path.join(d2, 'b.jsonl'), [
+      { cwd: '/Users/foo/p2', type: 'meta' },
+      { type: 'ai-title', aiTitle: 'p2' },
+    ]);
+    const out = await scanImportableSessions();
+    expect(out.map((s) => s.projectDir).sort()).toEqual([
+      '-Users-foo-p1',
+      '-Users-foo-p2',
+    ]);
+  });
+
+  it('honors a runtime CLAUDE_CONFIG_DIR mutation between calls', async () => {
+    // First call: original tmpRoot, populated.
+    const d = mkProject('-Users-foo-run1');
+    writeJsonl(path.join(d, 'a.jsonl'), [
+      { cwd: '/Users/foo/run1', type: 'meta' },
+      { type: 'ai-title', aiTitle: 'r1' },
+    ]);
+    const first = await scanImportableSessions();
+    expect(first).toHaveLength(1);
+
+    // Second call: redirect to an empty tmp.
+    const altRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-import-scanner-alt-'));
+    try {
+      process.env.CLAUDE_CONFIG_DIR = altRoot;
+      const second = await scanImportableSessions();
+      expect(second).toEqual([]);
+    } finally {
+      process.env.CLAUDE_CONFIG_DIR = tmpRoot; // restore for afterEach
+      fs.rmSync(altRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('parseHead', () => {
+  it('returns null on a head with no useful fields', () => {
+    expect(parseHead([JSON.stringify({ type: 'noise' })])).toBeNull();
+  });
+
+  it('returns null on a sidechain first frame', () => {
+    expect(
+      parseHead([
+        JSON.stringify({ isSidechain: true, cwd: '/x' }),
+        JSON.stringify({ type: 'user', message: { content: 'hi' } }),
+      ])
+    ).toBeNull();
+  });
+
+  it('skips malformed lines and continues', () => {
+    const head = parseHead([
+      'garbage',
+      JSON.stringify({ cwd: '/x' }),
+      JSON.stringify({ type: 'ai-title', aiTitle: 'T' }),
+    ]);
+    expect(head).toEqual({ cwd: '/x', title: 'T', model: null });
+  });
+
+  it('uses "~" as cwd fallback when none was found but other fields exist', () => {
+    const head = parseHead([JSON.stringify({ type: 'ai-title', aiTitle: 'T' })]);
+    expect(head).toEqual({ cwd: '~', title: 'T', model: null });
+  });
+
+  it('extracts model from message.model on assistant frames', () => {
+    const head = parseHead([
+      JSON.stringify({ cwd: '/x' }),
+      JSON.stringify({ type: 'assistant', message: { model: 'opus' } }),
+    ]);
+    expect(head?.model).toBe('opus');
+  });
+
+  it('accepts top-level `model` as a fallback', () => {
+    const head = parseHead([
+      JSON.stringify({ cwd: '/x', model: 'sonnet' }),
+    ]);
+    expect(head?.model).toBe('sonnet');
+  });
+
+  it('extracts user text from array-content messages', () => {
+    const head = parseHead([
+      JSON.stringify({ cwd: '/x' }),
+      JSON.stringify({
+        type: 'user',
+        message: { content: [{ type: 'text', text: 'array form' }] },
+      }),
+    ]);
+    expect(head?.title).toBe('array form');
+  });
+
+  it('truncates long titles', () => {
+    const long = 'x'.repeat(200);
+    const head = parseHead([
+      JSON.stringify({ cwd: '/x' }),
+      JSON.stringify({ type: 'user', message: { content: long } }),
+    ]);
+    expect(head?.title.length).toBeLessThanOrEqual(80);
+    expect(head?.title.endsWith('…')).toBe(true);
+  });
+});
+
+describe('isSidechainFrame', () => {
+  it('flags frames with isSidechain:true', () => {
+    expect(isSidechainFrame({ isSidechain: true })).toBe(true);
+  });
+  it('flags frames with non-empty parentUuid', () => {
+    expect(isSidechainFrame({ parentUuid: 'p' })).toBe(true);
+  });
+  it('does NOT flag normal frames with parentUuid:null', () => {
+    expect(isSidechainFrame({ parentUuid: null })).toBe(false);
+  });
+  it('does NOT flag non-objects', () => {
+    expect(isSidechainFrame(null)).toBe(false);
+    expect(isSidechainFrame('x')).toBe(false);
+  });
+});
+
+describe('isCCSMTempCwd', () => {
+  it('matches a ccsm-prefixed segment under os.tmpdir()', () => {
+    expect(isCCSMTempCwd(path.join(os.tmpdir(), 'ccsm-A1', 'sub'))).toBe(true);
+  });
+  it('matches the legacy agentory-* prefix', () => {
+    expect(isCCSMTempCwd(path.join(os.tmpdir(), 'agentory-X', 'q'))).toBe(true);
+  });
+  it('matches /tmp/ccsm-* even when os.tmpdir() differs (macOS aliasing)', () => {
+    expect(isCCSMTempCwd('/tmp/ccsm-foo/bar')).toBe(true);
+  });
+  it('matches /var/folders/.../ccsm-* prefix', () => {
+    expect(isCCSMTempCwd('/var/folders/aa/bb/T/ccsm-foo')).toBe(true);
+  });
+  it('matches Windows AppData\\Local\\Temp\\ccsm-* (case-insensitive)', () => {
+    expect(
+      isCCSMTempCwd('C:/Users/me/AppData/Local/Temp/ccsm-foo')
+    ).toBe(true);
+    expect(
+      isCCSMTempCwd('C:\\Users\\me\\AppData\\Local\\Temp\\ccsm-foo')
+    ).toBe(true);
+  });
+  it('does not match a user-named path that contains "agentory"', () => {
+    expect(isCCSMTempCwd('/Users/me/projects/my-agentory-fork')).toBe(false);
+  });
+  it('does not match a normal cwd outside any temp root', () => {
+    expect(isCCSMTempCwd('/Users/me/proj')).toBe(false);
+  });
+  it('returns false for empty / non-string inputs', () => {
+    expect(isCCSMTempCwd('')).toBe(false);
+    // @ts-expect-error — exercising the runtime guard
+    expect(isCCSMTempCwd(undefined)).toBe(false);
+  });
+});
+
+describe('deriveRecentCwds', () => {
+  it('returns [] for empty input', () => {
+    expect(deriveRecentCwds([])).toEqual([]);
+  });
+
+  it('drops "~" placeholder cwds', () => {
+    expect(
+      deriveRecentCwds([
+        { cwd: '~', mtime: 5 },
+        { cwd: '~', mtime: 4 },
+      ])
+    ).toEqual([]);
+  });
+
+  it('ranks by frequency in the recent window, ties broken by recency', () => {
+    const out = deriveRecentCwds([
+      { cwd: '/a', mtime: 10 },
+      { cwd: '/a', mtime: 9 },
+      { cwd: '/a', mtime: 8 },
+      { cwd: '/b', mtime: 7 },
+      { cwd: '/b', mtime: 6 },
+      { cwd: '/c', mtime: 5 },
+    ]);
+    expect(out).toEqual(['/a', '/b', '/c']);
+  });
+
+  it('respects the windowSize bound — older entries do not contribute', () => {
+    // window=2: only the two newest contribute. /a wins 2-0 over /b even
+    // though /b dominates the long tail.
+    const out = deriveRecentCwds(
+      [
+        { cwd: '/a', mtime: 10 },
+        { cwd: '/a', mtime: 9 },
+        { cwd: '/b', mtime: 8 },
+        { cwd: '/b', mtime: 7 },
+        { cwd: '/b', mtime: 6 },
+      ],
+      10,
+      2
+    );
+    expect(out).toEqual(['/a']);
+  });
+
+  it('respects the max bound', () => {
+    const sessions = Array.from({ length: 5 }, (_, i) => ({
+      cwd: `/p${i}`,
+      mtime: 100 - i,
+    }));
+    expect(deriveRecentCwds(sessions, 2)).toEqual(['/p0', '/p1']);
+  });
+});

--- a/electron/__tests__/updater.test.ts
+++ b/electron/__tests__/updater.test.ts
@@ -201,7 +201,7 @@ describe('updater: IPC wiring', () => {
     expect(sendsFor('updates:status')).toContainEqual({ kind: 'error', message: 'boom' });
   });
 
-  it('updates:install calls quitAndInstall with visible installer + relaunch', async () => {
+  it('updates:install calls quitAndInstall silently + relaunch', async () => {
     // Defense-in-depth gate (#TBD): updates:install refuses unless
     // lastStatus is `downloaded`. Drive the broadcast first so the
     // handler can proceed.
@@ -211,7 +211,9 @@ describe('updater: IPC wiring', () => {
     expect(res).toEqual({ ok: true });
     // quitAndInstall is scheduled via setImmediate — flush it.
     await new Promise((r) => setImmediate(r));
-    expect(quitAndInstallCalls).toEqual([{ isSilent: false, isForceRunAfter: true }]);
+    // isSilent=true pairs with NSIS oneClick=true to give a VSCode-style
+    // restart-and-done UX — no installer wizard, no progress popup.
+    expect(quitAndInstallCalls).toEqual([{ isSilent: true, isForceRunAfter: true }]);
   });
 
   it('updates:install refuses when no download has completed', () => {

--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 import type { App } from 'electron';
 
 // Mock electron — appLifecycle.ts top-level imports `Menu`, which would
@@ -18,7 +18,10 @@ vi.mock('electron', () => {
 // intercepts ESM `import`, NOT Node-native CJS require — and Node's CJS
 // resolver can't find the .ts source on its own. Patch the CJS require
 // to short-circuit any '../i18n' lookup with our deterministic stub.
-// Restored in afterAll-equivalent below if we ever need it.
+// MUST be restored in afterAll: vitest's default per-file isolation hides
+// the leak today, but if anyone flips to `pool: 'threads'` + `isolate: false`
+// an un-restored patch would bleed into sibling test files (e.g. anything
+// that itself does `require('../i18n')`) and surface as mysterious failures.
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const Module = require('node:module') as typeof import('node:module');
 const ModuleProto = (Module as unknown as { prototype: { require: (id: string) => unknown } })
@@ -30,6 +33,10 @@ ModuleProto.require = function patchedRequire(this: NodeJS.Module, id: string) {
   }
   return originalRequire.call(this, id);
 };
+
+afterAll(() => {
+  ModuleProto.require = originalRequire;
+});
 
 import { Menu } from 'electron';
 import {

--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { App } from 'electron';
+
+// Mock electron — appLifecycle.ts top-level imports `Menu`, which would
+// trigger "Electron failed to install correctly" on the lint+test runner
+// (no electron binary on CI). We control the spies via the mock factory
+// and read them back via vi.mocked() in tests.
+vi.mock('electron', () => {
+  const buildFromTemplate = vi.fn(() => ({ items: [] }));
+  const setApplicationMenu = vi.fn();
+  return {
+    Menu: { buildFromTemplate, setApplicationMenu },
+  };
+});
+
+// applyAppMenuLocale uses a dynamic `require('../i18n')` to dodge a
+// circular-import edge in the production graph. vitest's vi.mock only
+// intercepts ESM `import`, NOT Node-native CJS require — and Node's CJS
+// resolver can't find the .ts source on its own. Patch the CJS require
+// to short-circuit any '../i18n' lookup with our deterministic stub.
+// Restored in afterAll-equivalent below if we ever need it.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Module = require('node:module') as typeof import('node:module');
+const ModuleProto = (Module as unknown as { prototype: { require: (id: string) => unknown } })
+  .prototype;
+const originalRequire = ModuleProto.require;
+ModuleProto.require = function patchedRequire(this: NodeJS.Module, id: string) {
+  if (id === '../i18n') {
+    return { tMenu: (key: string) => `MENU_${key}` };
+  }
+  return originalRequire.call(this, id);
+};
+
+import { Menu } from 'electron';
+import {
+  applyAppMenuLocale,
+  registerLifecycleHandlers,
+  type LifecycleDeps,
+} from '../appLifecycle';
+
+type EventName = 'before-quit' | 'window-all-closed' | 'activate';
+
+interface FakeApp {
+  on: ReturnType<typeof vi.fn>;
+  quit: ReturnType<typeof vi.fn>;
+  /** invoke a registered listener for a given event */
+  fire: (event: EventName) => void;
+}
+
+function createFakeApp(): FakeApp {
+  const handlers = new Map<EventName, () => void>();
+  const on = vi.fn((event: EventName, cb: () => void) => {
+    handlers.set(event, cb);
+  });
+  const quit = vi.fn();
+  return {
+    on,
+    quit,
+    fire: (event) => {
+      const cb = handlers.get(event);
+      if (!cb) throw new Error(`no handler registered for ${event}`);
+      cb();
+    },
+  };
+}
+
+function buildDeps(overrides: Partial<LifecycleDeps> = {}): {
+  deps: LifecycleDeps;
+  fakeApp: FakeApp;
+  spies: {
+    setIsQuitting: ReturnType<typeof vi.fn>;
+    killAllPtySessions: ReturnType<typeof vi.fn>;
+    closeDb: ReturnType<typeof vi.fn>;
+    createWindow: ReturnType<typeof vi.fn>;
+    disposeNotifyPipeline: ReturnType<typeof vi.fn>;
+  };
+  state: { isQuitting: boolean; windowCount: number };
+} {
+  const fakeApp = createFakeApp();
+  const state = { isQuitting: false, windowCount: 0 };
+  const setIsQuitting = vi.fn((v: boolean) => {
+    state.isQuitting = v;
+  });
+  const killAllPtySessions = vi.fn();
+  const closeDb = vi.fn();
+  const createWindow = vi.fn();
+  const disposeNotifyPipeline = vi.fn();
+  const deps: LifecycleDeps = {
+    app: fakeApp as unknown as App,
+    getIsQuitting: () => state.isQuitting,
+    setIsQuitting,
+    killAllPtySessions,
+    closeDb,
+    createWindow,
+    getWindowCount: () => state.windowCount,
+    disposeNotifyPipeline,
+    ...overrides,
+  };
+  return {
+    deps,
+    fakeApp,
+    spies: {
+      setIsQuitting,
+      killAllPtySessions,
+      closeDb,
+      createWindow,
+      disposeNotifyPipeline,
+    },
+    state,
+  };
+}
+
+describe('applyAppMenuLocale', () => {
+  beforeEach(() => {
+    vi.mocked(Menu.buildFromTemplate).mockClear();
+    vi.mocked(Menu.setApplicationMenu).mockClear();
+  });
+
+  it('builds a hidden Edit-role accelerator menu and installs it', () => {
+    applyAppMenuLocale();
+    expect(Menu.buildFromTemplate).toHaveBeenCalledTimes(1);
+    expect(Menu.setApplicationMenu).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the localized "Edit" label from i18n.tMenu', () => {
+    applyAppMenuLocale();
+    const template = vi.mocked(Menu.buildFromTemplate).mock.calls[0][0];
+    expect(template).toHaveLength(1);
+    expect(template[0].label).toBe('MENU_edit');
+  });
+
+  it('omits paste from the submenu (terminal pane installs its own handler)', () => {
+    applyAppMenuLocale();
+    const template = vi.mocked(Menu.buildFromTemplate).mock.calls[0][0];
+    const submenu = template[0].submenu as Array<{ role?: string; type?: string }>;
+    const roles = submenu.map((item) => item.role).filter(Boolean);
+    expect(roles).not.toContain('paste');
+    // sanity-check the roles we DO want survive the rebuild
+    expect(roles).toEqual(
+      expect.arrayContaining(['undo', 'redo', 'cut', 'copy', 'selectAll']),
+    );
+  });
+
+  it('rebuilds the menu on every call (locale change re-runs)', () => {
+    applyAppMenuLocale();
+    applyAppMenuLocale();
+    expect(Menu.buildFromTemplate).toHaveBeenCalledTimes(2);
+    expect(Menu.setApplicationMenu).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('registerLifecycleHandlers', () => {
+  it('registers listeners for before-quit, window-all-closed, and activate', () => {
+    const { deps, fakeApp } = buildDeps();
+    registerLifecycleHandlers(deps);
+    const events = fakeApp.on.mock.calls.map((c) => c[0]);
+    expect(events).toEqual(
+      expect.arrayContaining(['before-quit', 'window-all-closed', 'activate']),
+    );
+    expect(fakeApp.on).toHaveBeenCalledTimes(3);
+  });
+
+  describe('before-quit', () => {
+    it('flips isQuitting to true', () => {
+      const { deps, fakeApp, spies, state } = buildDeps();
+      registerLifecycleHandlers(deps);
+      fakeApp.fire('before-quit');
+      expect(spies.setIsQuitting).toHaveBeenCalledWith(true);
+      expect(state.isQuitting).toBe(true);
+    });
+
+    it('reaps pty sessions', () => {
+      const { deps, fakeApp, spies } = buildDeps();
+      registerLifecycleHandlers(deps);
+      fakeApp.fire('before-quit');
+      expect(spies.killAllPtySessions).toHaveBeenCalledTimes(1);
+    });
+
+    it('disposes the notify pipeline when present', () => {
+      const { deps, fakeApp, spies } = buildDeps();
+      registerLifecycleHandlers(deps);
+      fakeApp.fire('before-quit');
+      expect(spies.disposeNotifyPipeline).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not throw when disposeNotifyPipeline is omitted (early-failure path)', () => {
+      const { deps, fakeApp } = buildDeps({ disposeNotifyPipeline: undefined });
+      registerLifecycleHandlers(deps);
+      expect(() => fakeApp.fire('before-quit')).not.toThrow();
+    });
+
+    it('swallows killAllPtySessions errors (best-effort cleanup)', () => {
+      const { deps, fakeApp, spies } = buildDeps({
+        killAllPtySessions: vi.fn(() => {
+          throw new Error('pty reap blew up');
+        }),
+      });
+      registerLifecycleHandlers(deps);
+      expect(() => fakeApp.fire('before-quit')).not.toThrow();
+      // disposeNotifyPipeline still runs even if kill threw
+      expect(spies.disposeNotifyPipeline).toHaveBeenCalledTimes(1);
+    });
+
+    it('swallows disposeNotifyPipeline errors', () => {
+      const { deps, fakeApp } = buildDeps({
+        disposeNotifyPipeline: vi.fn(() => {
+          throw new Error('dispose blew up');
+        }),
+      });
+      registerLifecycleHandlers(deps);
+      expect(() => fakeApp.fire('before-quit')).not.toThrow();
+    });
+  });
+
+  describe('window-all-closed', () => {
+    it('quits and closes db when isQuitting is already true', () => {
+      const { deps, fakeApp, spies, state } = buildDeps();
+      state.isQuitting = true;
+      registerLifecycleHandlers(deps);
+      fakeApp.fire('window-all-closed');
+      expect(spies.closeDb).toHaveBeenCalledTimes(1);
+      expect(fakeApp.quit).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT quit when isQuitting is false (tray-resident behavior)', () => {
+      const { deps, fakeApp, spies, state } = buildDeps();
+      state.isQuitting = false;
+      registerLifecycleHandlers(deps);
+      fakeApp.fire('window-all-closed');
+      expect(spies.closeDb).not.toHaveBeenCalled();
+      expect(fakeApp.quit).not.toHaveBeenCalled();
+    });
+
+    it('reads the live isQuitting flag (not a snapshot at registration time)', () => {
+      const { deps, fakeApp, spies, state } = buildDeps();
+      // register while isQuitting=false, then flip before firing the event
+      registerLifecycleHandlers(deps);
+      state.isQuitting = true;
+      fakeApp.fire('window-all-closed');
+      expect(spies.closeDb).toHaveBeenCalledTimes(1);
+      expect(fakeApp.quit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('activate', () => {
+    it('spawns a new window when no windows exist', () => {
+      const { deps, fakeApp, spies, state } = buildDeps();
+      state.windowCount = 0;
+      registerLifecycleHandlers(deps);
+      fakeApp.fire('activate');
+      expect(spies.createWindow).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT spawn a window when one already exists', () => {
+      const { deps, fakeApp, spies, state } = buildDeps();
+      state.windowCount = 1;
+      registerLifecycleHandlers(deps);
+      fakeApp.fire('activate');
+      expect(spies.createWindow).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -29,7 +29,7 @@ import { app, BrowserWindow, ipcMain, type Tray } from 'electron';
 import { initDb, closeDb } from './db';
 import { buildTrayIcon } from './branding/icon';
 import { initSentry } from './sentry/init';
-import { createWindow as createMainWindowFactory } from './window/createWindow';
+import { createWindow as createMainWindowFactory, installContextMenuSuppressIpc } from './window/createWindow';
 import { createTray, type TrayController } from './tray/createTray';
 
 // safety net — escaped main-proc rejections kill app on Node 20+ default
@@ -223,6 +223,13 @@ app.whenReady().then(() => {
   });
   registerWindowIpc({ ipcMain });
   registerUtilityIpc({ ipcMain });
+
+  // Process-wide IPC for the terminal pane's `onContextMenu` handler to
+  // ask main to skip the native context menu for one upcoming click.
+  // Registered here (alongside the other IPC handlers) rather than in
+  // `createWindow` because the channel is window-agnostic — see
+  // `installContextMenuSuppressIpc` in electron/window/createWindow.ts.
+  installContextMenuSuppressIpc(ipcMain);
 
   installUpdaterIpc();
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -71,6 +71,7 @@ import { registerDbIpc } from './ipc/dbIpc';
 import { registerSystemIpc } from './ipc/systemIpc';
 import { registerSessionIpc } from './ipc/sessionIpc';
 import { registerWindowIpc } from './ipc/windowIpc';
+import { startMobileRemoteServer } from './remote/mobileRemoteServer';
 import {
   registerUtilityIpc,
   primeImportableCache,
@@ -123,6 +124,7 @@ let isQuitting = false;
 let badgeManager: BadgeManager | null = null;
 let notifyPipeline: NotifyPipeline | null = null;
 let notifyPipelineDispose: (() => void) | null = null;
+let mobileRemoteServer: { close: () => void } | null = null;
 const badgeController = new BadgeController(() => badgeManager);
 
 function getTrayBaseImage() {
@@ -252,6 +254,8 @@ app.whenReady().then(() => {
     () => BrowserWindow.getAllWindows()[0] ?? null,
   );
 
+  mobileRemoteServer = startMobileRemoteServer();
+
   // ─────────────────────── notify pipeline (Phase C, #689) ───────────────
   // BadgeManager is bumped via `onNotified` to update the tray/dock badge.
   // The pipeline + its producer subscriptions (PTY, focus/blur, unwatched)
@@ -326,5 +330,9 @@ registerLifecycleHandlers({
     createWindow();
   },
   getWindowCount: () => BrowserWindow.getAllWindows().length,
-  disposeNotifyPipeline: () => notifyPipelineDispose?.(),
+  disposeNotifyPipeline: () => {
+    mobileRemoteServer?.close();
+    mobileRemoteServer = null;
+    notifyPipelineDispose?.();
+  },
 });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -65,6 +65,7 @@ import {
 } from './sessionTitles';
 import { loadNotifyEnabled, subscribeNotifyEnabledInvalidation } from './prefs/notifyEnabled';
 import { subscribeCrashReportingInvalidation } from './prefs/crashReporting';
+import { subscribeScrollbackInvalidation } from './prefs/scrollback';
 import { BadgeController } from './badgeController';
 import { registerDbIpc } from './ipc/dbIpc';
 import { registerSystemIpc } from './ipc/systemIpc';
@@ -188,6 +189,7 @@ app.whenReady().then(() => {
   // See `tech-debt-12-functional-core.md` leak #5 / Task #818.
   subscribeCrashReportingInvalidation();
   subscribeNotifyEnabledInvalidation();
+  subscribeScrollbackInvalidation();
   // Order is significant for systemIpc: it seeds the active i18n language
   // from the OS locale, so any subsequent producer that calls i18n.t()
   // sees the correct active language.

--- a/electron/notify/__tests__/runStateTracker.test.ts
+++ b/electron/notify/__tests__/runStateTracker.test.ts
@@ -1,24 +1,33 @@
-import { describe, it, expect } from 'vitest';
-import { createRunStateTracker } from '../runStateTracker';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRunStateTracker, RING_DEBOUNCE_MS } from '../runStateTracker';
 import { decide, DEDUPE_MS, SHORT_TASK_MS } from '../notifyDecider';
+import type { Decision } from '../notifyDecider';
 
 const NOW = 1_700_000_000_000;
 
 describe('runStateTracker — pure decider', () => {
-  it('running → idle: fires a decision (Rule 5 unfocused branch)', () => {
-    const t = createRunStateTracker(decide);
+  it('running → idle: fires a decision (Rule 5 unfocused branch); toast is deferred', () => {
+    const fires: Decision[] = [];
+    const t = createRunStateTracker(decide, {
+      onDeferredToast: (d) => fires.push(d),
+    });
     t.setFocused(false); // Rule 5: not focused → toast + flash
     expect(t.onTitle('s1', 'running', NOW)).toBeNull();
     expect(t._internals().runStartTs.get('s1')).toBe(NOW);
     const dec = t.onTitle('s1', 'idle', NOW + 1_000);
     expect(dec).not.toBeNull();
     expect(dec?.sid).toBe('s1');
-    expect(dec?.toast).toBe(true);
+    // Toast is debounced — immediate decision carries flash only.
+    expect(dec?.toast).toBe(false);
     expect(dec?.flash).toBe(true);
     // runStartTs cleared after non-running title
     expect(t._internals().runStartTs.has('s1')).toBe(false);
-    // lastFiredTs recorded
+    // lastFiredTs recorded (for the flash)
     expect(t._internals().lastFiredTs.get('s1')).toBe(NOW + 1_000);
+    // A pending deferred toast is scheduled.
+    expect(t._internals().pendingToastSids).toEqual(['s1']);
+    expect(fires).toEqual([]);
+    t.dispose();
   });
 
   it('dedupes back-to-back idle titles within DEDUPE_MS', () => {
@@ -31,6 +40,7 @@ describe('runStateTracker — pure decider', () => {
     t.onTitle('s1', 'running', NOW + 200);
     const second = t.onTitle('s1', 'idle', NOW + 100 + DEDUPE_MS - 1);
     expect(second).toBeNull();
+    t.dispose();
   });
 
   it('mute window prevents toast (Rule 7) but flash still fires', () => {
@@ -42,15 +52,26 @@ describe('runStateTracker — pure decider', () => {
     expect(dec).not.toBeNull();
     expect(dec?.toast).toBe(false);
     expect(dec?.flash).toBe(true);
+    // Muted sids must not even schedule a deferred toast (the timer would
+    // be re-suppressed at fire-time anyway, so keep the pending-set tidy).
+    expect(t._internals().pendingToastSids).toEqual([]);
+    t.dispose();
   });
 
   it('expired mute (untilTs in the past) no longer suppresses toast', () => {
-    const t = createRunStateTracker(decide);
+    const fires: Decision[] = [];
+    const t = createRunStateTracker(decide, {
+      onDeferredToast: (d) => fires.push(d),
+    });
     t.setFocused(false);
     t.setMuted('s1', NOW - 1); // already expired
     t.onTitle('s1', 'running', NOW);
     const dec = t.onTitle('s1', 'idle', NOW + 1_000);
-    expect(dec?.toast).toBe(true);
+    // Immediate is flash-only (toast deferred); pending toast exists.
+    expect(dec?.toast).toBe(false);
+    expect(dec?.flash).toBe(true);
+    expect(t._internals().pendingToastSids).toEqual(['s1']);
+    t.dispose();
   });
 
   it('setMuted(null) clears the mute', () => {
@@ -60,7 +81,11 @@ describe('runStateTracker — pure decider', () => {
     t.setMuted('s1', null);
     t.onTitle('s1', 'running', NOW);
     const dec = t.onTitle('s1', 'idle', NOW + 1_000);
-    expect(dec?.toast).toBe(true);
+    // Immediate flash fires; toast is deferred.
+    expect(dec?.toast).toBe(false);
+    expect(dec?.flash).toBe(true);
+    expect(t._internals().pendingToastSids).toEqual(['s1']);
+    t.dispose();
   });
 
   it('forgetSid clears all per-sid state', () => {
@@ -85,10 +110,15 @@ describe('runStateTracker — pure decider', () => {
     expect(after.mutedSids.has('s1')).toBe(false);
     expect(after.lastFiredTs.has('s1')).toBe(false);
     expect(after.lastUserInputTs.has('s1')).toBe(false);
+    expect(after.pendingToastSids).toEqual([]);
+    t.dispose();
   });
 
   it('multiple sids tracked independently', () => {
-    const t = createRunStateTracker(decide);
+    const fires: Decision[] = [];
+    const t = createRunStateTracker(decide, {
+      onDeferredToast: (d) => fires.push(d),
+    });
     t.setFocused(false);
     t.onTitle('s1', 'running', NOW);
     t.onTitle('s2', 'running', NOW + 500);
@@ -106,6 +136,7 @@ describe('runStateTracker — pure decider', () => {
     // Forgetting s1 doesn't touch s2
     t.forgetSid('s1');
     expect(t._internals().lastFiredTs.has('s2')).toBe(true);
+    t.dispose();
   });
 
   it('classification "unknown" is a no-op', () => {
@@ -114,6 +145,7 @@ describe('runStateTracker — pure decider', () => {
     expect(t.onTitle('s1', 'unknown', NOW)).toBeNull();
     expect(t._internals().runStartTs.has('s1')).toBe(false);
     expect(t._internals().lastFiredTs.has('s1')).toBe(false);
+    t.dispose();
   });
 
   it('Rule 1: user-input within 60s suppresses fire', () => {
@@ -124,10 +156,14 @@ describe('runStateTracker — pure decider', () => {
     // Idle 1s later — Rule 1 mute window still active
     const dec = t.onTitle('s1', 'idle', NOW + 1_000);
     expect(dec).toBeNull();
+    t.dispose();
   });
 
   it('Rule 2 vs Rule 3: foreground active sid splits on SHORT_TASK_MS', () => {
-    const t = createRunStateTracker(decide);
+    const fires: Decision[] = [];
+    const t = createRunStateTracker(decide, {
+      onDeferredToast: (d) => fires.push(d),
+    });
     t.setFocused(true);
     t.setActiveSid('s1');
 
@@ -137,24 +173,33 @@ describe('runStateTracker — pure decider', () => {
     expect(shortDec).not.toBeNull();
     expect(shortDec?.toast).toBe(false);
     expect(shortDec?.flash).toBe(true);
+    // Rule 2 doesn't toast → no deferred timer scheduled.
+    expect(t._internals().pendingToastSids).toEqual([]);
 
-    // Wait past dedupe, then long task — Rule 3: toast + flash
+    // Wait past dedupe, then long task — Rule 3: toast + flash.
+    // Toast is debounced, so the immediate Decision still carries flash only;
+    // the toast surfaces via the deferred callback.
     const t2 = NOW + DEDUPE_MS + 10_000;
     t.onTitle('s1', 'running', t2);
     const longDec = t.onTitle('s1', 'idle', t2 + SHORT_TASK_MS + 1_000);
     expect(longDec).not.toBeNull();
-    expect(longDec?.toast).toBe(true);
+    expect(longDec?.toast).toBe(false);
     expect(longDec?.flash).toBe(true);
+    expect(t._internals().pendingToastSids).toEqual(['s1']);
+    t.dispose();
   });
 
-  it('Rule 4: foreground but viewing a different sid → toast + flash', () => {
+  it('Rule 4: foreground but viewing a different sid → toast + flash (toast deferred)', () => {
     const t = createRunStateTracker(decide);
     t.setFocused(true);
     t.setActiveSid('s2'); // viewing s2
     t.onTitle('s1', 'running', NOW);
     const dec = t.onTitle('s1', 'idle', NOW + 1_000);
-    expect(dec?.toast).toBe(true);
+    // Toast debounced; immediate is flash-only.
+    expect(dec?.toast).toBe(false);
     expect(dec?.flash).toBe(true);
+    expect(t._internals().pendingToastSids).toEqual(['s1']);
+    t.dispose();
   });
 
   it('runStartTs is cleared after every non-running title (even when no decision fires)', () => {
@@ -166,6 +211,7 @@ describe('runStateTracker — pure decider', () => {
     const dec = t.onTitle('s1', 'idle', NOW + 1_000);
     expect(dec).toBeNull();
     expect(t._internals().runStartTs.has('s1')).toBe(false);
+    t.dispose();
   });
 
   // ---------------------------------------------------------------------------
@@ -196,6 +242,7 @@ describe('runStateTracker — pure decider', () => {
     // No mutation: lastFiredTs must stay empty (the bug also poisoned the
     // 5s dedupe window with a phantom fire).
     expect(t._internals().lastFiredTs.has('s1')).toBe(false);
+    t.dispose();
   });
 
   it('Task #767: does not fire when first title for a sid is "waiting"', () => {
@@ -205,6 +252,7 @@ describe('runStateTracker — pure decider', () => {
     const dec = t.onTitle('s1', 'waiting', NOW);
     expect(dec).toBeNull();
     expect(t._internals().lastFiredTs.has('s1')).toBe(false);
+    t.dispose();
   });
 
   it('Task #767 regression guard: still fires on idle AFTER a running title', () => {
@@ -223,6 +271,7 @@ describe('runStateTracker — pure decider', () => {
     expect(dec).not.toBeNull();
     expect(dec?.toast).toBe(false);
     expect(dec?.flash).toBe(true);
+    t.dispose();
   });
 
   it('Task #767: forgetSid resets the hasObservedRunning gate', () => {
@@ -242,5 +291,200 @@ describe('runStateTracker — pure decider', () => {
     // lifetime).
     const dec2 = t.onTitle('s1', 'idle', NOW + 10_000);
     expect(dec2).toBeNull();
+    t.dispose();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// "Ring the last waiting" debounce (toast-spam fix).
+//
+// Real-world burst: agent runs a long task with several mid-task permission
+// prompts. Each prompt = a 'waiting' title; user answers in-app, agent
+// resumes (next 'running'), next prompt arrives ~5s later. Pre-debounce
+// the user got 3-5 toasts back-to-back. Post-debounce, each waiting
+// (re)starts a RING_DEBOUNCE_MS timer; only the LAST waiting (i.e. the one
+// where the agent actually gets stuck) fires a toast.
+// ---------------------------------------------------------------------------
+describe('runStateTracker — ring-last debounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function newTracker(): { tracker: ReturnType<typeof createRunStateTracker>; fires: Decision[] } {
+    const fires: Decision[] = [];
+    const tracker = createRunStateTracker(decide, {
+      onDeferredToast: (d) => fires.push(d),
+      // nowFn defaults to Date.now which vi.useFakeTimers also patches.
+    });
+    return { tracker, fires };
+  }
+
+  it('edge case 1: quick waiting (title flips out before debounce) → no toast', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false); // Rule 5 path → would-toast
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    expect(tracker._internals().pendingToastSids).toEqual(['s1']);
+    // User answers in-app: agent resumes BEFORE the debounce window closes.
+    vi.advanceTimersByTime(2_000);
+    tracker.onTitle('s1', 'running', NOW + 3_000);
+    expect(tracker._internals().pendingToastSids).toEqual([]);
+    // Advance well past the original deadline — no toast fires.
+    vi.advanceTimersByTime(RING_DEBOUNCE_MS + 1_000);
+    expect(fires).toEqual([]);
+    tracker.dispose();
+  });
+
+  it('edge case 2: single sustained waiting → exactly one toast at +RING_DEBOUNCE_MS', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    // Advance past the debounce window — toast fires.
+    vi.advanceTimersByTime(RING_DEBOUNCE_MS + 10);
+    expect(fires.length).toBe(1);
+    expect(fires[0]!.toast).toBe(true);
+    expect(fires[0]!.flash).toBe(false);
+    expect(fires[0]!.sid).toBe('s1');
+    expect(tracker._internals().pendingToastSids).toEqual([]);
+    tracker.dispose();
+  });
+
+  it('edge case 3: long task with 3 quick prompts then sustained → exactly one toast', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    // Initial run starts at NOW.
+    tracker.onTitle('s1', 'running', NOW);
+    // Prompt #1 at +5s; user answers in 2s (running at +7s).
+    vi.advanceTimersByTime(5_000);
+    tracker.onTitle('s1', 'idle', NOW + 5_000);
+    vi.advanceTimersByTime(2_000); // timer not yet exhausted
+    tracker.onTitle('s1', 'running', NOW + 7_000);
+    expect(fires).toEqual([]);
+    // Prompt #2 at +12s; user answers in 3s.
+    vi.advanceTimersByTime(5_000);
+    tracker.onTitle('s1', 'idle', NOW + 12_000);
+    vi.advanceTimersByTime(3_000);
+    tracker.onTitle('s1', 'running', NOW + 15_000);
+    expect(fires).toEqual([]);
+    // Prompt #3 at +20s; this one sticks (user is away).
+    vi.advanceTimersByTime(5_000);
+    tracker.onTitle('s1', 'idle', NOW + 20_000);
+    // Advance the full debounce window.
+    vi.advanceTimersByTime(RING_DEBOUNCE_MS + 10);
+    expect(fires.length).toBe(1);
+    expect(fires[0]!.sid).toBe('s1');
+    tracker.dispose();
+  });
+
+  it('edge case 4a: Rule 1 (user-input) still suppresses at fire-time', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    // 2s into the wait, user touches the sid (e.g. presses Enter from inside
+    // ccsm to take an action). The timer is still pending; at fire-time the
+    // user-init window is active and suppresses the toast.
+    vi.advanceTimersByTime(2_000);
+    tracker.markUserInput('s1', NOW + 3_000);
+    vi.advanceTimersByTime(RING_DEBOUNCE_MS); // fires at NOW + 9_000
+    expect(fires).toEqual([]);
+    tracker.dispose();
+  });
+
+  it('edge case 4b: Rule 7 (per-sid mute) still suppresses at fire-time', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    expect(tracker._internals().pendingToastSids).toEqual(['s1']);
+    // Mute the sid during the wait — fire-time re-check suppresses.
+    vi.advanceTimersByTime(2_000);
+    tracker.setMuted('s1', Number.POSITIVE_INFINITY);
+    vi.advanceTimersByTime(RING_DEBOUNCE_MS);
+    expect(fires).toEqual([]);
+    tracker.dispose();
+  });
+
+  it('edge case 5: multiple sids run independent timers', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s2', 'running', NOW + 100);
+    // s1 starts waiting at +1s → deadline NOW+9_000.
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    // s2 starts waiting at +3s → deadline NOW+11_000.
+    vi.advanceTimersByTime(2_000);
+    tracker.onTitle('s2', 'idle', NOW + 3_000);
+    expect(tracker._internals().pendingToastSids.sort()).toEqual(['s1', 's2']);
+    // Advance to NOW+9_010 — only s1 fires.
+    vi.advanceTimersByTime(6_010);
+    expect(fires.length).toBe(1);
+    expect(fires[0]!.sid).toBe('s1');
+    expect(tracker._internals().pendingToastSids).toEqual(['s2']);
+    // Advance to NOW+11_010 — s2 fires too.
+    vi.advanceTimersByTime(2_000);
+    expect(fires.length).toBe(2);
+    expect(fires[1]!.sid).toBe('s2');
+    tracker.dispose();
+  });
+
+  it('forgetSid cancels any pending deferred toast', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    expect(tracker._internals().pendingToastSids).toEqual(['s1']);
+    tracker.forgetSid('s1');
+    expect(tracker._internals().pendingToastSids).toEqual([]);
+    vi.advanceTimersByTime(RING_DEBOUNCE_MS + 1_000);
+    expect(fires).toEqual([]);
+    tracker.dispose();
+  });
+
+  it('dispose cancels all pending deferred toasts', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    tracker.onTitle('s2', 'running', NOW + 100);
+    tracker.onTitle('s2', 'idle', NOW + 1_100);
+    expect(tracker._internals().pendingToastSids.length).toBe(2);
+    tracker.dispose();
+    expect(tracker._internals().pendingToastSids).toEqual([]);
+    vi.advanceTimersByTime(RING_DEBOUNCE_MS + 1_000);
+    expect(fires).toEqual([]);
+  });
+
+  it('two bursts past dedupe: the LAST waiting wins (timer pushed out by each fresh idle)', () => {
+    // Burst pattern with running flips between idles. Each fresh idle past
+    // the 5s dedupe window pushes the deadline out — only the final waiting
+    // (no follow-up running) actually rings.
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    // Idle #1 at +1s.
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    // 6s later (past the 5s dedupe), agent resumes briefly.
+    vi.advanceTimersByTime(6_000); // now NOW+7_000
+    tracker.onTitle('s1', 'running', NOW + 7_000);
+    // No fire yet — running cancelled the pending timer.
+    expect(fires).toEqual([]);
+    expect(tracker._internals().pendingToastSids).toEqual([]);
+    // Idle #2 at +8s; this one sticks.
+    vi.advanceTimersByTime(1_000); // now NOW+8_000
+    tracker.onTitle('s1', 'idle', NOW + 8_000);
+    // Deadline now NOW+16_000. Advance to NOW+15_500 — not fired yet.
+    vi.advanceTimersByTime(7_500);
+    expect(fires).toEqual([]);
+    // Past the deadline.
+    vi.advanceTimersByTime(1_000);
+    expect(fires.length).toBe(1);
+    expect(fires[0]!.sid).toBe('s1');
+    tracker.dispose();
   });
 });

--- a/electron/notify/runStateTracker.ts
+++ b/electron/notify/runStateTracker.ts
@@ -29,9 +29,48 @@
 //   * `forgetSid(sid)` clears every per-sid map entry in one shot
 //                      (mirrors pipeline.forgetSid for the state it owns).
 
-import type { Ctx, Decision, Event } from './notifyDecider';
+import { USER_INIT_MUTE_MS, type Ctx, type Decision, type Event } from './notifyDecider';
 
 export type TitleClassification = 'idle' | 'running' | 'waiting' | 'unknown';
+
+/**
+ * "Ring the last waiting" debounce window.
+ *
+ * Real-world burst pattern: a long agent task issues several quick
+ * permission / question prompts back-to-back (waiting → user answers in-app
+ * → running → waiting → …). Pre-debounce, each waiting fired its own toast,
+ * giving the user 3-5 OS notifications for a single task. Post-debounce,
+ * each waiting (re)starts a 8s timer; if the title flips back to running
+ * before 8s elapses (because the user answered in-app, or the CLI moved on
+ * on its own), the timer is cancelled and no toast fires. Only the FINAL,
+ * still-waiting prompt that has settled for 8s rings.
+ *
+ * Trade-off: a single long-waiting prompt is now delayed by 8s vs. fire-
+ * immediately. We accept the slight latency in exchange for the burst-
+ * collapse — toast spam is the louder complaint. Tune via PR if needed.
+ *
+ * The flash (sidebar halo) still fires IMMEDIATELY on each waiting — only
+ * the OS toast is debounced. The user gets instant in-app feedback;
+ * the OS-level interrupt is reserved for genuinely stuck waits.
+ */
+export const RING_DEBOUNCE_MS = 8_000;
+
+export interface RunStateTrackerOptions {
+  /** Override the debounce window (test only). Defaults to RING_DEBOUNCE_MS. */
+  ringDebounceMs?: number;
+  /** Wall-clock provider for deferred-toast fire-time re-evaluation. Defaults
+   *  to Date.now. Tests inject a mock to advance time deterministically. */
+  nowFn?: () => number;
+  /** setTimeout / clearTimeout overrides. Default to globalThis. Tests using
+   *  vi.useFakeTimers() can rely on the defaults, but explicit injection is
+   *  available if a test needs a hand-rolled scheduler. */
+  setTimeoutFn?: (cb: () => void, ms: number) => unknown;
+  clearTimeoutFn?: (handle: unknown) => void;
+  /** Sink callback for a deferred toast that survived the debounce window.
+   *  Receives a Decision with `toast:true, flash:false` (flash already fired
+   *  on the immediate path when the debounce started). */
+  onDeferredToast?: (decision: Decision) => void;
+}
 
 export interface RunStateTracker {
   /** Producer entry — feed a classified title for `sid` at `nowTs`.
@@ -48,6 +87,8 @@ export interface RunStateTracker {
   /** Mute `sid` until `untilTs` (use `Infinity` for sticky). Pass
    *  `null` to clear. */
   setMuted(sid: string, untilTs: number | null): void;
+  /** Cancel all pending deferred toasts (test / shutdown cleanup). */
+  dispose(): void;
   /** Test-only — read internal maps for assertion. */
   _internals(): {
     runStartTs: Map<string, number>;
@@ -56,17 +97,34 @@ export interface RunStateTracker {
     lastUserInputTs: Map<string, number>;
     focused: boolean;
     activeSid: string | null;
+    /** sids with an outstanding deferred-toast timer. */
+    pendingToastSids: string[];
   };
 }
 
 export function createRunStateTracker(
   decide: (event: Event, ctx: Ctx) => Decision | null,
+  options: RunStateTrackerOptions = {},
 ): RunStateTracker {
+  const ringDebounceMs = options.ringDebounceMs ?? RING_DEBOUNCE_MS;
+  const nowFn = options.nowFn ?? Date.now;
+  const setTimeoutFn =
+    options.setTimeoutFn ?? ((cb: () => void, ms: number) => setTimeout(cb, ms));
+  const clearTimeoutFn =
+    options.clearTimeoutFn ?? ((h: unknown) => clearTimeout(h as ReturnType<typeof setTimeout>));
+  const onDeferredToast = options.onDeferredToast;
+
   const runStartTs = new Map<string, number>();
   /** Map<sid, untilTs> — entry present + nowTs < untilTs ⇒ sid is muted. */
   const mutedSids = new Map<string, number>();
   const lastFiredTs = new Map<string, number>();
   const lastUserInputTs = new Map<string, number>();
+  /** Per-sid outstanding deferred-toast timer handle. Cancelled on:
+   *    - 'running' classification (task resumed → no ring)
+   *    - forgetSid (session teardown)
+   *    - dispose (pipeline / process shutdown)
+   *  Reset on each new waiting signal (debounce semantics — ring the LAST). */
+  const pendingToastTimers = new Map<string, unknown>();
   /**
    * Per-sid gate (Task #767): true once we have observed a 'running' title
    * for this sid in the current process lifetime. The decider's Rule 2
@@ -94,6 +152,51 @@ export function createRunStateTracker(
     return out;
   }
 
+  function isMutedNow(sid: string, nowTs: number): boolean {
+    const until = mutedSids.get(sid);
+    return until !== undefined && nowTs < until;
+  }
+
+  function cancelPendingToast(sid: string): void {
+    const t = pendingToastTimers.get(sid);
+    if (t !== undefined) {
+      clearTimeoutFn(t);
+      pendingToastTimers.delete(sid);
+    }
+  }
+
+  /**
+   * Schedule (or reset) the deferred-toast timer for `sid`.
+   *
+   * Each fresh waiting signal pushes the fire deadline out to NOW +
+   * ringDebounceMs. Burst-collapse: rapid running ↔ waiting flips never
+   * exhaust the timer; only sustained waiting does.
+   */
+  function schedulePendingToast(sid: string): void {
+    cancelPendingToast(sid);
+    const handle = setTimeoutFn(() => {
+      pendingToastTimers.delete(sid);
+      if (!onDeferredToast) return;
+      // Re-evaluate at fire-time. We deliberately do NOT re-run the full
+      // decider here — runStartTs has been cleared (so Rule 2 would fire
+      // flash-only and Rule 3 would never fire). Instead, re-check the
+      // two dynamic suppressors that may have flipped during the wait:
+      //   1. Rule 1 user-init mute (user touched this sid in last 60s)
+      //   2. Rule 7 per-sid mute
+      // Global mute is enforced one layer up in pipeline.ts (the pipeline
+      // never feeds idle through to the tracker when global mute is on, so
+      // a deferred fire on a globally-muted sid cannot happen unless the
+      // mute toggled on AFTER schedule — acceptable, pipeline owns it).
+      const fireTs = nowFn();
+      const lastInput = lastUserInputTs.get(sid);
+      if (lastInput !== undefined && fireTs - lastInput < USER_INIT_MUTE_MS) return;
+      if (isMutedNow(sid, fireTs)) return;
+      lastFiredTs.set(sid, fireTs);
+      onDeferredToast({ toast: true, flash: false, sid });
+    }, ringDebounceMs);
+    pendingToastTimers.set(sid, handle);
+  }
+
   return {
     onTitle(sid, classification, nowTs) {
       if (classification === 'unknown') return null;
@@ -101,6 +204,9 @@ export function createRunStateTracker(
       if (classification === 'running') {
         if (!runStartTs.has(sid)) runStartTs.set(sid, nowTs);
         hasObservedRunning.add(sid);
+        // Cancel any pending deferred toast — the task moved on, the user
+        // (or the CLI) already handled the previous waiting signal.
+        cancelPendingToast(sid);
         return null;
       }
 
@@ -129,16 +235,41 @@ export function createRunStateTracker(
         now: nowTs,
       };
       const event: Event = { type: 'osc-title', sid, title: 'waiting', ts: nowTs };
-      const decision = decide(event, ctx);
+      const immediate = decide(event, ctx);
 
       // Mirror pipeline behaviour: always clear runStartTs after a
       // non-running title so the next run starts a fresh elapsed clock.
       runStartTs.delete(sid);
 
-      if (decision !== null) {
-        lastFiredTs.set(sid, nowTs);
+      // Debounce-style "ring the LAST waiting": any waiting signal that
+      // would otherwise toast (re)starts the deferred-toast timer.
+      // We trigger the schedule when EITHER:
+      //   - decide() returned toast:true (the original "yes, toast" path), OR
+      //   - decide() returned null AND a deferred toast is already pending
+      //     (a follow-up waiting inside a burst — even if the immediate
+      //     decision was suppressed by 5s dedupe, we still want the timer
+      //     pushed out so the LAST waiting wins).
+      // We do NOT schedule when the sid is currently muted (no point
+      // firing later either — re-eval at fire-time would suppress anyway,
+      // and avoiding the timer keeps the pending-set tidy).
+      const shouldDefer =
+        !isMutedNow(sid, nowTs) &&
+        ((immediate !== null && immediate.toast) || pendingToastTimers.has(sid));
+      if (shouldDefer) {
+        schedulePendingToast(sid);
       }
-      return decision;
+
+      if (immediate !== null) {
+        lastFiredTs.set(sid, nowTs);
+        if (immediate.toast) {
+          // Strip the toast from the immediate fan-out — it will fire (or
+          // not) via the deferred path. Flash still fires immediately so
+          // the in-app halo is instant.
+          return { toast: false, flash: immediate.flash, sid };
+        }
+        return immediate;
+      }
+      return null;
     },
     forgetSid(sid) {
       runStartTs.delete(sid);
@@ -146,6 +277,7 @@ export function createRunStateTracker(
       lastFiredTs.delete(sid);
       lastUserInputTs.delete(sid);
       hasObservedRunning.delete(sid);
+      cancelPendingToast(sid);
     },
     setFocused(next) {
       focused = next;
@@ -160,6 +292,10 @@ export function createRunStateTracker(
       if (untilTs === null) mutedSids.delete(sid);
       else mutedSids.set(sid, untilTs);
     },
+    dispose() {
+      for (const handle of pendingToastTimers.values()) clearTimeoutFn(handle);
+      pendingToastTimers.clear();
+    },
     _internals() {
       return {
         runStartTs,
@@ -168,6 +304,7 @@ export function createRunStateTracker(
         lastUserInputTs,
         focused,
         activeSid,
+        pendingToastSids: Array.from(pendingToastTimers.keys()),
       };
     },
   };

--- a/electron/notify/sinks/__tests__/pipeline.test.ts
+++ b/electron/notify/sinks/__tests__/pipeline.test.ts
@@ -59,32 +59,43 @@ describe('installNotifyPipeline (Task #743 orchestrator)', () => {
   });
 
   it('running -> idle (unfocused) feeds a toast + flash via the sinks', () => {
-    const { win, sends } = makeStubWin();
-    const onNotified = vi.fn();
-    const pipeline = installNotifyPipeline({
-      getMainWindow: () => win as never,
-      isGlobalMutedFn: () => false,
-      getNameFn: () => 'Test',
-      onNotified,
-    });
-    pipeline.setFocused(false); // Rule 5
+    vi.useFakeTimers();
+    try {
+      const { win, sends } = makeStubWin();
+      const onNotified = vi.fn();
+      const pipeline = installNotifyPipeline({
+        getMainWindow: () => win as never,
+        isGlobalMutedFn: () => false,
+        getNameFn: () => 'Test',
+        onNotified,
+      });
+      pipeline.setFocused(false); // Rule 5
 
-    pipeline.feedChunk('s1', osc(RUNNING_TITLE));
-    pipeline.feedChunk('s1', osc(IDLE_TITLE));
+      pipeline.feedChunk('s1', osc(RUNNING_TITLE));
+      pipeline.feedChunk('s1', osc(IDLE_TITLE));
 
-    // Toast sink fired (test-hook impl writes to globalThis log).
-    const log = (globalThis as { __ccsmNotifyLog?: Array<{ sid: string }> }).__ccsmNotifyLog;
-    expect(log).toBeDefined();
-    expect(log!.length).toBe(1);
-    expect(log![0]!.sid).toBe('s1');
-    expect(onNotified).toHaveBeenCalledWith('s1');
+      // Flash sink fired immediately (sidebar halo is instant).
+      const flashSends = sends.filter((s) => s.channel === 'notify:flash');
+      expect(flashSends.length).toBe(1);
+      expect(flashSends[0]!.payload).toEqual({ sid: 's1', on: true });
 
-    // Flash sink fired notify:flash IPC.
-    const flashSends = sends.filter((s) => s.channel === 'notify:flash');
-    expect(flashSends.length).toBe(1);
-    expect(flashSends[0]!.payload).toEqual({ sid: 's1', on: true });
+      // Toast is DEBOUNCED — nothing yet.
+      const log0 = (globalThis as { __ccsmNotifyLog?: Array<{ sid: string }> }).__ccsmNotifyLog;
+      expect(log0 ?? []).toEqual([]);
+      expect(onNotified).not.toHaveBeenCalled();
 
-    pipeline.dispose();
+      // Advance past the ring-debounce window — toast fires.
+      vi.advanceTimersByTime(10_000);
+      const log = (globalThis as { __ccsmNotifyLog?: Array<{ sid: string }> }).__ccsmNotifyLog;
+      expect(log).toBeDefined();
+      expect(log!.length).toBe(1);
+      expect(log![0]!.sid).toBe('s1');
+      expect(onNotified).toHaveBeenCalledWith('s1');
+
+      pipeline.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('global mute short-circuits BEFORE the tracker runs (no decision, no fire)', () => {
@@ -143,25 +154,33 @@ describe('installNotifyPipeline (Task #743 orchestrator)', () => {
   });
 
   it('setMuted suppresses toast for the sid (Rule 7) but a different sid still fires', () => {
-    const { win } = makeStubWin();
-    const onNotified = vi.fn();
-    const pipeline = installNotifyPipeline({
-      getMainWindow: () => win as never,
-      isGlobalMutedFn: () => false,
-      onNotified,
-    });
-    pipeline.setFocused(false);
-    pipeline.setMuted('s1', true);
+    vi.useFakeTimers();
+    try {
+      const { win } = makeStubWin();
+      const onNotified = vi.fn();
+      const pipeline = installNotifyPipeline({
+        getMainWindow: () => win as never,
+        isGlobalMutedFn: () => false,
+        onNotified,
+      });
+      pipeline.setFocused(false);
+      pipeline.setMuted('s1', true);
 
-    pipeline.feedChunk('s1', osc(RUNNING_TITLE));
-    pipeline.feedChunk('s1', osc(IDLE_TITLE));
-    expect(onNotified).not.toHaveBeenCalledWith('s1');
+      pipeline.feedChunk('s1', osc(RUNNING_TITLE));
+      pipeline.feedChunk('s1', osc(IDLE_TITLE));
 
-    // A non-muted sid still fires through the same pipeline.
-    pipeline.feedChunk('s2', osc(RUNNING_TITLE));
-    pipeline.feedChunk('s2', osc(IDLE_TITLE));
-    expect(onNotified).toHaveBeenCalledWith('s2');
-    pipeline.dispose();
+      // A non-muted sid still fires through the same pipeline.
+      pipeline.feedChunk('s2', osc(RUNNING_TITLE));
+      pipeline.feedChunk('s2', osc(IDLE_TITLE));
+
+      // s2's toast is debounced — drain the timer.
+      vi.advanceTimersByTime(10_000);
+      expect(onNotified).not.toHaveBeenCalledWith('s1');
+      expect(onNotified).toHaveBeenCalledWith('s2');
+      pipeline.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('projectCtx surfaces tracker focused/active state for inspectors', () => {

--- a/electron/notify/sinks/pipeline.ts
+++ b/electron/notify/sinks/pipeline.ts
@@ -84,7 +84,17 @@ export function installNotifyPipeline(opts: NotifyPipelineOptions): NotifyPipeli
     onNotified: opts.onNotified,
   });
   const flash = createFlashSink({ getMainWindow: opts.getMainWindow });
-  const tracker = createRunStateTracker(decide);
+  // Deferred-toast wiring (Task: "ring the last waiting"). The tracker
+  // strips toast:true from its synchronous return and instead schedules a
+  // RING_DEBOUNCE_MS timer per sid; on timer fire (no 'running' arrived
+  // in the meantime), it calls back here to ring exactly once. The
+  // `onNotified` badge bump still fires via toastSink.apply, so unread
+  // counts stay consistent regardless of which path the toast took.
+  const tracker = createRunStateTracker(decide, {
+    onDeferredToast: (decision) => {
+      toast.apply(decision);
+    },
+  });
 
   // Diagnostics for e2e probes — counts what each layer sees so we can tell
   // whether failure is "no PTY data", "no OSC titles", "titles seen but
@@ -207,6 +217,11 @@ export function installNotifyPipeline(opts: NotifyPipelineOptions): NotifyPipeli
       // pipeline disposal — visible as a slow-growing handle count in
       // long-running tests / HMR reloads.
       flash.dispose();
+      // Cancel any outstanding deferred-toast timers held by the tracker.
+      // Same leak class as flashSink timers — without this, a still-pending
+      // ring would fire after the pipeline (and its sinks) are torn down,
+      // attempting to toast against a destroyed BrowserWindow.
+      tracker.dispose();
     },
     _internals() {
       return { ctx: projectCtx(), sniffer, tracker, toast, flash, diag };

--- a/electron/prefs/__tests__/scrollback.test.ts
+++ b/electron/prefs/__tests__/scrollback.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const stateStore = new Map<string, string | null>();
+let throwOnLoad = false;
+
+vi.mock('../../db', () => ({
+  loadState: (key: string) => {
+    if (throwOnLoad) throw new Error('boom');
+    return stateStore.has(key) ? stateStore.get(key)! : null;
+  },
+  saveState: (key: string, value: string) => {
+    stateStore.set(key, value);
+  },
+}));
+
+beforeEach(() => {
+  stateStore.clear();
+  throwOnLoad = false;
+  vi.resetModules();
+});
+
+describe('parseScrollbackLines', () => {
+  it('returns the default when raw is null/undefined/empty', async () => {
+    const { parseScrollbackLines, DEFAULT_SCROLLBACK_LINES } = await import(
+      '../scrollback'
+    );
+    expect(parseScrollbackLines(null)).toBe(DEFAULT_SCROLLBACK_LINES);
+    expect(parseScrollbackLines(undefined)).toBe(DEFAULT_SCROLLBACK_LINES);
+    expect(parseScrollbackLines('')).toBe(DEFAULT_SCROLLBACK_LINES);
+  });
+
+  it('accepts numeric strings (TEXT-column round-trip)', async () => {
+    const { parseScrollbackLines } = await import('../scrollback');
+    expect(parseScrollbackLines('2500')).toBe(2500);
+  });
+
+  it('clamps below MIN', async () => {
+    const { parseScrollbackLines, MIN_SCROLLBACK_LINES } = await import(
+      '../scrollback'
+    );
+    expect(parseScrollbackLines(0)).toBe(MIN_SCROLLBACK_LINES);
+    expect(parseScrollbackLines(-9999)).toBe(MIN_SCROLLBACK_LINES);
+  });
+
+  it('clamps above MAX', async () => {
+    const { parseScrollbackLines, MAX_SCROLLBACK_LINES } = await import(
+      '../scrollback'
+    );
+    expect(parseScrollbackLines(999_999)).toBe(MAX_SCROLLBACK_LINES);
+  });
+
+  it('rounds non-integers', async () => {
+    const { parseScrollbackLines } = await import('../scrollback');
+    expect(parseScrollbackLines(1500.4)).toBe(1500);
+    expect(parseScrollbackLines(1500.6)).toBe(1501);
+  });
+
+  it('falls back to default for NaN / non-numeric strings', async () => {
+    const { parseScrollbackLines, DEFAULT_SCROLLBACK_LINES } = await import(
+      '../scrollback'
+    );
+    expect(parseScrollbackLines('abc')).toBe(DEFAULT_SCROLLBACK_LINES);
+    expect(parseScrollbackLines(NaN)).toBe(DEFAULT_SCROLLBACK_LINES);
+  });
+});
+
+describe('loadScrollbackLines', () => {
+  it('returns the default when the row is missing', async () => {
+    const { loadScrollbackLines, DEFAULT_SCROLLBACK_LINES } = await import(
+      '../scrollback'
+    );
+    expect(loadScrollbackLines()).toBe(DEFAULT_SCROLLBACK_LINES);
+  });
+
+  it('reads the persisted value (numeric string)', async () => {
+    stateStore.set('scrollbackLines', '3000');
+    const { loadScrollbackLines } = await import('../scrollback');
+    expect(loadScrollbackLines()).toBe(3000);
+  });
+
+  it('clamps an out-of-range persisted value', async () => {
+    stateStore.set('scrollbackLines', '999999');
+    const { loadScrollbackLines, MAX_SCROLLBACK_LINES } = await import(
+      '../scrollback'
+    );
+    expect(loadScrollbackLines()).toBe(MAX_SCROLLBACK_LINES);
+  });
+
+  it('returns the default when loadState throws', async () => {
+    throwOnLoad = true;
+    const { loadScrollbackLines, DEFAULT_SCROLLBACK_LINES } = await import(
+      '../scrollback'
+    );
+    expect(loadScrollbackLines()).toBe(DEFAULT_SCROLLBACK_LINES);
+  });
+
+  it('caches after first read; cache invalidation re-reads', async () => {
+    stateStore.set('scrollbackLines', '500');
+    const { loadScrollbackLines, invalidateScrollbackCache } = await import(
+      '../scrollback'
+    );
+    expect(loadScrollbackLines()).toBe(500);
+    stateStore.set('scrollbackLines', '4000');
+    // Cache still serves the old value.
+    expect(loadScrollbackLines()).toBe(500);
+    invalidateScrollbackCache();
+    expect(loadScrollbackLines()).toBe(4000);
+  });
+});
+
+describe('subscribeScrollbackInvalidation', () => {
+  it('invalidates the cache when stateSavedBus emits SCROLLBACK_KEY', async () => {
+    stateStore.set('scrollbackLines', '500');
+    const { loadScrollbackLines, subscribeScrollbackInvalidation } =
+      await import('../scrollback');
+    const { emitStateSaved, _resetStateSavedBusForTests } = await import(
+      '../../shared/stateSavedBus'
+    );
+    _resetStateSavedBusForTests();
+    const off = subscribeScrollbackInvalidation();
+    expect(loadScrollbackLines()).toBe(500);
+
+    stateStore.set('scrollbackLines', '4000');
+    emitStateSaved('scrollbackLines');
+    expect(loadScrollbackLines()).toBe(4000);
+    off();
+  });
+
+  it('ignores unrelated keys', async () => {
+    stateStore.set('scrollbackLines', '500');
+    const { loadScrollbackLines, subscribeScrollbackInvalidation } =
+      await import('../scrollback');
+    const { emitStateSaved, _resetStateSavedBusForTests } = await import(
+      '../../shared/stateSavedBus'
+    );
+    _resetStateSavedBusForTests();
+    const off = subscribeScrollbackInvalidation();
+    expect(loadScrollbackLines()).toBe(500);
+
+    stateStore.set('scrollbackLines', '4000');
+    emitStateSaved('closeAction');
+    // Unrelated key did not invalidate; cache still serves 500.
+    expect(loadScrollbackLines()).toBe(500);
+    off();
+  });
+
+  it('reverse-verify: unsubscribed listener no longer invalidates', async () => {
+    stateStore.set('scrollbackLines', '500');
+    const { loadScrollbackLines, subscribeScrollbackInvalidation } =
+      await import('../scrollback');
+    const { emitStateSaved, _resetStateSavedBusForTests } = await import(
+      '../../shared/stateSavedBus'
+    );
+    _resetStateSavedBusForTests();
+    const off = subscribeScrollbackInvalidation();
+    loadScrollbackLines(); // prime cache
+    off();
+
+    stateStore.set('scrollbackLines', '4000');
+    emitStateSaved('scrollbackLines');
+    // Listener detached → cache still stale.
+    expect(loadScrollbackLines()).toBe(500);
+  });
+});

--- a/electron/prefs/scrollback.ts
+++ b/electron/prefs/scrollback.ts
@@ -1,0 +1,66 @@
+// Terminal scrollback line cap preference.
+//
+// Single user-facing knob that bounds BOTH the headless authoritative buffer
+// (PR-A #861) and the per-attach `getBufferSnapshot` payload (PR-B #865).
+// Lowered from the legacy 10000-line headless cap / 5000-line visible cap
+// to a 1500-line default so a long-running session no longer pays MB-sized
+// snapshot serialize cost on every attach.
+//
+// Persisted in app_state under `scrollbackLines`. Read synchronously inside
+// `entryFactory.makeEntry` (when constructing the headless Terminal) and
+// `lifecycle.attach` / `lifecycle.getBufferSnapshot` (when serializing) —
+// the SQLite read is a single point lookup so the cost is negligible. The
+// in-process cache + stateSavedBus invalidation pattern matches
+// `notifyEnabled` and `crashReporting`: see tech-debt-12 leak #5.
+
+import { loadState } from '../db';
+import { onStateSaved } from '../shared/stateSavedBus';
+
+export const SCROLLBACK_KEY = 'scrollbackLines';
+
+/** Default cap. Applied when the row is missing or unparseable. */
+export const DEFAULT_SCROLLBACK_LINES = 1500;
+
+/** User-facing range. Anything outside this is clamped (not rejected) so a
+ *  legacy snapshot with the old 5000/10000 value still loads sensibly. */
+export const MIN_SCROLLBACK_LINES = 100;
+export const MAX_SCROLLBACK_LINES = 50000;
+
+let _cached: number | undefined;
+
+/** Pure parser: clamp + integerize a raw persisted value into the valid
+ *  range. Exported so the renderer setter can share the same sanitization. */
+export function parseScrollbackLines(raw: unknown): number {
+  let n: number;
+  if (typeof raw === 'number') n = raw;
+  else if (typeof raw === 'string' && raw.length > 0) n = Number(raw);
+  else return DEFAULT_SCROLLBACK_LINES;
+  if (!Number.isFinite(n)) return DEFAULT_SCROLLBACK_LINES;
+  n = Math.round(n);
+  if (n < MIN_SCROLLBACK_LINES) return MIN_SCROLLBACK_LINES;
+  if (n > MAX_SCROLLBACK_LINES) return MAX_SCROLLBACK_LINES;
+  return n;
+}
+
+export function loadScrollbackLines(): number {
+  if (_cached !== undefined) return _cached;
+  try {
+    const raw = loadState(SCROLLBACK_KEY);
+    _cached = parseScrollbackLines(raw);
+    return _cached;
+  } catch {
+    return DEFAULT_SCROLLBACK_LINES;
+  }
+}
+
+export function invalidateScrollbackCache(): void {
+  _cached = undefined;
+}
+
+/** Wire cache invalidation to the stateSavedBus. Call once during boot
+ *  (before `registerDbIpc`). Returns the unsubscribe handle. */
+export function subscribeScrollbackInvalidation(): () => void {
+  return onStateSaved((key) => {
+    if (key === SCROLLBACK_KEY) invalidateScrollbackCache();
+  });
+}

--- a/electron/preload/bridges/__tests__/ccsmCore.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmCore.test.ts
@@ -1,0 +1,283 @@
+// Pins the `window.ccsm` preload bridge surface. Each entry in the IPC
+// surface is a renderer-visible API that callers (src/stores/persist.ts,
+// src/stores/drafts.ts, the StatusBar cwd popover, the in-app updater
+// dialog, the CloseActionDialog, etc.) bind to early at boot. Silent
+// removal or rename of any key would brick those callers with no compiler
+// signal — the preload runs in its own isolated module graph that's only
+// linked at runtime via `contextBridge.exposeInMainWorld`. These tests
+// freeze the shape and the IPC channel mapping so a future refactor must
+// touch this file too. Channel names are a wire contract with the main
+// process (`electron/ipc/*Ipc.ts` handlers); rename one without updating
+// the matching handler and the renderer call hangs forever waiting for
+// `invoke` to resolve.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { exposeSpy, invokeSpy, sendSpy, onSpy, removeListenerSpy } = vi.hoisted(() => ({
+  exposeSpy: vi.fn(),
+  invokeSpy: vi.fn(),
+  sendSpy: vi.fn(),
+  onSpy: vi.fn(),
+  removeListenerSpy: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: exposeSpy },
+  ipcRenderer: {
+    invoke: invokeSpy,
+    send: sendSpy,
+    on: onSpy,
+    removeListener: removeListenerSpy,
+  },
+}));
+
+import { installCcsmCoreBridge } from '../ccsmCore';
+
+type AnyApi = Record<string, unknown>;
+
+function getApi(): AnyApi {
+  expect(exposeSpy).toHaveBeenCalled();
+  const last = exposeSpy.mock.calls[exposeSpy.mock.calls.length - 1];
+  expect(last[0]).toBe('ccsm');
+  return last[1] as AnyApi;
+}
+
+describe('ccsmCore preload bridge', () => {
+  beforeEach(() => {
+    exposeSpy.mockClear();
+    invokeSpy.mockReset();
+    invokeSpy.mockResolvedValue(undefined);
+    sendSpy.mockReset();
+    onSpy.mockReset();
+    removeListenerSpy.mockReset();
+    installCcsmCoreBridge();
+  });
+
+  it('exposes a stable top-level key set under "ccsm"', () => {
+    const api = getApi();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'defaultModel',
+        'getVersion',
+        'i18n',
+        'loadState',
+        'onUpdateDownloaded',
+        'onUpdateStatus',
+        'openExternal',
+        'pathsExist',
+        'pickCwd',
+        'recentCwds',
+        'saveState',
+        'scanImportable',
+        'updatesCheck',
+        'updatesDownload',
+        'updatesGetAutoCheck',
+        'updatesInstall',
+        'updatesSetAutoCheck',
+        'updatesStatus',
+        'userCwds',
+        'userHome',
+        'window',
+      ].sort(),
+    );
+  });
+
+  it('nests i18n / userCwds / window with their own stable keys', () => {
+    const api = getApi();
+    expect(Object.keys(api.i18n as AnyApi).sort()).toEqual(
+      ['getSystemLocale', 'setLanguage'].sort(),
+    );
+    expect(Object.keys(api.userCwds as AnyApi).sort()).toEqual(
+      ['get', 'push'].sort(),
+    );
+    expect(Object.keys(api.window as AnyApi).sort()).toEqual(
+      [
+        'close',
+        'isMaximized',
+        'minimize',
+        'onAfterShow',
+        'onAskCloseAction',
+        'onBeforeHide',
+        'onMaximizedChanged',
+        'platform',
+        'resolveCloseAction',
+        'toggleMaximize',
+      ].sort(),
+    );
+  });
+
+  it.each<[string, string, unknown[]]>([
+    ['loadState', 'db:load', ['some.key']],
+    ['getVersion', 'app:getVersion', []],
+    ['scanImportable', 'import:scan', []],
+    ['recentCwds', 'import:recentCwds', []],
+    ['userHome', 'app:userHome', []],
+    ['pickCwd', 'cwd:pick', [undefined]],
+    ['defaultModel', 'settings:defaultModel', []],
+    ['pathsExist', 'paths:exist', [['/a', '/b']]],
+    ['openExternal', 'ccsm:openExternal', ['https://example.com']],
+    ['updatesStatus', 'updates:status', []],
+    ['updatesCheck', 'updates:check', []],
+    ['updatesDownload', 'updates:download', []],
+    ['updatesInstall', 'updates:install', []],
+    ['updatesGetAutoCheck', 'updates:getAutoCheck', []],
+    ['updatesSetAutoCheck', 'updates:setAutoCheck', [true]],
+  ])('forwards %s -> ipcRenderer.invoke("%s", ...)', async (m, chan, args) => {
+    const api = getApi();
+    const fn = api[m] as (...a: unknown[]) => Promise<unknown>;
+    await fn(...args);
+    if (m === 'pickCwd') {
+      // Bridge wraps the optional defaultPath in an object literal.
+      expect(invokeSpy).toHaveBeenCalledWith(chan, { defaultPath: args[0] });
+    } else {
+      expect(invokeSpy).toHaveBeenCalledWith(chan, ...args);
+    }
+  });
+
+  it('saveState unwraps {ok:true} silently', async () => {
+    invokeSpy.mockResolvedValueOnce({ ok: true });
+    const api = getApi();
+    await expect(
+      (api.saveState as (k: string, v: string) => Promise<void>)('k', 'v'),
+    ).resolves.toBeUndefined();
+    expect(invokeSpy).toHaveBeenCalledWith('db:save', 'k', 'v');
+  });
+
+  it('saveState rethrows on {ok:false} so .catch handlers fire', async () => {
+    invokeSpy.mockResolvedValueOnce({ ok: false, error: 'disk-full' });
+    const api = getApi();
+    await expect(
+      (api.saveState as (k: string, v: string) => Promise<void>)('k', 'v'),
+    ).rejects.toThrow('disk-full');
+  });
+
+  it('i18n.getSystemLocale invokes ccsm:get-system-locale', async () => {
+    const api = getApi();
+    await (api.i18n as { getSystemLocale: () => Promise<unknown> }).getSystemLocale();
+    expect(invokeSpy).toHaveBeenCalledWith('ccsm:get-system-locale');
+  });
+
+  it('i18n.setLanguage sends one-way ccsm:set-language', () => {
+    const api = getApi();
+    (api.i18n as { setLanguage: (l: 'en' | 'zh') => void }).setLanguage('zh');
+    expect(sendSpy).toHaveBeenCalledWith('ccsm:set-language', 'zh');
+  });
+
+  it('userCwds.get / push forward to app:userCwds:* channels', async () => {
+    const api = getApi();
+    const u = api.userCwds as {
+      get: () => Promise<unknown>;
+      push: (p: string) => Promise<unknown>;
+    };
+    await u.get();
+    expect(invokeSpy).toHaveBeenCalledWith('app:userCwds:get');
+    await u.push('/tmp/x');
+    expect(invokeSpy).toHaveBeenCalledWith('app:userCwds:push', '/tmp/x');
+  });
+
+  it.each<[string, string, unknown[]]>([
+    ['minimize', 'window:minimize', []],
+    ['toggleMaximize', 'window:toggleMaximize', []],
+    ['close', 'window:close', []],
+    ['isMaximized', 'window:isMaximized', []],
+  ])('window.%s invokes "%s"', async (m, chan, args) => {
+    const api = getApi();
+    const w = api.window as Record<string, (...a: unknown[]) => Promise<unknown>>;
+    await w[m](...args);
+    expect(invokeSpy).toHaveBeenCalledWith(chan, ...args);
+  });
+
+  it('window.resolveCloseAction sends one-way window:resolveCloseAction', () => {
+    const api = getApi();
+    const payload = {
+      requestId: 'req-1',
+      choice: 'tray' as const,
+      dontAskAgain: false,
+    };
+    (
+      api.window as { resolveCloseAction: (p: typeof payload) => void }
+    ).resolveCloseAction(payload);
+    expect(sendSpy).toHaveBeenCalledWith('window:resolveCloseAction', payload);
+  });
+
+  it('window.platform mirrors process.platform', () => {
+    const api = getApi();
+    expect((api.window as { platform: string }).platform).toBe(process.platform);
+  });
+
+  // ---- Listener registration & unsubscribe round-trip --------------------
+  // Each `on*` call must (a) register an ipcRenderer listener on the right
+  // channel and (b) hand back an unsubscribe that calls removeListener with
+  // the EXACT SAME wrap function reference. Mismatching identities would
+  // make the unsubscribe a silent no-op and leak a handler on every dialog
+  // open / window-state change.
+  it.each<[string, string]>([
+    ['onUpdateStatus', 'updates:status'],
+    ['onUpdateDownloaded', 'update:downloaded'],
+  ])('%s registers and cleanly unsubscribes on "%s"', (m, chan) => {
+    const api = getApi();
+    const cb = vi.fn();
+    const off = (api[m] as (cb: unknown) => () => void)(cb);
+    expect(onSpy).toHaveBeenCalled();
+    const matching = onSpy.mock.calls.find((c) => c[0] === chan);
+    expect(matching).toBeDefined();
+    const wrap = matching![1];
+    off();
+    expect(removeListenerSpy).toHaveBeenCalledWith(chan, wrap);
+  });
+
+  it.each<[string, string]>([
+    ['onMaximizedChanged', 'window:maximizedChanged'],
+    ['onBeforeHide', 'window:beforeHide'],
+    ['onAfterShow', 'window:afterShow'],
+    ['onAskCloseAction', 'window:askCloseAction'],
+  ])('window.%s registers and unsubscribes on "%s"', (m, chan) => {
+    const api = getApi();
+    const w = api.window as Record<string, (cb: unknown) => () => void>;
+    const cb = vi.fn();
+    const off = w[m](cb);
+    const matching = onSpy.mock.calls.find((c) => c[0] === chan);
+    expect(matching).toBeDefined();
+    const wrap = matching![1];
+    off();
+    expect(removeListenerSpy).toHaveBeenCalledWith(chan, wrap);
+  });
+
+  it('onUpdateStatus wrap forwards payload through to user handler', () => {
+    const api = getApi();
+    const cb = vi.fn();
+    (api.onUpdateStatus as (cb: unknown) => () => void)(cb);
+    const wrap = onSpy.mock.calls.find((c) => c[0] === 'updates:status')![1] as (
+      e: unknown,
+      p: unknown,
+    ) => void;
+    wrap({}, { kind: 'idle' });
+    expect(cb).toHaveBeenCalledWith({ kind: 'idle' });
+  });
+
+  it('window.onAskCloseAction wrap forwards labels payload', () => {
+    const api = getApi();
+    const cb = vi.fn();
+    (
+      api.window as {
+        onAskCloseAction: (cb: unknown) => () => void;
+      }
+    ).onAskCloseAction(cb);
+    const wrap = onSpy.mock.calls.find(
+      (c) => c[0] === 'window:askCloseAction',
+    )![1] as (e: unknown, p: unknown) => void;
+    const payload = {
+      requestId: 'req-2',
+      labels: {
+        message: 'm',
+        detail: 'd',
+        tray: 't',
+        quit: 'q',
+        cancel: 'c',
+        dontAskAgain: 'a',
+      },
+    };
+    wrap({}, payload);
+    expect(cb).toHaveBeenCalledWith(payload);
+  });
+});

--- a/electron/preload/bridges/__tests__/ccsmNotify.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmNotify.test.ts
@@ -1,0 +1,100 @@
+// Pins the `window.ccsmNotify` preload bridge — small surface (one fan-out
+// + one one-way send), but the IPC channel names are wire contracts with
+// `electron/notify/sinks/flashSink.ts` and the decider's Rule 1 input
+// mute. Renaming either side without the other silently breaks the
+// AgentIcon flash halo or the 60s post-input toast suppression.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { exposeSpy, sendSpy, onSpy, removeListenerSpy } = vi.hoisted(() => ({
+  exposeSpy: vi.fn(),
+  sendSpy: vi.fn(),
+  onSpy: vi.fn(),
+  removeListenerSpy: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: exposeSpy },
+  ipcRenderer: {
+    invoke: vi.fn(),
+    send: sendSpy,
+    on: onSpy,
+    removeListener: removeListenerSpy,
+  },
+}));
+
+import { installCcsmNotifyBridge } from '../ccsmNotify';
+
+type AnyApi = Record<string, unknown>;
+
+function lastApi(): AnyApi {
+  const last = exposeSpy.mock.calls[exposeSpy.mock.calls.length - 1];
+  expect(last[0]).toBe('ccsmNotify');
+  return last[1] as AnyApi;
+}
+
+describe('ccsmNotify preload bridge', () => {
+  beforeEach(() => {
+    exposeSpy.mockClear();
+    sendSpy.mockReset();
+    onSpy.mockReset();
+    removeListenerSpy.mockReset();
+    installCcsmNotifyBridge();
+  });
+
+  it('exposes a stable key set under "ccsmNotify"', () => {
+    const api = lastApi();
+    expect(Object.keys(api).sort()).toEqual(['markUserInput', 'onFlash'].sort());
+  });
+
+  it('install registers exactly one fan-out on "notify:flash"', () => {
+    const calls = onSpy.mock.calls.map((c) => c[0]);
+    expect(calls).toEqual(['notify:flash']);
+  });
+
+  it('onFlash fan-out delivers payload, unsubscribe stops delivery', () => {
+    const api = lastApi();
+    const cb = vi.fn();
+    const off = (api.onFlash as (cb: unknown) => () => void)(cb);
+    const dispatch = onSpy.mock.calls.find((c) => c[0] === 'notify:flash')![1] as (
+      e: unknown,
+      p: unknown,
+    ) => void;
+    dispatch({}, { sid: 's1', on: true });
+    expect(cb).toHaveBeenCalledWith({ sid: 's1', on: true });
+    off();
+    dispatch({}, { sid: 's1', on: false });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('throwing onFlash listener does not abort siblings', () => {
+    const api = lastApi();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const bad = vi.fn(() => {
+      throw new Error('x');
+    });
+    const good = vi.fn();
+    (api.onFlash as (cb: unknown) => () => void)(bad);
+    (api.onFlash as (cb: unknown) => () => void)(good);
+    const dispatch = onSpy.mock.calls.find((c) => c[0] === 'notify:flash')![1] as (
+      e: unknown,
+      p: unknown,
+    ) => void;
+    dispatch({}, { sid: 's', on: true });
+    expect(bad).toHaveBeenCalled();
+    expect(good).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('markUserInput sends one-way notify:userInput', () => {
+    const api = lastApi();
+    (api.markUserInput as (sid: string) => void)('s-42');
+    expect(sendSpy).toHaveBeenCalledWith('notify:userInput', 's-42');
+  });
+
+  it('markUserInput("") is a no-op (does NOT send)', () => {
+    const api = lastApi();
+    (api.markUserInput as (sid: string) => void)('');
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+});

--- a/electron/preload/bridges/__tests__/ccsmPty.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmPty.test.ts
@@ -104,6 +104,14 @@ describe('ccsmPty preload bridge', () => {
     expect(invokeSpy).toHaveBeenCalledWith(chan, ...args);
   });
 
+  it('spawn with forkSourceSid forwards 3 args to pty:spawn', async () => {
+    const api = lastApi();
+    await (
+      api.spawn as (sid: string, cwd: string, forkSourceSid?: string) => Promise<unknown>
+    )('s1', '/cwd', 'source-sid');
+    expect(invokeSpy).toHaveBeenCalledWith('pty:spawn', 's1', '/cwd', 'source-sid');
+  });
+
   it('checkClaudeAvailable defaults its opts to {}', async () => {
     const api = lastApi();
     await (api.checkClaudeAvailable as (o?: unknown) => Promise<unknown>)();

--- a/electron/preload/bridges/__tests__/ccsmPty.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmPty.test.ts
@@ -1,0 +1,182 @@
+// Pins the `window.ccsmPty` preload bridge surface. This bridge fronts the
+// in-process node-pty host (replaces ttyd) plus folds the CLI-availability
+// probe and clipboard. `onData` / `onExit` use the same listener-set
+// fan-out as ccsmSession so every TerminalPane mount doesn't leak a fresh
+// ipcRenderer handler on the shared `pty:data` / `pty:exit` channels —
+// that's the whole reason the bridge exists in this shape.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  exposeSpy,
+  invokeSpy,
+  onSpy,
+  removeListenerSpy,
+  clipboardReadSpy,
+  clipboardWriteSpy,
+} = vi.hoisted(() => ({
+  exposeSpy: vi.fn(),
+  invokeSpy: vi.fn(),
+  onSpy: vi.fn(),
+  removeListenerSpy: vi.fn(),
+  clipboardReadSpy: vi.fn(() => 'clip-text'),
+  clipboardWriteSpy: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: exposeSpy },
+  ipcRenderer: {
+    invoke: invokeSpy,
+    send: vi.fn(),
+    on: onSpy,
+    removeListener: removeListenerSpy,
+  },
+  clipboard: {
+    readText: () => clipboardReadSpy(),
+    writeText: (t: string) => clipboardWriteSpy(t),
+  },
+}));
+
+import { installCcsmPtyBridge } from '../ccsmPty';
+
+type AnyApi = Record<string, unknown>;
+
+function lastApi(): AnyApi {
+  const last = exposeSpy.mock.calls[exposeSpy.mock.calls.length - 1];
+  expect(last[0]).toBe('ccsmPty');
+  return last[1] as AnyApi;
+}
+
+describe('ccsmPty preload bridge', () => {
+  beforeEach(() => {
+    exposeSpy.mockClear();
+    invokeSpy.mockReset();
+    invokeSpy.mockResolvedValue(undefined);
+    onSpy.mockReset();
+    removeListenerSpy.mockReset();
+    clipboardReadSpy.mockClear();
+    clipboardWriteSpy.mockClear();
+    installCcsmPtyBridge();
+  });
+
+  it('exposes a stable key set under "ccsmPty"', () => {
+    const api = lastApi();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'attach',
+        'checkClaudeAvailable',
+        'clipboard',
+        'detach',
+        'get',
+        'getBufferSnapshot',
+        'input',
+        'kill',
+        'list',
+        'onData',
+        'onExit',
+        'resize',
+        'spawn',
+      ].sort(),
+    );
+    expect(Object.keys(api.clipboard as AnyApi).sort()).toEqual(
+      ['readText', 'writeText'].sort(),
+    );
+  });
+
+  it('install registers fan-outs for "pty:data" and "pty:exit"', () => {
+    const channels = onSpy.mock.calls.map((c) => c[0]).sort();
+    expect(channels).toEqual(['pty:data', 'pty:exit'].sort());
+  });
+
+  it.each<[string, string, unknown[]]>([
+    ['list', 'pty:list', []],
+    ['spawn', 'pty:spawn', ['s1', '/cwd']],
+    ['attach', 'pty:attach', ['s1']],
+    ['detach', 'pty:detach', ['s1']],
+    ['input', 'pty:input', ['s1', 'hello']],
+    ['resize', 'pty:resize', ['s1', 80, 24]],
+    ['kill', 'pty:kill', ['s1']],
+    ['get', 'pty:get', ['s1']],
+    ['getBufferSnapshot', 'pty:getBufferSnapshot', ['s1']],
+  ])('forwards %s -> ipcRenderer.invoke("%s", ...)', async (m, chan, args) => {
+    const api = lastApi();
+    await (api[m] as (...a: unknown[]) => Promise<unknown>)(...args);
+    expect(invokeSpy).toHaveBeenCalledWith(chan, ...args);
+  });
+
+  it('checkClaudeAvailable defaults its opts to {}', async () => {
+    const api = lastApi();
+    await (api.checkClaudeAvailable as (o?: unknown) => Promise<unknown>)();
+    expect(invokeSpy).toHaveBeenCalledWith('pty:checkClaudeAvailable', {});
+  });
+
+  it('checkClaudeAvailable forwards explicit opts', async () => {
+    const api = lastApi();
+    await (
+      api.checkClaudeAvailable as (o?: { force?: boolean }) => Promise<unknown>
+    )({ force: true });
+    expect(invokeSpy).toHaveBeenCalledWith('pty:checkClaudeAvailable', {
+      force: true,
+    });
+  });
+
+  it('clipboard.readText / writeText delegate to electron.clipboard', () => {
+    const api = lastApi();
+    const c = api.clipboard as { readText: () => string; writeText: (s: string) => void };
+    expect(c.readText()).toBe('clip-text');
+    expect(clipboardReadSpy).toHaveBeenCalledTimes(1);
+    c.writeText('hi');
+    expect(clipboardWriteSpy).toHaveBeenCalledWith('hi');
+  });
+
+  it('onData fan-out delivers payload, unsubscribe stops delivery', () => {
+    const api = lastApi();
+    const cb = vi.fn();
+    const off = (api.onData as (cb: unknown) => () => void)(cb);
+    const dispatch = onSpy.mock.calls.find((c) => c[0] === 'pty:data')![1] as (
+      e: unknown,
+      p: unknown,
+    ) => void;
+    const payload = { sid: 's1', chunk: 'abc', seq: 7 };
+    dispatch({}, payload);
+    expect(cb).toHaveBeenCalledWith(payload);
+    off();
+    dispatch({}, payload);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('onExit fan-out delivers payload, unsubscribe stops delivery', () => {
+    const api = lastApi();
+    const cb = vi.fn();
+    const off = (api.onExit as (cb: unknown) => () => void)(cb);
+    const dispatch = onSpy.mock.calls.find((c) => c[0] === 'pty:exit')![1] as (
+      e: unknown,
+      p: unknown,
+    ) => void;
+    const payload = { sessionId: 's1', code: 0, signal: null };
+    dispatch({}, payload);
+    expect(cb).toHaveBeenCalledWith(payload);
+    off();
+    dispatch({}, payload);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('throwing onData listener does not abort siblings', () => {
+    const api = lastApi();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const bad = vi.fn(() => {
+      throw new Error('x');
+    });
+    const good = vi.fn();
+    (api.onData as (cb: unknown) => () => void)(bad);
+    (api.onData as (cb: unknown) => () => void)(good);
+    const dispatch = onSpy.mock.calls.find((c) => c[0] === 'pty:data')![1] as (
+      e: unknown,
+      p: unknown,
+    ) => void;
+    dispatch({}, { sid: 's', chunk: '', seq: 0 });
+    expect(bad).toHaveBeenCalled();
+    expect(good).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/electron/preload/bridges/__tests__/ccsmPty.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmPty.test.ts
@@ -75,6 +75,7 @@ describe('ccsmPty preload bridge', () => {
         'onData',
         'onExit',
         'resize',
+        'saveClipboardImage',
         'spawn',
       ].sort(),
     );
@@ -98,6 +99,8 @@ describe('ccsmPty preload bridge', () => {
     ['kill', 'pty:kill', ['s1']],
     ['get', 'pty:get', ['s1']],
     ['getBufferSnapshot', 'pty:getBufferSnapshot', ['s1']],
+    // Task #42 — clipboard image autosave channel.
+    ['saveClipboardImage', 'pty:saveClipboardImage', []],
   ])('forwards %s -> ipcRenderer.invoke("%s", ...)', async (m, chan, args) => {
     const api = lastApi();
     await (api[m] as (...a: unknown[]) => Promise<unknown>)(...args);

--- a/electron/preload/bridges/__tests__/ccsmSession.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmSession.test.ts
@@ -1,0 +1,162 @@
+// Pins the `window.ccsmSession` preload bridge surface. This bridge owns
+// 4 listener-set fan-outs (state / activate / title / cwdRedirected) — the
+// install function registers ONE ipcRenderer.on per channel and dispatches
+// to the renderer-side Set, so multiple subscribers (Sidebar, notify integration,
+// store hydration) don't each leak a handler on the shared channel. We
+// verify (a) exposed shape, (b) one-way setters forward to the right channel,
+// and (c) each fan-out actually delivers the payload to a registered cb
+// AND that the returned unsubscribe drops it from the Set so subsequent
+// pushes don't re-fire.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { exposeSpy, sendSpy, onSpy, removeListenerSpy } = vi.hoisted(() => ({
+  exposeSpy: vi.fn(),
+  sendSpy: vi.fn(),
+  onSpy: vi.fn(),
+  removeListenerSpy: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: exposeSpy },
+  ipcRenderer: {
+    invoke: vi.fn(),
+    send: sendSpy,
+    on: onSpy,
+    removeListener: removeListenerSpy,
+  },
+}));
+
+import { installCcsmSessionBridge } from '../ccsmSession';
+
+type AnyApi = Record<string, unknown>;
+
+function lastApi(): AnyApi {
+  const last = exposeSpy.mock.calls[exposeSpy.mock.calls.length - 1];
+  expect(last[0]).toBe('ccsmSession');
+  return last[1] as AnyApi;
+}
+
+function findRegisteredHandler(chan: string): (e: unknown, payload: unknown) => void {
+  const match = onSpy.mock.calls.find((c) => c[0] === chan);
+  expect(match, `no ipcRenderer.on registration for ${chan}`).toBeDefined();
+  return match![1] as (e: unknown, payload: unknown) => void;
+}
+
+describe('ccsmSession preload bridge', () => {
+  beforeEach(() => {
+    exposeSpy.mockClear();
+    sendSpy.mockReset();
+    onSpy.mockReset();
+    removeListenerSpy.mockReset();
+    installCcsmSessionBridge();
+  });
+
+  it('exposes a stable key set under "ccsmSession"', () => {
+    const api = lastApi();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'onActivate',
+        'onCwdRedirected',
+        'onState',
+        'onTitle',
+        'setActive',
+        'setName',
+      ].sort(),
+    );
+  });
+
+  it('install registers exactly the 4 fan-out channels on ipcRenderer', () => {
+    const channels = onSpy.mock.calls.map((c) => c[0]).sort();
+    expect(channels).toEqual(
+      [
+        'session:state',
+        'session:title',
+        'session:cwdRedirected',
+        'session:activate',
+      ].sort(),
+    );
+  });
+
+  it.each<[string, string, unknown]>([
+    ['onState', 'session:state', { sid: 's1', state: 'running' }],
+    ['onActivate', 'session:activate', { sid: 's1' }],
+    ['onTitle', 'session:title', { sid: 's1', title: 'hi' }],
+    [
+      'onCwdRedirected',
+      'session:cwdRedirected',
+      { sid: 's1', newCwd: '/new/cwd' },
+    ],
+  ])('%s subscribes to %s fan-out and unsubscribe stops delivery', (m, chan, payload) => {
+    const api = lastApi();
+    const cb = vi.fn();
+    const off = (api[m] as (cb: unknown) => () => void)(cb);
+
+    const dispatch = findRegisteredHandler(chan);
+    dispatch({}, payload);
+    expect(cb).toHaveBeenCalledWith(payload);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    off();
+    dispatch({}, payload);
+    // After unsubscribe, no further deliveries.
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('multiple subscribers all receive the same payload (fan-out)', () => {
+    const api = lastApi();
+    const cbA = vi.fn();
+    const cbB = vi.fn();
+    (api.onState as (cb: unknown) => () => void)(cbA);
+    (api.onState as (cb: unknown) => () => void)(cbB);
+    const dispatch = findRegisteredHandler('session:state');
+    dispatch({}, { sid: 's2', state: 'idle' });
+    expect(cbA).toHaveBeenCalledTimes(1);
+    expect(cbB).toHaveBeenCalledTimes(1);
+  });
+
+  it('a throwing listener does not abort delivery to siblings', () => {
+    const api = lastApi();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const bad = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const good = vi.fn();
+    (api.onState as (cb: unknown) => () => void)(bad);
+    (api.onState as (cb: unknown) => () => void)(good);
+    findRegisteredHandler('session:state')({}, { sid: 's', state: 'idle' });
+    expect(bad).toHaveBeenCalled();
+    expect(good).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it('setActive sends "session:setActive" with sid (or empty string for null)', () => {
+    const api = lastApi();
+    const fn = api.setActive as (s: string | null) => void;
+    fn('s-123');
+    expect(sendSpy).toHaveBeenCalledWith('session:setActive', 's-123');
+    fn(null);
+    expect(sendSpy).toHaveBeenCalledWith('session:setActive', '');
+  });
+
+  it('setName sends "session:setName" with normalized null name', () => {
+    const api = lastApi();
+    const fn = api.setName as (sid: string, n: string | null) => void;
+    fn('s-1', 'Friendly');
+    expect(sendSpy).toHaveBeenCalledWith('session:setName', {
+      sid: 's-1',
+      name: 'Friendly',
+    });
+    fn('s-1', null);
+    expect(sendSpy).toHaveBeenCalledWith('session:setName', {
+      sid: 's-1',
+      name: '',
+    });
+  });
+
+  it('setName with empty sid is a no-op (does NOT send)', () => {
+    const api = lastApi();
+    (api.setName as (sid: string, n: string | null) => void)('', 'x');
+    expect(sendSpy).not.toHaveBeenCalled();
+  });
+});

--- a/electron/preload/bridges/__tests__/ccsmSessionTitles.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmSessionTitles.test.ts
@@ -1,0 +1,74 @@
+// Pins the `window.ccsmSessionTitles` preload bridge. Pure invoke
+// pass-through to the main-process sessionTitles module — the substrate
+// (per-sid serialization, 2s TTL, ENOENT classification, pending-rename
+// queue) all lives on main. The renderer surface is small but every
+// channel is a wire contract with `electron/sessionTitles/index.ts`
+// handlers; rename one without the other and the renderer rename action
+// hangs forever.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { exposeSpy, invokeSpy } = vi.hoisted(() => ({
+  exposeSpy: vi.fn(),
+  invokeSpy: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: exposeSpy },
+  ipcRenderer: {
+    invoke: invokeSpy,
+    send: vi.fn(),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  },
+}));
+
+import { installCcsmSessionTitlesBridge } from '../ccsmSessionTitles';
+
+type AnyApi = Record<string, unknown>;
+
+function lastApi(): AnyApi {
+  const last = exposeSpy.mock.calls[exposeSpy.mock.calls.length - 1];
+  expect(last[0]).toBe('ccsmSessionTitles');
+  return last[1] as AnyApi;
+}
+
+describe('ccsmSessionTitles preload bridge', () => {
+  beforeEach(() => {
+    exposeSpy.mockClear();
+    invokeSpy.mockReset();
+    invokeSpy.mockResolvedValue(undefined);
+    installCcsmSessionTitlesBridge();
+  });
+
+  it('exposes a stable key set under "ccsmSessionTitles"', () => {
+    const api = lastApi();
+    expect(Object.keys(api).sort()).toEqual(
+      [
+        'enqueuePending',
+        'flushPending',
+        'get',
+        'listForProject',
+        'rename',
+      ].sort(),
+    );
+  });
+
+  it.each<[string, string, unknown[]]>([
+    ['get', 'sessionTitles:get', ['sid-1', '/some/dir']],
+    ['get', 'sessionTitles:get', ['sid-1', undefined]],
+    ['rename', 'sessionTitles:rename', ['sid-1', 'New Title', '/d']],
+    ['rename', 'sessionTitles:rename', ['sid-1', 'New Title', undefined]],
+    ['listForProject', 'sessionTitles:listForProject', ['proj-key']],
+    [
+      'enqueuePending',
+      'sessionTitles:enqueuePending',
+      ['sid-1', 'Title', '/d'],
+    ],
+    ['flushPending', 'sessionTitles:flushPending', ['sid-1']],
+  ])('forwards %s -> ipcRenderer.invoke("%s", ...)', async (m, chan, args) => {
+    const api = lastApi();
+    await (api[m] as (...a: unknown[]) => Promise<unknown>)(...args);
+    expect(invokeSpy).toHaveBeenLastCalledWith(chan, ...args);
+  });
+});

--- a/electron/preload/bridges/__tests__/ccsmShell.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmShell.test.ts
@@ -1,0 +1,62 @@
+// Pins the `window.ccsmShell` preload bridge — single one-shot for
+// renderer-driven native-context-menu suppression (Task #41). The IPC
+// channel name `shell:suppressContextMenuOnce` is a wire contract with
+// `installContextMenuSuppressIpc` in electron/window/createWindow.ts;
+// renaming one side silently breaks the terminal pane's right-click
+// inline copy/paste UX (the native menu races on top).
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { exposeSpy, sendSpy } = vi.hoisted(() => ({
+  exposeSpy: vi.fn(),
+  sendSpy: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  contextBridge: { exposeInMainWorld: exposeSpy },
+  ipcRenderer: {
+    invoke: vi.fn(),
+    send: sendSpy,
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  },
+}));
+
+import { installCcsmShellBridge } from '../ccsmShell';
+
+type AnyApi = Record<string, unknown>;
+
+function lastApi(): AnyApi {
+  const last = exposeSpy.mock.calls[exposeSpy.mock.calls.length - 1];
+  expect(last[0]).toBe('ccsmShell');
+  return last[1] as AnyApi;
+}
+
+describe('ccsmShell preload bridge', () => {
+  beforeEach(() => {
+    exposeSpy.mockClear();
+    sendSpy.mockReset();
+    installCcsmShellBridge();
+  });
+
+  it('exposes a stable key set under "ccsmShell"', () => {
+    const api = lastApi();
+    expect(Object.keys(api).sort()).toEqual(['suppressContextMenuOnce']);
+  });
+
+  it('suppressContextMenuOnce sends one-way IPC on the canonical channel', () => {
+    const api = lastApi();
+    (api.suppressContextMenuOnce as () => void)();
+    expect(sendSpy).toHaveBeenCalledWith('shell:suppressContextMenuOnce');
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('repeated calls send one IPC each (no internal coalescing)', () => {
+    const api = lastApi();
+    (api.suppressContextMenuOnce as () => void)();
+    (api.suppressContextMenuOnce as () => void)();
+    (api.suppressContextMenuOnce as () => void)();
+    // Main side handles coalescing via its deadline; bridge stays dumb.
+    expect(sendSpy).toHaveBeenCalledTimes(3);
+  });
+});

--- a/electron/preload/bridges/__tests__/index.test.ts
+++ b/electron/preload/bridges/__tests__/index.test.ts
@@ -1,0 +1,53 @@
+// Pins the preload entry point. The 5 `install*` calls are independent
+// (order is preserved for diff clarity, not correctness) — but if a
+// future refactor drops one of them, the corresponding `window.ccsm*`
+// surface goes silently missing in the renderer with no compiler signal.
+// The Sentry preload import must also stay first so error capture is
+// armed before any bridge runs (its initializer hooks into webContents).
+
+import { describe, it, expect, vi } from 'vitest';
+
+const {
+  installCore,
+  installPty,
+  installSession,
+  installNotify,
+  installSessionTitles,
+  sentryLoaded,
+} = vi.hoisted(() => ({
+  installCore: vi.fn(),
+  installPty: vi.fn(),
+  installSession: vi.fn(),
+  installNotify: vi.fn(),
+  installSessionTitles: vi.fn(),
+  sentryLoaded: vi.fn(),
+}));
+
+vi.mock('@sentry/electron/preload', () => {
+  sentryLoaded();
+  return {};
+});
+vi.mock('../ccsmCore', () => ({ installCcsmCoreBridge: installCore }));
+vi.mock('../ccsmPty', () => ({ installCcsmPtyBridge: installPty }));
+vi.mock('../ccsmSession', () => ({
+  installCcsmSessionBridge: installSession,
+}));
+vi.mock('../ccsmNotify', () => ({
+  installCcsmNotifyBridge: installNotify,
+}));
+vi.mock('../ccsmSessionTitles', () => ({
+  installCcsmSessionTitlesBridge: installSessionTitles,
+}));
+
+describe('preload/index entry point', () => {
+  it('loads sentry/preload and invokes every install function exactly once', async () => {
+    await import('../../index');
+
+    expect(sentryLoaded).toHaveBeenCalledTimes(1);
+    expect(installCore).toHaveBeenCalledTimes(1);
+    expect(installPty).toHaveBeenCalledTimes(1);
+    expect(installSession).toHaveBeenCalledTimes(1);
+    expect(installNotify).toHaveBeenCalledTimes(1);
+    expect(installSessionTitles).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/preload/bridges/__tests__/index.test.ts
+++ b/electron/preload/bridges/__tests__/index.test.ts
@@ -13,6 +13,7 @@ const {
   installSession,
   installNotify,
   installSessionTitles,
+  installShell,
   sentryLoaded,
 } = vi.hoisted(() => ({
   installCore: vi.fn(),
@@ -20,6 +21,7 @@ const {
   installSession: vi.fn(),
   installNotify: vi.fn(),
   installSessionTitles: vi.fn(),
+  installShell: vi.fn(),
   sentryLoaded: vi.fn(),
 }));
 
@@ -38,6 +40,9 @@ vi.mock('../ccsmNotify', () => ({
 vi.mock('../ccsmSessionTitles', () => ({
   installCcsmSessionTitlesBridge: installSessionTitles,
 }));
+vi.mock('../ccsmShell', () => ({
+  installCcsmShellBridge: installShell,
+}));
 
 describe('preload/index entry point', () => {
   it('loads sentry/preload and invokes every install function exactly once', async () => {
@@ -49,5 +54,6 @@ describe('preload/index entry point', () => {
     expect(installSession).toHaveBeenCalledTimes(1);
     expect(installNotify).toHaveBeenCalledTimes(1);
     expect(installSessionTitles).toHaveBeenCalledTimes(1);
+    expect(installShell).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/preload/bridges/ccsmPty.ts
+++ b/electron/preload/bridges/ccsmPty.ts
@@ -30,8 +30,10 @@ const ptyExitListeners = new Set<(e: PtyExitPayload) => void>();
 
 const ccsmPty = {
   list: (): Promise<unknown> => ipcRenderer.invoke('pty:list'),
-  spawn: (sid: string, cwd: string): Promise<unknown> =>
-    ipcRenderer.invoke('pty:spawn', sid, cwd),
+  spawn: (sid: string, cwd: string, forkSourceSid?: string): Promise<unknown> =>
+    forkSourceSid === undefined
+      ? ipcRenderer.invoke('pty:spawn', sid, cwd)
+      : ipcRenderer.invoke('pty:spawn', sid, cwd, forkSourceSid),
   attach: (sid: string): Promise<unknown> => ipcRenderer.invoke('pty:attach', sid),
   detach: (sid: string): Promise<void> => ipcRenderer.invoke('pty:detach', sid),
   input: (sid: string, data: string): Promise<void> =>

--- a/electron/preload/bridges/ccsmPty.ts
+++ b/electron/preload/bridges/ccsmPty.ts
@@ -64,6 +64,11 @@ const ccsmPty = {
     readText: (): string => clipboard.readText(),
     writeText: (text: string): void => clipboard.writeText(text),
   },
+  // Task #42 — main-process IPC because clipboard.readImage() PNG encoding
+  // and the userData write both need the main side; renderer also doesn't
+  // get app.getPath('userData').
+  saveClipboardImage: (): Promise<string | null> =>
+    ipcRenderer.invoke('pty:saveClipboardImage'),
   checkClaudeAvailable: (opts?: { force?: boolean }): Promise<CheckClaudeAvailableResult> =>
     ipcRenderer.invoke('pty:checkClaudeAvailable', opts ?? {}),
 };

--- a/electron/preload/bridges/ccsmShell.ts
+++ b/electron/preload/bridges/ccsmShell.ts
@@ -1,0 +1,35 @@
+// `window.ccsmShell` — small bridge for renderer-driven shell-level UX
+// gestures that don't fit `ccsm` (catch-all) or `ccsmPty` (terminal data).
+//
+// Currently exposes a single one-shot: `suppressContextMenuOnce()`. The
+// terminal pane calls this from its renderer-side `onContextMenu` handler
+// immediately before its `preventDefault()` returns, so that the
+// main-process `webContents.on('context-menu', ...)` listener (installed
+// per-window by `installContextMenu` in electron/window/createWindow.ts)
+// can step aside and let the renderer handle the click natively
+// (copy-on-selection / paste-on-empty) without a popover.
+//
+// Why a separate bridge: Electron's `webContents.on('context-menu')` fires
+// on every renderer right-click regardless of DOM `preventDefault()`. Without
+// this one-shot, the terminal's renderer-side handler would race the native
+// menu and lose (the OS popup appears on top of any inline action). A
+// per-IPC deadline gives main the signal it cannot get from the DOM.
+
+import { contextBridge, ipcRenderer } from 'electron';
+
+const ccsmShell = {
+  /** Tell main to skip the very next `context-menu` event on this
+   *  WebContents. One-shot — main resets the suppression as soon as the
+   *  next event arrives, OR after a short deadline (~100ms) if no event
+   *  arrives. Call this immediately BEFORE returning from a renderer
+   *  `onContextMenu` handler that handles the click itself. */
+  suppressContextMenuOnce: (): void => {
+    ipcRenderer.send('shell:suppressContextMenuOnce');
+  },
+};
+
+export type CCSMShellAPI = typeof ccsmShell;
+
+export function installCcsmShellBridge(): void {
+  contextBridge.exposeInMainWorld('ccsmShell', ccsmShell);
+}

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -2,9 +2,11 @@
 // `path.join(__dirname, '..', 'preload', 'index.js')` (resolves to
 // `dist/electron/preload/index.js` post-tsc). Splits into 5 single-concern
 // bridges (#769, SRP wave-2 PR-A) — each bridge owns its own listener
-// sets, IPC channels, and exposed type. The order of `install*` calls is
-// not load-bearing (each bridge is independent), but kept in the original
-// preload.ts order for diff clarity.
+// sets, IPC channels, and exposed type. Call order below is cosmetic
+// (each `install*` is independent and load-safe — just `ipcRenderer.on`
+// registrations + `contextBridge.exposeInMainWorld`), kept in the
+// original preload.ts order for diff clarity. The Sentry import sits at
+// the top by convention, not because the bridges can throw on load.
 
 import '@sentry/electron/preload';
 

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -15,15 +15,18 @@ import { installCcsmPtyBridge } from './bridges/ccsmPty';
 import { installCcsmSessionBridge } from './bridges/ccsmSession';
 import { installCcsmNotifyBridge } from './bridges/ccsmNotify';
 import { installCcsmSessionTitlesBridge } from './bridges/ccsmSessionTitles';
+import { installCcsmShellBridge } from './bridges/ccsmShell';
 
 installCcsmCoreBridge();
 installCcsmPtyBridge();
 installCcsmSessionBridge();
 installCcsmNotifyBridge();
 installCcsmSessionTitlesBridge();
+installCcsmShellBridge();
 
 export type { CCSMAPI } from './bridges/ccsmCore';
 export type { CCSMPtyAPI } from './bridges/ccsmPty';
 export type { CCSMSessionAPI, SessionState } from './bridges/ccsmSession';
 export type { CCSMNotifyAPI } from './bridges/ccsmNotify';
 export type { CCSMSessionTitlesAPI } from './bridges/ccsmSessionTitles';
+export type { CCSMShellAPI } from './bridges/ccsmShell';

--- a/electron/ptyHost/__tests__/bufferSnapshot.test.ts
+++ b/electron/ptyHost/__tests__/bufferSnapshot.test.ts
@@ -11,7 +11,27 @@
 //
 // Out of scope (PR-B/E): visible xterm replay, IPC wire format, detach/reattach.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// `lifecycle.getBufferSnapshot` now consults the user's scrollbackLines
+// preference (electron/prefs/scrollback) on every call so the cap honors
+// live setting changes. The prefs module imports `../db`, which calls
+// Electron's `app.getPath()` on first use — fatal in pure-node tests.
+// Stub the prefs module to a fixed cap so the lifecycle path stays
+// hermetic. Each individual test that wants to assert "the cap is
+// passed to serialize" overrides this via vi.mocked(...) below.
+let _stubbedCap = 1500;
+vi.mock('../../prefs/scrollback', () => ({
+  loadScrollbackLines: () => _stubbedCap,
+  DEFAULT_SCROLLBACK_LINES: 1500,
+  MIN_SCROLLBACK_LINES: 100,
+  MAX_SCROLLBACK_LINES: 50000,
+  SCROLLBACK_KEY: 'scrollbackLines',
+  parseScrollbackLines: (v: unknown) => (typeof v === 'number' ? v : 1500),
+  invalidateScrollbackCache: () => {},
+  subscribeScrollbackInvalidation: () => () => {},
+}));
+
 import { Terminal as HeadlessTerminal } from '@xterm/headless';
 import { SerializeAddon } from '@xterm/addon-serialize';
 import { SCROLLBACK } from '../entryFactory';
@@ -33,14 +53,24 @@ function makeRealHeadless(): { term: HeadlessTerminal; serialize: SerializeAddon
   return { term, serialize };
 }
 
-// Build a fake Entry that just exposes a `serialize.serialize()` returning
-// the supplied string. Other Entry fields are stubbed because
-// getBufferSnapshot only reads `entry.serialize` and `entry.seq`.
-function fakeEntry(snapshot: string, seq: number = 0): Entry {
+// Build a fake Entry that just exposes a `serialize.serialize(opts?)` echoing
+// back whatever string the test supplied. The `optsCapture` array (when
+// passed) records every options arg the lifecycle layer hands through, so
+// tests can assert the user-configured cap reaches SerializeAddon.
+function fakeEntry(
+  snapshot: string,
+  seq: number = 0,
+  optsCapture?: unknown[],
+): Entry {
   return {
     pty: { pid: 0 } as Entry['pty'],
     headless: {} as Entry['headless'],
-    serialize: { serialize: () => snapshot } as unknown as Entry['serialize'],
+    serialize: {
+      serialize: (opts?: unknown) => {
+        if (optsCapture) optsCapture.push(opts);
+        return snapshot;
+      },
+    } as unknown as Entry['serialize'],
     attached: new Map(),
     cols: 80,
     rows: 24,
@@ -50,8 +80,8 @@ function fakeEntry(snapshot: string, seq: number = 0): Entry {
 }
 
 describe('headless authoritative buffer (PR-A real wiring)', () => {
-  it('SCROLLBACK is bumped to 10000 lines for L4', () => {
-    expect(SCROLLBACK).toBe(10000);
+  it('SCROLLBACK default cap is 1500 lines', () => {
+    expect(SCROLLBACK).toBe(1500);
   });
 
   it('headless buffer accumulates writes across chunks', async () => {
@@ -64,11 +94,11 @@ describe('headless authoritative buffer (PR-A real wiring)', () => {
     expect(snap).toContain('second line');
   });
 
-  it('scrollback cap of 10000 truncates the OLDEST lines once exceeded', async () => {
+  it('scrollback cap of SCROLLBACK truncates the OLDEST lines once exceeded', async () => {
     const { term, serialize } = makeRealHeadless();
-    // Write 10500 distinct lines. After the cap, the first ~500 + the 24
-    // visible rows offset should be gone.
-    const TOTAL = 10500;
+    // Write more lines than the cap. After the cap, the oldest lines
+    // should be evicted while the newest survive.
+    const TOTAL = SCROLLBACK + 500;
     let buf = '';
     for (let i = 0; i < TOTAL; i++) buf += `LINE${i}\r\n`;
     await new Promise<void>((r) => term.write(buf, r));
@@ -77,7 +107,6 @@ describe('headless authoritative buffer (PR-A real wiring)', () => {
     expect(snap).toContain(`LINE${TOTAL - 1}`);
     // The very first line MUST have been evicted (well under the cap window).
     expect(snap).not.toContain('LINE0\n');
-    expect(snap).not.toContain('LINE100\n');
     // A line comfortably inside the surviving cap window must still be present.
     expect(snap).toContain(`LINE${TOTAL - 100}`);
   });
@@ -150,5 +179,62 @@ describe('lifecycle.getBufferSnapshot (PR-A async chunking + PR-B seq capture)',
     // Expect at least the number of inter-chunk yields - 1; in practice
     // we should see >= 3 immediates fire alongside 4 internal yields.
     expect(immediateFired).toBeGreaterThanOrEqual(3);
+  });
+
+  it('passes the user-configured scrollback cap as serialize options', async () => {
+    const sessions = new Map<string, Entry>();
+    const optsCapture: unknown[] = [];
+    sessions.set('s4', fakeEntry('payload', 7, optsCapture));
+    _stubbedCap = 1500;
+    await getBufferSnapshot(sessions, 's4');
+    expect(optsCapture).toHaveLength(1);
+    expect(optsCapture[0]).toEqual({ scrollback: 1500 });
+  });
+
+  it('honors a changed scrollback cap on subsequent calls (live setting)', async () => {
+    const sessions = new Map<string, Entry>();
+    const optsCapture: unknown[] = [];
+    sessions.set('s5', fakeEntry('payload', 0, optsCapture));
+    _stubbedCap = 200;
+    await getBufferSnapshot(sessions, 's5');
+    _stubbedCap = 9000;
+    await getBufferSnapshot(sessions, 's5');
+    expect(optsCapture).toEqual([{ scrollback: 200 }, { scrollback: 9000 }]);
+  });
+
+  it('returns at most `cap` lines when serialize honors the option (real addon, real cap)', async () => {
+    // End-to-end check against the real SerializeAddon: a buffer with
+    // many more rows than the cap should yield a snapshot whose line
+    // count is bounded by the cap (plus some constant for terminal
+    // mode/style prefixes).
+    _stubbedCap = 500;
+    const { term, serialize } = makeRealHeadless();
+    const TOTAL = 3000;
+    let buf = '';
+    for (let i = 0; i < TOTAL; i++) buf += `L${i}\r\n`;
+    await new Promise<void>((r) => term.write(buf, r));
+
+    const sessions = new Map<string, Entry>();
+    // Wire the real entry's serialize so getBufferSnapshot calls the
+    // real addon with our cap.
+    sessions.set('real', {
+      pty: { pid: 0 } as Entry['pty'],
+      headless: term as unknown as Entry['headless'],
+      serialize: serialize as unknown as Entry['serialize'],
+      attached: new Map(),
+      cols: 80,
+      rows: 24,
+      cwd: '/tmp',
+      seq: 0,
+    } as Entry);
+    const result = await getBufferSnapshot(sessions, 'real');
+    // Sanity: the newest line must survive.
+    expect(result.snapshot).toContain(`L${TOTAL - 1}`);
+    // The cap must have evicted lines well outside the bottom 500
+    // — anything older than ~600 lines from the bottom should be gone.
+    expect(result.snapshot).not.toContain(`L${TOTAL - 1000}`);
+    // Conservative line-count cap: 500 + a small overhead for ANSI
+    // escapes and trailing rows. We just assert "much less than TOTAL".
+    expect(result.snapshot.split('\n').length).toBeLessThan(700);
   });
 });

--- a/electron/ptyHost/__tests__/claudeResolver.test.ts
+++ b/electron/ptyHost/__tests__/claudeResolver.test.ts
@@ -5,10 +5,17 @@
 // and the failure-mode contract (returns null when both lookups fail — never
 // the literal string "claude" — so the IPC channel can surface a clean
 // `available: false` for the renderer's ClaudeMissingGuide).
+//
+// Resolver is async (#PERF: original spawnSync blocked the main process
+// event loop on Windows cold start). Tests await each call and the
+// `spawn` mock returns an EventEmitter-like child whose stdout pushes
+// scripted bytes then emits `exit` with a scripted code on the next tick.
 
+import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Hoisted module-level state the spawnSync mock reads. Tests rewrite
+// Hoisted module-level state the spawn mock reads. Tests rewrite
 // `__bus` between cases; the mock factory captures `globalThis` lazily.
 interface SpawnCall {
   cmd: string;
@@ -25,22 +32,36 @@ function bus(): SpawnFakeBus {
 }
 
 vi.mock('node:child_process', () => {
-  const spawnSync = (cmd: string, args: readonly string[]) => {
+  const spawn = (cmd: string, args: readonly string[]) => {
     const b = bus();
     b.calls.push({ cmd, args });
-    if (b.shouldThrow) throw new Error('spawnSync EPERM');
+    if (b.shouldThrow) throw new Error('spawn EPERM');
     const key = `${cmd} ${args.join(' ')}`;
-    const r = b.results.get(key);
-    if (r) return { status: r.status, stdout: r.stdout, stderr: '' };
-    return { status: 1, stdout: '', stderr: '' };
+    const r = b.results.get(key) ?? { status: 1, stdout: '' };
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: Readable;
+    };
+    const stdout = new Readable({ read() {} });
+    child.stdout = stdout;
+    // Push data on next microtask so the resolver's `'data'` listener
+    // (attached synchronously after spawn returns) receives it. Emit
+    // `exit` on the FOLLOWING tick — after the readable has drained the
+    // pushed buffer to the listener — so the resolver doesn't snapshot
+    // an empty stdout buffer before the data event fires.
+    queueMicrotask(() => {
+      if (r.stdout) stdout.push(Buffer.from(r.stdout, 'utf8'));
+      stdout.push(null);
+      setImmediate(() => child.emit('exit', r.status));
+    });
+    return child;
   };
   return {
-    default: { spawnSync },
-    spawnSync,
+    default: { spawn },
+    spawn,
   };
 });
 
-// Import AFTER vi.mock so the resolver picks up the mocked spawnSync.
+// Import AFTER vi.mock so the resolver picks up the mocked spawn.
 import { __resetClaudeResolverForTest, resolveClaude } from '../claudeResolver';
 
 const ORIGINAL_PLATFORM = process.platform;
@@ -70,93 +91,103 @@ afterEach(() => {
 describe('resolveClaude on Windows', () => {
   beforeEach(() => setPlatform('win32'));
 
-  it('returns the path from `where claude.cmd` when present', () => {
+  it('returns the path from `where claude.cmd` when present', async () => {
     bus().results.set('where claude.cmd', {
       status: 0,
       stdout: 'C:\\Users\\u\\AppData\\Roaming\\npm\\claude.cmd\r\n',
     });
-    expect(resolveClaude()).toBe('C:\\Users\\u\\AppData\\Roaming\\npm\\claude.cmd');
+    expect(await resolveClaude()).toBe('C:\\Users\\u\\AppData\\Roaming\\npm\\claude.cmd');
     expect(bus().calls.map((c) => c.args[0])).toEqual(['claude.cmd']);
   });
 
-  it('falls back to `where claude` when claude.cmd lookup fails', () => {
+  it('falls back to `where claude` when claude.cmd lookup fails', async () => {
     bus().results.set('where claude.cmd', { status: 1, stdout: '' });
     bus().results.set('where claude', {
       status: 0,
       stdout: 'C:\\tools\\claude\n',
     });
-    expect(resolveClaude()).toBe('C:\\tools\\claude');
+    expect(await resolveClaude()).toBe('C:\\tools\\claude');
     expect(bus().calls.map((c) => c.args[0])).toEqual(['claude.cmd', 'claude']);
   });
 
-  it('returns null (never the literal "claude") when both lookups fail', () => {
-    expect(resolveClaude()).toBeNull();
+  it('returns null (never the literal "claude") when both lookups fail', async () => {
+    expect(await resolveClaude()).toBeNull();
     expect(bus().calls).toHaveLength(2);
   });
 
-  it('takes the FIRST line of multi-line where output (PATH may have dupes)', () => {
+  it('takes the FIRST line of multi-line where output (PATH may have dupes)', async () => {
     bus().results.set('where claude.cmd', {
       status: 0,
       stdout: 'C:\\first\\claude.cmd\r\nC:\\second\\claude.cmd\r\n',
     });
-    expect(resolveClaude()).toBe('C:\\first\\claude.cmd');
+    expect(await resolveClaude()).toBe('C:\\first\\claude.cmd');
   });
 
-  it('treats blank-stdout success as not-found (status==0 but no path)', () => {
+  it('treats blank-stdout success as not-found (status==0 but no path)', async () => {
     bus().results.set('where claude.cmd', { status: 0, stdout: '\r\n  \r\n' });
     bus().results.set('where claude', { status: 0, stdout: 'C:\\fallback\\claude' });
-    expect(resolveClaude()).toBe('C:\\fallback\\claude');
+    expect(await resolveClaude()).toBe('C:\\fallback\\claude');
   });
 });
 
 describe('resolveClaude on POSIX', () => {
   beforeEach(() => setPlatform('linux'));
 
-  it('uses `which claude` (single lookup)', () => {
+  it('uses `which claude` (single lookup)', async () => {
     bus().results.set('which claude', { status: 0, stdout: '/usr/local/bin/claude\n' });
-    expect(resolveClaude()).toBe('/usr/local/bin/claude');
+    expect(await resolveClaude()).toBe('/usr/local/bin/claude');
     expect(bus().calls).toEqual([{ cmd: 'which', args: ['claude'] }]);
   });
 
-  it('returns null when `which claude` fails', () => {
-    expect(resolveClaude()).toBeNull();
+  it('returns null when `which claude` fails', async () => {
+    expect(await resolveClaude()).toBeNull();
     expect(bus().calls).toHaveLength(1);
   });
 
-  it('returns null when spawnSync itself throws', () => {
+  it('returns null when spawn itself throws', async () => {
     bus().shouldThrow = true;
-    expect(resolveClaude()).toBeNull();
+    expect(await resolveClaude()).toBeNull();
   });
 });
 
 describe('resolveClaude caching', () => {
   beforeEach(() => setPlatform('linux'));
 
-  it('caches the resolved path — second call does not re-spawn', () => {
+  it('caches the resolved path — second call does not re-spawn', async () => {
     bus().results.set('which claude', { status: 0, stdout: '/bin/claude\n' });
-    expect(resolveClaude()).toBe('/bin/claude');
-    expect(resolveClaude()).toBe('/bin/claude');
+    expect(await resolveClaude()).toBe('/bin/claude');
+    expect(await resolveClaude()).toBe('/bin/claude');
     expect(bus().calls).toHaveLength(1);
   });
 
-  it('caches the null result — second call does not re-spawn', () => {
-    expect(resolveClaude()).toBeNull();
-    expect(resolveClaude()).toBeNull();
+  it('caches the null result — second call does not re-spawn', async () => {
+    expect(await resolveClaude()).toBeNull();
+    expect(await resolveClaude()).toBeNull();
     expect(bus().calls).toHaveLength(1);
   });
 
-  it('force:true bypasses the cache (re-check button on ClaudeMissingGuide)', () => {
-    expect(resolveClaude()).toBeNull();
+  it('force:true bypasses the cache (re-check button on ClaudeMissingGuide)', async () => {
+    expect(await resolveClaude()).toBeNull();
     bus().results.set('which claude', { status: 0, stdout: '/bin/claude\n' });
-    expect(resolveClaude({ force: true })).toBe('/bin/claude');
+    expect(await resolveClaude({ force: true })).toBe('/bin/claude');
     expect(bus().calls).toHaveLength(2);
   });
 
-  it('__resetClaudeResolverForTest clears the cache', () => {
+  it('__resetClaudeResolverForTest clears the cache', async () => {
     bus().results.set('which claude', { status: 0, stdout: '/bin/claude\n' });
-    expect(resolveClaude()).toBe('/bin/claude');
+    expect(await resolveClaude()).toBe('/bin/claude');
     __resetClaudeResolverForTest();
     bus().results.clear();
-    expect(resolveClaude()).toBeNull();
+    expect(await resolveClaude()).toBeNull();
+  });
+
+  it('dedups concurrent first-callers into a single in-flight spawn', async () => {
+    bus().results.set('which claude', { status: 0, stdout: '/bin/claude\n' });
+    // Fire two callers BEFORE awaiting — both should share the same
+    // in-flight Promise rather than each spawning their own `where`.
+    const [a, b] = await Promise.all([resolveClaude(), resolveClaude()]);
+    expect(a).toBe('/bin/claude');
+    expect(b).toBe('/bin/claude');
+    expect(bus().calls).toHaveLength(1);
   });
 });

--- a/electron/ptyHost/__tests__/claudeResolver.test.ts
+++ b/electron/ptyHost/__tests__/claudeResolver.test.ts
@@ -25,6 +25,8 @@ interface SpawnFakeBus {
   results: Map<string, { status: number; stdout: string }>;
   calls: SpawnCall[];
   shouldThrow: boolean;
+  hang: boolean;
+  killed: number;
 }
 function bus(): SpawnFakeBus {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,9 +42,17 @@ vi.mock('node:child_process', () => {
     const r = b.results.get(key) ?? { status: 1, stdout: '' };
     const child = new EventEmitter() as EventEmitter & {
       stdout: Readable;
+      kill: () => void;
     };
     const stdout = new Readable({ read() {} });
     child.stdout = stdout;
+    child.kill = () => {
+      b.killed += 1;
+    };
+    // When `hang` is set, simulate a stuck `where`/`which`: never push
+    // data, never emit exit. The resolver's timeout is the only way the
+    // promise can settle. Used by the where_timeout test.
+    if (b.hang) return child;
     // Push data on next microtask so the resolver's `'data'` listener
     // (attached synchronously after spawn returns) receives it. Emit
     // `exit` on the FOLLOWING tick — after the readable has drained the
@@ -62,7 +72,7 @@ vi.mock('node:child_process', () => {
 });
 
 // Import AFTER vi.mock so the resolver picks up the mocked spawn.
-import { __resetClaudeResolverForTest, resolveClaude } from '../claudeResolver';
+import { __resetClaudeResolverForTest, resolveClaude, whereAsync } from '../claudeResolver';
 
 const ORIGINAL_PLATFORM = process.platform;
 
@@ -76,6 +86,8 @@ beforeEach(() => {
     results: new Map(),
     calls: [],
     shouldThrow: false,
+    hang: false,
+    killed: 0,
   } satisfies SpawnFakeBus;
   __resetClaudeResolverForTest();
 });
@@ -189,5 +201,43 @@ describe('resolveClaude caching', () => {
     expect(a).toBe('/bin/claude');
     expect(b).toBe('/bin/claude');
     expect(bus().calls).toHaveLength(1);
+  });
+});
+
+describe('whereAsync timeout', () => {
+  // Pins the 5s hard cap on a single `where`/`which` invocation. A
+  // broken PATH / slow shell / AV interception used to hang the lookup
+  // forever; without rejection the IPC handler stays pending and the
+  // renderer's spinner never resolves.
+  beforeEach(() => {
+    setPlatform('linux');
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('rejects with where_timeout error after 5s when the child never exits', async () => {
+    bus().hang = true;
+    const promise = whereAsync('claude');
+    // Attach catch synchronously so an early rejection isn't unhandled.
+    const settled = promise.catch((e: Error) => e);
+    await vi.advanceTimersByTimeAsync(5000);
+    const err = await settled;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/^where_timeout: /);
+    expect((err as Error).message).toContain('5000ms');
+    // Resolver must kill the stuck child so the FD/handle isn't leaked.
+    expect(bus().killed).toBe(1);
+  });
+
+  it('resolveClaude collapses where_timeout to null (UI shows ClaudeMissingGuide, not undefined cwd)', async () => {
+    bus().hang = true;
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const promise = resolveClaude();
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(await promise).toBeNull();
+    expect(warn).toHaveBeenCalledWith('[claudeResolver]', expect.stringMatching(/^where_timeout:/));
+    warn.mockRestore();
   });
 });

--- a/electron/ptyHost/__tests__/entryFactory.test.ts
+++ b/electron/ptyHost/__tests__/entryFactory.test.ts
@@ -239,6 +239,57 @@ describe('entryFactory.makeEntry', () => {
       | undefined;
     expect(opts?.scrollback).toBe(1500);
   });
+
+  // Right-click "Copy session" path: when the renderer mints a fresh sid
+  // (no JSONL on disk yet) AND passes a `forkSourceSid`, makeEntry must
+  // spawn `claude --resume <src> --fork-session --session-id <new>` so the
+  // CLI duplicates the source's transcript natively. The bare new-session
+  // path (`['--session-id', sid]`) would lose the source context entirely.
+  it('forks via --resume + --fork-session + --session-id when forkSourceSid is set and no JSONL exists', () => {
+    bus().sourceJsonl = null;
+    makeEntry(
+      'sid-NEW',
+      '/work',
+      '/bin/claude',
+      80,
+      24,
+      { onExit: vi.fn() },
+      'sid-SOURCE',
+    );
+    const args = bus().ptySpawn.mock.calls[0][1] as string[];
+    expect(args).toEqual([
+      '--resume',
+      'sid-SOURCE',
+      '--fork-session',
+      '--session-id',
+      'sid-NEW',
+    ]);
+    // No import-resume copy expected — sourceJsonl is null so the existing
+    // `ensureResumeJsonlAtSpawnCwd` branch is skipped (correct: claude
+    // CLI handles the transcript copy itself with --fork-session).
+    expect(bus().ensureJsonl).not.toHaveBeenCalled();
+  });
+
+  // Defensive: once the forked session has booted at least once, its own
+  // JSONL exists at `<newSid>.jsonl`. A re-spawn (Retry, app relaunch)
+  // must NOT re-issue --fork-session — that would copy the transcript a
+  // SECOND time. Falling through to the normal `--resume <new>` path is
+  // the right behavior. We model this by setting sourceJsonl truthy
+  // (i.e. findJsonlForSid found the new sid's jsonl).
+  it('skips --fork-session and resumes the new sid directly when the new sid already has a JSONL', () => {
+    bus().sourceJsonl = '/proj/sid-NEW.jsonl';
+    makeEntry(
+      'sid-NEW',
+      '/work',
+      '/bin/claude',
+      80,
+      24,
+      { onExit: vi.fn() },
+      'sid-SOURCE',
+    );
+    const args = bus().ptySpawn.mock.calls[0][1] as string[];
+    expect(args).toEqual(['--resume', 'sid-NEW']);
+  });
 });
 
 // L4 PR-C (#863): the onData handler is now an extracted, named

--- a/electron/ptyHost/__tests__/entryFactory.test.ts
+++ b/electron/ptyHost/__tests__/entryFactory.test.ts
@@ -51,6 +51,11 @@ vi.mock('node-pty', () => ({
 
 vi.mock('@xterm/headless', () => ({
   Terminal: class {
+    constructor(opts?: unknown) {
+      // Record constructor opts so tests can pin scrollback wiring.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (globalThis as any).__pf_lastHeadlessOpts = opts;
+    }
     // Mirror @xterm/headless's `write(data, callback?)` signature so tests
     // can exercise PR-C backpressure (we count pending writes by deferring
     // the callback until the test fires it).
@@ -99,6 +104,17 @@ vi.mock('../cwdResolver', () => ({
 
 vi.mock('../dataFanout', () => ({
   emitPtyData: (sid: string, chunk: string) => bus().emitData(sid, chunk),
+}));
+
+// The user-configured scrollback cap is now read at headless construction
+// time. Stub the prefs module so tests don't hit the SQLite-backed
+// loadState path; tests that care about the cap value flip
+// `globalThis.__pf_scrollback` directly.
+vi.mock('../../prefs/scrollback', () => ({
+  loadScrollbackLines: () =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (((globalThis as any).__pf_scrollback as number | undefined) ?? 1500),
+  DEFAULT_SCROLLBACK_LINES: 1500,
 }));
 
 import { makeEntry } from '../entryFactory';
@@ -200,6 +216,28 @@ describe('entryFactory.makeEntry', () => {
     expect(e.rows).toBe(40);
     expect(e.cwd).toBe('/work');
     expect(e.attached.size).toBe(0);
+  });
+
+  it('passes the user-configured scrollback cap into the headless Terminal constructor', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).__pf_scrollback = 2500;
+    makeEntry('sid-SCROLL', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const opts = (globalThis as any).__pf_lastHeadlessOpts as
+      | { scrollback?: number }
+      | undefined;
+    expect(opts?.scrollback).toBe(2500);
+  });
+
+  it('falls back to the default cap when the prefs module returns the default', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (globalThis as any).__pf_scrollback;
+    makeEntry('sid-DEFAULT', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const opts = (globalThis as any).__pf_lastHeadlessOpts as
+      | { scrollback?: number }
+      | undefined;
+    expect(opts?.scrollback).toBe(1500);
   });
 });
 

--- a/electron/ptyHost/__tests__/ipcRegistrar.test.ts
+++ b/electron/ptyHost/__tests__/ipcRegistrar.test.ts
@@ -9,15 +9,31 @@
 // ...args)` directly.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 interface RegistrarBus {
   resolveClaude: ReturnType<typeof vi.fn>;
   watcherListeners: Map<string, Array<(evt: unknown) => void>>;
+  // Task #42 — per-test overrides for the clipboard image stub. We keep
+  // these in the bus so vi.mock (hoisted) can reference them lazily
+  // without dragging state across tests.
+  clipboardReadImage: () => { isEmpty: () => boolean; toPNG: () => Buffer };
+  userDataDir: string;
 }
 function bus(): RegistrarBus {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (globalThis as any).__irBus as RegistrarBus;
 }
+
+// Task #42 — registrar now imports `app` and `clipboard` from electron at
+// module load. Provide a thin stub; per-test behaviour is steered via the
+// bus accessors so the mock factory itself stays static.
+vi.mock('electron', () => ({
+  app: { getPath: (_k: string) => bus().userDataDir },
+  clipboard: { readImage: () => bus().clipboardReadImage() },
+}));
 
 vi.mock('../claudeResolver', () => ({
   resolveClaude: (opts?: unknown) => bus().resolveClaude(opts),
@@ -99,6 +115,10 @@ beforeEach(() => {
   (globalThis as any).__irBus = {
     resolveClaude: vi.fn(),
     watcherListeners: new Map<string, Array<(evt: unknown) => void>>(),
+    // Default to an empty clipboard so the channel returns null cleanly
+    // for tests that don't touch the image branch.
+    clipboardReadImage: () => ({ isEmpty: () => true, toPNG: () => Buffer.alloc(0) }),
+    userDataDir: fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-ipcregistrar-')),
   } satisfies RegistrarBus;
 });
 
@@ -111,7 +131,7 @@ afterEach(() => {
 // ─── handler registration shape ───────────────────────────────────────────
 
 describe('registerPtyIpc handler registration', () => {
-  it('registers all nine pty:* channels (8 legacy + getBufferSnapshot)', () => {
+  it('registers all ten pty:* channels (8 legacy + getBufferSnapshot + saveClipboardImage)', () => {
     const ipc = makeFakeIpc();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
@@ -126,6 +146,7 @@ describe('registerPtyIpc handler registration', () => {
         'pty:kill',
         'pty:list',
         'pty:resize',
+        'pty:saveClipboardImage',
         'pty:spawn',
       ].sort(),
     );
@@ -472,6 +493,58 @@ describe('pty:checkClaudeAvailable', () => {
     for (const call of bus().resolveClaude.mock.calls) {
       expect(call[0]).toEqual({ force: false });
     }
+  });
+});
+
+// ─── pty:saveClipboardImage (Task #42) ────────────────────────────────────
+
+describe('pty:saveClipboardImage', () => {
+  it('writes PNG buffer under <userData>/clipboard-images/ and returns the absolute path', async () => {
+    const ipc = makeFakeIpc();
+    const pngBuf = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    bus().clipboardReadImage = () => ({ isEmpty: () => false, toPNG: () => pngBuf });
+    registerPtyIpc(ipc as unknown as Electron.IpcMain, makeDeps());
+    const out = (await ipc.handlers.get('pty:saveClipboardImage')!({})) as string;
+    expect(typeof out).toBe('string');
+    expect(path.isAbsolute(out)).toBe(true);
+    expect(out.startsWith(path.join(bus().userDataDir, 'clipboard-images'))).toBe(true);
+    expect(path.basename(out)).toMatch(/^\d{8}-\d{6}(-\d{3})?\.png$/);
+    expect(fs.readFileSync(out).equals(pngBuf)).toBe(true);
+  });
+
+  it('returns null and writes nothing when clipboard image is empty', async () => {
+    const ipc = makeFakeIpc();
+    // Default bus stub returns isEmpty=true.
+    registerPtyIpc(ipc as unknown as Electron.IpcMain, makeDeps());
+    const out = await ipc.handlers.get('pty:saveClipboardImage')!({});
+    expect(out).toBeNull();
+    const dir = path.join(bus().userDataDir, 'clipboard-images');
+    // mkdir not even attempted on the empty path; dir should not exist.
+    expect(fs.existsSync(dir)).toBe(false);
+  });
+
+  it('appends -001 suffix when the base timestamp file already exists (collision)', async () => {
+    const ipc = makeFakeIpc();
+    const pngBuf = Buffer.from([1, 2, 3, 4]);
+    bus().clipboardReadImage = () => ({ isEmpty: () => false, toPNG: () => pngBuf });
+
+    // Freeze Date so first and second invocations produce the same base.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 4, 22, 10, 11, 12));
+
+    registerPtyIpc(ipc as unknown as Electron.IpcMain, makeDeps());
+
+    const first = (await ipc.handlers.get('pty:saveClipboardImage')!({})) as string;
+    expect(path.basename(first)).toBe('20260522-101112.png');
+
+    const second = (await ipc.handlers.get('pty:saveClipboardImage')!({})) as string;
+    expect(path.basename(second)).toBe('20260522-101112-001.png');
+
+    // Both files must exist with the expected content.
+    expect(fs.readFileSync(first).equals(pngBuf)).toBe(true);
+    expect(fs.readFileSync(second).equals(pngBuf)).toBe(true);
+
+    vi.useRealTimers();
   });
 });
 

--- a/electron/ptyHost/__tests__/ipcRegistrar.test.ts
+++ b/electron/ptyHost/__tests__/ipcRegistrar.test.ts
@@ -203,18 +203,18 @@ describe('pty:input / resize / kill / get pass-through', () => {
 // ─── pty:spawn — claude resolution + spawn delegation + cwd-redirect ──────
 
 describe('pty:spawn', () => {
-  it('returns {ok:false, error:claude_not_found} when resolveClaude returns null', () => {
+  it('returns {ok:false, error:claude_not_found} when resolveClaude returns null', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue(null);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    expect(ipc.handlers.get('pty:spawn')!({}, 'sid', '/work')).toEqual({
+    expect(await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work')).toEqual({
       ok: false,
       error: 'claude_not_found',
     });
   });
 
-  it('returns {ok:true, ...info} on success and forwards args to spawnPtySession', () => {
+  it('returns {ok:true, ...info} on success and forwards args to spawnPtySession', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     const deps = makeDeps({
@@ -222,7 +222,7 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    const out = ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
+    const out = await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
     expect(out).toEqual({ ok: true, sid: 'sid', pid: 1, cols: 80, rows: 24, cwd: '/picked' });
     const call = (deps.spawnPtySession as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[0]).toBe('sid');
@@ -237,7 +237,7 @@ describe('pty:spawn', () => {
   // (PR-D #866) reflows both the headless source-of-truth buffer and the
   // visible xterm to the real container. The IPC handler therefore no
   // longer parses or threads cols/rows into spawnPtySession opts.
-  it('does not forward cols/rows to spawnPtySession (#867 — PR-D resize+replay covers #852)', () => {
+  it('does not forward cols/rows to spawnPtySession (#867 — PR-D resize+replay covers #852)', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     const deps = makeDeps({
@@ -248,7 +248,7 @@ describe('pty:spawn', () => {
     // Even if a (legacy) renderer were to send the third opts argument,
     // the IPC handler ignores it — the only opt threaded into the
     // lifecycle is onCwdRedirect (#603).
-    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work', { cols: 134, rows: 51 });
+    await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work', { cols: 134, rows: 51 });
     const call = (deps.spawnPtySession as ReturnType<typeof vi.fn>).mock.calls[0];
     const opts = call[3] as { cols?: number; rows?: number; onCwdRedirect?: unknown };
     expect(opts.cols).toBeUndefined();
@@ -256,7 +256,7 @@ describe('pty:spawn', () => {
     expect(typeof opts.onCwdRedirect).toBe('function');
   });
 
-  it('omits opts argument entirely from `pty:spawn` (post-#867)', () => {
+  it('omits opts argument entirely from `pty:spawn` (post-#867)', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     const deps = makeDeps({
@@ -264,7 +264,7 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
+    await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
     const call = (deps.spawnPtySession as ReturnType<typeof vi.fn>).mock.calls[0];
     const opts = call[3] as { cols?: number; rows?: number; onCwdRedirect?: unknown };
     expect(opts.cols).toBeUndefined();
@@ -272,7 +272,7 @@ describe('pty:spawn', () => {
     expect(typeof opts.onCwdRedirect).toBe('function');
   });
 
-  it('returns {ok:false, error:spawn_failed:...} when spawnPtySession throws', () => {
+  it('returns {ok:false, error:spawn_failed:...} when spawnPtySession throws', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     const deps = makeDeps({
@@ -280,12 +280,12 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    const out = ipc.handlers.get('pty:spawn')!({}, 'sid', '/work') as { ok: boolean; error: string };
+    const out = (await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work')) as { ok: boolean; error: string };
     expect(out.ok).toBe(false);
     expect(out.error).toMatch(/^spawn_failed: ENOENT$/);
   });
 
-  it('onCwdRedirect callback sends session:cwdRedirected to the main window', () => {
+  it('onCwdRedirect callback sends session:cwdRedirected to the main window', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     const wc = makeWc(1);
@@ -301,13 +301,13 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
+    await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
     expect(captured).not.toBeNull();
     captured!('/new/cwd');
     expect(wc.send).toHaveBeenCalledWith('session:cwdRedirected', { sid: 'sid', newCwd: '/new/cwd' });
   });
 
-  it('onCwdRedirect is a no-op when main window is null', () => {
+  it('onCwdRedirect is a no-op when main window is null', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     let captured: ((newCwd: string) => void) | null = null;
@@ -320,11 +320,11 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
+    await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
     expect(() => captured!('/new')).not.toThrow();
   });
 
-  it('onCwdRedirect swallows wc.send throws (renderer gone)', () => {
+  it('onCwdRedirect swallows wc.send throws (renderer gone)', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     const wc = makeWc(1, { sendThrows: true });
@@ -340,7 +340,7 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
+    await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
     expect(() => captured!('/new')).not.toThrow();
   });
 });
@@ -430,45 +430,45 @@ describe('pty:detach', () => {
 // ─── pty:checkClaudeAvailable ─────────────────────────────────────────────
 
 describe('pty:checkClaudeAvailable', () => {
-  it('returns {available:true, path} when resolveClaude succeeds', () => {
+  it('returns {available:true, path} when resolveClaude succeeds', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    expect(ipc.handlers.get('pty:checkClaudeAvailable')!({}, undefined)).toEqual({
+    expect(await ipc.handlers.get('pty:checkClaudeAvailable')!({}, undefined)).toEqual({
       available: true,
       path: '/bin/claude',
     });
   });
 
-  it('returns {available:false} when resolveClaude returns null', () => {
+  it('returns {available:false} when resolveClaude returns null', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue(null);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    expect(ipc.handlers.get('pty:checkClaudeAvailable')!({}, undefined)).toEqual({
+    expect(await ipc.handlers.get('pty:checkClaudeAvailable')!({}, undefined)).toEqual({
       available: false,
     });
   });
 
-  it('passes {force:true} through to resolveClaude when opts.force === true', () => {
+  it('passes {force:true} through to resolveClaude when opts.force === true', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    ipc.handlers.get('pty:checkClaudeAvailable')!({}, { force: true });
+    await ipc.handlers.get('pty:checkClaudeAvailable')!({}, { force: true });
     expect(bus().resolveClaude).toHaveBeenCalledWith({ force: true });
   });
 
-  it('does NOT pass force when opts is malformed (string / number / null / no force key)', () => {
+  it('does NOT pass force when opts is malformed (string / number / null / no force key)', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    ipc.handlers.get('pty:checkClaudeAvailable')!({}, 'not-an-object');
-    ipc.handlers.get('pty:checkClaudeAvailable')!({}, null);
-    ipc.handlers.get('pty:checkClaudeAvailable')!({}, {});
-    ipc.handlers.get('pty:checkClaudeAvailable')!({}, { force: 'yes' });
+    await ipc.handlers.get('pty:checkClaudeAvailable')!({}, 'not-an-object');
+    await ipc.handlers.get('pty:checkClaudeAvailable')!({}, null);
+    await ipc.handlers.get('pty:checkClaudeAvailable')!({}, {});
+    await ipc.handlers.get('pty:checkClaudeAvailable')!({}, { force: 'yes' });
     for (const call of bus().resolveClaude.mock.calls) {
       expect(call[0]).toEqual({ force: false });
     }

--- a/electron/ptyHost/__tests__/ipcRegistrar.test.ts
+++ b/electron/ptyHost/__tests__/ipcRegistrar.test.ts
@@ -87,7 +87,7 @@ function makeDeps(over: Partial<PtyIpcDeps> = {}): PtyIpcDeps {
     spawnPtySession: vi.fn(() => ({ sid: 's', pid: 1, cols: 80, rows: 24, cwd: '/' })),
     inputPtySession: vi.fn(),
     resizePtySession: vi.fn(),
-    killPtySession: vi.fn(() => true),
+    killPtySession: vi.fn(async () => true),
     getPtySession: vi.fn(() => null),
     getBufferSnapshot: vi.fn(async () => ({ snapshot: '', seq: 0 })),
     ...over,
@@ -181,12 +181,12 @@ describe('pty:input / resize / kill / get pass-through', () => {
     expect(deps.resizePtySession).toHaveBeenCalledWith('sid', 100, 30);
   });
 
-  it('kill returns the deps result', () => {
+  it('kill returns the deps result', async () => {
     const ipc = makeFakeIpc();
-    const deps = makeDeps({ killPtySession: vi.fn(() => false) });
+    const deps = makeDeps({ killPtySession: vi.fn(async () => false) });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    expect(ipc.handlers.get('pty:kill')!({}, 'sid')).toBe(false);
+    await expect(ipc.handlers.get('pty:kill')!({}, 'sid')).resolves.toBe(false);
     expect(deps.killPtySession).toHaveBeenCalledWith('sid');
   });
 

--- a/electron/ptyHost/__tests__/lifecycle.test.ts
+++ b/electron/ptyHost/__tests__/lifecycle.test.ts
@@ -12,6 +12,9 @@ interface FakePty {
   write: ReturnType<typeof vi.fn>;
   resize: ReturnType<typeof vi.fn>;
   kill: ReturnType<typeof vi.fn>;
+  onExit: (cb: () => void) => { dispose: () => void };
+  /** Test helper — fire the registered onExit listener. */
+  __fireExit?: () => void;
   killShouldThrow?: boolean;
   writeShouldThrow?: boolean;
   resizeShouldThrow?: boolean;
@@ -68,14 +71,34 @@ vi.mock('../../prefs/scrollback', () => ({
 
 import * as L from '../lifecycle';
 
+function makeFakePty(over: Partial<FakePty> = {}): FakePty {
+  // Multi-listener onExit (mirrors node-pty's IEvent contract — see
+  // node-pty.d.ts: `readonly onExit: IEvent<...>`). The lifecycle race fix
+  // (#1277 review) registers a listener inside `kill()` to await entry
+  // removal; entryFactory also registers one for the cleanup pump. Both
+  // must fire on a single exit event.
+  const listeners = new Set<() => void>();
+  const pty: FakePty = {
+    pid: 1234,
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    onExit: (cb: () => void) => {
+      listeners.add(cb);
+      return { dispose: () => listeners.delete(cb) };
+    },
+    __fireExit: () => {
+      // Snapshot listeners — a listener may dispose itself when fired.
+      for (const cb of [...listeners]) cb();
+    },
+    ...over,
+  };
+  return pty;
+}
+
 function makeFakeEntry(over: Partial<FakeEntry> = {}): FakeEntry {
   return {
-    pty: {
-      pid: 1234,
-      write: vi.fn(),
-      resize: vi.fn(),
-      kill: vi.fn(),
-    },
+    pty: makeFakePty(),
     headless: { resize: vi.fn() },
     serialize: { serialize: () => 'snapshot' },
     attached: new Map(),
@@ -108,7 +131,7 @@ afterEach(() => {
 describe('lifecycle.spawn', () => {
   it('inserts a new Entry into the map and returns its info', () => {
     const sessions = new Map<string, FakeEntry>();
-    const entry = makeFakeEntry({ pty: { pid: 9, write: vi.fn(), resize: vi.fn(), kill: vi.fn() }, cwd: '/picked' });
+    const entry = makeFakeEntry({ pty: makeFakePty({ pid: 9 }), cwd: '/picked' });
     bus().makeEntry.mockReturnValue(entry);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -140,7 +163,7 @@ describe('lifecycle.spawn', () => {
 
   it('is idempotent — second spawn for the same sid returns existing Entry, no makeEntry call', () => {
     const sessions = new Map<string, FakeEntry>();
-    const entry = makeFakeEntry({ pty: { pid: 99, write: vi.fn(), resize: vi.fn(), kill: vi.fn() } });
+    const entry = makeFakeEntry({ pty: makeFakePty({ pid: 99 }) });
     sessions.set('sid-A', entry);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -177,8 +200,8 @@ describe('lifecycle.spawn', () => {
 describe('lifecycle.list and get', () => {
   it('list returns one info per entry', () => {
     const sessions = new Map<string, FakeEntry>();
-    sessions.set('a', makeFakeEntry({ cwd: '/a', pty: { pid: 1, write: vi.fn(), resize: vi.fn(), kill: vi.fn() } }));
-    sessions.set('b', makeFakeEntry({ cwd: '/b', pty: { pid: 2, write: vi.fn(), resize: vi.fn(), kill: vi.fn() } }));
+    sessions.set('a', makeFakeEntry({ cwd: '/a', pty: makeFakePty({ pid: 1 }) }));
+    sessions.set('b', makeFakeEntry({ cwd: '/b', pty: makeFakePty({ pid: 2 }) }));
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const out = L.list(sessions as any);
@@ -195,7 +218,7 @@ describe('lifecycle.list and get', () => {
 
   it('get returns the info for an existing entry', () => {
     const sessions = new Map<string, FakeEntry>();
-    sessions.set('s', makeFakeEntry({ cwd: '/c', pty: { pid: 7, write: vi.fn(), resize: vi.fn(), kill: vi.fn() } }));
+    sessions.set('s', makeFakeEntry({ cwd: '/c', pty: makeFakePty({ pid: 7 }) }));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(L.get(sessions as any, 's')).toEqual({ sid: 's', pid: 7, cols: 80, rows: 24, cwd: '/c' });
   });
@@ -215,7 +238,7 @@ describe('lifecycle.attach and detach', () => {
     sessions.set('s', makeFakeEntry({
       cols: 99,
       rows: 33,
-      pty: { pid: 55, write: vi.fn(), resize: vi.fn(), kill: vi.fn() },
+      pty: makeFakePty({ pid: 55 }),
       serialize: { serialize: serializeSpy },
     }));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -317,53 +340,159 @@ describe('lifecycle.resize', () => {
 // ─── kill / killAll ───────────────────────────────────────────────────────
 
 describe('lifecycle.kill', () => {
-  it('returns false for an unknown sid (no side effects)', () => {
+  it('resolves to false for an unknown sid (no side effects)', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(L.kill(new Map() as any, 'ghost')).toBe(false);
+    await expect(L.kill(new Map() as any, 'ghost')).resolves.toBe(false);
     expect(bus().killCalls).toEqual([]);
     expect(bus().watcherStopCalls).toEqual([]);
   });
 
-  it('captures pid BEFORE pty.kill (binding may zero pid post-kill)', () => {
+  it('captures pid BEFORE pty.kill (binding may zero pid post-kill)', async () => {
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
     entry.pty.pid = 4242;
-    // simulate the binding zeroing pid on kill
-    entry.pty.kill = vi.fn(() => { entry.pty.pid = 0; });
+    // simulate the binding zeroing pid on kill, then firing onExit (the
+    // production race-fix path: kill() awaits onExit before resolving).
+    entry.pty.kill = vi.fn(() => { entry.pty.pid = 0; entry.pty.__fireExit!(); });
     sessions.set('s', entry);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(L.kill(sessions as any, 's')).toBe(true);
+    await expect(L.kill(sessions as any, 's')).resolves.toBe(true);
     expect(bus().killCalls).toEqual([4242]);
   });
 
-  it('always invokes killProcessSubtree even if pty.kill throws', () => {
+  it('always invokes killProcessSubtree even if pty.kill throws', async () => {
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
     entry.pty.pid = 7;
     entry.pty.kill = vi.fn(() => { throw new Error('already dead'); });
     sessions.set('s', entry);
+    // pty.kill threw, no onExit fired → resolves false via timeout
+    vi.useFakeTimers();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(L.kill(sessions as any, 's')).toBe(true);
+    const p = L.kill(sessions as any, 's');
     expect(bus().killCalls).toEqual([7]);
+    await vi.advanceTimersByTimeAsync(L.KILL_EXIT_TIMEOUT_MS + 10);
+    await expect(p).resolves.toBe(false);
+    vi.useRealTimers();
   });
 
-  it('always invokes sessionWatcher.stopWatching (belt-and-braces, swallows throws)', () => {
+  it('always invokes sessionWatcher.stopWatching (belt-and-braces, swallows throws)', async () => {
     const sessions = new Map<string, FakeEntry>();
-    sessions.set('s', makeFakeEntry());
+    const entry = makeFakeEntry();
+    // Fire onExit synchronously inside kill so the promise resolves promptly.
+    entry.pty.kill = vi.fn(() => entry.pty.__fireExit!());
+    sessions.set('s', entry);
     bus().watcherStopShouldThrow = true;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect(() => L.kill(sessions as any, 's')).not.toThrow();
+    await expect(L.kill(sessions as any, 's')).resolves.toBe(true);
     expect(bus().watcherStopCalls).toEqual(['s']);
+  });
+
+  // ─── #1277 review race fix ─────────────────────────────────────────────
+
+  it('awaits pty.onExit before resolving — renderer-attach race fix', async () => {
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    entry.pty.pid = 100;
+    // pty.kill() does NOT auto-fire onExit (the production node-pty contract:
+    // kill dispatches a signal; onExit fires when the OS reaps the process).
+    entry.pty.kill = vi.fn();
+    sessions.set('s', entry);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p = L.kill(sessions as any, 's');
+    // pty.kill + processKiller already ran synchronously (kill signal dispatched).
+    expect(entry.pty.kill).toHaveBeenCalled();
+    expect(bus().killCalls).toEqual([100]);
+
+    // But the promise must NOT have resolved yet — the renderer awaits this
+    // before bumping reloadNonce, and the entry hasn't been removed.
+    let resolved: boolean | 'pending' = 'pending';
+    void p.then((v) => { resolved = v; });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe('pending');
+
+    // Fire the OS-reap event. Now the kill promise should resolve.
+    entry.pty.__fireExit!();
+    await expect(p).resolves.toBe(true);
+  });
+
+  it('falls back to a 3s timeout when pty.onExit never fires (wedged kill)', async () => {
+    vi.useFakeTimers();
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    entry.pty.pid = 200;
+    // Simulates a wedged pty: kill signal dispatched but the process never
+    // exits (onExit silent). Without the timeout the renderer would hang
+    // forever on `await ccsmPty.kill(sid)`.
+    entry.pty.kill = vi.fn();
+    sessions.set('s', entry);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p = L.kill(sessions as any, 's');
+    let resolved: boolean | 'pending' = 'pending';
+    void p.then((v) => { resolved = v; });
+
+    // Advance just under the timeout — still pending.
+    await vi.advanceTimersByTimeAsync(L.KILL_EXIT_TIMEOUT_MS - 100);
+    expect(resolved).toBe('pending');
+
+    // Cross the timeout — resolves false (entry-removed signal not observed),
+    // letting the renderer's reloadNonce path proceed instead of hanging.
+    await vi.advanceTimersByTimeAsync(200);
+    await expect(p).resolves.toBe(false);
+    vi.useRealTimers();
+  });
+
+  it('dedupes concurrent kills for the same sid — second call shares the first promise', async () => {
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    entry.pty.pid = 300;
+    entry.pty.kill = vi.fn();
+    sessions.set('s', entry);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p1 = L.kill(sessions as any, 's');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p2 = L.kill(sessions as any, 's');
+    // Same promise — second call is a no-op short-circuit, no extra
+    // pty.kill / processKiller / stopWatching invocations.
+    expect(p1).toBe(p2);
+    expect(entry.pty.kill).toHaveBeenCalledTimes(1);
+    expect(bus().killCalls).toEqual([300]);
+    expect(bus().watcherStopCalls).toEqual(['s']);
+
+    // Drain.
+    entry.pty.__fireExit!();
+    await expect(p1).resolves.toBe(true);
+  });
+
+  it('a fresh kill after the previous one completes is NOT deduped', async () => {
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    entry.pty.pid = 400;
+    entry.pty.kill = vi.fn(() => entry.pty.__fireExit!());
+    sessions.set('s', entry);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await L.kill(sessions as any, 's');
+    // Re-add the entry (simulating spawn-on-null fallback creating a new pty
+    // for the same sid) and kill again — this must NOT short-circuit.
+    sessions.set('s', entry);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await L.kill(sessions as any, 's');
+    expect(entry.pty.kill).toHaveBeenCalledTimes(2);
   });
 });
 
 describe('lifecycle.killAll', () => {
   it('kills every entry via the kill op', () => {
     const sessions = new Map<string, FakeEntry>();
-    sessions.set('a', makeFakeEntry({ pty: { pid: 1, write: vi.fn(), resize: vi.fn(), kill: vi.fn() } }));
-    sessions.set('b', makeFakeEntry({ pty: { pid: 2, write: vi.fn(), resize: vi.fn(), kill: vi.fn() } }));
-    sessions.set('c', makeFakeEntry({ pty: { pid: 3, write: vi.fn(), resize: vi.fn(), kill: vi.fn() } }));
+    sessions.set('a', makeFakeEntry({ pty: makeFakePty({ pid: 1 }) }));
+    sessions.set('b', makeFakeEntry({ pty: makeFakePty({ pid: 2 }) }));
+    sessions.set('c', makeFakeEntry({ pty: makeFakePty({ pid: 3 }) }));
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     L.killAll(sessions as any);
     expect(bus().killCalls.sort()).toEqual([1, 2, 3]);

--- a/electron/ptyHost/__tests__/lifecycle.test.ts
+++ b/electron/ptyHost/__tests__/lifecycle.test.ts
@@ -60,6 +60,12 @@ vi.mock('../entryFactory', () => ({
   makeEntry: (...args: unknown[]) => bus().makeEntry(...args),
 }));
 
+// scrollback prefs transitively import `electron` (via `../db` → `app`).
+// We don't exercise scrollback caps in these lifecycle tests — stub it.
+vi.mock('../../prefs/scrollback', () => ({
+  loadScrollbackLines: () => 1500,
+}));
+
 import * as L from '../lifecycle';
 
 function makeFakeEntry(over: Partial<FakeEntry> = {}): FakeEntry {

--- a/electron/ptyHost/__tests__/lifecycle.test.ts
+++ b/electron/ptyHost/__tests__/lifecycle.test.ts
@@ -446,6 +446,67 @@ describe('lifecycle.kill', () => {
     vi.useRealTimers();
   });
 
+  it('evicts the zombie entry on timeout so subsequent attach returns null (spawn-on-null unblocked)', async () => {
+    // #1277 follow-up: when KILL_EXIT_TIMEOUT_MS fires, kill() resolves false
+    // but the entry was still in the map — a subsequent pty:attach would
+    // return the zombie and bypass the spawn-on-null fallback, leaving the
+    // renderer registered on a dead pty (crash overlay → manual Retry).
+    // Fix: force SIGKILL + delete from map on timeout.
+    vi.useFakeTimers();
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    entry.pty.pid = 500;
+    // Track SIGKILL escalation — pty.kill called twice (first signal-less in
+    // production code, second with 'SIGKILL' on timeout).
+    entry.pty.kill = vi.fn();
+    sessions.set('s', entry);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p = L.kill(sessions as any, 's');
+
+    // Cross the timeout — SIGKILL escalation + zombie eviction.
+    await vi.advanceTimersByTimeAsync(L.KILL_EXIT_TIMEOUT_MS + 10);
+    await expect(p).resolves.toBe(false);
+
+    // SIGKILL escalation attempted on the wedged pty.
+    expect(entry.pty.kill).toHaveBeenCalledWith('SIGKILL');
+    // Zombie removed from registry — attach now returns null, letting the
+    // renderer's reloadNonce → spawn-on-null fallback create a fresh PTY.
+    expect(sessions.has('s')).toBe(false);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(L.attach(sessions as any, 's')).toBeNull();
+    vi.useRealTimers();
+  });
+
+  it('swallows SIGKILL throws on timeout (still evicts the zombie + logs)', async () => {
+    // On Windows node-pty emulates signals; SIGKILL may throw. The timeout
+    // path must still delete the entry from the map (else the zombie blocks
+    // spawn-on-null forever) and must not propagate the throw.
+    vi.useFakeTimers();
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    entry.pty.pid = 600;
+    let calls = 0;
+    entry.pty.kill = vi.fn((signal?: string) => {
+      calls += 1;
+      // First call (signal-less production kill) succeeds; SIGKILL throws.
+      if (signal === 'SIGKILL') throw new Error('signal not supported');
+    });
+    sessions.set('s', entry);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const p = L.kill(sessions as any, 's');
+    await vi.advanceTimersByTimeAsync(L.KILL_EXIT_TIMEOUT_MS + 10);
+    await expect(p).resolves.toBe(false);
+
+    expect(calls).toBe(2); // initial kill + SIGKILL escalation
+    expect(sessions.has('s')).toBe(false);
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining('SIGKILL also failed'),
+    );
+    vi.useRealTimers();
+  });
+
   it('dedupes concurrent kills for the same sid — second call shares the first promise', async () => {
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();

--- a/electron/ptyHost/claudeResolver.ts
+++ b/electron/ptyHost/claudeResolver.ts
@@ -26,35 +26,75 @@
 // bypass the cache (the renderer's "Re-check" button on ClaudeMissingGuide
 // uses this so the user can install claude in a separate terminal and
 // recover in-place without restarting the app).
+//
+// Async since #PERF: the original `spawnSync` blocked the main process
+// event loop for 50-200ms on Windows during cold start (first
+// `pty:checkClaudeAvailable` from App.tsx + first `pty:spawn`), causing
+// a visible "window hang" stutter. Both callers are `ipcMain.handle`
+// handlers that already await Promise returns, so flipping to async is
+// free at the call site. A module-level in-flight Promise dedups
+// concurrent first-callers so two simultaneous IPCs don't double-spawn
+// `where`.
 
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 
 let cached: string | null | undefined; // undefined = never tried
+let inFlight: Promise<string | null> | null = null;
 
-function tryWhere(name: string): string | null {
+function whereAsync(name: string): Promise<string | null> {
   const cmd = process.platform === 'win32' ? 'where' : 'which';
-  try {
-    const r = spawnSync(cmd, [name], { encoding: 'utf8', windowsHide: true });
-    if (r.status !== 0) return null;
-    const first = r.stdout.split(/\r?\n/).find((l) => l.trim().length > 0);
-    return first ? first.trim() : null;
-  } catch {
-    return null;
-  }
+  return new Promise((resolve) => {
+    let stdout = '';
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(cmd, [name], { windowsHide: true });
+    } catch {
+      resolve(null);
+      return;
+    }
+    child.stdout?.on('data', (b: Buffer) => {
+      stdout += b.toString('utf8');
+    });
+    child.on('error', () => resolve(null));
+    child.on('exit', (code) => {
+      if (code !== 0) {
+        resolve(null);
+        return;
+      }
+      const first = stdout.split(/\r?\n/).find((l) => l.trim().length > 0);
+      resolve(first ? first.trim() : null);
+    });
+  });
 }
 
-export function resolveClaude({ force = false }: { force?: boolean } = {}): string | null {
-  if (!force && cached !== undefined) return cached;
+async function doResolve(): Promise<string | null> {
   if (process.platform === 'win32') {
-    cached = tryWhere('claude.cmd') ?? tryWhere('claude');
-  } else {
-    cached = tryWhere('claude');
+    return (await whereAsync('claude.cmd')) ?? (await whereAsync('claude'));
   }
-  return cached;
+  return whereAsync('claude');
+}
+
+export function resolveClaude({ force = false }: { force?: boolean } = {}): Promise<string | null> {
+  if (!force && cached !== undefined) return Promise.resolve(cached);
+  // Concurrent-caller dedup: while the first lookup is in flight, hand
+  // the same Promise to every additional caller. Without this, an N-wide
+  // burst of `pty:checkClaudeAvailable` + `pty:spawn` on cold start
+  // would spawn N copies of `where` instead of one.
+  if (!force && inFlight) return inFlight;
+  inFlight = doResolve()
+    .then((result) => {
+      cached = result;
+      return result;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+  return inFlight;
 }
 
 // Test seam — used by harness-real-cli's ttyd cases to force a fresh
 // lookup between cases. Production code never invokes this.
 export function __resetClaudeResolverForTest(): void {
   cached = undefined;
+  inFlight = null;
 }

--- a/electron/ptyHost/claudeResolver.ts
+++ b/electron/ptyHost/claudeResolver.ts
@@ -41,9 +41,18 @@ import { spawn } from 'node:child_process';
 let cached: string | null | undefined; // undefined = never tried
 let inFlight: Promise<string | null> | null = null;
 
-function whereAsync(name: string): Promise<string | null> {
+// Hard cap on a single `where`/`which` invocation. A broken PATH, slow
+// shell startup, or AV interception can hang the lookup indefinitely;
+// without a timeout the whole resolveClaude promise never settles and
+// the IPC handler stays pending forever (renderer spinner stuck).
+const WHERE_TIMEOUT_MS = 5000;
+
+// Exported for the timeout unit test (asserts the rejection shape). Not
+// part of the module's public API — production callers go through
+// `resolveClaude`.
+export function whereAsync(name: string): Promise<string | null> {
   const cmd = process.platform === 'win32' ? 'where' : 'which';
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     let stdout = '';
     let child: ReturnType<typeof spawn>;
     try {
@@ -52,11 +61,23 @@ function whereAsync(name: string): Promise<string | null> {
       resolve(null);
       return;
     }
+    const timer = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        /* ignore */
+      }
+      reject(new Error(`where_timeout: '${cmd} ${name}' did not complete in ${WHERE_TIMEOUT_MS}ms`));
+    }, WHERE_TIMEOUT_MS);
     child.stdout?.on('data', (b: Buffer) => {
       stdout += b.toString('utf8');
     });
-    child.on('error', () => resolve(null));
+    child.on('error', () => {
+      clearTimeout(timer);
+      resolve(null);
+    });
     child.on('exit', (code) => {
+      clearTimeout(timer);
       if (code !== 0) {
         resolve(null);
         return;
@@ -68,10 +89,20 @@ function whereAsync(name: string): Promise<string | null> {
 }
 
 async function doResolve(): Promise<string | null> {
-  if (process.platform === 'win32') {
-    return (await whereAsync('claude.cmd')) ?? (await whereAsync('claude'));
+  // Catch where_timeout at the boundary: collapse to null so the IPC
+  // contract stays the same (renderer surfaces ClaudeMissingGuide rather
+  // than seeing an unhandled rejection / silent fallback to undefined
+  // cwd). The warning lets diagnosis trace a hang back to a stuck
+  // `where`/`which` rather than a "claude not installed" misdiagnosis.
+  try {
+    if (process.platform === 'win32') {
+      return (await whereAsync('claude.cmd')) ?? (await whereAsync('claude'));
+    }
+    return await whereAsync('claude');
+  } catch (err) {
+    console.warn('[claudeResolver]', (err as Error).message);
+    return null;
   }
-  return whereAsync('claude');
 }
 
 export function resolveClaude({ force = false }: { force?: boolean } = {}): Promise<string | null> {

--- a/electron/ptyHost/entryFactory.ts
+++ b/electron/ptyHost/entryFactory.ts
@@ -210,11 +210,32 @@ export function makeEntry(
   cols: number,
   rows: number,
   deps: MakeEntryDeps,
+  forkSourceSid?: string,
 ): Entry {
   const claudeSid = toClaudeSid(sid);
   const sourceJsonl = findJsonlForSid(claudeSid);
-  const flag = sourceJsonl ? '--resume' : '--session-id';
-  const args = [flag, claudeSid];
+
+  // `--fork-session` path: the renderer is creating a new session that should
+  // boot with another (source) session's full transcript context but write to
+  // its own JSONL. Claude CLI handles the duplication natively — we hand it
+  // BOTH the source sid (`--resume`) AND the desired new sid (`--session-id`)
+  // along with `--fork-session`, and it copies the transcript on first write.
+  // The new sid's JSONL DOES NOT EXIST YET (since we just minted it in the
+  // renderer), so the normal `findJsonlForSid` branch below would route us
+  // into a `--session-id`-only spawn that reuses the bare new id — losing
+  // the parent context. Handle fork explicitly first, before the resume/
+  // session-id picker; once the fork finishes the first turn, the new JSONL
+  // exists and any subsequent re-spawn (e.g. user kills + retries) will fall
+  // through `findJsonlForSid` → `--resume` like any other ccsm-tracked
+  // session, no special-casing needed downstream.
+  let args: string[];
+  if (forkSourceSid && !sourceJsonl) {
+    const sourceClaudeSid = toClaudeSid(forkSourceSid);
+    args = ['--resume', sourceClaudeSid, '--fork-session', '--session-id', claudeSid];
+  } else {
+    const flag = sourceJsonl ? '--resume' : '--session-id';
+    args = [flag, claudeSid];
+  }
 
   const spawnCwd = resolveSpawnCwd(cwd);
 

--- a/electron/ptyHost/entryFactory.ts
+++ b/electron/ptyHost/entryFactory.ts
@@ -33,14 +33,21 @@ import {
 } from './jsonlResolver';
 import { resolveSpawnCwd } from './cwdResolver';
 import { emitPtyData } from './dataFanout';
+import { loadScrollbackLines } from '../prefs/scrollback';
 
 export const DEFAULT_COLS = 120;
 export const DEFAULT_ROWS = 30;
-// L4 PR-A (#861): scrollback bumped from 5000 -> 10000 lines so the headless
-// terminal becomes a session-level authoritative buffer suitable for serving
-// re-attach replays, not just the live screen. 10000 was 80/20-decided by the
-// owner; bump only here and in any future replay-budget calculation.
-export const SCROLLBACK = 10000;
+// User-facing scrollback cap defaults to 1500 lines (see
+// `electron/prefs/scrollback.ts`). The headless mirror's per-entry buffer
+// is sized at construction time from `loadScrollbackLines()`; this constant
+// is the static fallback used when the prefs read fails (e.g. db init race)
+// and is kept exported for tests that bypass the prefs path.
+//
+// History: PR #861 bumped to 10000 to back re-attach replay; user-driven
+// research showed 10000 was unnecessarily generous for typical usage and
+// caused multi-megabyte snapshot serializes on every attach. Lowered as
+// part of the user-facing scrollback knob landing in this PR.
+export const SCROLLBACK = 1500;
 
 // L4 PR-C (#863): when the visible xterm cannot keep up with PTY output the
 // headless mirror's `write(data, cb)` callback is invoked asynchronously.
@@ -248,7 +255,11 @@ export function makeEntry(
   const headless = new HeadlessTerminal({
     cols,
     rows,
-    scrollback: SCROLLBACK,
+    // Read the user-configured cap at construction time. Existing entries
+    // keep their already-sized buffer when the user changes the setting
+    // — only newly-spawned sessions pick up the new value, matching the
+    // "applies on next attach" UX contract documented in SettingsDialog.
+    scrollback: loadScrollbackLines(),
     allowProposedApi: true,
   });
   const serialize = new SerializeAddon();

--- a/electron/ptyHost/index.ts
+++ b/electron/ptyHost/index.ts
@@ -81,7 +81,7 @@ export const inputPtySession = (sid: string, data: string): void =>
 export const resizePtySession = (sid: string, cols: number, rows: number): void =>
   L.resize(sessions, sid, cols, rows);
 
-export const killPtySession = (sid: string): boolean => L.kill(sessions, sid);
+export const killPtySession = (sid: string): Promise<boolean> => L.kill(sessions, sid);
 
 export const getPtySession = (sid: string): L.PtySessionInfo | null =>
   L.get(sessions, sid);

--- a/electron/ptyHost/ipcRegistrar.ts
+++ b/electron/ptyHost/ipcRegistrar.ts
@@ -87,8 +87,8 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
 
   ipcMain.handle('pty:list', () => deps.listPtySessions());
 
-  ipcMain.handle('pty:spawn', (_event, sid: string, cwd: string) => {
-    const claudePath = resolveClaude();
+  ipcMain.handle('pty:spawn', async (_event, sid: string, cwd: string) => {
+    const claudePath = await resolveClaude();
     if (!claudePath) {
       return { ok: false, error: 'claude_not_found' };
     }
@@ -182,10 +182,10 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
   // `force: true` bypasses the resolver's success-cache so the user can
   // install claude in another terminal and recover in-place via the
   // ClaudeMissingGuide "Re-check" button without restarting the app.
-  ipcMain.handle('pty:checkClaudeAvailable', (_event, opts: unknown) => {
+  ipcMain.handle('pty:checkClaudeAvailable', async (_event, opts: unknown) => {
     const force =
       typeof opts === 'object' && opts !== null && (opts as { force?: unknown }).force === true;
-    const p = resolveClaude({ force });
+    const p = await resolveClaude({ force });
     return p ? { available: true as const, path: p } : { available: false as const };
   });
 }

--- a/electron/ptyHost/ipcRegistrar.ts
+++ b/electron/ptyHost/ipcRegistrar.ts
@@ -6,10 +6,41 @@
 // tangled with the IPC surface. The registrar owns no state of its own
 // beyond the one-shot `stateBridgeInstalled` guard.
 
-import type { BrowserWindow, IpcMain } from 'electron';
+import fs from 'node:fs';
+import path from 'node:path';
+import { app, clipboard, type BrowserWindow, type IpcMain } from 'electron';
 import { resolveClaude } from './claudeResolver';
 import { sessionWatcher } from '../sessionWatcher';
 import type { AttachResult, BufferSnapshot, PtySessionInfo } from './lifecycle';
+
+/**
+ * Task #42 — clipboard image auto-save. Filename format:
+ * `YYYYMMDD-HHMMSS[-NNN].png`. Local time (matches the user's Finder /
+ * Explorer column when they go looking for the file). The `-NNN` suffix
+ * is appended on same-second collisions; we cap retries at 999 so a
+ * runaway loop can't pin the main thread.
+ */
+function formatClipboardImageTimestamp(d: Date): string {
+  const pad = (n: number, w = 2): string => String(n).padStart(w, '0');
+  return (
+    `${d.getFullYear()}${pad(d.getMonth() + 1)}${pad(d.getDate())}-` +
+    `${pad(d.getHours())}${pad(d.getMinutes())}${pad(d.getSeconds())}`
+  );
+}
+
+/**
+ * Resolve a non-colliding filename inside `dir` for the given timestamp
+ * base. Uses sync existsSync because the loop must be atomic w.r.t. the
+ * subsequent write — interleaving another async tick here would race
+ * two paste-image calls landing the same second.
+ */
+function resolveClipboardImagePath(dir: string, base: string): string {
+  let file = path.join(dir, `${base}.png`);
+  for (let n = 1; n < 1000 && fs.existsSync(file); n++) {
+    file = path.join(dir, `${base}-${String(n).padStart(3, '0')}.png`);
+  }
+  return file;
+}
 
 interface SessionEntryHandle {
   pty: { pid: number };
@@ -208,5 +239,30 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
       typeof opts === 'object' && opts !== null && (opts as { force?: unknown }).force === true;
     const p = await resolveClaude({ force });
     return p ? { available: true as const, path: p } : { available: false as const };
+  });
+
+  // Task #42 — when the renderer detects a paste intent and the clipboard
+  // holds an image (e.g. user took a screenshot, dragged a PNG into the
+  // clipboard, or copied from a browser), drop it to disk under
+  // `<userData>/clipboard-images/` and return the absolute path so the
+  // renderer can inject the path into the active PTY. Claude reads files
+  // by path, so this is the canonical way to feed it a screenshot.
+  //
+  // Returns null when there is no image on the clipboard — renderer falls
+  // back to its normal text-paste path. We do NOT inspect text here, even
+  // when text is also present, because Windows readText() is unreliable
+  // when the clipboard holds an image (readImage().isEmpty() IS reliable).
+  // The renderer holds the text fallback synchronously before invoking us.
+  ipcMain.handle('pty:saveClipboardImage', async () => {
+    const img = clipboard.readImage();
+    if (img.isEmpty()) return null;
+    const buf = img.toPNG();
+    if (buf.length === 0) return null;
+    const dir = path.join(app.getPath('userData'), 'clipboard-images');
+    await fs.promises.mkdir(dir, { recursive: true });
+    const base = formatClipboardImageTimestamp(new Date());
+    const file = resolveClipboardImagePath(dir, base);
+    await fs.promises.writeFile(file, buf);
+    return file;
   });
 }

--- a/electron/ptyHost/ipcRegistrar.ts
+++ b/electron/ptyHost/ipcRegistrar.ts
@@ -31,7 +31,12 @@ export interface PtyIpcDeps {
     sid: string,
     cwd: string,
     claudePath: string,
-    opts?: { cols?: number; rows?: number; onCwdRedirect?: (newCwd: string) => void },
+    opts?: {
+      cols?: number;
+      rows?: number;
+      onCwdRedirect?: (newCwd: string) => void;
+      forkSourceSid?: string;
+    },
   ) => PtySessionInfo;
   inputPtySession: (sid: string, data: string) => void;
   resizePtySession: (sid: string, cols: number, rows: number) => void;
@@ -87,11 +92,19 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
 
   ipcMain.handle('pty:list', () => deps.listPtySessions());
 
-  ipcMain.handle('pty:spawn', async (_event, sid: string, cwd: string) => {
+  ipcMain.handle('pty:spawn', async (_event, sid: string, cwd: string, forkSourceSid?: string) => {
     const claudePath = await resolveClaude();
     if (!claudePath) {
       return { ok: false, error: 'claude_not_found' };
     }
+    // Defense-in-depth: only accept a string (and in the same shape as `sid`
+    // — `toClaudeSid` will throw on anything that doesn't pass `VALID_SID_RE`,
+    // so a malformed value here surfaces as `spawn_failed:` rather than
+    // landing as raw argv text). Anything else (number, object, array,
+    // undefined → rest-arg behavior) is dropped to undefined.
+    const fork = typeof forkSourceSid === 'string' && forkSourceSid.length > 0
+      ? forkSourceSid
+      : undefined;
     // L4 PR-F (#867): the renderer no longer forwards initial cols/rows.
     // The PTY launches at the lifecycle defaults (DEFAULT_COLS/ROWS) and
     // the renderer's post-attach `pty:resize` (with snapshot replay,
@@ -103,6 +116,7 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
     // redundant; it has been removed.
     try {
       const info = deps.spawnPtySession(sid, cwd, claudePath, {
+        forkSourceSid: fork,
         // Import-resume cwd-redirect (#603 reviewer Layer-1 fix). When the
         // copy helper relocates the JSONL into the spawn cwd's projectDir,
         // the renderer's `session.cwd` (still pointing at the original

--- a/electron/ptyHost/ipcRegistrar.ts
+++ b/electron/ptyHost/ipcRegistrar.ts
@@ -35,7 +35,7 @@ export interface PtyIpcDeps {
   ) => PtySessionInfo;
   inputPtySession: (sid: string, data: string) => void;
   resizePtySession: (sid: string, cols: number, rows: number) => void;
-  killPtySession: (sid: string) => boolean;
+  killPtySession: (sid: string) => Promise<boolean>;
   getPtySession: (sid: string) => PtySessionInfo | null;
   /** L4 PR-B (#865): async chunked snapshot + capture seq. Routed through
    *  the deps surface (rather than direct module import) so the registrar
@@ -163,7 +163,14 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
     deps.resizePtySession(sid, cols, rows);
   });
 
-  ipcMain.handle('pty:kill', (_event, sid: string) => deps.killPtySession(sid));
+  // Race fix (#1277 review): killPtySession returns a Promise that resolves
+  // only after pty.onExit fires (entry removed from sessions Map) or
+  // KILL_EXIT_TIMEOUT_MS elapses. ipcMain.handle awaits the return so the
+  // renderer's `await ccsmPty.kill(sid)` does NOT resolve until the entry
+  // is gone — a subsequent `pty:attach` is then guaranteed to see null and
+  // walk the spawn-on-null fallback rather than registering as a viewer of
+  // a dying pty.
+  ipcMain.handle('pty:kill', async (_event, sid: string) => deps.killPtySession(sid));
 
   ipcMain.handle('pty:get', (_event, sid: string) => deps.getPtySession(sid));
 

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -122,15 +122,89 @@ export function resize(
   }
 }
 
-export function kill(sessions: Map<string, Entry>, sid: string): boolean {
+// Max wait for pty.onExit to fire after kill() before we give up and resolve
+// the kill promise anyway. The renderer awaits `kill(sid)` before bumping
+// reloadNonce; if the pty is wedged we still want the renderer to fall through
+// to the spawn-on-null fallback rather than hanging the UI. 3s comfortably
+// covers ConPTY teardown + processKiller subtree walk on slow Windows boxes
+// while staying short enough that a stuck kill doesn't feel broken.
+export const KILL_EXIT_TIMEOUT_MS = 3000;
+
+// Dedupe re-entrant kills for the same sid (e.g. user spam-clicks Reload).
+// Keyed by `sessions` Map so multiple registries (tests) don't collide.
+const pendingKills: WeakMap<Map<string, Entry>, Map<string, Promise<boolean>>> =
+  new WeakMap();
+
+function getPendingKills(sessions: Map<string, Entry>): Map<string, Promise<boolean>> {
+  let m = pendingKills.get(sessions);
+  if (!m) {
+    m = new Map();
+    pendingKills.set(sessions, m);
+  }
+  return m;
+}
+
+export function kill(sessions: Map<string, Entry>, sid: string): Promise<boolean> {
+  const inflight = getPendingKills(sessions).get(sid);
+  if (inflight) return inflight;
+
   const entry = sessions.get(sid);
-  if (!entry) return false;
+  if (!entry) return Promise.resolve(false);
+
   // Capture pid BEFORE pty.kill() — the binding may zero it after kill.
   const pid = entry.pty.pid;
+
+  // Race fix (#1277 review): pty.kill() returns synchronously but the entry
+  // is removed from `sessions` only when the onExit pump in entryFactory
+  // fires (async). Without awaiting that, a renderer doing
+  // `await ccsmPty.kill(sid)` then re-attaching can land on the dying entry,
+  // skip the spawn-on-null fallback, and end up registered to a dead pty
+  // that immediately fires pty:exit → user sees a crash overlay. Hold the
+  // kill IPC open until either onExit fires (entry removed, headless
+  // disposed, watchers stopped) or KILL_EXIT_TIMEOUT_MS elapses.
+  //
+  // We register the promise in `pendingKills` BEFORE side effects so a
+  // concurrent caller dedupes correctly; we delete the slot inside `settle`
+  // AFTER `resolve()`. Order matters: with a sync `pty.kill()` mock that
+  // fires `onExit` immediately, settle runs inside the Promise executor,
+  // so the slot must already exist when settle fires (otherwise the slot
+  // delete is a no-op then a stale `set` re-inserts a resolved promise,
+  // and the next `kill()` for the same sid short-circuits forever).
+  let resolveOuter!: (v: boolean) => void;
+  const promise = new Promise<boolean>((r) => { resolveOuter = r; });
+  getPendingKills(sessions).set(sid, promise);
+
+  let settled = false;
+  let exitDisposable: { dispose(): void } | undefined;
+  const settle = (v: boolean) => {
+    if (settled) return;
+    settled = true;
+    // Best-effort dispose of the listener; if the binding's onExit already
+    // fired and disposed itself this is a no-op.
+    try { exitDisposable?.dispose(); } catch { /* ignore */ }
+    clearTimeout(timer);
+    // Free the dedup slot BEFORE resolving so anything `await kill()`s
+    // and immediately calls `kill()` again (e.g. spawn-on-null then
+    // user-driven reload) gets a fresh kill, not a no-op short-circuit.
+    if (getPendingKills(sessions).get(sid) === promise) {
+      getPendingKills(sessions).delete(sid);
+    }
+    resolveOuter(v);
+  };
+
+  try {
+    exitDisposable = entry.pty.onExit(() => settle(true));
+  } catch {
+    /* onExit registration failed (already-exited binding) — fall through;
+       the timeout will resolve us, and processKiller below still runs. */
+  }
+
+  const timer = setTimeout(() => settle(false), KILL_EXIT_TIMEOUT_MS);
+
   try {
     entry.pty.kill();
   } catch {
-    /* already dead */
+    /* already dead — onExit may or may not fire; timeout covers us */
   }
   // ConPTY's kill only terminates the cmd.exe / OpenConsole wrapper; on Windows
   // the claude.exe child (and its grandchildren) survive as orphans. On
@@ -141,7 +215,8 @@ export function kill(sessions: Map<string, Entry>, sid: string): boolean {
   // pty.kill that races with onExit can't leak the fs.watch handle.
   // sessionWatcher.stopWatching is idempotent.
   try { sessionWatcher.stopWatching(sid); } catch { /* never throws */ }
-  return true;
+
+  return promise;
 }
 
 export function get(sessions: Map<string, Entry>, sid: string): PtySessionInfo | null {
@@ -219,9 +294,12 @@ export async function getBufferSnapshot(
 }
 
 // Kill every running pty. Call from app `before-quit` so renderer-side
-// claude processes don't leak past Electron exit.
+// claude processes don't leak past Electron exit. Fire-and-forget — we don't
+// block app teardown on the per-pty onExit/timeout dance; the kill signal +
+// processKiller subtree walk dispatch synchronously inside `kill()` before
+// the awaited onExit, which is what actually reaps the children.
 export function killAll(sessions: Map<string, Entry>): void {
   for (const sid of [...sessions.keys()]) {
-    kill(sessions, sid);
+    void kill(sessions, sid);
   }
 }

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -216,7 +216,29 @@ export function kill(sessions: Map<string, Entry>, sid: string): Promise<boolean
        the timeout will resolve us, and processKiller below still runs. */
   }
 
-  const timer = setTimeout(() => settle(false), KILL_EXIT_TIMEOUT_MS);
+  const timer = setTimeout(() => {
+    // Wedged-pty zombie cleanup (#1277 follow-up): the 3s timeout fired
+    // before onExit, which means the cleanup pump in entryFactory never
+    // ran and `sessions` still holds this sid. If we just resolved here a
+    // subsequent `pty:attach` from the renderer's reloadNonce bump would
+    // return the zombie entry, skip the spawn-on-null fallback, and
+    // register the viewer on a dead pty → crash overlay, manual Retry.
+    //
+    // Force-evict the entry so attach returns null and the renderer gets
+    // a transparent fresh PTY. The process is still live (kill signal
+    // was sent but the OS never reaped it); attempt SIGKILL as a last
+    // resort. On Windows node-pty emulates signals so SIGKILL may be a
+    // no-op — at minimum we've logged the leak so it's visible.
+    try {
+      entry.pty.kill('SIGKILL');
+    } catch (e) {
+      console.warn(
+        `[ptyHost] kill ${sid} wedged: SIGKILL also failed (${e instanceof Error ? e.message : String(e)}); pid ${pid} may leak`,
+      );
+    }
+    if (sessions.get(sid) === entry) sessions.delete(sid);
+    settle(false);
+  }, KILL_EXIT_TIMEOUT_MS);
 
   try {
     entry.pty.kill();

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -52,16 +52,33 @@ export function spawn(
   sid: string,
   cwd: string,
   claudePath: string,
-  opts?: { cols?: number; rows?: number; onCwdRedirect?: (newCwd: string) => void },
+  opts?: {
+    cols?: number;
+    rows?: number;
+    onCwdRedirect?: (newCwd: string) => void;
+    /** When set, spawn args include `--resume <forkSourceSid> --fork-session
+     *  --session-id <sid>` so the new session boots with the source's
+     *  transcript but writes a fresh JSONL keyed to `sid`. Threaded through
+     *  to `makeEntry` — see entryFactory.ts for the flag-picker. */
+    forkSourceSid?: string;
+  },
 ): PtySessionInfo {
   const existing = sessions.get(sid);
   if (existing) return infoFromEntry(sid, existing);
   const cols = opts?.cols ?? DEFAULT_COLS;
   const rows = opts?.rows ?? DEFAULT_ROWS;
-  const entry = makeEntry(sid, cwd, claudePath, cols, rows, {
-    onExit: (s) => { sessions.delete(s); },
-    onCwdRedirect: opts?.onCwdRedirect,
-  });
+  const entry = makeEntry(
+    sid,
+    cwd,
+    claudePath,
+    cols,
+    rows,
+    {
+      onExit: (s) => { sessions.delete(s); },
+      onCwdRedirect: opts?.onCwdRedirect,
+    },
+    opts?.forkSourceSid,
+  );
   sessions.set(sid, entry);
   return infoFromEntry(sid, entry);
 }

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -15,6 +15,7 @@ import { sessionWatcher } from '../sessionWatcher';
 import { killProcessSubtree } from './processKiller';
 import { DEFAULT_COLS, DEFAULT_ROWS, makeEntry } from './entryFactory';
 import type { Entry } from './entryFactory';
+import { loadScrollbackLines } from '../prefs/scrollback';
 
 export interface PtySessionInfo {
   sid: string;
@@ -152,14 +153,17 @@ export function get(sessions: Map<string, Entry>, sid: string): PtySessionInfo |
 // L4 PR-A (#861) + PR-B (#865): async, chunked snapshot of the headless
 // authoritative buffer, paired with the per-entry monotonic chunk seq.
 //
-// SerializeAddon.serialize() itself is synchronous and walks the entire
-// scrollback (cap 10000 lines). With the bumped cap the serialized string can
-// reach ~MBs for long sessions; concatenating + handing back the full string
-// in one tick would briefly block the main thread. We yield to the event loop
-// every CHUNK_LINES (~1000) lines via setImmediate so other I/O (IPC, JSONL
-// tail, OSC sniffer fanout) keeps making progress while a large snapshot is
-// being assembled. The returned value is still the FULL serialized string —
-// chunking is purely a yield strategy, not a streaming protocol.
+// SerializeAddon.serialize() itself is synchronous and walks the requested
+// rows from the bottom of the scrollback (cap configurable via the
+// `scrollbackLines` user preference, default 1500 — see
+// `electron/prefs/scrollback.ts`). With the bumped cap the serialized
+// string can still reach hundreds of KB; concatenating + handing back the
+// full string in one tick would briefly block the main thread. We yield
+// to the event loop every CHUNK_LINES (~1000) lines via setImmediate so
+// other I/O (IPC, JSONL tail, OSC sniffer fanout) keeps making progress
+// while a large snapshot is being assembled. The returned value is still
+// the FULL serialized string — chunking is purely a yield strategy, not
+// a streaming protocol.
 //
 // PR-B adds the `seq` field: captured ATOMICALLY with `serialize.serialize()`
 // (both happen synchronously, no chunk can arrive between them under Node's
@@ -189,7 +193,13 @@ export async function getBufferSnapshot(
   if (!entry) return { snapshot: '', seq: 0 };
   // Capture seq + serialized string atomically (both sync, no awaits).
   const seq = entry.seq;
-  const full = entry.serialize.serialize();
+  // PR-B contract: serialize captures whatever lives in the headless buffer
+  // at this instant, paired with `seq`. We bound the payload to the user's
+  // configured scrollback cap (last N rows from the bottom of the scrollback)
+  // so a long-running session doesn't return MB of lines on every attach.
+  // Cap honors the live setting (read fresh per call), so the user's
+  // change takes effect on the next attach without restarting the entry.
+  const full = entry.serialize.serialize({ scrollback: loadScrollbackLines() });
   if (!full) return { snapshot: '', seq };
   // Split on '\n' so we yield on a line boundary; preserves the original
   // separator on rejoin. setImmediate is available in Electron main (Node

--- a/electron/remote/mobileRemoteServer.ts
+++ b/electron/remote/mobileRemoteServer.ts
@@ -16,11 +16,19 @@ type MobileRemoteServer = {
 type WsClient = {
   socket: Duplex;
   pending: Buffer;
+  /** Accumulator for fragmented text messages (FIN=0). Reset on each
+   *  complete message; non-empty means we're mid-fragment. */
+  fragment: Buffer;
   send: (payload: unknown) => void;
 };
 
 const DEFAULT_PORT = 4177;
 const HOST = '127.0.0.1';
+/** Hard cap on a single inbound text message. Anything beyond this is a
+ *  protocol violation or a buggy client; we close with 1009 rather than let
+ *  Buffer.concat OOM the main process. 1 MiB is generous for our protocol
+ *  (largest legitimate message is session.input, typically << 64 KiB). */
+const MAX_MESSAGE_BYTES = 1 << 20;
 
 export function startMobileRemoteServer(): MobileRemoteServer | null {
   if (process.env.CCSM_MOBILE_REMOTE !== '1') return null;
@@ -68,6 +76,7 @@ export function startMobileRemoteServer(): MobileRemoteServer | null {
     const client: WsClient = {
       socket,
       pending: Buffer.alloc(0),
+      fragment: Buffer.alloc(0),
       send: (payload) => {
         if (socket.destroyed) return;
         socket.write(encodeFrame(JSON.stringify(payload)));
@@ -79,10 +88,21 @@ export function startMobileRemoteServer(): MobileRemoteServer | null {
 
     socket.on('data', (chunk) => {
       client.pending = Buffer.concat([client.pending, chunk]);
-      const decoded = decodeFrames(client.pending);
-      client.pending = decoded.remaining;
+      const decoded = decodeFrames(client);
+      if (decoded.kind === 'fatal') {
+        closeSocket(socket, decoded.code);
+        clients.delete(client);
+        return;
+      }
       for (const message of decoded.messages) {
         void handleClientMessage(client, message);
+      }
+      for (const pong of decoded.pongs) {
+        if (!socket.destroyed) socket.write(encodeControlFrame(0xa, pong));
+      }
+      if (decoded.close) {
+        closeSocket(socket, 1000);
+        clients.delete(client);
       }
     });
     socket.on('close', () => clients.delete(client));
@@ -212,67 +232,163 @@ function buildUpgradeResponse(key: string): string {
 }
 
 function encodeFrame(payload: string): Buffer {
-  const body = Buffer.from(payload, 'utf8');
+  return encodeFrameBytes(0x81, Buffer.from(payload, 'utf8'));
+}
+
+function encodeControlFrame(opcode: number, payload: Buffer): Buffer {
+  return encodeFrameBytes(0x80 | (opcode & 0x0f), payload);
+}
+
+function encodeFrameBytes(firstByte: number, body: Buffer): Buffer {
   if (body.length < 126) {
-    return Buffer.concat([Buffer.from([0x81, body.length]), body]);
+    return Buffer.concat([Buffer.from([firstByte, body.length]), body]);
   }
   if (body.length <= 0xffff) {
     const header = Buffer.allocUnsafe(4);
-    header[0] = 0x81;
+    header[0] = firstByte;
     header[1] = 126;
     header.writeUInt16BE(body.length, 2);
     return Buffer.concat([header, body]);
   }
   const header = Buffer.allocUnsafe(10);
-  header[0] = 0x81;
+  header[0] = firstByte;
   header[1] = 127;
   header.writeBigUInt64BE(BigInt(body.length), 2);
   return Buffer.concat([header, body]);
 }
 
-function decodeFrames(buffer: Buffer): { messages: string[]; remaining: Buffer } {
+function closeSocket(socket: Duplex, code: number): void {
+  if (socket.destroyed) return;
+  const body = Buffer.allocUnsafe(2);
+  body.writeUInt16BE(code, 0);
+  try {
+    socket.write(encodeControlFrame(0x8, body));
+  } catch {
+    /* socket already gone */
+  }
+  socket.destroy();
+}
+
+type DecodeResult =
+  | {
+      kind: 'ok';
+      messages: string[];
+      pongs: Buffer[];
+      close: boolean;
+    }
+  | { kind: 'fatal'; code: number };
+
+/**
+ * Stateful WebSocket frame decoder. Mutates `client.pending` and
+ * `client.fragment`:
+ *   - `pending` keeps partially-arrived frame bytes between data events.
+ *   - `fragment` accumulates text fragments across FIN=0 frames.
+ *
+ * Returns either a batch of complete text messages + Ping payloads to Pong,
+ * or a fatal protocol-violation code that the caller should Close with.
+ */
+function decodeFrames(client: WsClient): DecodeResult {
   const messages: string[] = [];
+  const pongs: Buffer[] = [];
+  let close = false;
+  let buffer = client.pending;
   let offset = 0;
 
   while (offset + 2 <= buffer.length) {
     const frameStart = offset;
     const first = buffer[offset]!;
     const second = buffer[offset + 1]!;
+    const fin = (first & 0x80) !== 0;
+    const rsv = first & 0x70;
     const opcode = first & 0x0f;
     const masked = (second & 0x80) !== 0;
     let length = second & 0x7f;
     offset += 2;
 
+    if (rsv !== 0) return { kind: 'fatal', code: 1002 };
+
     if (length === 126) {
-      if (offset + 2 > buffer.length) return { messages, remaining: buffer.subarray(frameStart) };
+      if (offset + 2 > buffer.length) {
+        client.pending = buffer.subarray(frameStart);
+        return { kind: 'ok', messages, pongs, close };
+      }
       length = buffer.readUInt16BE(offset);
       offset += 2;
     } else if (length === 127) {
-      if (offset + 8 > buffer.length) return { messages, remaining: buffer.subarray(frameStart) };
+      if (offset + 8 > buffer.length) {
+        client.pending = buffer.subarray(frameStart);
+        return { kind: 'ok', messages, pongs, close };
+      }
       const big = buffer.readBigUInt64BE(offset);
-      if (big > BigInt(Number.MAX_SAFE_INTEGER)) return { messages, remaining: Buffer.alloc(0) };
+      if (big > BigInt(MAX_MESSAGE_BYTES)) return { kind: 'fatal', code: 1009 };
       length = Number(big);
       offset += 8;
     }
 
-    if (!masked) return { messages, remaining: Buffer.alloc(0) };
-    if (offset + 4 + length > buffer.length) return { messages, remaining: buffer.subarray(frameStart) };
+    if (!masked) return { kind: 'fatal', code: 1002 };
+    if (length > MAX_MESSAGE_BYTES) return { kind: 'fatal', code: 1009 };
+
+    const isControl = (opcode & 0x8) !== 0;
+    if (isControl && (!fin || length > 125)) return { kind: 'fatal', code: 1002 };
+
+    if (offset + 4 + length > buffer.length) {
+      client.pending = buffer.subarray(frameStart);
+      return { kind: 'ok', messages, pongs, close };
+    }
     const mask = buffer.subarray(offset, offset + 4);
     offset += 4;
-    const payload = buffer.subarray(offset, offset + length);
+    const payload = unmask(buffer.subarray(offset, offset + length), mask);
     offset += length;
 
-    if (opcode === 0x8) return { messages, remaining: Buffer.alloc(0) };
-    if (opcode !== 0x1) continue;
-
-    const decoded = Buffer.allocUnsafe(payload.length);
-    for (let i = 0; i < payload.length; i += 1) {
-      decoded[i] = payload[i]! ^ mask[i % 4]!;
+    if (opcode === 0x8) {
+      close = true;
+      break;
     }
-    messages.push(decoded.toString('utf8'));
+    if (opcode === 0x9) {
+      pongs.push(payload);
+      continue;
+    }
+    if (opcode === 0xa) {
+      // Pong reply to our (currently nonexistent) Pings — ignore.
+      continue;
+    }
+
+    // Data frames: 0x0 continuation, 0x1 text, 0x2 binary.
+    if (opcode === 0x2) return { kind: 'fatal', code: 1003 };
+    if (opcode === 0x1) {
+      if (client.fragment.length > 0) return { kind: 'fatal', code: 1002 };
+      if (fin) {
+        messages.push(payload.toString('utf8'));
+      } else {
+        if (payload.length > MAX_MESSAGE_BYTES) return { kind: 'fatal', code: 1009 };
+        client.fragment = payload;
+      }
+      continue;
+    }
+    if (opcode === 0x0) {
+      if (client.fragment.length === 0) return { kind: 'fatal', code: 1002 };
+      const next = Buffer.concat([client.fragment, payload]);
+      if (next.length > MAX_MESSAGE_BYTES) return { kind: 'fatal', code: 1009 };
+      client.fragment = next;
+      if (fin) {
+        messages.push(client.fragment.toString('utf8'));
+        client.fragment = Buffer.alloc(0);
+      }
+      continue;
+    }
+    return { kind: 'fatal', code: 1002 };
   }
 
-  return { messages, remaining: buffer.subarray(offset) };
+  client.pending = buffer.subarray(offset);
+  return { kind: 'ok', messages, pongs, close };
+}
+
+function unmask(payload: Buffer, mask: Buffer): Buffer {
+  const out = Buffer.allocUnsafe(payload.length);
+  for (let i = 0; i < payload.length; i += 1) {
+    out[i] = payload[i]! ^ mask[i % 4]!;
+  }
+  return out;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/electron/remote/mobileRemoteServer.ts
+++ b/electron/remote/mobileRemoteServer.ts
@@ -1,0 +1,403 @@
+import * as crypto from 'crypto';
+import * as http from 'http';
+import type { Duplex } from 'stream';
+import {
+  getBufferSnapshot,
+  getPtySession,
+  inputPtySession,
+  listPtySessions,
+  onPtyData,
+} from '../ptyHost';
+
+type MobileRemoteServer = {
+  close: () => void;
+};
+
+type WsClient = {
+  socket: Duplex;
+  pending: Buffer;
+  send: (payload: unknown) => void;
+};
+
+const DEFAULT_PORT = 4177;
+const HOST = '127.0.0.1';
+
+export function startMobileRemoteServer(): MobileRemoteServer | null {
+  if (process.env.CCSM_MOBILE_REMOTE !== '1') return null;
+
+  const token = crypto.randomBytes(32).toString('base64url');
+  const port = resolvePort(process.env.CCSM_MOBILE_REMOTE_PORT);
+  const clients = new Set<WsClient>();
+  const seqBySid = new Map<string, number>();
+
+  const server = http.createServer((req, res) => {
+    const url = parseRequestUrl(req.url);
+    if (!url) {
+      sendText(res, 400, 'Bad request');
+      return;
+    }
+
+    if (url.pathname === '/') {
+      if (url.searchParams.get('token') !== token) {
+        sendText(res, 401, 'Unauthorized');
+        return;
+      }
+      sendHtml(res, renderMobilePage());
+      return;
+    }
+
+    sendText(res, 404, 'Not found');
+  });
+
+  server.on('upgrade', (req, socket) => {
+    const url = parseRequestUrl(req.url);
+    if (!url || url.pathname !== '/ws' || url.searchParams.get('token') !== token) {
+      socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+
+    const key = req.headers['sec-websocket-key'];
+    if (typeof key !== 'string') {
+      socket.write('HTTP/1.1 400 Bad Request\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+
+    socket.write(buildUpgradeResponse(key));
+    const client: WsClient = {
+      socket,
+      pending: Buffer.alloc(0),
+      send: (payload) => {
+        if (socket.destroyed) return;
+        socket.write(encodeFrame(JSON.stringify(payload)));
+      },
+    };
+    clients.add(client);
+    client.send({ type: 'auth.ok' });
+    client.send({ type: 'sessions.list', sessions: listPtySessions() });
+
+    socket.on('data', (chunk) => {
+      client.pending = Buffer.concat([client.pending, chunk]);
+      const decoded = decodeFrames(client.pending);
+      client.pending = decoded.remaining;
+      for (const message of decoded.messages) {
+        void handleClientMessage(client, message);
+      }
+    });
+    socket.on('close', () => clients.delete(client));
+    socket.on('error', () => clients.delete(client));
+  });
+
+  const offPtyData = onPtyData((sid, chunk) => {
+    const seq = (seqBySid.get(sid) ?? 0) + 1;
+    seqBySid.set(sid, seq);
+    for (const client of clients) {
+      client.send({ type: 'pty.data', sid, chunk, seq });
+    }
+  });
+
+  server.listen(port, HOST, () => {
+    console.log(`[mobile-remote] listening at http://${HOST}:${port}/?token=${token}`);
+    console.log(`[mobile-remote] tailscale: tailscale serve --bg http://${HOST}:${port}`);
+  });
+
+  server.on('error', (err) => {
+    console.error('[mobile-remote] server error:', err);
+  });
+
+  return {
+    close: () => {
+      offPtyData();
+      for (const client of clients) client.socket.destroy();
+      clients.clear();
+      server.close();
+    },
+  };
+}
+
+async function handleClientMessage(client: WsClient, raw: string): Promise<void> {
+  let message: unknown;
+  try {
+    message = JSON.parse(raw);
+  } catch {
+    client.send({ type: 'error', message: 'invalid_json' });
+    return;
+  }
+
+  if (!isRecord(message) || typeof message.type !== 'string') {
+    client.send({ type: 'error', message: 'invalid_message' });
+    return;
+  }
+
+  if (message.type === 'sessions.list') {
+    client.send({ type: 'sessions.list', sessions: listPtySessions() });
+    return;
+  }
+
+  if (message.type === 'session.snapshot') {
+    if (typeof message.sid !== 'string') {
+      client.send({ type: 'error', message: 'missing_sid' });
+      return;
+    }
+    const snapshot = await getBufferSnapshot(message.sid);
+    const info = getPtySession(message.sid);
+    client.send({
+      type: 'session.snapshot',
+      sid: message.sid,
+      cols: info?.cols ?? null,
+      rows: info?.rows ?? null,
+      ...snapshot,
+    });
+    return;
+  }
+
+  if (message.type === 'session.input') {
+    if (typeof message.sid !== 'string' || typeof message.data !== 'string') {
+      client.send({ type: 'error', message: 'invalid_input' });
+      return;
+    }
+    inputPtySession(message.sid, message.data);
+    return;
+  }
+
+  client.send({ type: 'error', message: 'unknown_type' });
+}
+
+function resolvePort(raw: string | undefined): number {
+  if (!raw) return DEFAULT_PORT;
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 65535) return DEFAULT_PORT;
+  return parsed;
+}
+
+function parseRequestUrl(raw: string | undefined): URL | null {
+  if (!raw) return null;
+  try {
+    return new URL(raw, `http://${HOST}`);
+  } catch {
+    return null;
+  }
+}
+
+function sendHtml(res: http.ServerResponse, body: string): void {
+  res.writeHead(200, {
+    'content-type': 'text/html; charset=utf-8',
+    'cache-control': 'no-store',
+  });
+  res.end(body);
+}
+
+function sendText(res: http.ServerResponse, status: number, body: string): void {
+  res.writeHead(status, {
+    'content-type': 'text/plain; charset=utf-8',
+    'cache-control': 'no-store',
+  });
+  res.end(body);
+}
+
+function buildUpgradeResponse(key: string): string {
+  const accept = crypto
+    .createHash('sha1')
+    .update(`${key}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+    .digest('base64');
+  return [
+    'HTTP/1.1 101 Switching Protocols',
+    'Upgrade: websocket',
+    'Connection: Upgrade',
+    `Sec-WebSocket-Accept: ${accept}`,
+    '',
+    '',
+  ].join('\r\n');
+}
+
+function encodeFrame(payload: string): Buffer {
+  const body = Buffer.from(payload, 'utf8');
+  if (body.length < 126) {
+    return Buffer.concat([Buffer.from([0x81, body.length]), body]);
+  }
+  if (body.length <= 0xffff) {
+    const header = Buffer.allocUnsafe(4);
+    header[0] = 0x81;
+    header[1] = 126;
+    header.writeUInt16BE(body.length, 2);
+    return Buffer.concat([header, body]);
+  }
+  const header = Buffer.allocUnsafe(10);
+  header[0] = 0x81;
+  header[1] = 127;
+  header.writeBigUInt64BE(BigInt(body.length), 2);
+  return Buffer.concat([header, body]);
+}
+
+function decodeFrames(buffer: Buffer): { messages: string[]; remaining: Buffer } {
+  const messages: string[] = [];
+  let offset = 0;
+
+  while (offset + 2 <= buffer.length) {
+    const frameStart = offset;
+    const first = buffer[offset]!;
+    const second = buffer[offset + 1]!;
+    const opcode = first & 0x0f;
+    const masked = (second & 0x80) !== 0;
+    let length = second & 0x7f;
+    offset += 2;
+
+    if (length === 126) {
+      if (offset + 2 > buffer.length) return { messages, remaining: buffer.subarray(frameStart) };
+      length = buffer.readUInt16BE(offset);
+      offset += 2;
+    } else if (length === 127) {
+      if (offset + 8 > buffer.length) return { messages, remaining: buffer.subarray(frameStart) };
+      const big = buffer.readBigUInt64BE(offset);
+      if (big > BigInt(Number.MAX_SAFE_INTEGER)) return { messages, remaining: Buffer.alloc(0) };
+      length = Number(big);
+      offset += 8;
+    }
+
+    if (!masked) return { messages, remaining: Buffer.alloc(0) };
+    if (offset + 4 + length > buffer.length) return { messages, remaining: buffer.subarray(frameStart) };
+    const mask = buffer.subarray(offset, offset + 4);
+    offset += 4;
+    const payload = buffer.subarray(offset, offset + length);
+    offset += length;
+
+    if (opcode === 0x8) return { messages, remaining: Buffer.alloc(0) };
+    if (opcode !== 0x1) continue;
+
+    const decoded = Buffer.allocUnsafe(payload.length);
+    for (let i = 0; i < payload.length; i += 1) {
+      decoded[i] = payload[i]! ^ mask[i % 4]!;
+    }
+    messages.push(decoded.toString('utf8'));
+  }
+
+  return { messages, remaining: buffer.subarray(offset) };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function renderMobilePage(): string {
+  return `<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CCSM Mobile Remote</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css" />
+  <style>
+    * { box-sizing: border-box; }
+    html, body { margin: 0; height: 100%; background: #0b1020; color: #e5e7eb; font: 14px system-ui, sans-serif; }
+    body { display: flex; flex-direction: column; }
+    header { padding: 10px 12px; background: #111827; border-bottom: 1px solid #263042; }
+    #sessions { display: flex; gap: 8px; overflow-x: auto; padding: 8px 12px; background: #0f172a; border-bottom: 1px solid #1f2937; }
+    #sessions button { flex: 0 0 auto; border: 1px solid #374151; border-radius: 10px; background: #1f2937; color: #e5e7eb; padding: 8px 12px; font: inherit; }
+    #sessions button.active { border-color: #60a5fa; background: #1e3a8a; }
+    #terminal { flex: 1; min-height: 0; background: #000; padding: 6px; overflow: auto; }
+    #terminal .xterm { height: 100% !important; }
+    .muted { color: #9ca3af; }
+  </style>
+</head>
+<body>
+  <header>
+    <strong>CCSM Mobile Remote</strong>
+    <span id="status" class="muted"> · Connecting...</span>
+  </header>
+  <div id="sessions"><span class="muted">Loading sessions...</span></div>
+  <div id="terminal"></div>
+  <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+  <script>
+    const token = new URLSearchParams(location.search).get('token') || '';
+    const statusEl = document.getElementById('status');
+    const sessionsEl = document.getElementById('sessions');
+    const terminalEl = document.getElementById('terminal');
+    const term = new window.Terminal({
+      convertEol: false,
+      disableStdin: false,
+      cursorBlink: true,
+      fontSize: 12,
+      fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, monospace',
+      theme: { background: '#000000' },
+      scrollback: 5000,
+      cols: 120,
+      rows: 30,
+    });
+    term.open(terminalEl);
+    term.onData((data) => {
+      if (!activeSid) return;
+      send({ type: 'session.input', sid: activeSid, data });
+    });
+
+    let activeSid = '';
+    let sessions = [];
+    let lastCols = 0;
+    let lastRows = 0;
+    const wsUrl = new URL('/ws', location.href);
+    wsUrl.protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    wsUrl.searchParams.set('token', token);
+    const ws = new WebSocket(wsUrl);
+
+    ws.onopen = () => { statusEl.textContent = ' · Connected'; };
+    ws.onclose = () => { statusEl.textContent = ' · Disconnected'; };
+    ws.onerror = () => { statusEl.textContent = ' · Connection error'; };
+    ws.onmessage = (event) => {
+      const msg = JSON.parse(event.data);
+      if (msg.type === 'sessions.list') {
+        sessions = msg.sessions || [];
+        renderSessions();
+        if (!activeSid && sessions.length) selectSession(sessions[0].sid);
+        return;
+      }
+      if (msg.type === 'session.snapshot' && msg.sid === activeSid) {
+        applySize(msg.cols, msg.rows);
+        term.reset();
+        term.write(msg.snapshot || '');
+        return;
+      }
+      if (msg.type === 'pty.data' && msg.sid === activeSid) {
+        term.write(msg.chunk || '');
+        return;
+      }
+    };
+
+    function applySize(cols, rows) {
+      const c = Number.isInteger(cols) && cols > 0 ? cols : lastCols || 120;
+      const r = Number.isInteger(rows) && rows > 0 ? rows : lastRows || 30;
+      if (c === lastCols && r === lastRows) return;
+      lastCols = c;
+      lastRows = r;
+      try { term.resize(c, r); } catch {}
+    }
+
+    function send(msg) {
+      if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(msg));
+    }
+    function selectSession(sid) {
+      activeSid = sid;
+      renderSessions();
+      term.reset();
+      send({ type: 'session.snapshot', sid });
+    }
+    function renderSessions() {
+      sessionsEl.textContent = '';
+      if (!sessions.length) {
+        const span = document.createElement('span');
+        span.className = 'muted';
+        span.textContent = 'No live PTY sessions. Open a CCSM session on desktop first.';
+        sessionsEl.appendChild(span);
+        return;
+      }
+      for (const session of sessions) {
+        const btn = document.createElement('button');
+        btn.textContent = session.sid.slice(0, 8);
+        btn.className = session.sid === activeSid ? 'active' : '';
+        btn.onclick = () => selectSession(session.sid);
+        sessionsEl.appendChild(btn);
+      }
+    }
+  </script>
+</body>
+</html>`;
+}

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -174,9 +174,11 @@ export function installUpdaterIpc(): void {
     if (lastStatus.kind !== 'downloaded') {
       return { ok: false as const, reason: 'not-ready' as const };
     }
-    // quitAndInstall: (isSilent, isForceRunAfter). We want a visible installer
-    // on Windows (isSilent=false) and to relaunch after install on all OSes.
-    setImmediate(() => autoUpdater.quitAndInstall(false, true));
+    // quitAndInstall: (isSilent, isForceRunAfter). With NSIS oneClick=true the
+    // installer runs without UI; pair with isSilent=true so electron-updater
+    // doesn't pop a redundant progress window. isForceRunAfter=true relaunches
+    // CCSM after install on all OSes — VSCode-style restart-to-update.
+    setImmediate(() => autoUpdater.quitAndInstall(true, true));
     return { ok: true as const };
   });
 

--- a/electron/window/__tests__/createWindow.test.ts
+++ b/electron/window/__tests__/createWindow.test.ts
@@ -1,9 +1,72 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Capture context-menu listener + popup invocations from the BrowserWindow
 // mock. Each test flushes via beforeEach so `popupCalls.length === 0` is the
 // reverse-verify baseline that proves the listener actually wired up.
 const popupCalls: Array<{ items: unknown[]; window: unknown }> = [];
+
+// Stash for the most-recently-constructed BrowserWindow mock. The `createWindow`
+// factory builds the window via `new BrowserWindow(...)` (not a deps-injected
+// ctor — the deps bag intentionally only carries cross-module references), so
+// the only seam is `vi.mock('electron')`. The mock ctor pushes the latest
+// instance into `latestWin` so each factory test can drive its listeners.
+interface FakeWin {
+  ctorOpts: Record<string, unknown>;
+  listeners: Map<string, (...args: unknown[]) => void>;
+  webContentsListeners: Map<string, (...args: unknown[]) => void>;
+  hide: ReturnType<typeof vi.fn>;
+  show: ReturnType<typeof vi.fn>;
+  loadURL: ReturnType<typeof vi.fn>;
+  loadFile: ReturnType<typeof vi.fn>;
+  isDestroyed: ReturnType<typeof vi.fn>;
+  isMaximized: ReturnType<typeof vi.fn>;
+  setMenuBarVisibility: ReturnType<typeof vi.fn>;
+  webContents: {
+    on: ReturnType<typeof vi.fn>;
+    send: ReturnType<typeof vi.fn>;
+    setWindowOpenHandler: ReturnType<typeof vi.fn>;
+    openDevTools: ReturnType<typeof vi.fn>;
+    focus: ReturnType<typeof vi.fn>;
+    setBackgroundThrottling: ReturnType<typeof vi.fn>;
+    isDestroyed: ReturnType<typeof vi.fn>;
+  };
+  on: ReturnType<typeof vi.fn>;
+}
+
+let latestWin: FakeWin | null = null;
+let appQuitMock: ReturnType<typeof vi.fn>;
+
+function makeFakeWin(opts: Record<string, unknown>): FakeWin {
+  const listeners = new Map<string, (...args: unknown[]) => void>();
+  const webContentsListeners = new Map<string, (...args: unknown[]) => void>();
+  const win: FakeWin = {
+    ctorOpts: opts,
+    listeners,
+    webContentsListeners,
+    hide: vi.fn(),
+    show: vi.fn(),
+    loadURL: vi.fn(),
+    loadFile: vi.fn(),
+    isDestroyed: vi.fn(() => false),
+    isMaximized: vi.fn(() => false),
+    setMenuBarVisibility: vi.fn(),
+    webContents: {
+      on: vi.fn((evt: string, cb: (...args: unknown[]) => void) => {
+        webContentsListeners.set(evt, cb);
+      }),
+      send: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      openDevTools: vi.fn(),
+      focus: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+    },
+    on: vi.fn((evt: string, cb: (...args: unknown[]) => void) => {
+      listeners.set(evt, cb);
+    }),
+  };
+  return win;
+}
 
 vi.mock('electron', () => {
   const Menu = {
@@ -12,10 +75,49 @@ vi.mock('electron', () => {
         popupCalls.push({ items, window: opts.window }),
     }),
   };
-  return { Menu };
+  class BrowserWindow {
+    constructor(opts: Record<string, unknown>) {
+      const w = makeFakeWin(opts);
+      latestWin = w;
+      // Returning an object from a constructor overrides `this`, so the
+      // factory's `win` variable is the same FakeWin we expose via
+      // `latestWin` — re-stubbing methods on `latestWin` (e.g.
+      // `latestWin.isMaximized = vi.fn(() => true)`) is observed by the
+      // factory's captured listeners.
+      return w as unknown as BrowserWindow;
+    }
+  }
+  const app = {
+    quit: (...args: unknown[]) => appQuitMock(...args),
+    isPackaged: false,
+  };
+  return { BrowserWindow, Menu, app };
 });
 
-import { installContextMenu, isAllowedNavigation, decideCloseAction } from '../createWindow';
+// Mock the close-action prefs module — both reads + writes are observed.
+const getCloseActionMock = vi.fn<[], 'ask' | 'tray' | 'quit'>(() => 'tray');
+const setCloseActionMock = vi.fn();
+vi.mock('../../prefs/closeAction', () => ({
+  getCloseAction: () => getCloseActionMock(),
+  setCloseAction: (v: 'ask' | 'tray' | 'quit') => setCloseActionMock(v),
+}));
+
+// i18n + branding are leaf imports we don't want to exercise.
+vi.mock('../../i18n', () => ({
+  tCloseDialog: (k: string) => `close.${k}`,
+}));
+vi.mock('../../branding/icon', () => ({
+  buildAppIcon: () => ({ __mockIcon: true }),
+}));
+
+import {
+  installContextMenu,
+  isAllowedNavigation,
+  decideCloseAction,
+  createWindow,
+  CLOSE_ASK_TIMEOUT_MS,
+  type CreateWindowDeps,
+} from '../createWindow';
 
 interface ContextMenuParams {
   selectionText: string;
@@ -238,5 +340,348 @@ describe('decideCloseAction (#1253)', () => {
       action: 'cancel',
       persist: null,
     });
+  });
+});
+
+// Factory-level coverage. The pure helpers above are well-tested, but the
+// `createWindow()` body itself (lines 174-476 — BrowserWindow ctor opts,
+// `will-navigate` hookup, dev-vs-prod load branch, the close-action choreography
+// across `tray | quit | ask` × `CCSM_DEV_QUIT_ON_CLOSE` × `isQuitting`, and the
+// IPC ask-dialog round-trip) was uncovered. These cases drive the factory
+// through the captured listener map so each branch is hit deterministically
+// without booting Electron.
+describe('createWindow factory', () => {
+  let ipcHandlers: Map<string, (...args: unknown[]) => void>;
+  let removedIpcChannels: string[];
+  let deps: CreateWindowDeps;
+  let isQuittingFlag: boolean;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    popupCalls.length = 0;
+    latestWin = null;
+    isQuittingFlag = false;
+    appQuitMock = vi.fn();
+    getCloseActionMock.mockReset().mockReturnValue('tray');
+    setCloseActionMock.mockReset();
+    ipcHandlers = new Map();
+    removedIpcChannels = [];
+    // Default env: not e2e-hidden, no dev-quit override, no custom port.
+    delete process.env.CCSM_E2E_HIDDEN;
+    delete process.env.CCSM_DEV_QUIT_ON_CLOSE;
+    delete process.env.CCSM_DEV_PORT;
+    deps = {
+      isDev: false,
+      getActiveSid: vi.fn(() => null),
+      onFocusChange: vi.fn(),
+      getIsQuitting: vi.fn(() => isQuittingFlag),
+      setIsQuitting: vi.fn((v: boolean) => {
+        isQuittingFlag = v;
+      }),
+      ipcMain: {
+        on: vi.fn((channel: string, cb: (...args: unknown[]) => void) => {
+          ipcHandlers.set(channel, cb);
+        }),
+        removeListener: vi.fn((channel: string) => {
+          removedIpcChannels.push(channel);
+        }),
+      } as unknown as CreateWindowDeps['ipcMain'],
+    };
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    warnSpy.mockRestore();
+  });
+
+  // ─── BrowserWindow ctor opts (hidden-mode positioning + skipTaskbar) ──
+  it('non-hidden launch creates a normally-positioned window', () => {
+    createWindow(deps);
+    expect(latestWin).not.toBeNull();
+    expect(latestWin!.ctorOpts.x).toBeUndefined();
+    expect(latestWin!.ctorOpts.y).toBeUndefined();
+    expect(latestWin!.ctorOpts.skipTaskbar).toBe(false);
+    expect(latestWin!.ctorOpts.show).toBe(true);
+  });
+
+  it('CCSM_E2E_HIDDEN=1 positions window offscreen and hides from taskbar', () => {
+    process.env.CCSM_E2E_HIDDEN = '1';
+    createWindow(deps);
+    expect(latestWin!.ctorOpts.x).toBe(-32000);
+    expect(latestWin!.ctorOpts.y).toBe(-32000);
+    expect(latestWin!.ctorOpts.skipTaskbar).toBe(true);
+    // Hidden mode also primes Chromium-level focus and disables throttling.
+    expect(latestWin!.webContents.focus).toHaveBeenCalled();
+    expect(latestWin!.webContents.setBackgroundThrottling).toHaveBeenCalledWith(false);
+  });
+
+  // ─── dev vs prod renderer load ─────────────────────────────────────────
+  it('dev mode loads the webpack-dev-server URL on the configured port', () => {
+    process.env.CCSM_DEV_PORT = '5174';
+    createWindow({ ...deps, isDev: true });
+    expect(latestWin!.loadURL).toHaveBeenCalledWith('http://localhost:5174');
+    expect(latestWin!.loadFile).not.toHaveBeenCalled();
+    // DevTools open in detached mode when not e2e-hidden.
+    expect(latestWin!.webContents.openDevTools).toHaveBeenCalledWith({ mode: 'detach' });
+  });
+
+  it('dev mode falls back to port 4100 when CCSM_DEV_PORT unset', () => {
+    createWindow({ ...deps, isDev: true });
+    expect(latestWin!.loadURL).toHaveBeenCalledWith('http://localhost:4100');
+  });
+
+  it('prod mode loads the packaged renderer file', () => {
+    createWindow(deps);
+    expect(latestWin!.loadFile).toHaveBeenCalled();
+    expect(latestWin!.loadURL).not.toHaveBeenCalled();
+  });
+
+  // ─── will-navigate guard wiring (delegates to isAllowedNavigation) ────
+  it('will-navigate prevents external URL navigation', () => {
+    createWindow(deps);
+    const willNav = latestWin!.webContentsListeners.get('will-navigate')!;
+    expect(willNav).toBeDefined();
+    const evt = { preventDefault: vi.fn() };
+    willNav(evt, 'https://evil.example.com/');
+    expect(evt.preventDefault).toHaveBeenCalled();
+  });
+
+  it('will-navigate allows the configured dev-server origin', () => {
+    process.env.CCSM_DEV_PORT = '4100';
+    createWindow(deps);
+    const willNav = latestWin!.webContentsListeners.get('will-navigate')!;
+    const evt = { preventDefault: vi.fn() };
+    willNav(evt, 'http://localhost:4100/index.html');
+    expect(evt.preventDefault).not.toHaveBeenCalled();
+  });
+
+  // ─── window-open handler denies popups (preload-leak hardening) ───────
+  it('blocks renderer-initiated window.open() calls', () => {
+    createWindow(deps);
+    const handler = latestWin!.webContents.setWindowOpenHandler.mock.calls[0][0];
+    expect(handler()).toEqual({ action: 'deny' });
+  });
+
+  // ─── focus / maximize forwarding ──────────────────────────────────────
+  it('focus event forwards activeSid to onFocusChange', () => {
+    deps.getActiveSid = vi.fn(() => 'sid-42');
+    createWindow(deps);
+    latestWin!.listeners.get('focus')!();
+    expect(deps.onFocusChange).toHaveBeenCalledWith({ focused: true, activeSid: 'sid-42' });
+  });
+
+  it('maximize/unmaximize broadcast window:maximizedChanged', () => {
+    createWindow(deps);
+    latestWin!.isMaximized = vi.fn(() => true);
+    latestWin!.listeners.get('maximize')!();
+    expect(latestWin!.webContents.send).toHaveBeenCalledWith('window:maximizedChanged', true);
+    latestWin!.isMaximized = vi.fn(() => false);
+    latestWin!.listeners.get('unmaximize')!();
+    expect(latestWin!.webContents.send).toHaveBeenLastCalledWith('window:maximizedChanged', false);
+  });
+
+  it('show event re-sends window:afterShow so renderer can clear fade opacity', () => {
+    createWindow(deps);
+    latestWin!.webContents.send.mockClear();
+    latestWin!.listeners.get('show')!();
+    expect(latestWin!.webContents.send).toHaveBeenCalledWith('window:afterShow');
+  });
+
+  // ─── close-action: tray (default) → fade-then-hide ────────────────────
+  it('close with pref=tray prevents default and fades to hide after 180ms', () => {
+    getCloseActionMock.mockReturnValue('tray');
+    createWindow(deps);
+    const closeEvt = { preventDefault: vi.fn() };
+    latestWin!.listeners.get('close')!(closeEvt);
+    expect(closeEvt.preventDefault).toHaveBeenCalled();
+    // Renderer is told to start fading first.
+    expect(latestWin!.webContents.send).toHaveBeenCalledWith('window:beforeHide', { durationMs: 180 });
+    // Hide is deferred to the end of the fade window.
+    expect(latestWin!.hide).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(180);
+    expect(latestWin!.hide).toHaveBeenCalled();
+  });
+
+  it('multiple close presses during fade are coalesced (single hide)', () => {
+    getCloseActionMock.mockReturnValue('tray');
+    createWindow(deps);
+    const closeHandler = latestWin!.listeners.get('close')!;
+    closeHandler({ preventDefault: vi.fn() });
+    closeHandler({ preventDefault: vi.fn() });
+    closeHandler({ preventDefault: vi.fn() });
+    vi.advanceTimersByTime(180);
+    expect(latestWin!.hide).toHaveBeenCalledTimes(1);
+  });
+
+  // ─── close-action: quit ────────────────────────────────────────────────
+  it('close with pref=quit flips isQuitting and lets default through', () => {
+    getCloseActionMock.mockReturnValue('quit');
+    createWindow(deps);
+    const closeEvt = { preventDefault: vi.fn() };
+    latestWin!.listeners.get('close')!(closeEvt);
+    expect(deps.setIsQuitting).toHaveBeenCalledWith(true);
+    expect(closeEvt.preventDefault).not.toHaveBeenCalled();
+    expect(latestWin!.hide).not.toHaveBeenCalled();
+  });
+
+  // ─── isQuitting short-circuit ─────────────────────────────────────────
+  it('close with isQuitting=true short-circuits with no preventDefault and no hide', () => {
+    isQuittingFlag = true;
+    getCloseActionMock.mockReturnValue('tray');
+    createWindow(deps);
+    const closeEvt = { preventDefault: vi.fn() };
+    latestWin!.listeners.get('close')!(closeEvt);
+    expect(closeEvt.preventDefault).not.toHaveBeenCalled();
+    expect(latestWin!.hide).not.toHaveBeenCalled();
+    expect(getCloseActionMock).not.toHaveBeenCalled();
+  });
+
+  // ─── dev-loop escape hatch ─────────────────────────────────────────────
+  it('CCSM_DEV_QUIT_ON_CLOSE=1 bypasses tray and quits even with pref=tray', () => {
+    process.env.CCSM_DEV_QUIT_ON_CLOSE = '1';
+    getCloseActionMock.mockReturnValue('tray');
+    createWindow(deps);
+    const closeEvt = { preventDefault: vi.fn() };
+    latestWin!.listeners.get('close')!(closeEvt);
+    expect(deps.setIsQuitting).toHaveBeenCalledWith(true);
+    expect(closeEvt.preventDefault).not.toHaveBeenCalled();
+    expect(latestWin!.hide).not.toHaveBeenCalled();
+    // Pref is never consulted on this branch.
+    expect(getCloseActionMock).not.toHaveBeenCalled();
+  });
+
+  // ─── close-action: ask → IPC round-trip ───────────────────────────────
+  it('close with pref=ask sends IPC askCloseAction and registers resolve handler', () => {
+    getCloseActionMock.mockReturnValue('ask');
+    createWindow(deps);
+    expect(ipcHandlers.has('window:resolveCloseAction')).toBe(true);
+    const closeEvt = { preventDefault: vi.fn() };
+    latestWin!.listeners.get('close')!(closeEvt);
+    expect(closeEvt.preventDefault).toHaveBeenCalled();
+    const sendCall = latestWin!.webContents.send.mock.calls.find(
+      (c) => c[0] === 'window:askCloseAction',
+    );
+    expect(sendCall).toBeDefined();
+    const payload = sendCall![1] as { requestId: string; labels: Record<string, string> };
+    expect(typeof payload.requestId).toBe('string');
+    expect(payload.labels.tray).toBe('close.tray');
+  });
+
+  it('ask → renderer chooses tray + dontAskAgain persists tray and hides', () => {
+    getCloseActionMock.mockReturnValue('ask');
+    createWindow(deps);
+    latestWin!.listeners.get('close')!({ preventDefault: vi.fn() });
+    const askPayload = latestWin!.webContents.send.mock.calls.find(
+      (c) => c[0] === 'window:askCloseAction',
+    )![1] as { requestId: string };
+    const resolve = ipcHandlers.get('window:resolveCloseAction')!;
+    resolve({}, { requestId: askPayload.requestId, choice: 'tray', dontAskAgain: true });
+    expect(setCloseActionMock).toHaveBeenCalledWith('tray');
+    vi.advanceTimersByTime(180);
+    expect(latestWin!.hide).toHaveBeenCalled();
+  });
+
+  it('ask → renderer chooses quit triggers app.quit and flips isQuitting', () => {
+    getCloseActionMock.mockReturnValue('ask');
+    createWindow(deps);
+    latestWin!.listeners.get('close')!({ preventDefault: vi.fn() });
+    const askPayload = latestWin!.webContents.send.mock.calls.find(
+      (c) => c[0] === 'window:askCloseAction',
+    )![1] as { requestId: string };
+    const resolve = ipcHandlers.get('window:resolveCloseAction')!;
+    resolve({}, { requestId: askPayload.requestId, choice: 'quit', dontAskAgain: false });
+    expect(deps.setIsQuitting).toHaveBeenCalledWith(true);
+    expect(appQuitMock).toHaveBeenCalled();
+    expect(setCloseActionMock).not.toHaveBeenCalled();
+  });
+
+  it('ask → renderer chooses cancel does nothing destructive', () => {
+    getCloseActionMock.mockReturnValue('ask');
+    createWindow(deps);
+    latestWin!.listeners.get('close')!({ preventDefault: vi.fn() });
+    const askPayload = latestWin!.webContents.send.mock.calls.find(
+      (c) => c[0] === 'window:askCloseAction',
+    )![1] as { requestId: string };
+    const resolve = ipcHandlers.get('window:resolveCloseAction')!;
+    resolve({}, { requestId: askPayload.requestId, choice: 'cancel', dontAskAgain: true });
+    expect(setCloseActionMock).not.toHaveBeenCalled();
+    expect(appQuitMock).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(500);
+    expect(latestWin!.hide).not.toHaveBeenCalled();
+  });
+
+  it('ask → stale resolve with mismatched requestId is ignored', () => {
+    getCloseActionMock.mockReturnValue('ask');
+    createWindow(deps);
+    latestWin!.listeners.get('close')!({ preventDefault: vi.fn() });
+    const resolve = ipcHandlers.get('window:resolveCloseAction')!;
+    resolve({}, { requestId: 'not-a-real-id', choice: 'quit', dontAskAgain: false });
+    expect(deps.setIsQuitting).not.toHaveBeenCalled();
+    expect(appQuitMock).not.toHaveBeenCalled();
+  });
+
+  it('ask → repeated close presses while ask is in flight do not stack dialogs', () => {
+    getCloseActionMock.mockReturnValue('ask');
+    createWindow(deps);
+    const closeHandler = latestWin!.listeners.get('close')!;
+    closeHandler({ preventDefault: vi.fn() });
+    closeHandler({ preventDefault: vi.fn() });
+    const asks = latestWin!.webContents.send.mock.calls.filter(
+      (c) => c[0] === 'window:askCloseAction',
+    );
+    expect(asks).toHaveLength(1);
+  });
+
+  it('ask → renderer never replies; CLOSE_ASK_TIMEOUT_MS triggers tray fallback', () => {
+    getCloseActionMock.mockReturnValue('ask');
+    createWindow(deps);
+    latestWin!.listeners.get('close')!({ preventDefault: vi.fn() });
+    expect(latestWin!.hide).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(CLOSE_ASK_TIMEOUT_MS);
+    // Timeout warns + falls through to fadeThenHide → setTimeout(180).
+    expect(warnSpy).toHaveBeenCalled();
+    vi.advanceTimersByTime(180);
+    expect(latestWin!.hide).toHaveBeenCalled();
+    // Timeout path explicitly does NOT persist anything.
+    expect(setCloseActionMock).not.toHaveBeenCalled();
+  });
+
+  it('ask → renderer destroyed before send falls straight to tray fallback', () => {
+    getCloseActionMock.mockReturnValue('ask');
+    createWindow(deps);
+    latestWin!.webContents.isDestroyed = vi.fn(() => true);
+    latestWin!.listeners.get('close')!({ preventDefault: vi.fn() });
+    // No askCloseAction send (renderer is gone), straight to fade-then-hide.
+    const asks = latestWin!.webContents.send.mock.calls.filter(
+      (c) => c[0] === 'window:askCloseAction',
+    );
+    expect(asks).toHaveLength(0);
+    vi.advanceTimersByTime(180);
+    expect(latestWin!.hide).toHaveBeenCalled();
+  });
+
+  // ─── closed event cleans up the IPC listener ──────────────────────────
+  it('closed event removes the resolveCloseAction IPC listener', () => {
+    createWindow(deps);
+    latestWin!.listeners.get('closed')!();
+    expect(removedIpcChannels).toContain('window:resolveCloseAction');
+  });
+
+  it('closed event clears any pending ask timer', () => {
+    getCloseActionMock.mockReturnValue('ask');
+    createWindow(deps);
+    latestWin!.listeners.get('close')!({ preventDefault: vi.fn() });
+    latestWin!.listeners.get('closed')!();
+    // Advancing past the timeout must NOT trigger the tray fallback now.
+    vi.advanceTimersByTime(CLOSE_ASK_TIMEOUT_MS + 500);
+    expect(latestWin!.hide).not.toHaveBeenCalled();
+  });
+
+  // ─── installContextMenu wired up during factory ───────────────────────
+  it('factory installs the context-menu listener on webContents', () => {
+    createWindow(deps);
+    expect(latestWin!.webContentsListeners.has('context-menu')).toBe(true);
   });
 });

--- a/electron/window/__tests__/createWindow.test.ts
+++ b/electron/window/__tests__/createWindow.test.ts
@@ -112,10 +112,15 @@ vi.mock('../../branding/icon', () => ({
 
 import {
   installContextMenu,
+  installContextMenuSuppressIpc,
   isAllowedNavigation,
+  isContextMenuSuppressed,
+  recordContextMenuSuppression,
   decideCloseAction,
   createWindow,
   CLOSE_ASK_TIMEOUT_MS,
+  __resetContextMenuSuppressionForTests,
+  __resetSuppressIpcForTests,
   type CreateWindowDeps,
 } from '../createWindow';
 
@@ -153,6 +158,7 @@ function makeFakeWindow() {
 describe('installContextMenu', () => {
   beforeEach(() => {
     popupCalls.length = 0;
+    __resetContextMenuSuppressionForTests();
   });
 
   it('registers a single context-menu listener on the window webContents', () => {
@@ -244,6 +250,173 @@ describe('installContextMenu', () => {
     const items = popupCalls[0].items as Array<Record<string, unknown>>;
     const paste = items.find((i) => i.role === 'paste');
     expect(paste?.enabled).toBe(false);
+  });
+
+  // ─── Task #41: terminal pane's one-shot suppression ──────────────────
+  // The terminal pane handles right-click inline (copy-on-selection /
+  // paste-on-empty, no popover). Electron fires `context-menu` on the
+  // WebContents regardless of renderer `preventDefault()`, so the pane
+  // sends `shell:suppressContextMenuOnce` immediately before its
+  // onContextMenu returns; main records a short deadline and the
+  // listener installed here consults it.
+
+  it('suppresses native menu when within suppression deadline (Task #41)', () => {
+    const fake = makeFakeWindow();
+    installContextMenu(fake.win);
+    recordContextMenuSuppression(Date.now());
+    fake.fire({
+      selectionText: 'something',
+      isEditable: false,
+      editFlags: {
+        canCut: false,
+        canCopy: true,
+        canPaste: false,
+        canSelectAll: true,
+      },
+    });
+    expect(popupCalls).toHaveLength(0);
+  });
+
+  it('the suppression is one-shot: a second right-click gets the menu', () => {
+    const fake = makeFakeWindow();
+    installContextMenu(fake.win);
+    recordContextMenuSuppression(Date.now());
+    // First click suppressed.
+    fake.fire({
+      selectionText: '',
+      isEditable: false,
+      editFlags: { canCut: false, canCopy: false, canPaste: false, canSelectAll: true },
+    });
+    // Second click — no new suppression sent — must produce a popup.
+    fake.fire({
+      selectionText: 'second',
+      isEditable: false,
+      editFlags: { canCut: false, canCopy: true, canPaste: false, canSelectAll: true },
+    });
+    expect(popupCalls).toHaveLength(1);
+  });
+
+  it('an expired suppression deadline does not block the menu', () => {
+    const fake = makeFakeWindow();
+    installContextMenu(fake.win);
+    // Record a suppression "200ms in the past" by mutating Date.now via a
+    // narrow spy — keeps the test independent of vi.useFakeTimers (which
+    // the parent describe does not enable).
+    const realNow = Date.now;
+    const stableNow = realNow();
+    Date.now = () => stableNow - 200;
+    try {
+      recordContextMenuSuppression(Date.now());
+    } finally {
+      Date.now = realNow;
+    }
+    // Now-now is 200ms past the recorded deadline — listener should
+    // proceed to popup as normal.
+    fake.fire({
+      selectionText: 'hello',
+      isEditable: false,
+      editFlags: { canCut: false, canCopy: true, canPaste: false, canSelectAll: true },
+    });
+    expect(popupCalls).toHaveLength(1);
+  });
+});
+
+// ─── Task #41: pure suppression decider + IPC wiring ────────────────────
+// Pure helpers + the IPC registration so the suppression mechanism can be
+// driven without mounting an Electron window. The deadline math is a
+// strict `<` (not `<=`) so a request recorded at T=1000 with a 100ms
+// window suppresses everything up to T=1099 inclusive and allows T=1100.
+
+describe('isContextMenuSuppressed (Task #41)', () => {
+  it('returns true when now is before the deadline', () => {
+    expect(isContextMenuSuppressed(1000, 999)).toBe(true);
+  });
+
+  it('returns false at the deadline boundary', () => {
+    expect(isContextMenuSuppressed(1000, 1000)).toBe(false);
+  });
+
+  it('returns false after the deadline', () => {
+    expect(isContextMenuSuppressed(1000, 1001)).toBe(false);
+  });
+
+  it('returns false for the default uninitialised deadline of 0', () => {
+    expect(isContextMenuSuppressed(0, 12345)).toBe(false);
+  });
+});
+
+describe('recordContextMenuSuppression (Task #41)', () => {
+  beforeEach(() => {
+    __resetContextMenuSuppressionForTests();
+  });
+
+  it('records a deadline 100ms after the supplied now', () => {
+    const deadline = recordContextMenuSuppression(1000);
+    expect(deadline).toBe(1100);
+  });
+
+  it('later calls extend (overwrite) the deadline, never shrink it relative to live now', () => {
+    expect(recordContextMenuSuppression(1000)).toBe(1100);
+    // A second call at T=1050 sets the deadline to 1150. This is the
+    // intended "renew the one-shot" behavior — a fresh request always
+    // pushes the deadline forward.
+    expect(recordContextMenuSuppression(1050)).toBe(1150);
+  });
+});
+
+describe('installContextMenuSuppressIpc (Task #41)', () => {
+  beforeEach(() => {
+    __resetSuppressIpcForTests();
+    __resetContextMenuSuppressionForTests();
+    popupCalls.length = 0;
+  });
+
+  it('registers exactly one listener on shell:suppressContextMenuOnce', () => {
+    const handlers = new Map<string, (...args: unknown[]) => void>();
+    const ipcMain = {
+      on: vi.fn((ch: string, cb: (...args: unknown[]) => void) => {
+        handlers.set(ch, cb);
+      }),
+    } as unknown as import('electron').IpcMain;
+    installContextMenuSuppressIpc(ipcMain);
+    expect(handlers.has('shell:suppressContextMenuOnce')).toBe(true);
+  });
+
+  it('the registered handler arms a suppression that blocks the next menu', () => {
+    const handlers = new Map<string, (...args: unknown[]) => void>();
+    const ipcMain = {
+      on: vi.fn((ch: string, cb: (...args: unknown[]) => void) => {
+        handlers.set(ch, cb);
+      }),
+    } as unknown as import('electron').IpcMain;
+    installContextMenuSuppressIpc(ipcMain);
+    const fake = makeFakeWindow();
+    installContextMenu(fake.win);
+    // No suppression yet — popup fires.
+    fake.fire({
+      selectionText: 'a',
+      isEditable: false,
+      editFlags: { canCut: false, canCopy: true, canPaste: false, canSelectAll: true },
+    });
+    expect(popupCalls).toHaveLength(1);
+    // Renderer asks to suppress; next popup is swallowed.
+    handlers.get('shell:suppressContextMenuOnce')!();
+    fake.fire({
+      selectionText: 'b',
+      isEditable: false,
+      editFlags: { canCut: false, canCopy: true, canPaste: false, canSelectAll: true },
+    });
+    expect(popupCalls).toHaveLength(1);
+  });
+
+  it('is idempotent — repeated installs do not double-register', () => {
+    const handlers: string[] = [];
+    const ipcMain = {
+      on: vi.fn((ch: string) => handlers.push(ch)),
+    } as unknown as import('electron').IpcMain;
+    installContextMenuSuppressIpc(ipcMain);
+    installContextMenuSuppressIpc(ipcMain);
+    expect(handlers.filter((c) => c === 'shell:suppressContextMenuOnce')).toHaveLength(1);
   });
 });
 

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -82,11 +82,86 @@ export function isAllowedNavigation(
   }
 }
 
+// One-shot suppression deadline for the native context menu. The terminal
+// pane fires `shell:suppressContextMenuOnce` from its renderer-side
+// `onContextMenu` handler immediately before calling `preventDefault()`;
+// Electron's `webContents.on('context-menu')` then fires regardless (DOM
+// preventDefault does NOT cancel the main-process event) and the listener
+// installed by `installContextMenu` consults this deadline to decide
+// whether to show the native menu or step aside.
+//
+// Module-scope (process-wide) because:
+//  * the IPC channel is one-way `send`, no per-window routing payload —
+//    keeping it process-wide matches the wire contract;
+//  * ccsm is a single-window app in practice; the BrowserWindow that
+//    fires `context-menu` is always the same one that just sent the
+//    suppress. 100ms is generous enough to absorb IPC latency on slow
+//    machines without suppressing a deliberate right-click ~100ms later.
+const SUPPRESS_CONTEXT_MENU_WINDOW_MS = 100;
+let contextMenuSuppressedUntilMs = 0;
+
+/** Pure decider — extracted for unit test. Returns true iff `nowMs` is
+ *  strictly before `deadlineMs`. */
+export function isContextMenuSuppressed(
+  deadlineMs: number,
+  nowMs: number,
+): boolean {
+  return nowMs < deadlineMs;
+}
+
+/** Record a fresh one-shot suppression starting at `nowMs`. Exported so the
+ *  IPC handler in `installContextMenuSuppressIpc` can be unit-tested
+ *  without reaching into module state. Returns the new deadline ms. */
+export function recordContextMenuSuppression(nowMs: number): number {
+  contextMenuSuppressedUntilMs = nowMs + SUPPRESS_CONTEXT_MENU_WINDOW_MS;
+  return contextMenuSuppressedUntilMs;
+}
+
+/** Test-only — reset suppression deadline so tests start from a clean
+ *  baseline. */
+export function __resetContextMenuSuppressionForTests(): void {
+  contextMenuSuppressedUntilMs = 0;
+}
+
+let suppressIpcRegistered = false;
+
+/** Register the one-shot suppression IPC handler. Idempotent — safe to call
+ *  more than once (subsequent registrations are no-ops). Called from the
+ *  `app.whenReady()` IPC wiring site, NOT from `createWindow`, because the
+ *  channel is process-wide rather than per-window. */
+export function installContextMenuSuppressIpc(ipcMain: IpcMain): void {
+  if (suppressIpcRegistered) return;
+  suppressIpcRegistered = true;
+  ipcMain.on('shell:suppressContextMenuOnce', () => {
+    recordContextMenuSuppression(Date.now());
+  });
+}
+
+/** Test-only — undo `installContextMenuSuppressIpc` so a fresh test can
+ *  re-register the handler against a fresh mock ipcMain. */
+export function __resetSuppressIpcForTests(): void {
+  suppressIpcRegistered = false;
+}
+
 // Right-click context menu for the renderer — Copy/Cut/Paste/Select All,
 // contextually enabled based on selection + editable state. Attached per
 // window in createWindow().
+//
+// The terminal pane handles its own right-click in the renderer (immediate
+// copy-on-selection / paste-on-empty, no popover) and asks main to skip
+// the native menu via `shell:suppressContextMenuOnce` immediately before
+// returning from its onContextMenu handler. Electron fires `context-menu`
+// on the WebContents regardless of DOM `preventDefault`, so the
+// suppression deadline is the only way to inhibit it from main.
 export function installContextMenu(win: BrowserWindow): void {
   win.webContents.on('context-menu', (_e, params) => {
+    if (isContextMenuSuppressed(contextMenuSuppressedUntilMs, Date.now())) {
+      // Consume the one-shot — subsequent right-clicks outside the
+      // terminal pane (which never sends `suppressContextMenuOnce`) get
+      // the native menu as normal.
+      contextMenuSuppressedUntilMs = 0;
+      return;
+    }
     const { selectionText, editFlags, isEditable } = params;
     const hasSelection = !!selectionText && selectionText.trim().length > 0;
     const items: MenuItemConstructorOptions[] = [];

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -402,6 +402,19 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
 
   win.on('close', (e) => {
     if (deps.getIsQuitting()) return;
+    // Dev-loop escape hatch (Task #11): `scripts/dev-electron.mjs` sets
+    // CCSM_DEV_QUIT_ON_CLOSE=1 so closing the window during `npm run dev`
+    // fully quits the app instead of going tray-resident. Without this,
+    // the Electron main proc lingered in the tray AND its sibling
+    // webpack-dev-server (concurrently `dev:web`, port 4100) kept
+    // running because concurrently's `-k` only reaps when one child
+    // exits — every restart needed a manual taskkill. Scoped to the dev
+    // wrapper's env so production, manual `electron .`, and e2e probes
+    // still get the real close-to-tray choreography below.
+    if (process.env.CCSM_DEV_QUIT_ON_CLOSE === '1') {
+      deps.setIsQuitting(true);
+      return;
+    }
     const pref = getCloseAction();
     if (pref === 'quit') {
       deps.setIsQuitting(true);

--- a/package.json
+++ b/package.json
@@ -152,10 +152,8 @@
       "artifactName": "${productName}-Setup-${version}-${arch}.${ext}"
     },
     "nsis": {
-      "oneClick": false,
+      "oneClick": true,
       "perMachine": false,
-      "allowToChangeInstallationDirectory": true,
-      "allowElevation": true,
       "deleteAppDataOnUninstall": false,
       "createDesktopShortcut": true,
       "createStartMenuShortcut": true,

--- a/scripts/dev-electron.mjs
+++ b/scripts/dev-electron.mjs
@@ -38,7 +38,21 @@ const child = spawn(
   {
     cwd: repoRoot,
     stdio: 'inherit',
-    env: { ...process.env, CCSM_E2E_NO_SINGLE_INSTANCE: '1' },
+    env: {
+      ...process.env,
+      CCSM_E2E_NO_SINGLE_INSTANCE: '1',
+      // Dev-loop ergonomics (Task #11): closing the main window during
+      // `npm run dev` should fully quit the Electron app instead of
+      // going production tray-resident, so concurrently's `-k` reaps
+      // the sibling `dev:web` (webpack-dev-server on :4100). Without
+      // this, closing the window leaves the Electron main proc alive
+      // in the tray AND keeps webpack-dev-server holding port 4100 —
+      // every restart needed a manual taskkill. Scoped to this wrapper
+      // so manual `electron .` runs and e2e probes still get the real
+      // close-to-tray choreography. Read by
+      // `electron/window/createWindow.ts`.
+      CCSM_DEV_QUIT_ON_CLOSE: '1',
+    },
   },
 );
 

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -6,10 +6,9 @@
 //   2. switch-session-keeps-chat     — UX F: session A↔B switch reuses pty, scrollback intact
 //   3. cwd-projects-claude           — UX E: real cwd flows into claude's JSONL hash
 //   4. import-resume                 — UX H: import existing JSONL, claude --resume restores
-//   5. default-cwd-from-userCwds-lru — task #551: new-session cwd defaults to LRU head
-//   6. new-session-focus-cli         — UX C': button focus does not double-fire
-//   7. pty-pid-stable-across-switch  — direct-xterm: pty pid stable across A→B→A switch
-//   8. reopen-resume                 — UX G: close ccsm, reopen, click session, --resume restores
+//   5. new-session-focus-cli         — UX C': button focus does not double-fire
+//   6. pty-pid-stable-across-switch  — direct-xterm: pty pid stable across A→B→A switch
+//   7. reopen-resume                 — UX G: close ccsm, reopen, click session, --resume restores
 //
 // Sharing strategy:
 //   * Cases 1–6 share ONE Electron launch + ONE isolated tempDir. Each case
@@ -1863,119 +1862,6 @@ async function caseImportLandsInFocusedGroup({ win, tempDir }) {
 }
 
 // ============================================================================
-// Case: default-cwd-from-userCwds-lru (task #551)
-//
-// New session creation must default the cwd to the user's most-recently
-// used cwd from the ccsm-owned `userCwds` LRU (head of the list), with
-// a fallback to `userHome` only when the LRU is empty.
-//
-// Reproduces the bug from PR #392's "default cwd is always home" policy:
-// the user re-picks the same project on every new session because the
-// LRU is consulted only by the picker, never by the default.
-//
-// Steps:
-//   1. Read userHome from the renderer.
-//   2. Push a synthetic non-home cwd into the LRU via `window.ccsm.userCwds.push`.
-//   3. Wait for `lastUsedCwd` to reflect the new head in the store.
-//   4. Call `createSession()` with NO opts.cwd — the new session's cwd
-//      MUST equal the pushed path, NOT userHome.
-//   5. Soft-cleanup: delete the new session so subsequent cases see a
-//      clean shared launch.
-// ============================================================================
-
-async function caseDefaultCwdFromUserCwdsLru({ electronApp: _e, win, tempDir }) {
-  // Boot probe must have resolved (renderer needs userCwds IPC + store).
-  await win.waitForFunction(
-    () => !document.querySelector('[data-testid="claude-availability-probing"]'),
-    null,
-    { timeout: 30000 },
-  );
-
-  // Synthetic project dir distinct from tempDir so we don't collide with
-  // earlier cases that may have pushed tempDir already.
-  const projectDir = path.join(tempDir, 'lru-project-' + Math.random().toString(36).slice(2, 8));
-  mkdirSync(projectDir, { recursive: true });
-  const normalizedExpected = projectDir.replace(/[\\/]+$/, '');
-
-  // Push the cwd through the real IPC. The renderer-side `lastUsedCwd`
-  // cache is normally updated by store mutators (createSession /
-  // setSessionCwd / importSession) that wrap the push call; pushing the
-  // raw IPC bypasses those wrappers, so we mirror what `hydrateStore`
-  // does at boot — read the LRU back via `userCwds.get` and seed
-  // `lastUsedCwd` from the head. This matches the real path for the
-  // first `+` click of every fresh launch.
-  const pushed = await win.evaluate(async (p) => {
-    const api = window.ccsm;
-    if (!api?.userCwds?.push || !api?.userCwds?.get) {
-      return { ok: false, reason: 'userCwds IPC unavailable' };
-    }
-    await api.userCwds.push(p);
-    const list = await api.userCwds.get();
-    const head = Array.isArray(list) && list.length > 0 ? list[0] : null;
-    if (head) {
-      window.__ccsmStore.setState({ lastUsedCwd: head });
-    }
-    return { ok: true, head };
-  }, projectDir);
-  if (!pushed.ok) throw new Error(`userCwds.push failed: ${pushed.reason}`);
-
-  // Wait briefly for the setState to flush. The check polls instead of
-  // relying on react-batching timing.
-  await win.waitForFunction(
-    (expected) => {
-      const st = window.__ccsmStore?.getState?.();
-      return !!st && (st.lastUsedCwd || '').replace(/[\\/]+$/, '') === expected;
-    },
-    normalizedExpected,
-    { timeout: 5000 },
-  );
-
-  // Snapshot pre-create state for the failure message.
-  const before = await win.evaluate(() => {
-    const st = window.__ccsmStore.getState();
-    return {
-      lastUsedCwd: st.lastUsedCwd,
-      userHome: st.userHome,
-      sessionCount: st.sessions.length,
-    };
-  });
-
-  // Create the new session WITHOUT specifying cwd — this is the defaulted
-  // path the bug is about. Read back the active session's cwd.
-  const result = await win.evaluate(() => {
-    const useStore = window.__ccsmStore;
-    const { createSession } = useStore.getState();
-    createSession({ name: 'lru-default-probe' });
-    const st = useStore.getState();
-    const active = st.sessions.find((s) => s.id === st.activeId);
-    return { sid: st.activeId, cwd: active?.cwd ?? null };
-  });
-
-  const actual = (result.cwd || '').replace(/[\\/]+$/, '');
-  if (actual !== normalizedExpected) {
-    throw new Error(
-      `default cwd did not honor userCwds LRU.\n` +
-        `  expected (LRU head): ${normalizedExpected}\n` +
-        `  actual (session.cwd): ${result.cwd}\n` +
-        `  store.lastUsedCwd:   ${before.lastUsedCwd}\n` +
-        `  store.userHome:      ${before.userHome}`,
-    );
-  }
-
-  // Negative: actual MUST NOT equal userHome (the regressed default).
-  if (before.userHome && actual === before.userHome.replace(/[\\/]+$/, '')) {
-    throw new Error(`default cwd fell back to userHome (${before.userHome}) despite non-empty LRU`);
-  }
-
-  // Cleanup so subsequent cases see no extra session row.
-  await win.evaluate((sid) => {
-    const useStore = window.__ccsmStore;
-    const { deleteSession } = useStore.getState();
-    deleteSession?.(sid);
-  }, result.sid);
-}
-
-// ============================================================================
 // Case: new-session-focus-cli — clicking "New Session" must transfer focus
 // AWAY from the trigger button so a subsequent Enter goes to the CLI, not
 // to the still-focused button (which would re-fire and spawn yet another
@@ -2506,8 +2392,10 @@ async function _waitBoot(win) {
 }
 
 async function _seedRecentCwd(win, projectDir) {
-  // Push the cwd through the real IPC and mirror lastUsedCwd, matching the
-  // boot path used by hydrateStore. See caseDefaultCwdFromUserCwdsLru.
+  // Push the cwd into the ccsm-owned `userCwds` LRU. The LRU feeds the
+  // chevron popover's "Recent" column — NOT the new-session default.
+  // Per PR #392 spec, the default cwd is always `userHome`; the chevron
+  // covers the "open in another recent project" case.
   mkdirSync(projectDir, { recursive: true });
   const result = await win.evaluate(async (p) => {
     const api = window.ccsm;
@@ -2517,7 +2405,6 @@ async function _seedRecentCwd(win, projectDir) {
     await api.userCwds.push(p);
     const list = await api.userCwds.get();
     const head = Array.isArray(list) && list.length > 0 ? list[0] : null;
-    if (head) window.__ccsmStore.setState({ lastUsedCwd: head });
     return { ok: true, head };
   }, projectDir);
   if (!result.ok) throw new Error(`userCwds.push failed: ${result.reason}`);
@@ -2557,13 +2444,18 @@ async function _seedGroup(win, name) {
 }
 
 // Case: cwd-picker-top-default
-//   Click the top `+` (NOT the chevron). Asserts the new session uses the
-//   LRU default cwd (lastUsedCwd), proving that the `+` half is unaffected
-//   by the chevron addition.
+//   Click the top `+` (NOT the chevron). Asserts the new session uses
+//   `userHome` as the default cwd, even when the userCwds LRU has a
+//   non-home head. Per PR #392 spec ("default cwd is home, no fallback
+//   chains") — the chevron popover is the explicit path for picking a
+//   recent project; the bare `+` must always land at home.
 async function caseCwdPickerTopDefault({ win, tempDir }) {
   await _waitBoot(win);
+  // Seed the LRU with a non-home cwd. The default MUST ignore it.
   const projectDir = path.join(tempDir, 'cwd-pick-top-default-' + Math.random().toString(36).slice(2, 8));
-  const expected = _norm(await _seedRecentCwd(win, projectDir));
+  await _seedRecentCwd(win, projectDir);
+  const userHome = _norm(await win.evaluate(() => window.__ccsmStore.getState().userHome));
+  if (!userHome) throw new Error('userHome not seeded yet — boot probe race');
 
   const before = await _sessionCount(win);
   // The top "+" lives inside [data-sidebar-newsession-cluster] as the
@@ -2579,8 +2471,10 @@ async function caseCwdPickerTopDefault({ win, tempDir }) {
   const after = await _sessionCount(win);
   if (after - before !== 1) throw new Error(`expected 1 new session, got delta=${after - before}`);
   const actual = _norm(await _activeCwd(win));
-  if (actual !== expected) {
-    throw new Error(`top + did not honor LRU default. expected=${expected} actual=${actual}`);
+  if (actual !== userHome) {
+    throw new Error(
+      `top + did not default to userHome.\n  expected (userHome): ${userHome}\n  actual (session.cwd): ${actual}\n  (LRU head was ${_norm(projectDir)} — must be ignored by the default)`,
+    );
   }
   await _deleteActive(win);
 }
@@ -3448,7 +3342,6 @@ const CASE_REGISTRY = [
   { name: 'caseSpacesInCwdSpawnsCorrectly', group: 'shared', run: caseSpacesInCwdSpawnsCorrectly },
   { name: 'import-resume',               group: 'shared', run: caseImportResume },
   { name: 'import-lands-in-focused-group', group: 'shared', run: caseImportLandsInFocusedGroup },
-  { name: 'default-cwd-from-userCwds-lru', group: 'shared', run: caseDefaultCwdFromUserCwdsLru },
   { name: 'new-session-focus-cli',       group: 'shared', run: caseNewSessionFocusCli },
   { name: 'pty-pid-stable-across-switch',group: 'shared', run: casePtyPidStableAcrossSwitch },
   { name: 'cwd-picker-top-default',      group: 'shared', run: caseCwdPickerTopDefault },

--- a/scripts/probe-session-reload.mjs
+++ b/scripts/probe-session-reload.mjs
@@ -1,0 +1,144 @@
+// Right-click "Reload session" diagnostic probe.
+//
+// Question this answers: when the user invokes `reloadSession(sid)` from
+// the sidebar's right-click menu, does the renderer correctly:
+//   1. kill the running pty (observable as a `pty:kill` IPC call), and
+//   2. re-spawn a fresh pty for the same sid (observable as a NEW pid),
+// while preserving the visible xterm host (same sid wired up after the
+// reload — claude transcript continuation is the SDK's responsibility,
+// out of scope here).
+//
+// Strategy:
+//   1. Launch ccsm isolated + seed a session, wait for terminal ready.
+//   2. Capture the pid of the spawned pty (read via `ccsmPty.get(sid)`
+//      from the renderer; the main-process bridge already exposes pid).
+//   3. Patch the `pty:kill` ipcMain handler to count invocations
+//      (mirrors probe-paste-double-fire's pattern — `ccsmPty` is frozen
+//      so we can't monkey-patch from the renderer).
+//   4. Drive the store action: `useStore.getState().reloadSession(sid)`.
+//   5. Wait for the attach effect to settle (poll `pty.get(sid)` until
+//      pid changes from the pre-reload pid).
+//   6. Assert: kill was called once, new pid differs from old pid, host
+//      element still present with same data-active-sid.
+//
+// This is a workshop probe — it requires `npm run build` + a working
+// claude binary. CI does NOT run it; reviewer runs locally to validate
+// the reload path end-to-end.
+
+import {
+  createIsolatedClaudeDir,
+  launchCcsmIsolated,
+  seedSession,
+  waitForTerminalReady,
+  dismissFirstRunModals,
+} from './probe-utils-real-cli.mjs';
+
+async function main() {
+  const { tempDir } = await createIsolatedClaudeDir();
+  console.log('[probe] tempDir=', tempDir);
+
+  const { electronApp, win } = await launchCcsmIsolated({ tempDir });
+
+  try {
+    await win.waitForFunction(
+      () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+      null,
+      { timeout: 30000 },
+    );
+
+    const { sid } = await seedSession(win, { name: 'reload-probe', cwd: tempDir });
+    if (!sid) throw new Error('seedSession returned empty sid');
+    console.log('[probe] seeded sid=', sid);
+
+    await new Promise((r) => setTimeout(r, 4000));
+    await waitForTerminalReady(win, sid, { timeout: 60000 });
+    await dismissFirstRunModals(win);
+
+    // Patch pty:kill to count calls.
+    await electronApp.evaluate(({ ipcMain }) => {
+      const g = globalThis;
+      g.__reloadProbeKills = [];
+      const internal = ipcMain;
+      const handlers = internal._invokeHandlers;
+      const orig = handlers.get('pty:kill');
+      if (!orig) {
+        g.__reloadProbeError = 'no existing pty:kill handler';
+        return;
+      }
+      handlers.set('pty:kill', async (event, ...args) => {
+        const [killedSid] = args;
+        g.__reloadProbeKills.push({ sid: killedSid, ts: Date.now() });
+        return orig(event, ...args);
+      });
+      g.__reloadProbeReady = true;
+    });
+    const ipcReady = await electronApp.evaluate(() => ({
+      ready: globalThis.__reloadProbeReady === true,
+      error: globalThis.__reloadProbeError || null,
+    }));
+    console.log('[probe] ipcMain patch:', ipcReady);
+    if (!ipcReady.ready) throw new Error('failed to patch ipcMain.handle for pty:kill');
+
+    // Capture pre-reload pid.
+    const preInfo = await win.evaluate(async (s) => {
+      return await window.ccsmPty.get(s);
+    }, sid);
+    console.log('[probe] pre-reload info:', preInfo);
+    if (!preInfo || typeof preInfo.pid !== 'number') {
+      throw new Error('no pid for sid before reload — pty not running?');
+    }
+    const prePid = preInfo.pid;
+
+    // Drive the action.
+    await win.evaluate((s) => {
+      const useStore = window.__ccsmStore;
+      if (!useStore) throw new Error('window.__ccsmStore not ready');
+      const { reloadSession } = useStore.getState();
+      void reloadSession(s);
+    }, sid);
+
+    // Wait for the attach effect to spawn a new pty (different pid).
+    const start = Date.now();
+    let postInfo = null;
+    while (Date.now() - start < 30000) {
+      postInfo = await win
+        .evaluate(async (s) => await window.ccsmPty.get(s), sid)
+        .catch(() => null);
+      if (postInfo && typeof postInfo.pid === 'number' && postInfo.pid !== prePid) break;
+      await new Promise((r) => setTimeout(r, 200));
+    }
+    console.log('[probe] post-reload info:', postInfo);
+
+    const kills = await electronApp.evaluate(() => globalThis.__reloadProbeKills.slice());
+    console.log(`[probe] pty:kill invoked ${kills.length} time(s):`, kills);
+
+    // Verify the host element is still rendered for this sid.
+    const hostStillPresent = await win.evaluate(
+      (s) => !!document.querySelector(`[data-terminal-host][data-active-sid="${s}"]`),
+      sid,
+    );
+    console.log('[probe] host element present after reload:', hostStillPresent);
+
+    console.log('\n[probe] === summary ===');
+    console.log(`pre-reload pid:     ${prePid}`);
+    console.log(`post-reload pid:    ${postInfo?.pid ?? '(none)'}`);
+    console.log(`pty:kill calls:     ${kills.length}`);
+    console.log(`host preserved:     ${hostStillPresent}`);
+
+    const ok =
+      kills.length >= 1 &&
+      postInfo &&
+      typeof postInfo.pid === 'number' &&
+      postInfo.pid !== prePid &&
+      hostStillPresent;
+    console.log(`\n[probe] result:     ${ok ? 'PASS' : 'FAIL'}`);
+    if (!ok) process.exitCode = 1;
+  } finally {
+    try { await electronApp.close(); } catch (_) { /* ignore */ }
+  }
+}
+
+main().catch((e) => {
+  console.error('[probe] failed:', e);
+  process.exit(1);
+});

--- a/scripts/screenshot-552-chevron-picker.mjs
+++ b/scripts/screenshot-552-chevron-picker.mjs
@@ -31,9 +31,6 @@ async function seedRecent(win, p) {
   await win.evaluate(async (path_) => {
     const api = window.ccsm;
     if (api?.userCwds?.push) await api.userCwds.push(path_);
-    const list = await api.userCwds.get();
-    const head = Array.isArray(list) && list.length > 0 ? list[0] : null;
-    if (head) window.__ccsmStore.setState({ lastUsedCwd: head });
   }, p);
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -85,6 +85,12 @@ export default function App() {
   // persisted snapshot lands.
   const hydrated = useStore((s) => s.hydrated);
 
+  // Hold these as direct Zustand action refs (not inline arrows) so the
+  // Sidebar -> GroupRow / SessionRow / ArchivedSection React.memo chain
+  // stays effective — any inline `() => store.selectSession(id)` here
+  // would generate a new function identity per render and force every
+  // memoized row to re-render on every state tick (e.g. JSONL chunks
+  // toggling a single session's waiting<->idle). See PR #1269.
   const selectSession = useStore((s) => s.selectSession);
   const focusGroup = useStore((s) => s.focusGroup);
   const applyExternalTitle = useStore((s) => s._applyExternalTitle);

--- a/src/app-effects/useSessionNameBridge.ts
+++ b/src/app-effects/useSessionNameBridge.ts
@@ -19,24 +19,42 @@ interface SessionLike {
  * `sessionNamesFromRenderer` map doesn't grow unbounded across the app
  * lifetime as sessions are created and deleted (#613, follow-up to #509).
  *
+ * Perf: the effect's dep is `sessions`, whose array reference changes on
+ * every session-runtime store patch (state toggle, title backfill, cwd
+ * redirect, etc.) — including hot paths like waiting<->idle on JSONL
+ * chunks. Without per-sid diffing we'd fire one IPC per session per chunk
+ * even though no name changed. The `prevNamesRef` map below makes the
+ * common case (no name changed) a free pass — IPC fires only for the
+ * actual delta (added sid, renamed sid, deleted sid).
+ *
  * Extracted from App.tsx for SRP under Task #758 Phase C.
  */
 export function useSessionNameBridge(sessions: ReadonlyArray<SessionLike>): void {
-  const prevSidsRef = useRef<Set<string>>(new Set());
+  const prevNamesRef = useRef<Map<string, string | null>>(new Map());
   useEffect(() => {
     type Bridge = { setName: (sid: string, name: string | null) => void };
     const bridge = (window as unknown as { ccsmSession?: Bridge }).ccsmSession;
     if (!bridge || typeof bridge.setName !== 'function') return;
-    const currentSids = new Set<string>();
+    const prev = prevNamesRef.current;
+    const next = new Map<string, string | null>();
     for (const sess of sessions) {
-      bridge.setName(sess.id, sess.name ?? null);
-      currentSids.add(sess.id);
+      const name = sess.name ?? null;
+      next.set(sess.id, name);
+      // Only IPC when the name (per sid) actually changed — covers mount
+      // (sid absent from prev) and rename (sid present, name differs).
+      // Pure state-toggle store updates re-run this effect with every
+      // sess.name unchanged, so we short-circuit those without any IPC.
+      if (!prev.has(sess.id) || prev.get(sess.id) !== name) {
+        bridge.setName(sess.id, name);
+      }
     }
-    for (const staleSid of prevSidsRef.current) {
-      if (!currentSids.has(staleSid)) {
+    // Clear any sid that disappeared since the previous render so main's
+    // map doesn't leak across the app lifetime.
+    for (const [staleSid] of prev) {
+      if (!next.has(staleSid)) {
         bridge.setName(staleSid, null);
       }
     }
-    prevSidsRef.current = currentSids;
+    prevNamesRef.current = next;
   }, [sessions]);
 }

--- a/src/components/AgentIcon.tsx
+++ b/src/components/AgentIcon.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { motion } from 'framer-motion';
 import { cn } from '../lib/cn';
+import { CLAUDE_CODE_AGENT_ID } from '../shared/agentIds';
 import type { AgentType, SessionState } from '../types';
 
 type Size = 'sm' | 'md';
@@ -76,7 +77,7 @@ export function AgentIcon({
     : state === 'waiting' || flashing
       ? 'waiting-or-flashing'
       : 'idle';
-  const inner = agentType === 'claude-code' ? <ClaudeAsterisk size={glyph} /> : null;
+  const inner = agentType === CLAUDE_CODE_AGENT_ID ? <ClaudeAsterisk size={glyph} /> : null;
   return (
     <motion.span
       data-agent-icon-state={state}

--- a/src/components/ScrollToBottomButton.tsx
+++ b/src/components/ScrollToBottomButton.tsx
@@ -1,14 +1,16 @@
-import { AnimatePresence, motion } from 'framer-motion';
 import { ArrowDown } from 'lucide-react';
 import { useTranslation } from '../i18n/useTranslation';
 
 // Floating "jump to bottom" affordance for the terminal viewport.
 // Mounted inside the TerminalPane's relative wrapper so it absolutely
-// positions over the bottom-right corner of the xterm host. Only
-// renders when the user has scrolled up (atBottom === false); fades
-// itself out the moment they hit bottom again (either by clicking
-// this button or by xterm's own behaviour after Page Down / scroll
-// wheel down).
+// positions over the bottom-right corner of the xterm host.
+//
+// Always rendered while the terminal is in the `ready` state — the
+// previous `atBottom`-gated visibility was flaky in practice (xterm's
+// onScroll/onLineFeed signals can miss edges, leaving the button hidden
+// when the user has scrolled up). Clicking while already at bottom is a
+// no-op (xterm's scrollToBottom is idempotent), so always-on costs us
+// nothing behaviourally.
 //
 // Sits above xterm's canvas (z-10) so it stays clickable — the canvas
 // renderer stacks its own absolutely-positioned canvases inside the
@@ -16,47 +18,34 @@ import { useTranslation } from '../i18n/useTranslation';
 //
 // Visual: 32px circle, IconButton's `raised` aesthetic (matches the
 // other elevated controls in the app) with the lucide ArrowDown glyph.
-// Framer-motion handles fade + 4px translate for entry/exit so the
-// button feels like it slid up from the corner rather than popping.
 export function ScrollToBottomButton({
-  visible,
   onClick,
 }: {
-  visible: boolean;
   onClick: () => void;
 }) {
   const { t } = useTranslation();
   return (
-    <AnimatePresence>
-      {visible ? (
-        <motion.button
-          type="button"
-          onClick={onClick}
-          aria-label={t('terminal.scrollToBottom')}
-          title={t('terminal.scrollToBottom')}
-          initial={{ opacity: 0, y: 4 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: 4 }}
-          transition={{ duration: 0.15, ease: [0.32, 0.72, 0, 1] }}
-          whileTap={{ scale: 0.94 }}
-          data-scroll-to-bottom
-          className={[
-            'absolute bottom-4 right-4 z-10',
-            'inline-grid place-items-center',
-            'h-8 w-8 rounded-full',
-            'text-fg-secondary',
-            'bg-[oklch(0.32_0.003_240)] border border-[oklch(0.42_0.003_240)]',
-            'shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.10),0_2px_8px_0_oklch(0_0_0_/_0.45)]',
-            'hover:bg-[oklch(0.38_0.003_240)] hover:text-fg-primary hover:border-[oklch(0.50_0.003_240)]',
-            'active:bg-[oklch(0.30_0.003_240)]',
-            'focus-visible:outline-none focus-visible:shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.10),0_2px_8px_0_oklch(0_0_0_/_0.45),0_0_0_2px_oklch(1_0_0_/_0.18)]',
-            'transition-[background-color,border-color,color] duration-150',
-          ].join(' ')}
-        >
-          <ArrowDown size={16} strokeWidth={2} />
-        </motion.button>
-      ) : null}
-    </AnimatePresence>
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={t('terminal.scrollToBottom')}
+      title={t('terminal.scrollToBottom')}
+      data-scroll-to-bottom
+      className={[
+        'absolute bottom-4 right-4 z-10',
+        'inline-grid place-items-center',
+        'h-8 w-8 rounded-full',
+        'text-fg-secondary',
+        'bg-[oklch(0.32_0.003_240)] border border-[oklch(0.42_0.003_240)]',
+        'shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.10),0_2px_8px_0_oklch(0_0_0_/_0.45)]',
+        'hover:bg-[oklch(0.38_0.003_240)] hover:text-fg-primary hover:border-[oklch(0.50_0.003_240)]',
+        'active:bg-[oklch(0.30_0.003_240)] active:scale-[0.94]',
+        'focus-visible:outline-none focus-visible:shadow-[inset_0_1px_0_0_oklch(1_0_0_/_0.10),0_2px_8px_0_oklch(0_0_0_/_0.45),0_0_0_2px_oklch(1_0_0_/_0.18)]',
+        'transition-[background-color,border-color,color,transform] duration-150',
+      ].join(' ')}
+    >
+      <ArrowDown size={16} strokeWidth={2} />
+    </button>
   );
 }
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -55,6 +55,36 @@ export function Sidebar({ onCreateSession, onCreateSessionWithCwd, onOpenSetting
   // re-renders triggered by unrelated store mutations.
   const normal = useMemo(() => groups.filter((g) => g.kind === 'normal'), [groups]);
   const archived = useMemo(() => groups.filter((g) => g.kind === 'archive'), [groups]);
+  // Perf: bucket sessions by groupId ONCE per `sessions` ref change instead
+  // of calling `sessions.filter(s => s.groupId === g.id)` inline per GroupRow
+  // per render. The inline filter produced a fresh array reference for every
+  // GroupRow on every parent render, defeating React.memo on GroupRow /
+  // SessionRow and causing the entire sidebar tree (dnd-kit + framer-motion)
+  // to re-render whenever any session toggled state (e.g. waiting<->idle on
+  // every JSONL stream chunk). The store-side mutators
+  // (`_applySessionState`, `_applyExternalTitle`, `_applyCwdRedirect`,
+  // `sessionCrudSlice.*`) all preserve untouched session refs via per-element
+  // map / slice, so as long as we don't break that here, each GroupRow's
+  // `sessions` prop ref stays stable when its own bucket didn't change.
+  const sessionsByGroup = useMemo(() => {
+    const map = new Map<string, Session[]>();
+    for (const s of sessions) {
+      let bucket = map.get(s.groupId);
+      if (!bucket) {
+        bucket = [];
+        map.set(s.groupId, bucket);
+      }
+      bucket.push(s);
+    }
+    return map;
+  }, [sessions]);
+  // Shared empty-array sentinel so the "group with no sessions" common case
+  // is also fully ref-stable across renders.
+  const emptySessions = useMemo<Session[]>(() => [], []);
+  const getSessionsForGroup = React.useCallback(
+    (gid: string): Session[] => sessionsByGroup.get(gid) ?? emptySessions,
+    [sessionsByGroup, emptySessions]
+  );
   // J2: track the most recently created group so its <GroupRow> mounts in
   // inline-rename mode. Cleared after the next render cycle so toggling rename
   // off (or remounting) doesn't accidentally re-trigger it.
@@ -220,13 +250,13 @@ export function Sidebar({ onCreateSession, onCreateSessionWithCwd, onOpenSetting
               <GroupRow
                 key={g.id}
                 group={g}
-                sessions={sessions.filter((s) => s.groupId === g.id)}
+                sessions={getSessionsForGroup(g.id)}
                 activeSessionId={activeSessionId}
                 focused={focusedGroupId === g.id}
                 anyGroupFocused={focusedGroupId !== null}
                 autoRename={justCreatedGroupId === g.id}
                 onSelectSession={onSelectSession}
-                onFocus={() => onFocusGroup(g.id)}
+                onFocusGroup={onFocusGroup}
                 normalGroups={normal}
               />
             ))}
@@ -237,7 +267,7 @@ export function Sidebar({ onCreateSession, onCreateSessionWithCwd, onOpenSetting
           <ArchivedSection
             archivedGroups={archived}
             normalGroups={normal}
-            sessions={sessions}
+            getSessionsForGroup={getSessionsForGroup}
             activeSessionId={activeSessionId}
             focusedGroupId={focusedGroupId}
             onSelectSession={onSelectSession}

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -32,7 +32,10 @@ export function TerminalPane({ sessionId, cwd }: Props) {
   useXtermSingleton(hostRef);
   useTerminalResize(hostRef);
   const { state, onRetry } = usePtyAttach(sessionId, cwd);
-  const { atBottom, scrollToBottom } = useAtBottom(sessionId);
+  // `atBottom` is intentionally unused — the button is always visible while
+  // ready (see ScrollToBottomButton). We keep the hook subscribed so the
+  // detection logic (and its tests) stay live for future use.
+  const { scrollToBottom } = useAtBottom(sessionId);
 
   return (
     <div
@@ -44,9 +47,12 @@ export function TerminalPane({ sessionId, cwd }: Props) {
       <Overlay state={state} onRetry={onRetry} t={t} />
       {/* Hide the jump-to-bottom affordance while an overlay (attaching /
           error / exit) is up — those cover the viewport and the button
-          would be meaningless. */}
+          would be meaningless. While ready, the button is always visible:
+          clicking it when already at bottom is a no-op (xterm's
+          scrollToBottom is idempotent), and conditional visibility based
+          on the atBottom signal proved flaky in practice. */}
       {state.kind === 'ready' ? (
-        <ScrollToBottomButton visible={!atBottom} onClick={scrollToBottom} />
+        <ScrollToBottomButton onClick={scrollToBottom} />
       ) : null}
     </div>
   );

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -1,10 +1,11 @@
-import { useRef } from 'react';
+import { useCallback, useRef, type MouseEvent } from 'react';
 import '@xterm/xterm/css/xterm.css';
 import { useTranslation } from '../i18n/useTranslation';
 import { useXtermSingleton } from '../terminal/useXtermSingleton';
 import { useTerminalResize } from '../terminal/useTerminalResize';
 import { usePtyAttach, type PtyAttachState } from '../terminal/usePtyAttach';
 import { useAtBottom } from '../terminal/useAtBottom';
+import { terminalCopy, terminalPaste } from '../terminal/xtermSingleton';
 import { ScrollToBottomButton } from './ScrollToBottomButton';
 
 // TerminalPane is the host shell for the singleton xterm view. The three
@@ -37,11 +38,34 @@ export function TerminalPane({ sessionId, cwd }: Props) {
   // detection logic (and its tests) stay live for future use.
   const { scrollToBottom } = useAtBottom(sessionId);
 
+  // Native CLI / terminal-emulator right-click behavior. Mirrors Windows
+  // Terminal / gnome-terminal: right-click with selection → copy (+ clear
+  // for visual feedback); right-click with no selection → paste. No
+  // popover, ever. The native context menu installed in
+  // `electron/window/createWindow.ts` would race on top by default —
+  // `ccsmShell.suppressContextMenuOnce()` tells main to skip the next
+  // popup for this WebContents (DOM `preventDefault()` alone does NOT
+  // cancel Electron's main-process `context-menu` event). Optional chain
+  // on the bridge because tests / e2e probes may not install it.
+  const onContextMenu = useCallback((e: MouseEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    try {
+      window.ccsmShell?.suppressContextMenuOnce();
+    } catch {
+      // best-effort — falling through to inline copy/paste still works,
+      // user just sees the native menu race briefly.
+    }
+    const copied = terminalCopy();
+    if (!copied) terminalPaste();
+  }, []);
+
   return (
     <div
       className="relative flex-1 w-full h-full bg-black ring-1 ring-inset ring-white/5"
       data-terminal-host
       data-active-sid={sessionId}
+      onContextMenu={onContextMenu}
     >
       <div ref={hostRef} className="absolute inset-0" />
       <Overlay state={state} onRetry={onRetry} t={t} />

--- a/src/components/settings/AppearancePane.tsx
+++ b/src/components/settings/AppearancePane.tsx
@@ -3,6 +3,12 @@ import { cn } from '../../lib/cn';
 import { useStore } from '../../stores/store';
 import { useTranslation } from '../../i18n/useTranslation';
 import { usePreferences } from '../../store/preferences';
+import {
+  SCROLLBACK_LINES_DEFAULT,
+  SCROLLBACK_LINES_MAX,
+  SCROLLBACK_LINES_MIN,
+} from '../../stores/slices/types';
+import { sanitizeScrollbackLines } from '../../stores/slices/appearanceSlice';
 import { Field } from './Field';
 import { Segmented } from './Segmented';
 
@@ -62,6 +68,7 @@ export function AppearancePane() {
         </div>
       </Field>
       <CloseBehaviorField />
+      <ScrollbackField />
     </>
   );
 }
@@ -113,6 +120,84 @@ function CloseBehaviorField() {
             { value: 'quit', label: t('closeBehaviorOptions.quit') }
           ]}
         />
+      </div>
+    </Field>
+  );
+}
+
+// Terminal scrollback line cap. Single user-facing knob that bounds BOTH
+// the visible xterm buffer (next-launch effect — the renderer's xterm
+// singleton reads this once at construction) and the headless
+// authoritative buffer in main (next-spawn effect — `entryFactory.makeEntry`
+// reads from the same `scrollbackLines` row). Persisted via `db:save` to
+// match the closeBehavior pattern, NOT via the renderer's PERSISTED_KEYS
+// JSON blob, so the main process can read the same value directly.
+//
+// We mirror the value into zustand on change so the live xterm singleton
+// has a synchronous reader; the on-disk row is the source of truth.
+function ScrollbackField() {
+  const { t } = useTranslation('settings');
+  const storeValue = useStore((s) => s.scrollbackLines);
+  const setStoreValue = useStore((s) => s.setScrollbackLines);
+  // Local "what the user is currently typing" buffer so we don't clobber
+  // their keystrokes mid-edit with the sanitized round-trip. Synced to
+  // the store value when the input loses focus / user commits.
+  const [draft, setDraft] = useState<string>(String(storeValue));
+
+  // If the store value changes from elsewhere (e.g. another window, future
+  // multi-window support, or hydrate), reflect it into the input.
+  useEffect(() => {
+    setDraft(String(storeValue));
+  }, [storeValue]);
+
+  const commit = (raw: string): void => {
+    const sanitized = sanitizeScrollbackLines(raw);
+    setStoreValue(sanitized);
+    setDraft(String(sanitized));
+    // Persist to the same db row main reads from in
+    // electron/prefs/scrollback.ts. Fire-and-forget — the renderer's view
+    // (zustand) is already updated synchronously above, so a slow IPC
+    // doesn't block the UI. Persist as a string for parity with how
+    // closeAction is stored (db column is TEXT).
+    void window.ccsm?.saveState('scrollbackLines', String(sanitized));
+  };
+
+  return (
+    <Field label={t('scrollback')} hint={t('scrollbackHint')}>
+      <div className="flex items-center gap-3">
+        <input
+          type="number"
+          min={SCROLLBACK_LINES_MIN}
+          max={SCROLLBACK_LINES_MAX}
+          step={100}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={(e) => commit(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              (e.target as HTMLInputElement).blur();
+            }
+          }}
+          aria-label={t('scrollbackAriaLabel')}
+          className={cn(
+            'h-7 w-24 px-2 rounded-sm bg-bg-input text-fg-primary text-chrome',
+            'border border-border-subtle focus-ring outline-none tabular-nums'
+          )}
+        />
+        <span className="text-meta text-fg-secondary">
+          {t('scrollbackUnit')}
+        </span>
+        <button
+          type="button"
+          onClick={() => commit(String(SCROLLBACK_LINES_DEFAULT))}
+          className={cn(
+            'h-7 px-2 rounded-sm text-meta text-fg-secondary',
+            'hover:bg-bg-hover hover:text-fg-primary focus-ring outline-none transition-colors'
+          )}
+        >
+          {t('scrollbackReset', { default: SCROLLBACK_LINES_DEFAULT.toString() })}
+        </button>
       </div>
     </Field>
   );

--- a/src/components/sidebar/ArchivedSection.tsx
+++ b/src/components/sidebar/ArchivedSection.tsx
@@ -20,7 +20,7 @@ import { GroupRow } from './GroupRow';
 // built once per `sessions` ref change, so each archived GroupRow's
 // `sessions` prop ref stays stable when its own bucket didn't change —
 // preserving React.memo on GroupRow / SessionRow.
-export function ArchivedSection({
+function ArchivedSectionImpl({
   archivedGroups,
   normalGroups,
   getSessionsForGroup,
@@ -85,3 +85,13 @@ export function ArchivedSection({
     </>
   );
 }
+
+// Memoize for symmetry with GroupRow / SessionRow so a Sidebar re-render
+// driven by an unrelated store mutation (e.g. a session state toggle on a
+// non-archived row) doesn't re-render the archived block. All props are
+// ref-stable upstream: `archivedGroups` / `normalGroups` come from
+// useMemo'd partitions of `groups`, `getSessionsForGroup` is useCallback'd,
+// `activeSessionId` / `focusedGroupId` are primitives, and
+// `onSelectSession` / `onFocusGroup` are direct Zustand action refs passed
+// through App.tsx unchanged. See PR #1269.
+export const ArchivedSection = React.memo(ArchivedSectionImpl);

--- a/src/components/sidebar/ArchivedSection.tsx
+++ b/src/components/sidebar/ArchivedSection.tsx
@@ -14,10 +14,16 @@ import { GroupRow } from './GroupRow';
 // J14: archived groups are a "viewer" surface — DnD onto archived headers is
 // rejected upstream in useSidebarDnd. The archived rows here intentionally
 // don't render their own SortableContext (no empty-drop targets either).
+//
+// Perf: receives a `getSessionsForGroup` lookup from <Sidebar> rather than a
+// flat `sessions` array we'd have to .filter() per row. The parent bucket is
+// built once per `sessions` ref change, so each archived GroupRow's
+// `sessions` prop ref stays stable when its own bucket didn't change —
+// preserving React.memo on GroupRow / SessionRow.
 export function ArchivedSection({
   archivedGroups,
   normalGroups,
-  sessions,
+  getSessionsForGroup,
   activeSessionId,
   focusedGroupId,
   onSelectSession,
@@ -25,7 +31,7 @@ export function ArchivedSection({
 }: {
   archivedGroups: Group[];
   normalGroups: Group[];
-  sessions: Session[];
+  getSessionsForGroup: (groupId: string) => Session[];
   activeSessionId: string;
   focusedGroupId: string | null;
   onSelectSession: (id: string) => void;
@@ -65,12 +71,12 @@ export function ArchivedSection({
             <GroupRow
               key={g.id}
               group={g}
-              sessions={sessions.filter((s) => s.groupId === g.id)}
+              sessions={getSessionsForGroup(g.id)}
               activeSessionId={activeSessionId}
               focused={focusedGroupId === g.id}
               anyGroupFocused={focusedGroupId !== null}
               onSelectSession={onSelectSession}
-              onFocus={() => onFocusGroup(g.id)}
+              onFocusGroup={onFocusGroup}
               normalGroups={normalGroups}
             />
           ))}

--- a/src/components/sidebar/GroupRow.tsx
+++ b/src/components/sidebar/GroupRow.tsx
@@ -29,7 +29,7 @@ import type { Group, Session } from '../../types';
 import { headerDroppableId } from './dnd';
 import { SessionRow } from './SessionRow';
 
-export function GroupRow({
+function GroupRowImpl({
   group,
   sessions,
   activeSessionId,
@@ -37,7 +37,7 @@ export function GroupRow({
   anyGroupFocused,
   autoRename,
   onSelectSession,
-  onFocus,
+  onFocusGroup,
   normalGroups
 }: {
   group: Group;
@@ -50,7 +50,10 @@ export function GroupRow({
    *  group without an extra click. Cleared by the parent once consumed. */
   autoRename?: boolean;
   onSelectSession: (id: string) => void;
-  onFocus: () => void;
+  /** Receives this group's id when the row gets focus. id-passing (vs. a
+   *  pre-bound `() => void`) keeps the prop reference stable across parent
+   *  re-renders so React.memo can short-circuit unrelated GroupRows. */
+  onFocusGroup: (id: string) => void;
   /** Pre-filtered list of normal (non-archive) groups, hoisted to the parent
    *  Sidebar so we don't recompute per SessionRow per render. */
   normalGroups: Group[];
@@ -127,7 +130,7 @@ export function GroupRow({
             )}
             <button
               onClick={() => {
-                onFocus();
+                onFocusGroup(group.id);
                 if (!renaming) setGroupCollapsed(group.id, !collapsed);
               }}
               onKeyDown={(e) => {
@@ -256,7 +259,7 @@ export function GroupRow({
               session={s}
               active={s.id === activeSessionId}
               selected={!anyGroupFocused && s.id === activeSessionId}
-              onSelect={() => onSelectSession(s.id)}
+              onSelectSession={onSelectSession}
               normalGroups={normalGroups}
             />
           ))}
@@ -289,3 +292,11 @@ export function GroupRow({
     </div>
   );
 }
+
+// Memoize so a parent re-render driven by an unrelated store mutation (e.g.
+// another group's session toggling waiting<->idle on a JSONL chunk) doesn't
+// also re-render this group's body. Relies on the parent Sidebar handing us
+// a stable `sessions` array reference via its bucketed
+// `getSessionsForGroup` lookup — see Sidebar.tsx. Default shallow-equals is
+// correct here: every prop is either a primitive or a ref-stable object.
+export const GroupRow = React.memo(GroupRowImpl);

--- a/src/components/sidebar/SessionRow.tsx
+++ b/src/components/sidebar/SessionRow.tsx
@@ -64,6 +64,7 @@ function SessionRowImpl({
   const createGroup = useStore((s) => s.createGroup);
   const archiveSession = useStore((s) => s.archiveSession);
   const unarchiveSession = useStore((s) => s.unarchiveSession);
+  const reloadSession = useStore((s) => s.reloadSession);
   // The session is archived (lives in an archive container) iff its
   // parent group has `kind === 'archive'`. We detect it via the prop
   // `normalGroups` indirectly: archived sessions are rendered through
@@ -115,6 +116,18 @@ function SessionRowImpl({
         action: { label: t('common.undo'), onClick: () => restoreSession(snap) }
       });
     }
+  };
+  // J7: right-click "Reload session" — kills the current pty and lets the
+  // attach effect re-spawn it (env / config refresh). No confirm: the
+  // operation is non-destructive (claude resumes the same transcript via
+  // the JSONL resolver) and the toast gives the user feedback during the
+  // ~1-2s blank window between kill and re-attach.
+  const performReload = () => {
+    void reloadSession(session.id);
+    toast.push({
+      kind: 'info',
+      title: t('sidebar.reloadingSessionToast', { name: session.name }),
+    });
   };
   return (
     <ContextMenu>
@@ -303,6 +316,9 @@ function SessionRowImpl({
           );
         })()}
         <ContextMenuSeparator />
+        <ContextMenuItem onSelect={performReload}>
+          {t('sidebar.reloadSession')}
+        </ContextMenuItem>
         <ContextMenuItem
           onSelect={() =>
             isArchived ? unarchiveSession(session.id) : archiveSession(session.id)

--- a/src/components/sidebar/SessionRow.tsx
+++ b/src/components/sidebar/SessionRow.tsx
@@ -24,17 +24,20 @@ import {
 } from '../../lib/motion';
 import type { Group, Session } from '../../types';
 
-export function SessionRow({
+function SessionRowImpl({
   session,
   active,
   selected,
-  onSelect,
+  onSelectSession,
   normalGroups
 }: {
   session: Session;
   active: boolean;
   selected: boolean;
-  onSelect: () => void;
+  /** Receives this row's session id. id-passing (vs. a pre-bound `() => void`)
+   *  keeps the prop reference stable across parent re-renders so React.memo
+   *  can short-circuit when only an unrelated session changed. */
+  onSelectSession: (id: string) => void;
   normalGroups: Group[];
 }) {
   const { t } = useTranslation();
@@ -134,12 +137,12 @@ export function SessionRow({
           aria-selected={selected}
           tabIndex={renaming ? -1 : selected ? 0 : -1}
           data-session-id={session.id}
-          onClick={onSelect}
+          onClick={() => onSelectSession(session.id)}
           onContextMenu={() => {
             // J4b: right-click selects the row first, matching standard GUI
             // behavior where the context menu acts on "this row" — and the
             // user expects "this row" to be visually highlighted.
-            onSelect();
+            onSelectSession(session.id);
           }}
           onKeyDown={(e) => {
             // Only handle keys when the <li> itself is the focused element.
@@ -157,7 +160,7 @@ export function SessionRow({
             }
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault();
-              onSelect();
+              onSelectSession(session.id);
             }
           }}
           title={
@@ -314,3 +317,15 @@ export function SessionRow({
     </ContextMenu>
   );
 }
+
+// Memoize so a parent re-render driven by another session's state toggle
+// (e.g. waiting<->idle on a JSONL chunk for a different row) does not
+// re-render this row. SessionRow is the hot row — it mounts dnd-kit's
+// useSortable + framer-motion's <motion.li>, so a churning re-render here
+// dominated the streaming-flicker cost flagged by the perf audit. Relies on
+// stable parent props: `session` ref-stable thanks to the store's per-element
+// patch (sessionRuntimeSlice / sessionTitleBackfillSlice / sessionCrudSlice
+// all use slice/map with per-id patch), `normalGroups` ref-stable via the
+// parent's useMemo, and `onSelectSession` ref-stable now that the parent
+// passes the id-accepting store action through unchanged.
+export const SessionRow = React.memo(SessionRowImpl);

--- a/src/components/sidebar/SessionRow.tsx
+++ b/src/components/sidebar/SessionRow.tsx
@@ -65,6 +65,21 @@ function SessionRowImpl({
   const archiveSession = useStore((s) => s.archiveSession);
   const unarchiveSession = useStore((s) => s.unarchiveSession);
   const reloadSession = useStore((s) => s.reloadSession);
+  const copySession = useStore((s) => s.copySession);
+  // `copySession` arms `pendingRenameId` so the freshly-minted row enters
+  // inline rename without a follow-up click. Read the flag here and, when
+  // it matches this row's id, auto-toggle `renaming` on mount, then clear
+  // the flag so a re-mount (e.g. group collapse/expand) doesn't loop. We
+  // intentionally watch only the matching-id signal (boolean) — subscribing
+  // to the raw string would re-render every row on any pendingRenameId
+  // change, including unrelated copy operations.
+  const wantsRename = useStore((s) => s.pendingRenameId === session.id);
+  const consumePendingRename = useStore((s) => s.consumePendingRename);
+  useEffect(() => {
+    if (!wantsRename) return;
+    setRenaming(true);
+    consumePendingRename(session.id);
+  }, [wantsRename, session.id, consumePendingRename]);
   // The session is archived (lives in an archive container) iff its
   // parent group has `kind === 'archive'`. We detect it via the prop
   // `normalGroups` indirectly: archived sessions are rendered through
@@ -282,6 +297,7 @@ function SessionRowImpl({
         onCloseAutoFocus={(e) => e.preventDefault()}
       >
         <ContextMenuItem onSelect={() => setRenaming(true)}>{t('common.rename')}</ContextMenuItem>
+        <ContextMenuItem onSelect={() => copySession(session.id)}>{t('sidebar.copySession')}</ContextMenuItem>
         {(() => {
           // Exclude the session's current group from the destination list so
           // users can only move TO another group (#612). The submenu is

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -125,6 +125,12 @@ const en = {
       tray: 'Minimize to tray',
       quit: 'Quit'
     },
+    scrollback: 'Terminal scrollback',
+    scrollbackHint:
+      'How many lines each terminal keeps in its scrollback buffer. Applies on next attach for the headless mirror and on next launch for the visible terminal.',
+    scrollbackUnit: 'lines',
+    scrollbackAriaLabel: 'Terminal scrollback in lines',
+    scrollbackReset: 'Reset to default ({{default}})',
     version: 'Version',
     checkForUpdates: 'Check for updates',
     crashReporting: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -54,6 +54,7 @@ const en = {
     unarchiveSession: 'Unarchive',
     reloadSession: 'Reload session',
     reloadingSessionToast: 'Reloading "{{name}}"…',
+    copySession: 'Copy session',
     deleteGroupEllipsis: 'Delete group…',
     deleteGroup: 'Delete group',
     deleteGroupConfirmTitle: 'Delete "{{name}}"?',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -52,6 +52,8 @@ const en = {
     unarchiveGroup: 'Unarchive group',
     archiveSession: 'Archive',
     unarchiveSession: 'Unarchive',
+    reloadSession: 'Reload session',
+    reloadingSessionToast: 'Reloading "{{name}}"…',
     deleteGroupEllipsis: 'Delete group…',
     deleteGroup: 'Delete group',
     deleteGroupConfirmTitle: 'Delete "{{name}}"?',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -120,6 +120,12 @@ const zh: EnCatalog = {
       tray: '最小化到托盘',
       quit: '退出'
     },
+    scrollback: '终端回滚行数',
+    scrollbackHint:
+      '每个终端在回滚缓冲区中保留的行数。后台镜像缓冲区在下次接入时生效，可见终端在下次启动时生效。',
+    scrollbackUnit: '行',
+    scrollbackAriaLabel: '终端回滚行数',
+    scrollbackReset: '重置为默认值 ({{default}})',
     version: '版本',
     checkForUpdates: '检查更新',
     crashReporting: {

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -52,6 +52,8 @@ const zh: EnCatalog = {
     unarchiveGroup: '取消归档',
     archiveSession: '归档',
     unarchiveSession: '取消归档',
+    reloadSession: '重启会话',
+    reloadingSessionToast: '正在重启"{{name}}"…',
     deleteGroupEllipsis: '删除分组…',
     deleteGroup: '删除分组',
     deleteGroupConfirmTitle: '确认删除"{{name}}"？',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -54,6 +54,7 @@ const zh: EnCatalog = {
     unarchiveSession: '取消归档',
     reloadSession: '重启会话',
     reloadingSessionToast: '正在重启"{{name}}"…',
+    copySession: '复制会话',
     deleteGroupEllipsis: '删除分组…',
     deleteGroup: '删除分组',
     deleteGroupConfirmTitle: '确认删除"{{name}}"？',

--- a/src/pty.d.ts
+++ b/src/pty.d.ts
@@ -64,7 +64,11 @@ export type CheckClaudeAvailableResult =
 
 export interface CcsmPtyApi {
   list(): Promise<PtySessionInfo[]>;
-  spawn(sid: string, cwd: string): Promise<SpawnResult>;
+  /** When `forkSourceSid` is set, main spawns
+   *  `claude --resume <forkSourceSid> --fork-session --session-id <sid>` so the
+   *  new pty boots with the source session's full transcript context but
+   *  writes to its own JSONL. Used by the right-click "Copy session" flow. */
+  spawn(sid: string, cwd: string, forkSourceSid?: string): Promise<SpawnResult>;
   attach(sid: string): Promise<AttachResult | null>;
   detach(sid: string): Promise<void>;
   input(sid: string, data: string): Promise<void>;

--- a/src/pty.d.ts
+++ b/src/pty.d.ts
@@ -89,6 +89,14 @@ export interface CcsmPtyApi {
 declare global {
   interface Window {
     ccsmPty: CcsmPtyApi;
+    ccsmShell?: {
+      /** Tell main to skip the very next native context-menu popup. Used
+       *  by TerminalPane's `onContextMenu` handler so right-click can
+       *  copy/paste inline without a popover racing on top. See
+       *  `electron/preload/bridges/ccsmShell.ts`. Optional because tests
+       *  / e2e probes may not install the bridge. */
+      suppressContextMenuOnce(): void;
+    };
     __ccsmTerm?: import('@xterm/xterm').Terminal;
   }
 }

--- a/src/pty.d.ts
+++ b/src/pty.d.ts
@@ -83,6 +83,14 @@ export interface CcsmPtyApi {
     readText(): string;
     writeText(text: string): void;
   };
+  /**
+   * Task #42 — if the clipboard holds an image, save it as a PNG under
+   * `<userData>/clipboard-images/YYYYMMDD-HHMMSS[-NNN].png` and return
+   * the absolute path (native separators). Returns null if no image is
+   * present. Used by the paste path to convert pasted screenshots into
+   * file paths that claude can read.
+   */
+  saveClipboardImage(): Promise<string | null>;
   checkClaudeAvailable(opts?: { force?: boolean }): Promise<CheckClaudeAvailableResult>;
 }
 

--- a/src/shared/agentIds.ts
+++ b/src/shared/agentIds.ts
@@ -1,0 +1,15 @@
+// Cross-boundary (renderer + main) agent identifier constants.
+//
+// These string literals are PERSISTED in SQLite (`sessions.agent_type`
+// column) and stored in user prefs / serialized state. Once shipped,
+// changing the wire value silently breaks existing user data — every
+// row read from disk would no longer match.
+//
+// Phase 1 of the multi-agent refactor: extract the magic string into a
+// named constant so future agents (codex/cursor/aider/...) can be added
+// without grepping for `'claude-code'` literals scattered across the
+// codebase, and so DB migrations can reference the same symbol the
+// runtime uses to write.
+//
+// `tests/shared/agentIds.test.ts` pins the wire value — do not change it.
+export const CLAUDE_CODE_AGENT_ID = 'claude-code' as const;

--- a/src/stores/slices/appearanceSlice.ts
+++ b/src/stores/slices/appearanceSlice.ts
@@ -12,6 +12,11 @@ import type {
   SetFn,
   GetFn,
 } from './types';
+import {
+  SCROLLBACK_LINES_DEFAULT,
+  SCROLLBACK_LINES_MAX,
+  SCROLLBACK_LINES_MIN,
+} from './types';
 
 /** Map the legacy `sm`/`md`/`lg` enum to the numeric pixel scale. The old
  * values kept only three stops (12/13/14); the new slider exposes 12–16.
@@ -37,6 +42,21 @@ export function sanitizeFontSizePx(raw: unknown): FontSizePx {
   const n = typeof raw === 'number' ? Math.round(raw) : NaN;
   if (n === 12 || n === 13 || n === 14 || n === 15 || n === 16) return n;
   return 14;
+}
+
+/** Clamp + integerize a raw scrollback value into the valid range. Mirrors
+ *  the main-side `parseScrollbackLines` so the renderer-mirrored value
+ *  always agrees with what the headless side reads from the same db row. */
+export function sanitizeScrollbackLines(raw: unknown): number {
+  let n: number;
+  if (typeof raw === 'number') n = raw;
+  else if (typeof raw === 'string' && raw.length > 0) n = Number(raw);
+  else return SCROLLBACK_LINES_DEFAULT;
+  if (!Number.isFinite(n)) return SCROLLBACK_LINES_DEFAULT;
+  n = Math.round(n);
+  if (n < SCROLLBACK_LINES_MIN) return SCROLLBACK_LINES_MIN;
+  if (n > SCROLLBACK_LINES_MAX) return SCROLLBACK_LINES_MAX;
+  return n;
 }
 
 export const SIDEBAR_WIDTH_DEFAULT = 260;
@@ -83,9 +103,11 @@ export type AppearanceSlice = Pick<
   | 'theme'
   | 'fontSize'
   | 'fontSizePx'
+  | 'scrollbackLines'
   | 'setTheme'
   | 'setFontSize'
   | 'setFontSizePx'
+  | 'setScrollbackLines'
   | 'setSidebarWidth'
   | 'resetSidebarWidth'
 >;
@@ -97,6 +119,7 @@ export function createAppearanceSlice(set: SetFn, _get: GetFn): AppearanceSlice 
     theme: 'system',
     fontSize: 'md',
     fontSizePx: 14,
+    scrollbackLines: SCROLLBACK_LINES_DEFAULT,
 
     // actions
     setTheme: (theme) => set({ theme }),
@@ -104,6 +127,8 @@ export function createAppearanceSlice(set: SetFn, _get: GetFn): AppearanceSlice 
       set({ fontSize, fontSizePx: legacyFontSizeToPx(fontSize) }),
     setFontSizePx: (fontSizePx) =>
       set({ fontSizePx, fontSize: pxToLegacyFontSize(fontSizePx) }),
+    setScrollbackLines: (n) =>
+      set({ scrollbackLines: sanitizeScrollbackLines(n) }),
     setSidebarWidth: (px) => set({ sidebarWidth: sanitizeSidebarWidth(px) }),
     resetSidebarWidth: () => set({ sidebarWidth: SIDEBAR_WIDTH_DEFAULT }),
   };

--- a/src/stores/slices/sessionCrudSlice.ts
+++ b/src/stores/slices/sessionCrudSlice.ts
@@ -14,6 +14,7 @@
 // `sessionTitleBackfillSlice` (split per Task #736 / PR #754 review).
 
 import type { Group, Session } from '../../types';
+import { CLAUDE_CODE_AGENT_ID } from '../../shared/agentIds';
 import { hydrateDrafts as _unused, deleteDrafts, snapshotDraft, restoreDraft } from '../drafts';
 import { resolvePreferredGroup } from '../lib/preferredGroupResolver';
 import {
@@ -203,7 +204,7 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
         cwd: opts.cwd ?? defaultCwd,
         model: initialModel,
         groupId: targetGroupId,
-        agentType: 'claude-code',
+        agentType: CLAUDE_CODE_AGENT_ID,
       };
       const targetGroup = baseGroups.find((g) => g.id === targetGroupId);
       const nextGroups =
@@ -291,7 +292,7 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
         cwd,
         model: initialModel,
         groupId: ensured.groupId,
-        agentType: 'claude-code',
+        agentType: CLAUDE_CODE_AGENT_ID,
         resumeSessionId,
       };
       set({

--- a/src/stores/slices/sessionCrudSlice.ts
+++ b/src/stores/slices/sessionCrudSlice.ts
@@ -1,6 +1,5 @@
 // Session CRUD slice: create / import / delete / restore / move /
-// rename / changeCwd / setSessionModel + active selection + LRU cwd
-// seed.
+// rename / changeCwd / setSessionModel + active selection.
 //
 // `ensureUsableGroup` is colocated here because the only callers are
 // session creation/import — it picks (or synthesizes) a target group so
@@ -131,7 +130,6 @@ export type SessionCrudSlice = Pick<
   | 'focusedGroupId'
   | 'userHome'
   | 'claudeSettingsDefaultModel'
-  | 'lastUsedCwd'
   | 'selectSession'
   | 'focusGroup'
   | 'createSession'
@@ -154,7 +152,6 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
     focusedGroupId: null,
     userHome: '',
     claudeSettingsDefaultModel: null,
-    lastUsedCwd: null,
 
     selectSession: (id) => {
       set((s) => ({
@@ -180,7 +177,6 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
         activeId,
         userHome,
         claudeSettingsDefaultModel,
-        lastUsedCwd,
       } = get();
       const activeGroupId = sessions.find((s) => s.id === activeId)?.groupId;
       const preferred = resolvePreferredGroup(
@@ -193,7 +189,11 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
       const targetGroupId = ensured.groupId;
       const baseGroups = ensured.groups;
       const id = newSessionId();
-      const defaultCwd = lastUsedCwd ?? userHome ?? '';
+      // Default cwd is `os.homedir()` always — no fallback chain. Per
+      // PR #392 spec ("default cwd is home, no fallback chains"). The
+      // chevron popover next to the `+` covers the "open in another
+      // recent project" case so the default doesn't need to guess.
+      const defaultCwd = userHome ?? '';
       let initialModel = '';
       if (!initialModel) initialModel = claudeSettingsDefaultModel ?? '';
       const newSession: Session = {
@@ -219,14 +219,7 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
       const finalCwd = newSession.cwd;
       if (finalCwd && userHome && finalCwd !== userHome) {
         const api = window.ccsm;
-        void api?.userCwds?.push(finalCwd)
-          .then((list) => {
-            if (Array.isArray(list) && list.length > 0) {
-              set({ lastUsedCwd: list[0] ?? null });
-            }
-          })
-          .catch(() => {});
-        if (finalCwd !== lastUsedCwd) set({ lastUsedCwd: finalCwd });
+        void api?.userCwds?.push(finalCwd).catch(() => {});
       }
     },
 
@@ -310,14 +303,7 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
       const userHome = get().userHome;
       if (cwd && userHome && cwd !== userHome) {
         const api = window.ccsm;
-        void api?.userCwds?.push(cwd)
-          .then((list) => {
-            if (Array.isArray(list) && list.length > 0) {
-              set({ lastUsedCwd: list[0] ?? null });
-            }
-          })
-          .catch(() => {});
-        if (cwd !== get().lastUsedCwd) set({ lastUsedCwd: cwd });
+        void api?.userCwds?.push(cwd).catch(() => {});
       }
       return id;
     },
@@ -446,14 +432,7 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
       const userHome = get().userHome;
       if (cwd && cwd !== userHome) {
         const api = window.ccsm;
-        void api?.userCwds?.push(cwd)
-          .then((list) => {
-            if (Array.isArray(list) && list.length > 0) {
-              set({ lastUsedCwd: list[0] ?? null });
-            }
-          })
-          .catch(() => {});
-        if (cwd !== get().lastUsedCwd) set({ lastUsedCwd: cwd });
+        void api?.userCwds?.push(cwd).catch(() => {});
       }
     },
 

--- a/src/stores/slices/sessionCrudSlice.ts
+++ b/src/stores/slices/sessionCrudSlice.ts
@@ -143,6 +143,10 @@ export type SessionCrudSlice = Pick<
   | 'setSessionModel'
   | 'archiveSession'
   | 'unarchiveSession'
+  | 'pendingRenameId'
+  | 'pendingForkSource'
+  | 'copySession'
+  | 'consumePendingRename'
 >;
 
 export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice {
@@ -153,6 +157,8 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
     focusedGroupId: null,
     userHome: '',
     claudeSettingsDefaultModel: null,
+    pendingRenameId: null,
+    pendingForkSource: {},
 
     selectSession: (id) => {
       set((s) => ({
@@ -543,6 +549,60 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
         const nextActive = s.activeId === '' ? sessionId : s.activeId;
         return { groups, sessions, activeId: nextActive };
       });
+    },
+
+    copySession: (sourceId) => {
+      const cur = get();
+      const source = cur.sessions.find((x) => x.id === sourceId);
+      if (!source) return null;
+      const newId = newSessionId();
+      // Place the copy in the same group as the source. If the source lives
+      // in an archive container we still honor that — user can unarchive
+      // afterwards. cwd/model/groupId/agentType all sourced from the
+      // original; archivedAt is intentionally NOT carried over so a copy
+      // never inherits a stale archive timestamp.
+      const copy: Session = {
+        id: newId,
+        name: `${source.name} (copy)`,
+        state: 'idle',
+        cwd: source.cwd,
+        model: source.model,
+        groupId: source.groupId,
+        agentType: source.agentType,
+        // Inherit cwdMissing — the directory state is independent of which
+        // session points at it; if it's missing for the source it's missing
+        // for the copy too.
+        ...(source.cwdMissing ? { cwdMissing: true as const } : {}),
+      };
+      // Insert the copy directly after the source so the new row appears
+      // adjacent to its origin (matches Finder "Duplicate" behavior). The
+      // sidebar renders sessions in order; so list-position == sidebar
+      // position. activeId flips to the new id; pendingRenameId arms
+      // inline rename for the matching <SessionRow>; pendingForkSource
+      // carries the source's claude UUID so the very first `pty.spawn`
+      // for newId becomes a `--resume <src> --fork-session --session-id
+      // <new>` invocation in main.
+      set((s) => {
+        const idx = s.sessions.findIndex((x) => x.id === sourceId);
+        const insertAt = idx === -1 ? 0 : idx + 1;
+        const sessions = [
+          ...s.sessions.slice(0, insertAt),
+          copy,
+          ...s.sessions.slice(insertAt),
+        ];
+        return {
+          sessions,
+          activeId: newId,
+          focusedGroupId: null,
+          pendingRenameId: newId,
+          pendingForkSource: { ...s.pendingForkSource, [newId]: sourceId },
+        };
+      });
+      return newId;
+    },
+
+    consumePendingRename: (sessionId) => {
+      set((s) => (s.pendingRenameId === sessionId ? { pendingRenameId: null } : {}));
     },
   };
 }

--- a/src/stores/slices/sessionRuntimeSlice.ts
+++ b/src/stores/slices/sessionRuntimeSlice.ts
@@ -23,11 +23,13 @@ export type SessionRuntimeSlice = Pick<
   RootStore,
   | 'flashStates'
   | 'disconnectedSessions'
+  | 'reloadNonce'
   | '_applySessionState'
   | '_setFlash'
   | '_applyCwdRedirect'
   | '_applyPtyExit'
   | '_clearPtyExit'
+  | 'reloadSession'
 >;
 
 export function createSessionRuntimeSlice(
@@ -39,6 +41,7 @@ export function createSessionRuntimeSlice(
     // initial state
     flashStates: {},
     disconnectedSessions: {},
+    reloadNonce: {},
 
     _applySessionState: (sid, state) => {
       set((s) => {
@@ -94,6 +97,37 @@ export function createSessionRuntimeSlice(
         const next = { ...s.disconnectedSessions };
         delete next[sid];
         return { disconnectedSessions: next };
+      });
+    },
+
+    reloadSession: async (sid) => {
+      // Kill the current pty (best-effort — it may already be exiting,
+      // in which case `kill` resolves with `ok: false` which we ignore).
+      // The renderer's preload bridge swallows IPC errors via `.catch()`
+      // pattern at other call sites; we mirror that here.
+      try {
+        await window.ccsmPty?.kill(sid);
+      } catch {
+        /* renderer started without preload (tests) — no-op */
+      }
+      // Drop any stale exit-classification entry from the previous pty
+      // so the sidebar red dot doesn't linger across the reload window
+      // (the new pty's attach effect will also clearPtyExit on success,
+      // but doing it eagerly here avoids a brief flash for crashed-then-
+      // reload-to-recover sequences).
+      set((s) => {
+        const nextDisc = s.disconnectedSessions[sid]
+          ? (() => {
+              const next = { ...s.disconnectedSessions };
+              delete next[sid];
+              return next;
+            })()
+          : s.disconnectedSessions;
+        const cur = s.reloadNonce[sid] ?? 0;
+        return {
+          disconnectedSessions: nextDisc,
+          reloadNonce: { ...s.reloadNonce, [sid]: cur + 1 },
+        };
       });
     },
   };

--- a/src/stores/slices/sessionTitleBackfillSlice.ts
+++ b/src/stores/slices/sessionTitleBackfillSlice.ts
@@ -4,9 +4,14 @@
 //
 // Owned actions:
 //   `_applyExternalTitle` — patch a session's `name` from an external
-//      source (SDK title bridge IPC, or `_backfillTitles` below). Stable
-//      no-op if the name already matches so we don't churn the persisted
-//      snapshot or trigger unnecessary re-renders.
+//      source (SDK title bridge IPC, or `_backfillTitles` below).
+//      First-write-wins: only overwrites the default placeholder
+//      (`'New session'` etc.). Once a session has a real name (auto
+//      from the first turn's OSC title, backfilled summary, or user
+//      rename) subsequent external titles are dropped — claude TUI
+//      rewrites the window title every prompt, so without this guard
+//      the session name flickers turn-to-turn. Stable no-op if the
+//      name already matches.
 //   `_backfillTitles` — one-shot post-hydrate pass that pulls
 //      per-project summaries from the SDK and renames any sessions still
 //      stuck on a default name (`'New session'` etc.).
@@ -37,8 +42,7 @@ export function createSessionTitleBackfillSlice(
       // fire `title-changed` with the pre-rename summary; without this
       // guard the user's name flicks back. Clear the guard once we observe
       // an external title equal to the desired name — that proves the
-      // round-trip landed and future external changes (e.g. claude
-      // `/title`) should apply normally.
+      // round-trip landed.
       const desired = getPendingManualRename(sid);
       if (desired !== undefined) {
         if (title !== desired) return;
@@ -47,7 +51,18 @@ export function createSessionTitleBackfillSlice(
       set((s) => {
         const idx = s.sessions.findIndex((x) => x.id === sid);
         if (idx === -1) return s;
-        if (s.sessions[idx]!.name === title) return s;
+        const cur = s.sessions[idx]!.name;
+        if (cur === title) return s;
+        // First-write-wins on auto naming. The OSC title sniffer in
+        // ptyHost emits a fresh title every time the user types a new
+        // prompt (claude TUI rewrites the window title each turn);
+        // before this guard the session name flickered between turns
+        // and any user rename downstream of the initial backfill could
+        // be clobbered by the next turn. Only allow external titles to
+        // overwrite the *default* placeholder; once the row carries a
+        // real name (auto-named on the first turn, or user-renamed via
+        // `renameSession`) external titles are dropped.
+        if (!BACKFILL_DEFAULT_NAMES.has(cur)) return s;
         const next = s.sessions.slice();
         next[idx] = { ...next[idx]!, name: title };
         return { ...s, sessions: next };

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -85,6 +85,19 @@ export type State = {
    * Not persisted — purely a transient nudge for the attach hook.
    */
   reloadNonce: Record<string, number>;
+  /** Transient UI signal: when a session is freshly copied (`copySession`),
+   *  this holds its id so the matching `<SessionRow>` mounts directly into
+   *  inline-rename mode. Cleared by the row after it consumes the flag, or
+   *  by any subsequent `selectSession` to a different id. */
+  pendingRenameId: string | null;
+  /** Map newSid → source ccsm sid for sessions created via `copySession`.
+   *  `usePtyAttach` reads it on the very first `pty.spawn` for a given sid
+   *  and threads the source through to main so the spawn args become
+   *  `--resume <srcUuid> --fork-session --session-id <newUuid>`. The entry
+   *  is cleared the moment the spawn IPC is dispatched so subsequent
+   *  re-attach / Retry paths fall back to the normal `--session-id` flow
+   *  (the JSONL exists by then so `--resume` will pick it up). */
+  pendingForkSource: Record<string, string>;
 };
 
 export type Actions = {
@@ -128,6 +141,18 @@ export type Actions = {
   setSessionModel: (sessionId: string, model: ModelId) => void;
   archiveSession: (sessionId: string) => void;
   unarchiveSession: (sessionId: string) => void;
+  /** Right-click "Copy session" — fork a session in place. Creates a new
+   *  Session row with the source's group/cwd/model, name `<source> (copy)`,
+   *  selects it, sets `pendingRenameId` so the new row enters inline rename,
+   *  and registers the source in `pendingForkSource` so the renderer's
+   *  `pty.spawn(newSid, …)` IPC carries `forkSourceSid` and main spawns
+   *  `claude --resume <srcUuid> --fork-session --session-id <newUuid>` —
+   *  i.e. the new session boots with the source's full transcript context
+   *  but writes to its own JSONL. Returns the new session id (or null when
+   *  the source isn't found). */
+  copySession: (sourceId: string) => string | null;
+  /** Clear `pendingRenameId` once a SessionRow has consumed it. */
+  consumePendingRename: (sessionId: string) => void;
 
   // appearance
   setTheme: (theme: Theme) => void;

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -17,6 +17,14 @@ export type Theme = 'system' | 'light' | 'dark';
 export type FontSize = 'sm' | 'md' | 'lg';
 export type FontSizePx = 12 | 13 | 14 | 15 | 16;
 
+/** Terminal scrollback line cap. Single user-facing knob for both the
+ *  visible xterm (next-launch effect) and the headless authoritative buffer
+ *  in main (next-spawn effect). Range enforced by `sanitizeScrollbackLines`
+ *  (mirrors the main-side `parseScrollbackLines`). */
+export const SCROLLBACK_LINES_DEFAULT = 1500;
+export const SCROLLBACK_LINES_MIN = 100;
+export const SCROLLBACK_LINES_MAX = 50000;
+
 export type EndpointKind =
   | 'anthropic'
   | 'openai-compat'
@@ -61,6 +69,7 @@ export type State = {
   theme: Theme;
   fontSize: FontSize;
   fontSizePx: FontSizePx;
+  scrollbackLines: number;
   flashStates: Record<string, boolean>;
   hydrated: boolean;
   installerCorrupt: boolean;
@@ -111,6 +120,7 @@ export type Actions = {
   setTheme: (theme: Theme) => void;
   setFontSize: (size: FontSize) => void;
   setFontSizePx: (px: FontSizePx) => void;
+  setScrollbackLines: (n: number) => void;
   setSidebarWidth: (px: number) => void;
   resetSidebarWidth: () => void;
 

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -74,7 +74,6 @@ export type State = {
   hydrated: boolean;
   installerCorrupt: boolean;
   openPopoverId: string | null;
-  lastUsedCwd: string | null;
   disconnectedSessions: Record<
     string,
     { kind: 'clean' | 'crashed'; code: number | null; signal: string | number | null; at: number }

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -78,6 +78,13 @@ export type State = {
     string,
     { kind: 'clean' | 'crashed'; code: number | null; signal: string | number | null; at: number }
   >;
+  /**
+   * Per-session counter bumped by `reloadSession()` to force the
+   * `usePtyAttach` effect to re-run for an unchanged sid (kill the
+   * current pty, then re-spawn via the existing spawn-on-null fallback).
+   * Not persisted — purely a transient nudge for the attach hook.
+   */
+  reloadNonce: Record<string, number>;
 };
 
 export type Actions = {
@@ -102,6 +109,13 @@ export type Actions = {
     payload: { code: number | null; signal: string | number | null }
   ) => void;
   _clearPtyExit: (sid: string) => void;
+  /**
+   * Right-click "Reload session" — kill the current pty and bump the
+   * per-session reload nonce so the `usePtyAttach` effect re-runs and
+   * spawns a fresh pty (via the existing spawn-on-null fallback).
+   * Used to pick up env / config changes that require a new claude process.
+   */
+  reloadSession: (sid: string) => Promise<void>;
   _backfillTitles: () => Promise<void>;
   deleteSession: (id: string) => SessionSnapshot | null;
   restoreSession: (snapshot: SessionSnapshot) => void;

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -9,6 +9,7 @@ import {
   createAppearanceSlice,
   legacyFontSizeToPx,
   sanitizeFontSizePx,
+  sanitizeScrollbackLines,
   resolvePersistedSidebarWidth,
 } from './slices/appearanceSlice';
 import { createInstallerSlice } from './slices/installerSlice';
@@ -72,6 +73,19 @@ export async function hydrateStore(): Promise<void> {
   // an empty string that flashes for one tick.
   await hydrateDrafts();
   const persisted = await loadPersisted();
+  // Terminal scrollback cap lives in its own app_state row (keyed
+  // `scrollbackLines`) — the SAME row the main process reads via
+  // `electron/prefs/scrollback.ts`, so renderer + main agree on a single
+  // user-facing value. Read it here (before flipping `hydrated`) so the
+  // very first `ensureTerminal()` call in TerminalPane sees the correct
+  // cap. Best-effort — falls back to the slice's default on any failure.
+  let persistedScrollback: number | null = null;
+  try {
+    const raw = await window.ccsm?.loadState('scrollbackLines');
+    if (raw != null) persistedScrollback = sanitizeScrollbackLines(raw);
+  } catch {
+    /* default already in the slice */
+  }
   if (persisted) {
     const stillActive = persisted.sessions.some((s) => s.id === persisted.activeId);
     // Migration: older snapshots may carry `model`, `permission`, and
@@ -90,6 +104,9 @@ export async function hydrateStore(): Promise<void> {
         ? sanitizeFontSizePx(persisted.fontSizePx)
         : legacyFontSizeToPx(persisted.fontSize ?? 'md'),
     });
+  }
+  if (persistedScrollback !== null) {
+    useStore.setState({ scrollbackLines: persistedScrollback });
   }
   // Flip `hydrated` BEFORE kicking off the deferred IPCs below — components
   // that gate their first paint on this can stop showing skeleton state the

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -167,22 +167,6 @@ export async function hydrateStore(): Promise<void> {
           claudeSettingsDefaultModel: typeof defaultModel === 'string' ? defaultModel : null,
         });
       }
-      // Seed `lastUsedCwd` from the ccsm-owned `userCwds` LRU so the very
-      // first `+` click after launch already lands in the user's most
-      // recent project. Without this, the first session of every boot
-      // would silently fall back to home and re-train the picker. Skip
-      // when the only entry is `userHome` — that's the empty-LRU sentinel
-      // (`getUserCwds()` always appends home), which means "no real
-      // pick", so we leave `lastUsedCwd` null and let createSession use
-      // userHome via the explicit fallback.
-      if (api?.userCwds?.get) {
-        const list = await api.userCwds.get().catch(() => [] as string[]);
-        const head = Array.isArray(list) && list.length > 0 ? list[0] : null;
-        const home = useStore.getState().userHome;
-        if (head && head !== home) {
-          useStore.setState({ lastUsedCwd: head });
-        }
-      }
     } catch {
       /* IPC unavailable — boot continues with empty defaults */
     }

--- a/src/terminal/usePtyAttach.ts
+++ b/src/terminal/usePtyAttach.ts
@@ -161,9 +161,34 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
           | { cols: number; rows: number; pid: number }
           | null;
         if (!res) {
-          const spawnResult = (await pty.spawn(sessionId, cwd ?? '')) as
+          // Right-click "Copy session" → `copySession` registers the source
+          // sid in `pendingForkSource[newSid]`. Read it BEFORE we hand off
+          // to the spawn IPC; main turns it into `--resume <src>
+          // --fork-session --session-id <new>` so the new pty boots with
+          // the source's transcript context. Pass `undefined` for the
+          // common (non-fork) path so `pty.spawn`'s 3rd arg stays absent
+          // over the wire (matches the pre-fork IPC shape exactly when no
+          // copy is in flight).
+          const forkSourceSid =
+            useStore.getState().pendingForkSource[sessionId] ?? undefined;
+          const spawnResult = (await pty.spawn(sessionId, cwd ?? '', forkSourceSid)) as
             | { ok: true; sid: string; pid: number; cols: number; rows: number }
             | { ok: false; error: string };
+          // Clear the fork marker regardless of spawn outcome. On success
+          // the JSONL now exists, so any subsequent re-spawn (Retry, new
+          // session row mount) takes the normal `--resume` branch in
+          // `entryFactory`. On failure we don't want to re-fire `--fork-
+          // session` against a CLI that just rejected it — Retry should
+          // attempt a clean `--session-id` spawn so the user isn't stuck
+          // in a fork loop.
+          if (forkSourceSid) {
+            useStore.setState((s) => {
+              if (!s.pendingForkSource[sessionId]) return {};
+              const next = { ...s.pendingForkSource };
+              delete next[sessionId];
+              return { pendingForkSource: next };
+            });
+          }
           if (!spawnResult || spawnResult.ok === false) {
             const reason =
               spawnResult && spawnResult.ok === false ? spawnResult.error : 'spawn_failed';

--- a/src/terminal/usePtyAttach.ts
+++ b/src/terminal/usePtyAttach.ts
@@ -60,6 +60,11 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
   const requestedSidRef = useRef<string>(sessionId);
   // Bumped by Retry to force the attach effect to re-run for the same sid.
   const [attachNonce, setAttachNonce] = useState(0);
+  // Right-click "Reload session" — the slice action `reloadSession` kills
+  // the pty and bumps this nonce, which we read here so the attach effect
+  // re-runs and walks the spawn-on-null fallback for a fresh pty. Same
+  // re-attach semantics as Retry, just with an external trigger.
+  const reloadNonce = useStore((s) => s.reloadNonce?.[sessionId] ?? 0);
 
   // Attach effect: on sessionId change (or Retry), detach the previous
   // session, reset the terminal, attach the new one, and wire data flow.
@@ -442,7 +447,10 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
       }
     };
     // attachNonce is intentional: bumping it re-runs the attach for Retry.
-  }, [sessionId, attachNonce, cwd]);
+    // reloadNonce is intentional: bumping it (via `reloadSession` after a
+    // pty.kill) re-runs the attach so the spawn-on-null fallback brings
+    // up a fresh pty for the same sid (env / config refresh).
+  }, [sessionId, attachNonce, reloadNonce, cwd]);
 
   // pty:exit subscription for the active session → flip to exit state with
   // a classification (clean vs crashed) shared with the store via

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -130,6 +130,30 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
     allowProposedApi: true,
     scrollback,
     theme: { background: '#000000' },
+    // Wheel-scroll tuning. xterm's `Viewport.getLinesScrolled` multiplies
+    // `event.deltaY` by `scrollSensitivity` BEFORE dividing by row height
+    // (~17px at our 13px font), so a Windows precision-mouse / touchpad
+    // notch reporting `deltaY` in the 100–400px range with the default
+    // sensitivity of 1 lands the user 6–25 lines down per notch — "a
+    // light flick scrolls to the middle of the page" reported in dogfood.
+    // 0.5 brings a ~120px notch back to ~3 lines, matching a native CLI
+    // terminal's feel without making intentional fast scrolls sluggish
+    // (the Alt modifier still gives 5x for long jumps).
+    //
+    // 0.5 is also safe for low-deltaY trackpads: xterm's Viewport keeps a
+    // `_wheelPartialScroll %= 1` accumulator (Viewport.ts:360-362) that
+    // carries the sub-row remainder across wheel events, so a trackpad
+    // emitting `deltaY` in the 4–10px range still scrolls smoothly — the
+    // partial line just lands on the next event instead of being dropped.
+    //
+    // `fastScrollSensitivity` and `fastScrollModifier` are pinned to their
+    // current xterm defaults explicitly — manager-pinned to defend against
+    // upstream default drift; if a future xterm starts treating
+    // `fastScrollModifier: 'alt'` as default-fast, the runaway scroll
+    // returns silently.
+    scrollSensitivity: 0.5,
+    fastScrollSensitivity: 5,
+    fastScrollModifier: 'alt',
   });
   fit = new FitAddon();
   term.loadAddon(fit);

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -97,6 +97,49 @@ export function setSnapshotReplay(fn: (() => Promise<void>) | null): void {
 }
 
 /**
+ * Task #42 — image-first paste pipeline (shared by every paste path:
+ * capture-phase DOM event in `ensureTerminal`, Ctrl/Cmd+V keydown via
+ * `pasteFromClipboard`, right-click via `terminalPaste`).
+ *
+ * Why image-first: on Windows, `clipboard.readText()` is unreliable when
+ * the clipboard also holds an image (returns empty / stale text), but
+ * `readImage().isEmpty()` IS reliable. So we ask main "is there an image"
+ * first; if yes, main writes it under `<userData>/clipboard-images/` and
+ * returns the absolute path, which we inject into the PTY. Claude reads
+ * files by path, so this turns a pasted screenshot into "claude can see
+ * the screenshot" with no extra user steps.
+ *
+ * `fallbackText` is read by the caller synchronously (clipboardData for
+ * the capture-phase listener; `clipboard.readText()` for the keyboard /
+ * right-click paths) so the text survives the async hop to main.
+ *
+ * Returns the promise so callers that need to sequence after the paste
+ * (currently only tests) can await; production paste paths fire-and-forget
+ * via `void`.
+ */
+export async function pasteIntoActivePty(fallbackText: string | undefined): Promise<void> {
+  // N1 race fix (reviewer): snapshot `activeSid` BEFORE the async IPC hop.
+  // `saveClipboardImage` round-trips to main; the user can switch sessions
+  // during that window. Without this snapshot, the saved image path (or
+  // fallback text) would land in whichever session happens to be active
+  // when the promise resolves — i.e. the wrong one. Bind the target sid
+  // at intent time so the inject always goes to the session the user was
+  // looking at when they hit paste.
+  const sid = activeSid;
+  if (!sid) return;
+  try {
+    const imagePath = await window.ccsmPty?.saveClipboardImage?.();
+    if (imagePath) {
+      window.ccsmPty.input(sid, imagePath);
+      return;
+    }
+  } catch {
+    // best-effort — fall through to text paste on IPC failure.
+  }
+  if (fallbackText) window.ccsmPty.input(sid, fallbackText);
+}
+
+/**
  * Create (or re-attach) the singleton Terminal against `host`. Idempotent:
  * subsequent calls reuse the cached instance and only re-`open` if React
  * remounted into a different DOM node.
@@ -248,6 +291,10 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
   // versions then dispatch a native `paste` event a moment later;
   // the keydown handler sets `keyboardPasteHandled` so this listener
   // discards that follow-up event and we paste exactly once.
+  // Task #42 — image-first paste pipeline. See `pasteIntoActivePty` at
+  // module scope: every paste path (capture-phase DOM event, Ctrl/Cmd+V
+  // keydown, right-click `terminalPaste`) funnels through that helper so
+  // pasted screenshots auto-save and inject as a path.
   const onPasteCapture = (e: ClipboardEvent): void => {
     e.stopImmediatePropagation();
     e.preventDefault();
@@ -255,14 +302,10 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
       keyboardPasteHandled = false;
       return;
     }
-    const text = e.clipboardData?.getData('text/plain');
-    if (text && activeSid) {
-      try {
-        window.ccsmPty.input(activeSid, text);
-      } catch {
-        // best-effort — write can fail if PTY isn't attached.
-      }
-    }
+    // Read text synchronously: clipboardData is only valid during the
+    // event dispatch, so we can't await before reading it.
+    const text = e.clipboardData?.getData('text/plain') ?? '';
+    void pasteIntoActivePty(text || undefined);
   };
   host.addEventListener('paste', onPasteCapture, { capture: true });
 
@@ -293,12 +336,15 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
     // setTimeout 0 task lands AFTER the native paste dispatch, so the
     // capture listener sees the flag and suppresses.
     setTimeout(() => { keyboardPasteHandled = false; }, 0);
+    let text: string | undefined;
     try {
-      const text = window.ccsmPty?.clipboard?.readText();
-      if (text && activeSid) window.ccsmPty.input(activeSid, text);
+      text = window.ccsmPty?.clipboard?.readText() || undefined;
     } catch {
       // best-effort — clipboard read can fail under permission edge cases.
     }
+    // Task #42 — route through the image-first helper so a copied
+    // screenshot lands as a file path rather than empty text.
+    void pasteIntoActivePty(text);
   };
 
   // Copy/paste keyboard shortcuts (Windows Terminal style):
@@ -441,10 +487,13 @@ export function terminalPaste(): void {
   setTimeout(() => {
     keyboardPasteHandled = false;
   }, 0);
+  let text: string | undefined;
   try {
-    const text = window.ccsmPty?.clipboard?.readText();
-    if (text) window.ccsmPty.input(activeSid, text);
+    text = window.ccsmPty?.clipboard?.readText() || undefined;
   } catch {
     // best-effort — clipboard read can fail under permission edge cases.
   }
+  // Task #42 — route through the image-first helper so right-click on a
+  // copied screenshot lands as a file path rather than empty text.
+  void pasteIntoActivePty(text);
 }

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -4,6 +4,8 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import { ClipboardAddon } from '@xterm/addon-clipboard';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { CanvasAddon } from '@xterm/addon-canvas';
+import { useStore } from '../stores/store';
+import { SCROLLBACK_LINES_DEFAULT } from '../stores/slices/types';
 
 // Module-scope singleton state for the renderer's xterm view.
 //
@@ -111,12 +113,22 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
     return term;
   }
 
+  // The scrollback cap is read ONCE at construction. Changing the user
+  // setting after the singleton exists does not retroactively resize the
+  // visible buffer (xterm.js doesn't expose a mutable scrollback setter),
+  // so the SettingsDialog helper text says "applies on next launch". Read
+  // synchronously from the zustand store, which `hydrateStore()` populates
+  // from db:load before TerminalPane mounts (App.tsx gates on `hydrated`).
+  // Falls back to the default constant if the store somehow isn't ready
+  // yet (e.g. test mounts that bypass hydrate).
+  const scrollback =
+    useStore.getState().scrollbackLines ?? SCROLLBACK_LINES_DEFAULT;
   term = new Terminal({
     fontFamily: 'Cascadia Mono, Consolas, "Courier New", monospace',
     fontSize: 13,
     cursorBlink: true,
     allowProposedApi: true,
-    scrollback: 5000,
+    scrollback,
     theme: { background: '#000000' },
   });
   fit = new FitAddon();

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -304,6 +304,9 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
   // Copy/paste keyboard shortcuts (Windows Terminal style):
   //   Ctrl+C  → if selection, copy; else fall through to SIGINT
   //   Ctrl+V  → paste (single canonical path, see above)
+  //   Ctrl+A  → select-all (xterm has no built-in; we wire it here so the
+  //             keyboard offers parity with the previous native context
+  //             menu's "Select All" item)
   //   Ctrl+Shift+C / Ctrl+Shift+V → explicit always-clipboard
   // On macOS the same handler matches Cmd via `metaKey`.
   term.attachCustomKeyEventHandler((ev) => {
@@ -312,7 +315,21 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
     if (!mod || ev.altKey) return true;
     const isC = ev.key === 'C' || ev.key === 'c';
     const isV = ev.key === 'V' || ev.key === 'v';
+    const isA = ev.key === 'A' || ev.key === 'a';
 
+    if (!ev.shiftKey && isA) {
+      // Ctrl/Cmd+A → select-all. xterm has no built-in keybinding for
+      // this, and removing the native right-click "Select All" item (in
+      // favor of native CLI right-click behavior) leaves the user with
+      // no other entry point. Returning `false` keeps xterm from also
+      // translating the keystroke into a 0x01 SOH control byte.
+      try {
+        term?.selectAll();
+      } catch {
+        // ignore — best-effort.
+      }
+      return false;
+    }
     if (!ev.shiftKey && isC) {
       const sel = term?.getSelection();
       if (sel) {
@@ -374,5 +391,60 @@ export function __resetSingletonForTests(): void {
   keyboardPasteHandled = false;
   if (typeof window !== 'undefined') {
     delete window.__ccsmTerm;
+  }
+}
+
+/**
+ * Right-click handlers — called from `TerminalPane`'s `onContextMenu` to
+ * implement native CLI/terminal behavior (Windows Terminal / gnome-terminal
+ * style): right-click with selection copies + clears, right-click without
+ * selection pastes. No popover, ever.
+ *
+ * `terminalCopy` returns `true` iff a selection existed and was copied
+ * (caller uses this to choose between copy and paste branches without
+ * having to re-read `getSelection`). `clearSelection` happens here too so
+ * the user gets visual feedback that the copy landed.
+ *
+ * `terminalPaste` routes through the same canonical paste sink as the
+ * Ctrl+V keydown hook (see `pasteFromClipboard` block above) — sets the
+ * `keyboardPasteHandled` flag so the capture-phase paste listener
+ * suppresses any follow-up native paste event, reads clipboard via
+ * `ccsmPty.clipboard.readText()`, writes via `ccsmPty.input(activeSid)`.
+ *
+ * Both are no-ops when no Terminal exists yet (pane unmounted).
+ */
+export function terminalCopy(): boolean {
+  if (!term) return false;
+  const sel = term.getSelection();
+  if (!sel) return false;
+  try {
+    window.ccsmPty?.clipboard?.writeText(sel);
+  } catch {
+    // ignore — selection still highlights, user can ctrl+c retry.
+  }
+  try {
+    term.clearSelection();
+  } catch {
+    // ignore — visual feedback is best-effort.
+  }
+  return true;
+}
+
+export function terminalPaste(): void {
+  if (!term || !activeSid) return;
+  // Reuse the same handoff flag the keydown handler uses; the capture-phase
+  // paste listener installed in `ensureTerminal` checks it to suppress a
+  // duplicate inject from any browser-dispatched follow-up `paste` event.
+  // `setTimeout(0)` (NOT `queueMicrotask`) — see comment on
+  // `pasteFromClipboard` inside ensureTerminal.
+  keyboardPasteHandled = true;
+  setTimeout(() => {
+    keyboardPasteHandled = false;
+  }, 0);
+  try {
+    const text = window.ccsmPty?.clipboard?.readText();
+    if (text) window.ccsmPty.input(activeSid, text);
+  } catch {
+    // best-effort — clipboard read can fail under permission edge cases.
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { CLAUDE_CODE_AGENT_ID } from './shared/agentIds';
+
 // Renderer-side UI display state for `Session.state` — a 2-state model
 // derived from the 3-state IPC vocabulary. The mapping CLI/IPC →
 // renderer lives in `src/agent/lifecycle.ts:mapState`:
@@ -14,7 +16,10 @@ export type SessionState = 'idle' | 'waiting';
 
 // MVP scope is single-agent. Keeping this as a discriminated string lets us
 // add 'codex' / 'gemini' later without touching call sites that just key off it.
-export type AgentType = 'claude-code';
+//
+// The wire value is owned by `src/shared/agentIds.ts` (cross-boundary so
+// main + renderer + DB-migration code agree on the persisted string).
+export type AgentType = typeof CLAUDE_CODE_AGENT_ID;
 
 export interface Session {
   id: string;

--- a/tests/app-effects/useSessionNameBridge.test.tsx
+++ b/tests/app-effects/useSessionNameBridge.test.tsx
@@ -25,7 +25,7 @@ describe('useSessionNameBridge', () => {
     expect(setName).toHaveBeenCalledWith('s2', null);
   });
 
-  it('emits null clear for sids that disappear between renders', () => {
+  it('emits null clear for sids that disappear between renders, without re-emitting unchanged names', () => {
     const { rerender } = renderHook(
       ({ list }: { list: Array<{ id: string; name?: string | null }> }) =>
         useSessionNameBridge(list),
@@ -40,9 +40,48 @@ describe('useSessionNameBridge', () => {
     );
     setName.mockClear();
     rerender({ list: [{ id: 's1', name: 'Alpha' }] });
-    // s1 re-emitted, s2 cleared.
-    expect(setName).toHaveBeenCalledWith('s1', 'Alpha');
+    // s2 cleared. s1 is NOT re-emitted because its name didn't change —
+    // re-emitting on every render would fire one IPC per session per JSONL
+    // state toggle, which is the perf regression this diff guards against.
     expect(setName).toHaveBeenCalledWith('s2', null);
+    expect(setName).not.toHaveBeenCalledWith('s1', 'Alpha');
+  });
+
+  it('only IPCs for sids whose name actually changed', () => {
+    const { rerender } = renderHook(
+      ({ list }: { list: Array<{ id: string; name?: string | null }> }) =>
+        useSessionNameBridge(list),
+      {
+        initialProps: {
+          list: [
+            { id: 's1', name: 'Alpha' },
+            { id: 's2', name: 'Beta' },
+          ],
+        },
+      }
+    );
+    setName.mockClear();
+    // Rerender with a NEW array reference but identical contents — this is
+    // the hot path when the store toggles a different session's `state`
+    // field. Zero IPCs expected.
+    rerender({
+      list: [
+        { id: 's1', name: 'Alpha' },
+        { id: 's2', name: 'Beta' },
+      ],
+    });
+    expect(setName).not.toHaveBeenCalled();
+
+    // Rename s2 only — exactly one IPC, for s2.
+    setName.mockClear();
+    rerender({
+      list: [
+        { id: 's1', name: 'Alpha' },
+        { id: 's2', name: 'Beta renamed' },
+      ],
+    });
+    expect(setName).toHaveBeenCalledTimes(1);
+    expect(setName).toHaveBeenCalledWith('s2', 'Beta renamed');
   });
 
   it('is a no-op when the bridge is missing', () => {

--- a/tests/components/ImportDialog.test.tsx
+++ b/tests/components/ImportDialog.test.tsx
@@ -1,0 +1,400 @@
+// UT for src/components/ImportDialog.tsx — covers the multi-step picker UI
+// that wraps electron/import-scanner.ts output. Mocks the store and
+// `window.ccsm.scanImportable` so the file exercises pure dialog state +
+// the importSession action contract.
+//
+// Coverage targets the import-flow data contract:
+//   1. Loading state while scan promise is pending
+//   2. Empty / error scanner result → empty-state copy
+//   3. Toggling rows, toggling whole buckets, select-all / deselect-all
+//   4. Bucket collapse / expand
+//   5. Selecting a row → enables the primary button + updates the count
+//   6. Submit → fans out one importSession() call per picked row, passing
+//      cwd / title / projectDir / resumeSessionId verbatim
+//   7. Submit → routes into focused group when one is selected
+//   8. Submit → creates the "Imported" group when none focused + bucket missing
+//   9. Submit → closes the dialog via onOpenChange(false)
+//  10. Already-known sessions are filtered out before display
+import React from 'react';
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, act, within } from '@testing-library/react';
+import { ImportDialog } from '../../src/components/ImportDialog';
+
+// ---- Store mock -----------------------------------------------------------
+// ImportDialog reads via `useStore((s) => s.field)` — we mock the hook to
+// pull from a shared mutable state container so each test can preset
+// fixtures (sessions, groups, focusedGroupId) and then introspect the
+// action calls the component fires.
+
+type ScannableRow = {
+  sessionId: string;
+  cwd: string;
+  title: string;
+  mtime: number;
+  projectDir: string;
+  model: string | null;
+};
+
+type StoreShape = {
+  sessions: Array<{ id: string }>;
+  groups: Array<{ id: string; name: string; kind: 'normal' | 'archive' }>;
+  focusedGroupId: string | null;
+  importSession: ReturnType<typeof vi.fn>;
+  createGroup: ReturnType<typeof vi.fn>;
+  renameGroup: ReturnType<typeof vi.fn>;
+};
+
+const storeState: StoreShape = {
+  sessions: [],
+  groups: [],
+  focusedGroupId: null,
+  importSession: vi.fn(),
+  createGroup: vi.fn(),
+  renameGroup: vi.fn(),
+};
+
+vi.mock('../../src/stores/store', () => ({
+  useStore: <T,>(selector: (s: StoreShape) => T): T => selector(storeState),
+}));
+
+// ---- Bridge mock ----------------------------------------------------------
+function installBridge(scan: () => Promise<ScannableRow[]>) {
+  const api = { scanImportable: vi.fn(scan) };
+  (window as unknown as { ccsm: unknown }).ccsm = api;
+  return api;
+}
+
+function deferredScan(): { promise: Promise<ScannableRow[]>; resolve: (r: ScannableRow[]) => void; reject: (e: unknown) => void } {
+  let resolve!: (r: ScannableRow[]) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<ScannableRow[]>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function row(over: Partial<ScannableRow> = {}): ScannableRow {
+  return {
+    sessionId: over.sessionId ?? 'sid-' + Math.random().toString(36).slice(2, 8),
+    cwd: over.cwd ?? '/Users/foo/proj',
+    title: over.title ?? 'Some title',
+    mtime: over.mtime ?? Date.now(),
+    projectDir: over.projectDir ?? '-Users-foo-proj',
+    model: over.model ?? null,
+  };
+}
+
+beforeEach(() => {
+  storeState.sessions = [];
+  storeState.groups = [];
+  storeState.focusedGroupId = null;
+  storeState.importSession = vi.fn();
+  storeState.createGroup = vi.fn(() => 'g-created');
+  storeState.renameGroup = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  delete (window as unknown as { ccsm?: unknown }).ccsm;
+});
+
+// ---- Helpers --------------------------------------------------------------
+async function renderOpen(rows: ScannableRow[]) {
+  installBridge(() => Promise.resolve(rows));
+  const onOpenChange = vi.fn();
+  await act(async () => {
+    render(<ImportDialog open onOpenChange={onOpenChange} />);
+    // Flush the scan promise.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+  return { onOpenChange };
+}
+
+describe('<ImportDialog />', () => {
+  it('shows the loading copy while the scan promise is pending', async () => {
+    const d = deferredScan();
+    installBridge(() => d.promise);
+    render(<ImportDialog open onOpenChange={vi.fn()} />);
+    // Synchronous: useEffect kicks off the scan, loading=true is set
+    // before the promise resolves. The mocked-i18n 'en' bundle uses
+    // 'Scanning…' for this key.
+    expect(screen.getByText(/Scanning/i)).toBeInTheDocument();
+
+    await act(async () => {
+      d.resolve([]);
+      await Promise.resolve();
+    });
+  });
+
+  it('shows the empty-state copy when the scanner returns no rows', async () => {
+    await renderOpen([]);
+    expect(screen.getByText(/No importable transcripts/i)).toBeInTheDocument();
+    expect(screen.getByText('~/.claude/projects/')).toBeInTheDocument();
+  });
+
+  it('shows the empty-state copy when the scanner promise rejects', async () => {
+    installBridge(() => Promise.reject(new Error('boom')));
+    await act(async () => {
+      render(<ImportDialog open onOpenChange={vi.fn()} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(screen.getByText(/No importable transcripts/i)).toBeInTheDocument();
+  });
+
+  it('renders one row per scanned session with cwd and title visible', async () => {
+    await renderOpen([
+      row({ sessionId: 's1', title: 'First', cwd: '/work/a' }),
+      row({ sessionId: 's2', title: 'Second', cwd: '/work/b' }),
+    ]);
+    expect(screen.getByText('First')).toBeInTheDocument();
+    expect(screen.getByText('Second')).toBeInTheDocument();
+    expect(screen.getByText(/\/work\/a/)).toBeInTheDocument();
+    expect(screen.getByText(/\/work\/b/)).toBeInTheDocument();
+  });
+
+  it('filters out sessions already known to the store', async () => {
+    storeState.sessions = [{ id: 'already-here' }];
+    await renderOpen([
+      row({ sessionId: 'already-here', title: 'Dup' }),
+      row({ sessionId: 'fresh', title: 'New one' }),
+    ]);
+    expect(screen.queryByText('Dup')).not.toBeInTheDocument();
+    expect(screen.getByText('New one')).toBeInTheDocument();
+  });
+
+  it('Select-all checks every row and the count flips to N', async () => {
+    await renderOpen([
+      row({ sessionId: 's1', title: 'one' }),
+      row({ sessionId: 's2', title: 'two' }),
+      row({ sessionId: 's3', title: 'three' }),
+    ]);
+    expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
+    const selectAll = screen.getByRole('button', { name: /select all/i });
+    fireEvent.click(selectAll);
+    expect(screen.getByText(/3 selected/i)).toBeInTheDocument();
+    // Button flips to deselect all.
+    expect(screen.getByRole('button', { name: /deselect all/i })).toBeInTheDocument();
+  });
+
+  it('Deselect-all clears the selection after a full-select', async () => {
+    await renderOpen([
+      row({ sessionId: 's1', title: 'one' }),
+      row({ sessionId: 's2', title: 'two' }),
+    ]);
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    expect(screen.getByText(/2 selected/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /deselect all/i }));
+    expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
+  });
+
+  it('clicking a row toggles its selection', async () => {
+    await renderOpen([row({ sessionId: 's1', title: 'pick me' })]);
+    const li = screen.getByText('pick me').closest('li')!;
+    fireEvent.click(li);
+    expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+    fireEvent.click(li);
+    expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
+  });
+
+  it('the bucket "select group" button picks every row in that bucket', async () => {
+    // Two rows in the same bucket (Today) -> one bucket button "Select group".
+    await renderOpen([
+      row({ sessionId: 's1', title: 'a' }),
+      row({ sessionId: 's2', title: 'b' }),
+    ]);
+    const btn = screen.getByRole('button', { name: /^select group$/i });
+    fireEvent.click(btn);
+    expect(screen.getByText(/2 selected/i)).toBeInTheDocument();
+    // After full bucket selection the button label flips.
+    expect(screen.getByRole('button', { name: /^deselect group$/i })).toBeInTheDocument();
+  });
+
+  it('collapsing a bucket hides its rows', async () => {
+    await renderOpen([row({ sessionId: 's1', title: 'hide me' })]);
+    expect(screen.getByText('hide me')).toBeInTheDocument();
+    const collapseBtn = screen.getByRole('button', { name: /collapse/i });
+    fireEvent.click(collapseBtn);
+    expect(screen.queryByText('hide me')).not.toBeInTheDocument();
+    // Expand label appears in its place.
+    expect(screen.getByRole('button', { name: /expand/i })).toBeInTheDocument();
+  });
+
+  it('primary action is disabled when nothing is selected', async () => {
+    await renderOpen([row({ sessionId: 's1', title: 'x' })]);
+    const importBtn = screen.getByRole('button', { name: /^Import 0$/ });
+    expect((importBtn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('submit fans out one importSession call per selected row with the full payload', async () => {
+    const { onOpenChange } = await renderOpen([
+      row({
+        sessionId: 'sid-A',
+        title: 'titleA',
+        cwd: '/work/a',
+        projectDir: '-work-a',
+      }),
+      row({
+        sessionId: 'sid-B',
+        title: 'titleB',
+        cwd: '/work/b',
+        projectDir: '-work-b',
+      }),
+    ]);
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    const importBtn = screen.getByRole('button', { name: /^Import 2$/ });
+    await act(async () => {
+      fireEvent.click(importBtn);
+      await Promise.resolve();
+    });
+    expect(storeState.importSession).toHaveBeenCalledTimes(2);
+    // Each call payload must carry through cwd / title / projectDir /
+    // resumeSessionId verbatim — this is the contract reviewer locks down.
+    const calls = storeState.importSession.mock.calls.map((c) => c[0]);
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'titleA',
+          cwd: '/work/a',
+          projectDir: '-work-a',
+          resumeSessionId: 'sid-A',
+        }),
+        expect.objectContaining({
+          name: 'titleB',
+          cwd: '/work/b',
+          projectDir: '-work-b',
+          resumeSessionId: 'sid-B',
+        }),
+      ])
+    );
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('routes imports into the focused group when one is selected', async () => {
+    storeState.groups = [
+      { id: 'g-focused', name: 'My Group', kind: 'normal' },
+      { id: 'g-other', name: 'Imported', kind: 'normal' },
+    ];
+    storeState.focusedGroupId = 'g-focused';
+    await renderOpen([row({ sessionId: 's1', title: 'x' })]);
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Import 1$/ }));
+      await Promise.resolve();
+    });
+    expect(storeState.importSession).toHaveBeenCalledWith(
+      expect.objectContaining({ groupId: 'g-focused' })
+    );
+    expect(storeState.createGroup).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the existing "Imported" bucket when no group is focused', async () => {
+    storeState.groups = [
+      { id: 'g-bucket', name: 'Imported', kind: 'normal' },
+      { id: 'g-other', name: 'Other', kind: 'normal' },
+    ];
+    storeState.focusedGroupId = null;
+    await renderOpen([row({ sessionId: 's1', title: 'x' })]);
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Import 1$/ }));
+      await Promise.resolve();
+    });
+    expect(storeState.importSession).toHaveBeenCalledWith(
+      expect.objectContaining({ groupId: 'g-bucket' })
+    );
+    expect(storeState.createGroup).not.toHaveBeenCalled();
+  });
+
+  it('creates an "Imported" group when none exists and nothing is focused', async () => {
+    storeState.groups = []; // no Imported bucket, no focus
+    storeState.focusedGroupId = null;
+    storeState.createGroup = vi.fn(() => 'g-newly-made');
+    await renderOpen([row({ sessionId: 's1', title: 'x' })]);
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Import 1$/ }));
+      await Promise.resolve();
+    });
+    expect(storeState.createGroup).toHaveBeenCalledWith('Imported');
+    expect(storeState.importSession).toHaveBeenCalledWith(
+      expect.objectContaining({ groupId: 'g-newly-made' })
+    );
+  });
+
+  it('ignores a focused archive group (only normal groups receive imports)', async () => {
+    storeState.groups = [
+      { id: 'g-arch', name: 'Old', kind: 'archive' },
+      { id: 'g-bucket', name: 'Imported', kind: 'normal' },
+    ];
+    storeState.focusedGroupId = 'g-arch';
+    await renderOpen([row({ sessionId: 's1', title: 'x' })]);
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Import 1$/ }));
+      await Promise.resolve();
+    });
+    expect(storeState.importSession).toHaveBeenCalledWith(
+      expect.objectContaining({ groupId: 'g-bucket' })
+    );
+  });
+
+  it('submit is a no-op when window.ccsm is missing', async () => {
+    // Render with a bridge so we get past loading, then yank it.
+    await renderOpen([row({ sessionId: 's1', title: 'x' })]);
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    delete (window as unknown as { ccsm?: unknown }).ccsm;
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /^Import 1$/ }));
+      await Promise.resolve();
+    });
+    expect(storeState.importSession).not.toHaveBeenCalled();
+  });
+
+  it('open=false does not trigger a scan', async () => {
+    const api = installBridge(() => Promise.resolve([]));
+    render(<ImportDialog open={false} onOpenChange={vi.fn()} />);
+    expect(api.scanImportable).not.toHaveBeenCalled();
+  });
+
+  it('re-opening (open false → true) clears stale selection and re-scans', async () => {
+    const rows = [row({ sessionId: 's1', title: 'first' })];
+    const api = installBridge(() => Promise.resolve(rows));
+    function Harness() {
+      const [open, setOpen] = React.useState(true);
+      return (
+        <>
+          <button data-testid="reopen" onClick={() => setOpen((v) => !v)}>x</button>
+          <ImportDialog open={open} onOpenChange={setOpen} />
+        </>
+      );
+    }
+    await act(async () => {
+      render(<Harness />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(api.scanImportable).toHaveBeenCalledTimes(1);
+    // Select everything, then close + reopen.
+    fireEvent.click(screen.getByRole('button', { name: /select all/i }));
+    expect(screen.getByText(/1 selected/i)).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reopen')); // close
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('reopen')); // reopen
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(api.scanImportable).toHaveBeenCalledTimes(2);
+    // Selection reset.
+    expect(screen.getByText(/0 selected/i)).toBeInTheDocument();
+  });
+});
+
+// `within` is unused above but pulled in as an extension point — explicit
+// import keeps the lint rule happy if a future test needs scoped queries.
+void within;

--- a/tests/components/TerminalPane.test.tsx
+++ b/tests/components/TerminalPane.test.tsx
@@ -1,0 +1,129 @@
+// Task #41: TerminalPane's native CLI/terminal-emulator right-click
+// behavior. Replaces the global native context menu (Cut/Copy/Paste/
+// SelectAll popup installed in electron/window/createWindow.ts) with
+// immediate inline copy-on-selection / paste-on-empty, mirroring Windows
+// Terminal and gnome-terminal. The host div's `onContextMenu`:
+//   1. preventDefault + stopPropagation on the React event
+//   2. sends `ccsmShell.suppressContextMenuOnce()` so main skips the
+//      native popup (DOM preventDefault does NOT cancel Electron's
+//      main-process `context-menu` event — separate one-shot needed)
+//   3. branches on the selection: copy + clear OR paste
+//
+// All four terminal hooks are mocked to no-ops so the pane mounts
+// without instantiating xterm or attaching to a PTY — the test is
+// strictly about the right-click wiring.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+
+const { copySpy, pasteSpy } = vi.hoisted(() => ({
+  copySpy: vi.fn(),
+  pasteSpy: vi.fn(),
+}));
+
+vi.mock('../../src/terminal/useXtermSingleton', () => ({
+  useXtermSingleton: () => undefined,
+}));
+vi.mock('../../src/terminal/useTerminalResize', () => ({
+  useTerminalResize: () => undefined,
+}));
+vi.mock('../../src/terminal/usePtyAttach', () => ({
+  // Return a `ready` state so the pane doesn't render the Attaching /
+  // Error / Exit overlay layers — they're orthogonal to right-click
+  // and rendering them just adds noise.
+  usePtyAttach: () => ({ state: { kind: 'ready' }, onRetry: vi.fn() }),
+}));
+vi.mock('../../src/terminal/useAtBottom', () => ({
+  useAtBottom: () => ({ atBottom: true, scrollToBottom: vi.fn() }),
+}));
+vi.mock('../../src/terminal/xtermSingleton', () => ({
+  terminalCopy: copySpy,
+  terminalPaste: pasteSpy,
+}));
+vi.mock('../../src/i18n/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+// Skip xterm CSS import in jsdom (jsdom doesn't load CSS anyway, but the
+// import resolver still walks the path).
+vi.mock('@xterm/xterm/css/xterm.css', () => ({}));
+
+import { TerminalPane } from '../../src/components/TerminalPane';
+
+interface MockShell {
+  suppressContextMenuOnce: ReturnType<typeof vi.fn>;
+}
+
+function installShellBridge(): MockShell {
+  const bridge: MockShell = { suppressContextMenuOnce: vi.fn() };
+  (window as unknown as { ccsmShell: MockShell }).ccsmShell = bridge;
+  return bridge;
+}
+
+function fireContextMenuOnHost(container: HTMLElement) {
+  const host = container.querySelector('[data-terminal-host]') as HTMLElement;
+  expect(host).not.toBeNull();
+  // `fireEvent.contextMenu` dispatches a real MouseEvent with the right
+  // type; React's onContextMenu hands the SyntheticEvent through so
+  // preventDefault on the synthetic event reaches the underlying native
+  // event via the React event pool.
+  const result = fireEvent.contextMenu(host);
+  return { host, result };
+}
+
+describe('TerminalPane right-click (Task #41)', () => {
+  beforeEach(() => {
+    copySpy.mockReset();
+    pasteSpy.mockReset();
+    delete (window as unknown as { ccsmShell?: unknown }).ccsmShell;
+  });
+
+  it('copy branch: with selection → terminalCopy, no paste, suppression sent, default prevented', () => {
+    copySpy.mockReturnValue(true);
+    const shell = installShellBridge();
+    const { container } = render(<TerminalPane sessionId="sid-1" cwd="/tmp" />);
+    const host = container.querySelector('[data-terminal-host]') as HTMLElement;
+    // `fireEvent` returns false when the event was preventDefault-ed.
+    const notPrevented = fireEvent.contextMenu(host);
+    expect(notPrevented).toBe(false);
+    expect(copySpy).toHaveBeenCalledTimes(1);
+    expect(pasteSpy).not.toHaveBeenCalled();
+    expect(shell.suppressContextMenuOnce).toHaveBeenCalledTimes(1);
+  });
+
+  it('paste branch: no selection → terminalPaste, suppression sent, default prevented', () => {
+    copySpy.mockReturnValue(false);
+    const shell = installShellBridge();
+    const { container } = render(<TerminalPane sessionId="sid-2" cwd="/tmp" />);
+    const host = container.querySelector('[data-terminal-host]') as HTMLElement;
+    const notPrevented = fireEvent.contextMenu(host);
+    expect(notPrevented).toBe(false);
+    expect(copySpy).toHaveBeenCalledTimes(1);
+    expect(pasteSpy).toHaveBeenCalledTimes(1);
+    expect(shell.suppressContextMenuOnce).toHaveBeenCalledTimes(1);
+  });
+
+  it('survives when ccsmShell bridge is missing (e2e probes / test harnesses)', () => {
+    // Bridge intentionally not installed — the optional-chain in the
+    // handler must keep the copy/paste branching alive.
+    copySpy.mockReturnValue(true);
+    const { container } = render(<TerminalPane sessionId="sid-3" cwd="/tmp" />);
+    const host = container.querySelector('[data-terminal-host]') as HTMLElement;
+    expect(() => fireEvent.contextMenu(host)).not.toThrow();
+    expect(copySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('throwing suppressContextMenuOnce does not block the inline copy/paste', () => {
+    copySpy.mockReturnValue(false);
+    const bridge: MockShell = {
+      suppressContextMenuOnce: vi.fn(() => {
+        throw new Error('IPC unavailable');
+      }),
+    };
+    (window as unknown as { ccsmShell: MockShell }).ccsmShell = bridge;
+    const { container } = render(<TerminalPane sessionId="sid-4" cwd="/tmp" />);
+    const { host } = fireContextMenuOnHost(container);
+    expect(host).toBeTruthy();
+    // Paste still ran despite the IPC throw.
+    expect(pasteSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/fixtures/electronStub.cjs
+++ b/tests/fixtures/electronStub.cjs
@@ -147,6 +147,9 @@ const clipboard = {
   writeText: noop,
   clear: noop,
   has: () => false,
+  // Task #42 — default to an empty image so tests that hit
+  // `pty:saveClipboardImage` get null unless they override the stub.
+  readImage: () => ({ isEmpty: () => true, toPNG: () => Buffer.alloc(0) }),
 };
 const contextBridge = { exposeInMainWorld: noop };
 const webContents = { getAllWebContents: () => [], fromId: () => null };

--- a/tests/settings-scrollback.test.tsx
+++ b/tests/settings-scrollback.test.tsx
@@ -1,0 +1,200 @@
+// Coverage for the terminal scrollback setting in the Appearance pane.
+//
+// Pins:
+//   - The number input renders and reflects the persisted store value.
+//   - Editing the input commits via blur → updates the zustand store
+//     (synchronous renderer-side read for ensureTerminal) AND writes
+//     through window.ccsm.saveState('scrollbackLines', ...) so the main
+//     process pref module sees the new value (via stateSavedBus
+//     invalidation) on next read.
+//   - Clamping enforces the documented MIN/MAX (sanitizeScrollbackLines).
+//   - The reset button restores the documented default.
+//
+// Reverse-verify: stub `setScrollbackLines` to a no-op → `commit` no longer
+// updates the input AND no longer fires saveState — both expectations fail.
+
+import React, { useState } from 'react';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  within,
+  act,
+} from '@testing-library/react';
+import { SettingsDialog } from '../src/components/SettingsDialog';
+import { useStore } from '../src/stores/store';
+import { initI18n } from '../src/i18n';
+import {
+  SCROLLBACK_LINES_DEFAULT,
+  SCROLLBACK_LINES_MAX,
+  SCROLLBACK_LINES_MIN,
+} from '../src/stores/slices/types';
+
+let saveStateSpy: ReturnType<typeof vi.fn>;
+let loadStateSpy: ReturnType<typeof vi.fn>;
+
+function stubCcsm() {
+  saveStateSpy = vi.fn(async () => {});
+  loadStateSpy = vi.fn(async () => undefined);
+  const api = {
+    getVersion: vi.fn(async () => '0.0.0-test'),
+    updatesStatus: vi.fn(async () => ({ kind: 'idle' as const })),
+    updatesGetAutoCheck: vi.fn(async () => true),
+    updatesSetAutoCheck: vi.fn(async (v: boolean) => v),
+    updatesCheck: vi.fn(async () => {}),
+    updatesDownload: vi.fn(async () => {}),
+    updatesInstall: vi.fn(async () => {}),
+    onUpdateStatus: () => () => {},
+    loadState: loadStateSpy,
+    saveState: saveStateSpy,
+    settingsLoad: vi.fn(async () => ({})),
+    settingsOpenInEditor: vi.fn(async () => {}),
+    modelsList: vi.fn(async () => []),
+  };
+  (window as { ccsm?: unknown }).ccsm = api;
+  return api;
+}
+
+function stubMatchMedia() {
+  if (window.matchMedia) return;
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (q: string) => ({
+      matches: false,
+      media: q,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }),
+  });
+}
+
+function Harness() {
+  const [open, setOpen] = useState(true);
+  return (
+    <SettingsDialog open={open} onOpenChange={setOpen} initialTab="appearance" />
+  );
+}
+
+beforeEach(() => {
+  cleanup();
+  stubCcsm();
+  stubMatchMedia();
+  initI18n('en');
+  // Reset the slice's value to default before each test.
+  act(() => {
+    useStore.getState().setScrollbackLines(SCROLLBACK_LINES_DEFAULT);
+  });
+});
+
+afterEach(() => {
+  delete (window as { ccsm?: unknown }).ccsm;
+});
+
+describe('Settings: terminal scrollback', () => {
+  it('renders the scrollback input and label', () => {
+    render(<Harness />);
+    const dialog = screen.getByRole('dialog');
+    // Field label visible.
+    expect(within(dialog).getByText(/Terminal scrollback/i)).toBeInTheDocument();
+    // Input present and reflects current store default.
+    const input = within(dialog).getByLabelText(
+      /Terminal scrollback in lines/i,
+    ) as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe(String(SCROLLBACK_LINES_DEFAULT));
+  });
+
+  it('reflects the current zustand store value at mount', () => {
+    act(() => useStore.getState().setScrollbackLines(2222));
+    render(<Harness />);
+    const input = screen.getByLabelText(
+      /Terminal scrollback in lines/i,
+    ) as HTMLInputElement;
+    expect(input.value).toBe('2222');
+  });
+
+  it('persists the new value on blur via setScrollbackLines + saveState', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText(
+      /Terminal scrollback in lines/i,
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '3500' } });
+    fireEvent.blur(input);
+
+    // Renderer source-of-truth (zustand) updated.
+    expect(useStore.getState().scrollbackLines).toBe(3500);
+    // Through-write to db (main reads from this same row).
+    expect(saveStateSpy).toHaveBeenCalledWith('scrollbackLines', '3500');
+    // Input echoes the sanitized value.
+    expect(input.value).toBe('3500');
+  });
+
+  it('clamps a too-large value to MAX', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText(
+      /Terminal scrollback in lines/i,
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '999999' } });
+    fireEvent.blur(input);
+
+    expect(useStore.getState().scrollbackLines).toBe(SCROLLBACK_LINES_MAX);
+    expect(saveStateSpy).toHaveBeenCalledWith(
+      'scrollbackLines',
+      String(SCROLLBACK_LINES_MAX),
+    );
+    expect(input.value).toBe(String(SCROLLBACK_LINES_MAX));
+  });
+
+  it('clamps a too-small value to MIN', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText(
+      /Terminal scrollback in lines/i,
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '0' } });
+    fireEvent.blur(input);
+
+    expect(useStore.getState().scrollbackLines).toBe(SCROLLBACK_LINES_MIN);
+    expect(input.value).toBe(String(SCROLLBACK_LINES_MIN));
+  });
+
+  it('reset button restores the documented default', () => {
+    act(() => useStore.getState().setScrollbackLines(4242));
+    render(<Harness />);
+    const dialog = screen.getByRole('dialog');
+    // Localized label: "Reset to default ({{default}})".
+    const resetBtn = within(dialog).getByRole('button', {
+      name: /Reset to default/i,
+    });
+    fireEvent.click(resetBtn);
+
+    expect(useStore.getState().scrollbackLines).toBe(SCROLLBACK_LINES_DEFAULT);
+    expect(saveStateSpy).toHaveBeenCalledWith(
+      'scrollbackLines',
+      String(SCROLLBACK_LINES_DEFAULT),
+    );
+  });
+
+  it('Enter key triggers blur which commits the value', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText(
+      /Terminal scrollback in lines/i,
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '2750' } });
+    // jsdom doesn't reliably forward `el.blur()` from a keydown handler
+    // back into a synthetic React onBlur event in this test environment.
+    // Drive the keydown for behavioural coverage of the handler itself
+    // (preventDefault path), then fire the blur directly to verify the
+    // commit pipeline. Production behavior is unchanged: keydown calls
+    // .blur(), the browser fires onBlur, commit runs.
+    fireEvent.keyDown(input, { key: 'Enter' });
+    fireEvent.blur(input);
+    expect(useStore.getState().scrollbackLines).toBe(2750);
+    expect(saveStateSpy).toHaveBeenCalledWith('scrollbackLines', '2750');
+  });
+});

--- a/tests/shared/agentIds.test.ts
+++ b/tests/shared/agentIds.test.ts
@@ -1,0 +1,17 @@
+// Pin the persisted wire value of CLAUDE_CODE_AGENT_ID.
+//
+// The constant is written into the SQLite `sessions.agent_type` column
+// and serialized into prefs / app state. Once shipped, changing the
+// string silently breaks every existing user's data — rows on disk
+// would no longer match the new symbol. This test exists to fail loudly
+// in CI if anyone touches the literal value, including future DB
+// migrations that should reference the constant rather than re-hardcode.
+
+import { describe, it, expect } from 'vitest';
+import { CLAUDE_CODE_AGENT_ID } from '../../src/shared/agentIds';
+
+describe('CLAUDE_CODE_AGENT_ID', () => {
+  it('matches the DB persistence wire value', () => {
+    expect(CLAUDE_CODE_AGENT_ID).toBe('claude-code');
+  });
+});

--- a/tests/sidebar/ArchivedSection.test.tsx
+++ b/tests/sidebar/ArchivedSection.test.tsx
@@ -20,13 +20,27 @@ function renderArchived(props: {
   normalGroups?: Group[];
   sessions?: Session[];
 }) {
+  const sessions = props.sessions ?? [];
+  // Mirror the bucketing the parent <Sidebar> does so the component's new
+  // getSessionsForGroup API matches its production contract.
+  const byGroup = new Map<string, Session[]>();
+  for (const s of sessions) {
+    let bucket = byGroup.get(s.groupId);
+    if (!bucket) {
+      bucket = [];
+      byGroup.set(s.groupId, bucket);
+    }
+    bucket.push(s);
+  }
+  const EMPTY: Session[] = [];
+  const getSessionsForGroup = (gid: string) => byGroup.get(gid) ?? EMPTY;
   return render(
     <ToastProvider>
       <DndContext>
         <ArchivedSection
           archivedGroups={props.archivedGroups}
           normalGroups={props.normalGroups ?? []}
-          sessions={props.sessions ?? []}
+          getSessionsForGroup={getSessionsForGroup}
           activeSessionId=""
           focusedGroupId={null}
           onSelectSession={() => {}}

--- a/tests/sidebar/GroupRow.test.tsx
+++ b/tests/sidebar/GroupRow.test.tsx
@@ -30,7 +30,7 @@ describe('<GroupRow /> (extracted)', () => {
             focused={false}
             anyGroupFocused={false}
             onSelectSession={() => {}}
-            onFocus={() => {}}
+            onFocusGroup={() => {}}
             normalGroups={[group]}
           />
         </DndContext>

--- a/tests/sidebar/SessionRow.test.tsx
+++ b/tests/sidebar/SessionRow.test.tsx
@@ -40,7 +40,7 @@ describe('<SessionRow /> (extracted)', () => {
                 session={session}
                 active={opts.active ?? false}
                 selected={opts.selected ?? false}
-                onSelect={() => {}}
+                onSelectSession={() => {}}
                 normalGroups={[group]}
               />
             </ul>

--- a/tests/sidebar/session-row-dot-selection.test.tsx
+++ b/tests/sidebar/session-row-dot-selection.test.tsx
@@ -54,7 +54,7 @@ describe('<SessionRow /> selection dot — only on active row (#784)', () => {
                   session={s}
                   active={s.id === activeId}
                   selected={s.id === activeId}
-                  onSelect={() => {}}
+                  onSelectSession={() => {}}
                   normalGroups={[group]}
                 />
               ))}

--- a/tests/sidebar/session-row-name.test.tsx
+++ b/tests/sidebar/session-row-name.test.tsx
@@ -43,7 +43,7 @@ describe('<SessionRow /> renders store.name, not id (#788)', () => {
                 session={session}
                 active={false}
                 selected={false}
-                onSelect={() => {}}
+                onSelectSession={() => {}}
                 normalGroups={[group]}
               />
             </ul>

--- a/tests/stores/slices/sessionCrudSlice.test.ts
+++ b/tests/stores/slices/sessionCrudSlice.test.ts
@@ -307,4 +307,76 @@ describe('sessionCrudSlice', () => {
       expect(h.state().sessions).toEqual([]);
     });
   });
+
+  describe('copySession', () => {
+    it('returns null when source does not exist', () => {
+      const h = harness({
+        sessions: [],
+        groups: [{ id: 'g1', name: 'g1', collapsed: false, kind: 'normal' }],
+      });
+      expect(h.sessions.copySession('nope')).toBeNull();
+    });
+
+    it('inserts a `<name> (copy)` row immediately after the source, inheriting cwd/model/group', () => {
+      const h = harness({
+        sessions: [
+          mkSession('a', 'g1', { name: 'before', cwd: '/x' }),
+          mkSession('src', 'g1', { name: 'fork me', cwd: '/picked', model: 'opus' }),
+          mkSession('z', 'g1', { name: 'after' }),
+        ],
+        groups: [{ id: 'g1', name: 'g1', collapsed: false, kind: 'normal' }],
+        pendingForkSource: {},
+      });
+      const newId = h.sessions.copySession('src');
+      expect(newId).toBeTruthy();
+      const ids = h.state().sessions.map((s) => s.id);
+      // Position: directly after `src`, NOT at top — preserves the user's
+      // mental model of "duplicate this row, right here".
+      expect(ids).toEqual(['a', 'src', newId!, 'z']);
+      const copy = h.state().sessions.find((s) => s.id === newId)!;
+      expect(copy.name).toBe('fork me (copy)');
+      expect(copy.cwd).toBe('/picked');
+      expect(copy.model).toBe('opus');
+      expect(copy.groupId).toBe('g1');
+      // The original is untouched — same name, same model.
+      expect(h.state().sessions.find((s) => s.id === 'src')!.name).toBe('fork me');
+    });
+
+    it('flips activeId to the new session, arms pendingRenameId, and registers pendingForkSource', () => {
+      const h = harness({
+        sessions: [mkSession('src', 'g1')],
+        groups: [{ id: 'g1', name: 'g1', collapsed: false, kind: 'normal' }],
+        activeId: 'src',
+        pendingForkSource: {},
+        pendingRenameId: null,
+      });
+      const newId = h.sessions.copySession('src')!;
+      expect(h.state().activeId).toBe(newId);
+      expect(h.state().pendingRenameId).toBe(newId);
+      expect(h.state().pendingForkSource).toEqual({ [newId]: 'src' });
+    });
+
+    it('does NOT carry archivedAt onto the copy (a fresh row is never archived in time)', () => {
+      const h = harness({
+        sessions: [mkSession('src', 'g1', { archivedAt: 12345 })],
+        groups: [{ id: 'g1', name: 'g1', collapsed: false, kind: 'normal' }],
+        pendingForkSource: {},
+      });
+      const newId = h.sessions.copySession('src')!;
+      const copy = h.state().sessions.find((s) => s.id === newId)!;
+      expect(copy.archivedAt).toBeUndefined();
+    });
+
+    it('consumePendingRename only clears when ids match (idempotent)', () => {
+      const h = harness({
+        sessions: [mkSession('a', 'g1')],
+        groups: [{ id: 'g1', name: 'g1', collapsed: false, kind: 'normal' }],
+        pendingRenameId: 'a',
+      });
+      h.sessions.consumePendingRename('b');
+      expect(h.state().pendingRenameId).toBe('a'); // mismatched id — no-op
+      h.sessions.consumePendingRename('a');
+      expect(h.state().pendingRenameId).toBeNull();
+    });
+  });
 });

--- a/tests/stores/slices/sessionCrudSlice.test.ts
+++ b/tests/stores/slices/sessionCrudSlice.test.ts
@@ -57,7 +57,6 @@ describe('sessionCrudSlice', () => {
     expect(s.sessions).toEqual([]);
     expect(s.activeId).toBe('');
     expect(s.focusedGroupId).toBeNull();
-    expect(s.lastUsedCwd).toBeNull();
     expect(s.userHome).toBe('');
     expect(s.claudeSettingsDefaultModel).toBeNull();
   });
@@ -100,18 +99,18 @@ describe('sessionCrudSlice', () => {
     expect(h.state().sessions[0].groupId).toMatch(/^g-/);
   });
 
-  it('createSession defaults cwd to lastUsedCwd, then userHome', () => {
+  it('createSession defaults cwd to userHome (no fallback chain, per PR #392 spec)', () => {
     const h = harness({
       groups: defaultGroups,
-      lastUsedCwd: '/recent',
       userHome: '/home/u',
     });
     h.sessions.createSession(null);
-    expect(h.state().sessions[0].cwd).toBe('/recent');
+    expect(h.state().sessions[0].cwd).toBe('/home/u');
 
-    const h2 = harness({ groups: defaultGroups, userHome: '/home/u' });
+    // No userHome → empty string, never falls back to anything else.
+    const h2 = harness({ groups: defaultGroups });
     h2.sessions.createSession(null);
-    expect(h2.state().sessions[0].cwd).toBe('/home/u');
+    expect(h2.state().sessions[0].cwd).toBe('');
   });
 
   it('createSession seeds initial model from claudeSettingsDefaultModel', () => {

--- a/tests/stores/slices/sessionRuntimeSlice.test.ts
+++ b/tests/stores/slices/sessionRuntimeSlice.test.ts
@@ -82,4 +82,36 @@ describe('sessionRuntimeSlice', () => {
     h.runtime._setFlash('a', false);
     expect(h.state().flashStates['a']).toBeUndefined();
   });
+
+  // Ref-stability regression guards for the sidebar perf path. The Sidebar
+  // buckets sessions by groupId via useMemo([sessions]) and relies on
+  // React.memo on GroupRow / SessionRow to short-circuit unrelated rows
+  // when a single session's `state` toggles (waiting<->idle on JSONL
+  // chunks). Both rely on the slice patching ONLY the changed session and
+  // preserving every other session's reference via per-element map. If
+  // that property regresses, the sidebar streaming-flicker bug returns.
+  it('_applySessionState is a noop (same sessions ref) when state is unchanged', () => {
+    const sessions = [mkSession('a', 'g1', { state: 'idle' })];
+    const h = harness({ sessions, activeId: 'b' });
+    const before = h.state().sessions;
+    h.runtime._applySessionState('a', 'idle');
+    // Same array ref — no subscriber notification, no persist scheduled.
+    expect(h.state().sessions).toBe(before);
+  });
+
+  it('_applySessionState preserves untouched session refs on real change', () => {
+    const a = mkSession('a', 'g1', { state: 'idle' });
+    const b = mkSession('b', 'g1', { state: 'idle' });
+    const c = mkSession('c', 'g2', { state: 'idle' });
+    const h = harness({ sessions: [a, b, c], activeId: 'x' });
+    h.runtime._applySessionState('b', 'waiting');
+    const next = h.state().sessions;
+    // `b` was patched — new object ref.
+    expect(next[1]).not.toBe(b);
+    expect(next[1].state).toBe('waiting');
+    // `a` and `c` were untouched — same ref so React.memo on SessionRow
+    // can short-circuit.
+    expect(next[0]).toBe(a);
+    expect(next[2]).toBe(c);
+  });
 });

--- a/tests/stores/slices/sessionRuntimeSlice.test.ts
+++ b/tests/stores/slices/sessionRuntimeSlice.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createSessionRuntimeSlice } from '../../../src/stores/slices/sessionRuntimeSlice';
 import type { RootStore } from '../../../src/stores/slices/types';
 import type { Session } from '../../../src/types';
@@ -113,5 +113,54 @@ describe('sessionRuntimeSlice', () => {
     // can short-circuit.
     expect(next[0]).toBe(a);
     expect(next[2]).toBe(c);
+  });
+
+  describe('reloadSession', () => {
+    let killSpy: ReturnType<typeof vi.fn>;
+    let prevPty: unknown;
+    beforeEach(() => {
+      killSpy = vi.fn().mockResolvedValue({ ok: true, killed: true });
+      prevPty = (window as unknown as { ccsmPty?: unknown }).ccsmPty;
+      (window as unknown as { ccsmPty: unknown }).ccsmPty = { kill: killSpy };
+    });
+    afterEach(() => {
+      (window as unknown as { ccsmPty: unknown }).ccsmPty = prevPty;
+    });
+
+    it('initial reloadNonce is empty', () => {
+      const h = harness();
+      expect(h.state().reloadNonce).toEqual({});
+    });
+
+    it('kills pty and bumps the per-session reloadNonce', async () => {
+      const h = harness({ sessions: [mkSession('a', 'g1')] });
+      await h.runtime.reloadSession('a');
+      expect(killSpy).toHaveBeenCalledWith('a');
+      expect(h.state().reloadNonce['a']).toBe(1);
+      await h.runtime.reloadSession('a');
+      expect(h.state().reloadNonce['a']).toBe(2);
+    });
+
+    it('clears any stale disconnect entry on reload', async () => {
+      const h = harness({ sessions: [mkSession('a', 'g1')] });
+      h.runtime._applyPtyExit('a', { code: 1, signal: null });
+      expect(h.state().disconnectedSessions['a'].kind).toBe('crashed');
+      await h.runtime.reloadSession('a');
+      expect(h.state().disconnectedSessions['a']).toBeUndefined();
+    });
+
+    it('swallows kill IPC errors so the nonce still bumps', async () => {
+      killSpy.mockRejectedValueOnce(new Error('not running'));
+      const h = harness({ sessions: [mkSession('a', 'g1')] });
+      await h.runtime.reloadSession('a');
+      expect(h.state().reloadNonce['a']).toBe(1);
+    });
+
+    it('tolerates ccsmPty being undefined (test env)', async () => {
+      (window as unknown as { ccsmPty: unknown }).ccsmPty = undefined;
+      const h = harness({ sessions: [mkSession('a', 'g1')] });
+      await h.runtime.reloadSession('a');
+      expect(h.state().reloadNonce['a']).toBe(1);
+    });
   });
 });

--- a/tests/stores/slices/sessionTitleBackfillSlice.test.ts
+++ b/tests/stores/slices/sessionTitleBackfillSlice.test.ts
@@ -51,9 +51,9 @@ describe('sessionTitleBackfillSlice', () => {
     _resetPendingManualRenamesForTests();
   });
 
-  it('_applyExternalTitle patches matching session, no-op for unknowns', () => {
+  it('_applyExternalTitle patches matching default-named session, no-op for unknowns', () => {
     const h = harness({
-      sessions: [mkSession('a', 'g1', { name: 'old' })],
+      sessions: [mkSession('a', 'g1', { name: 'New session' })],
     });
     h.titles._applyExternalTitle('a', 'new');
     expect(h.state().sessions[0].name).toBe('new');
@@ -66,6 +66,28 @@ describe('sessionTitleBackfillSlice', () => {
     const before = h.state().sessions;
     h.titles._applyExternalTitle('a', 'same');
     expect(h.state().sessions).toBe(before);
+  });
+
+  it('_applyExternalTitle is a no-op once the session has a non-default name', () => {
+    // claude TUI re-emits the OSC title every prompt; before the
+    // first-write-wins guard the session name flickered between turns.
+    // Only the default placeholder ('New session' / '新会话') is
+    // overwritable — anything else is treated as authoritative.
+    const h = harness({
+      sessions: [mkSession('a', 'g1', { name: 'first turn summary' })],
+    });
+    const before = h.state().sessions;
+    h.titles._applyExternalTitle('a', 'second turn rewrites the title');
+    expect(h.state().sessions).toBe(before);
+    expect(h.state().sessions[0].name).toBe('first turn summary');
+  });
+
+  it('_applyExternalTitle overwrites the legacy zh default placeholder', () => {
+    const h = harness({
+      sessions: [mkSession('a', 'g1', { name: '新会话' })],
+    });
+    h.titles._applyExternalTitle('a', 'auto-named');
+    expect(h.state().sessions[0].name).toBe('auto-named');
   });
 
   it('_backfillTitles is a no-op when no bridge is present', async () => {
@@ -89,7 +111,7 @@ describe('sessionTitleBackfillSlice', () => {
     expect(h.state().sessions[0].name).toBe('My label');
   });
 
-  it('_applyExternalTitle clears the guard and applies once the SDK round-trips', () => {
+  it('_applyExternalTitle clears the guard on round-trip then ignores later OSC titles', () => {
     const h = harness({
       sessions: [mkSession('a', 'g1', { name: 'My label' })],
     });
@@ -97,8 +119,10 @@ describe('sessionTitleBackfillSlice', () => {
     // First the JSONL rewrite lands: external title matches desired -> guard clears.
     h.titles._applyExternalTitle('a', 'My label');
     expect(h.state().sessions[0].name).toBe('My label');
-    // Later the user (or claude `/title`) legitimately changes it again.
+    // Later claude TUI re-emits the OSC title for a new prompt. The
+    // session already has a non-default name (user-renamed), so the
+    // first-write-wins guard drops the patch — the user's label sticks.
     h.titles._applyExternalTitle('a', 'Renamed by claude');
-    expect(h.state().sessions[0].name).toBe('Renamed by claude');
+    expect(h.state().sessions[0].name).toBe('My label');
   });
 });

--- a/tests/stores/store.test.ts
+++ b/tests/stores/store.test.ts
@@ -1,0 +1,336 @@
+// Tests for `hydrateStore()` in src/stores/store.ts.
+//
+// The module wires up a one-shot boot sequence (drafts + main snapshot +
+// scrollback + deferred IPCs + persist subscriber). It owns a
+// module-singleton `hydrated` flag, so each test path re-imports the module
+// via `vi.resetModules()` to get a clean run. Where `hydrateStore` touches
+// `loadPersisted` / `hydrateDrafts` / `schedulePersist`, we mock those
+// modules so we can drive the persisted shape from the test (rather than
+// stubbing real IDB / IPC plumbing).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import type { PersistedState } from '../../src/stores/persist';
+
+type CcsmShape = {
+  loadState?: ReturnType<typeof vi.fn>;
+  saveState?: ReturnType<typeof vi.fn>;
+  userHome?: ReturnType<typeof vi.fn>;
+  defaultModel?: ReturnType<typeof vi.fn>;
+  pathsExist?: ReturnType<typeof vi.fn>;
+};
+
+function installCcsm(overrides: CcsmShape = {}): CcsmShape {
+  const ccsm: CcsmShape = {
+    loadState: overrides.loadState ?? vi.fn(async () => null),
+    saveState: overrides.saveState ?? vi.fn(async () => undefined),
+    userHome: overrides.userHome ?? vi.fn(async () => '/home/tester'),
+    defaultModel: overrides.defaultModel ?? vi.fn(async () => 'claude-3-5-sonnet'),
+    pathsExist: overrides.pathsExist ?? vi.fn(async (paths: string[]) =>
+      Object.fromEntries(paths.map((p) => [p, true]))
+    ),
+  };
+  (window as unknown as { ccsm: CcsmShape }).ccsm = ccsm;
+  return ccsm;
+}
+
+function clearWindowExtras() {
+  delete (window as unknown as { ccsm?: unknown }).ccsm;
+  delete (window as unknown as { __ccsmHydrationTrace?: unknown }).__ccsmHydrationTrace;
+  delete (window as unknown as { __ccsmDrafts?: unknown }).__ccsmDrafts;
+}
+
+// Re-import store + persist + drafts after a resetModules so the
+// module-level singleton state (`hydrated`, `cache`, subscribers) starts
+// clean. Returns the freshly-loaded module bundle.
+async function freshStore() {
+  vi.resetModules();
+  const persist = await import('../../src/stores/persist');
+  const drafts = await import('../../src/stores/drafts');
+  const store = await import('../../src/stores/store');
+  return { persist, drafts, store };
+}
+
+beforeEach(() => {
+  clearWindowExtras();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  clearWindowExtras();
+});
+
+describe('hydrateStore: persisted snapshot load', () => {
+  it('starts hydrated=false and flips to true after hydrateStore resolves', async () => {
+    installCcsm();
+    const { store } = await freshStore();
+    expect(store.useStore.getState().hydrated).toBe(false);
+    await store.hydrateStore();
+    expect(store.useStore.getState().hydrated).toBe(true);
+  });
+
+  it('applies persisted sessions/groups/theme/font from the main snapshot', async () => {
+    const snap: PersistedState = {
+      version: 1,
+      sessions: [
+        // Just enough to satisfy `sessions.some(s => s.id === activeId)`.
+        // The slice doesn't reach into Session internals during hydrate.
+        { id: 's-1', name: 'one', cwd: '/x', model: 'claude-3-5-sonnet' } as unknown as PersistedState['sessions'][number],
+        { id: 's-2', name: 'two', cwd: '/y', model: 'claude-3-5-sonnet' } as unknown as PersistedState['sessions'][number],
+      ],
+      groups: [],
+      activeId: 's-2',
+      sidebarWidth: 320,
+      theme: 'dark',
+      fontSize: 'lg',
+      fontSizePx: 16,
+    };
+    installCcsm({
+      loadState: vi.fn(async (key: string) => {
+        if (key === 'main') return JSON.stringify(snap);
+        return null;
+      }),
+    });
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    const s = store.useStore.getState();
+    expect(s.sessions.map((x) => x.id)).toEqual(['s-1', 's-2']);
+    expect(s.activeId).toBe('s-2');
+    expect(s.theme).toBe('dark');
+    expect(s.fontSizePx).toBe(16);
+    expect(s.sidebarWidth).toBe(320);
+    expect(s.hydrated).toBe(true);
+  });
+
+  it('falls back to first session id when persisted activeId no longer exists', async () => {
+    const snap: PersistedState = {
+      version: 1,
+      sessions: [
+        { id: 's-1', name: 'one', cwd: '/x', model: 'm' } as unknown as PersistedState['sessions'][number],
+      ],
+      groups: [],
+      // activeId points to a session that's been deleted between runs.
+      activeId: 's-deleted',
+    };
+    installCcsm({
+      loadState: vi.fn(async (key: string) =>
+        key === 'main' ? JSON.stringify(snap) : null
+      ),
+    });
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    expect(store.useStore.getState().activeId).toBe('s-1');
+  });
+
+  it('returns gracefully when no persisted snapshot exists (fresh install)', async () => {
+    installCcsm();
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    const s = store.useStore.getState();
+    expect(s.hydrated).toBe(true);
+    expect(s.sessions).toEqual([]);
+    // Defaults from appearanceSlice survive untouched.
+    expect(s.theme).toBe('system');
+  });
+
+  it('is idempotent — calling twice does not re-apply persisted state', async () => {
+    const loadState = vi.fn(async () => null);
+    installCcsm({ loadState });
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    const callsAfterFirst = loadState.mock.calls.length;
+    await store.hydrateStore();
+    expect(loadState.mock.calls.length).toBe(callsAfterFirst);
+  });
+});
+
+describe('hydrateStore: scrollback key', () => {
+  it('applies a persisted scrollback line cap when present', async () => {
+    installCcsm({
+      loadState: vi.fn(async (key: string) => {
+        if (key === 'scrollbackLines') return '4096';
+        return null;
+      }),
+    });
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    expect(store.useStore.getState().scrollbackLines).toBe(4096);
+  });
+
+  it('keeps the slice default when scrollback load throws', async () => {
+    installCcsm({
+      loadState: vi.fn(async (key: string) => {
+        if (key === 'scrollbackLines') throw new Error('idb gone');
+        return null;
+      }),
+    });
+    const { store } = await freshStore();
+    await expect(store.hydrateStore()).resolves.toBeUndefined();
+    // Default from createAppearanceSlice — never overwritten on load failure.
+    expect(store.useStore.getState().scrollbackLines).toBe(1500);
+  });
+});
+
+describe('hydrateStore: drafts integration', () => {
+  it('awaits hydrateDrafts before flipping hydrated', async () => {
+    // Resolve order: drafts load (loadState('drafts')) must complete before
+    // hydrated flips. We assert ordering by tracking the moment each fires.
+    const order: string[] = [];
+    installCcsm({
+      loadState: vi.fn(async (key: string) => {
+        order.push(`load:${key}`);
+        return null;
+      }),
+    });
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    order.push('done');
+    // loadState('drafts') is called from hydrateDrafts() which runs first,
+    // then loadState('main') from loadPersisted(), then loadState('scrollbackLines').
+    expect(order[0]).toBe('load:drafts');
+    expect(order).toContain('load:main');
+    expect(order).toContain('load:scrollbackLines');
+    expect(order[order.length - 1]).toBe('done');
+  });
+
+  it('hydrate continues when a corrupt drafts blob is present', async () => {
+    installCcsm({
+      loadState: vi.fn(async (key: string) => {
+        if (key === 'drafts') return '{not json';
+        return null;
+      }),
+    });
+    const { store } = await freshStore();
+    await expect(store.hydrateStore()).resolves.toBeUndefined();
+    expect(store.useStore.getState().hydrated).toBe(true);
+  });
+});
+
+describe('hydrateStore: persist subscriber wiring', () => {
+  it('writes a curated snapshot through saveState when persisted state changes', async () => {
+    const saveState = vi.fn(async () => undefined);
+    installCcsm({ saveState });
+    vi.useFakeTimers();
+    try {
+      const { store } = await freshStore();
+      await store.hydrateStore();
+      // Trigger a mutation on a persisted field. theme is in PERSISTED_KEYS.
+      store.useStore.setState({ theme: 'dark' });
+      // schedulePersist's 250ms debounce + microtask drain.
+      await vi.advanceTimersByTimeAsync(300);
+      expect(saveState).toHaveBeenCalled();
+      const calls = saveState.mock.calls.filter((c) => c[0] === 'main');
+      expect(calls.length).toBeGreaterThan(0);
+      const lastBlob = JSON.parse(calls[calls.length - 1][1] as string);
+      expect(lastBlob).toHaveProperty('version', 1);
+      expect(lastBlob.theme).toBe('dark');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does NOT write when only non-persisted state mutates (early bail)', async () => {
+    const saveState = vi.fn(async () => undefined);
+    installCcsm({ saveState });
+    vi.useFakeTimers();
+    try {
+      const { store } = await freshStore();
+      await store.hydrateStore();
+      // The subscriber unconditionally writes the FIRST snapshot (prevSnap is
+      // null on the first mutation), so drain that baseline write before
+      // asserting the early-bail behaviour on subsequent mutations.
+      store.useStore.setState({ theme: 'light' });
+      await vi.advanceTimersByTimeAsync(300);
+      saveState.mockClear();
+      // `flashStates` is in State but NOT in PERSISTED_KEYS — the
+      // reference-equality comparator over PERSISTED_KEYS should early-bail.
+      store.useStore.setState({ flashStates: { 's-1': true } });
+      await vi.advanceTimersByTimeAsync(300);
+      expect(saveState).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('hydrateStore: deferred boot IPCs', () => {
+  it('seeds userHome + claudeSettingsDefaultModel from main after first paint', async () => {
+    const userHome = vi.fn(async () => '/home/me');
+    const defaultModel = vi.fn(async () => 'claude-haiku');
+    installCcsm({ userHome, defaultModel });
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    // The deferred IPC is fire-and-forget; drain pending promises.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(userHome).toHaveBeenCalled();
+    expect(defaultModel).toHaveBeenCalled();
+    const s = store.useStore.getState();
+    expect(s.userHome).toBe('/home/me');
+    expect(s.claudeSettingsDefaultModel).toBe('claude-haiku');
+  });
+
+  it('tags sessions whose cwd no longer exists via pathsExist', async () => {
+    const snap: PersistedState = {
+      version: 1,
+      sessions: [
+        { id: 's-1', name: 'one', cwd: '/exists', model: 'm' } as unknown as PersistedState['sessions'][number],
+        { id: 's-2', name: 'two', cwd: '/gone', model: 'm' } as unknown as PersistedState['sessions'][number],
+      ],
+      groups: [],
+      activeId: 's-1',
+    };
+    installCcsm({
+      loadState: vi.fn(async (k: string) => (k === 'main' ? JSON.stringify(snap) : null)),
+      pathsExist: vi.fn(async () => ({ '/exists': true, '/gone': false })),
+    });
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    // Drain deferred microtasks.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    const sessions = store.useStore.getState().sessions;
+    const tagged = sessions.find((s) => s.id === 's-2') as { cwdMissing?: boolean };
+    const healthy = sessions.find((s) => s.id === 's-1') as { cwdMissing?: boolean };
+    expect(tagged.cwdMissing).toBe(true);
+    expect(healthy.cwdMissing).toBeUndefined();
+  });
+
+  it('swallows pathsExist errors without blowing up hydrate', async () => {
+    const snap: PersistedState = {
+      version: 1,
+      sessions: [
+        { id: 's-1', name: 'one', cwd: '/x', model: 'm' } as unknown as PersistedState['sessions'][number],
+      ],
+      groups: [],
+      activeId: 's-1',
+    };
+    installCcsm({
+      loadState: vi.fn(async (k: string) => (k === 'main' ? JSON.stringify(snap) : null)),
+      pathsExist: vi.fn(async () => {
+        throw new Error('ipc dropped');
+      }),
+    });
+    const { store } = await freshStore();
+    await expect(store.hydrateStore()).resolves.toBeUndefined();
+    await new Promise((r) => setTimeout(r, 0));
+    // Sessions remain untouched — no cwdMissing tag.
+    const session = store.useStore.getState().sessions[0] as { cwdMissing?: boolean };
+    expect(session.cwdMissing).toBeUndefined();
+  });
+});
+
+describe('hydrateStore: trace bookkeeping', () => {
+  it('writes hydrateStartedAt / hydrateDoneAt onto window.__ccsmHydrationTrace', async () => {
+    installCcsm();
+    const { store } = await freshStore();
+    await store.hydrateStore();
+    const trace = (window as unknown as {
+      __ccsmHydrationTrace?: { hydrateStartedAt?: number; hydrateDoneAt?: number };
+    }).__ccsmHydrationTrace;
+    expect(trace).toBeTruthy();
+    expect(typeof trace?.hydrateStartedAt).toBe('number');
+    expect(typeof trace?.hydrateDoneAt).toBe('number');
+    expect((trace!.hydrateDoneAt as number)).toBeGreaterThanOrEqual(
+      trace!.hydrateStartedAt as number
+    );
+  });
+});

--- a/tests/terminal/usePtyAttach.test.tsx
+++ b/tests/terminal/usePtyAttach.test.tsx
@@ -57,11 +57,35 @@ vi.mock('../../src/terminal/xtermSingleton', async () => {
   };
 });
 
-// Mock store — _clearPtyExit is the only piece usePtyAttach reads.
+// Mock store — _clearPtyExit is the only piece usePtyAttach reads via the
+// hook selector. The fork-on-spawn path (right-click "Copy session") also
+// reaches into `useStore.getState().pendingForkSource[sid]` and calls
+// `useStore.setState((s) => …)` to clear the entry post-spawn, so the mock
+// must expose getState/setState statics on the same callable. Tests that
+// need to seed a fork source push into `mockStoreState.pendingForkSource`.
 const clearPtyExitSpy = vi.fn();
-vi.mock('../../src/stores/store', () => ({
-  useStore: (selector: (s: any) => any) => selector({ _clearPtyExit: clearPtyExitSpy }),
-}));
+const mockStoreState: { pendingForkSource: Record<string, string> } = {
+  pendingForkSource: {},
+};
+vi.mock('../../src/stores/store', () => {
+  const useStore = ((selector: (s: any) => any) =>
+    selector({ _clearPtyExit: clearPtyExitSpy, ...mockStoreState })) as any;
+  useStore.getState = () => ({ _clearPtyExit: clearPtyExitSpy, ...mockStoreState });
+  useStore.setState = (
+    patch:
+      | { pendingForkSource?: Record<string, string> }
+      | ((s: typeof mockStoreState) => { pendingForkSource?: Record<string, string> } | {}),
+  ) => {
+    const next =
+      typeof patch === 'function'
+        ? patch({ ...mockStoreState })
+        : patch;
+    if (next && 'pendingForkSource' in next && next.pendingForkSource) {
+      mockStoreState.pendingForkSource = next.pendingForkSource;
+    }
+  };
+  return { useStore };
+});
 
 import { usePtyAttach } from '../../src/terminal/usePtyAttach';
 import {
@@ -140,6 +164,7 @@ describe('usePtyAttach', () => {
     proposeDimensionsSpy.mockClear();
     proposeDimensionsSpy.mockReturnValue({ cols: 134, rows: 51 });
     clearPtyExitSpy.mockClear();
+    mockStoreState.pendingForkSource = {};
   });
 
   afterEach(() => {
@@ -204,11 +229,36 @@ describe('usePtyAttach', () => {
     renderHook(() => usePtyAttach('sid-C', '/cwd'));
     await flushAll();
 
-    expect(spies.spawn).toHaveBeenCalledWith('sid-C', '/cwd');
+    expect(spies.spawn).toHaveBeenCalledWith('sid-C', '/cwd', undefined);
     expect(spies.attach).toHaveBeenCalledTimes(2);
     // L4 PR-B (#865): the visible terminal paints the getBufferSnapshot
     // string, NOT the legacy attach.snapshot.
     expect(writeSpy).toHaveBeenCalledWith('after-spawn');
+  });
+
+  // Right-click "Copy session" → `copySession` registers `pendingForkSource[
+  // newSid] = sourceSid`. usePtyAttach's spawn-on-null-attach fallback must
+  // read it and pass `sourceSid` as the 3rd arg of `pty.spawn`, then clear
+  // the entry so a subsequent Retry doesn't re-fire `--fork-session` against
+  // an already-forked sid.
+  it('forwards pendingForkSource[sid] as the 3rd spawn arg, then clears it post-spawn', async () => {
+    let calls = 0;
+    const { bridge, spies } = makePtyBridge({ snapshot: { snapshot: 'forked', seq: 0 } });
+    spies.attach.mockImplementation(async () => {
+      calls += 1;
+      if (calls === 1) return null;
+      return { snapshot: 'ignored', cols: 80, rows: 24, pid: 1 };
+    });
+    (window as any).ccsmPty = bridge;
+    mockStoreState.pendingForkSource = { 'sid-FORK': 'sid-SOURCE' };
+
+    renderHook(() => usePtyAttach('sid-FORK', '/cwd'));
+    await flushAll();
+
+    expect(spies.spawn).toHaveBeenCalledWith('sid-FORK', '/cwd', 'sid-SOURCE');
+    // Post-spawn: pendingForkSource entry for this sid is gone, so a
+    // hypothetical re-spawn (Retry) wouldn't accidentally re-fork.
+    expect(mockStoreState.pendingForkSource['sid-FORK']).toBeUndefined();
   });
 
   // L4 PR-F (#867) — the spawn-time cols/rows hack added for #852 has been
@@ -232,8 +282,12 @@ describe('usePtyAttach', () => {
     renderHook(() => usePtyAttach('sid-867', '/cwd'));
     await flushAll();
 
-    // Spawn is called with sid + cwd ONLY — no opts argument.
-    expect(spies.spawn).toHaveBeenCalledWith('sid-867', '/cwd');
+    // Spawn is called with sid + cwd + an explicit `undefined` 3rd arg
+    // (forkSourceSid). The 3rd arg is only set on the right-click "Copy
+    // session" fork path; for the normal spawn-on-null-attach fallback it
+    // must be undefined so main takes the standard `--session-id <sid>`
+    // branch in `entryFactory.makeEntry`.
+    expect(spies.spawn).toHaveBeenCalledWith('sid-867', '/cwd', undefined);
     // FitAddon.proposeDimensions is no longer called pre-spawn.
     expect(proposeDimensionsSpy).not.toHaveBeenCalled();
   });

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -4,12 +4,15 @@ import { renderHook } from '@testing-library/react';
 // Mock xterm constructors BEFORE importing the hook so the singleton
 // uses the spies. Use vi.hoisted because vi.mock factories run before
 // any top-level `const`.
-const { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, terminalCtor, webLinksCtor } =
+const { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, getSelectionSpy, clearSelectionSpy, selectAllSpy, terminalCtor, webLinksCtor } =
   vi.hoisted(() => {
     const openSpy = vi.fn();
     const loadAddonSpy = vi.fn();
     const onSelectionChangeSpy = vi.fn();
     const attachCustomKeyEventHandlerSpy = vi.fn();
+    const getSelectionSpy = vi.fn(() => '');
+    const clearSelectionSpy = vi.fn();
+    const selectAllSpy = vi.fn();
     // vitest v3+ requires `function`/`class` (not arrow) for mocks invoked
     // with `new` — otherwise tinyspy throws "is not a constructor".
     const terminalCtor = vi.fn(function () {
@@ -18,6 +21,9 @@ const { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandler
         loadAddon: loadAddonSpy,
         onSelectionChange: onSelectionChangeSpy,
         attachCustomKeyEventHandler: attachCustomKeyEventHandlerSpy,
+        getSelection: getSelectionSpy,
+        clearSelection: clearSelectionSpy,
+        selectAll: selectAllSpy,
         unicode: { activeVersion: '6' },
         _core: { _parent: null },
       };
@@ -25,7 +31,7 @@ const { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandler
     const webLinksCtor = vi.fn(function () {
       return {};
     });
-    return { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, terminalCtor, webLinksCtor };
+    return { openSpy, loadAddonSpy, onSelectionChangeSpy, attachCustomKeyEventHandlerSpy, getSelectionSpy, clearSelectionSpy, selectAllSpy, terminalCtor, webLinksCtor };
   });
 
 vi.mock('@xterm/xterm', () => ({ Terminal: terminalCtor }));
@@ -40,6 +46,8 @@ import {
   __resetSingletonForTests,
   getTerm,
   setActiveSid,
+  terminalCopy,
+  terminalPaste,
 } from '../../src/terminal/xtermSingleton';
 
 describe('useXtermSingleton', () => {
@@ -290,6 +298,116 @@ describe('useXtermSingleton', () => {
       const handler = getKeyHandler();
       handler({ type: 'keydown', key: 'v', ctrlKey: true });
       expect(inputSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  // Task #41: right-click handlers + Ctrl+A select-all. The host div's
+  // onContextMenu in TerminalPane calls these directly; we exercise them
+  // standalone to pin contract independent of the React wiring (which
+  // tests/components/TerminalPane.test.tsx covers separately with mocked
+  // singleton). Plus the new Ctrl+A keybinding so the user retains a
+  // select-all path after the native menu's "Select All" item is no
+  // longer shown for the terminal pane.
+  describe('Task #41: terminalCopy / terminalPaste / Ctrl+A', () => {
+    let inputSpy: ReturnType<typeof vi.fn>;
+    let readTextSpy: ReturnType<typeof vi.fn>;
+    let writeTextSpy: ReturnType<typeof vi.fn>;
+    let host: HTMLDivElement;
+
+    beforeEach(() => {
+      inputSpy = vi.fn();
+      readTextSpy = vi.fn().mockReturnValue('pasted-text');
+      writeTextSpy = vi.fn();
+      (window as unknown as { ccsmPty: unknown }).ccsmPty = {
+        input: inputSpy,
+        clipboard: {
+          readText: readTextSpy,
+          writeText: writeTextSpy,
+        },
+      };
+      host = document.createElement('div');
+      document.body.appendChild(host);
+      renderHook(() => useXtermSingleton({ current: host }));
+      setActiveSid('sid-rc');
+      getSelectionSpy.mockReset().mockReturnValue('');
+      clearSelectionSpy.mockReset();
+      selectAllSpy.mockReset();
+    });
+
+    afterEach(() => {
+      document.body.removeChild(host);
+      delete (window as unknown as { ccsmPty?: unknown }).ccsmPty;
+    });
+
+    it('terminalCopy returns true + writes selection + clears it when selection exists', () => {
+      getSelectionSpy.mockReturnValue('selected-text');
+      const copied = terminalCopy();
+      expect(copied).toBe(true);
+      expect(writeTextSpy).toHaveBeenCalledWith('selected-text');
+      expect(clearSelectionSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('terminalCopy returns false + no clipboard write when selection is empty', () => {
+      getSelectionSpy.mockReturnValue('');
+      const copied = terminalCopy();
+      expect(copied).toBe(false);
+      expect(writeTextSpy).not.toHaveBeenCalled();
+      expect(clearSelectionSpy).not.toHaveBeenCalled();
+    });
+
+    it('terminalPaste reads clipboard and routes through ccsmPty.input', () => {
+      terminalPaste();
+      expect(readTextSpy).toHaveBeenCalledTimes(1);
+      expect(inputSpy).toHaveBeenCalledWith('sid-rc', 'pasted-text');
+    });
+
+    it('terminalPaste arms the keyboardPasteHandled flag so a follow-up native paste is suppressed', () => {
+      terminalPaste();
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+      // Synthetic native paste from a different source — must be dropped
+      // because terminalPaste just armed the flag.
+      const evt = new Event('paste', { bubbles: true, cancelable: true }) as ClipboardEvent;
+      Object.defineProperty(evt, 'clipboardData', {
+        value: { getData: () => 'should-be-dropped' },
+      });
+      host.dispatchEvent(evt);
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('terminalPaste is a no-op when no active session', () => {
+      setActiveSid(null);
+      terminalPaste();
+      expect(inputSpy).not.toHaveBeenCalled();
+    });
+
+    it('Ctrl+A invokes term.selectAll() and returns false to stop SOH translation', () => {
+      const handler = attachCustomKeyEventHandlerSpy.mock.calls[0][0];
+      const ret = handler({ type: 'keydown', key: 'a', ctrlKey: true });
+      expect(ret).toBe(false);
+      expect(selectAllSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('Cmd+A also invokes term.selectAll() (macOS)', () => {
+      const handler = attachCustomKeyEventHandlerSpy.mock.calls[0][0];
+      const ret = handler({ type: 'keydown', key: 'a', metaKey: true });
+      expect(ret).toBe(false);
+      expect(selectAllSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('Ctrl+Shift+A does NOT select-all (shift modifier reserved for other bindings)', () => {
+      const handler = attachCustomKeyEventHandlerSpy.mock.calls[0][0];
+      const ret = handler({ type: 'keydown', key: 'A', ctrlKey: true, shiftKey: true });
+      // Shift+A is not one of our explicit shifted bindings (only C/V are);
+      // returning true keeps xterm's default handling intact.
+      expect(ret).toBe(true);
+      expect(selectAllSpy).not.toHaveBeenCalled();
+    });
+
+    it('plain "a" keydown (no modifier) is left to xterm as normal input', () => {
+      const handler = attachCustomKeyEventHandlerSpy.mock.calls[0][0];
+      const ret = handler({ type: 'keydown', key: 'a' });
+      expect(ret).toBe(true);
+      expect(selectAllSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -68,6 +68,27 @@ describe('useXtermSingleton', () => {
     expect(window.__ccsmTerm).toBe(getTerm());
   });
 
+  // Wheel-scroll tuning regression guard. xterm's `Viewport.getLinesScrolled`
+  // multiplies `event.deltaY` by `scrollSensitivity` before dividing by row
+  // height; without these explicit values, a Windows precision-mouse notch
+  // reporting `deltaY` ~120-400px lands the user 6-25 lines down per notch
+  // ("light flick scrolls to middle of page"). A future refactor that drops
+  // any of these three options silently resurrects the bug — pin them in a
+  // test so the constructor contract is enforced.
+  it('constructs Terminal with explicit wheel-scroll tuning', () => {
+    const host = document.createElement('div');
+    renderHook(() => useXtermSingleton({ current: host }));
+    expect(terminalCtor).toHaveBeenCalledTimes(1);
+    const opts = terminalCtor.mock.calls[0][0] as {
+      scrollSensitivity?: number;
+      fastScrollSensitivity?: number;
+      fastScrollModifier?: string;
+    };
+    expect(opts.scrollSensitivity).toBe(0.5);
+    expect(opts.fastScrollSensitivity).toBe(5);
+    expect(opts.fastScrollModifier).toBe('alt');
+  });
+
   it('reuses the singleton across remounts (does NOT recreate)', () => {
     const host = document.createElement('div');
     const ref = { current: host };

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -45,6 +45,7 @@ import { useXtermSingleton } from '../../src/terminal/useXtermSingleton';
 import {
   __resetSingletonForTests,
   getTerm,
+  pasteIntoActivePty,
   setActiveSid,
   terminalCopy,
   terminalPaste,
@@ -206,6 +207,10 @@ describe('useXtermSingleton', () => {
           readText: readTextSpy,
           writeText: vi.fn(),
         },
+        // Task #42 — default to "no image on clipboard" so existing
+        // text-paste assertions stay green; image-branch tests override
+        // per-case.
+        saveClipboardImage: vi.fn().mockResolvedValue(null),
       };
       // The hook receives a real DOM node so the capture-phase paste
       // listener it installs is exercised by real events.
@@ -233,26 +238,34 @@ describe('useXtermSingleton', () => {
       return evt;
     }
 
-    it('Ctrl+V keydown injects clipboard text exactly once', () => {
+    it('Ctrl+V keydown injects clipboard text exactly once', async () => {
       const handler = getKeyHandler();
       const ret = handler({ type: 'keydown', key: 'v', ctrlKey: true });
       expect(ret).toBe(false);
       expect(readTextSpy).toHaveBeenCalledTimes(1);
+      // Task #42 — paste now hops through `saveClipboardImage` first; the
+      // text injection lands on the microtask after that promise resolves.
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
       expect(inputSpy).toHaveBeenCalledWith('sid-1', 'hello');
     });
 
-    it('Cmd+V keydown injects clipboard text exactly once (macOS)', () => {
+    it('Cmd+V keydown injects clipboard text exactly once (macOS)', async () => {
       const handler = getKeyHandler();
       const ret = handler({ type: 'keydown', key: 'v', metaKey: true });
       expect(ret).toBe(false);
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
       expect(inputSpy).toHaveBeenCalledWith('sid-1', 'hello');
     });
 
-    it('keydown-driven paste suppresses the follow-up native paste event', () => {
+    it('keydown-driven paste suppresses the follow-up native paste event', async () => {
       const handler = getKeyHandler();
       handler({ type: 'keydown', key: 'v', ctrlKey: true });
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
 
       // The browser's native paste event arrives after our synchronous
@@ -260,12 +273,16 @@ describe('useXtermSingleton', () => {
       // ccsmPty.input call.
       const evt = makePasteEvent('hello');
       host.dispatchEvent(evt);
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('right-click / context-menu paste (no preceding keydown) injects once', () => {
+    it('right-click / context-menu paste (no preceding keydown) injects once', async () => {
       const evt = makePasteEvent('world');
       host.dispatchEvent(evt);
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
       expect(inputSpy).toHaveBeenCalledWith('sid-1', 'world');
       // xterm's built-in paste pipeline must not see the event.
@@ -277,6 +294,8 @@ describe('useXtermSingleton', () => {
       // Keyboard paste with NO follow-up native event (e.g. focus on
       // canvas — browser doesn't dispatch paste to non-editable nodes).
       handler({ type: 'keydown', key: 'v', ctrlKey: true });
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
 
       // Wait for the macrotask that resets the flag. We use setTimeout 0
@@ -289,14 +308,18 @@ describe('useXtermSingleton', () => {
       // A later paste from a different source must still be delivered.
       const evt = makePasteEvent('later');
       host.dispatchEvent(evt);
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(2);
       expect(inputSpy).toHaveBeenLastCalledWith('sid-1', 'later');
     });
 
-    it('Ctrl+V is a no-op when no active session', () => {
+    it('Ctrl+V is a no-op when no active session', async () => {
       setActiveSid(null);
       const handler = getKeyHandler();
       handler({ type: 'keydown', key: 'v', ctrlKey: true });
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).not.toHaveBeenCalled();
     });
   });
@@ -324,6 +347,9 @@ describe('useXtermSingleton', () => {
           readText: readTextSpy,
           writeText: writeTextSpy,
         },
+        // Task #42 — default to "no image"; image-branch test overrides
+        // per-case to assert the path-injection branch.
+        saveClipboardImage: vi.fn().mockResolvedValue(null),
       };
       host = document.createElement('div');
       document.body.appendChild(host);
@@ -355,14 +381,19 @@ describe('useXtermSingleton', () => {
       expect(clearSelectionSpy).not.toHaveBeenCalled();
     });
 
-    it('terminalPaste reads clipboard and routes through ccsmPty.input', () => {
+    it('terminalPaste reads clipboard and routes through ccsmPty.input', async () => {
       terminalPaste();
+      // Async hop via saveClipboardImage; flush microtasks before assert.
+      await Promise.resolve();
+      await Promise.resolve();
       expect(readTextSpy).toHaveBeenCalledTimes(1);
       expect(inputSpy).toHaveBeenCalledWith('sid-rc', 'pasted-text');
     });
 
-    it('terminalPaste arms the keyboardPasteHandled flag so a follow-up native paste is suppressed', () => {
+    it('terminalPaste arms the keyboardPasteHandled flag so a follow-up native paste is suppressed', async () => {
       terminalPaste();
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
       // Synthetic native paste from a different source — must be dropped
       // because terminalPaste just armed the flag.
@@ -371,13 +402,83 @@ describe('useXtermSingleton', () => {
         value: { getData: () => 'should-be-dropped' },
       });
       host.dispatchEvent(evt);
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('terminalPaste is a no-op when no active session', () => {
+    it('terminalPaste is a no-op when no active session', async () => {
       setActiveSid(null);
       terminalPaste();
+      await Promise.resolve();
+      await Promise.resolve();
       expect(inputSpy).not.toHaveBeenCalled();
+    });
+
+    // Task #42 — image-first paste branch. When `saveClipboardImage`
+    // returns a saved-file path, we MUST inject that path (not the
+    // fallback text) so claude reads the screenshot via the file path.
+    it('terminalPaste injects the saved image path when clipboard holds an image', async () => {
+      const fakePath = 'C:\\Users\\me\\AppData\\Roaming\\CCSM\\clipboard-images\\20260522-100000.png';
+      (window as unknown as { ccsmPty: { saveClipboardImage: ReturnType<typeof vi.fn> } })
+        .ccsmPty.saveClipboardImage = vi.fn().mockResolvedValue(fakePath);
+      terminalPaste();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+      expect(inputSpy).toHaveBeenCalledWith('sid-rc', fakePath);
+      // The synchronously-read text MUST NOT be injected; the image branch
+      // wins.
+      expect(inputSpy).not.toHaveBeenCalledWith('sid-rc', 'pasted-text');
+    });
+
+    // Task #42 — text fallback. When `saveClipboardImage` returns null
+    // (no image on clipboard), the previously-read text is injected as
+    // the regular paste payload. Default beforeEach stub already returns
+    // null, but spell it out for documentation.
+    it('terminalPaste falls back to text injection when no image is on clipboard', async () => {
+      (window as unknown as { ccsmPty: { saveClipboardImage: ReturnType<typeof vi.fn> } })
+        .ccsmPty.saveClipboardImage = vi.fn().mockResolvedValue(null);
+      terminalPaste();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+      expect(inputSpy).toHaveBeenCalledWith('sid-rc', 'pasted-text');
+    });
+
+    // N1 race fix (reviewer): `saveClipboardImage` is an async IPC hop;
+    // if the user switches sessions while it's in flight, the injected
+    // text / image-path MUST land in the session that was active at
+    // paste-intent time, NOT whichever session happens to be active
+    // when the promise resolves. `pasteIntoActivePty` snapshots
+    // `activeSid` at entry to enforce this. Drive the helper directly
+    // (rather than through `terminalPaste`) so the timing is precise.
+    it('pasteIntoActivePty binds the target sid at intent time, not at promise-resolution time', async () => {
+      // Defer the resolution of saveClipboardImage until we explicitly
+      // resolve it — gives us a clean window to flip activeSid mid-flight.
+      let resolveImage: (v: string | null) => void = () => {};
+      const pending = new Promise<string | null>((r) => { resolveImage = r; });
+      (window as unknown as { ccsmPty: { saveClipboardImage: ReturnType<typeof vi.fn> } })
+        .ccsmPty.saveClipboardImage = vi.fn().mockReturnValue(pending);
+
+      setActiveSid('sid-original');
+      const pasted = pasteIntoActivePty('typed-into-original');
+
+      // Simulate the user switching sessions while we wait on the IPC.
+      setActiveSid('sid-different');
+
+      // Resolve the IPC with no image so we exercise the text-fallback
+      // branch (the more dangerous one — image path comes from main and
+      // is obviously global, but the text fallback could plausibly look
+      // session-scoped if you squint at the old code).
+      resolveImage(null);
+      await pasted;
+
+      // MUST go to the sid that was active when paste was invoked, not
+      // the sid that's active now.
+      expect(inputSpy).toHaveBeenCalledTimes(1);
+      expect(inputSpy).toHaveBeenCalledWith('sid-original', 'typed-into-original');
+      expect(inputSpy).not.toHaveBeenCalledWith('sid-different', 'typed-into-original');
     });
 
     it('Ctrl+A invokes term.selectAll() and returns false to stop SOH translation', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -30,17 +30,34 @@ export default defineConfig({
         'tests/**',
         'scripts/**',
         'dist/**',
+        // Procedural / bootstrap files (Task #43) — pure wiring with no
+        // branching logic, not meaningfully unit-testable. Covered by e2e
+        // smoke + manual dogfood. Excluding lifts headline `lines` from
+        // ~79% to ~87.1% on the same suite. See PR body for justification.
+        'electron/main.ts',
+        'electron/testHooks.ts',
+        'electron/db-validate.ts',
+        'electron/agent/read-default-model.ts',
+        'electron/branding/icon.ts',
+        'electron/sentry/init.ts',
+        'electron/tray/createTray.ts',
+        'electron/ipc/systemIpc.ts',
+        'electron/ipc/windowIpc.ts',
+        'electron/notify/badge.ts',
+        'src/index.tsx',
+        'src/components/ScrollToBottomButton.tsx',
       ],
-      // Initial roll-out — start lenient. Adjusted to current actuals
-      // (see PR #802 body for measured numbers). Bump in follow-up tasks
-      // as suites grow. Thresholds are NOT enforced in CI yet — the CI
-      // job runs `npm run coverage` to produce lcov.info as an artifact
-      // but does not fail on threshold misses for this initial roll-out.
+      // Task #43 — gate is now enforced in CI. Thresholds set ~8pp below
+      // measured post-exclusion baseline (lines 87.08%, statements 84.60%,
+      // functions 84.52%, branches 76.28%) so normal week-to-week churn
+      // doesn't flake the gate, while regressions of >8pp are caught.
+      // Raise these as suites grow; never lower without a written
+      // justification in the PR body.
       thresholds: {
-        lines: 60,
-        functions: 60,
-        branches: 50,
-        statements: 60,
+        lines: 78,
+        functions: 76,
+        branches: 68,
+        statements: 76,
       },
     },
   },


### PR DESCRIPTION
## Why

Nightly promote workflow has been failing for ~30+ commits because `EXPECTED_CHECKS` in `.github/workflows/daily-promote-release.yml` required `check-source`, which only fires on PRs targeting `main` (per `main-source-guard.yml`'s `on.pull_request.branches: [main]`). PR #1295 dropped that check.

The fix itself ships in this batch — but cron/`workflow_dispatch` reads the workflow file from `main`, which still has the old version. Chicken-and-egg. This PR breaks the loop by manually promoting working → main once, after which the next cron run will use the new workflow and self-heal.

## What's in this batch

32 commits, including:
- #1295 — the nightly fix (drop check-source from EXPECTED_CHECKS)
- #1290 — native CLI-style right-click
- #1293 — clipboard image auto-save
- Coverage batches + CI coverage gate
- Silent updater, native context menu, paste fixes
- Two direct pushes to working: `1e47560` (env-gated mobile remote server scaffold) + `ea50b5e` (WS framing hardening). Author-acknowledged.

## After merge

Cron self-heals on next nightly. No manual dispatch needed (and dispatch would still pull old workflow until the next cron tick anyway — wait it out).