### PR TITLE
chore: bump version to 0.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccsm",
-  "version": "0.2.3",
+  "version": "0.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccsm",
-      "version": "0.2.3",
+      "version": "0.2.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccsm",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "CCSM (Claude Code Session Manager) — group-first manager for many Claude Code sessions",
   "productName": "CCSM",
   "license": "MIT",


### PR DESCRIPTION
## Release v0.2.5

Bumps package.json from 0.2.4 → 0.2.5 for the v0.2.5 release.

## What's shipping since v0.2.4

32 commits merged via PR #1297 + scroll-fix PR (re-PR of #1296). Highlights:
- Native CLI-style right-click (copy on selection, paste on empty) (#1290)
- Clipboard image auto-save on paste (#1293)
- Silent updater (VSCode-style restart-to-update) (#1278)
- Attach scroll lands at bottom (re-PR of #1296)
- Multiple coverage batches + CI coverage gate (#1289)
- createSession cwd fallback to home (#1276)
- claudeResolver async + timeout (#1280)
- Various performance, paste race fixes, lifecycle hardening

## Release flow (post working-branch retirement)

After this merges, tag `v0.2.5` on main and push to trigger `release.yml`:
```bash
git fetch origin && git checkout main && git pull --ff-only
git tag v0.2.5 && git push origin v0.2.5
```