### PR TITLE
fix(import): refresh session list on every dialog open

### DIFF
--- a/electron/ipc/__tests__/utilityIpc.test.ts
+++ b/electron/ipc/__tests__/utilityIpc.test.ts
@@ -4,6 +4,9 @@ import * as os from 'os';
 import * as path from 'path';
 
 const openExternalMock = vi.fn(async (_url: string) => undefined);
+const scanImportableSessionsMock = vi.hoisted(() =>
+  vi.fn(async () => [] as unknown[]),
+);
 
 vi.mock('electron', () => ({
   BrowserWindow: { fromWebContents: () => null },
@@ -11,7 +14,7 @@ vi.mock('electron', () => ({
   shell: { openExternal: (url: string) => openExternalMock(url) },
 }));
 vi.mock('../../import-scanner', () => ({
-  scanImportableSessions: async () => [],
+  scanImportableSessions: scanImportableSessionsMock,
 }));
 vi.mock('../../prefs/userCwds', () => ({
   getUserCwds: () => [os.homedir()],
@@ -196,5 +199,88 @@ describe('ccsm:openExternal IPC handler', () => {
     expect(r).toBe(false);
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();
+  });
+});
+
+describe('import:scan IPC handler — fresh scan, no stale cache (regression)', () => {
+  // Bug: ImportDialog showed stale list on second open if new on-disk
+  // sessions appeared since the first open. Root cause: the handler used
+  // stale-while-revalidate, returning the cached array immediately and
+  // kicking an async refresh whose result the current caller never saw.
+  // Fix: always await a fresh scan (concurrent IPCs still share the
+  // in-flight promise via the importablePending mutex).
+  type Handler = (e: unknown, ...args: unknown[]) => unknown;
+  let handler: Handler;
+
+  function makeSession(id: string, mtime: number) {
+    return {
+      sessionId: id,
+      cwd: `/tmp/cwd-${id}`,
+      title: `Session ${id}`,
+      mtime,
+      projectDir: `/tmp/proj-${id}`,
+      model: null,
+    };
+  }
+
+  beforeEach(async () => {
+    scanImportableSessionsMock.mockReset();
+    // Force a fresh module instance so module-scoped cache state from
+    // earlier tests doesn't bleed in.
+    vi.resetModules();
+    const mod = await import('../utilityIpc');
+    const handlers = new Map<string, Handler>();
+    const ipcMain = {
+      handle: (ch: string, fn: Handler) => handlers.set(ch, fn),
+      on: (ch: string, fn: Handler) => handlers.set(ch, fn),
+    } as unknown as Electron.IpcMain;
+    mod.registerUtilityIpc({ ipcMain });
+    handler = handlers.get('import:scan')!;
+    expect(handler).toBeDefined();
+  });
+
+  it('returns the fresh on-disk list, not the previously-cached one', async () => {
+    const first = makeSession('a', 1);
+    const second = makeSession('b', 2);
+
+    // First open: only one session exists on disk.
+    scanImportableSessionsMock.mockResolvedValueOnce([first]);
+    const r1 = (await handler({})) as Array<{ sessionId: string }>;
+    expect(r1.map((s) => s.sessionId)).toEqual(['a']);
+
+    // Between opens, a second session is recorded on disk.
+    scanImportableSessionsMock.mockResolvedValueOnce([first, second]);
+    const r2 = (await handler({})) as Array<{ sessionId: string }>;
+
+    // Old (stale-while-revalidate) behaviour would have returned `[a]`
+    // here and only refreshed in the background. Fresh-scan behaviour
+    // must include both sessions.
+    expect(r2.map((s) => s.sessionId)).toEqual(['a', 'b']);
+    expect(scanImportableSessionsMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares a single in-flight scan across concurrent callers (single-flight mutex)', async () => {
+    let resolveScan: ((rows: unknown[]) => void) | undefined;
+    scanImportableSessionsMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveScan = resolve as (rows: unknown[]) => void;
+        }),
+    );
+
+    const p1 = handler({}) as Promise<unknown[]>;
+    const p2 = handler({}) as Promise<unknown[]>;
+    const p3 = handler({}) as Promise<unknown[]>;
+
+    // All three callers should be waiting on the same in-flight scan.
+    expect(scanImportableSessionsMock).toHaveBeenCalledTimes(1);
+
+    const rows = [makeSession('x', 1)];
+    resolveScan!(rows);
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+    expect(r1).toEqual(rows);
+    expect(r2).toEqual(rows);
+    expect(r3).toEqual(rows);
+    expect(scanImportableSessionsMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/ipc/utilityIpc.ts
+++ b/electron/ipc/utilityIpc.ts
@@ -30,9 +30,13 @@ export interface UtilityIpcDeps {
 // The CLI transcripts under ~/.claude/projects can run into hundreds of
 // files; the head-parse is fast per file but the cumulative latency makes
 // the ImportDialog's "Scanning…" state visible for several seconds on cold
-// open. Eager-load the scan at app `ready` and serve cached results to
-// renderers, refreshing in the background on each request so newly-recorded
-// sessions show up without a manual reload.
+// open. Eager-load the scan at app `ready` via `primeImportableCache()` so
+// the first user open just awaits the already-resolved priming promise;
+// subsequent opens always await a fresh scan so newly-recorded sessions
+// show up without a manual reload (bug: stale list on second open).
+//
+// `importablePending` is a single-flight mutex: concurrent IPCs share the
+// in-flight scan rather than each triggering their own filesystem walk.
 let importableCache: ScannableSession[] = [];
 let importablePending: Promise<ScannableSession[]> | null = null;
 
@@ -54,13 +58,11 @@ function refreshImportableCache(): Promise<ScannableSession[]> {
 }
 
 async function getImportableSessions(): Promise<ScannableSession[]> {
-  // Hot cache: serve instantly and refresh in the background so the next
-  // call sees fresher data. Cold cache: await the in-flight (or new) scan
-  // so the renderer never gets [].
-  if (importableCache.length > 0) {
-    void refreshImportableCache();
-    return importableCache;
-  }
+  // Always await a fresh scan. Concurrent callers share the in-flight
+  // promise via `importablePending` so opening the dialog never double-
+  // scans. Cold-open latency is mitigated by `primeImportableCache()`
+  // running at app `ready`: by the time the user opens the dialog the
+  // priming scan has typically already resolved.
   return refreshImportableCache();
 }
 


### PR DESCRIPTION
## Symptom
User report: "import的时候，好像列表会保持在刚打开的时候加载的session list，不会刷新" — ImportDialog shows stale data on second open; sessions recorded between the first and second open never appear until the app restarts.

## Root cause
`getImportableSessions()` in `electron/ipc/utilityIpc.ts` used stale-while-revalidate: it returned the cached array immediately and kicked an async refresh whose result the current caller never awaited.

## Fix
Always `await refreshImportableCache()`. The existing `importablePending` single-flight mutex is preserved so concurrent IPCs share one in-flight scan rather than double-scanning. Cold-open latency stays mitigated by `primeImportableCache()` at app `ready`.

## Test
`electron/ipc/__tests__/utilityIpc.test.ts` — new describe block "import:scan IPC handler — fresh scan, no stale cache (regression)":
- Primes handler with one session, simulates a second appearing on disk between calls, asserts the second call returns both. Reverse-verified: this test fails on the previous SWR implementation.
- Single-flight assertion: three concurrent handler calls share one underlying scan.

All 25 tests in the file pass; `npm run typecheck` clean; `npm run lint` shows 0 errors (pre-existing warnings only).