### PR TITLE
fix(groups): rename now overrides i18n default group name

### DIFF
--- a/src/stores/slices/groupsSlice.ts
+++ b/src/stores/slices/groupsSlice.ts
@@ -81,8 +81,15 @@ export function createGroupsSlice(set: SetFn, get: GetFn): GroupsSlice {
     },
 
     renameGroup: (id, name) => {
+      // Clear `nameKey` so the user-supplied name wins over the i18n default.
+      // Default groups seed both `name` and `nameKey` (so language switches
+      // re-localize), but once the user renames, that's explicit intent —
+      // the renderer (`GroupRow`) prefers `nameKey` when present, so leaving
+      // it set would make the rename invisible.
       set((s) => ({
-        groups: s.groups.map((g) => (g.id === id ? { ...g, name } : g)),
+        groups: s.groups.map((g) =>
+          g.id === id ? { ...g, name, nameKey: undefined } : g
+        ),
       }));
     },
 

--- a/tests/stores/slices/groupsSlice.test.ts
+++ b/tests/stores/slices/groupsSlice.test.ts
@@ -71,6 +71,20 @@ describe('groupsSlice', () => {
     expect(h.state().groups.find((g) => g.id === 'g-default')!.name).toBe('Renamed');
   });
 
+  it('renameGroup clears nameKey so user input overrides i18n default', () => {
+    // The bootstrap "Sessions" group seeds both `name` and `nameKey`. The
+    // renderer prefers `nameKey` when set, so a rename that only updates
+    // `name` is invisible. Verify that `renameGroup` drops `nameKey`.
+    const h = harness();
+    expect(h.state().groups.find((g) => g.id === 'g-default')!.nameKey).toBe(
+      'sidebar.defaultGroupName'
+    );
+    h.slice.renameGroup('g-default', 'Renamed');
+    const renamed = h.state().groups.find((g) => g.id === 'g-default')!;
+    expect(renamed.name).toBe('Renamed');
+    expect(renamed.nameKey).toBeUndefined();
+  });
+
   it('archiveGroup / unarchiveGroup flips kind', () => {
     const h = harness();
     h.slice.archiveGroup('g-default');


### PR DESCRIPTION
## Symptom
Renaming the default "会话/Sessions" group has no visible effect — the sidebar keeps showing the localized default.

## Root cause
The bootstrap group seeds both `name` and `nameKey: 'sidebar.defaultGroupName'`, and `GroupRow` does `group.nameKey ? t(group.nameKey) : group.name` — the i18n key always wins, so `renameGroup` (which only updated `name`) was invisible.

## Fix
`renameGroup` now also sets `nameKey: undefined`, treating a user rename as explicit intent that overrides the localized default.

## Test
Added `tests/stores/slices/groupsSlice.test.ts` case asserting `nameKey` is cleared and `name` is updated after `renameGroup`. Full file passes (13/13). `npm run typecheck` clean.