### PR TITLE
fix(terminal): rebind paste capture on host change

### DIFF
--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -49,6 +49,20 @@ let keyboardPasteHandled = false;
 // the per-attach `snapSeq` to the snapshot's seq so subsequent live
 // chunks dedupe correctly.
 let snapshotReplay: (() => Promise<void>) | null = null;
+// Capture-phase `paste` listener bookkeeping. The listener is bound to the
+// host DOM node passed into `ensureTerminal`; React can remount TerminalPane
+// (e.g. close-all → create-new flow), which produces a brand-new host div.
+// When the retarget branch below re-`open`s xterm against the new host, the
+// listener attached to the old (now-orphaned) host stops receiving paste
+// events from the live DOM tree. The Electron context-menu paste / Shift+
+// Insert paths then fall through to xterm's built-in paste pipeline,
+// regressing the bracketed-paste/CRLF fix from #1303.
+//
+// Track the currently-bound host + listener at module scope so we can
+// `removeEventListener` from the old host and `addEventListener` on the
+// new host every time `ensureTerminal` rebinds. See `attachPasteCapture`.
+let pasteHost: HTMLElement | null = null;
+let pasteListener: ((e: ClipboardEvent) => void) | null = null;
 
 export function getTerm(): Terminal | null {
   return term;
@@ -173,6 +187,47 @@ export async function pasteIntoActivePty(fallbackText: string | undefined): Prom
   if (fallbackText) window.ccsmPty.input(sid, fallbackText);
 }
 
+// Module-scope capture-phase paste listener. Hoisted out of `ensureTerminal`
+// so the same function identity can be removed from the previously-bound host
+// and re-attached to the new host on retarget. Closes over no construction-
+// local state — only the module-level `keyboardPasteHandled` flag and
+// `pasteIntoActivePty`. See the long comment inside `ensureTerminal` for the
+// design rationale of the single canonical paste path.
+function onPasteCapture(e: ClipboardEvent): void {
+  e.stopImmediatePropagation();
+  e.preventDefault();
+  if (keyboardPasteHandled) {
+    keyboardPasteHandled = false;
+    return;
+  }
+  // Read text synchronously: clipboardData is only valid during the
+  // event dispatch, so we can't await before reading it.
+  const text = e.clipboardData?.getData('text/plain') ?? '';
+  void pasteIntoActivePty(text || undefined);
+}
+
+/**
+ * Attach the capture-phase paste listener to `host`, detaching it from the
+ * previously-bound host first if any. Idempotent and safe to call after
+ * every `term.open(host)` (both first-construction and the retarget branch
+ * inside `ensureTerminal`).
+ *
+ * Why this exists: TerminalPane remount produces a new host div. The
+ * retarget branch re-`open`s xterm against the new host, but without this
+ * helper the paste listener stayed on the orphaned old host — Electron
+ * context-menu paste and Shift+Insert then bypassed `pasteIntoActivePty`
+ * and fell through to xterm's built-in pipeline, regressing the
+ * bracketed-paste/CRLF fix from #1303.
+ */
+function attachPasteCapture(host: HTMLElement): void {
+  if (pasteHost && pasteListener) {
+    pasteHost.removeEventListener('paste', pasteListener, true);
+  }
+  pasteListener = onPasteCapture;
+  host.addEventListener('paste', pasteListener, true);
+  pasteHost = host;
+}
+
 /**
  * Create (or re-attach) the singleton Terminal against `host`. Idempotent:
  * subsequent calls reuse the cached instance and only re-`open` if React
@@ -186,6 +241,12 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
       } catch {
         // open() throws if already attached to this exact host; ignore.
       }
+      // Rebind the capture-phase paste listener to the new host. Without
+      // this the listener stays on the orphaned old host and Electron
+      // context-menu paste / Shift+Insert fall through to xterm's built-in
+      // pipeline (regression of #1303 bracketed-paste/CRLF fix). See
+      // `attachPasteCapture` for details.
+      attachPasteCapture(host);
     }
     return term;
   }
@@ -329,19 +390,11 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
   // module scope: every paste path (capture-phase DOM event, Ctrl/Cmd+V
   // keydown, right-click `terminalPaste`) funnels through that helper so
   // pasted screenshots auto-save and inject as a path.
-  const onPasteCapture = (e: ClipboardEvent): void => {
-    e.stopImmediatePropagation();
-    e.preventDefault();
-    if (keyboardPasteHandled) {
-      keyboardPasteHandled = false;
-      return;
-    }
-    // Read text synchronously: clipboardData is only valid during the
-    // event dispatch, so we can't await before reading it.
-    const text = e.clipboardData?.getData('text/plain') ?? '';
-    void pasteIntoActivePty(text || undefined);
-  };
-  host.addEventListener('paste', onPasteCapture, { capture: true });
+  //
+  // The listener function (`onPasteCapture`) and the binding logic are at
+  // module scope so the retarget branch above can rebind cleanly when
+  // TerminalPane remounts into a new host div.
+  attachPasteCapture(host);
 
   // ttyd-style: auto-copy on selection change. Works in alt-screen apps
   // (claude/Ink) when user holds Shift to bypass mouse tracking and
@@ -469,6 +522,17 @@ export function __resetSingletonForTests(): void {
   inputDisposable = null;
   snapshotReplay = null;
   keyboardPasteHandled = false;
+  // Detach the capture-phase paste listener from whichever host it landed
+  // on so tests that mount fresh hosts don't see stale listeners firing.
+  if (pasteHost && pasteListener) {
+    try {
+      pasteHost.removeEventListener('paste', pasteListener, true);
+    } catch {
+      // best-effort — host may already be detached.
+    }
+  }
+  pasteHost = null;
+  pasteListener = null;
   if (typeof window !== 'undefined') {
     delete window.__ccsmTerm;
   }

--- a/tests/terminal/useXtermSingleton.test.tsx
+++ b/tests/terminal/useXtermSingleton.test.tsx
@@ -511,4 +511,57 @@ describe('useXtermSingleton', () => {
       expect(selectAllSpy).not.toHaveBeenCalled();
     });
   });
+
+  // Regression guard: capture-phase paste listener MUST be rebound on host
+  // change. TerminalPane remount (close-all → create-new flow) produces a
+  // new host div; the retarget branch in `ensureTerminal` re-`open`s xterm
+  // against the new host. Without listener rebinding, the paste listener
+  // stays on the orphaned old host — Electron context-menu paste and
+  // Shift+Insert then bypass `pasteIntoActivePty` and fall through to
+  // xterm's built-in paste pipeline, regressing the bracketed-paste/CRLF
+  // fix from #1303.
+  describe('paste listener rebinds on host change', () => {
+    it('removes the listener from the old host and adds it to the new host on retarget', () => {
+      const hostA = document.createElement('div');
+      const hostB = document.createElement('div');
+      document.body.appendChild(hostA);
+      document.body.appendChild(hostB);
+
+      const addSpyA = vi.spyOn(hostA, 'addEventListener');
+      const removeSpyA = vi.spyOn(hostA, 'removeEventListener');
+      const addSpyB = vi.spyOn(hostB, 'addEventListener');
+      const removeSpyB = vi.spyOn(hostB, 'removeEventListener');
+
+      // First ensureTerminal binds against hostA.
+      renderHook(() => useXtermSingleton({ current: hostA }));
+      const pasteAddOnA = addSpyA.mock.calls.filter((c) => c[0] === 'paste');
+      expect(pasteAddOnA).toHaveLength(1);
+
+      // Flip the mock's `_parent` so the retarget branch's
+      // `_core._parent !== host` check triggers — otherwise the second
+      // ensureTerminal hits the no-op "same host, already attached" path
+      // and we'd never exercise the rebind.
+      const t = getTerm() as unknown as { _core: { _parent: HTMLElement | null } };
+      t._core._parent = hostA;
+
+      renderHook(() => useXtermSingleton({ current: hostB }));
+
+      // Old host: listener removed.
+      const pasteRemoveOnA = removeSpyA.mock.calls.filter((c) => c[0] === 'paste');
+      expect(pasteRemoveOnA).toHaveLength(1);
+      // New host: listener added.
+      const pasteAddOnB = addSpyB.mock.calls.filter((c) => c[0] === 'paste');
+      expect(pasteAddOnB).toHaveLength(1);
+      // Same listener identity across remove + add so the rebind is
+      // not allocating a stale closure on each call.
+      expect(pasteRemoveOnA[0][1]).toBe(pasteAddOnB[0][1]);
+      // No spurious add on the old host during retarget, no remove on the
+      // brand-new host.
+      expect(addSpyA.mock.calls.filter((c) => c[0] === 'paste')).toHaveLength(1);
+      expect(removeSpyB.mock.calls.filter((c) => c[0] === 'paste')).toHaveLength(0);
+
+      document.body.removeChild(hostA);
+      document.body.removeChild(hostB);
+    });
+  });
 });


### PR DESCRIPTION
## Symptom

In the close-all -> create-new flow, Electron context-menu paste and Shift+Insert in the freshly-remounted `TerminalPane` regress to xterm's built-in paste pipeline, undoing the bracketed-paste/CRLF fix from #1303.

## Root cause

The capture-phase `paste` listener was attached inside the first-construction branch of `ensureTerminal` (`src/terminal/xtermSingleton.ts`). When `TerminalPane` remounts into a new host div, the retarget branch (`_core._parent !== host` -> `term.open(host)`) re-`open`s xterm against the new host but never moved the listener -- it stayed on the orphaned old div, so live paste events bypassed `pasteIntoActivePty` and fell through to xterm's built-in pipeline.

## Fix

- Hoist `onPasteCapture` to module scope. It closes over no construction-local state (only the module-level `keyboardPasteHandled` flag + `pasteIntoActivePty`), so the lift is mechanical.
- Add module-level `pasteHost` / `pasteListener` bookkeeping plus an `attachPasteCapture(host)` helper that detaches from the previously-bound host before attaching to the new one.
- Call `attachPasteCapture(host)` after every `term.open(host)` -- both first-construction and the retarget branch.
- `__resetSingletonForTests` clears the new state and detaches the listener for clean test isolation.

## Test

- `tests/terminal/useXtermSingleton.test.tsx` adds a `paste listener rebinds on host change` regression guard: spies on `addEventListener` / `removeEventListener` on two distinct hosts, mutates the singleton's `_core._parent` so the retarget branch fires on the second `ensureTerminal`, then asserts (a) `removeEventListener('paste', ...)` was called on the old host, (b) `addEventListener('paste', ...)` was called on the new host, and (c) the same function identity is used across the two calls (no stale closure churn).
- Full suite green: `npx vitest run tests/terminal/` -> 53/53 pass.
- `npm run typecheck` clean.
- `npm run lint` -- 0 errors (warnings unchanged from main).

## Test plan

- [ ] Open ccsm, create a session, close all sessions, create a new one.
- [ ] Right-click in the terminal pane -> Paste a multi-line string. Verify it arrives with bracketed-paste/CRLF normalization (no raw `\r` swallow, no double-paste).
- [ ] Shift+Insert in the same pane after a remount. Verify the same.
- [ ] Existing Ctrl/Cmd+V keydown path and image-first paste still inject exactly once.

Generated with [Claude Code](https://claude.com/claude-code)