### PR TITLE
fix(sessions): unarchive uses ensureUsableGroup fallback (no orphan)

### DIFF
--- a/src/stores/slices/sessionCrudSlice.ts
+++ b/src/stores/slices/sessionCrudSlice.ts
@@ -512,7 +512,13 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
 
     unarchiveSession: (sessionId) => {
       // Clear `archivedAt`, move back to original source group if it
-      // still exists and is normal — otherwise fall back to g-default.
+      // still exists and is normal — otherwise route through
+      // `ensureUsableGroup` so the session lands in a real `kind:'normal'`
+      // group (the same fallback createSession/importSession use). The
+      // earlier literal `'g-default'` fallback could orphan the session
+      // when the user had deleted every normal group: the row was
+      // persisted but invisible (Sidebar filters by group existence) with
+      // no UI path to recover.
       // If the archive container empties after the move, delete it.
       // If the user has no active session (e.g. they just archived the
       // active one and then immediately unarchived it), restore activeId
@@ -529,10 +535,9 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
       if (!container || container.kind !== 'archive' || !container.sourceGroupId) {
         return;
       }
-      const origin = store.groups.find(
-        (g) => g.id === container.sourceGroupId && g.kind === 'normal'
-      );
-      const targetGroupId = origin ? origin.id : 'g-default';
+      const ensured = ensureUsableGroup(store.groups, container.sourceGroupId);
+      const targetGroupId = ensured.groupId;
+      const baseGroups = ensured.groups;
       set((s) => {
         const sessions = s.sessions.map((x) => {
           if (x.id !== sessionId) return x;
@@ -543,9 +548,12 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
         const remainingInContainer = sessions.some(
           (x) => x.groupId === containerId
         );
+        // `baseGroups` already reflects any synthesized fallback group
+        // (prepended by ensureUsableGroup). Strip the now-empty archive
+        // container off that array, not off `s.groups`.
         const groups = remainingInContainer
-          ? s.groups
-          : s.groups.filter((g) => g.id !== containerId);
+          ? baseGroups
+          : baseGroups.filter((g) => g.id !== containerId);
         const nextActive = s.activeId === '' ? sessionId : s.activeId;
         return { groups, sessions, activeId: nextActive };
       });

--- a/tests/stores/slices/archiveSession.test.ts
+++ b/tests/stores/slices/archiveSession.test.ts
@@ -264,6 +264,54 @@ describe('archiveSession / unarchiveSession', () => {
     expect(s.groups!.find((g) => g.id === containerId)).toBeUndefined();
   });
 
+  it('unarchiveSession synthesizes a normal group when source AND all other normal groups are gone', () => {
+    // P1 bug repro: if the user has deleted g-default plus every other
+    // normal group (only the archive container remains), the old code
+    // fell back to the literal id 'g-default' which doesn't exist in
+    // state.groups → Sidebar filters out the session (groupId points at
+    // a non-existent group) so the row is persisted but invisible with
+    // no UI recovery path. Fix routes through ensureUsableGroup, which
+    // synthesizes a kind:'normal' group on demand (matches the
+    // createSession/importSession fallback contract).
+    const h = harness({
+      groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+      sessions: [mkSession('s1', 'g-default')],
+      activeId: 's1',
+    });
+    h.get().archiveSession('s1');
+    // g-default still exists but is empty; delete it. s1 lives in the
+    // archive container now, so deleting g-default doesn't cascade to s1.
+    const containerId = h.state().groups!.find(
+      (g) => g.kind === 'archive' && g.sourceGroupId === 'g-default'
+    )!.id;
+    h.get().deleteGroup('g-default');
+    const afterDelete = h.state();
+    // Sanity: no normal groups left, only the archive container.
+    expect(
+      afterDelete.groups!.filter((g) => g.kind === 'normal').length
+    ).toBe(0);
+    expect(afterDelete.groups!.find((g) => g.id === containerId)).toBeDefined();
+    expect(afterDelete.sessions!.find((x) => x.id === 's1')).toBeDefined();
+
+    h.get().unarchiveSession('s1');
+    const s = h.state();
+    const s1 = s.sessions!.find((x) => x.id === 's1')!;
+    // A new normal group must exist.
+    const normalGroups = s.groups!.filter((g) => g.kind === 'normal');
+    expect(normalGroups.length).toBe(1);
+    const synth = normalGroups[0]!;
+    // Session points at the new group (NOT the dead 'g-default' literal).
+    expect(s1.groupId).toBe(synth.id);
+    expect(s1.groupId).not.toBe('g-default');
+    // Sidebar visibility contract: the session's groupId resolves to an
+    // existing group in state.groups (this is the predicate Sidebar uses
+    // when filtering rows; failure here = invisible session).
+    expect(s.groups!.find((g) => g.id === s1.groupId)).toBeDefined();
+    expect(s1.archivedAt).toBeUndefined();
+    // Empty archive container cleaned up.
+    expect(s.groups!.find((g) => g.id === containerId)).toBeUndefined();
+  });
+
   it('unarchiveGroup on a container bulk-unarchives all members', () => {
     const h = harness({
       sessions: [


### PR DESCRIPTION
## Symptom

P1: if a user has deleted every normal group (including `g-default`) before unarchiving a session from an archive container, the session is persisted but **invisible**. Sidebar filters rows by `groups.find(g => g.id === session.groupId)` and the literal `'g-default'` fallback didn't exist in `state.groups`, so the row never rendered. No UI recovery path — power user only.

## Cause

`sessionCrudSlice.ts` `unarchiveSession`:

```ts
const targetGroupId = origin ? origin.id : 'g-default';
```

Assumes the seed `g-default` always exists. It usually does — but the user can delete it (plus every other normal group), leaving only archive containers.

## Fix

Route through the same `ensureUsableGroup(groups, preferredId)` helper that `createSession` / `importSession` already use:
- prefers the original source group (`container.sourceGroupId`)
- falls back to any other `kind:'normal'` group
- synthesizes a fresh normal group with the default name when none exist

The (possibly synthesized) groups array is folded into the same `set()` that clears `archivedAt` and (conditionally) deletes the empty archive container, so groups + sessions stay consistent in one tick.

## Test

`tests/stores/slices/archiveSession.test.ts` — new scenario:
- seed only `g-default`, archive `s1`
- delete `g-default` (s1 lives in the container, so it survives)
- unarchive `s1`
- assert a new normal group exists, `s1.groupId` points at it (not the dead literal `'g-default'`), `archivedAt` cleared, empty container cleaned up, and the Sidebar visibility predicate holds (`groups.find(g => g.id === s1.groupId)` defined)

## Gates

- `npx vitest run tests/stores/` — 107/107 pass (1 new test)
- `npm run typecheck` — clean
- `npm run lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)