### PR TITLE
fix(shortcuts): wire Ctrl+Shift+N to create new group (was advertised but unbound)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,6 +93,7 @@ export default function App() {
   // toggling a single session's waiting<->idle). See PR #1269.
   const selectSession = useStore((s) => s.selectSession);
   const focusGroup = useStore((s) => s.focusGroup);
+  const createGroup = useStore((s) => s.createGroup);
   const applyExternalTitle = useStore((s) => s._applyExternalTitle);
   const applyCwdRedirect = useStore((s) => s._applyCwdRedirect);
   const applyPtyExit = useStore((s) => s._applyPtyExit);
@@ -158,11 +159,21 @@ export default function App() {
     }));
   }, []));
 
-  // Global keyboard shortcuts (Ctrl+/, "?", Ctrl+F, Ctrl+,).
+  // Global keyboard shortcuts (Ctrl+/, "?", Ctrl+F, Ctrl+,, Ctrl+Shift+N).
   useShortcutHandlers({
     toggleShortcuts: React.useCallback(() => setShortcutsOpen((p) => !p), []),
     togglePalette: React.useCallback(() => setPaletteOpen((p) => !p), []),
     openSettings: React.useCallback(() => setSettingsOpen(true), []),
+    // Mirrors Sidebar.handleNewGroup: create then focus, so a subsequent
+    // "New session" lands inside the freshly created group. Auto-rename is
+    // intentionally not replicated — that's Sidebar-local state and the
+    // CommandPalette "New group" command (the prior global entry-point)
+    // doesn't trigger it either; the chord should behave consistently with
+    // its sibling surface.
+    createNewGroup: React.useCallback(() => {
+      const id = createGroup();
+      focusGroup(id);
+    }, [createGroup, focusGroup]),
   });
 
   // Mirror resolved language to main for OS-level surfaces (tray menu,

--- a/src/app-effects/useShortcutHandlers.ts
+++ b/src/app-effects/useShortcutHandlers.ts
@@ -35,17 +35,25 @@ export interface ShortcutHandlersDeps {
   togglePalette: () => void;
   /** Open the settings dialog. Bound to Ctrl+,. */
   openSettings: () => void;
+  /**
+   * Create a new sidebar group and focus it. Bound to Ctrl+Shift+N.
+   * Mirrors Sidebar's "+" button (handleNewGroup) so the keyboard path
+   * lands on the same row a click would. Suppressed while a text input,
+   * textarea, or contenteditable surface has focus so the chord can't
+   * fire mid-typing.
+   */
+  createNewGroup: () => void;
 }
 
 /**
  * Composite hook that installs all global keyboard shortcuts handled at
  * the App level. Combines what was previously a single inline `keydown`
- * listener in App.tsx covering: Ctrl+/, "?", Ctrl+F, Ctrl+,.
+ * listener in App.tsx covering: Ctrl+/, "?", Ctrl+F, Ctrl+,, Ctrl+Shift+N.
  *
  * Extracted for SRP under Task #724.
  */
 export function useShortcutHandlers(deps: ShortcutHandlersDeps): void {
-  const { toggleShortcuts, togglePalette, openSettings } = deps;
+  const { toggleShortcuts, togglePalette, openSettings, createNewGroup } = deps;
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
@@ -68,9 +76,18 @@ export function useShortcutHandlers(deps: ShortcutHandlersDeps): void {
       } else if (e.key === ',') {
         e.preventDefault();
         openSettings();
+      } else if (k === 'n' && e.shiftKey) {
+        // Ctrl/⌘ + Shift + N — create a new sidebar group. Both
+        // ShortcutOverlay and CommandPalette advertise this chord; without
+        // this branch the hint pointed at a no-op. Editable-target gate
+        // mirrors the "?" branch so typing "N" in the InputBar with Shift
+        // held (a capital N) can't spawn groups behind the user.
+        if (isEditableTarget(e.target)) return;
+        e.preventDefault();
+        createNewGroup();
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [toggleShortcuts, togglePalette, openSettings]);
+  }, [toggleShortcuts, togglePalette, openSettings, createNewGroup]);
 }

--- a/tests/app-effects/useShortcutHandlers.test.tsx
+++ b/tests/app-effects/useShortcutHandlers.test.tsx
@@ -15,11 +15,13 @@ describe('useShortcutHandlers', () => {
   let toggleShortcuts: ReturnType<typeof vi.fn>;
   let togglePalette: ReturnType<typeof vi.fn>;
   let openSettings: ReturnType<typeof vi.fn>;
+  let createNewGroup: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     toggleShortcuts = vi.fn();
     togglePalette = vi.fn();
     openSettings = vi.fn();
+    createNewGroup = vi.fn();
   });
 
   function mount() {
@@ -28,6 +30,7 @@ describe('useShortcutHandlers', () => {
         toggleShortcuts,
         togglePalette,
         openSettings,
+        createNewGroup,
       })
     );
   }
@@ -50,6 +53,7 @@ describe('useShortcutHandlers', () => {
     expect(togglePalette).not.toHaveBeenCalled();
     expect(toggleShortcuts).not.toHaveBeenCalled();
     expect(openSettings).not.toHaveBeenCalled();
+    expect(createNewGroup).not.toHaveBeenCalled();
   });
 
   it('Ctrl+, opens settings', () => {
@@ -83,6 +87,48 @@ describe('useShortcutHandlers', () => {
     expect(togglePalette).not.toHaveBeenCalled();
     expect(toggleShortcuts).not.toHaveBeenCalled();
     expect(openSettings).not.toHaveBeenCalled();
+    expect(createNewGroup).not.toHaveBeenCalled();
+  });
+
+  // ShortcutOverlay + CommandPalette advertise Ctrl+Shift+N for "New
+  // group"; the chord was previously unbound (silent no-op when the user
+  // followed the in-app hint). These cases lock the wiring in.
+  it('Ctrl+Shift+N creates a new group', () => {
+    mount();
+    dispatchKey({ key: 'N', ctrlKey: true, shiftKey: true });
+    expect(createNewGroup).toHaveBeenCalledTimes(1);
+  });
+
+  it('Cmd+Shift+N creates a new group (macOS modifier)', () => {
+    mount();
+    dispatchKey({ key: 'N', metaKey: true, shiftKey: true });
+    expect(createNewGroup).toHaveBeenCalledTimes(1);
+  });
+
+  it('Ctrl+N (without Shift) is NOT bound to createNewGroup', () => {
+    mount();
+    dispatchKey({ key: 'n', ctrlKey: true });
+    dispatchKey({ key: 'N', ctrlKey: true });
+    expect(createNewGroup).not.toHaveBeenCalled();
+  });
+
+  it('Ctrl+Shift+N is suppressed when an editable target has focus', () => {
+    mount();
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    dispatchKey({ key: 'N', ctrlKey: true, shiftKey: true, target: input });
+    expect(createNewGroup).not.toHaveBeenCalled();
+    document.body.removeChild(input);
+
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    dispatchKey({ key: 'N', ctrlKey: true, shiftKey: true, target: textarea });
+    expect(createNewGroup).not.toHaveBeenCalled();
+    document.body.removeChild(textarea);
+
+    // Note: contenteditable surfaces are also gated via `isContentEditable`
+    // in the editable check; not asserted here because jsdom doesn't
+    // propagate the `contentEditable` attribute to that getter reliably.
   });
 
   it('removes the keydown listener on unmount', () => {


### PR DESCRIPTION
## Symptom
ShortcutOverlay (\`src/components/ShortcutOverlay.tsx:39\`) and CommandPalette (\`src/components/CommandPalette.tsx:120\`) both advertise **Ctrl/Cmd+Shift+N → New group**. Pressing the combo did nothing — the in-app hint pointed at a no-op.

## Cause
When global shortcuts were extracted into \`useShortcutHandlers\` (Task #724), only Ctrl+/, "?", Ctrl+F, Ctrl+, were carried over. The new-group chord lived only in the help surfaces, never in code.

## Fix
- \`src/app-effects/useShortcutHandlers.ts\`: add a \`createNewGroup\` dep and branch on \`mod && shift && key === 'n'\`. Honor the editable-target guard so the chord can't fire while typing capital-N in the InputBar.
- \`src/App.tsx\`: wire the dep to \`createGroup() + focusGroup(id)\`, mirroring \`Sidebar.handleNewGroup\`'s focus follow-up so a subsequent "New session" lands inside the freshly created group.
- Auto-rename (Sidebar-local state) is intentionally **not** replicated — the CommandPalette "New group" command (the prior global entry-point for this action) doesn't trigger it either; keeping the chord and the palette consistent is the right tradeoff vs. lifting Sidebar-local state into the store.

## Test
\`tests/app-effects/useShortcutHandlers.test.tsx\`:
- [x] Ctrl+Shift+N triggers \`createNewGroup\`
- [x] Cmd+Shift+N triggers \`createNewGroup\` (macOS modifier)
- [x] Ctrl+N (no Shift) does NOT trigger (avoids hijacking common rebind)
- [x] Suppressed when an \`<input>\` / \`<textarea>\` has focus (contenteditable case noted but skipped — jsdom doesn't propagate \`contentEditable\` to \`isContentEditable\` reliably; the production check still covers it)
- [x] Existing Ctrl+B / Ctrl+K negative assertions extended to confirm \`createNewGroup\` is not collateral-fired

Verified locally:
\`\`\`
npx vitest run tests/app-effects/   # 62 pass
npm run typecheck                   # clean
npm run lint                        # 0 errors (pre-existing warnings only)
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)