### PR TITLE
fix(pty): async taskkill — quit no longer freezes UI

### DIFF
--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -50,25 +50,42 @@ type EventName = 'before-quit' | 'window-all-closed' | 'activate';
 interface FakeApp {
   on: ReturnType<typeof vi.fn>;
   quit: ReturnType<typeof vi.fn>;
-  /** invoke a registered listener for a given event */
-  fire: (event: EventName) => void;
+  /** invoke a registered listener for a given event; for `before-quit` we
+   *  pass an Event-like object with a `preventDefault` spy so tests can
+   *  assert the async-cleanup gate fired (and inspect re-quit re-entry). */
+  fire: (event: EventName, arg?: { preventDefault: () => void }) => void;
 }
 
 function createFakeApp(): FakeApp {
-  const handlers = new Map<EventName, () => void>();
-  const on = vi.fn((event: EventName, cb: () => void) => {
+  const handlers = new Map<EventName, (arg?: unknown) => void>();
+  const on = vi.fn((event: EventName, cb: (arg?: unknown) => void) => {
     handlers.set(event, cb);
   });
   const quit = vi.fn();
   return {
     on,
     quit,
-    fire: (event) => {
+    fire: (event, arg) => {
       const cb = handlers.get(event);
       if (!cb) throw new Error(`no handler registered for ${event}`);
-      cb();
+      cb(arg);
     },
   };
+}
+
+/** Build a fake Electron Event with a preventDefault spy. */
+function fakeEvent(): { preventDefault: ReturnType<typeof vi.fn> } {
+  return { preventDefault: vi.fn() };
+}
+
+/** Drain pending microtasks so awaited async work inside the before-quit
+ *  handler settles before assertions. We use multiple `await` cycles because
+ *  the handler chains `await killAllPtySessions()` → optional dispose →
+ *  `app.quit()`; one microtask tick isn't enough. */
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve();
+  }
 }
 
 function buildDeps(overrides: Partial<LifecycleDeps> = {}): {
@@ -76,6 +93,8 @@ function buildDeps(overrides: Partial<LifecycleDeps> = {}): {
   fakeApp: FakeApp;
   spies: {
     setIsQuitting: ReturnType<typeof vi.fn>;
+    // killAllPtySessions returns Promise<void> in production so the
+    // before-quit handler can await the parallel taskkill fanout.
     killAllPtySessions: ReturnType<typeof vi.fn>;
     closeDb: ReturnType<typeof vi.fn>;
     createWindow: ReturnType<typeof vi.fn>;
@@ -88,7 +107,7 @@ function buildDeps(overrides: Partial<LifecycleDeps> = {}): {
   const setIsQuitting = vi.fn((v: boolean) => {
     state.isQuitting = v;
   });
-  const killAllPtySessions = vi.fn();
+  const killAllPtySessions = vi.fn(() => Promise.resolve());
   const closeDb = vi.fn();
   const createWindow = vi.fn();
   const disposeNotifyPipeline = vi.fn();
@@ -171,51 +190,115 @@ describe('registerLifecycleHandlers', () => {
     it('flips isQuitting to true', () => {
       const { deps, fakeApp, spies, state } = buildDeps();
       registerLifecycleHandlers(deps);
-      fakeApp.fire('before-quit');
+      fakeApp.fire('before-quit', fakeEvent());
       expect(spies.setIsQuitting).toHaveBeenCalledWith(true);
       expect(state.isQuitting).toBe(true);
     });
 
-    it('reaps pty sessions', () => {
+    it('preventDefaults the sync quit so async cleanup can run before exit', () => {
+      const { deps, fakeApp } = buildDeps();
+      registerLifecycleHandlers(deps);
+      const ev = fakeEvent();
+      fakeApp.fire('before-quit', ev);
+      // First-pass before-quit MUST block Electron's sync teardown — otherwise
+      // the process exits before killAllPtySessions's parallel taskkill
+      // fanout has a chance to complete, leaving orphan claude.exe children
+      // on Windows and freezing the visible UI for N × taskkill latency.
+      expect(ev.preventDefault).toHaveBeenCalledTimes(1);
+    });
+
+    it('reaps pty sessions', async () => {
       const { deps, fakeApp, spies } = buildDeps();
       registerLifecycleHandlers(deps);
-      fakeApp.fire('before-quit');
+      fakeApp.fire('before-quit', fakeEvent());
+      await flushAsync();
       expect(spies.killAllPtySessions).toHaveBeenCalledTimes(1);
     });
 
-    it('disposes the notify pipeline when present', () => {
+    it('re-invokes app.quit() after async cleanup settles (second-pass exit)', async () => {
       const { deps, fakeApp, spies } = buildDeps();
       registerLifecycleHandlers(deps);
-      fakeApp.fire('before-quit');
+      fakeApp.fire('before-quit', fakeEvent());
+      // Sync: not yet — we're still awaiting killAllPtySessions().
+      expect(fakeApp.quit).not.toHaveBeenCalled();
+      await flushAsync();
+      // Async: cleanup done → handler re-fires quit so Electron exits cleanly.
+      expect(fakeApp.quit).toHaveBeenCalledTimes(1);
+      expect(spies.killAllPtySessions).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT loop forever — re-entry on the quit-driven before-quit is a pass-through', async () => {
+      const { deps, fakeApp, spies } = buildDeps();
+      registerLifecycleHandlers(deps);
+      // First-pass: starts cleanup, preventDefaults.
+      const ev1 = fakeEvent();
+      fakeApp.fire('before-quit', ev1);
+      await flushAsync();
+      expect(ev1.preventDefault).toHaveBeenCalledTimes(1);
+      expect(fakeApp.quit).toHaveBeenCalledTimes(1);
+      // Simulate Electron firing before-quit again from the internal
+      // `app.quit()` we just dispatched. Guard MUST let it through —
+      // no second preventDefault, no second cleanup.
+      const ev2 = fakeEvent();
+      fakeApp.fire('before-quit', ev2);
+      await flushAsync();
+      expect(ev2.preventDefault).not.toHaveBeenCalled();
+      expect(spies.killAllPtySessions).toHaveBeenCalledTimes(1);
+      // The pass-through doesn't re-invoke app.quit either (else infinite loop)
+      expect(fakeApp.quit).toHaveBeenCalledTimes(1);
+    });
+
+    it('disposes the notify pipeline when present', async () => {
+      const { deps, fakeApp, spies } = buildDeps();
+      registerLifecycleHandlers(deps);
+      fakeApp.fire('before-quit', fakeEvent());
+      await flushAsync();
       expect(spies.disposeNotifyPipeline).toHaveBeenCalledTimes(1);
     });
 
-    it('does not throw when disposeNotifyPipeline is omitted (early-failure path)', () => {
+    it('does not throw when disposeNotifyPipeline is omitted (early-failure path)', async () => {
       const { deps, fakeApp } = buildDeps({ disposeNotifyPipeline: undefined });
       registerLifecycleHandlers(deps);
-      expect(() => fakeApp.fire('before-quit')).not.toThrow();
+      expect(() => fakeApp.fire('before-quit', fakeEvent())).not.toThrow();
+      await expect(flushAsync()).resolves.toBeUndefined();
     });
 
-    it('swallows killAllPtySessions errors (best-effort cleanup)', () => {
+    it('swallows killAllPtySessions rejections (best-effort cleanup) and still proceeds to quit', async () => {
+      const { deps, fakeApp, spies } = buildDeps({
+        killAllPtySessions: vi.fn(() => Promise.reject(new Error('pty reap blew up'))),
+      });
+      registerLifecycleHandlers(deps);
+      fakeApp.fire('before-quit', fakeEvent());
+      await flushAsync();
+      // disposeNotifyPipeline still runs even if kill rejected
+      expect(spies.disposeNotifyPipeline).toHaveBeenCalledTimes(1);
+      // app.quit still re-fires so the process actually exits
+      expect(fakeApp.quit).toHaveBeenCalledTimes(1);
+    });
+
+    it('swallows synchronous killAllPtySessions throws too', async () => {
       const { deps, fakeApp, spies } = buildDeps({
         killAllPtySessions: vi.fn(() => {
-          throw new Error('pty reap blew up');
+          throw new Error('pty reap sync blew up');
         }),
       });
       registerLifecycleHandlers(deps);
-      expect(() => fakeApp.fire('before-quit')).not.toThrow();
-      // disposeNotifyPipeline still runs even if kill threw
+      expect(() => fakeApp.fire('before-quit', fakeEvent())).not.toThrow();
+      await flushAsync();
       expect(spies.disposeNotifyPipeline).toHaveBeenCalledTimes(1);
+      expect(fakeApp.quit).toHaveBeenCalledTimes(1);
     });
 
-    it('swallows disposeNotifyPipeline errors', () => {
+    it('swallows disposeNotifyPipeline errors', async () => {
       const { deps, fakeApp } = buildDeps({
         disposeNotifyPipeline: vi.fn(() => {
           throw new Error('dispose blew up');
         }),
       });
       registerLifecycleHandlers(deps);
-      expect(() => fakeApp.fire('before-quit')).not.toThrow();
+      expect(() => fakeApp.fire('before-quit', fakeEvent())).not.toThrow();
+      await flushAsync();
+      expect(fakeApp.quit).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -76,8 +76,12 @@ export interface LifecycleDeps {
   setIsQuitting: (v: boolean) => void;
   /** Best-effort reap of any live node-pty children spawned through
    *  ptyHost. Idempotent; critical on Windows where conpty can otherwise
-   *  leak the claude child past Electron quit. */
-  killAllPtySessions: () => void;
+   *  leak the claude child past Electron quit. Returns a Promise so the
+   *  before-quit handler can await the parallel `taskkill` fanout before
+   *  letting Electron tear down — previously the sync version froze the
+   *  quit UI for N × 200-2000ms while `spawnSync('taskkill', ...)` ran
+   *  serially per session. */
+  killAllPtySessions: () => Promise<void> | void;
   /** Tear down the notify pipeline + its app-level listeners (focus/blur,
    *  sessionWatcher 'unwatched') and any pending flash timers. Optional
    *  because `before-quit` may fire before the pipeline is constructed
@@ -105,20 +109,47 @@ export function registerLifecycleHandlers(deps: LifecycleDeps): void {
     disposeNotifyPipeline,
   } = deps;
 
-  app.on('before-quit', () => {
+  // Re-entry guard for the async before-quit dance below. Once we've
+  // dispatched the async cleanup we call `app.quit()` again, which re-fires
+  // `before-quit`; on that second pass we must let Electron proceed
+  // unmolested (no preventDefault, no double-cleanup) — otherwise we'd
+  // loop forever. The flag is in module scope rather than on the deps bag
+  // because it's purely an implementation detail of THIS handler.
+  let cleanupStarted = false;
+
+  app.on('before-quit', (event) => {
     setIsQuitting(true);
-    try {
-      killAllPtySessions();
-    } catch {
-      /* ignore — best-effort cleanup on quit */
+    if (cleanupStarted) {
+      // Second-pass quit after async cleanup resolved — let Electron exit.
+      return;
     }
-    if (disposeNotifyPipeline) {
+    cleanupStarted = true;
+
+    // Block the synchronous quit so we can wait for the parallel `taskkill`
+    // (Windows) / SIGTERM-SIGKILL (POSIX) fanout to settle. Without this,
+    // Electron tears down before `killAllPtySessions` finishes, leaving
+    // orphaned claude.exe children on Windows AND freezing the visible UI
+    // for N × 200-2000ms while the old sync `spawnSync('taskkill')` ran
+    // serially per session.
+    event.preventDefault();
+
+    const runCleanup = async () => {
       try {
-        disposeNotifyPipeline();
+        await killAllPtySessions();
       } catch {
         /* ignore — best-effort cleanup on quit */
       }
-    }
+      if (disposeNotifyPipeline) {
+        try {
+          disposeNotifyPipeline();
+        } catch {
+          /* ignore — best-effort cleanup on quit */
+        }
+      }
+      // Re-trigger quit; the re-entry guard above lets this pass through.
+      app.quit();
+    };
+    void runCleanup();
   });
 
   app.on('window-all-closed', () => {

--- a/electron/ptyHost/__tests__/lifecycle.test.ts
+++ b/electron/ptyHost/__tests__/lifecycle.test.ts
@@ -43,7 +43,13 @@ function bus(): LifecycleBus {
 }
 
 vi.mock('../processKiller', () => ({
-  killProcessSubtree: (pid: number | undefined) => bus().killCalls.push(pid),
+  killProcessSubtree: (pid: number | undefined) => {
+    bus().killCalls.push(pid);
+    // Real impl returns Promise<void>; the lifecycle kill() awaits it via
+    // Promise.all so the outer kill resolves only after the subtree walk
+    // settles. Resolve synchronously here so test timing is unchanged.
+    return Promise.resolve();
+  },
 }));
 
 vi.mock('../../sessionWatcher', () => ({

--- a/electron/ptyHost/__tests__/processKiller.test.ts
+++ b/electron/ptyHost/__tests__/processKiller.test.ts
@@ -1,6 +1,30 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { spawn as spawnFn } from 'node:child_process';
 
-import { killProcessSubtree } from '../processKiller';
+// Hoist the spawn spy so vi.mock's factory (also hoisted) closes over the
+// same reference the tests assert against.
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }));
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+  // Re-export the few symbols transitively touched by the runtime to keep
+  // unrelated imports happy. Anything else throws — these tests don't need
+  // it, and the production code under test only uses `spawn`.
+  default: { spawn: spawnMock },
+}));
+
+import { killProcessSubtree, TASKKILL_TIMEOUT_MS } from '../processKiller';
+
+/** A minimal stand-in for ChildProcess that exposes `once('exit'|'error')`
+ *  + `kill()` — enough for processKiller to drive its resolve/timeout race. */
+function makeFakeChild() {
+  const ee = new EventEmitter() as EventEmitter & {
+    kill: ReturnType<typeof vi.fn>;
+    once: (e: string, cb: (...a: unknown[]) => void) => EventEmitter;
+  };
+  ee.kill = vi.fn();
+  return ee;
+}
 
 describe('killProcessSubtree — guards', () => {
   // No spawn / no process.kill should be invoked for invalid pids.
@@ -8,40 +32,115 @@ describe('killProcessSubtree — guards', () => {
     ['undefined', undefined],
     ['zero', 0],
     ['negative', -1],
-  ])('no-op for %s pid', (_label, pid) => {
+  ])('no-op for %s pid (resolves immediately)', async (_label, pid) => {
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(((..._args: unknown[]) => true) as never);
     try {
-      // Should not throw and not signal anything.
-      expect(() => killProcessSubtree(pid as number | undefined)).not.toThrow();
+      await expect(killProcessSubtree(pid as number | undefined)).resolves.toBeUndefined();
       expect(killSpy).not.toHaveBeenCalled();
+      expect(spawnMock).not.toHaveBeenCalled();
     } finally {
       killSpy.mockRestore();
     }
   });
 });
 
-describe('killProcessSubtree — windows path', () => {
+describe('killProcessSubtree — windows path (async spawn)', () => {
   const originalPlatform = process.platform;
 
   beforeEach(() => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
+    spawnMock.mockReset();
   });
 
   afterEach(() => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
+    vi.useRealTimers();
   });
 
-  it('does not throw for a non-existent pid (taskkill swallows)', () => {
-    // 999999 almost certainly does not exist; taskkill returns nonzero
-    // but spawnSync does not throw. Production code wraps in try/catch
-    // anyway.
-    expect(() => killProcessSubtree(999999)).not.toThrow();
+  it('invokes taskkill with /F /T /PID <pid> and windowsHide', async () => {
+    const child = makeFakeChild();
+    spawnMock.mockReturnValue(child as unknown as ReturnType<typeof spawnFn>);
+    const promise = killProcessSubtree(4242);
+    // Caller should have invoked spawn synchronously with the canonical args.
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(spawnMock).toHaveBeenCalledWith(
+      'taskkill',
+      ['/F', '/T', '/PID', '4242'],
+      expect.objectContaining({ windowsHide: true, stdio: 'ignore' }),
+    );
+    // Promise hasn't resolved yet — waiting on taskkill exit.
+    // Fire exit; promise should resolve.
+    child.emit('exit', 0, null);
+    await expect(promise).resolves.toBeUndefined();
   });
 
-  it('does not invoke process.kill on win32 (uses taskkill instead)', () => {
+  it('resolves on child error (taskkill binary missing / spawn ENOENT)', async () => {
+    const child = makeFakeChild();
+    spawnMock.mockReturnValue(child as unknown as ReturnType<typeof spawnFn>);
+    const promise = killProcessSubtree(7);
+    child.emit('error', new Error('ENOENT'));
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('resolves on a synchronous spawn throw (also no leak)', async () => {
+    spawnMock.mockImplementation(() => {
+      throw new Error('spawn blew up');
+    });
+    // No `unhandledRejection` — the promise resolves cleanly.
+    await expect(killProcessSubtree(11)).resolves.toBeUndefined();
+  });
+
+  it('resolves after TASKKILL_TIMEOUT_MS if exit never fires (wedged taskkill)', async () => {
+    vi.useFakeTimers();
+    const child = makeFakeChild();
+    spawnMock.mockReturnValue(child as unknown as ReturnType<typeof spawnFn>);
+    const promise = killProcessSubtree(99);
+    let resolved = false;
+    void promise.then(() => { resolved = true; });
+    // Before the timeout: promise still pending.
+    await Promise.resolve(); // let microtasks drain
+    expect(resolved).toBe(false);
+    // Advance just under the timeout — still pending.
+    vi.advanceTimersByTime(TASKKILL_TIMEOUT_MS - 1);
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    // Cross the timeout boundary — promise resolves; child.kill() called as
+    // a last-ditch attempt to free the wedged taskkill handle.
+    vi.advanceTimersByTime(1);
+    await promise;
+    expect(resolved).toBe(true);
+    expect(child.kill).toHaveBeenCalled();
+  });
+
+  it('parallel kills do not serialize on each other (Promise.all stays cheap)', async () => {
+    // Stub each spawn with its own EE — none of them resolve until we say so.
+    const children: ReturnType<typeof makeFakeChild>[] = [];
+    spawnMock.mockImplementation(() => {
+      const c = makeFakeChild();
+      children.push(c);
+      return c as unknown as ReturnType<typeof spawnFn>;
+    });
+    const all = Promise.all([
+      killProcessSubtree(1),
+      killProcessSubtree(2),
+      killProcessSubtree(3),
+    ]);
+    // All three taskkills were dispatched synchronously — none waited on
+    // the previous one. This is the property the old `spawnSync` path
+    // violated and the bug fix protects.
+    expect(spawnMock).toHaveBeenCalledTimes(3);
+    children.forEach((c) => c.emit('exit', 0, null));
+    await expect(all).resolves.toEqual([undefined, undefined, undefined]);
+  });
+
+  it('does not invoke process.kill on win32 (uses taskkill instead)', async () => {
+    const child = makeFakeChild();
+    spawnMock.mockReturnValue(child as unknown as ReturnType<typeof spawnFn>);
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(((..._args: unknown[]) => true) as never);
     try {
-      killProcessSubtree(999999);
+      const p = killProcessSubtree(999999);
+      child.emit('exit', 1, null);
+      await p;
       expect(killSpy).not.toHaveBeenCalled();
     } finally {
       killSpy.mockRestore();
@@ -55,6 +154,7 @@ describe('killProcessSubtree — posix path', () => {
   beforeEach(() => {
     Object.defineProperty(process, 'platform', { value: 'linux' });
     vi.useFakeTimers();
+    spawnMock.mockReset();
   });
 
   afterEach(() => {
@@ -62,16 +162,20 @@ describe('killProcessSubtree — posix path', () => {
     vi.useRealTimers();
   });
 
-  it('signals process group SIGTERM, then SIGKILL after 500ms', () => {
+  it('signals process group SIGTERM, then SIGKILL after 500ms; resolves immediately', async () => {
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(((..._args: unknown[]) => true) as never);
     try {
-      killProcessSubtree(4321);
+      const promise = killProcessSubtree(4321);
 
       // Immediate SIGTERM to negative pid (process group)
       expect(killSpy).toHaveBeenCalledWith(-4321, 'SIGTERM');
       expect(killSpy).toHaveBeenCalledTimes(1);
 
-      // Advance timers — SIGKILL should fire
+      // Promise resolves without needing the SIGKILL timer to fire — POSIX
+      // path is non-blocking, so we don't make callers wait 500ms on quit.
+      await expect(promise).resolves.toBeUndefined();
+
+      // Advance timers — SIGKILL still fires for the actual process.
       vi.advanceTimersByTime(500);
       expect(killSpy).toHaveBeenCalledWith(-4321, 'SIGKILL');
       expect(killSpy).toHaveBeenCalledTimes(2);
@@ -80,12 +184,18 @@ describe('killProcessSubtree — posix path', () => {
     }
   });
 
-  it('swallows SIGTERM throw (group already gone) and still schedules SIGKILL', () => {
+  it('does not spawn taskkill on linux', async () => {
+    vi.spyOn(process, 'kill').mockImplementation(((..._args: unknown[]) => true) as never);
+    await killProcessSubtree(123);
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows SIGTERM throw (group already gone) and still schedules SIGKILL', async () => {
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(((..._args: unknown[]) => {
       throw new Error('ESRCH');
     }) as never);
     try {
-      expect(() => killProcessSubtree(7)).not.toThrow();
+      await expect(killProcessSubtree(7)).resolves.toBeUndefined();
       // SIGKILL after timeout should also be swallowed
       expect(() => vi.advanceTimersByTime(500)).not.toThrow();
       // Both attempts were made

--- a/electron/ptyHost/index.ts
+++ b/electron/ptyHost/index.ts
@@ -86,7 +86,7 @@ export const killPtySession = (sid: string): Promise<boolean> => L.kill(sessions
 export const getPtySession = (sid: string): L.PtySessionInfo | null =>
   L.get(sessions, sid);
 
-export const killAllPtySessions = (): void => L.killAll(sessions);
+export const killAllPtySessions = (): Promise<void> => L.killAll(sessions);
 
 // L4 PR-A (#861) + PR-B (#865): async chunked snapshot of the per-session
 // authoritative headless buffer paired with the per-entry chunk seq.

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -248,14 +248,39 @@ export function kill(sessions: Map<string, Entry>, sid: string): Promise<boolean
   // ConPTY's kill only terminates the cmd.exe / OpenConsole wrapper; on Windows
   // the claude.exe child (and its grandchildren) survive as orphans. On
   // mac/linux the pgid may also have stragglers. Walk the tree via a
-  // platform-native call to guarantee a clean shutdown.
-  killProcessSubtree(pid);
+  // platform-native call to guarantee a clean shutdown. The dispatch itself
+  // is async (Windows uses `spawn` + 5s timeout, POSIX is fire-and-forget);
+  // we ensure the returned `kill()` promise waits for that walk to settle so
+  // `killAll` on `before-quit` can `Promise.all` and let N taskkills run in
+  // parallel rather than blocking the main thread serially.
+  const subtreePromise = killProcessSubtree(pid);
   // Belt-and-braces: also stop the watcher synchronously here so a
   // pty.kill that races with onExit can't leak the fs.watch handle.
   // sessionWatcher.stopWatching is idempotent.
   try { sessionWatcher.stopWatching(sid); } catch { /* never throws */ }
 
-  return promise;
+  // Resolve the outer promise only after BOTH the pty teardown and the
+  // subtree walk have settled. `promise` is the existing onExit/timeout
+  // race; combining via Promise.all keeps the boolean (true = clean exit,
+  // false = wedged) while gating on the platform-native cleanup.
+  const combined = Promise.all([promise, subtreePromise]).then(([clean]) => clean);
+  // Re-register the combined promise as the dedup slot so concurrent callers
+  // observe `===`-identity against what `kill()` returns (not the inner
+  // onExit promise). The slot is freed inside `settle()` by-value comparison
+  // against `promise`, so we must NOT keep the inner promise as the slot
+  // value — replace it here. (The `settle` cleanup still finds nothing to
+  // delete after this replace, which is fine: the inner `promise` resolving
+  // also triggers `combined` to settle, and pendingKills is cleared on the
+  // next `kill()` for the same sid via the slot-replace dance below.)
+  // To keep the slot drained on settle, swap the comparison key inside
+  // settle by also storing `combined` in pendingKills with a tombstone
+  // mechanism — simpler: just delete the slot when `combined` settles.
+  const map = getPendingKills(sessions);
+  map.set(sid, combined);
+  combined.finally(() => {
+    if (map.get(sid) === combined) map.delete(sid);
+  });
+  return combined;
 }
 
 export function get(sessions: Map<string, Entry>, sid: string): PtySessionInfo | null {
@@ -333,12 +358,16 @@ export async function getBufferSnapshot(
 }
 
 // Kill every running pty. Call from app `before-quit` so renderer-side
-// claude processes don't leak past Electron exit. Fire-and-forget — we don't
-// block app teardown on the per-pty onExit/timeout dance; the kill signal +
-// processKiller subtree walk dispatch synchronously inside `kill()` before
-// the awaited onExit, which is what actually reaps the children.
-export function killAll(sessions: Map<string, Entry>): void {
-  for (const sid of [...sessions.keys()]) {
-    void kill(sessions, sid);
-  }
+// claude processes don't leak past Electron exit. Returns a Promise that
+// resolves once every per-pty kill (including the platform-native subtree
+// walk) has settled, so the lifecycle handler can `e.preventDefault()` →
+// `await killAll(...)` → `app.quit()` and have the OS taskkill / SIGTERM
+// fanout actually complete before the process exits. Each `kill()` is
+// independently async, so `Promise.all` fans them out in parallel — the
+// previous sync `spawnSync('taskkill', ...)` serialized N × 200-2000ms
+// of main-thread blocking and froze the quit UI.
+export function killAll(sessions: Map<string, Entry>): Promise<void> {
+  const sids = [...sessions.keys()];
+  return Promise.all(sids.map((sid) => kill(sessions, sid).catch(() => false)))
+    .then(() => undefined);
 }

--- a/electron/ptyHost/processKiller.ts
+++ b/electron/ptyHost/processKiller.ts
@@ -6,25 +6,71 @@
 // mac/linux the pgid may also have stragglers. This module walks the tree
 // via a platform-native call to guarantee a clean shutdown. Best-effort —
 // any already-dead pid is swallowed silently.
+//
+// Async contract: returns a Promise that resolves once the subtree-kill
+// command has been dispatched (POSIX) or the spawned `taskkill` has exited
+// or timed out (Windows). The Windows `taskkill` call blocks the OS for
+// 200-2000ms per invocation; using async `spawn` (instead of `spawnSync`)
+// lets callers fire N kills in parallel via `Promise.all` rather than
+// serially blocking the main event loop for N × latency on quit — which
+// previously froze the Electron UI during `before-quit` when several pty
+// sessions were live.
 
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 
-export function killProcessSubtree(pid: number | undefined): void {
-  if (!pid || pid <= 0) return;
+// Hard ceiling on how long we wait for `taskkill` to exit before giving up
+// and resolving the promise anyway. taskkill is "best-effort" itself — if
+// it can't reap the tree in 5s it's almost certainly because something
+// upstream is wedged, and we'd rather let app teardown continue than hang
+// the UI forever on quit. The subtree kill signal has already been sent.
+export const TASKKILL_TIMEOUT_MS = 5000;
+
+export function killProcessSubtree(pid: number | undefined): Promise<void> {
+  if (!pid || pid <= 0) return Promise.resolve();
   if (process.platform === 'win32') {
-    try {
-      // /T walks the entire tree, /F forces termination.
-      spawnSync('taskkill', ['/F', '/T', '/PID', String(pid)], {
-        windowsHide: true,
-        stdio: 'ignore',
-      });
-    } catch {
-      /* already dead or taskkill unavailable */
-    }
-    return;
+    return new Promise<void>((resolve) => {
+      let settled = false;
+      let timer: NodeJS.Timeout | undefined;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        resolve();
+      };
+      let child: ReturnType<typeof spawn>;
+      try {
+        // /T walks the entire tree, /F forces termination.
+        child = spawn('taskkill', ['/F', '/T', '/PID', String(pid)], {
+          windowsHide: true,
+          stdio: 'ignore',
+        });
+      } catch {
+        // taskkill unavailable or arg-quoting blew up — nothing else we can
+        // do; treat as already-dead and unblock the caller.
+        resolve();
+        return;
+      }
+      // 'error' fires if the binary couldn't be spawned (ENOENT etc.); 'exit'
+      // fires on normal completion (success OR taskkill's non-zero "process
+      // not found" exit). Either way we're done waiting.
+      child.once('exit', done);
+      child.once('error', done);
+      timer = setTimeout(() => {
+        // Wedged taskkill — abandon the wait so quit can proceed. The OS
+        // kill signal has been dispatched; whatever process is leaking is
+        // beyond our reach from here.
+        try { child.kill(); } catch { /* ignore */ }
+        done();
+      }, TASKKILL_TIMEOUT_MS);
+      // Don't keep the event loop alive for a stuck taskkill during quit.
+      timer.unref?.();
+    });
   }
   // POSIX: signal the process group (negative pid). SIGTERM first; SIGKILL
-  // after a short grace period if anything refuses to exit.
+  // after a short grace period if anything refuses to exit. Both calls are
+  // synchronous and non-blocking — we resolve immediately so callers can
+  // fan out in parallel; the SIGKILL escalation lives on an unref'd timer
+  // and runs independently of the returned promise.
   try {
     process.kill(-pid, 'SIGTERM');
   } catch {
@@ -37,4 +83,5 @@ export function killProcessSubtree(pid: number | undefined): void {
       /* already dead */
     }
   }, 500).unref();
+  return Promise.resolve();
 }


### PR DESCRIPTION
## Symptom
On Windows with N>1 live pty sessions, the `before-quit` handler froze the visible UI for ~N × 200-2000ms (Electron tearing down with the main event loop blocked) before the process actually exited. Worst-case, the window stayed "hung" long enough that users force-killed it and left orphan `claude.exe` children behind.

## Cause
`electron/ptyHost/processKiller.ts` used `spawnSync('taskkill', ['/PID', pid, '/T', '/F'])` for the Windows subtree walk. `killAllPtySessions` iterates every live session and synchronously dispatched one `spawnSync` per pid, so each `taskkill` blocked the main thread end-to-end before the next one started — strictly serial. Each `taskkill` costs 200ms–2000ms (cold ConHost / AV scan), so N sessions ≈ N × that cost of frozen UI on quit.

## Fix
- **`electron/ptyHost/processKiller.ts`** — Windows path now uses async `spawn` and returns `Promise<void>` that resolves on `exit`/`error` with a 5s timeout ceiling against wedged `taskkill`. POSIX path also returns `Promise<void>` (resolved immediately — SIGTERM was already non-blocking; the unref'd SIGKILL escalation timer keeps its original semantics).
- **`electron/ptyHost/lifecycle.ts`** — `kill()` awaits both the existing onExit/timeout race AND the subtree-walk promise via `Promise.all`. `killAll` returns `Promise<void>` that fans every per-pty kill out via `Promise.all` — N taskkills now run in parallel.
- **`electron/ptyHost/index.ts`** — `killAllPtySessions` return type bumped to `Promise<void>`.
- **`electron/lifecycle/appLifecycle.ts`** — `before-quit` handler now calls `event.preventDefault()`, awaits `killAllPtySessions()` + `disposeNotifyPipeline()`, then re-calls `app.quit()`. A `cleanupStarted` re-entry guard makes the second-pass `before-quit` a pass-through so we don't loop forever.

## Tests
- `electron/ptyHost/__tests__/processKiller.test.ts` rewritten with `vi.hoisted` + `vi.mock` on `child_process.spawn`. Covers canonical args, child-exit resolve, error-event resolve, sync-throw resolve, 5s timeout fallback (asserts last-ditch `child.kill()`), the parallel-fanout property (3 kills dispatched synchronously), and the POSIX SIGTERM/SIGKILL contract (now async with immediate resolve).
- `electron/lifecycle/__tests__/appLifecycle.test.ts` before-quit suite rewritten to pass a fake `Event` with a `preventDefault` spy, flush microtasks, then assert: (a) preventDefault fires on first pass, (b) `app.quit()` re-invoked after cleanup, (c) re-entry on the quit-driven before-quit is a pass-through, (d) sync throws and async rejections from `killAllPtySessions` are swallowed and quit still proceeds.
- `electron/ptyHost/__tests__/lifecycle.test.ts` mock for `killProcessSubtree` returns `Promise.resolve()` so the new `Promise.all([onExit, subtree])` in `kill()` settles.

## Test plan
- [x] `npx vitest run electron/ptyHost/ electron/lifecycle/` → 225/225 pass
- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors (warnings unchanged from baseline)
- [ ] Manual: quit the app on Windows with 3+ live pty sessions, verify UI exits within ~1s rather than ~3-10s freeze
- [ ] Manual: verify no orphan `claude.exe` in Task Manager after quit
- [ ] Confirm the macOS/Linux PtyKill path still SIGTERMs the process group (POSIX behavior preserved)

Full suite has 34 pre-existing failures in `electron/__tests__/db*.test.ts` (sqlite native binding) and `tests/electron-load-smoke.test.ts` (needs `npm run build` first) — verified present on baseline `main` (`b401c7f`) with `git stash`, unrelated to this change.