### PR TITLE
docs(arch): TerminalRuntime + SessionActionIntent design proposals

### DIFF
--- a/docs/superpowers/plans/2026-05-22-session-action-intent.md
+++ b/docs/superpowers/plans/2026-05-22-session-action-intent.md
@@ -41,17 +41,30 @@ parallel maps means too many subtrees re-rendering on every action.
 
 | Current | Replaced by |
 |---|---|
-| `reloadNonce`, `attachNonce`, retry counter logic | One `attemptId` field on the session entity; `usePtyAttach`'s `useEffect` depends on `attemptId`, no separate nonce |
-| `pendingForkSource: Record<sid, sid>` | `pendingAction: SessionAction \| null` on the new session entity, with discriminated union variants |
+| `reloadNonce`, `attachNonce`, retry counter logic | One `attemptId` field in a **parallel runtime map** (`sessionRuntimeById`); `usePtyAttach`'s `useEffect` depends on `attemptId`, no separate nonce |
+| `pendingForkSource: Record<sid, sid>` | `pendingAction: SessionAction \| null` in the same parallel runtime map, with discriminated union variants |
 | `pendingRenameId: sid \| null` | Same `pendingAction` slot — `{kind: 'rename'}` variant — consumed by RenameInput |
 | Imperative store mutators that orchestrate IPC + multiple `set` calls (`reloadSession`, `copySession`) | A thin `dispatchSessionAction(intent)` reducer that produces the new state synchronously; an effect layer reads the pending action and performs IPC |
 | Each action's UI handler reaching into 3 slices | UI just dispatches `SessionActionIntent` |
+
+**Out of scope** (not migrated by this proposal):
+- `flashStates: Record<sid, FlashState>` — UI attention derived from
+  session state, not a session-action intent.
+- `disconnectedSessions: Record<sid, ExitInfo>` — runtime exit state
+  written by the ptyExit classifier, not an action the user dispatched.
+
+Both stay where they are; conflating them with action intents would
+muddy the discriminated union for no win.
 
 ## What this proposal does NOT change
 
 - **The `SessionEntity` data model.** Audit #2 (sidebar agent) flagged
   this as a larger refactor; this proposal **does not** normalize the
-  entity. It only reduces the number of parallel maps. If we want to
+  entity. It only reduces the number of parallel maps. The new
+  `pendingAction` + `attemptId` fields live in a **parallel runtime
+  map** (`sessionRuntimeById: Record<sid, SessionRuntime>`), NOT on the
+  `SessionEntity` itself. This keeps the persisted entity untouched
+  (see "Transient state — must not be persisted" below). If we want to
   normalize later, it's an independent step.
 - **IPC contracts.** `window.ccsmPty.spawn / kill / etc.` keep their
   current shape.
@@ -81,11 +94,14 @@ parallel maps means too many subtrees re-rendering on every action.
 ┌───────────────────────────────────────────────────────────────────┐
 │  Intent reducer (in store)                                        │
 │                                                                   │
-│  Synchronously updates state:                                     │
-│    - sessions[sid].pendingAction = {kind, payload}                │
-│    - sessions[sid].attemptId += 1 (if action implies re-attach)   │
+│  Synchronously updates state in a parallel runtime map:           │
+│    - sessionRuntimeById[sid].pendingAction = {kind, payload}      │
+│    - sessionRuntimeById[sid].attemptId += 1 (only AFTER any       │
+│        side-effect that must precede re-attach has completed —    │
+│        see "two-phase actions" below)                             │
 │                                                                   │
 │  This is the entire store-side of an action. No IPC calls here.   │
+│  sessionRuntimeById is NOT persisted (see transient-state note).  │
 └───────────────────────────────────────────────────────────────────┘
                             │
                             ▼
@@ -93,12 +109,14 @@ parallel maps means too many subtrees re-rendering on every action.
 │  Side-effect runner (a hook in App.tsx, or a small effect file)   │
 │                                                                   │
 │  Subscribes to pendingAction changes; for each pending action:    │
-│    - reload: ptyKill → wait → clear pending; usePtyAttach's       │
-│        attemptId-dependent effect re-runs and re-attaches         │
-│    - copy:   createNewSid → spawn(fork) → clear pending           │
+│    - reload (phase 'killing'):  ptyKill → on success dispatch     │
+│        follow-up reducer step that flips to phase 'attaching'     │
+│        AND bumps attemptId; usePtyAttach re-runs on attemptId     │
+│    - copy:   createNewSid → spawn(fork); if andThenRename, then   │
+│        flip pendingAction to {kind:'rename'} on the new sid       │
 │    - rename: focus the rename input → clear pending on submit     │
 │    - archive: store mutation only → clear pending                 │
-│    - retry: same as reload but no kill                            │
+│    - retry: same shape as reload but no kill phase                │
 └───────────────────────────────────────────────────────────────────┘
 ```
 
@@ -106,19 +124,49 @@ parallel maps means too many subtrees re-rendering on every action.
 
 ```ts
 type SessionAction =
-  | { kind: 'reload' }
-  | { kind: 'copy'; sourceSid: string }
+  | { kind: 'reload'; phase: 'killing' | 'attaching' }
+  | { kind: 'copy'; sourceSid: string; andThenRename: boolean }
   | { kind: 'rename' }
-  | { kind: 'archive'; toGroupId: string | null }
+  | { kind: 'archive' }
   | { kind: 'retry' };
 
-// On the session entity:
-type SessionUiState = {
+// Parallel runtime map — NOT on the persisted SessionEntity:
+type SessionRuntime = {
   pendingAction: SessionAction | null;
   attemptId: number;
-  // existing fields stay
+};
+
+// In the store slice (transient, not persisted — see partialize note):
+type SessionRuntimeState = {
+  sessionRuntimeById: Record<string /* sid */, SessionRuntime>;
 };
 ```
+
+Notes on each variant:
+
+- **`reload`** is two-phase. Reducer step A sets
+  `{kind:'reload', phase:'killing'}` and does NOT bump `attemptId`.
+  The side-effect runner awaits `pty.kill`. On kill success, the runner
+  dispatches reducer step B which flips to
+  `{kind:'reload', phase:'attaching'}` AND bumps `attemptId`. Only then
+  does `usePtyAttach`'s effect (which depends on `attemptId`) re-run,
+  so we never re-attach to a dying PTY. This two-phase pattern is the
+  general principle for any action whose side-effect must complete
+  before attach re-runs.
+- **`copy`** is composite: a single `pendingAction` slot can't
+  represent "copy AND rename" if they were separate variants, so the
+  variant carries an `andThenRename` flag. The right-click "Copy
+  session" path uses `andThenRename: true` (matches today's behavior
+  where `copySession` sets both `pendingForkSource[newId]` and
+  `pendingRenameId = newId`). A hypothetical "copy without rename"
+  UX would set it false.
+- **`archive`** is parameter-less in the user-action sense. Current
+  `archiveSession` / `unarchiveSession` create or reuse archive
+  containers — they don't move to arbitrary groups. The target-group
+  resolution stays in the side-effect runner (or a helper), not in
+  the intent.
+- **`retry`** is the no-kill analogue of `reload`: reducer bumps
+  `attemptId` synchronously; runner has nothing to do.
 
 **Why one slot, not one map per action:** today each map is sparse and
 mostly empty; their union semantics are "at most one pending action per
@@ -128,10 +176,10 @@ auto-enforces the "one outstanding action per session" rule.
 
 **`attemptId` instead of `reloadNonce`+`attachNonce`:** the existing
 two-nonce setup splits "things that re-run attach" between a store nonce
-(reload) and a hook-local nonce (Retry). A single `attemptId` on the
-entity is incremented by the reducer for any action that needs re-attach.
-`usePtyAttach`'s effect depends on `attemptId`; both reload and retry
-just increment it.
+(reload) and a hook-local nonce (Retry). A single `attemptId` in the
+parallel runtime map is incremented by the reducer for any action that
+needs re-attach. `usePtyAttach`'s effect depends on `attemptId`; both
+reload (after kill completes) and retry just increment it.
 
 ## Implementation phases (each = 1 PR)
 
@@ -145,15 +193,22 @@ one nonce, one IPC call.
 `pendingAction` runs in parallel; once tests pass, old nonce removed.
 
 **Deliverables:**
-- `src/stores/slices/sessionActionSlice.ts` (new) — the reducer +
-  `dispatchSessionAction(intent)` action
-- `SessionAction` type in `types.ts`
+- `src/stores/slices/sessionActionSlice.ts` (new) — holds
+  `sessionRuntimeById` (transient, see partialize note) + the reducer
+  + `dispatchSessionAction(intent)` action
+- `SessionAction` + `SessionRuntime` types in `types.ts`
 - Side-effect runner for `reload` in a new `useSessionActionRunner` hook
-  mounted at App level
-- `usePtyAttach` depends on `session.attemptId` instead of `reloadNonce`
+  mounted at App level. Implements the two-phase reload: reducer sets
+  phase `'killing'` (no attemptId bump) → runner awaits `pty.kill` →
+  runner dispatches phase-B reducer that flips to `'attaching'` and
+  bumps `attemptId`. `usePtyAttach`'s effect depends only on
+  `attemptId`, so it cannot re-attach to a dying PTY.
+- `usePtyAttach` reads `attemptId` from `sessionRuntimeById[sid]`
+  instead of `reloadNonce`
 - Delete `reloadNonce` + `_clearReloadNonce` after migration
 - Tests at the reducer level (pure, no React) + integration test that
-  asserts the full reload flow
+  asserts the full reload flow, including a test that asserts attach
+  does NOT re-run between phase-A and phase-B
 
 ### Phase 2 — Migrate `copy / pendingForkSource` and `rename / pendingRenameId`
 
@@ -166,11 +221,16 @@ Mitigation: the reducer doesn't change the side-effect logic, it just
 reorganizes where state lives. Existing fork tests catch regressions.
 
 **Deliverables:**
-- Reducer handles `{kind: 'copy', sourceSid}` and `{kind: 'rename'}`
-- Side-effect runner for both
+- Reducer handles `{kind: 'copy', sourceSid, andThenRename}` and
+  `{kind: 'rename'}`
+- Side-effect runner for both. For `copy` with `andThenRename:true`,
+  on spawn-success the runner sets the new sid's `pendingAction` to
+  `{kind:'rename'}` (sequential composite, second step driven by the
+  same runner — no action chaining magic).
 - Delete `pendingForkSource: Record<...>` and `pendingRenameId`
 - `usePtyAttach`'s spawn-on-null fallback reads
-  `session.pendingAction?.kind === 'copy' ? action.sourceSid : undefined`
+  `sessionRuntimeById[sid]?.pendingAction?.kind === 'copy'
+    ? action.sourceSid : undefined`
   instead of reaching into the global map
 
 ### Phase 3 — Migrate `retry` and `archive`
@@ -243,19 +303,47 @@ After all three phases ship:
 
 ## Sequencing with the terminal runtime proposal
 
-Recommended order:
+Recommended order (revised — fewer interleavings, more stability):
 
-1. **TerminalRuntime phase 1** (introduce runtime, hooks still adapters)
-2. **SessionActionIntent phase 1** (reload migrated; uses
-   `runtime.reload()`)
-3. **TerminalRuntime phase 2** (drop snapshotReplay callback)
-4. **SessionActionIntent phase 2** (copy + rename migrated)
-5. **TerminalRuntime phase 3** (retire deprecated accessors)
-6. **SessionActionIntent phase 3** (retry + archive migrated)
+1. **TerminalRuntime phase 1 + 2 first.** The runtime is the stable
+   target API; alternating six PRs before that API settles increases
+   churn for both proposals.
+2. **SessionActionIntent phase 1** (reload — the simplest action,
+   built against the now-stable runtime).
+3. **Revisit interleaving** for the remaining phases based on how
+   Phase 1 went. We may find Phase 2/3 of either proposal can ship
+   independently, or that bundling them is cleaner — that call is
+   better made with one phase of evidence in hand.
 
-Total: 6 PRs over ~3 weeks, each shippable and behavior-equivalent on its
-own. No big-bang. Every PR can be reverted without dragging the rest
-back.
+Total still ~6 PRs over ~3 weeks, each shippable and behavior-equivalent
+on its own. No big-bang. Every PR can be reverted without dragging the
+rest back.
+
+---
+
+## Cross-cutting concern: transient state must NOT be persisted
+
+Both this proposal and the TerminalRuntime proposal introduce new
+in-memory state (`sessionRuntimeById` here; FSM state + replay buffers
+in the runtime). **None of it belongs in the persisted store.**
+Sessions are persisted by `src/stores/persist.ts` (zustand `persist`
+middleware). Anything we add for action coordination or runtime state
+must be excluded from the persisted snapshot — typically via
+`partialize` in the persist config, or by living in a slice that the
+persist config does not opt in.
+
+Concretely:
+
+- `sessionRuntimeById` must be omitted from `partialize`. A reloaded
+  app should start with an empty runtime map; pending actions don't
+  survive a restart (the IPC side-effect they were driving is also
+  gone).
+- The TerminalRuntime's FSM state, buffered writes, and snapshot
+  sequence numbers are renderer-process lifetime only and never
+  touch the persistor — already true today, must remain true.
+
+This is the single source of truth for the constraint; both proposals
+defer to it.
 
 ---
 

--- a/docs/superpowers/plans/2026-05-22-session-action-intent.md
+++ b/docs/superpowers/plans/2026-05-22-session-action-intent.md
@@ -113,8 +113,11 @@ muddy the discriminated union for no win.
 │    - reload (phase 'killing'):  ptyKill → on success dispatch     │
 │        follow-up reducer step that flips to phase 'attaching'     │
 │        AND bumps attemptId; usePtyAttach re-runs on attemptId     │
-│    - copy:   createNewSid → spawn(fork); if andThenRename, then   │
-│        flip pendingAction to {kind:'rename'} on the new sid       │
+│    - copy:   (reducer already created newSid + stored             │
+│        pendingAction on sessionRuntimeById[newSid]); on first     │
+│        attach, spawn-on-null fallback reads pendingAction and     │
+│        calls pty.spawn with sourceSid; on spawn success, runner   │
+│        flips pendingAction to {kind:'rename'} on the new sid      │
 │    - rename: focus the rename input → clear pending on submit     │
 │    - archive / unarchive: store mutation only → clear pending     │
 │    - retry: same shape as reload but no kill phase                │
@@ -294,7 +297,7 @@ This matches the current observable behavior; only the storage shape
 moves (one `pendingAction` slot on `sessionRuntimeById[newSid]` instead
 of two parallel maps `pendingForkSource[newSid]` + `pendingRenameId`).
 
-### Phase 3 — Migrate `retry` and `archive`
+### Phase 3 — Migrate `retry`, `archive`, and `unarchive`
 
 **Goal:** consolidate the remaining two action paths.
 

--- a/docs/superpowers/plans/2026-05-22-session-action-intent.md
+++ b/docs/superpowers/plans/2026-05-22-session-action-intent.md
@@ -1,0 +1,267 @@
+# SessionActionIntent — design proposal (architectural plan)
+
+> **Status:** PROPOSAL — not an executable plan yet. Companion to
+> `2026-05-22-terminal-runtime.md`. This proposal targets the **second-
+> highest leverage** debt surfaced by the architecture audit (4 parallel
+> subagents, 2026-05-22): the coordination maps that grew piecemeal to
+> support right-click actions on sessions. Like the terminal runtime
+> proposal, this needs review BEFORE breaking into bite-sized
+> implementation plans.
+
+## The problem in one paragraph
+
+A "session action" — reload, copy/fork, rename, archive, retry — is one
+verb in the user's mental model. Each action has a side-effect lifecycle
+that crosses store, hook, IPC, and back. We've added one **parallel
+ad-hoc coordination map** for each action as the need arose:
+
+- `reloadNonce: Record<sid, number>` (`sessionRuntimeSlice`) — bumped by
+  `reloadSession` after `pty.kill`, watched by `usePtyAttach` to re-run
+  attach.
+- `attachNonce` (local to `usePtyAttach`, bumped by Retry) — same shape,
+  different layer.
+- `pendingForkSource: Record<newSid, srcSid>` (`sessionCrudSlice`) —
+  written by `copySession`, read by `usePtyAttach`'s spawn-on-null path,
+  cleared post-spawn.
+- `pendingRenameId: sid | null` (`types.ts`) — armed by `copySession`,
+  consumed by the rename input.
+- `disconnectedSessions: Record<sid, ExitInfo>` — written by ptyExit
+  classifier, cleared by `_clearPtyExit` on next successful attach.
+- `flashStates: Record<sid, FlashState>` (UI attention) — derived from
+  session state.
+
+Each map was a reasonable local solution. The cumulative effect: the
+"what happens when a user right-clicks a session row" answer requires
+reading 4–6 files. New actions (e.g. "duplicate without forking", "move
+to group") will each invent another map. The sidebar's memo-chain
+contract (#1271) is downstream pressure from this same shape — too many
+parallel maps means too many subtrees re-rendering on every action.
+
+## What this proposal replaces
+
+| Current | Replaced by |
+|---|---|
+| `reloadNonce`, `attachNonce`, retry counter logic | One `attemptId` field on the session entity; `usePtyAttach`'s `useEffect` depends on `attemptId`, no separate nonce |
+| `pendingForkSource: Record<sid, sid>` | `pendingAction: SessionAction \| null` on the new session entity, with discriminated union variants |
+| `pendingRenameId: sid \| null` | Same `pendingAction` slot — `{kind: 'rename'}` variant — consumed by RenameInput |
+| Imperative store mutators that orchestrate IPC + multiple `set` calls (`reloadSession`, `copySession`) | A thin `dispatchSessionAction(intent)` reducer that produces the new state synchronously; an effect layer reads the pending action and performs IPC |
+| Each action's UI handler reaching into 3 slices | UI just dispatches `SessionActionIntent` |
+
+## What this proposal does NOT change
+
+- **The `SessionEntity` data model.** Audit #2 (sidebar agent) flagged
+  this as a larger refactor; this proposal **does not** normalize the
+  entity. It only reduces the number of parallel maps. If we want to
+  normalize later, it's an independent step.
+- **IPC contracts.** `window.ccsmPty.spawn / kill / etc.` keep their
+  current shape.
+- **What the user sees.** No UX change; right-click menus, rename
+  flow, fork flow are identical.
+- **The terminal runtime.** If both proposals ship, they intersect
+  cleanly: the runtime exposes `runtime.attach(sid, cwd)` /
+  `runtime.reload()`; the intent dispatcher calls those. Today,
+  `usePtyAttach` reads `reloadNonce` directly from the store — that
+  becomes "intent dispatcher schedules a `reload` action; the
+  side-effect runner calls `runtime.reload()`."
+
+## Target architecture
+
+```
+┌───────────────────────────────────────────────────────────────────┐
+│  Sidebar row / context menu                                       │
+│                                                                   │
+│  onClick → dispatchSessionAction({                                │
+│    kind: 'reload' | 'copy' | 'rename' | 'archive' | 'retry',      │
+│    sessionId: '...',                                              │
+│    payload?: ...                                                  │
+│  })                                                               │
+└───────────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌───────────────────────────────────────────────────────────────────┐
+│  Intent reducer (in store)                                        │
+│                                                                   │
+│  Synchronously updates state:                                     │
+│    - sessions[sid].pendingAction = {kind, payload}                │
+│    - sessions[sid].attemptId += 1 (if action implies re-attach)   │
+│                                                                   │
+│  This is the entire store-side of an action. No IPC calls here.   │
+└───────────────────────────────────────────────────────────────────┘
+                            │
+                            ▼
+┌───────────────────────────────────────────────────────────────────┐
+│  Side-effect runner (a hook in App.tsx, or a small effect file)   │
+│                                                                   │
+│  Subscribes to pendingAction changes; for each pending action:    │
+│    - reload: ptyKill → wait → clear pending; usePtyAttach's       │
+│        attemptId-dependent effect re-runs and re-attaches         │
+│    - copy:   createNewSid → spawn(fork) → clear pending           │
+│    - rename: focus the rename input → clear pending on submit     │
+│    - archive: store mutation only → clear pending                 │
+│    - retry: same as reload but no kill                            │
+└───────────────────────────────────────────────────────────────────┘
+```
+
+### Discriminated union shape
+
+```ts
+type SessionAction =
+  | { kind: 'reload' }
+  | { kind: 'copy'; sourceSid: string }
+  | { kind: 'rename' }
+  | { kind: 'archive'; toGroupId: string | null }
+  | { kind: 'retry' };
+
+// On the session entity:
+type SessionUiState = {
+  pendingAction: SessionAction | null;
+  attemptId: number;
+  // existing fields stay
+};
+```
+
+**Why one slot, not one map per action:** today each map is sparse and
+mostly empty; their union semantics are "at most one pending action per
+session anyway" because the UI gates them (you can't fork-and-reload the
+same row). Collapsing into one slot makes the constraint visible and
+auto-enforces the "one outstanding action per session" rule.
+
+**`attemptId` instead of `reloadNonce`+`attachNonce`:** the existing
+two-nonce setup splits "things that re-run attach" between a store nonce
+(reload) and a hook-local nonce (Retry). A single `attemptId` on the
+entity is incremented by the reducer for any action that needs re-attach.
+`usePtyAttach`'s effect depends on `attemptId`; both reload and retry
+just increment it.
+
+## Implementation phases (each = 1 PR)
+
+### Phase 1 — Introduce `SessionAction` + reducer; migrate ONE action (reload) end-to-end
+
+**Goal:** prove the pattern on the smallest action first. Reload is
+ideal: 2 files today (`sessionRuntimeSlice.ts` + `usePtyAttach.ts`),
+one nonce, one IPC call.
+
+**Risk:** low — additive. Old `reloadNonce` stays initially; new
+`pendingAction` runs in parallel; once tests pass, old nonce removed.
+
+**Deliverables:**
+- `src/stores/slices/sessionActionSlice.ts` (new) — the reducer +
+  `dispatchSessionAction(intent)` action
+- `SessionAction` type in `types.ts`
+- Side-effect runner for `reload` in a new `useSessionActionRunner` hook
+  mounted at App level
+- `usePtyAttach` depends on `session.attemptId` instead of `reloadNonce`
+- Delete `reloadNonce` + `_clearReloadNonce` after migration
+- Tests at the reducer level (pure, no React) + integration test that
+  asserts the full reload flow
+
+### Phase 2 — Migrate `copy / pendingForkSource` and `rename / pendingRenameId`
+
+**Goal:** the two remaining ad-hoc maps disappear, replaced by the
+`pendingAction` slot.
+
+**Risk:** medium — copy/fork has the most complex side-effect chain
+(create session → spawn with fork source → focus → arm rename).
+Mitigation: the reducer doesn't change the side-effect logic, it just
+reorganizes where state lives. Existing fork tests catch regressions.
+
+**Deliverables:**
+- Reducer handles `{kind: 'copy', sourceSid}` and `{kind: 'rename'}`
+- Side-effect runner for both
+- Delete `pendingForkSource: Record<...>` and `pendingRenameId`
+- `usePtyAttach`'s spawn-on-null fallback reads
+  `session.pendingAction?.kind === 'copy' ? action.sourceSid : undefined`
+  instead of reaching into the global map
+
+### Phase 3 — Migrate `retry` and `archive`
+
+**Goal:** consolidate the remaining two action paths.
+
+**Risk:** low — retry is trivially analogous to reload; archive is
+mostly a store mutation today.
+
+**Deliverables:**
+- Move `Retry` handler in `TerminalPane` to dispatch `{kind: 'retry'}`
+  instead of bumping local `attachNonce` state
+- Move archive/unarchive context-menu handlers to dispatch
+  `{kind: 'archive'}`
+- Delete `attachNonce` from `usePtyAttach`
+- Final cleanup of sidebar handlers — every right-click action now
+  goes through one dispatch call, no slice-reaching
+
+## Open questions for review
+
+1. **Slot vs queue.** `pendingAction: SessionAction | null` (slot) vs
+   `pendingActions: SessionAction[]` (queue)? Today there's no scenario
+   where two actions queue legitimately — the UI gates them — so the
+   slot is correct AND enforces the gate at the type level.
+   **Recommendation: slot.**
+
+2. **Should the reducer fire IPC directly?** Audit's intuition: no.
+   Keeping IPC out of the reducer keeps store mutations sync + testable
+   without mocks; the side-effect runner is the seam where IPC happens.
+   **Recommendation: reducer is sync state-only; side-effect runner is
+   the only IPC caller.**
+
+3. **`attemptId` overflow / scope.** A monotonic counter on a single
+   entity is fine for the foreseeable lifetime (a user retrying once a
+   second for the age of the universe would not overflow JS Number).
+   No special handling needed.
+
+4. **Interaction with the terminal runtime proposal.** If
+   TerminalRuntime ships first, the side-effect runner for `reload`
+   calls `runtime.reload()`; for `retry` calls `runtime.retry()`;
+   `usePtyAttach`'s dependency on `attemptId` is replaced by the
+   runtime's `attach()` command being called by the runner. Cleaner
+   layering: store dispatches intent → runner reads intent →
+   runner calls runtime → runtime emits state → adapters react.
+   **Recommendation: ship TerminalRuntime phase 1 BEFORE
+   SessionActionIntent phase 1 so the runner has a clean target.**
+
+5. **Test coverage cost.** Each phase adds reducer-level unit tests
+   (cheap, pure) and replaces some hook-level integration tests.
+   Net: more tests, but flatter — pure reducer tests beat mocked
+   hook tests for catching regressions in coordination logic.
+
+## What success looks like
+
+After all three phases ship:
+
+- `types.ts`'s coordination-map zoo (`reloadNonce`, `pendingForkSource`,
+  `pendingRenameId`, `attachNonce` references) collapses to one
+  `pendingAction: SessionAction | null` field on the session entity
+- "How does the right-click reload work?" answered by reading 2 files
+  (the reducer + the runner) instead of 5
+- New session actions are additive: add a variant to the union, add
+  a case in the runner, add a context menu handler — no new map, no
+  new slice surgery
+- The sidebar's memo-chain contract (#1271) becomes less load-bearing:
+  one stable `pendingAction` reference per row instead of looking up
+  from multiple maps each render
+
+---
+
+## Sequencing with the terminal runtime proposal
+
+Recommended order:
+
+1. **TerminalRuntime phase 1** (introduce runtime, hooks still adapters)
+2. **SessionActionIntent phase 1** (reload migrated; uses
+   `runtime.reload()`)
+3. **TerminalRuntime phase 2** (drop snapshotReplay callback)
+4. **SessionActionIntent phase 2** (copy + rename migrated)
+5. **TerminalRuntime phase 3** (retire deprecated accessors)
+6. **SessionActionIntent phase 3** (retry + archive migrated)
+
+Total: 6 PRs over ~3 weeks, each shippable and behavior-equivalent on its
+own. No big-bang. Every PR can be reverted without dragging the rest
+back.
+
+---
+
+## Next step
+
+Same as the terminal runtime proposal: if approved, each phase becomes a
+`docs/superpowers/plans/` implementation plan with `superpowers:writing-
+plans`-style bite-sized TDD steps. Generating those steps now is
+premature; many decisions above are still revisable.

--- a/docs/superpowers/plans/2026-05-22-session-action-intent.md
+++ b/docs/superpowers/plans/2026-05-22-session-action-intent.md
@@ -84,7 +84,8 @@ muddy the discriminated union for no win.
 │  Sidebar row / context menu                                       │
 │                                                                   │
 │  onClick → dispatchSessionAction({                                │
-│    kind: 'reload' | 'copy' | 'rename' | 'archive' | 'retry',      │
+│    kind: 'reload' | 'copy' | 'rename'                             │
+│        | 'archive' | 'unarchive' | 'retry',                       │
 │    sessionId: '...',                                              │
 │    payload?: ...                                                  │
 │  })                                                               │
@@ -115,7 +116,7 @@ muddy the discriminated union for no win.
 │    - copy:   createNewSid → spawn(fork); if andThenRename, then   │
 │        flip pendingAction to {kind:'rename'} on the new sid       │
 │    - rename: focus the rename input → clear pending on submit     │
-│    - archive: store mutation only → clear pending                 │
+│    - archive / unarchive: store mutation only → clear pending     │
 │    - retry: same shape as reload but no kill phase                │
 └───────────────────────────────────────────────────────────────────┘
 ```
@@ -128,6 +129,7 @@ type SessionAction =
   | { kind: 'copy'; sourceSid: string; andThenRename: boolean }
   | { kind: 'rename' }
   | { kind: 'archive' }
+  | { kind: 'unarchive' }
   | { kind: 'retry' };
 
 // Parallel runtime map — NOT on the persisted SessionEntity:
@@ -136,7 +138,7 @@ type SessionRuntime = {
   attemptId: number;
 };
 
-// In the store slice (transient, not persisted — see partialize note):
+// In the store slice (transient, not persisted — see PERSISTED_KEYS note):
 type SessionRuntimeState = {
   sessionRuntimeById: Record<string /* sid */, SessionRuntime>;
 };
@@ -150,9 +152,20 @@ Notes on each variant:
   dispatches reducer step B which flips to
   `{kind:'reload', phase:'attaching'}` AND bumps `attemptId`. Only then
   does `usePtyAttach`'s effect (which depends on `attemptId`) re-run,
-  so we never re-attach to a dying PTY. This two-phase pattern is the
-  general principle for any action whose side-effect must complete
-  before attach re-runs.
+  so we never re-attach to a dying PTY.
+
+  **Kill-failure semantics.** `pty.kill` is best-effort today
+  (`sessionRuntimeSlice.reloadSession` bumps `reloadNonce` regardless
+  of kill outcome). The proposal preserves this: on kill failure the
+  runner still dispatches the phase-B reducer (flip to `'attaching'` +
+  bump `attemptId`) and logs a warning. The attach path then handles
+  whatever PTY state results — either the old PTY died after all and a
+  fresh spawn-on-null succeeds, or it is still alive and the attach
+  reuses it. We do NOT introduce a new error variant for kill failure;
+  doing so would diverge from current behavior for no observable user
+  benefit. This two-phase pattern is the general principle for any
+  action whose side-effect must complete (or be observed to have
+  failed) before attach re-runs.
 - **`copy`** is composite: a single `pendingAction` slot can't
   represent "copy AND rename" if they were separate variants, so the
   variant carries an `andThenRename` flag. The right-click "Copy
@@ -160,11 +173,26 @@ Notes on each variant:
   where `copySession` sets both `pendingForkSource[newId]` and
   `pendingRenameId = newId`). A hypothetical "copy without rename"
   UX would set it false.
-- **`archive`** is parameter-less in the user-action sense. Current
-  `archiveSession` / `unarchiveSession` create or reuse archive
-  containers — they don't move to arbitrary groups. The target-group
-  resolution stays in the side-effect runner (or a helper), not in
-  the intent.
+
+  **Target-sid ownership.** Today, `pendingForkSource` is keyed by the
+  NEW sid (see `src/stores/slices/sessionCrudSlice.ts` —
+  `pendingForkSource[newId] = sourceId`). The proposal mirrors this:
+  the `{kind:'copy', sourceSid, andThenRename}` action is stored on
+  the NEW session's runtime slot
+  (`sessionRuntimeById[newSid].pendingAction`), NOT on the source sid.
+  The source session does not need to know it is being copied — only
+  the new session needs to know where to fork from on first attach.
+  `usePtyAttach` for the new sid reads its own runtime slot, sees
+  `kind === 'copy'`, and passes `action.sourceSid` to the
+  spawn-on-null fallback.
+- **`archive` / `unarchive`** are parameter-less in the user-action
+  sense. They are split into two variants (rather than one variant with
+  a `mode` field) because they are semantically opposite operations and
+  the discriminated union reads cleaner that way — the runner has two
+  obviously-paired cases. Current `archiveSession` / `unarchiveSession`
+  create or reuse archive containers — they don't move to arbitrary
+  groups. The target-group resolution stays in the side-effect runner
+  (or a helper), not in the intent.
 - **`retry`** is the no-kill analogue of `reload`: reducer bumps
   `attemptId` synchronously; runner has nothing to do.
 
@@ -194,15 +222,18 @@ one nonce, one IPC call.
 
 **Deliverables:**
 - `src/stores/slices/sessionActionSlice.ts` (new) — holds
-  `sessionRuntimeById` (transient, see partialize note) + the reducer
+  `sessionRuntimeById` (transient; deliberately NOT added to
+  `PERSISTED_KEYS` — see the persistence note) + the reducer
   + `dispatchSessionAction(intent)` action
 - `SessionAction` + `SessionRuntime` types in `types.ts`
 - Side-effect runner for `reload` in a new `useSessionActionRunner` hook
   mounted at App level. Implements the two-phase reload: reducer sets
   phase `'killing'` (no attemptId bump) → runner awaits `pty.kill` →
   runner dispatches phase-B reducer that flips to `'attaching'` and
-  bumps `attemptId`. `usePtyAttach`'s effect depends only on
-  `attemptId`, so it cannot re-attach to a dying PTY.
+  bumps `attemptId`. On kill failure the runner ALSO dispatches phase-B
+  (best-effort, mirrors current `reloadSession` behavior) and logs a
+  warning. `usePtyAttach`'s effect depends only on `attemptId`, so it
+  cannot re-attach to a dying PTY.
 - `usePtyAttach` reads `attemptId` from `sessionRuntimeById[sid]`
   instead of `reloadNonce`
 - Delete `reloadNonce` + `_clearReloadNonce` after migration
@@ -233,6 +264,36 @@ reorganizes where state lives. Existing fork tests catch regressions.
     ? action.sourceSid : undefined`
   instead of reaching into the global map
 
+**Explicit step-by-step for `copy` (the composite case):**
+
+The runtime slot for the copy action lives on the NEW sid, mirroring
+how `pendingForkSource` is keyed today. End-to-end:
+
+1. UI handler calls `dispatchSessionAction({kind:'copy', sessionId:
+   sourceSid, payload:{andThenRename:true}})`.
+2. Reducer creates the new session row (same shape as today's
+   `copySession`) with a fresh `newSid`, and sets
+   `sessionRuntimeById[newSid].pendingAction =
+   {kind:'copy', sourceSid, andThenRename:true}`. The source sid's
+   runtime slot is untouched.
+3. Reducer sets `activeId = newSid`, which causes the terminal pane to
+   mount/attach for `newSid` (same trigger as today).
+4. `usePtyAttach` runs for `newSid`. The spawn-on-null fallback reads
+   `sessionRuntimeById[newSid]?.pendingAction`; sees
+   `kind === 'copy'`; calls `pty.spawn` with
+   `--fork-session=action.sourceSid`.
+5. On spawn success, the runner observes the spawn completed and
+   transitions `sessionRuntimeById[newSid].pendingAction` from
+   `{kind:'copy', ...}` to `{kind:'rename'}` (only when
+   `andThenRename:true`; otherwise clears to `null`).
+6. The RenameInput, watching the new sid's `pendingAction` slot for
+   `{kind:'rename'}`, focuses itself. On submit, the reducer clears
+   the slot to `null`.
+
+This matches the current observable behavior; only the storage shape
+moves (one `pendingAction` slot on `sessionRuntimeById[newSid]` instead
+of two parallel maps `pendingForkSource[newSid]` + `pendingRenameId`).
+
 ### Phase 3 — Migrate `retry` and `archive`
 
 **Goal:** consolidate the remaining two action paths.
@@ -243,8 +304,10 @@ mostly a store mutation today.
 **Deliverables:**
 - Move `Retry` handler in `TerminalPane` to dispatch `{kind: 'retry'}`
   instead of bumping local `attachNonce` state
-- Move archive/unarchive context-menu handlers to dispatch
-  `{kind: 'archive'}`
+- Move the archive context-menu handler to dispatch
+  `{kind: 'archive'}` and the unarchive context-menu handler to
+  dispatch `{kind: 'unarchive'}` (two distinct variants — see the
+  variant notes above for the rationale)
 - Delete `attachNonce` from `usePtyAttach`
 - Final cleanup of sidebar handlers — every right-click action now
   goes through one dispatch call, no slice-reaching
@@ -289,7 +352,9 @@ After all three phases ship:
 
 - `types.ts`'s coordination-map zoo (`reloadNonce`, `pendingForkSource`,
   `pendingRenameId`, `attachNonce` references) collapses to one
-  `pendingAction: SessionAction | null` field on the session entity
+  `pendingAction: SessionAction | null` slot in
+  `sessionRuntimeById[sid]` — a transient parallel map, never on the
+  persisted `SessionEntity`
 - "How does the right-click reload work?" answered by reading 2 files
   (the reducer + the runner) instead of 5
 - New session actions are additive: add a variant to the union, add
@@ -326,18 +391,24 @@ rest back.
 Both this proposal and the TerminalRuntime proposal introduce new
 in-memory state (`sessionRuntimeById` here; FSM state + replay buffers
 in the runtime). **None of it belongs in the persisted store.**
-Sessions are persisted by `src/stores/persist.ts` (zustand `persist`
-middleware). Anything we add for action coordination or runtime state
-must be excluded from the persisted snapshot — typically via
-`partialize` in the persist config, or by living in a slice that the
-persist config does not opt in.
+Persistence in this codebase is NOT zustand's `persist` middleware —
+it is a custom allowlist in `src/stores/persist.ts`: the
+`PERSISTED_KEYS` array enumerates the top-level state keys that flow
+into the snapshot written via `schedulePersist` / `flushNow`. A
+compile-time assertion in `src/stores/store.ts`
+(`_AssertPersistedKeysOnState` / `_AssertPersistedKeysOnPersisted`)
+guarantees every key in `PERSISTED_KEYS` exists on both the runtime
+state type and the on-disk `PersistedState` shape. Anything we add
+for action coordination or runtime state must therefore be excluded
+from persistence by **not being added to `PERSISTED_KEYS`** — the
+allowlist is the single switch.
 
 Concretely:
 
-- `sessionRuntimeById` must be omitted from `partialize`. A reloaded
-  app should start with an empty runtime map; pending actions don't
-  survive a restart (the IPC side-effect they were driving is also
-  gone).
+- `sessionRuntimeById` must NOT appear in `PERSISTED_KEYS` and must
+  NOT be added to `PersistedState`. A reloaded app should start with
+  an empty runtime map; pending actions don't survive a restart (the
+  IPC side-effect they were driving is also gone).
 - The TerminalRuntime's FSM state, buffered writes, and snapshot
   sequence numbers are renderer-process lifetime only and never
   touch the persistor — already true today, must remain true.

--- a/docs/superpowers/plans/2026-05-22-terminal-runtime.md
+++ b/docs/superpowers/plans/2026-05-22-terminal-runtime.md
@@ -12,7 +12,7 @@
 The renderer-side terminal is conceptually one thing — "a visible xterm that
 mirrors a server-side authoritative PTY buffer, attaches to one session at a
 time, survives container resizes, and stays at the prompt on attach." In
-practice it is implemented as **three React hooks + one mutable module
+practice it is implemented as **four React hooks + one mutable module
 singleton + a callback handshake between them**:
 
 - `useXtermSingleton` constructs the Terminal once.
@@ -26,10 +26,11 @@ singleton + a callback handshake between them**:
   a manual getter/setter pair, with no invariants enforced between them.
 
 This shape has accreted across 8+ PRs (#852, #864–#867, #888, #1263, #1268,
-#1273, #1290, #1291, #1293, #1308) and the latest one (#1308) added two
-*more* coordination flags (`replayInFlight`, `replayPending`) because the
-two replay drivers raced. Future bugs in this layer will keep adding more
-flags unless we collapse the implicit state machine into an explicit one.
+#1273, #1290, #1291, #1293, #1308) and the in-flight scroll-bottom fix
+PR (#1308) adds yet two *more* coordination flags (`replayInFlight`,
+`replayPending`) because the two replay drivers raced. Future bugs in
+this layer will keep adding more flags unless we collapse the implicit
+state machine into an explicit one.
 
 ## What this proposal replaces
 
@@ -134,6 +135,25 @@ These are exactly the rules that #1308's flag soup + scattered
 single object makes them testable in isolation and removes the cross-hook
 callback handshake.
 
+### Error transitions
+
+The happy path above is half the story. The runtime must also encode the
+failure modes that the current hook scatters across try/catch sites:
+
+- **`pty.attach` returns null AND `spawn` fails** → FSM goes to a new
+  `error` state with `{message: string}`; UI renders Retry.
+- **`getBufferSnapshot` throws during initial attach** → `error`.
+- **`getBufferSnapshot` throws during a replay** → stay in `live`, log
+  warning, do **not** reset. Mirrors current behavior at
+  `usePtyAttach.ts:325-332`: a stale grid beats a dropped session.
+- **`pty.resize` IPC throws** → log, stay in current state, do not run
+  replay.
+- **Stale attach resolves AFTER a session switch** → discarded by the
+  runtime's "current attempt id" check (the equivalent of today's
+  `requestedSidRef`).
+- **`detach()` called while in `replaying`** → cancel the in-flight
+  replay (best-effort), transition to `detached`.
+
 ## Implementation phases (each = 1 PR)
 
 The total surface (4 files in `src/terminal/`, 3 test files, no IPC
@@ -146,14 +166,26 @@ changes) is small enough to do in 3 PRs, each shippable on its own.
 is unchanged externally. Hooks become thin adapters; `xtermSingleton.ts`
 shrinks to a module-singleton holder for the runtime itself.
 
-**Risk:** low — internal refactor, behavior preserved, harness (#1309)
-already covers the assertion surface.
+**Risk:** medium — phase 1 touches the entire renderer attach/resize/
+input/paste surface (rewriting `usePtyAttach.ts` and `xtermSingleton.ts`
+means touching attach, spawn-on-null, fork source, resize replay, input,
+exit overlay, focus, AND paste lifecycle — paste glue lives in
+`xtermSingleton.ts`); the test harness (#1309) is a hard prerequisite
+for keeping behavior pinned.
+
+**Hard prerequisite:** `#1309 (test harness)` must be merged before
+phase 1 starts. If #1309 is not merged when phase 1 starts, the harness
+migration must be done first.
 
 **Deliverables:**
 - `src/terminal/TerminalRuntime.ts` (new)
 - `src/terminal/xtermSingleton.ts` reduced to `getRuntime()` accessor +
   deprecated re-exports of `getTerm/getFit/...` that delegate to the
   runtime for one transitional release
+- **`setSnapshotReplay`/`getSnapshotReplay` are KEPT during Phase 1 as
+  deprecated compatibility seams that delegate to the runtime** —
+  `useTerminalResize` continues to call them unchanged. Phase 2 deletes
+  these seams. This is what keeps phase 1 a pure internal refactor.
 - Hooks rewritten as `runtime.attach(sid, cwd)` / `runtime.resize()` /
   `runtime.subscribe(setState)` adapters
 - Tests at two levels:

--- a/docs/superpowers/plans/2026-05-22-terminal-runtime.md
+++ b/docs/superpowers/plans/2026-05-22-terminal-runtime.md
@@ -1,0 +1,250 @@
+# TerminalRuntime — design proposal (architectural plan)
+
+> **Status:** PROPOSAL — not an executable plan yet. The architecture audit
+> (4 parallel subagents, 2026-05-22) identified this as the highest-leverage
+> single refactor in the terminal layer. This document captures the design
+> so it can be reviewed BEFORE breaking it into per-PR implementation plans.
+> Once approved, each phase below becomes a separate `docs/superpowers/plans/`
+> implementation plan with bite-sized TDD steps.
+
+## The problem in one paragraph
+
+The renderer-side terminal is conceptually one thing — "a visible xterm that
+mirrors a server-side authoritative PTY buffer, attaches to one session at a
+time, survives container resizes, and stays at the prompt on attach." In
+practice it is implemented as **three React hooks + one mutable module
+singleton + a callback handshake between them**:
+
+- `useXtermSingleton` constructs the Terminal once.
+- `usePtyAttach` owns attach/detach + the snapshot/seq dedupe + live-tail
+  buffering + the post-attach resize replay + scroll invariant.
+- `useTerminalResize` owns the ResizeObserver and re-fires the replay
+  callback that `usePtyAttach` installed via `setSnapshotReplay`.
+- `useAtBottom` reads buffer state directly from `getTerm()`.
+- `xtermSingleton.ts` holds `term`, `fit`, `activeSid`, `unsubscribeData`,
+  `inputDisposable`, `snapshotReplay`, `keyboardPasteHandled`, each behind
+  a manual getter/setter pair, with no invariants enforced between them.
+
+This shape has accreted across 8+ PRs (#852, #864–#867, #888, #1263, #1268,
+#1273, #1290, #1291, #1293, #1308) and the latest one (#1308) added two
+*more* coordination flags (`replayInFlight`, `replayPending`) because the
+two replay drivers raced. Future bugs in this layer will keep adding more
+flags unless we collapse the implicit state machine into an explicit one.
+
+## What this proposal replaces
+
+| Current | Replaced by |
+|---|---|
+| `xtermSingleton.ts` module-scope `let` cells + 12 getter/setter fns | `TerminalRuntime` class instance, single source of truth |
+| `setSnapshotReplay` callback handshake | Runtime owns replay; resize hook calls `runtime.resize(...)` directly |
+| `snapSeq: null | number` + `buffered[]` + `replayInFlight` + `replayPending` ad-hoc state | Explicit FSM with states `detached / attaching / live / replaying` and a single in-flight controller |
+| `attachNonce` + `reloadNonce` driving `useEffect` re-runs | `runtime.attach(sessionId, cwd)` / `runtime.reload()` commands; React just observes state |
+| `scrollToBottom()` sprinkled at "the right places" (#1308) | Runtime invariant: after every state transition into `live`, viewport pinned to bottom unless user has explicitly scrolled away |
+| `keyboardPasteHandled` module flag for paste dedupe | Owned by the paste sub-controller inside the runtime |
+
+## What this proposal does NOT change
+
+- **xterm.js itself.** We're not switching renderers or addons. CanvasAddon,
+  ClipboardAddon, Unicode11Addon, WebLinksAddon stay.
+- **The main-process side (`electron/ptyHost`).** The audit flagged a parallel
+  "ptyHost should be actor-modeled" debt (#3 in the terminal report) — that
+  is a separate proposal. This refactor treats `window.ccsmPty` as the
+  contract and changes nothing across the IPC boundary.
+- **Test contracts.** All current behaviors stay covered. The shared test
+  harness from PR #1309 (`tests/util/terminalHarness.ts`) is the bridge —
+  tests assert against the same fakeTerm spies; we add a small set of
+  runtime-level tests beside the hook-level ones.
+- **#1308 scroll-bottom invariant.** That stays. The runtime makes it
+  unconditional rather than scattered.
+
+## Target architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                       TerminalRuntime                           │
+│                                                                 │
+│  state: FSM   { detached | attaching | live | replaying }       │
+│                                                                 │
+│  owns:                                                          │
+│    - Terminal instance (xterm.js)                               │
+│    - FitAddon                                                   │
+│    - activeSessionId                                            │
+│    - data subscription (single, lifetime = process)             │
+│    - dedupe state (snapSeq, buffered[])                         │
+│    - replay coalescing (in-flight + pending bits)               │
+│    - scroll invariant enforcement                               │
+│                                                                 │
+│  commands:                                                      │
+│    - attach(sessionId, cwd) → Promise<AttachOutcome>            │
+│    - detach() → void                                            │
+│    - resize() → Promise<void>          // called by RO hook     │
+│    - retry() → Promise<AttachOutcome>  // user-driven           │
+│                                                                 │
+│  events (react to via runtime.subscribe(listener)):             │
+│    - state changes (drives overlay rendering)                   │
+│    - exit (drives ExitOverlay + sidebar red-dot)                │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+       ▲                          ▲                       ▲
+       │                          │                       │
+┌──────┴──────────┐    ┌──────────┴────────┐    ┌─────────┴───────┐
+│ usePtyAttach    │    │ useTerminalResize │    │ useAtBottom     │
+│ (adapter)       │    │ (adapter)         │    │ (adapter)       │
+│                 │    │                   │    │                 │
+│ - on sid change │    │ - RO triggers     │    │ - reads runtime │
+│   → attach      │    │   runtime.resize  │    │   buffer state  │
+│ - exposes state │    │   (debounced)     │    │                 │
+└─────────────────┘    └───────────────────┘    └─────────────────┘
+```
+
+### State machine
+
+```
+                  attach(sid)
+   detached ──────────────────────► attaching
+      ▲                                │
+      │ detach()                       │ snapshot landed
+      │                                ▼
+      └─────────── live ◄──────────────┘
+                    │
+                    │ resize()  (coalesced)
+                    ▼
+                replaying
+                    │
+                    └─── snapshot landed ──► live
+```
+
+**Invariants:**
+
+1. `detached → attaching`: tear down prior subscription, install fresh data
+   listener in **buffering** mode (snapSeq = null), call `pty.attach`,
+   handle spawn-on-null fallback.
+2. `attaching → live`: snapshot has been fetched and written; bumped
+   snapSeq; drained `buffered[]`; **`term.scrollToBottom()` called**.
+3. `live → replaying`: coalesces. If already `replaying`, set pending bit
+   and return; the in-flight transition will re-enter `replaying` once on
+   completion if pending is set. Fresh snapshot fetched, `term.reset()`,
+   write, drain.
+4. `replaying → live`: **`term.scrollToBottom()` called**.
+5. `* → detached`: dispose subscription + input handler, clear xterm reset,
+   reset internal flags.
+
+These are exactly the rules that #1308's flag soup + scattered
+`scrollToBottom()` calls were trying to encode — formalising them into a
+single object makes them testable in isolation and removes the cross-hook
+callback handshake.
+
+## Implementation phases (each = 1 PR)
+
+The total surface (4 files in `src/terminal/`, 3 test files, no IPC
+changes) is small enough to do in 3 PRs, each shippable on its own.
+
+### Phase 1 — Introduce `TerminalRuntime` as the new internal owner; keep hooks as facades
+
+**Goal:** the runtime exists and owns the state, but the public API
+(`useXtermSingleton`, `usePtyAttach`, `useTerminalResize`, `useAtBottom`)
+is unchanged externally. Hooks become thin adapters; `xtermSingleton.ts`
+shrinks to a module-singleton holder for the runtime itself.
+
+**Risk:** low — internal refactor, behavior preserved, harness (#1309)
+already covers the assertion surface.
+
+**Deliverables:**
+- `src/terminal/TerminalRuntime.ts` (new)
+- `src/terminal/xtermSingleton.ts` reduced to `getRuntime()` accessor +
+  deprecated re-exports of `getTerm/getFit/...` that delegate to the
+  runtime for one transitional release
+- Hooks rewritten as `runtime.attach(sid, cwd)` / `runtime.resize()` /
+  `runtime.subscribe(setState)` adapters
+- Tests at two levels:
+  - **runtime-level** (new): direct unit tests against `TerminalRuntime`
+    methods, no React. Covers the FSM transitions and invariants
+    explicitly.
+  - **hook-level** (kept): existing `tests/terminal/usePtyAttach.test.tsx`
+    + `useTerminalResize.test.tsx` still pass byte-for-byte against the
+    harness from #1309 — these now indirectly verify the adapter layer.
+
+### Phase 2 — Remove the `setSnapshotReplay` callback handshake
+
+**Goal:** with runtime owning resize-driven replay directly, the
+`setSnapshotReplay` callback channel and its `getSnapshotReplay()`
+accessor disappear. `useTerminalResize` calls `runtime.resize()` instead.
+
+**Risk:** low — the channel was only used by these two files.
+
+**Deliverables:**
+- Delete `getSnapshotReplay` / `setSnapshotReplay` (and matching test
+  doubles)
+- Update `useTerminalResize` to call `runtime.resize()` (debounced
+  internally to preserve the 80ms behavior)
+- Remove the post-attach fit gate's separate replay trigger inside
+  `TerminalRuntime.attach` — it's now indistinguishable from any other
+  resize call, eliminating the double-replay race at its root (rather
+  than coalescing it as #1308 does today)
+
+### Phase 3 — Retire the deprecated module-singleton accessors
+
+**Goal:** delete `getTerm / getFit / getActiveSid / ...` from
+`xtermSingleton.ts`; only `getRuntime()` remains. `__ccsmTerm` global
+(used by e2e probes) becomes `__ccsmRuntime` exposing a stable test
+surface.
+
+**Risk:** medium — e2e probes change. Mitigate by keeping both globals
+for one release.
+
+**Deliverables:**
+- Remove deprecated re-exports from `xtermSingleton.ts`
+- Update e2e probes that read `window.__ccsmTerm` to read
+  `window.__ccsmRuntime.term` (a thin runtime field exposed for tests)
+- Migrate `tests/util/terminalHarness.ts` to mock the runtime directly
+  instead of mocking the singleton module. Tests are unchanged in
+  behavior; only the seam moves up one layer.
+
+## Open questions for review
+
+These are the decisions worth explicitly flagging before phase 1 starts:
+
+1. **Class vs closure.** TerminalRuntime as an exported class with a
+   module-singleton instance, or as a closure factory returning the
+   command/event API? Audit reports lean toward the class for the FSM
+   visibility; closure has fewer testing seams. **Recommendation: class.**
+
+2. **Scroll-bottom strictness.** #1308 made `scrollToBottom()` an
+   unconditional invariant at attach + post-replay. Should the runtime
+   also pin to bottom if a programmatic write happens while the user has
+   scrolled up? Today xterm decides via its auto-follow latch; we should
+   **not** override that for live writes — only for transitions into
+   `live`. **Recommendation: explicit invariant only on FSM transitions.**
+
+3. **e2e probe stability.** The `__ccsmTerm` global is read by probes
+   that bypass mocks (real Electron + real xterm). Phase 3 changes its
+   shape. **Recommendation: keep `__ccsmTerm` aliased to `runtime.term`
+   for 2 minor releases; deprecation comment + grep targets in probe
+   files.**
+
+4. **Headless replica.** The audit's #3 ("ptyHost should be actor-modeled")
+   is orthogonal — that's a main-process change. Should anything in the
+   runtime API anticipate it? **Recommendation: no — keep the runtime
+   IPC-shaped exactly like `window.ccsmPty` today; the actor refactor
+   on the main side can change implementation without renaming the
+   contract.**
+
+## What success looks like
+
+After all three phases ship:
+
+- `usePtyAttach.ts` shrinks from ~520 lines to ~80 (it becomes a `useSyncExternalStore`-style adapter)
+- `xtermSingleton.ts` shrinks from ~500 lines to ~40 (runtime instance + paste helpers that don't fit the runtime)
+- Replay-race regression class is structurally impossible (one replay owner)
+- "Attach lands at scroll-top" regression class is structurally impossible (FSM invariant + tested at runtime level, not buried in a hook)
+- Next session-attach bug ships with one test against the FSM, not three flag tweaks across three files
+
+---
+
+## Next step
+
+If this proposal is approved, I'll generate three `docs/superpowers/plans/`
+files (one per phase), each with the bite-sized TDD step structure that
+`superpowers:writing-plans` produces — at that point the steps know exactly
+what file changes, what tests, what to commit. Generating those steps
+NOW is premature: too many decisions above are still revisable.


### PR DESCRIPTION
## Summary

Two architecture proposals (NOT executable plans yet) capturing the highest-leverage refactors surfaced by an audit (4 parallel subagents covering terminal/pty, store/IPC, sidebar/UI, and test infra). Each proposal is a **review document** — open questions are explicit, phases are listed, and bite-sized TDD implementation plans will only be generated AFTER decisions are locked in.

### Proposals
- **TerminalRuntime** — collapse the implicit state machine spread across \`usePtyAttach\` + \`useTerminalResize\` + \`useAtBottom\` + \`xtermSingleton\`'s mutable globals into one explicit FSM. The latest scroll-bottom fix (#1308) added two more coordination flags (\`replayInFlight\` + \`replayPending\`) on top of the existing snapSeq/buffered/snapshotReplay handshake — this is the structural root that keeps adding flag soup PR after PR.
- **SessionActionIntent** — collapse the parallel coordination maps (\`reloadNonce\` + \`attachNonce\` + \`pendingForkSource\` + \`pendingRenameId\`) that grew piecemeal as right-click actions were added. Each user verb is currently a 4–6 file change. One discriminated-union slot per session + a reducer + a side-effect runner replaces the zoo.

### Sequencing
Each proposal lists phases (1 PR each, all shippable independently). Recommended interleaving of both refactors is at the bottom of \`2026-05-22-session-action-intent.md\` — 6 PRs over ~3 weeks, no big-bang, every step reversible.

### Companion work
- #1308 — the scroll-bottom bug fix that motivated this audit
- #1309 — shared terminal test harness (prerequisite for TerminalRuntime phase 1)

## Test plan
- [x] No code changes — docs only
- [ ] Review open questions in each proposal before locking in phase 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)