### PR TITLE
feat(remote): V2 mobile remote host (WSS signaling + WebRTC P2P)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -72,6 +72,8 @@ import { registerSystemIpc } from './ipc/systemIpc';
 import { registerSessionIpc } from './ipc/sessionIpc';
 import { registerWindowIpc } from './ipc/windowIpc';
 import { startMobileRemoteServer } from './remote/mobileRemoteServer';
+import { startMobileRemoteV2 } from './remote/mobileRemoteHostV2';
+import { registerDeviceFlowIpc } from './remote/deviceFlow';
 import {
   registerUtilityIpc,
   primeImportableCache,
@@ -125,6 +127,7 @@ let badgeManager: BadgeManager | null = null;
 let notifyPipeline: NotifyPipeline | null = null;
 let notifyPipelineDispose: (() => void) | null = null;
 let mobileRemoteServer: { close: () => void } | null = null;
+let mobileRemoteV2: { close: () => void } | null = null;
 const badgeController = new BadgeController(() => badgeManager);
 
 function getTrayBaseImage() {
@@ -255,6 +258,8 @@ app.whenReady().then(() => {
   );
 
   mobileRemoteServer = startMobileRemoteServer();
+  registerDeviceFlowIpc();
+  mobileRemoteV2 = startMobileRemoteV2();
 
   // ─────────────────────── notify pipeline (Phase C, #689) ───────────────
   // BadgeManager is bumped via `onNotified` to update the tray/dock badge.
@@ -333,6 +338,8 @@ registerLifecycleHandlers({
   disposeNotifyPipeline: () => {
     mobileRemoteServer?.close();
     mobileRemoteServer = null;
+    mobileRemoteV2?.close();
+    mobileRemoteV2 = null;
     notifyPipelineDispose?.();
   },
 });

--- a/electron/remote/deviceFlow.ts
+++ b/electron/remote/deviceFlow.ts
@@ -1,0 +1,63 @@
+// GitHub Device Flow login for the V2 mobile remote host. Triggered via IPC
+// (`remote-v2:device:start`). Opens the GitHub verification URL in the user's
+// default browser, polls the cc-sm Worker until the user completes auth, then
+// stashes the returned JWT on disk for `startMobileRemoteV2` to pick up.
+
+import { ipcMain, shell } from 'electron';
+import { writeJwt } from './mobileRemoteHostV2';
+
+const SIGNAL_ORIGIN_DEFAULT = 'https://cc-sm.workers.dev';
+
+type DeviceCodeResp = {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+};
+
+type PollResp =
+  | { jwt: string; login: string }
+  | { error: string }
+  | Record<string, unknown>;
+
+async function startDeviceFlow(origin: string): Promise<{ login: string }> {
+  const codeRes = await fetch(`${origin}/api/device/code`, { method: 'POST' });
+  if (!codeRes.ok) throw new Error(`device/code ${codeRes.status}`);
+  const code = (await codeRes.json()) as DeviceCodeResp;
+  console.log(
+    `[remote-v2-device] open ${code.verification_uri} and enter code: ${code.user_code}`,
+  );
+  await shell.openExternal(code.verification_uri);
+
+  const deadline = Date.now() + code.expires_in * 1000;
+  const intervalMs = Math.max(code.interval ?? 5, 5) * 1000;
+  while (Date.now() < deadline) {
+    await sleep(intervalMs);
+    const r = await fetch(`${origin}/api/device/poll`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ device_code: code.device_code }),
+    });
+    const j = (await r.json()) as PollResp;
+    if ('jwt' in j && typeof j.jwt === 'string' && typeof j.login === 'string') {
+      writeJwt(j.jwt);
+      return { login: j.login };
+    }
+    if ('error' in j && j.error && j.error !== 'authorization_pending' && j.error !== 'slow_down') {
+      throw new Error(String(j.error));
+    }
+  }
+  throw new Error('device flow expired');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+export function registerDeviceFlowIpc(): void {
+  ipcMain.handle('remote-v2:device:start', async () => {
+    const origin = process.env.CCSM_REMOTE_ORIGIN || SIGNAL_ORIGIN_DEFAULT;
+    return startDeviceFlow(origin);
+  });
+}

--- a/electron/remote/mobileRemoteHostPage.html
+++ b/electron/remote/mobileRemoteHostPage.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>CCSM Remote Host (hidden)</title>
+</head>
+<body>
+<script>
+// This page runs in a hidden BrowserWindow with sandbox=true; no nodeIntegration.
+// It uses fetch + WebSocket + RTCPeerConnection (renderer-side Web APIs) for the
+// V2 host transport. It communicates with the Electron main process via the
+// `ccsmRemoteV2` bridge exposed by the preload (see mobileRemoteHostPreload.ts).
+// If the preload isn't wired, the page logs and exits silently.
+const bridge = window.ccsmRemoteV2;
+if (!bridge) {
+  console.error('[remote-v2-host] preload bridge missing; aborting');
+} else {
+  const params = new URLSearchParams(location.search);
+  const origin = params.get('origin');
+  const room = params.get('room');
+  const jwt = params.get('jwt');
+  const wsUrl = origin.replace(/^http/, 'ws') + '/ws/' + encodeURIComponent(room) + '?role=host&token=' + encodeURIComponent(jwt);
+
+  let ws = null;
+  let pc = null;
+  let dc = null;
+  let backoffMs = 1000;
+
+  function connect() {
+    ws = new WebSocket(wsUrl);
+    ws.onopen = () => { console.log('[remote-v2-host] ws open'); backoffMs = 1000; };
+    ws.onclose = () => { console.log('[remote-v2-host] ws close; reconnect in', backoffMs); setTimeout(connect, backoffMs); backoffMs = Math.min(backoffMs * 2, 30000); cleanupPc(); };
+    ws.onerror = (e) => { console.warn('[remote-v2-host] ws error', e); };
+    ws.onmessage = onSignal;
+  }
+
+  async function onSignal(ev) {
+    let m;
+    try { m = JSON.parse(ev.data); } catch { return; }
+    if (m.type === 'hello') {
+      console.log('[remote-v2-host] hello; peerPresent=', m.peerPresent);
+      return;
+    }
+    if (m.type === 'peer-joined') {
+      // Reset any prior pc — new peer means a fresh offer is coming.
+      cleanupPc();
+      return;
+    }
+    if (m.type === 'peer-left') { cleanupPc(); return; }
+    if (m.type === 'offer') {
+      cleanupPc();
+      pc = new RTCPeerConnection({ iceServers: [{ urls: 'stun:stun.cloudflare.com:3478' }] });
+      pc.onicecandidate = (e) => {
+        if (e.candidate && ws && ws.readyState === 1) {
+          ws.send(JSON.stringify({ type: 'ice', candidate: e.candidate }));
+        }
+      };
+      pc.onconnectionstatechange = () => {
+        console.log('[remote-v2-host] pc state:', pc.connectionState);
+        if (pc.connectionState === 'failed' || pc.connectionState === 'closed') cleanupPc();
+      };
+      pc.ondatachannel = (e) => {
+        dc = e.channel;
+        dc.onopen = () => console.log('[remote-v2-host] dc open');
+        dc.onclose = () => { dc = null; console.log('[remote-v2-host] dc closed'); };
+        dc.onmessage = (ev2) => {
+          let msg;
+          try { msg = JSON.parse(ev2.data); } catch { return; }
+          bridge.send(msg);
+        };
+      };
+      await pc.setRemoteDescription({ type: 'offer', sdp: m.sdp });
+      const ans = await pc.createAnswer();
+      await pc.setLocalDescription(ans);
+      ws.send(JSON.stringify({ type: 'answer', sdp: ans.sdp }));
+      return;
+    }
+    if (m.type === 'ice' && m.candidate) {
+      try { await pc.addIceCandidate(m.candidate); } catch (e) { console.warn('addIceCandidate', e); }
+      return;
+    }
+  }
+
+  function cleanupPc() {
+    if (dc) { try { dc.close(); } catch {} dc = null; }
+    if (pc) { try { pc.close(); } catch {} pc = null; }
+  }
+
+  // Main → DataChannel forwarder (sessions.list / session.snapshot / pty.data).
+  bridge.onSend((msg) => {
+    if (dc && dc.readyState === 'open') {
+      try { dc.send(JSON.stringify(msg)); } catch {}
+    }
+  });
+  // pty.data fan-in from main.
+  bridge.onPtyData(({ sid, chunk }) => {
+    if (dc && dc.readyState === 'open') {
+      try { dc.send(JSON.stringify({ type: 'pty.data', sid, chunk })); } catch {}
+    }
+  });
+
+  connect();
+}
+</script>
+</body>
+</html>

--- a/electron/remote/mobileRemoteHostPreload.ts
+++ b/electron/remote/mobileRemoteHostPreload.ts
@@ -1,0 +1,18 @@
+// Preload for the hidden V2 mobile-remote host BrowserWindow. Exposes a
+// narrow `ccsmRemoteV2` bridge so the page (sandbox=true, no node integration)
+// can talk to the Electron main process for PTY ops.
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('ccsmRemoteV2', {
+  // DataChannel -> main: forward parsed messages from the phone.
+  send: (msg: unknown) => ipcRenderer.send('remote-v2:dc-recv', msg),
+  // main -> DataChannel: subscribe to messages main wants to push to the phone
+  // (e.g. snapshot results, sessions.list responses).
+  onSend: (cb: (msg: unknown) => void) => {
+    ipcRenderer.on('remote-v2:dc-send', (_e, m) => cb(m));
+  },
+  // main -> DataChannel: pty.data fan-in (one stream, multiplexed by sid).
+  onPtyData: (cb: (m: { sid: string; chunk: string }) => void) => {
+    ipcRenderer.on('remote-v2:pty-data', (_e, m) => cb(m));
+  },
+});

--- a/electron/remote/mobileRemoteHostV2.ts
+++ b/electron/remote/mobileRemoteHostV2.ts
@@ -1,0 +1,128 @@
+// V2 mobile remote host: connects this Electron instance to the cc-sm
+// signaling Worker as `role=host`, runs an RTCPeerConnection (answerer) in a
+// hidden BrowserWindow (since WebRTC is a renderer-only Web API), and bridges
+// the DataChannel to the existing ptyHost APIs over IPC.
+//
+// Gated by `CCSM_MOBILE_REMOTE_V2=1` and requires a JWT obtained out-of-band
+// via GitHub Device Flow (see `deviceFlow.ts`). The JWT is stashed in
+// app.getPath('userData')/.ccsm-remote-jwt for now — replace with safeStorage
+// before turning this on by default.
+
+import { app, BrowserWindow, ipcMain } from 'electron';
+import * as path from 'path';
+import * as fs from 'fs';
+import {
+  getBufferSnapshot,
+  getPtySession,
+  inputPtySession,
+  listPtySessions,
+  onPtyData,
+} from '../ptyHost';
+
+type V2Server = { close: () => void };
+
+const SIGNAL_ORIGIN_DEFAULT = 'https://cc-sm.workers.dev';
+const ROOM_DEFAULT = 'default';
+
+export function startMobileRemoteV2(): V2Server | null {
+  if (process.env.CCSM_MOBILE_REMOTE_V2 !== '1') return null;
+
+  const origin = process.env.CCSM_REMOTE_ORIGIN || SIGNAL_ORIGIN_DEFAULT;
+  const room = process.env.CCSM_REMOTE_ROOM || ROOM_DEFAULT;
+
+  const jwt = readJwt();
+  if (!jwt) {
+    console.warn(
+      '[mobile-remote-v2] no JWT on disk; run GitHub Device Flow first ' +
+        '(IPC: remote:device:start). Skipping.',
+    );
+    return null;
+  }
+
+  const win = new BrowserWindow({
+    show: false,
+    webPreferences: {
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      preload: path.join(__dirname, 'mobileRemoteHostPreload.js'),
+    },
+  });
+
+  const offPtyData = onPtyData((sid, chunk) => {
+    if (win.isDestroyed()) return;
+    win.webContents.send('remote-v2:pty-data', { sid, chunk });
+  });
+
+  const handleHostMsg = async (
+    _e: Electron.IpcMainEvent,
+    raw: unknown,
+  ): Promise<void> => {
+    if (!isRecord(raw) || typeof raw.type !== 'string') return;
+    if (raw.type === 'sessions.list') {
+      win.webContents.send('remote-v2:dc-send', {
+        type: 'sessions.list',
+        sessions: listPtySessions(),
+      });
+      return;
+    }
+    if (raw.type === 'session.snapshot' && typeof raw.sid === 'string') {
+      const snapshot = await getBufferSnapshot(raw.sid);
+      const info = getPtySession(raw.sid);
+      win.webContents.send('remote-v2:dc-send', {
+        type: 'session.snapshot',
+        sid: raw.sid,
+        cols: info?.cols ?? null,
+        rows: info?.rows ?? null,
+        ...snapshot,
+      });
+      return;
+    }
+    if (
+      raw.type === 'session.input' &&
+      typeof raw.sid === 'string' &&
+      typeof raw.data === 'string'
+    ) {
+      inputPtySession(raw.sid, raw.data);
+      return;
+    }
+  };
+  ipcMain.on('remote-v2:dc-recv', handleHostMsg);
+
+  const htmlPath = path.join(__dirname, 'mobileRemoteHostPage.html');
+  const params = new URLSearchParams({ origin, room, jwt });
+  // mobileRemoteHostPage.html is shipped alongside the compiled JS via the
+  // copy-remote-assets prebuild step (see scripts/copy-remote-assets.cjs).
+  win.loadFile(htmlPath, { search: params.toString() }).catch((e) => {
+    console.error('[mobile-remote-v2] loadFile failed:', e);
+  });
+
+  return {
+    close: () => {
+      offPtyData();
+      ipcMain.removeListener('remote-v2:dc-recv', handleHostMsg);
+      if (!win.isDestroyed()) win.destroy();
+    },
+  };
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === 'object' && v !== null;
+}
+
+function jwtPath(): string {
+  return path.join(app.getPath('userData'), '.ccsm-remote-jwt');
+}
+
+export function readJwt(): string | null {
+  try {
+    const s = fs.readFileSync(jwtPath(), 'utf8').trim();
+    return s || null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeJwt(jwt: string): void {
+  fs.writeFileSync(jwtPath(), jwt, { encoding: 'utf8', mode: 0o600 });
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dev:web": "webpack serve --config webpack.config.js --mode development",
     "dev:app": "wait-on http://localhost:4100 && tsc -p tsconfig.electron.json && node scripts/dev-electron.mjs",
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
-    "build": "npm run clean && tsc -p tsconfig.electron.json && webpack --mode production && node -e \"const fs=require('fs');const p='dist/renderer/bundle.js';const t=Date.now()/1000;fs.utimesSync(p,t,t)\"",
+    "build": "npm run clean && tsc -p tsconfig.electron.json && node scripts/copy-remote-assets.cjs && webpack --mode production && node -e \"const fs=require('fs');const p='dist/renderer/bundle.js';const t=Date.now()/1000;fs.utimesSync(p,t,t)\"",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.electron.json",
     "lint": "eslint . --ext .ts,.tsx",
     "test": "vitest run",

--- a/scripts/copy-remote-assets.cjs
+++ b/scripts/copy-remote-assets.cjs
@@ -1,0 +1,12 @@
+// Copy non-TS assets the V2 mobile remote host needs (the hidden BrowserWindow
+// HTML) into `dist/electron/remote/`. Runs from `npm run build` before
+// electron-builder packages the app.
+const fs = require('fs');
+const path = require('path');
+
+const src = path.join(__dirname, '..', 'electron', 'remote', 'mobileRemoteHostPage.html');
+const dst = path.join(__dirname, '..', 'dist', 'electron', 'remote', 'mobileRemoteHostPage.html');
+
+fs.mkdirSync(path.dirname(dst), { recursive: true });
+fs.copyFileSync(src, dst);
+console.log('[copy-remote-assets] copied', src, '->', dst);


### PR DESCRIPTION
## Summary
- V2 transport for the mobile remote: persistent WSS to the cc-sm signaling Worker as role=host, RTCPeerConnection answerer in a hidden BrowserWindow, DataChannel bridged to the existing ptyHost over IPC.
- Adds GitHub Device Flow login (`remote-v2:device:start` IPC) that stashes a JWT under `app.getPath('userData')/.ccsm-remote-jwt`.
- Gated behind `CCSM_MOBILE_REMOTE_V2=1`. V1 (Tailscale) path is untouched and still the default.

## Files
- `electron/remote/mobileRemoteHostV2.ts` — main-side orchestrator + JWT read/write.
- `electron/remote/mobileRemoteHostPage.html` — page in hidden window, owns WSS + WebRTC + DataChannel.
- `electron/remote/mobileRemoteHostPreload.ts` — narrow `ccsmRemoteV2` bridge (sandbox+contextIsolation).
- `electron/remote/deviceFlow.ts` — GitHub Device Flow.
- `scripts/copy-remote-assets.cjs` — copy HTML into `dist/` for electron-builder.
- `electron/main.ts` — register Device Flow IPC, start V2 host, dispose on quit.

## Test plan
- [ ] `npm run typecheck` clean
- [ ] CI green
- [ ] Manual: deploy cc-sm Worker → set env vars → run `remote-v2:device:start` IPC → open Pages on phone → see sessions → input/output flows over P2P (verify `pc.connectionState=connected`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)