### PR TITLE
fix(groups): clear nameKey on rename

### DIFF
--- a/src/stores/slices/groupsSlice.ts
+++ b/src/stores/slices/groupsSlice.ts
@@ -82,7 +82,7 @@ export function createGroupsSlice(set: SetFn, get: GetFn): GroupsSlice {
 
     renameGroup: (id, name) => {
       set((s) => ({
-        groups: s.groups.map((g) => (g.id === id ? { ...g, name } : g)),
+        groups: s.groups.map((g) => (g.id === id ? { ...g, name, nameKey: undefined } : g)),
       }));
     },
 

--- a/tests/stores/slices/groupsSlice.test.ts
+++ b/tests/stores/slices/groupsSlice.test.ts
@@ -71,6 +71,30 @@ describe('groupsSlice', () => {
     expect(h.state().groups.find((g) => g.id === 'g-default')!.name).toBe('Renamed');
   });
 
+  it('renameGroup clears nameKey so the user-typed name wins over i18n', () => {
+    // Default bootstrap group carries `nameKey: 'sidebar.defaultGroupName'`
+    // which the sidebar prefers over `name` for rendering. After a user
+    // rename we must drop `nameKey` so their text actually shows up.
+    const h = harness();
+    const before = h.state().groups.find((g) => g.id === 'g-default')!;
+    expect(before.nameKey).toBe('sidebar.defaultGroupName');
+
+    h.slice.renameGroup('g-default', 'My sessions');
+
+    const after = h.state().groups.find((g) => g.id === 'g-default')!;
+    expect(after.name).toBe('My sessions');
+    expect(after.nameKey).toBeUndefined();
+  });
+
+  it('renameGroup is a no-op on groups without nameKey (regression)', () => {
+    const h = harness();
+    const id = h.slice.createGroup('Original');
+    h.slice.renameGroup(id, 'Updated');
+    const g = h.state().groups.find((x) => x.id === id)!;
+    expect(g.name).toBe('Updated');
+    expect(g.nameKey).toBeUndefined();
+  });
+
   it('archiveGroup / unarchiveGroup flips kind', () => {
     const h = harness();
     h.slice.archiveGroup('g-default');


### PR DESCRIPTION
## Bug
Renaming the default \"Sessions\" group via the sidebar appeared to silently fail — the user's new name never showed up; the row kept rendering as \"Sessions\" (or its localized equivalent).

## Root cause
The bootstrap default group carries both \`name: 'Sessions'\` and \`nameKey: 'sidebar.defaultGroupName'\`. The sidebar prefers \`nameKey\` (running it through i18n) over \`name\` when both are present — this is what makes the default label re-localize on language switch. \`renameGroup\` updated \`name\` but left \`nameKey\` in place, so the i18n key kept winning and the user's input was invisible.

## Fix
One-line change in \`src/stores/slices/groupsSlice.ts\` \`renameGroup\`: also set \`nameKey: undefined\` when writing the new name. A rename is by definition an explicit user-chosen label, so the i18n fallback no longer applies.

\`\`\`ts
groups: s.groups.map((g) => (g.id === id ? { ...g, name, nameKey: undefined } : g)),
\`\`\`

## Tests
Extends \`tests/stores/slices/groupsSlice.test.ts\` with two cases:
- Renaming \`g-default\` (which has \`nameKey\`) sets \`name\` and clears \`nameKey\`.
- Renaming a user-created group (no \`nameKey\`) still works and leaves \`nameKey\` undefined (regression guard).

Local: \`npx vitest run tests/stores/slices/groupsSlice.test.ts\` -> 14/14 pass. \`npm run typecheck\` clean. \`npm run lint\` 0 errors.