### PR TITLE
fix(terminal): buffer pty writes during IME composition

### DIFF
--- a/src/terminal/usePtyAttach.ts
+++ b/src/terminal/usePtyAttach.ts
@@ -13,6 +13,7 @@ import {
   setSnapshotReplay,
   getSnapshotReplay,
   writeAndScrollToBottom,
+  writeOrBuffer,
 } from './xtermSingleton';
 
 export type PtyAttachState =
@@ -263,7 +264,7 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
             // Post-snapshot: drop anything seq <= snapSeq (already in
             // the snapshot we wrote) and write the rest live.
             if (payload.seq > snapSeq) {
-              getTerm()?.write(payload.chunk);
+              writeOrBuffer(payload.chunk);
             }
           }),
         );

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -37,6 +37,19 @@ let inputDisposable: { dispose: () => void } | null = null;
 // suppresses the native paste event reaching the current host element.
 // See the paste-path block inside `ensureTerminal` for details.
 let keyboardPasteHandled = false;
+// IME composition state: while a Chinese/Japanese/Korean IME is composing,
+// every term.write reanchors xterm's hidden textarea and makes the
+// composition preview box jump around. Buffer pty chunks until compositionend.
+let isComposing = false;
+let imeBuffer = '';
+
+export function writeOrBuffer(chunk: string): void {
+  if (isComposing) {
+    imeBuffer += chunk;
+    return;
+  }
+  term?.write(chunk);
+}
 // L4 PR-D (#866): callback installed by `usePtyAttach` once it has wired the
 // snapshot/dedupe-by-seq flow. Invoked by `useTerminalResize` AFTER pushing
 // a new size to the headless mirror so the visible xterm can re-render
@@ -308,6 +321,21 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
 
   term.open(host);
 
+  const ta = term.textarea;
+  if (ta) {
+    ta.addEventListener('compositionstart', () => {
+      isComposing = true;
+    });
+    ta.addEventListener('compositionend', () => {
+      isComposing = false;
+      if (imeBuffer) {
+        const pending = imeBuffer;
+        imeBuffer = '';
+        term?.write(pending);
+      }
+    });
+  }
+
   // Single canonical paste path.
   //
   // xterm.js exposes two competing entry points for paste:
@@ -496,6 +524,8 @@ export function __resetSingletonForTests(): void {
   inputDisposable = null;
   snapshotReplay = null;
   keyboardPasteHandled = false;
+  isComposing = false;
+  imeBuffer = '';
   if (typeof window !== 'undefined') {
     delete window.__ccsmTerm;
   }

--- a/tests/terminal/imeBuffering.test.ts
+++ b/tests/terminal/imeBuffering.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock xterm constructors BEFORE importing the module under test. The
+// mock Terminal exposes a real <textarea> so the singleton's
+// compositionstart/compositionend listeners (attached to `term.textarea`
+// inside `ensureTerminal`) can be exercised with real DOM events. The
+// `write` method is a plain spy so we can assert it (was not) called at
+// the right moments.
+const { writeSpy, textarea, terminalCtor } = vi.hoisted(() => {
+  const writeSpy = vi.fn();
+  const textarea = (globalThis as unknown as { document: Document }).document.createElement('textarea');
+  const terminalCtor = vi.fn(function () {
+    return {
+      open: vi.fn(),
+      loadAddon: vi.fn(),
+      onSelectionChange: vi.fn(),
+      attachCustomKeyEventHandler: vi.fn(),
+      getSelection: vi.fn(() => ''),
+      clearSelection: vi.fn(),
+      selectAll: vi.fn(),
+      unicode: { activeVersion: '6' },
+      modes: { bracketedPasteMode: false },
+      _core: { _parent: null },
+      textarea,
+      write: writeSpy,
+    };
+  });
+  return { writeSpy, textarea, terminalCtor };
+});
+
+vi.mock('@xterm/xterm', () => ({ Terminal: terminalCtor }));
+vi.mock('@xterm/addon-fit', () => ({ FitAddon: vi.fn(function () { return { fit: vi.fn() }; }) }));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-canvas', () => ({ CanvasAddon: vi.fn(function () { return {}; }) }));
+
+import {
+  __resetSingletonForTests,
+  ensureTerminal,
+  writeOrBuffer,
+} from '../../src/terminal/xtermSingleton';
+
+describe('writeOrBuffer — IME composition buffering', () => {
+  beforeEach(() => {
+    __resetSingletonForTests();
+    writeSpy.mockClear();
+    terminalCtor.mockClear();
+    // Fresh host each test so ensureTerminal's open() side-effects don't bleed.
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    ensureTerminal(host as HTMLDivElement);
+  });
+
+  afterEach(() => {
+    __resetSingletonForTests();
+    document.body.innerHTML = '';
+  });
+
+  it('writes immediately when not composing', () => {
+    writeOrBuffer('hello');
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(writeSpy).toHaveBeenCalledWith('hello');
+  });
+
+  it('buffers chunks while composing (no term.write calls)', () => {
+    textarea.dispatchEvent(new CompositionEvent('compositionstart'));
+    writeOrBuffer('a');
+    writeOrBuffer('b');
+    writeOrBuffer('c');
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it('flushes the buffered chunks in a single write on compositionend', () => {
+    textarea.dispatchEvent(new CompositionEvent('compositionstart'));
+    writeOrBuffer('foo');
+    writeOrBuffer('bar');
+    writeOrBuffer('baz');
+    expect(writeSpy).not.toHaveBeenCalled();
+
+    textarea.dispatchEvent(new CompositionEvent('compositionend'));
+    // One coalesced flush of the accumulated buffer.
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(writeSpy).toHaveBeenCalledWith('foobarbaz');
+  });
+
+  it('clears the buffer after flush so subsequent writes go direct', () => {
+    textarea.dispatchEvent(new CompositionEvent('compositionstart'));
+    writeOrBuffer('queued');
+    textarea.dispatchEvent(new CompositionEvent('compositionend'));
+    writeSpy.mockClear();
+
+    writeOrBuffer('after');
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(writeSpy).toHaveBeenCalledWith('after');
+  });
+
+  it('compositionend with no buffered chunks does not call write', () => {
+    textarea.dispatchEvent(new CompositionEvent('compositionstart'));
+    textarea.dispatchEvent(new CompositionEvent('compositionend'));
+    expect(writeSpy).not.toHaveBeenCalled();
+  });
+
+  it('a fresh compositionstart re-engages buffering after a prior cycle', () => {
+    textarea.dispatchEvent(new CompositionEvent('compositionstart'));
+    writeOrBuffer('x');
+    textarea.dispatchEvent(new CompositionEvent('compositionend'));
+    writeSpy.mockClear();
+
+    textarea.dispatchEvent(new CompositionEvent('compositionstart'));
+    writeOrBuffer('y');
+    expect(writeSpy).not.toHaveBeenCalled();
+    textarea.dispatchEvent(new CompositionEvent('compositionend'));
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(writeSpy).toHaveBeenCalledWith('y');
+  });
+});

--- a/tests/usePtyAttach-snapshot-replay.test.tsx
+++ b/tests/usePtyAttach-snapshot-replay.test.tsx
@@ -77,6 +77,13 @@ function installMockTerminal(): void {
     proposeDimensions: () => ({ cols: 80, rows: 24 }),
     fit: () => {},
   } as unknown as ReturnType<typeof singleton.getFit>);
+  // writeOrBuffer (IME buffering wrapper) normally forwards to the
+  // module-internal `term` instance which we don't construct in this
+  // test. Route it through the same mock write sink so live-chunk paths
+  // (post-snapshot) keep populating M.writes.
+  vi.spyOn(singleton, 'writeOrBuffer').mockImplementation((chunk: string) => {
+    if (chunk !== '') M.writes.push(chunk);
+  });
 }
 
 function installCcsmPty(): void {


### PR DESCRIPTION
## Symptom

When typing with an IME (Chinese/Japanese/Korean) into the xterm pane, the composition preview box jumps around and characters jitter mid-composition. This makes IME input effectively unusable in ccsm sessions during periods of active pty output.

## Root cause

Every incoming pty chunk flows through `term.write()`. xterm's write internally touches the hidden `<textarea>` (anchoring/caret/scroll), which the IME has commandeered for composition. Every reanchor reflows the OS-level IME popup, producing visible jitter for as long as the pty is emitting.

## Fix

Singleton-scope IME buffer in `src/terminal/xtermSingleton.ts`:

- Module-level `isComposing` flag + `imeBuffer` string.
- `compositionstart` / `compositionend` listeners on `term.textarea` set/clear the flag and flush the accumulated buffer in a single `term.write` call on end.
- New `writeOrBuffer(chunk)` helper: writes immediately if not composing, else appends to the buffer.
- `src/terminal/usePtyAttach.ts` swaps **only the live-chunk write path** (the post-snapshot `pty.onData` branch) to `writeOrBuffer`. Snapshot / drain / replay paths still use `writeAndScrollToBottom` unchanged so attach behavior is untouched.
- `__resetSingletonForTests` clears the new state.

## Tests

`tests/terminal/imeBuffering.test.ts` — 6 unit tests covering:

- write while NOT composing forwards to `term.write` immediately
- write while composing accumulates without calling `term.write`
- `compositionend` flushes the accumulated buffer in one coalesced `term.write`
- buffer is cleared after flush; subsequent writes go direct
- `compositionend` with empty buffer is a no-op
- a fresh `compositionstart` re-engages buffering after a prior cycle

Also updated the existing `tests/usePtyAttach-snapshot-replay.test.tsx` mock to route `writeOrBuffer` through the same write sink as the mock terminal (the live-chunk path now goes through the new helper).

`typecheck`, `lint` (0 errors), and all terminal-related vitest suites pass.