### PR TITLE
fix(ptyHost): prune destroyed webContents during PTY fanout

### DIFF
--- a/electron/ptyHost/__tests__/entryFactory.test.ts
+++ b/electron/ptyHost/__tests__/entryFactory.test.ts
@@ -424,4 +424,30 @@ describe('entryFactory.dispatchPtyChunk', () => {
     expect(bus().headlessWrite).toHaveBeenCalledWith('x', expect.any(Function));
     expect(entry.seq).toBe(1);
   });
+
+  it('prunes destroyed webContents from entry.attached during fanout (defense-in-depth vs ipcRegistrar destroy handler)', async () => {
+    const mod = await import('../entryFactory');
+    const entry = mod.makeEntry('sid-PRUNE', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
+    const dead = { isDestroyed: () => true, send: vi.fn() };
+    const alive = { isDestroyed: () => false, send: vi.fn() };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    entry.attached.set(1, dead as any);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    entry.attached.set(2, alive as any);
+    expect(entry.attached.size).toBe(2);
+
+    mod.dispatchPtyChunk('sid-PRUNE', entry, 'y');
+
+    // Live wc received the chunk.
+    expect(alive.send).toHaveBeenCalledTimes(1);
+    // Destroyed wc was evicted from the Map — leak fix.
+    expect(entry.attached.size).toBe(1);
+    expect(entry.attached.has(1)).toBe(false);
+    expect(entry.attached.has(2)).toBe(true);
+
+    // Subsequent chunks no longer visit the dead entry.
+    mod.dispatchPtyChunk('sid-PRUNE', entry, 'z');
+    expect(dead.send).not.toHaveBeenCalled();
+    expect(alive.send).toHaveBeenCalledTimes(2);
+  });
 });

--- a/electron/ptyHost/entryFactory.ts
+++ b/electron/ptyHost/entryFactory.ts
@@ -185,13 +185,26 @@ export function dispatchPtyChunk(sid: string, entry: Entry, chunk: string): void
 
   // Sink 2: visible-xterm IPC fanout. Best-effort per attached webContents
   // — a destroyed sender or an IPC throw must not wedge the PTY pump.
-  for (const wc of entry.attached.values()) {
-    if (!wc.isDestroyed()) {
-      try {
-        wc.send('pty:data', { sid, chunk, seq });
-      } catch {
-        /* renderer gone — best effort */
-      }
+  //
+  // Also actively prune destroyed entries as we iterate. The primary
+  // cleanup path is the `wc.once('destroyed')` handler registered in
+  // `ipcRegistrar` (attach IPC), but if that ever races or fails the
+  // entry would otherwise leak until the entire session is killed —
+  // costing iteration time on every chunk and pinning the WebContents
+  // meta alive across renderer churn (window reopens, dev hot-reloads).
+  // Deleting from a Map during iteration is safe: the iterator only
+  // visits live entries at the time of each `next()`. This is defense
+  // in depth; the `entry.attached.size` check above (backpressure-warn
+  // suppression) also stays accurate as dead entries are evicted.
+  for (const [id, wc] of entry.attached) {
+    if (wc.isDestroyed()) {
+      entry.attached.delete(id);
+      continue;
+    }
+    try {
+      wc.send('pty:data', { sid, chunk, seq });
+    } catch {
+      /* renderer gone — best effort */
     }
   }
 


### PR DESCRIPTION
## Summary

- `electron/ptyHost/entryFactory.ts::dispatchPtyChunk` previously skipped destroyed senders via `wc.isDestroyed()` but never removed them from `entry.attached`. On long-running sessions with renderer churn (window reopens, dev hot-reloads), dead entries accumulated — costing iteration time per chunk and pinning meta objects alive until the session was killed.
- The `wc.once('destroyed')` handler in `ipcRegistrar` was the only active cleanup path. This change adds defense-in-depth: when fanout sees a destroyed wc, it now deletes the entry from the Map as it iterates (Map iteration is safe under in-place delete). The `wc.once('destroyed')` handler remains the primary cleanup.
- The `entry.attached.size`-gated backpressure-warn suppression stays accurate since dead entries are evicted.

## Test plan

- [x] New regression test in `electron/ptyHost/__tests__/entryFactory.test.ts` (`prunes destroyed webContents from entry.attached during fanout ...`) asserts `Map.size` drops 2 -> 1 when a destroyed wc is visited, and that subsequent chunks no longer touch the dead entry.
- [x] `npm run typecheck` clean.
- [x] `npx vitest run electron/ptyHost/__tests__/entryFactory.test.ts` — 16/16 pass.