### PR TITLE
refactor(ipc): single source of truth for channel names

### DIFF
--- a/electron/__tests__/updater.test.ts
+++ b/electron/__tests__/updater.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EventEmitter } from 'events';
-import { UPDATES_CHANNELS } from '../shared/ipcChannels';
+import { UPDATE_CHANNELS, UPDATES_CHANNELS } from '../shared/ipcChannels';
 
 // ----------------------------------------------------------------------------
 // Mocks
@@ -156,7 +156,7 @@ describe('updater: IPC wiring', () => {
       releaseDate: '2026-01-01'
     });
 
-    const availableSends = sendsFor('update:available');
+    const availableSends = sendsFor(UPDATE_CHANNELS.available);
     expect(availableSends).toContainEqual({ version: '1.2.3', releaseDate: '2026-01-01' });
   });
 
@@ -164,14 +164,14 @@ describe('updater: IPC wiring', () => {
     autoUpdaterEmitter.emit('update-downloaded', { version: '1.2.3' });
 
     expect(sendsFor(UPDATES_CHANNELS.status)).toContainEqual({ kind: 'downloaded', version: '1.2.3' });
-    expect(sendsFor('update:downloaded')).toContainEqual({ version: '1.2.3' });
+    expect(sendsFor(UPDATE_CHANNELS.downloaded)).toContainEqual({ version: '1.2.3' });
   });
 
   it('broadcasts status on error and fires update:error channel', () => {
     autoUpdaterEmitter.emit('error', new Error('network down'));
 
     expect(sendsFor(UPDATES_CHANNELS.status)).toContainEqual({ kind: 'error', message: 'network down' });
-    expect(sendsFor('update:error')).toContainEqual({ message: 'network down' });
+    expect(sendsFor(UPDATE_CHANNELS.error)).toContainEqual({ message: 'network down' });
   });
 
   it('updates:check returns not-available in dev (unpackaged) without calling autoUpdater', async () => {

--- a/electron/__tests__/updater.test.ts
+++ b/electron/__tests__/updater.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { EventEmitter } from 'events';
+import { UPDATES_CHANNELS } from '../shared/ipcChannels';
 
 // ----------------------------------------------------------------------------
 // Mocks
@@ -106,12 +107,12 @@ describe('updater: IPC wiring', () => {
 
   it('registers all expected ipc handlers', () => {
     const expected = [
-      'updates:status',
-      'updates:check',
-      'updates:download',
-      'updates:install',
-      'updates:getAutoCheck',
-      'updates:setAutoCheck'
+      UPDATES_CHANNELS.status,
+      UPDATES_CHANNELS.check,
+      UPDATES_CHANNELS.download,
+      UPDATES_CHANNELS.install,
+      UPDATES_CHANNELS.getAutoCheck,
+      UPDATES_CHANNELS.setAutoCheck
     ];
     for (const ch of expected) {
       expect(ipcHandlers.has(ch), `missing handler: ${ch}`).toBe(true);
@@ -148,7 +149,7 @@ describe('updater: IPC wiring', () => {
   it('broadcasts status on update-available and fires update:available channel', () => {
     autoUpdaterEmitter.emit('update-available', { version: '1.2.3', releaseDate: '2026-01-01' });
 
-    const statusSends = sendsFor('updates:status');
+    const statusSends = sendsFor(UPDATES_CHANNELS.status);
     expect(statusSends).toContainEqual({
       kind: 'available',
       version: '1.2.3',
@@ -162,14 +163,14 @@ describe('updater: IPC wiring', () => {
   it('broadcasts status on update-downloaded and fires update:downloaded channel', () => {
     autoUpdaterEmitter.emit('update-downloaded', { version: '1.2.3' });
 
-    expect(sendsFor('updates:status')).toContainEqual({ kind: 'downloaded', version: '1.2.3' });
+    expect(sendsFor(UPDATES_CHANNELS.status)).toContainEqual({ kind: 'downloaded', version: '1.2.3' });
     expect(sendsFor('update:downloaded')).toContainEqual({ version: '1.2.3' });
   });
 
   it('broadcasts status on error and fires update:error channel', () => {
     autoUpdaterEmitter.emit('error', new Error('network down'));
 
-    expect(sendsFor('updates:status')).toContainEqual({ kind: 'error', message: 'network down' });
+    expect(sendsFor(UPDATES_CHANNELS.status)).toContainEqual({ kind: 'error', message: 'network down' });
     expect(sendsFor('update:error')).toContainEqual({ message: 'network down' });
   });
 
@@ -184,7 +185,7 @@ describe('updater: IPC wiring', () => {
       return { updateInfo: {} };
     };
 
-    const handler = ipcHandlers.get('updates:check')!;
+    const handler = ipcHandlers.get(UPDATES_CHANNELS.check)!;
     const result = await handler({});
     expect(result).toEqual({ kind: 'not-available', version: '0.1.2' });
     expect(checkCalled).toBe(false);
@@ -194,11 +195,11 @@ describe('updater: IPC wiring', () => {
     state.checkForUpdatesImpl = async () => {
       throw new Error('boom');
     };
-    const handler = ipcHandlers.get('updates:check')!;
+    const handler = ipcHandlers.get(UPDATES_CHANNELS.check)!;
     const result = (await handler({})) as { kind: string; message: string };
     expect(result.kind).toBe('error');
     expect(result.message).toBe('boom');
-    expect(sendsFor('updates:status')).toContainEqual({ kind: 'error', message: 'boom' });
+    expect(sendsFor(UPDATES_CHANNELS.status)).toContainEqual({ kind: 'error', message: 'boom' });
   });
 
   it('updates:install calls quitAndInstall silently + relaunch', async () => {
@@ -206,7 +207,7 @@ describe('updater: IPC wiring', () => {
     // lastStatus is `downloaded`. Drive the broadcast first so the
     // handler can proceed.
     autoUpdaterEmitter.emit('update-downloaded', { version: '0.1.3' });
-    const handler = ipcHandlers.get('updates:install')!;
+    const handler = ipcHandlers.get(UPDATES_CHANNELS.install)!;
     const res = handler({});
     expect(res).toEqual({ ok: true });
     // quitAndInstall is scheduled via setImmediate — flush it.
@@ -219,7 +220,7 @@ describe('updater: IPC wiring', () => {
   it('updates:install refuses when no download has completed', () => {
     // No `update-downloaded` event broadcast → lastStatus stays `idle`.
     // The defense-in-depth gate must short-circuit before quitAndInstall.
-    const handler = ipcHandlers.get('updates:install')!;
+    const handler = ipcHandlers.get(UPDATES_CHANNELS.install)!;
     const res = handler({});
     expect(res).toEqual({ ok: false, reason: 'not-ready' });
     expect(quitAndInstallCalls).toEqual([]);
@@ -227,7 +228,7 @@ describe('updater: IPC wiring', () => {
 
   it('updates:install refuses when not packaged', async () => {
     state.appIsPackaged = false;
-    const handler = ipcHandlers.get('updates:install')!;
+    const handler = ipcHandlers.get(UPDATES_CHANNELS.install)!;
     const res = handler({});
     expect(res).toEqual({ ok: false, reason: 'not-packaged' });
   });
@@ -237,15 +238,15 @@ describe('updater: IPC wiring', () => {
     state.downloadUpdateImpl = async () => {
       called = true;
     };
-    const handler = ipcHandlers.get('updates:download')!;
+    const handler = ipcHandlers.get(UPDATES_CHANNELS.download)!;
     const res = await handler({});
     expect(res).toEqual({ ok: true });
     expect(called).toBe(true);
   });
 
   it('updates:setAutoCheck toggles the preference', async () => {
-    const setHandler = ipcHandlers.get('updates:setAutoCheck')!;
-    const getHandler = ipcHandlers.get('updates:getAutoCheck')!;
+    const setHandler = ipcHandlers.get(UPDATES_CHANNELS.setAutoCheck)!;
+    const getHandler = ipcHandlers.get(UPDATES_CHANNELS.getAutoCheck)!;
     expect(await getHandler({})).toBe(true);
     expect(await setHandler({}, false)).toBe(false);
     expect(await getHandler({})).toBe(false);
@@ -254,7 +255,7 @@ describe('updater: IPC wiring', () => {
 
   it('updates:status returns the last broadcast status', async () => {
     autoUpdaterEmitter.emit('update-available', { version: '9.9.9' });
-    const handler = ipcHandlers.get('updates:status')!;
+    const handler = ipcHandlers.get(UPDATES_CHANNELS.status)!;
     const res = await handler({});
     expect(res).toEqual({ kind: 'available', version: '9.9.9', releaseDate: undefined });
   });

--- a/electron/ipc/dbIpc.ts
+++ b/electron/ipc/dbIpc.ts
@@ -17,6 +17,7 @@ import { loadState, saveState } from '../db';
 import { validateSaveStateInput } from '../db-validate';
 import { fromMainFrame } from '../security/ipcGuards';
 import { emitStateSaved } from '../shared/stateSavedBus';
+import { DB_CHANNELS } from '../shared/ipcChannels';
 
 export interface DbIpcDeps {
   ipcMain: IpcMain;
@@ -79,11 +80,11 @@ export function handleDbLoad(
 
 export function registerDbIpc(deps: DbIpcDeps): void {
   const { ipcMain } = deps;
-  ipcMain.handle('db:load', handleDbLoad);
+  ipcMain.handle(DB_CHANNELS.load, handleDbLoad);
   // Cap renderer-supplied state values. Mirrors the per-block cap in the
   // (now-retired) db:saveMessages handler but tighter (1 MB total): a single
   // app_state row holds drafts/persist snapshots that should never approach
   // this size — if one does, it's a bug in the persister and we refuse to
   // commit it rather than silently growing the WAL.
-  ipcMain.handle('db:save', handleDbSave);
+  ipcMain.handle(DB_CHANNELS.save, handleDbSave);
 }

--- a/electron/ipc/sessionIpc.ts
+++ b/electron/ipc/sessionIpc.ts
@@ -27,6 +27,7 @@ import {
   flushPendingRename,
 } from '../sessionTitles';
 import { fromMainFrame, isSafePath } from '../security/ipcGuards';
+import { SESSION_CHANNELS } from '../shared/ipcChannels';
 
 export interface SessionIpcDeps {
   ipcMain: IpcMain;
@@ -93,7 +94,7 @@ export function registerSessionIpc(deps: SessionIpcDeps): void {
   // Renderer mirrors its active session id here so the notify bridge can
   // suppress toasts for the session the user is currently viewing. Plain
   // `ipcMain.on` (no reply); the renderer fires this on every selectSession.
-  ipcMain.on('session:setActive', (e, sid: unknown) => {
+  ipcMain.on(SESSION_CHANNELS.setActive, (e, sid: unknown) => {
     if (!fromMainFrame(e)) return;
     const next =
       typeof sid === 'string' && sid.length > 0 ? sid : null;
@@ -122,7 +123,7 @@ export function registerSessionIpc(deps: SessionIpcDeps): void {
   // show "my-feature-branch" instead of the UUID. Empty/missing name clears
   // the entry (renderer signals "no longer have a name"). Same security
   // posture as session:setActive — main-frame only.
-  ipcMain.on('session:setName', (e, payload: unknown) => {
+  ipcMain.on(SESSION_CHANNELS.setName, (e, payload: unknown) => {
     if (!fromMainFrame(e)) return;
     if (!payload || typeof payload !== 'object') return;
     const { sid, name } = payload as { sid?: unknown; name?: unknown };

--- a/electron/ipc/windowIpc.ts
+++ b/electron/ipc/windowIpc.ts
@@ -8,6 +8,7 @@
 
 import type { IpcMain } from 'electron';
 import { BrowserWindow } from 'electron';
+import { WINDOW_CHANNELS } from '../shared/ipcChannels';
 
 export interface WindowIpcDeps {
   ipcMain: IpcMain;
@@ -15,20 +16,20 @@ export interface WindowIpcDeps {
 
 export function registerWindowIpc(deps: WindowIpcDeps): void {
   const { ipcMain } = deps;
-  ipcMain.handle('window:minimize', (e) => {
+  ipcMain.handle(WINDOW_CHANNELS.minimize, (e) => {
     BrowserWindow.fromWebContents(e.sender)?.minimize();
   });
-  ipcMain.handle('window:toggleMaximize', (e) => {
+  ipcMain.handle(WINDOW_CHANNELS.toggleMaximize, (e) => {
     const win = BrowserWindow.fromWebContents(e.sender);
     if (!win) return false;
     if (win.isMaximized()) win.unmaximize();
     else win.maximize();
     return win.isMaximized();
   });
-  ipcMain.handle('window:close', (e) => {
+  ipcMain.handle(WINDOW_CHANNELS.close, (e) => {
     BrowserWindow.fromWebContents(e.sender)?.close();
   });
-  ipcMain.handle('window:isMaximized', (e) => {
+  ipcMain.handle(WINDOW_CHANNELS.isMaximized, (e) => {
     return BrowserWindow.fromWebContents(e.sender)?.isMaximized() ?? false;
   });
 }

--- a/electron/notify/sinks/__tests__/toastSink.test.ts
+++ b/electron/notify/sinks/__tests__/toastSink.test.ts
@@ -3,13 +3,14 @@
 //   1. Resolves the user-visible name via getNameFn (placeholder/empty
 //      collapse to short sid prefix).
 //   2. Calls toastImpl.show with the i18n title/body + a click handler that
-//      focuses the window + sends 'session:activate'.
+//      focuses the window + sends SESSION_CHANNELS.activate.
 //   3. Bumps the unread badge via onNotified.
 //
 // We assert real behavior by injecting a recording toastImpl (no real
 // Notification spawn) and a stub BrowserWindow.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SESSION_CHANNELS } from '../../../shared/ipcChannels';
 
 // electron is statically imported for `Notification` and the BrowserWindow
 // type. Mock it so importing the sink doesn't require an Electron runtime.
@@ -166,7 +167,7 @@ describe('createToastSink', () => {
     expect(win.show).toHaveBeenCalledTimes(1);
     expect(win.restore).toHaveBeenCalledTimes(1);
     expect(win.focus).toHaveBeenCalledTimes(1);
-    expect(win.webContents.send).toHaveBeenCalledWith('session:activate', { sid: 's1' });
+    expect(win.webContents.send).toHaveBeenCalledWith(SESSION_CHANNELS.activate, { sid: 's1' });
   });
 
   it('click handler skips show/restore when window already visible+not-minimized', () => {

--- a/electron/notify/sinks/toastSink.ts
+++ b/electron/notify/sinks/toastSink.ts
@@ -22,6 +22,7 @@
 import { Notification, type BrowserWindow } from 'electron';
 import { tNotification } from '../../i18n';
 import type { Decision } from '../notifyDecider';
+import { SESSION_CHANNELS } from '../../shared/ipcChannels';
 
 export interface ToastPayload {
   sid: string;
@@ -76,7 +77,7 @@ function focusAndActivate(win: BrowserWindow | null, sid: string): void {
   }
   try {
     if (!win.webContents.isDestroyed()) {
-      win.webContents.send('session:activate', { sid });
+      win.webContents.send(SESSION_CHANNELS.activate, { sid });
     }
   } catch (err) {
     console.warn('[toastSink] session:activate send failed', err);

--- a/electron/preload/bridges/__tests__/ccsmCore.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmCore.test.ts
@@ -12,7 +12,7 @@
 // `invoke` to resolve.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { DB_CHANNELS, UPDATES_CHANNELS, WINDOW_CHANNELS } from '../../../shared/ipcChannels';
+import { DB_CHANNELS, UPDATE_CHANNELS, UPDATES_CHANNELS, WINDOW_CHANNELS } from '../../../shared/ipcChannels';
 
 const { exposeSpy, invokeSpy, sendSpy, onSpy, removeListenerSpy } = vi.hoisted(() => ({
   exposeSpy: vi.fn(),
@@ -214,7 +214,7 @@ describe('ccsmCore preload bridge', () => {
   // open / window-state change.
   it.each<[string, string]>([
     ['onUpdateStatus', UPDATES_CHANNELS.status],
-    ['onUpdateDownloaded', 'update:downloaded'],
+    ['onUpdateDownloaded', UPDATE_CHANNELS.downloaded],
   ])('%s registers and cleanly unsubscribes on "%s"', (m, chan) => {
     const api = getApi();
     const cb = vi.fn();

--- a/electron/preload/bridges/__tests__/ccsmCore.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmCore.test.ts
@@ -12,6 +12,7 @@
 // `invoke` to resolve.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DB_CHANNELS, UPDATES_CHANNELS, WINDOW_CHANNELS } from '../../../shared/ipcChannels';
 
 const { exposeSpy, invokeSpy, sendSpy, onSpy, removeListenerSpy } = vi.hoisted(() => ({
   exposeSpy: vi.fn(),
@@ -107,7 +108,7 @@ describe('ccsmCore preload bridge', () => {
   });
 
   it.each<[string, string, unknown[]]>([
-    ['loadState', 'db:load', ['some.key']],
+    ['loadState', DB_CHANNELS.load, ['some.key']],
     ['getVersion', 'app:getVersion', []],
     ['scanImportable', 'import:scan', []],
     ['recentCwds', 'import:recentCwds', []],
@@ -116,12 +117,12 @@ describe('ccsmCore preload bridge', () => {
     ['defaultModel', 'settings:defaultModel', []],
     ['pathsExist', 'paths:exist', [['/a', '/b']]],
     ['openExternal', 'ccsm:openExternal', ['https://example.com']],
-    ['updatesStatus', 'updates:status', []],
-    ['updatesCheck', 'updates:check', []],
-    ['updatesDownload', 'updates:download', []],
-    ['updatesInstall', 'updates:install', []],
-    ['updatesGetAutoCheck', 'updates:getAutoCheck', []],
-    ['updatesSetAutoCheck', 'updates:setAutoCheck', [true]],
+    ['updatesStatus', UPDATES_CHANNELS.status, []],
+    ['updatesCheck', UPDATES_CHANNELS.check, []],
+    ['updatesDownload', UPDATES_CHANNELS.download, []],
+    ['updatesInstall', UPDATES_CHANNELS.install, []],
+    ['updatesGetAutoCheck', UPDATES_CHANNELS.getAutoCheck, []],
+    ['updatesSetAutoCheck', UPDATES_CHANNELS.setAutoCheck, [true]],
   ])('forwards %s -> ipcRenderer.invoke("%s", ...)', async (m, chan, args) => {
     const api = getApi();
     const fn = api[m] as (...a: unknown[]) => Promise<unknown>;
@@ -140,7 +141,7 @@ describe('ccsmCore preload bridge', () => {
     await expect(
       (api.saveState as (k: string, v: string) => Promise<void>)('k', 'v'),
     ).resolves.toBeUndefined();
-    expect(invokeSpy).toHaveBeenCalledWith('db:save', 'k', 'v');
+    expect(invokeSpy).toHaveBeenCalledWith(DB_CHANNELS.save, 'k', 'v');
   });
 
   it('saveState rethrows on {ok:false} so .catch handlers fire', async () => {
@@ -176,10 +177,10 @@ describe('ccsmCore preload bridge', () => {
   });
 
   it.each<[string, string, unknown[]]>([
-    ['minimize', 'window:minimize', []],
-    ['toggleMaximize', 'window:toggleMaximize', []],
-    ['close', 'window:close', []],
-    ['isMaximized', 'window:isMaximized', []],
+    ['minimize', WINDOW_CHANNELS.minimize, []],
+    ['toggleMaximize', WINDOW_CHANNELS.toggleMaximize, []],
+    ['close', WINDOW_CHANNELS.close, []],
+    ['isMaximized', WINDOW_CHANNELS.isMaximized, []],
   ])('window.%s invokes "%s"', async (m, chan, args) => {
     const api = getApi();
     const w = api.window as Record<string, (...a: unknown[]) => Promise<unknown>>;
@@ -197,7 +198,7 @@ describe('ccsmCore preload bridge', () => {
     (
       api.window as { resolveCloseAction: (p: typeof payload) => void }
     ).resolveCloseAction(payload);
-    expect(sendSpy).toHaveBeenCalledWith('window:resolveCloseAction', payload);
+    expect(sendSpy).toHaveBeenCalledWith(WINDOW_CHANNELS.resolveCloseAction, payload);
   });
 
   it('window.platform mirrors process.platform', () => {
@@ -212,7 +213,7 @@ describe('ccsmCore preload bridge', () => {
   // make the unsubscribe a silent no-op and leak a handler on every dialog
   // open / window-state change.
   it.each<[string, string]>([
-    ['onUpdateStatus', 'updates:status'],
+    ['onUpdateStatus', UPDATES_CHANNELS.status],
     ['onUpdateDownloaded', 'update:downloaded'],
   ])('%s registers and cleanly unsubscribes on "%s"', (m, chan) => {
     const api = getApi();
@@ -227,10 +228,10 @@ describe('ccsmCore preload bridge', () => {
   });
 
   it.each<[string, string]>([
-    ['onMaximizedChanged', 'window:maximizedChanged'],
-    ['onBeforeHide', 'window:beforeHide'],
-    ['onAfterShow', 'window:afterShow'],
-    ['onAskCloseAction', 'window:askCloseAction'],
+    ['onMaximizedChanged', WINDOW_CHANNELS.maximizedChanged],
+    ['onBeforeHide', WINDOW_CHANNELS.beforeHide],
+    ['onAfterShow', WINDOW_CHANNELS.afterShow],
+    ['onAskCloseAction', WINDOW_CHANNELS.askCloseAction],
   ])('window.%s registers and unsubscribes on "%s"', (m, chan) => {
     const api = getApi();
     const w = api.window as Record<string, (cb: unknown) => () => void>;
@@ -247,7 +248,7 @@ describe('ccsmCore preload bridge', () => {
     const api = getApi();
     const cb = vi.fn();
     (api.onUpdateStatus as (cb: unknown) => () => void)(cb);
-    const wrap = onSpy.mock.calls.find((c) => c[0] === 'updates:status')![1] as (
+    const wrap = onSpy.mock.calls.find((c) => c[0] === UPDATES_CHANNELS.status)![1] as (
       e: unknown,
       p: unknown,
     ) => void;
@@ -264,7 +265,7 @@ describe('ccsmCore preload bridge', () => {
       }
     ).onAskCloseAction(cb);
     const wrap = onSpy.mock.calls.find(
-      (c) => c[0] === 'window:askCloseAction',
+      (c) => c[0] === WINDOW_CHANNELS.askCloseAction,
     )![1] as (e: unknown, p: unknown) => void;
     const payload = {
       requestId: 'req-2',

--- a/electron/preload/bridges/__tests__/ccsmPty.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmPty.test.ts
@@ -6,6 +6,7 @@
 // that's the whole reason the bridge exists in this shape.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { PTY_CHANNELS } from '../../../shared/ipcChannels';
 
 const {
   exposeSpy,
@@ -86,21 +87,21 @@ describe('ccsmPty preload bridge', () => {
 
   it('install registers fan-outs for "pty:data" and "pty:exit"', () => {
     const channels = onSpy.mock.calls.map((c) => c[0]).sort();
-    expect(channels).toEqual(['pty:data', 'pty:exit'].sort());
+    expect(channels).toEqual([PTY_CHANNELS.data, PTY_CHANNELS.exit].sort());
   });
 
   it.each<[string, string, unknown[]]>([
-    ['list', 'pty:list', []],
-    ['spawn', 'pty:spawn', ['s1', '/cwd']],
-    ['attach', 'pty:attach', ['s1']],
-    ['detach', 'pty:detach', ['s1']],
-    ['input', 'pty:input', ['s1', 'hello']],
-    ['resize', 'pty:resize', ['s1', 80, 24]],
-    ['kill', 'pty:kill', ['s1']],
-    ['get', 'pty:get', ['s1']],
-    ['getBufferSnapshot', 'pty:getBufferSnapshot', ['s1']],
+    ['list', PTY_CHANNELS.list, []],
+    ['spawn', PTY_CHANNELS.spawn, ['s1', '/cwd']],
+    ['attach', PTY_CHANNELS.attach, ['s1']],
+    ['detach', PTY_CHANNELS.detach, ['s1']],
+    ['input', PTY_CHANNELS.input, ['s1', 'hello']],
+    ['resize', PTY_CHANNELS.resize, ['s1', 80, 24]],
+    ['kill', PTY_CHANNELS.kill, ['s1']],
+    ['get', PTY_CHANNELS.get, ['s1']],
+    ['getBufferSnapshot', PTY_CHANNELS.getBufferSnapshot, ['s1']],
     // Task #42 — clipboard image autosave channel.
-    ['saveClipboardImage', 'pty:saveClipboardImage', []],
+    ['saveClipboardImage', PTY_CHANNELS.saveClipboardImage, []],
   ])('forwards %s -> ipcRenderer.invoke("%s", ...)', async (m, chan, args) => {
     const api = lastApi();
     await (api[m] as (...a: unknown[]) => Promise<unknown>)(...args);
@@ -112,13 +113,13 @@ describe('ccsmPty preload bridge', () => {
     await (
       api.spawn as (sid: string, cwd: string, forkSourceSid?: string) => Promise<unknown>
     )('s1', '/cwd', 'source-sid');
-    expect(invokeSpy).toHaveBeenCalledWith('pty:spawn', 's1', '/cwd', 'source-sid');
+    expect(invokeSpy).toHaveBeenCalledWith(PTY_CHANNELS.spawn, 's1', '/cwd', 'source-sid');
   });
 
   it('checkClaudeAvailable defaults its opts to {}', async () => {
     const api = lastApi();
     await (api.checkClaudeAvailable as (o?: unknown) => Promise<unknown>)();
-    expect(invokeSpy).toHaveBeenCalledWith('pty:checkClaudeAvailable', {});
+    expect(invokeSpy).toHaveBeenCalledWith(PTY_CHANNELS.checkClaudeAvailable, {});
   });
 
   it('checkClaudeAvailable forwards explicit opts', async () => {
@@ -126,7 +127,7 @@ describe('ccsmPty preload bridge', () => {
     await (
       api.checkClaudeAvailable as (o?: { force?: boolean }) => Promise<unknown>
     )({ force: true });
-    expect(invokeSpy).toHaveBeenCalledWith('pty:checkClaudeAvailable', {
+    expect(invokeSpy).toHaveBeenCalledWith(PTY_CHANNELS.checkClaudeAvailable, {
       force: true,
     });
   });
@@ -144,7 +145,7 @@ describe('ccsmPty preload bridge', () => {
     const api = lastApi();
     const cb = vi.fn();
     const off = (api.onData as (cb: unknown) => () => void)(cb);
-    const dispatch = onSpy.mock.calls.find((c) => c[0] === 'pty:data')![1] as (
+    const dispatch = onSpy.mock.calls.find((c) => c[0] === PTY_CHANNELS.data)![1] as (
       e: unknown,
       p: unknown,
     ) => void;
@@ -160,7 +161,7 @@ describe('ccsmPty preload bridge', () => {
     const api = lastApi();
     const cb = vi.fn();
     const off = (api.onExit as (cb: unknown) => () => void)(cb);
-    const dispatch = onSpy.mock.calls.find((c) => c[0] === 'pty:exit')![1] as (
+    const dispatch = onSpy.mock.calls.find((c) => c[0] === PTY_CHANNELS.exit)![1] as (
       e: unknown,
       p: unknown,
     ) => void;
@@ -181,7 +182,7 @@ describe('ccsmPty preload bridge', () => {
     const good = vi.fn();
     (api.onData as (cb: unknown) => () => void)(bad);
     (api.onData as (cb: unknown) => () => void)(good);
-    const dispatch = onSpy.mock.calls.find((c) => c[0] === 'pty:data')![1] as (
+    const dispatch = onSpy.mock.calls.find((c) => c[0] === PTY_CHANNELS.data)![1] as (
       e: unknown,
       p: unknown,
     ) => void;

--- a/electron/preload/bridges/__tests__/ccsmSession.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmSession.test.ts
@@ -9,6 +9,7 @@
 // pushes don't re-fire.
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SESSION_CHANNELS } from '../../../shared/ipcChannels';
 
 const { exposeSpy, sendSpy, onSpy, removeListenerSpy } = vi.hoisted(() => ({
   exposeSpy: vi.fn(),
@@ -70,21 +71,21 @@ describe('ccsmSession preload bridge', () => {
     const channels = onSpy.mock.calls.map((c) => c[0]).sort();
     expect(channels).toEqual(
       [
-        'session:state',
-        'session:title',
-        'session:cwdRedirected',
-        'session:activate',
+        SESSION_CHANNELS.state,
+        SESSION_CHANNELS.title,
+        SESSION_CHANNELS.cwdRedirected,
+        SESSION_CHANNELS.activate,
       ].sort(),
     );
   });
 
   it.each<[string, string, unknown]>([
-    ['onState', 'session:state', { sid: 's1', state: 'running' }],
-    ['onActivate', 'session:activate', { sid: 's1' }],
-    ['onTitle', 'session:title', { sid: 's1', title: 'hi' }],
+    ['onState', SESSION_CHANNELS.state, { sid: 's1', state: 'running' }],
+    ['onActivate', SESSION_CHANNELS.activate, { sid: 's1' }],
+    ['onTitle', SESSION_CHANNELS.title, { sid: 's1', title: 'hi' }],
     [
       'onCwdRedirected',
-      'session:cwdRedirected',
+      SESSION_CHANNELS.cwdRedirected,
       { sid: 's1', newCwd: '/new/cwd' },
     ],
   ])('%s subscribes to %s fan-out and unsubscribe stops delivery', (m, chan, payload) => {
@@ -109,7 +110,7 @@ describe('ccsmSession preload bridge', () => {
     const cbB = vi.fn();
     (api.onState as (cb: unknown) => () => void)(cbA);
     (api.onState as (cb: unknown) => () => void)(cbB);
-    const dispatch = findRegisteredHandler('session:state');
+    const dispatch = findRegisteredHandler(SESSION_CHANNELS.state);
     dispatch({}, { sid: 's2', state: 'idle' });
     expect(cbA).toHaveBeenCalledTimes(1);
     expect(cbB).toHaveBeenCalledTimes(1);
@@ -124,7 +125,7 @@ describe('ccsmSession preload bridge', () => {
     const good = vi.fn();
     (api.onState as (cb: unknown) => () => void)(bad);
     (api.onState as (cb: unknown) => () => void)(good);
-    findRegisteredHandler('session:state')({}, { sid: 's', state: 'idle' });
+    findRegisteredHandler(SESSION_CHANNELS.state)({}, { sid: 's', state: 'idle' });
     expect(bad).toHaveBeenCalled();
     expect(good).toHaveBeenCalled();
     errSpy.mockRestore();
@@ -134,21 +135,21 @@ describe('ccsmSession preload bridge', () => {
     const api = lastApi();
     const fn = api.setActive as (s: string | null) => void;
     fn('s-123');
-    expect(sendSpy).toHaveBeenCalledWith('session:setActive', 's-123');
+    expect(sendSpy).toHaveBeenCalledWith(SESSION_CHANNELS.setActive, 's-123');
     fn(null);
-    expect(sendSpy).toHaveBeenCalledWith('session:setActive', '');
+    expect(sendSpy).toHaveBeenCalledWith(SESSION_CHANNELS.setActive, '');
   });
 
   it('setName sends "session:setName" with normalized null name', () => {
     const api = lastApi();
     const fn = api.setName as (sid: string, n: string | null) => void;
     fn('s-1', 'Friendly');
-    expect(sendSpy).toHaveBeenCalledWith('session:setName', {
+    expect(sendSpy).toHaveBeenCalledWith(SESSION_CHANNELS.setName, {
       sid: 's-1',
       name: 'Friendly',
     });
     fn('s-1', null);
-    expect(sendSpy).toHaveBeenCalledWith('session:setName', {
+    expect(sendSpy).toHaveBeenCalledWith(SESSION_CHANNELS.setName, {
       sid: 's-1',
       name: '',
     });

--- a/electron/preload/bridges/ccsmCore.ts
+++ b/electron/preload/bridges/ccsmCore.ts
@@ -5,6 +5,11 @@
 // without behavioral change.
 
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
+import {
+  DB_CHANNELS,
+  UPDATES_CHANNELS,
+  WINDOW_CHANNELS,
+} from '../../shared/ipcChannels';
 
 type UpdateStatus =
   | { kind: 'idle' }
@@ -16,7 +21,7 @@ type UpdateStatus =
   | { kind: 'error'; message: string };
 
 const api = {
-  loadState: (key: string): Promise<string | null> => ipcRenderer.invoke('db:load', key),
+  loadState: (key: string): Promise<string | null> => ipcRenderer.invoke(DB_CHANNELS.load, key),
   // The IPC handler returns a `{ok}` shape so it never crosses the IPC
   // boundary as a thrown Error (Electron surfaces those as ugly stack
   // dumps in the renderer console). We unwrap here and re-throw on
@@ -25,7 +30,7 @@ const api = {
   // resolved `{ok:false}` would otherwise slip past `.catch` silently
   // and produce data loss with zero renderer signal.
   saveState: async (key: string, value: string): Promise<void> => {
-    const result = (await ipcRenderer.invoke('db:save', key, value)) as
+    const result = (await ipcRenderer.invoke(DB_CHANNELS.save, key, value)) as
       | { ok: true }
       | { ok: false; error: string };
     if (!result.ok) {
@@ -119,19 +124,19 @@ const api = {
   openExternal: (url: string): Promise<boolean> =>
     ipcRenderer.invoke('ccsm:openExternal', url),
 
-  updatesStatus: (): Promise<UpdateStatus> => ipcRenderer.invoke('updates:status'),
-  updatesCheck: (): Promise<UpdateStatus> => ipcRenderer.invoke('updates:check'),
+  updatesStatus: (): Promise<UpdateStatus> => ipcRenderer.invoke(UPDATES_CHANNELS.status),
+  updatesCheck: (): Promise<UpdateStatus> => ipcRenderer.invoke(UPDATES_CHANNELS.check),
   updatesDownload: (): Promise<{ ok: true } | { ok: false; reason: string }> =>
-    ipcRenderer.invoke('updates:download'),
+    ipcRenderer.invoke(UPDATES_CHANNELS.download),
   updatesInstall: (): Promise<{ ok: true } | { ok: false; reason: string }> =>
-    ipcRenderer.invoke('updates:install'),
-  updatesGetAutoCheck: (): Promise<boolean> => ipcRenderer.invoke('updates:getAutoCheck'),
+    ipcRenderer.invoke(UPDATES_CHANNELS.install),
+  updatesGetAutoCheck: (): Promise<boolean> => ipcRenderer.invoke(UPDATES_CHANNELS.getAutoCheck),
   updatesSetAutoCheck: (enabled: boolean): Promise<boolean> =>
-    ipcRenderer.invoke('updates:setAutoCheck', enabled),
+    ipcRenderer.invoke(UPDATES_CHANNELS.setAutoCheck, enabled),
   onUpdateStatus: (handler: (s: UpdateStatus) => void): (() => void) => {
     const wrap = (_e: IpcRendererEvent, payload: UpdateStatus) => handler(payload);
-    ipcRenderer.on('updates:status', wrap);
-    return () => ipcRenderer.removeListener('updates:status', wrap);
+    ipcRenderer.on(UPDATES_CHANNELS.status, wrap);
+    return () => ipcRenderer.removeListener(UPDATES_CHANNELS.status, wrap);
   },
   onUpdateDownloaded: (handler: (info: { version: string }) => void): (() => void) => {
     const wrap = (_e: IpcRendererEvent, payload: { version: string }) => handler(payload);
@@ -140,27 +145,27 @@ const api = {
   },
 
   window: {
-    minimize: (): Promise<void> => ipcRenderer.invoke('window:minimize'),
-    toggleMaximize: (): Promise<boolean> => ipcRenderer.invoke('window:toggleMaximize'),
-    close: (): Promise<void> => ipcRenderer.invoke('window:close'),
-    isMaximized: (): Promise<boolean> => ipcRenderer.invoke('window:isMaximized'),
+    minimize: (): Promise<void> => ipcRenderer.invoke(WINDOW_CHANNELS.minimize),
+    toggleMaximize: (): Promise<boolean> => ipcRenderer.invoke(WINDOW_CHANNELS.toggleMaximize),
+    close: (): Promise<void> => ipcRenderer.invoke(WINDOW_CHANNELS.close),
+    isMaximized: (): Promise<boolean> => ipcRenderer.invoke(WINDOW_CHANNELS.isMaximized),
     onMaximizedChanged: (handler: (max: boolean) => void): (() => void) => {
       const wrap = (_e: IpcRendererEvent, max: boolean) => handler(max);
-      ipcRenderer.on('window:maximizedChanged', wrap);
-      return () => ipcRenderer.removeListener('window:maximizedChanged', wrap);
+      ipcRenderer.on(WINDOW_CHANNELS.maximizedChanged, wrap);
+      return () => ipcRenderer.removeListener(WINDOW_CHANNELS.maximizedChanged, wrap);
     },
     onBeforeHide: (
       handler: (info: { durationMs: number }) => void
     ): (() => void) => {
       const wrap = (_e: IpcRendererEvent, payload: { durationMs: number }) =>
         handler(payload);
-      ipcRenderer.on('window:beforeHide', wrap);
-      return () => ipcRenderer.removeListener('window:beforeHide', wrap);
+      ipcRenderer.on(WINDOW_CHANNELS.beforeHide, wrap);
+      return () => ipcRenderer.removeListener(WINDOW_CHANNELS.beforeHide, wrap);
     },
     onAfterShow: (handler: () => void): (() => void) => {
       const wrap = () => handler();
-      ipcRenderer.on('window:afterShow', wrap);
-      return () => ipcRenderer.removeListener('window:afterShow', wrap);
+      ipcRenderer.on(WINDOW_CHANNELS.afterShow, wrap);
+      return () => ipcRenderer.removeListener(WINDOW_CHANNELS.afterShow, wrap);
     },
     /**
      * Main fires `window:askCloseAction` when the user clicks the window X
@@ -201,8 +206,8 @@ const api = {
           };
         },
       ) => handler(payload);
-      ipcRenderer.on('window:askCloseAction', wrap);
-      return () => ipcRenderer.removeListener('window:askCloseAction', wrap);
+      ipcRenderer.on(WINDOW_CHANNELS.askCloseAction, wrap);
+      return () => ipcRenderer.removeListener(WINDOW_CHANNELS.askCloseAction, wrap);
     },
     /**
      * Renderer's reply to the latest `window:askCloseAction` ping. The
@@ -219,7 +224,7 @@ const api = {
       choice: 'tray' | 'quit' | 'cancel';
       dontAskAgain: boolean;
     }): void => {
-      ipcRenderer.send('window:resolveCloseAction', payload);
+      ipcRenderer.send(WINDOW_CHANNELS.resolveCloseAction, payload);
     },
     platform: process.platform
   },

--- a/electron/preload/bridges/ccsmCore.ts
+++ b/electron/preload/bridges/ccsmCore.ts
@@ -7,6 +7,7 @@
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
 import {
   DB_CHANNELS,
+  UPDATE_CHANNELS,
   UPDATES_CHANNELS,
   WINDOW_CHANNELS,
 } from '../../shared/ipcChannels';
@@ -140,8 +141,8 @@ const api = {
   },
   onUpdateDownloaded: (handler: (info: { version: string }) => void): (() => void) => {
     const wrap = (_e: IpcRendererEvent, payload: { version: string }) => handler(payload);
-    ipcRenderer.on('update:downloaded', wrap);
-    return () => ipcRenderer.removeListener('update:downloaded', wrap);
+    ipcRenderer.on(UPDATE_CHANNELS.downloaded, wrap);
+    return () => ipcRenderer.removeListener(UPDATE_CHANNELS.downloaded, wrap);
   },
 
   window: {

--- a/electron/preload/bridges/ccsmPty.ts
+++ b/electron/preload/bridges/ccsmPty.ts
@@ -12,6 +12,7 @@
 // Extracted from `electron/preload.ts` in #769 (SRP wave-2 PR-A).
 
 import { contextBridge, ipcRenderer, clipboard, type IpcRendererEvent } from 'electron';
+import { PTY_CHANNELS } from '../../shared/ipcChannels';
 
 type PtyDataPayload = { sid: string; chunk: string; seq: number };
 type PtyExitPayload = {
@@ -29,25 +30,25 @@ const ptyDataListeners = new Set<(e: PtyDataPayload) => void>();
 const ptyExitListeners = new Set<(e: PtyExitPayload) => void>();
 
 const ccsmPty = {
-  list: (): Promise<unknown> => ipcRenderer.invoke('pty:list'),
+  list: (): Promise<unknown> => ipcRenderer.invoke(PTY_CHANNELS.list),
   spawn: (sid: string, cwd: string, forkSourceSid?: string): Promise<unknown> =>
     forkSourceSid === undefined
-      ? ipcRenderer.invoke('pty:spawn', sid, cwd)
-      : ipcRenderer.invoke('pty:spawn', sid, cwd, forkSourceSid),
-  attach: (sid: string): Promise<unknown> => ipcRenderer.invoke('pty:attach', sid),
-  detach: (sid: string): Promise<void> => ipcRenderer.invoke('pty:detach', sid),
+      ? ipcRenderer.invoke(PTY_CHANNELS.spawn, sid, cwd)
+      : ipcRenderer.invoke(PTY_CHANNELS.spawn, sid, cwd, forkSourceSid),
+  attach: (sid: string): Promise<unknown> => ipcRenderer.invoke(PTY_CHANNELS.attach, sid),
+  detach: (sid: string): Promise<void> => ipcRenderer.invoke(PTY_CHANNELS.detach, sid),
   input: (sid: string, data: string): Promise<void> =>
-    ipcRenderer.invoke('pty:input', sid, data),
+    ipcRenderer.invoke(PTY_CHANNELS.input, sid, data),
   resize: (sid: string, cols: number, rows: number): Promise<void> =>
-    ipcRenderer.invoke('pty:resize', sid, cols, rows),
-  kill: (sid: string): Promise<unknown> => ipcRenderer.invoke('pty:kill', sid),
-  get: (sid: string): Promise<unknown> => ipcRenderer.invoke('pty:get', sid),
+    ipcRenderer.invoke(PTY_CHANNELS.resize, sid, cols, rows),
+  kill: (sid: string): Promise<unknown> => ipcRenderer.invoke(PTY_CHANNELS.kill, sid),
+  get: (sid: string): Promise<unknown> => ipcRenderer.invoke(PTY_CHANNELS.get, sid),
   // L4 PR-B (#865): visible xterm attach replay. Returns the serialized
   // headless buffer plus the per-entry chunk seq captured atomically with
   // the serialize call. Renderer uses the seq to dedupe live `pty:data`
   // chunks already represented in the snapshot.
   getBufferSnapshot: (sid: string): Promise<BufferSnapshotPayload> =>
-    ipcRenderer.invoke('pty:getBufferSnapshot', sid),
+    ipcRenderer.invoke(PTY_CHANNELS.getBufferSnapshot, sid),
   onData: (cb: (e: PtyDataPayload) => void): (() => void) => {
     ptyDataListeners.add(cb);
     return () => {
@@ -68,15 +69,15 @@ const ccsmPty = {
   // and the userData write both need the main side; renderer also doesn't
   // get app.getPath('userData').
   saveClipboardImage: (): Promise<string | null> =>
-    ipcRenderer.invoke('pty:saveClipboardImage'),
+    ipcRenderer.invoke(PTY_CHANNELS.saveClipboardImage),
   checkClaudeAvailable: (opts?: { force?: boolean }): Promise<CheckClaudeAvailableResult> =>
-    ipcRenderer.invoke('pty:checkClaudeAvailable', opts ?? {}),
+    ipcRenderer.invoke(PTY_CHANNELS.checkClaudeAvailable, opts ?? {}),
 };
 
 export type CCSMPtyAPI = typeof ccsmPty;
 
 export function installCcsmPtyBridge(): void {
-  ipcRenderer.on('pty:data', (_e: IpcRendererEvent, payload: PtyDataPayload) => {
+  ipcRenderer.on(PTY_CHANNELS.data, (_e: IpcRendererEvent, payload: PtyDataPayload) => {
     for (const cb of ptyDataListeners) {
       try {
         cb(payload);
@@ -86,7 +87,7 @@ export function installCcsmPtyBridge(): void {
     }
   });
 
-  ipcRenderer.on('pty:exit', (_e: IpcRendererEvent, payload: PtyExitPayload) => {
+  ipcRenderer.on(PTY_CHANNELS.exit, (_e: IpcRendererEvent, payload: PtyExitPayload) => {
     for (const cb of ptyExitListeners) {
       try {
         cb(payload);

--- a/electron/preload/bridges/ccsmSession.ts
+++ b/electron/preload/bridges/ccsmSession.ts
@@ -14,6 +14,7 @@
 // Extracted from `electron/preload.ts` in #769 (SRP wave-2 PR-A).
 
 import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
+import { SESSION_CHANNELS } from '../../shared/ipcChannels';
 
 // Canonical 3-state vocabulary lives in `src/shared/sessionState.ts` so
 // the renderer (`src/session.d.ts`), the watcher (`electron/sessionWatcher/
@@ -59,7 +60,7 @@ const ccsmSession = {
   // suppress toasts for the session the user is currently viewing. Fire on
   // every selectSession; main caches the latest value.
   setActive: (sid: string | null): void => {
-    ipcRenderer.send('session:setActive', sid ?? '');
+    ipcRenderer.send(SESSION_CHANNELS.setActive, sid ?? '');
   },
   // Renderer pushes the user-visible name for a sid so notify toasts can
   // label the toast with the friendly name (rename or SDK auto-summary)
@@ -67,14 +68,14 @@ const ccsmSession = {
   // title apply, new session creation). Empty name clears the mirror.
   setName: (sid: string, name: string | null): void => {
     if (!sid) return;
-    ipcRenderer.send('session:setName', { sid, name: name ?? '' });
+    ipcRenderer.send(SESSION_CHANNELS.setName, { sid, name: name ?? '' });
   },
 };
 
 export type CCSMSessionAPI = typeof ccsmSession;
 
 export function installCcsmSessionBridge(): void {
-  ipcRenderer.on('session:state', (_e: IpcRendererEvent, payload: SessionStatePayload) => {
+  ipcRenderer.on(SESSION_CHANNELS.state, (_e: IpcRendererEvent, payload: SessionStatePayload) => {
     for (const cb of sessionStateListeners) {
       try {
         cb(payload);
@@ -88,7 +89,7 @@ export function installCcsmSessionBridge(): void {
   // (electron/sessionWatcher) when the SDK-derived `summary` for a session
   // changes. Renderer subscribes via `window.ccsmSession.onTitle` and pipes
   // into the store's `_applyExternalTitle` action.
-  ipcRenderer.on('session:title', (_e: IpcRendererEvent, payload: SessionTitlePayload) => {
+  ipcRenderer.on(SESSION_CHANNELS.title, (_e: IpcRendererEvent, payload: SessionTitlePayload) => {
     for (const cb of sessionTitleListeners) {
       try {
         cb(payload);
@@ -103,7 +104,7 @@ export function installCcsmSessionBridge(): void {
   // patches `session.cwd` so the sessionTitles bridge (rename / list /
   // backfill) reads/writes the COPY rather than the now-frozen SOURCE.
   ipcRenderer.on(
-    'session:cwdRedirected',
+    SESSION_CHANNELS.cwdRedirected,
     (_e: IpcRendererEvent, payload: SessionCwdRedirectedPayload) => {
       for (const cb of sessionCwdRedirectedListeners) {
         try {
@@ -118,7 +119,7 @@ export function installCcsmSessionBridge(): void {
   // Main pushes `session:activate` when the user clicks a desktop notification.
   // Renderer subscribes via `window.ccsmSession.onActivate` and calls its
   // `selectSession(sid)` so the chosen session lands focused.
-  ipcRenderer.on('session:activate', (_e: IpcRendererEvent, payload: SessionActivatePayload) => {
+  ipcRenderer.on(SESSION_CHANNELS.activate, (_e: IpcRendererEvent, payload: SessionActivatePayload) => {
     for (const cb of sessionActivateListeners) {
       try {
         cb(payload);

--- a/electron/ptyHost/__tests__/ipcRegistrar.test.ts
+++ b/electron/ptyHost/__tests__/ipcRegistrar.test.ts
@@ -12,6 +12,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { PTY_CHANNELS, SESSION_CHANNELS } from '../../shared/ipcChannels';
 
 interface RegistrarBus {
   resolveClaude: ReturnType<typeof vi.fn>;
@@ -137,17 +138,17 @@ describe('registerPtyIpc handler registration', () => {
     registerPtyIpc(ipc as any, makeDeps());
     expect(Array.from(ipc.handlers.keys()).sort()).toEqual(
       [
-        'pty:attach',
-        'pty:checkClaudeAvailable',
-        'pty:detach',
-        'pty:get',
-        'pty:getBufferSnapshot',
-        'pty:input',
-        'pty:kill',
-        'pty:list',
-        'pty:resize',
-        'pty:saveClipboardImage',
-        'pty:spawn',
+        PTY_CHANNELS.attach,
+        PTY_CHANNELS.checkClaudeAvailable,
+        PTY_CHANNELS.detach,
+        PTY_CHANNELS.get,
+        PTY_CHANNELS.getBufferSnapshot,
+        PTY_CHANNELS.input,
+        PTY_CHANNELS.kill,
+        PTY_CHANNELS.list,
+        PTY_CHANNELS.resize,
+        PTY_CHANNELS.saveClipboardImage,
+        PTY_CHANNELS.spawn,
       ].sort(),
     );
   });
@@ -163,7 +164,7 @@ describe('registerPtyIpc handler registration', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    const out = await ipc.handlers.get('pty:getBufferSnapshot')!({}, 'sid-Z');
+    const out = await ipc.handlers.get(PTY_CHANNELS.getBufferSnapshot)!({}, 'sid-Z');
     expect(out).toEqual({ snapshot: 'snap-for-sid-Z', seq: 7 });
     expect(deps.getBufferSnapshot).toHaveBeenCalledWith('sid-Z');
   });
@@ -171,13 +172,13 @@ describe('registerPtyIpc handler registration', () => {
 
 // ─── pty:list / get / input / resize / kill — thin pass-through ───────────
 
-describe('pty:list', () => {
+describe(PTY_CHANNELS.list, () => {
   it('delegates to deps.listPtySessions', () => {
     const ipc = makeFakeIpc();
     const deps = makeDeps({ listPtySessions: vi.fn(() => [{ sid: 'a', pid: 1, cols: 80, rows: 24, cwd: '/x' }]) });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    const out = ipc.handlers.get('pty:list')!({});
+    const out = ipc.handlers.get(PTY_CHANNELS.list)!({});
     expect(out).toEqual([{ sid: 'a', pid: 1, cols: 80, rows: 24, cwd: '/x' }]);
     expect(deps.listPtySessions).toHaveBeenCalledTimes(1);
   });
@@ -189,7 +190,7 @@ describe('pty:input / resize / kill / get pass-through', () => {
     const deps = makeDeps();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    ipc.handlers.get('pty:input')!({}, 'sid', 'echo\n');
+    ipc.handlers.get(PTY_CHANNELS.input)!({}, 'sid', 'echo\n');
     expect(deps.inputPtySession).toHaveBeenCalledWith('sid', 'echo\n');
   });
 
@@ -198,7 +199,7 @@ describe('pty:input / resize / kill / get pass-through', () => {
     const deps = makeDeps();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    ipc.handlers.get('pty:resize')!({}, 'sid', 100, 30);
+    ipc.handlers.get(PTY_CHANNELS.resize)!({}, 'sid', 100, 30);
     expect(deps.resizePtySession).toHaveBeenCalledWith('sid', 100, 30);
   });
 
@@ -207,7 +208,7 @@ describe('pty:input / resize / kill / get pass-through', () => {
     const deps = makeDeps({ killPtySession: vi.fn(async () => false) });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    await expect(ipc.handlers.get('pty:kill')!({}, 'sid')).resolves.toBe(false);
+    await expect(ipc.handlers.get(PTY_CHANNELS.kill)!({}, 'sid')).resolves.toBe(false);
     expect(deps.killPtySession).toHaveBeenCalledWith('sid');
   });
 
@@ -217,19 +218,19 @@ describe('pty:input / resize / kill / get pass-through', () => {
     const deps = makeDeps({ getPtySession: vi.fn(() => info) });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    expect(ipc.handlers.get('pty:get')!({}, 's')).toBe(info);
+    expect(ipc.handlers.get(PTY_CHANNELS.get)!({}, 's')).toBe(info);
   });
 });
 
 // ─── pty:spawn — claude resolution + spawn delegation + cwd-redirect ──────
 
-describe('pty:spawn', () => {
+describe(PTY_CHANNELS.spawn, () => {
   it('returns {ok:false, error:claude_not_found} when resolveClaude returns null', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue(null);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    expect(await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work')).toEqual({
+    expect(await ipc.handlers.get(PTY_CHANNELS.spawn)!({}, 'sid', '/work')).toEqual({
       ok: false,
       error: 'claude_not_found',
     });
@@ -243,7 +244,7 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    const out = await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
+    const out = await ipc.handlers.get(PTY_CHANNELS.spawn)!({}, 'sid', '/work');
     expect(out).toEqual({ ok: true, sid: 'sid', pid: 1, cols: 80, rows: 24, cwd: '/picked' });
     const call = (deps.spawnPtySession as ReturnType<typeof vi.fn>).mock.calls[0];
     expect(call[0]).toBe('sid');
@@ -269,7 +270,7 @@ describe('pty:spawn', () => {
     // Even if a (legacy) renderer were to send the third opts argument,
     // the IPC handler ignores it — the only opt threaded into the
     // lifecycle is onCwdRedirect (#603).
-    await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work', { cols: 134, rows: 51 });
+    await ipc.handlers.get(PTY_CHANNELS.spawn)!({}, 'sid', '/work', { cols: 134, rows: 51 });
     const call = (deps.spawnPtySession as ReturnType<typeof vi.fn>).mock.calls[0];
     const opts = call[3] as { cols?: number; rows?: number; onCwdRedirect?: unknown };
     expect(opts.cols).toBeUndefined();
@@ -285,7 +286,7 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
+    await ipc.handlers.get(PTY_CHANNELS.spawn)!({}, 'sid', '/work');
     const call = (deps.spawnPtySession as ReturnType<typeof vi.fn>).mock.calls[0];
     const opts = call[3] as { cols?: number; rows?: number; onCwdRedirect?: unknown };
     expect(opts.cols).toBeUndefined();
@@ -301,7 +302,7 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    const out = (await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work')) as { ok: boolean; error: string };
+    const out = (await ipc.handlers.get(PTY_CHANNELS.spawn)!({}, 'sid', '/work')) as { ok: boolean; error: string };
     expect(out.ok).toBe(false);
     expect(out.error).toMatch(/^spawn_failed: ENOENT$/);
   });
@@ -322,10 +323,10 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
+    await ipc.handlers.get(PTY_CHANNELS.spawn)!({}, 'sid', '/work');
     expect(captured).not.toBeNull();
     captured!('/new/cwd');
-    expect(wc.send).toHaveBeenCalledWith('session:cwdRedirected', { sid: 'sid', newCwd: '/new/cwd' });
+    expect(wc.send).toHaveBeenCalledWith(SESSION_CHANNELS.cwdRedirected, { sid: 'sid', newCwd: '/new/cwd' });
   });
 
   it('onCwdRedirect is a no-op when main window is null', async () => {
@@ -341,7 +342,7 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
+    await ipc.handlers.get(PTY_CHANNELS.spawn)!({}, 'sid', '/work');
     expect(() => captured!('/new')).not.toThrow();
   });
 
@@ -361,19 +362,19 @@ describe('pty:spawn', () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
-    await ipc.handlers.get('pty:spawn')!({}, 'sid', '/work');
+    await ipc.handlers.get(PTY_CHANNELS.spawn)!({}, 'sid', '/work');
     expect(() => captured!('/new')).not.toThrow();
   });
 });
 
 // ─── pty:attach / detach — webContents bookkeeping ────────────────────────
 
-describe('pty:attach', () => {
+describe(PTY_CHANNELS.attach, () => {
   it('returns null when entry is unknown', () => {
     const ipc = makeFakeIpc();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps({ getEntry: () => undefined }));
-    expect(ipc.handlers.get('pty:attach')!({ sender: makeWc(1) }, 'sid')).toBeNull();
+    expect(ipc.handlers.get(PTY_CHANNELS.attach)!({ sender: makeWc(1) }, 'sid')).toBeNull();
   });
 
   it('registers the sender wc into the entry.attached map and returns AttachResult (no snapshot — #888 follow-up)', () => {
@@ -394,7 +395,7 @@ describe('pty:attach', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     const wc = makeWc(7);
-    const res = ipc.handlers.get('pty:attach')!({ sender: wc }, 'sid');
+    const res = ipc.handlers.get(PTY_CHANNELS.attach)!({ sender: wc }, 'sid');
     expect(res).toEqual({ cols: 80, rows: 24, pid: 42 });
     expect(attached.get(7)).toBe(wc);
     // #888 follow-up: pty:attach MUST NOT serialize the headless buffer.
@@ -420,7 +421,7 @@ describe('pty:attach', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     const wc = makeWc(11);
-    ipc.handlers.get('pty:attach')!({ sender: wc }, 'sid');
+    ipc.handlers.get(PTY_CHANNELS.attach)!({ sender: wc }, 'sid');
     expect(attached.has(11)).toBe(true);
     expect(typeof wc.destroyedHandler).toBe('function');
     wc.destroyedHandler!();
@@ -428,7 +429,7 @@ describe('pty:attach', () => {
   });
 });
 
-describe('pty:detach', () => {
+describe(PTY_CHANNELS.detach, () => {
   it('removes the sender id from entry.attached', () => {
     const ipc = makeFakeIpc();
     const attached = new Map<number, unknown>([[5, makeWc(5)]]);
@@ -436,7 +437,7 @@ describe('pty:detach', () => {
     const entry = { attached } as any;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps({ getEntry: () => entry }));
-    ipc.handlers.get('pty:detach')!({ sender: makeWc(5) }, 'sid');
+    ipc.handlers.get(PTY_CHANNELS.detach)!({ sender: makeWc(5) }, 'sid');
     expect(attached.has(5)).toBe(false);
   });
 
@@ -444,19 +445,19 @@ describe('pty:detach', () => {
     const ipc = makeFakeIpc();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps({ getEntry: () => undefined }));
-    expect(() => ipc.handlers.get('pty:detach')!({ sender: makeWc(1) }, 'sid')).not.toThrow();
+    expect(() => ipc.handlers.get(PTY_CHANNELS.detach)!({ sender: makeWc(1) }, 'sid')).not.toThrow();
   });
 });
 
 // ─── pty:checkClaudeAvailable ─────────────────────────────────────────────
 
-describe('pty:checkClaudeAvailable', () => {
+describe(PTY_CHANNELS.checkClaudeAvailable, () => {
   it('returns {available:true, path} when resolveClaude succeeds', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    expect(await ipc.handlers.get('pty:checkClaudeAvailable')!({}, undefined)).toEqual({
+    expect(await ipc.handlers.get(PTY_CHANNELS.checkClaudeAvailable)!({}, undefined)).toEqual({
       available: true,
       path: '/bin/claude',
     });
@@ -467,7 +468,7 @@ describe('pty:checkClaudeAvailable', () => {
     bus().resolveClaude.mockReturnValue(null);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    expect(await ipc.handlers.get('pty:checkClaudeAvailable')!({}, undefined)).toEqual({
+    expect(await ipc.handlers.get(PTY_CHANNELS.checkClaudeAvailable)!({}, undefined)).toEqual({
       available: false,
     });
   });
@@ -477,7 +478,7 @@ describe('pty:checkClaudeAvailable', () => {
     bus().resolveClaude.mockReturnValue('/bin/claude');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    await ipc.handlers.get('pty:checkClaudeAvailable')!({}, { force: true });
+    await ipc.handlers.get(PTY_CHANNELS.checkClaudeAvailable)!({}, { force: true });
     expect(bus().resolveClaude).toHaveBeenCalledWith({ force: true });
   });
 
@@ -486,10 +487,10 @@ describe('pty:checkClaudeAvailable', () => {
     bus().resolveClaude.mockReturnValue('/bin/claude');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    await ipc.handlers.get('pty:checkClaudeAvailable')!({}, 'not-an-object');
-    await ipc.handlers.get('pty:checkClaudeAvailable')!({}, null);
-    await ipc.handlers.get('pty:checkClaudeAvailable')!({}, {});
-    await ipc.handlers.get('pty:checkClaudeAvailable')!({}, { force: 'yes' });
+    await ipc.handlers.get(PTY_CHANNELS.checkClaudeAvailable)!({}, 'not-an-object');
+    await ipc.handlers.get(PTY_CHANNELS.checkClaudeAvailable)!({}, null);
+    await ipc.handlers.get(PTY_CHANNELS.checkClaudeAvailable)!({}, {});
+    await ipc.handlers.get(PTY_CHANNELS.checkClaudeAvailable)!({}, { force: 'yes' });
     for (const call of bus().resolveClaude.mock.calls) {
       expect(call[0]).toEqual({ force: false });
     }
@@ -498,13 +499,13 @@ describe('pty:checkClaudeAvailable', () => {
 
 // ─── pty:saveClipboardImage (Task #42) ────────────────────────────────────
 
-describe('pty:saveClipboardImage', () => {
+describe(PTY_CHANNELS.saveClipboardImage, () => {
   it('writes PNG buffer under <userData>/clipboard-images/ and returns the absolute path', async () => {
     const ipc = makeFakeIpc();
     const pngBuf = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
     bus().clipboardReadImage = () => ({ isEmpty: () => false, toPNG: () => pngBuf });
     registerPtyIpc(ipc as unknown as Electron.IpcMain, makeDeps());
-    const out = (await ipc.handlers.get('pty:saveClipboardImage')!({})) as string;
+    const out = (await ipc.handlers.get(PTY_CHANNELS.saveClipboardImage)!({})) as string;
     expect(typeof out).toBe('string');
     expect(path.isAbsolute(out)).toBe(true);
     expect(out.startsWith(path.join(bus().userDataDir, 'clipboard-images'))).toBe(true);
@@ -516,7 +517,7 @@ describe('pty:saveClipboardImage', () => {
     const ipc = makeFakeIpc();
     // Default bus stub returns isEmpty=true.
     registerPtyIpc(ipc as unknown as Electron.IpcMain, makeDeps());
-    const out = await ipc.handlers.get('pty:saveClipboardImage')!({});
+    const out = await ipc.handlers.get(PTY_CHANNELS.saveClipboardImage)!({});
     expect(out).toBeNull();
     const dir = path.join(bus().userDataDir, 'clipboard-images');
     // mkdir not even attempted on the empty path; dir should not exist.
@@ -534,10 +535,10 @@ describe('pty:saveClipboardImage', () => {
 
     registerPtyIpc(ipc as unknown as Electron.IpcMain, makeDeps());
 
-    const first = (await ipc.handlers.get('pty:saveClipboardImage')!({})) as string;
+    const first = (await ipc.handlers.get(PTY_CHANNELS.saveClipboardImage)!({})) as string;
     expect(path.basename(first)).toBe('20260522-101112.png');
 
-    const second = (await ipc.handlers.get('pty:saveClipboardImage')!({})) as string;
+    const second = (await ipc.handlers.get(PTY_CHANNELS.saveClipboardImage)!({})) as string;
     expect(path.basename(second)).toBe('20260522-101112-001.png');
 
     // Both files must exist with the expected content.
@@ -579,7 +580,7 @@ describe('sessionWatcher → renderer bridge', () => {
       return;
     }
     listeners[0]!({ sid: 'a', state: 'idle' });
-    expect(wc.send).toHaveBeenCalledWith('session:state', { sid: 'a', state: 'idle' });
+    expect(wc.send).toHaveBeenCalledWith(SESSION_CHANNELS.state, { sid: 'a', state: 'idle' });
   });
 
   it('forwards title-changed events to the main window webContents (when listener present)', () => {
@@ -591,7 +592,7 @@ describe('sessionWatcher → renderer bridge', () => {
     const listeners = bus().watcherListeners.get('title-changed') ?? [];
     if (listeners.length === 0) return;
     listeners[0]!({ sid: 'a', title: 'fixing X' });
-    expect(wc.send).toHaveBeenCalledWith('session:title', { sid: 'a', title: 'fixing X' });
+    expect(wc.send).toHaveBeenCalledWith(SESSION_CHANNELS.title, { sid: 'a', title: 'fixing X' });
   });
 
   it('state-changed forward is a no-op when getMainWindow returns null', () => {

--- a/electron/ptyHost/entryFactory.ts
+++ b/electron/ptyHost/entryFactory.ts
@@ -34,6 +34,7 @@ import {
 import { resolveSpawnCwd } from './cwdResolver';
 import { emitPtyData } from './dataFanout';
 import { loadScrollbackLines } from '../prefs/scrollback';
+import { PTY_CHANNELS } from '../shared/ipcChannels';
 
 export const DEFAULT_COLS = 120;
 export const DEFAULT_ROWS = 30;
@@ -202,7 +203,7 @@ export function dispatchPtyChunk(sid: string, entry: Entry, chunk: string): void
       continue;
     }
     try {
-      wc.send('pty:data', { sid, chunk, seq });
+      wc.send(PTY_CHANNELS.data, { sid, chunk, seq });
     } catch {
       /* renderer gone — best effort */
     }
@@ -321,7 +322,7 @@ export function makeEntry(
     for (const wc of entry.attached.values()) {
       if (!wc.isDestroyed()) {
         try {
-          wc.send('pty:exit', {
+          wc.send(PTY_CHANNELS.exit, {
             sessionId: sid,
             code: exitCode ?? null,
             signal: signal ?? null,

--- a/electron/ptyHost/ipcRegistrar.ts
+++ b/electron/ptyHost/ipcRegistrar.ts
@@ -12,6 +12,7 @@ import { app, clipboard, type BrowserWindow, type IpcMain } from 'electron';
 import { resolveClaude } from './claudeResolver';
 import { sessionWatcher } from '../sessionWatcher';
 import type { AttachResult, BufferSnapshot, PtySessionInfo } from './lifecycle';
+import { PTY_CHANNELS, SESSION_CHANNELS } from '../shared/ipcChannels';
 
 /**
  * Task #42 — clipboard image auto-save. Filename format:
@@ -99,7 +100,7 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
       const wc = win.webContents;
       if (wc.isDestroyed()) return;
       try {
-        wc.send('session:state', evt);
+        wc.send(SESSION_CHANNELS.state, evt);
       } catch {
         /* renderer gone */
       }
@@ -113,7 +114,7 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
       const wc = win.webContents;
       if (wc.isDestroyed()) return;
       try {
-        wc.send('session:title', evt);
+        wc.send(SESSION_CHANNELS.title, evt);
       } catch {
         /* renderer gone */
       }
@@ -121,9 +122,9 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
     stateBridgeInstalled = true;
   }
 
-  ipcMain.handle('pty:list', () => deps.listPtySessions());
+  ipcMain.handle(PTY_CHANNELS.list, () => deps.listPtySessions());
 
-  ipcMain.handle('pty:spawn', async (_event, sid: string, cwd: string, forkSourceSid?: string) => {
+  ipcMain.handle(PTY_CHANNELS.spawn, async (_event, sid: string, cwd: string, forkSourceSid?: string) => {
     const claudePath = await resolveClaude();
     if (!claudePath) {
       return { ok: false, error: 'claude_not_found' };
@@ -161,7 +162,7 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
           const wc = win.webContents;
           if (wc.isDestroyed()) return;
           try {
-            wc.send('session:cwdRedirected', { sid, newCwd });
+            wc.send(SESSION_CHANNELS.cwdRedirected, { sid, newCwd });
           } catch {
             /* renderer gone */
           }
@@ -176,7 +177,7 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
     }
   });
 
-  ipcMain.handle('pty:attach', (event, sid: string) => {
+  ipcMain.handle(PTY_CHANNELS.attach, (event, sid: string) => {
     const entry = deps.getEntry(sid);
     if (!entry) return null;
     const wc = event.sender;
@@ -194,17 +195,17 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
     } satisfies AttachResult;
   });
 
-  ipcMain.handle('pty:detach', (event, sid: string) => {
+  ipcMain.handle(PTY_CHANNELS.detach, (event, sid: string) => {
     const entry = deps.getEntry(sid);
     if (!entry) return;
     entry.attached.delete(event.sender.id);
   });
 
-  ipcMain.handle('pty:input', (_event, sid: string, data: string) => {
+  ipcMain.handle(PTY_CHANNELS.input, (_event, sid: string, data: string) => {
     deps.inputPtySession(sid, data);
   });
 
-  ipcMain.handle('pty:resize', (_event, sid: string, cols: number, rows: number) => {
+  ipcMain.handle(PTY_CHANNELS.resize, (_event, sid: string, cols: number, rows: number) => {
     deps.resizePtySession(sid, cols, rows);
   });
 
@@ -215,16 +216,16 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
   // is gone — a subsequent `pty:attach` is then guaranteed to see null and
   // walk the spawn-on-null fallback rather than registering as a viewer of
   // a dying pty.
-  ipcMain.handle('pty:kill', async (_event, sid: string) => deps.killPtySession(sid));
+  ipcMain.handle(PTY_CHANNELS.kill, async (_event, sid: string) => deps.killPtySession(sid));
 
-  ipcMain.handle('pty:get', (_event, sid: string) => deps.getPtySession(sid));
+  ipcMain.handle(PTY_CHANNELS.get, (_event, sid: string) => deps.getPtySession(sid));
 
   // L4 PR-B (#865) — visible xterm attach replay channel. Returns the
   // serialized headless buffer plus the captured chunk seq so the
   // renderer can drop live `pty:data` chunks already baked into the
   // snapshot. Async so a multi-MB serialize doesn't block the main
   // thread — `lifecycle.getBufferSnapshot` chunks the join.
-  ipcMain.handle('pty:getBufferSnapshot', (_event, sid: string) =>
+  ipcMain.handle(PTY_CHANNELS.getBufferSnapshot, (_event, sid: string) =>
     deps.getBufferSnapshot(sid),
   );
 
@@ -234,7 +235,7 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
   // `force: true` bypasses the resolver's success-cache so the user can
   // install claude in another terminal and recover in-place via the
   // ClaudeMissingGuide "Re-check" button without restarting the app.
-  ipcMain.handle('pty:checkClaudeAvailable', async (_event, opts: unknown) => {
+  ipcMain.handle(PTY_CHANNELS.checkClaudeAvailable, async (_event, opts: unknown) => {
     const force =
       typeof opts === 'object' && opts !== null && (opts as { force?: unknown }).force === true;
     const p = await resolveClaude({ force });
@@ -253,7 +254,7 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
   // when text is also present, because Windows readText() is unreliable
   // when the clipboard holds an image (readImage().isEmpty() IS reliable).
   // The renderer holds the text fallback synchronously before invoking us.
-  ipcMain.handle('pty:saveClipboardImage', async () => {
+  ipcMain.handle(PTY_CHANNELS.saveClipboardImage, async () => {
     const img = clipboard.readImage();
     if (img.isEmpty()) return null;
     const buf = img.toPNG();

--- a/electron/shared/ipcChannels.ts
+++ b/electron/shared/ipcChannels.ts
@@ -10,12 +10,13 @@
 // OR main becomes a TypeScript error (`as const` gives literal types) rather
 // than a silent IPC dead-letter at runtime.
 //
-// Scope intentionally limited (per task brief) to the five high-churn
+// Scope intentionally limited (per task brief) to the six high-churn
 // namespaces:
 //   - pty:*       — node-pty bridge (lifecycle + data fan-out)
 //   - session:*   — sessionWatcher signals + renderer→main mirrors
 //   - window:*    — title-bar controls + close-action dialog
-//   - updates:*   — electron-updater status / actions
+//   - updates:*   — electron-updater status / actions (renderer↔main invokes)
+//   - update:*    — fan-out events from electron-updater (main→renderer sends)
 //   - db:*        — app_state key/value persistence
 //
 // Renderer-side `.d.ts` files (`src/pty.d.ts`, `src/session.d.ts`) deliberately
@@ -71,6 +72,16 @@ export const UPDATES_CHANNELS = {
   install: 'updates:install',
   getAutoCheck: 'updates:getAutoCheck',
   setAutoCheck: 'updates:setAutoCheck',
+} as const;
+
+// Fan-out events emitted by `electron/updater.ts` alongside the aggregated
+// `updates:status` channel. All three are main → renderer sends so renderer
+// listeners can subscribe to a single transition without switching on kind.
+export const UPDATE_CHANNELS = {
+  // main → renderer
+  available: 'update:available',
+  downloaded: 'update:downloaded',
+  error: 'update:error',
 } as const;
 
 export const DB_CHANNELS = {

--- a/electron/shared/ipcChannels.ts
+++ b/electron/shared/ipcChannels.ts
@@ -1,0 +1,79 @@
+// Single source of truth for IPC channel names.
+//
+// Before this module, channel names were inline string literals on BOTH
+// sides of the bridge: `electron/preload/bridges/*.ts` spelled `'pty:attach'`
+// by hand, and the main-process registrar in `electron/ipc/*.ts` +
+// `electron/ptyHost/ipcRegistrar.ts` spelled the same string independently.
+// Adding a channel required touching 3+ files; renaming was grep-and-pray.
+//
+// Every channel now appears in exactly one place. A typo in either preload
+// OR main becomes a TypeScript error (`as const` gives literal types) rather
+// than a silent IPC dead-letter at runtime.
+//
+// Scope intentionally limited (per task brief) to the five high-churn
+// namespaces:
+//   - pty:*       — node-pty bridge (lifecycle + data fan-out)
+//   - session:*   — sessionWatcher signals + renderer→main mirrors
+//   - window:*    — title-bar controls + close-action dialog
+//   - updates:*   — electron-updater status / actions
+//   - db:*        — app_state key/value persistence
+//
+// Renderer-side `.d.ts` files (`src/pty.d.ts`, `src/session.d.ts`) deliberately
+// remain untouched — they describe the `window.ccsm*` shape, not the channel
+// strings, and folding them in would require typed signatures (follow-up PR).
+
+export const PTY_CHANNELS = {
+  list: 'pty:list',
+  spawn: 'pty:spawn',
+  attach: 'pty:attach',
+  detach: 'pty:detach',
+  input: 'pty:input',
+  resize: 'pty:resize',
+  kill: 'pty:kill',
+  get: 'pty:get',
+  getBufferSnapshot: 'pty:getBufferSnapshot',
+  data: 'pty:data',
+  exit: 'pty:exit',
+  saveClipboardImage: 'pty:saveClipboardImage',
+  checkClaudeAvailable: 'pty:checkClaudeAvailable',
+} as const;
+
+export const SESSION_CHANNELS = {
+  // main → renderer
+  state: 'session:state',
+  title: 'session:title',
+  cwdRedirected: 'session:cwdRedirected',
+  activate: 'session:activate',
+  // renderer → main (one-way)
+  setActive: 'session:setActive',
+  setName: 'session:setName',
+} as const;
+
+export const WINDOW_CHANNELS = {
+  // renderer → main (invoke)
+  minimize: 'window:minimize',
+  toggleMaximize: 'window:toggleMaximize',
+  close: 'window:close',
+  isMaximized: 'window:isMaximized',
+  // renderer → main (one-way)
+  resolveCloseAction: 'window:resolveCloseAction',
+  // main → renderer
+  maximizedChanged: 'window:maximizedChanged',
+  beforeHide: 'window:beforeHide',
+  afterShow: 'window:afterShow',
+  askCloseAction: 'window:askCloseAction',
+} as const;
+
+export const UPDATES_CHANNELS = {
+  status: 'updates:status',
+  check: 'updates:check',
+  download: 'updates:download',
+  install: 'updates:install',
+  getAutoCheck: 'updates:getAutoCheck',
+  setAutoCheck: 'updates:setAutoCheck',
+} as const;
+
+export const DB_CHANNELS = {
+  load: 'db:load',
+  save: 'db:save',
+} as const;

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -1,5 +1,6 @@
 import { app, BrowserWindow, ipcMain } from 'electron';
 import { autoUpdater } from 'electron-updater';
+import { UPDATES_CHANNELS } from './shared/ipcChannels';
 
 // All status updates flow through one channel so the renderer doesn't have to
 // subscribe to N separate event names. The shape mirrors electron-updater's
@@ -29,7 +30,7 @@ const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
 const CHAN_AVAILABLE = 'update:available';
 const CHAN_DOWNLOADED = 'update:downloaded';
 const CHAN_ERROR = 'update:error';
-const CHAN_STATUS = 'updates:status';
+const CHAN_STATUS = UPDATES_CHANNELS.status;
 
 function sendAll(channel: string, payload: unknown): void {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -132,9 +133,9 @@ export function installUpdaterIpc(): void {
     broadcast({ kind: 'error', message: err?.message ?? String(err) })
   );
 
-  ipcMain.handle('updates:status', () => lastStatus);
+  ipcMain.handle(UPDATES_CHANNELS.status, () => lastStatus);
 
-  ipcMain.handle('updates:check', async () => {
+  ipcMain.handle(UPDATES_CHANNELS.check, async () => {
     if (!app.isPackaged) {
       const status: UpdateStatus = { kind: 'not-available', version: app.getVersion() };
       broadcast(status);
@@ -151,7 +152,7 @@ export function installUpdaterIpc(): void {
     }
   });
 
-  ipcMain.handle('updates:download', async () => {
+  ipcMain.handle(UPDATES_CHANNELS.download, async () => {
     if (!app.isPackaged) return { ok: false, reason: 'not-packaged' as const };
     try {
       await autoUpdater.downloadUpdate();
@@ -161,7 +162,7 @@ export function installUpdaterIpc(): void {
     }
   });
 
-  ipcMain.handle('updates:install', () => {
+  ipcMain.handle(UPDATES_CHANNELS.install, () => {
     if (!app.isPackaged) return { ok: false as const, reason: 'not-packaged' as const };
     // Defense-in-depth: refuse to call quitAndInstall unless we've
     // actually broadcast a `downloaded` event. Without this guard a
@@ -182,8 +183,8 @@ export function installUpdaterIpc(): void {
     return { ok: true as const };
   });
 
-  ipcMain.handle('updates:getAutoCheck', () => autoCheckEnabled);
-  ipcMain.handle('updates:setAutoCheck', (_e, enabled: boolean) => {
+  ipcMain.handle(UPDATES_CHANNELS.getAutoCheck, () => autoCheckEnabled);
+  ipcMain.handle(UPDATES_CHANNELS.setAutoCheck, (_e, enabled: boolean) => {
     autoCheckEnabled = !!enabled;
     if (autoCheckEnabled) {
       startPeriodicChecks();

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, ipcMain } from 'electron';
 import { autoUpdater } from 'electron-updater';
-import { UPDATES_CHANNELS } from './shared/ipcChannels';
+import { UPDATE_CHANNELS, UPDATES_CHANNELS } from './shared/ipcChannels';
 
 // All status updates flow through one channel so the renderer doesn't have to
 // subscribe to N separate event names. The shape mirrors electron-updater's
@@ -26,11 +26,8 @@ const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
 
 // Named event channels — requested in the release infra spec in addition to
 // the aggregated `updates:status` channel. Keeping both channels is cheap and
-// makes renderer code (e.g. "show a toast on downloaded") trivial.
-const CHAN_AVAILABLE = 'update:available';
-const CHAN_DOWNLOADED = 'update:downloaded';
-const CHAN_ERROR = 'update:error';
-const CHAN_STATUS = UPDATES_CHANNELS.status;
+// makes renderer code (e.g. "show a toast on downloaded") trivial. See
+// `UPDATE_CHANNELS` (singular) in shared/ipcChannels.ts.
 
 function sendAll(channel: string, payload: unknown): void {
   for (const win of BrowserWindow.getAllWindows()) {
@@ -40,15 +37,15 @@ function sendAll(channel: string, payload: unknown): void {
 
 function broadcast(status: UpdateStatus): void {
   lastStatus = status;
-  sendAll(CHAN_STATUS, status);
+  sendAll(UPDATES_CHANNELS.status, status);
   // Fan out to the specific channels too so renderer listeners that only
   // care about one transition don't have to switch on kind themselves.
   if (status.kind === 'available') {
-    sendAll(CHAN_AVAILABLE, { version: status.version, releaseDate: status.releaseDate });
+    sendAll(UPDATE_CHANNELS.available, { version: status.version, releaseDate: status.releaseDate });
   } else if (status.kind === 'downloaded') {
-    sendAll(CHAN_DOWNLOADED, { version: status.version });
+    sendAll(UPDATE_CHANNELS.downloaded, { version: status.version });
   } else if (status.kind === 'error') {
-    sendAll(CHAN_ERROR, { message: status.message });
+    sendAll(UPDATE_CHANNELS.error, { message: status.message });
   }
 }
 

--- a/electron/window/__tests__/createWindow.test.ts
+++ b/electron/window/__tests__/createWindow.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WINDOW_CHANNELS } from '../../shared/ipcChannels';
 
 // Capture context-menu listener + popup invocations from the BrowserWindow
 // mock. Each test flushes via beforeEach so `popupCalls.length === 0` is the
@@ -649,17 +650,17 @@ describe('createWindow factory', () => {
     createWindow(deps);
     latestWin!.isMaximized = vi.fn(() => true);
     latestWin!.listeners.get('maximize')!();
-    expect(latestWin!.webContents.send).toHaveBeenCalledWith('window:maximizedChanged', true);
+    expect(latestWin!.webContents.send).toHaveBeenCalledWith(WINDOW_CHANNELS.maximizedChanged, true);
     latestWin!.isMaximized = vi.fn(() => false);
     latestWin!.listeners.get('unmaximize')!();
-    expect(latestWin!.webContents.send).toHaveBeenLastCalledWith('window:maximizedChanged', false);
+    expect(latestWin!.webContents.send).toHaveBeenLastCalledWith(WINDOW_CHANNELS.maximizedChanged, false);
   });
 
   it('show event re-sends window:afterShow so renderer can clear fade opacity', () => {
     createWindow(deps);
     latestWin!.webContents.send.mockClear();
     latestWin!.listeners.get('show')!();
-    expect(latestWin!.webContents.send).toHaveBeenCalledWith('window:afterShow');
+    expect(latestWin!.webContents.send).toHaveBeenCalledWith(WINDOW_CHANNELS.afterShow);
   });
 
   // ─── close-action: tray (default) → fade-then-hide ────────────────────
@@ -670,7 +671,7 @@ describe('createWindow factory', () => {
     latestWin!.listeners.get('close')!(closeEvt);
     expect(closeEvt.preventDefault).toHaveBeenCalled();
     // Renderer is told to start fading first.
-    expect(latestWin!.webContents.send).toHaveBeenCalledWith('window:beforeHide', { durationMs: 180 });
+    expect(latestWin!.webContents.send).toHaveBeenCalledWith(WINDOW_CHANNELS.beforeHide, { durationMs: 180 });
     // Hide is deferred to the end of the fade window.
     expect(latestWin!.hide).not.toHaveBeenCalled();
     vi.advanceTimersByTime(180);
@@ -729,12 +730,12 @@ describe('createWindow factory', () => {
   it('close with pref=ask sends IPC askCloseAction and registers resolve handler', () => {
     getCloseActionMock.mockReturnValue('ask');
     createWindow(deps);
-    expect(ipcHandlers.has('window:resolveCloseAction')).toBe(true);
+    expect(ipcHandlers.has(WINDOW_CHANNELS.resolveCloseAction)).toBe(true);
     const closeEvt = { preventDefault: vi.fn() };
     latestWin!.listeners.get('close')!(closeEvt);
     expect(closeEvt.preventDefault).toHaveBeenCalled();
     const sendCall = latestWin!.webContents.send.mock.calls.find(
-      (c) => c[0] === 'window:askCloseAction',
+      (c) => c[0] === WINDOW_CHANNELS.askCloseAction,
     );
     expect(sendCall).toBeDefined();
     const payload = sendCall![1] as { requestId: string; labels: Record<string, string> };
@@ -747,9 +748,9 @@ describe('createWindow factory', () => {
     createWindow(deps);
     latestWin!.listeners.get('close')!({ preventDefault: vi.fn() });
     const askPayload = latestWin!.webContents.send.mock.calls.find(
-      (c) => c[0] === 'window:askCloseAction',
+      (c) => c[0] === WINDOW_CHANNELS.askCloseAction,
     )![1] as { requestId: string };
-    const resolve = ipcHandlers.get('window:resolveCloseAction')!;
+    const resolve = ipcHandlers.get(WINDOW_CHANNELS.resolveCloseAction)!;
     resolve({}, { requestId: askPayload.requestId, choice: 'tray', dontAskAgain: true });
     expect(setCloseActionMock).toHaveBeenCalledWith('tray');
     vi.advanceTimersByTime(180);
@@ -761,9 +762,9 @@ describe('createWindow factory', () => {
     createWindow(deps);
     latestWin!.listeners.get('close')!({ preventDefault: vi.fn() });
     const askPayload = latestWin!.webContents.send.mock.calls.find(
-      (c) => c[0] === 'window:askCloseAction',
+      (c) => c[0] === WINDOW_CHANNELS.askCloseAction,
     )![1] as { requestId: string };
-    const resolve = ipcHandlers.get('window:resolveCloseAction')!;
+    const resolve = ipcHandlers.get(WINDOW_CHANNELS.resolveCloseAction)!;
     resolve({}, { requestId: askPayload.requestId, choice: 'quit', dontAskAgain: false });
     expect(deps.setIsQuitting).toHaveBeenCalledWith(true);
     expect(appQuitMock).toHaveBeenCalled();
@@ -775,9 +776,9 @@ describe('createWindow factory', () => {
     createWindow(deps);
     latestWin!.listeners.get('close')!({ preventDefault: vi.fn() });
     const askPayload = latestWin!.webContents.send.mock.calls.find(
-      (c) => c[0] === 'window:askCloseAction',
+      (c) => c[0] === WINDOW_CHANNELS.askCloseAction,
     )![1] as { requestId: string };
-    const resolve = ipcHandlers.get('window:resolveCloseAction')!;
+    const resolve = ipcHandlers.get(WINDOW_CHANNELS.resolveCloseAction)!;
     resolve({}, { requestId: askPayload.requestId, choice: 'cancel', dontAskAgain: true });
     expect(setCloseActionMock).not.toHaveBeenCalled();
     expect(appQuitMock).not.toHaveBeenCalled();
@@ -789,7 +790,7 @@ describe('createWindow factory', () => {
     getCloseActionMock.mockReturnValue('ask');
     createWindow(deps);
     latestWin!.listeners.get('close')!({ preventDefault: vi.fn() });
-    const resolve = ipcHandlers.get('window:resolveCloseAction')!;
+    const resolve = ipcHandlers.get(WINDOW_CHANNELS.resolveCloseAction)!;
     resolve({}, { requestId: 'not-a-real-id', choice: 'quit', dontAskAgain: false });
     expect(deps.setIsQuitting).not.toHaveBeenCalled();
     expect(appQuitMock).not.toHaveBeenCalled();
@@ -802,7 +803,7 @@ describe('createWindow factory', () => {
     closeHandler({ preventDefault: vi.fn() });
     closeHandler({ preventDefault: vi.fn() });
     const asks = latestWin!.webContents.send.mock.calls.filter(
-      (c) => c[0] === 'window:askCloseAction',
+      (c) => c[0] === WINDOW_CHANNELS.askCloseAction,
     );
     expect(asks).toHaveLength(1);
   });
@@ -828,7 +829,7 @@ describe('createWindow factory', () => {
     latestWin!.listeners.get('close')!({ preventDefault: vi.fn() });
     // No askCloseAction send (renderer is gone), straight to fade-then-hide.
     const asks = latestWin!.webContents.send.mock.calls.filter(
-      (c) => c[0] === 'window:askCloseAction',
+      (c) => c[0] === WINDOW_CHANNELS.askCloseAction,
     );
     expect(asks).toHaveLength(0);
     vi.advanceTimersByTime(180);
@@ -839,7 +840,7 @@ describe('createWindow factory', () => {
   it('closed event removes the resolveCloseAction IPC listener', () => {
     createWindow(deps);
     latestWin!.listeners.get('closed')!();
-    expect(removedIpcChannels).toContain('window:resolveCloseAction');
+    expect(removedIpcChannels).toContain(WINDOW_CHANNELS.resolveCloseAction);
   });
 
   it('closed event clears any pending ask timer', () => {

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -37,6 +37,7 @@ import {
   setCloseAction,
 } from '../prefs/closeAction';
 import { tCloseDialog } from '../i18n';
+import { WINDOW_CHANNELS } from '../shared/ipcChannels';
 
 export interface CreateWindowDeps {
   /** True iff we should load the webpack-dev-server URL instead of the
@@ -378,7 +379,7 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
     // Reset the renderer's fade-opacity in case the window was just
     // restored after a fade-to-hide (see `window:beforeHide` below).
     if (!win.webContents.isDestroyed()) {
-      win.webContents.send('window:afterShow');
+      win.webContents.send(WINDOW_CHANNELS.afterShow);
     }
   });
 
@@ -387,7 +388,7 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
   });
 
   const emitMax = () =>
-    win.webContents.send('window:maximizedChanged', win.isMaximized());
+    win.webContents.send(WINDOW_CHANNELS.maximizedChanged, win.isMaximized());
   win.on('maximize', emitMax);
   win.on('unmaximize', emitMax);
 
@@ -416,7 +417,7 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
     fadePending = true;
     try {
       if (!win.webContents.isDestroyed()) {
-        win.webContents.send('window:beforeHide', { durationMs: HIDE_FADE_MS });
+        win.webContents.send(WINDOW_CHANNELS.beforeHide, { durationMs: HIDE_FADE_MS });
       }
     } catch {
       /* renderer unreachable — fall through to immediate hide */
@@ -466,9 +467,9 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
     pendingAsk = null;
     applyCloseDecision({ choice: payload.choice, dontAskAgain: payload.dontAskAgain });
   };
-  deps.ipcMain.on('window:resolveCloseAction', resolveHandler);
+  deps.ipcMain.on(WINDOW_CHANNELS.resolveCloseAction, resolveHandler);
   win.on('closed', () => {
-    deps.ipcMain.removeListener('window:resolveCloseAction', resolveHandler);
+    deps.ipcMain.removeListener(WINDOW_CHANNELS.resolveCloseAction, resolveHandler);
     if (pendingAsk) {
       clearTimeout(pendingAsk.timer);
       pendingAsk = null;
@@ -515,7 +516,7 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
     pendingAsk = { requestId, timer };
     try {
       if (!win.webContents.isDestroyed()) {
-        win.webContents.send('window:askCloseAction', {
+        win.webContents.send(WINDOW_CHANNELS.askCloseAction, {
           requestId,
           labels: {
             message: tCloseDialog('message'),


### PR DESCRIPTION
## Summary

Channels were inline string literals on **both** sides of the IPC bridge:

- `electron/preload/bridges/*.ts` spelled `'pty:attach'` by hand
- `electron/ipc/*.ts` + `electron/ptyHost/ipcRegistrar.ts` spelled the same string independently when registering the handler

Adding a channel required touching 3+ files. Renaming was grep-and-pray. A typo on either side was a silent IPC dead-letter, not a typecheck error.

This PR extracts a single typed constants module at `electron/shared/ipcChannels.ts` and migrates every call site. After this PR, each channel string appears in exactly one place; a typo on either preload OR main is a typecheck error.

## Namespaces migrated (6)

- `pty:*` — 13 channels (lifecycle + data/exit fan-out + clipboard image + claude probe)
- `session:*` — 6 channels (state/title/cwdRedirected/activate + setActive/setName)
- `window:*` — 9 channels (title-bar controls + close-action dialog)
- `updates:*` — 6 channels (electron-updater status / actions)
- `update:*` — 3 channels (fan-out events from updater, main→renderer; added in follow-up commit per review)
- `db:*` — 2 channels (app_state key/value persistence)

Total: **39 channels** across 6 namespaces.

## Verification

- Inline channel string literal sweep across `electron/` finds zero matches outside `ipcChannels.ts` (comments and test descriptions don't count — they're documentation, not channel references).
- No preload↔main mismatches were uncovered during migration: every preload `invoke`/`send`/`on` had a matching main `handle`/`on`/`send`. Translation: this codebase didn't have any latent IPC drift bugs — the refactor is purely preventive.

## Scope notes

- Renderer-side `src/pty.d.ts` / `src/session.d.ts` migration is **deliberately out of scope**. Those describe the `window.ccsm*` shape, not channel strings; folding them in requires typed signatures and is a larger follow-up PR.
- Test files were migrated alongside production code so renaming a constant key now fails loudly across both.

## Follow-up (post-review)

The first round of review caught that the singular `update:*` namespace (3 fan-out sends from `electron/updater.ts` + a listener in `ccsmCore.ts`) was missed. Fixed in a follow-up commit which adds `UPDATE_CHANNELS`, migrates updater.ts (also dropping the now-redundant `CHAN_*` locals so all four channel references use the constants directly), migrates the ccsmCore listener, and migrates the two test files that actually subscribe via these channel strings. Sweep is now clean.

## Test plan

- [x] `npm run typecheck` clean (both root + tsconfig.electron.json projects)
- [x] All previously-passing tests still pass: 1663/1697 (the 34 failures are the pre-existing `better-sqlite3` NODE_MODULE_VERSION mismatch on this dev machine — not in scope)
- [x] Touched-test sweep: 200/200 pass across the 11 migrated test files
- [x] Follow-up: `ccsmCore.test.ts` + `updater.test.ts` re-run, 51/51 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)