### PR TITLE
fix(log): defer renderer crash listeners until after React mount

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -67,6 +67,8 @@ export default [
         FocusEvent: 'readonly',
         DragEvent: 'readonly',
         ClipboardEvent: 'readonly',
+        ErrorEvent: 'readonly',
+        PromiseRejectionEvent: 'readonly',
         DataTransfer: 'readonly',
         File: 'readonly',
         FileList: 'readonly',

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { initI18n } from './i18n';
 import { useTranslation } from './i18n/useTranslation';
 import { usePreferences } from './store/preferences';
 import { useThemeEffect } from './app-effects/useThemeEffect';
+import { useRendererCrashNet } from './app-effects/useRendererCrashNet';
 import { useLanguageEffect } from './app-effects/useLanguageEffect';
 import { useAgentEventBridge } from './app-effects/useAgentEventBridge';
 import { useShortcutHandlers } from './app-effects/useShortcutHandlers';
@@ -132,6 +133,12 @@ export default function App() {
   }, []);
 
   // ---- Extracted effect hooks (Task #732 Phase B + Task #758 Phase C) ----
+  // Renderer crash net — install window-level error / unhandledrejection
+  // listeners. Deferred to a `useEffect` (rather than module-eval in
+  // index.tsx) because boot-phase registration regressed harness-dnd Case 1
+  // on Linux Chromium / xvfb. See useRendererCrashNet.ts for details.
+  useRendererCrashNet();
+
   // Theme application — reactive to user choice + (when system) OS scheme.
   useThemeEffect(theme);
 

--- a/src/app-effects/useRendererCrashNet.ts
+++ b/src/app-effects/useRendererCrashNet.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+import { error as logError } from '../shared/log';
+
+/**
+ * Installs window-level `'error'` and `'unhandledrejection'` listeners that
+ * forward to the shared logger (and, via that seam, to Sentry).
+ *
+ * History: these listeners used to be registered at module-eval time in
+ * `src/index.tsx`, BEFORE `createRoot` ran. On Linux Chromium under xvfb that
+ * boot-phase registration reproducibly broke `harness-dnd` Case 1
+ * ("s1 did not land in g2"): the bare presence of a top-level `'error'`
+ * listener before the React tree mounted appeared to perturb dnd-kit's
+ * synthetic pointer-event reconstruction (cancelable / microtask-ordering
+ * edge in some Chromium versions). Confirmed via git bisect of #1318.
+ *
+ * Moving the install into a `useEffect` defers it until after React mount,
+ * which closes the boot-phase window. Everything user-triggerable still runs
+ * inside the listeners' lifetime, so the crash net loses no real coverage.
+ */
+export function useRendererCrashNet(): void {
+  useEffect(() => {
+    const onRejection = (e: PromiseRejectionEvent) => {
+      logError('renderer', 'unhandled rejection', e.reason);
+    };
+    const onError = (e: ErrorEvent) => {
+      logError('renderer', 'uncaught error', e.error ?? e.message);
+    };
+    window.addEventListener('unhandledrejection', onRejection);
+    window.addEventListener('error', onError);
+    return () => {
+      window.removeEventListener('unhandledrejection', onRejection);
+      window.removeEventListener('error', onError);
+    };
+  }, []);
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,18 +8,13 @@ import App from './App';
 import { hydrateStore, type HydrationTrace } from './stores/store';
 import { flushNow, setPersistErrorHandler } from './stores/persist';
 import './styles/global.css';
-import { error as logError } from './shared/log';
 
-// Renderer crash net. Without this, an unhandledrejection or an
-// uncaught error in event handlers / async code disappears into
-// devtools (or the void in production builds where devtools isn't
-// open). The shared log seam will later forward these to Sentry.
-window.addEventListener('unhandledrejection', (e) => {
-  logError('renderer', 'unhandled rejection', e.reason);
-});
-window.addEventListener('error', (e) => {
-  logError('renderer', 'uncaught error', e.error ?? e.message);
-});
+// Renderer crash net (window-level `'error'` + `'unhandledrejection'`
+// listeners) is installed by `useRendererCrashNet` inside <App>, NOT here.
+// Module-eval registration in this file BEFORE `createRoot` regressed
+// harness-dnd Case 1 on Linux Chromium / xvfb (#1318 -> bisect). Deferring
+// until after React mounts loses no real coverage — there's no
+// user-triggerable code in the boot window before render.
 
 // All knobs (DSN, environment, opt-out gating) live in the main process
 // init. The renderer SDK auto-discovers them via the IPC bridge that


### PR DESCRIPTION
## Summary

Fixes ubuntu-latest e2e regression introduced by #1318 (logger + crash net phase 1).

PR #1318 installed `window.addEventListener('error', ...)` and `'unhandledrejection'` BEFORE the React root is created. On Linux Chromium with xvfb, this caused `harness-dnd` Case 1 (\"s1 did not land in g2\") to fail consistently — confirmed via git bisect: parent `5452c00` was green, `6aa1862` (#1318) was red 2/2 times.

This PR moves the listener registration into a top-level `useEffect` (new `useRendererCrashNet` hook) inside `<App>` so they install AFTER React has mounted. The crash net still catches everything that runs during normal app lifetime; only the brief boot window before the React tree mounts is now untrapped — and that window has no user-triggerable code paths, so the trade-off is safe.

## Test plan

- [x] typecheck clean
- [x] all previously-passing unit tests still pass (34 baseline better-sqlite3 ABI failures unchanged)
- [x] e2e dispatched on this branch: ubuntu DnD now passes (and macOS / Windows still pass) — run https://github.com/Jiahui-Gu/ccsm/actions/runs/26302902817
- [ ] manually trigger a `Promise.reject(new Error('test'))` in renderer devtools after the app boots; confirm `[renderer] unhandled rejection ...` still appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)