### PR TITLE
chore: bump version to 0.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccsm",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccsm",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccsm",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "CCSM (Claude Code Session Manager) — group-first manager for many Claude Code sessions",
   "productName": "CCSM",
   "license": "MIT",


### PR DESCRIPTION
Bumps `package.json` (and the top-level `package-lock.json` `version` field) from `0.2.5` to `0.2.6`.

Once merged to `main`, the new hourly auto-tag workflow (`.github/workflows/hourly-tag-release.yml`, from #1317) will push `v0.2.6` on its next tick — or it can be kicked manually via `workflow_dispatch`. That tag push then triggers `release.yml` to build and publish.

## User-visible fixes landing in v0.2.6
- fix(terminal): attach lands at bottom — coalesce replays + pin viewport (#1308, `5452c00`)
- fix(terminal): buffer pty writes during IME composition to stop input jitter (`71d1be5`)
- fix(paste): wrap in bracketed-paste when active + normalize CRLF (#1303)
- fix(import): always return fresh scan, not stale cache (#1301)
- fix(terminal): scroll to bottom after attach (#1300)
- fix(ptyHost): prune destroyed webContents during PTY fanout (#1315)
- fix(log): defer renderer crash listeners until after React mount (#1320)
- fix(groups): clear nameKey on rename so default group can be renamed
- feat(sidebar): regroup session context menu into edit/organize/lifecycle sections
- feat(log): thin shared logger + renderer crash net (phase 1) (#1318)

Also includes internal refactors (single source of truth for IPC channel names #1316), test coverage additions, and the hourly auto-release CI infra itself.

## Diff
Two-line change across `package.json` + `package-lock.json` — version string only, no dependency tree churn.