### PR TITLE
chore: bump version to 0.2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ccsm",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ccsm",
-      "version": "0.2.6",
+      "version": "0.2.7",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccsm",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "CCSM (Claude Code Session Manager) — group-first manager for many Claude Code sessions",
   "productName": "CCSM",
   "license": "MIT",


### PR DESCRIPTION
Bumps `package.json` + `package-lock.json` to `0.2.7`.

First release since PR #1322 flipped the release workflow to `draft: false`, so the auto-release for this tag should publish directly (no manual draft promotion). This bump validates the published-release path end-to-end.

## User-facing changes since v0.2.6
- fix(paste): wrap in bracketed-paste when active + normalize CRLF (#1303)
- fix(import): always return fresh scan, not stale cache (#1301)
- fix(terminal): scroll to bottom after attach (#1300)
- fix(terminal): attach lands at bottom — coalesce replays + pin viewport (#1308)
- fix(terminal): buffer pty writes during IME composition to stop input jitter
- fix(groups): clear nameKey on rename so default group can be renamed
- fix(ptyHost): prune destroyed webContents during PTY fanout (#1315)
- fix(log): defer renderer crash listeners until after React mount (#1320)
- feat(sidebar): regroup session context menu into edit/organize/lifecycle sections
- feat(log): thin shared logger + renderer crash net (phase 1) (#1318)

Plus internal refactors/tests/CI changes (IPC channel consolidation, terminal test harness, hourly auto-tag CI, release publish-directly).

## Verification
- `npm run typecheck` passes
- `npm run lint` passes (0 errors)