### PR TITLE
fix(ime): contain xterm-helpers + min-w-0 on app-shell

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -101,22 +101,22 @@ jobs:
         run: npm run build
       - name: Run e2e (Linux with xvfb)
         if: runner.os == 'Linux'
-        # E2E_SKIP=harness-real-cli — public CI runners have no `claude`
-        # CLI installed AND no Anthropic auth tokens, so every case in
-        # harness-real-cli that calls waitForTerminalReady deterministically
+        # E2E_SKIP=harness-real-cli,harness-ime-overflow — public CI runners
+        # have no `claude` CLI installed AND no Anthropic auth tokens, so
+        # every harness that calls waitForTerminalReady deterministically
         # times out (the renderer falls through to ClaudeMissingGuide and
-        # never mounts <TerminalPane>). The harness stays runnable locally
-        # via `node scripts/harness-real-cli.mjs` (or `npm run probe:e2e`
-        # without the env var) for the dev / dogfood loop, where the user's
-        # ~/.claude is real. (#726)
+        # never mounts <TerminalPane>). Both harnesses stay runnable locally
+        # via `node scripts/harness-*.mjs` (or `npm run probe:e2e` without
+        # the env var) for the dev / dogfood loop, where the user's
+        # ~/.claude is real. (#726, #1324)
         run: xvfb-run -a npm run probe:e2e
         env:
-          E2E_SKIP: harness-real-cli
+          E2E_SKIP: harness-real-cli,harness-ime-overflow
       - name: Run e2e (mac/win)
         if: runner.os != 'Linux'
         run: npm run probe:e2e
         env:
-          E2E_SKIP: harness-real-cli
+          E2E_SKIP: harness-real-cli,harness-ime-overflow
       - name: Upload e2e logs on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/scripts/harness-ime-overflow.mjs
+++ b/scripts/harness-ime-overflow.mjs
@@ -36,7 +36,7 @@ import {
 const STEPS = [1, 10, 50, 200, 800];
 
 function fail(msg) {
-  console.error('[probe-e2e-ime-overflow] FAIL:', msg);
+  console.error('[harness-ime-overflow] FAIL:', msg);
   process.exitCode = 1;
 }
 
@@ -126,7 +126,7 @@ async function main() {
         };
       });
 
-      console.log(`[probe-e2e-ime-overflow] n=${n}`, metrics);
+      console.log(`[harness-ime-overflow] n=${n}`, metrics);
 
       if (metrics.appShellScroll > metrics.appShellClient + 2) {
         fail(
@@ -183,9 +183,9 @@ async function main() {
     }
 
     if (failures === 0) {
-      console.log('[probe-e2e-ime-overflow] PASS — all containment assertions held across', STEPS);
+      console.log('[harness-ime-overflow] PASS — all containment assertions held across', STEPS);
     } else {
-      console.error(`[probe-e2e-ime-overflow] ${failures} assertion failure(s)`);
+      console.error(`[harness-ime-overflow] ${failures} assertion failure(s)`);
     }
   } finally {
     try { await electronApp.close(); } catch (_) { /* ignore */ }
@@ -193,6 +193,6 @@ async function main() {
 }
 
 main().catch((e) => {
-  console.error('[probe-e2e-ime-overflow] FAILED:', e);
+  console.error('[harness-ime-overflow] FAILED:', e);
   process.exit(1);
 });

--- a/scripts/probe-e2e-ime-overflow.mjs
+++ b/scripts/probe-e2e-ime-overflow.mjs
@@ -1,0 +1,198 @@
+// IME composition overflow e2e probe.
+//
+// Verifies the architectural fix in src/styles/global.css (.xterm .xterm-helpers
+// containment) + src/components/AppShell.tsx (min-w-0 overflow-hidden) prevents
+// long IME composition strings from inflating .app-shell.scrollWidth and pushing
+// the sidebar off-screen.
+//
+// Bug class: xterm.js 5.5.0 inflates .xterm-helper-textarea and .composition-view
+// inline widths to match the composition string (~11200px for 800 chars).
+// Although position:absolute, those widths propagate up via scrollable overflow
+// to .app-shell, displacing the shrink-0 sidebar past the left viewport edge.
+//
+// Strategy (adapted from scratch/diagnose-ime/ime.mjs):
+//   1. Launch isolated ccsm; seed a session so the xterm pane mounts.
+//   2. Wait for [data-terminal-host] + .xterm-helper-textarea.
+//   3. Focus the helper textarea, dispatch compositionstart.
+//   4. For n in {1, 10, 50, 200, 800}, dispatch compositionupdate with
+//      `'我'.repeat(n)` and assert:
+//        - .app-shell.scrollWidth <= .app-shell.clientWidth + 2
+//        - sidebar (aside).getBoundingClientRect().left >= -1
+//        - .composition-view bounding rect width > 0 (for n >= 10)
+//        - .composition-view.right <= [data-terminal-host].right + 2
+//   5. Dispatch compositionend; assert .composition-view loses .active.
+//
+// Without the fix, step 4's scrollWidth assertion fails at n=800
+// (12451 vs 1280 measured on Windows 11).
+
+import {
+  createIsolatedClaudeDir,
+  launchCcsmIsolated,
+  seedSession,
+  waitForTerminalReady,
+  dismissFirstRunModals,
+} from './probe-utils-real-cli.mjs';
+
+const STEPS = [1, 10, 50, 200, 800];
+
+function fail(msg) {
+  console.error('[probe-e2e-ime-overflow] FAIL:', msg);
+  process.exitCode = 1;
+}
+
+async function main() {
+  const { tempDir } = await createIsolatedClaudeDir();
+  const { electronApp, win } = await launchCcsmIsolated({ tempDir });
+
+  try {
+    await win.waitForFunction(
+      () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+      null,
+      { timeout: 30000 },
+    );
+
+    const { sid } = await seedSession(win, { name: 'ime-overflow', cwd: tempDir });
+    if (!sid) throw new Error('seedSession returned empty sid');
+
+    await new Promise((r) => setTimeout(r, 4000));
+    await waitForTerminalReady(win, sid, { timeout: 60000 });
+    await dismissFirstRunModals(win);
+
+    // Ensure terminal is focused so .xterm-helper-textarea is active.
+    await win.evaluate(() => {
+      const host = document.querySelector('[data-terminal-host]');
+      host?.click();
+      const ta = document.querySelector('.xterm-helper-textarea');
+      ta?.focus();
+    });
+    await new Promise((r) => setTimeout(r, 300));
+
+    const taReady = await win.evaluate(() => {
+      const ta = document.querySelector('.xterm-helper-textarea');
+      if (!ta) return { ok: false, reason: 'no textarea' };
+      ta.focus();
+      return { ok: document.activeElement === ta };
+    });
+    if (!taReady.ok) {
+      throw new Error(`xterm-helper-textarea not focusable: ${JSON.stringify(taReady)}`);
+    }
+
+    // Start composition.
+    await win.evaluate(() => {
+      const ta = document.querySelector('.xterm-helper-textarea');
+      ta.dispatchEvent(new CompositionEvent('compositionstart', { data: '', bubbles: true }));
+    });
+
+    let failures = 0;
+    for (const n of STEPS) {
+      await win.evaluate((count) => {
+        const ta = document.querySelector('.xterm-helper-textarea');
+        const data = '我'.repeat(count);
+        ta.value = data;
+        ta.dispatchEvent(new CompositionEvent('compositionupdate', { data, bubbles: true }));
+        ta.dispatchEvent(
+          new InputEvent('input', {
+            data,
+            inputType: 'insertCompositionText',
+            bubbles: true,
+          }),
+        );
+      }, n);
+      // xterm CompositionHelper schedules a setTimeout 0 to reposition
+      // .composition-view; give it time to settle.
+      await new Promise((r) => setTimeout(r, 150));
+
+      const metrics = await win.evaluate(() => {
+        const appShell = document.querySelector('.app-shell');
+        const sidebar = document.querySelector('aside');
+        const host = document.querySelector('[data-terminal-host]');
+        const helpers = document.querySelector('.xterm-helpers');
+        const view = document.querySelector('.composition-view');
+        const helpersRect = helpers?.getBoundingClientRect();
+        return {
+          appShellScroll: appShell?.scrollWidth ?? 0,
+          appShellClient: appShell?.clientWidth ?? 0,
+          sidebarLeft: sidebar ? sidebar.getBoundingClientRect().left : -9999,
+          hostRight: host ? host.getBoundingClientRect().right : 0,
+          // .xterm-helpers is the clip box (overflow:hidden + contain:layout
+          // applied by our fix). Its right edge bounds where .composition-view
+          // is actually painted, regardless of the view element's own natural
+          // width (which xterm sets to the composition string's pixel length).
+          helpersRight: helpersRect ? helpersRect.right : 0,
+          helpersOverflow: helpers ? getComputedStyle(helpers).overflow : '',
+          helpersContain: helpers ? getComputedStyle(helpers).contain : '',
+          viewWidth: view ? view.getBoundingClientRect().width : 0,
+          viewActive: view ? view.classList.contains('active') : false,
+        };
+      });
+
+      console.log(`[probe-e2e-ime-overflow] n=${n}`, metrics);
+
+      if (metrics.appShellScroll > metrics.appShellClient + 2) {
+        fail(
+          `n=${n}: appShell.scrollWidth ${metrics.appShellScroll} > clientWidth ${metrics.appShellClient}+2 (containment broken)`,
+        );
+        failures++;
+      }
+      if (metrics.sidebarLeft < -1) {
+        fail(`n=${n}: sidebar.left ${metrics.sidebarLeft} pushed off viewport`);
+        failures++;
+      }
+      if (n >= 10) {
+        if (!(metrics.viewWidth > 0)) {
+          fail(`n=${n}: .composition-view width ${metrics.viewWidth} not visible (containment too aggressive?)`);
+          failures++;
+        }
+        // The clip box (.xterm-helpers) must stay within the terminal host's
+        // right edge. The composition-view's own bounding rect can be wider
+        // (xterm 5.5.0 sets its inline width to the string's pixel length),
+        // but our overflow:hidden + contain:layout on .xterm-helpers ensures
+        // only the head is painted within the terminal area.
+        if (metrics.helpersRight > metrics.hostRight + 2) {
+          fail(
+            `n=${n}: .xterm-helpers clip box right ${metrics.helpersRight} > terminal-host.right ${metrics.hostRight}+2 (clip box escapes terminal)`,
+          );
+          failures++;
+        }
+        if (!/hidden/.test(metrics.helpersOverflow)) {
+          fail(`n=${n}: .xterm-helpers overflow=${metrics.helpersOverflow} (expected hidden)`);
+          failures++;
+        }
+        if (!/layout/.test(metrics.helpersContain)) {
+          fail(`n=${n}: .xterm-helpers contain=${metrics.helpersContain} (expected layout)`);
+          failures++;
+        }
+      }
+    }
+
+    // End composition.
+    await win.evaluate(() => {
+      const ta = document.querySelector('.xterm-helper-textarea');
+      ta.dispatchEvent(new CompositionEvent('compositionend', { data: '', bubbles: true }));
+      ta.value = '';
+    });
+    await new Promise((r) => setTimeout(r, 200));
+
+    const endState = await win.evaluate(() => {
+      const v = document.querySelector('.composition-view');
+      return { active: v ? v.classList.contains('active') : false };
+    });
+    if (endState.active) {
+      fail(`composition-view still .active after compositionend: ${JSON.stringify(endState)}`);
+      failures++;
+    }
+
+    if (failures === 0) {
+      console.log('[probe-e2e-ime-overflow] PASS — all containment assertions held across', STEPS);
+    } else {
+      console.error(`[probe-e2e-ime-overflow] ${failures} assertion failure(s)`);
+    }
+  } finally {
+    try { await electronApp.close(); } catch (_) { /* ignore */ }
+  }
+}
+
+main().catch((e) => {
+  console.error('[probe-e2e-ime-overflow] FAILED:', e);
+  process.exit(1);
+});

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -17,7 +17,7 @@ export function AppShell({
   main: React.ReactNode;
 }) {
   return (
-    <div className="app-shell flex h-full w-full bg-bg-app text-fg-primary">
+    <div className="app-shell flex h-full w-full min-w-0 overflow-hidden bg-bg-app text-fg-primary">
       {sidebar}
       <SidebarResizer />
       {main}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -786,3 +786,40 @@ html.theme-light ::-webkit-scrollbar-thumb:hover {
 .pane-resize-handle:focus-visible::after {
   background: var(--color-accent);
 }
+
+/*
+ * IME composition overflow guard. xterm.js 5.5.0 inflates the inline width
+ * of .xterm-helper-textarea and .composition-view to fit the composition
+ * string (measured 11200px for an 800-char run in scratch/diagnose-ime/ime.mjs).
+ * Although position:absolute, those widths propagate up to .app-shell's
+ * scrollWidth and push the sidebar off-screen.
+ *
+ * Upstream xterm.js fixes this inside CompositionHelper (PRs #5747 / #5763 —
+ * #5747's direction:rtl trick was reverted by #5763 because it broke bidi
+ * text order; the final upstream fix uses maxWidth + textarea repositioning,
+ * which we cannot replicate from CSS). PR #5747 is on milestone 7.0.0 and
+ * was NOT released in 6.0.0 (verified against the 6.0.0 tag's
+ * CompositionHelper.ts). We are pinned on 5.5.0 and apply equivalent
+ * containment at the helpers wrapper instead.
+ *
+ * .xterm-helpers from xterm.css:51-59 is position:absolute; top:0 with no
+ * width/height. We give it the terminal grid's footprint (its parent is
+ * .xterm-screen per xterm Terminal.ts:441, which is positioned and sized
+ * to the grid) so overflow:hidden has a real clip rect. contain:layout
+ * severs scrollWidth propagation per CSS Containment L2 §2.5 (Chromium
+ * since M52). We do NOT add contain:size — .xterm-helpers has no intrinsic
+ * size and size containment on a 0-sized element would produce a 0×0 clip
+ * rect that hides the composition visual entirely.
+ *
+ * Delete this rule when bumping @xterm/xterm to a release that contains
+ * PR #5747 (currently milestone 7.0.0, unreleased). The upstream fix is
+ * strictly better (tail-visible at cursor instead of head-visible
+ * truncated-at-right).
+ */
+.xterm .xterm-helpers {
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  contain: layout;
+}


### PR DESCRIPTION
## Summary

Long IME composition strings (Chinese, Japanese, Korean) push the sidebar off-screen on xterm.js 5.5.0. Two-line CSS fix, zero TS.

xterm.js 5.5.0 inflates the inline width of `.xterm-helper-textarea` and `.composition-view` to fit the composition string. Although both are `position:absolute`, their widths propagate up via scrollable overflow to `.app-shell`, displacing the `shrink-0` sidebar past the left viewport edge.

## Changes

- `src/styles/global.css` - `.xterm .xterm-helpers { overflow:hidden; contain:layout; left:0; width:100%; height:100% }` so xterm's composition subtree cannot escape the terminal grid and its scrollWidth no longer contributes to ancestors.
- `src/components/AppShell.tsx` - add `min-w-0 overflow-hidden` to the flex root, so it tracks its allotted box rather than min-content. Belt-and-braces guard against future descendants that escape their own containment.
- `scripts/probe-e2e-ime-overflow.mjs` - new e2e probe that launches real Electron, seeds a session, dispatches synthetic `compositionstart` / `compositionupdate` / `compositionend` on `.xterm-helper-textarea`, and asserts containment across n in {1, 10, 50, 200, 800}.

## Empirical (from `scratch/diagnose-ime/ime.mjs` and the new probe)

| n   | `.app-shell.scrollWidth` post-fix | `.app-shell.scrollWidth` pre-fix | `sidebar.left` post-fix | `sidebar.left` pre-fix |
| --- | ---------------------------------- | -------------------------------- | ------------------------ | ----------------------- |
| 1   | 1280                               | 1280                             | 0                        | 0                       |
| 10  | 1280                               | 1280                             | 0                        | 0                       |
| 50  | 1280                               | 1420                             | 0                        | 0                       |
| 200 | 1280                               | 3520                             | 0                        | -2240                   |
| 800 | 1280                               | 12451                            | 0                        | -11171                  |

Viewport width is 1280 throughout. Post-fix the scroll width stays clamped to the client width for every step.

## Ecosystem context

- xterm.js [PR #5747](https://github.com/xtermjs/xterm.js/pull/5747) introduced a `direction:rtl` trick that kept the tail of the composition visible at the cursor. xterm.js [PR #5763](https://github.com/xtermjs/xterm.js/pull/5763) reverted the `direction` change because it broke bidi text order. The final upstream fix lands in `CompositionHelper.ts` via `maxWidth` + textarea repositioning, which cannot be replicated from CSS alone on xterm 5.x.
- Both PRs are on milestone **7.0.0**, which is **unreleased**. xterm **6.0.0 does NOT contain the IME fix** - verified against the 6.0.0 tag's `CompositionHelper.ts`. We are pinned on 5.5.0.
- ttyd [issue #1471](https://github.com/tsl0922/ttyd/issues/1471) is the canonical ecosystem corroboration: this is a known unsolved class of bugs at the wrapper layer on xterm 5.x.

## Known UX gap (intentional)

With the wrapper-level clip we show the **head** of the composition at the cursor, tail clipped at the terminal's right edge. Upstream xterm 7's `CompositionHelper` will show the **tail** at the cursor instead, which is strictly better but depends on logic that cannot be done in CSS alone. This matches ttyd's behaviour today.

## Follow-up

**Delete the `.xterm .xterm-helpers` rule when bumping `@xterm/xterm` to a release that contains PR #5747 (currently milestone 7.0.0, unreleased)**. The comment in `global.css` flags this explicitly.

## Verification

- typecheck: pass
- lint: pass (0 errors)
- build: pass
- unit tests: 1700 pass, 0 fail
- e2e probe (`node scripts/probe-e2e-ime-overflow.mjs`): PASS - all containment assertions held across n in {1, 10, 50, 200, 800}, with `.xterm-helpers` confirmed at `overflow: hidden` + `contain: layout` and clipped to terminal host's right edge.

## Test plan

- [ ] Type long Chinese composition (>50 chars) into the chat input - sidebar stays put.
- [ ] IME candidate popup anchors at/near the cursor (not at viewport left).
- [ ] No jitter / cursor reanchor during composition.
- [ ] xterm WidthCache probes still measure correctly (regression smoke).