### PR TITLE
fix(release): atomic publish — only release when all platforms build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
 name: Release
 
 # Triggered by version tag pushes (vX.Y.Z) or manual dispatch for dry-runs.
-# Artifacts are published to a draft GitHub Release on real tag pushes only;
-# workflow_dispatch runs stop after the artifact upload so dry-runs don't
-# pollute the Releases tab.
+# Artifacts are published to a GitHub Release on real tag pushes only, and
+# only after ALL platform builds succeed (atomic publish — see the `publish`
+# job below). workflow_dispatch runs stop after the per-matrix artifact
+# upload so dry-runs don't pollute the Releases tab.
 on:
   push:
     tags:
@@ -201,11 +202,27 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      # Only create/update the GitHub Release when this was a real tag push —
-      # `workflow_dispatch` dry-runs stop at the artifact upload above so we
-      # don't pollute the Releases tab with `v0.0.0-dryrun` entries.
-      - name: Upload to GitHub Release (draft)
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+  # Atomic publish: only create/update the GitHub Release when ALL three
+  # platform builds succeeded. `needs: [build]` is implicitly all-must-pass,
+  # so a single failed matrix entry aborts this job and no partial release
+  # is surfaced to users (electron-updater's latest.yml stays consistent).
+  # Restructured from an in-matrix softprops step (which, combined with
+  # `fail-fast: false`, would publish a non-draft release from successful
+  # matrix entries even when one platform failed). See PR #1322 review.
+  publish:
+    name: publish GitHub Release
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ccsm-*
+          path: release
+          merge-multiple: true
+
+      - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           draft: false


### PR DESCRIPTION
## Summary

Follow-up to PR #1322 review feedback.

PR #1322 switched the Release workflow to publish non-draft. A cold-reviewer flagged a risk: the matrix uses `fail-fast: false`, and the `softprops/action-gh-release@v2` step ran **inside each matrix entry**. So if one of linux/mac/win failed its build, the other two would still publish their assets to the now-public Release — users on the failed platform would see an incomplete release with no installer, and `electron-updater` on that platform could misbehave (stale or missing `latest.yml`).

## What changed

- Removed the in-matrix `softprops/action-gh-release@v2` step.
- Added a new `publish` job that `needs: [build]` (implicitly all-must-succeed), runs once on `ubuntu-latest`, downloads every matrix artifact via `actions/download-artifact@v4` with `pattern: ccsm-*`, and calls `softprops/action-gh-release@v2` a single time with the full asset set.
- Same `if:` gate (`push` + tag ref) so `workflow_dispatch` dry-runs still stop after the per-matrix artifact upload and do not pollute the Releases tab.

## Why a separate job

This is the standard GitHub Actions pattern for "atomic publish across a matrix": build per-platform, upload each as a workflow artifact, then a single downstream job consumes them and publishes. Without the split, `fail-fast: false` + non-draft = partial releases, which is exactly the bug.

If a platform fails, the `publish` job is skipped — no release is created. The maintainer can re-run the failed platform job, and on success the publish job will run and create the complete release.

## Test plan

- [ ] Workflow YAML parses (validated locally with `yaml.safe_load`).
- [ ] Real tag push (next version bump) produces a single non-draft Release with all three platforms' assets.
- [ ] `workflow_dispatch` dry-run still uploads per-platform artifacts to the run and does NOT create a Release.
- [ ] Simulated single-platform failure: confirm `publish` job is skipped and no Release is created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)