### PR TITLE
fix(ime): simplify xterm-helpers containment to contain:layout only

### DIFF
--- a/scripts/harness-ime-overflow.mjs
+++ b/scripts/harness-ime-overflow.mjs
@@ -154,10 +154,6 @@ async function main() {
           );
           failures++;
         }
-        if (!/hidden/.test(metrics.helpersOverflow)) {
-          fail(`n=${n}: .xterm-helpers overflow=${metrics.helpersOverflow} (expected hidden)`);
-          failures++;
-        }
         if (!/layout/.test(metrics.helpersContain)) {
           fail(`n=${n}: .xterm-helpers contain=${metrics.helpersContain} (expected layout)`);
           failures++;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -788,38 +788,23 @@ html.theme-light ::-webkit-scrollbar-thumb:hover {
 }
 
 /*
- * IME composition overflow guard. xterm.js 5.5.0 inflates the inline width
- * of .xterm-helper-textarea and .composition-view to fit the composition
- * string (measured 11200px for an 800-char run in scratch/diagnose-ime/ime.mjs).
- * Although position:absolute, those widths propagate up to .app-shell's
- * scrollWidth and push the sidebar off-screen.
+ * IME composition overflow guard. xterm.js 5.5.0 inflates the inline width of
+ * .xterm-helper-textarea / .composition-view to fit the composition string,
+ * and although those descendants are position:absolute their scrollable
+ * overflow propagates up to .app-shell.scrollWidth (measured 1280 -> 12451)
+ * and pushes the sidebar off-screen.
  *
- * Upstream xterm.js fixes this inside CompositionHelper (PRs #5747 / #5763 —
- * #5747's direction:rtl trick was reverted by #5763 because it broke bidi
- * text order; the final upstream fix uses maxWidth + textarea repositioning,
- * which we cannot replicate from CSS). PR #5747 is on milestone 7.0.0 and
- * was NOT released in 6.0.0 (verified against the 6.0.0 tag's
- * CompositionHelper.ts). We are pinned on 5.5.0 and apply equivalent
- * containment at the helpers wrapper instead.
+ * `contain: layout` severs scrollable-overflow propagation to ancestors per
+ * CSS Containment L2 §2.5 (https://www.w3.org/TR/css-contain-2/#containment-layout).
+ * That alone restores scrollWidth to viewport width (12451 -> 1280) and is
+ * the entire fix. We deliberately do NOT set width/height/overflow: those
+ * inflate .xterm-helpers from its xterm.css-default 0x0 box to the terminal
+ * footprint, which moves the Windows TSF / OS IME anchor one row below the
+ * caret (P2 regression from the previous over-broad rule).
  *
- * .xterm-helpers from xterm.css:51-59 is position:absolute; top:0 with no
- * width/height. We give it the terminal grid's footprint (its parent is
- * .xterm-screen per xterm Terminal.ts:441, which is positioned and sized
- * to the grid) so overflow:hidden has a real clip rect. contain:layout
- * severs scrollWidth propagation per CSS Containment L2 §2.5 (Chromium
- * since M52). We do NOT add contain:size — .xterm-helpers has no intrinsic
- * size and size containment on a 0-sized element would produce a 0×0 clip
- * rect that hides the composition visual entirely.
- *
- * Delete this rule when bumping @xterm/xterm to a release that contains
- * PR #5747 (currently milestone 7.0.0, unreleased). The upstream fix is
- * strictly better (tail-visible at cursor instead of head-visible
- * truncated-at-right).
+ * Delete this rule when bumping @xterm/xterm to a release containing
+ * upstream PRs #5747 / #5763 (milestone 7.0.0, unreleased).
  */
 .xterm .xterm-helpers {
-  left: 0;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
   contain: layout;
 }


### PR DESCRIPTION
## Summary

PR #1324 added five properties to `.xterm .xterm-helpers` to clip IME composition overflow:

```css
.xterm .xterm-helpers {
  left: 0;
  width: 100%;
  height: 100%;
  overflow: hidden;
  contain: layout;
}
```

Empirical bisection (`scratch/diagnose-ime-row/scrollwidth-bisect.mjs`) shows only `contain: layout` is load-bearing for the scrollWidth gate. The other four properties are redundant, and `width:100% + height:100%` inflate `.xterm-helpers` from its xterm.css-default 0x0 box to ~1001x765 — which moves the Windows TSF / OS IME candidate window one row below the caret (P2 regression introduced by #1324).

### Bisection result (paraphrased from `scrollwidth-bisect.mjs`)

| Rule variant                                | `.app-shell.scrollWidth` (n=800) |
| ------------------------------------------- | -------------------------------- |
| no rule (pre-#1324)                         | 12451 (broken)                   |
| `contain: layout` only                      | 1280 (fixed)                     |
| `overflow: hidden` only (no contain)        | 12451 (broken)                   |
| `width/height/overflow` without `contain`   | 12451 (broken)                   |
| all five (PR #1324)                         | 1280 (fixed, but anchors IME row below caret) |

`contain: layout` severs scrollable-overflow propagation to ancestors per [CSS Containment L2 §2.5](https://www.w3.org/TR/css-contain-2/#containment-layout). With it alone, `.xterm-helpers` stays at its 0x0 default so Windows TSF / OS IME anchors at the caret — same as pre-#1324 behavior — while scrollWidth stays at viewport width.

## Why strictly better than #1324

- Same scrollWidth / sidebar-displacement protection (verified by `harness-ime-overflow.mjs`: `appShellScroll: 1280` at n=800).
- Smaller surface — only the property that actually matters.
- Restores Windows IME anchoring (P2 regression in #1324).
- `min-w-0 overflow-hidden` on `.app-shell` from #1324 is **kept** — still correct and load-bearing.

## Validation needed

This still needs user dogfood validation for the Windows IME anchoring fix. Playwright cannot drive Windows TSF / Microsoft Pinyin candidate-window positioning, so the regression cannot be auto-tested. The scrollWidth/sidebar-displacement protection IS auto-tested by `harness-ime-overflow.mjs`.

## Predecessor

- #1324 — original `.xterm-helpers` containment rule.

## Test plan

- [x] `npm run lint` — 0 errors (warnings pre-existing).
- [x] `npm run typecheck` — clean.
- [x] `npm run build` — clean.
- [x] `npm test` — all non-sqlite suites pass; 2 files fail with pre-existing `better-sqlite3` NODE_MODULE_VERSION mismatch unrelated to this change.
- [x] `node scripts/harness-ime-overflow.mjs` — PASS across n in {1, 10, 50, 200, 800}; `appShellScroll == clientWidth (1280)` at all steps with `helpersContain: 'layout'`, `helpersRight: 264` (small box).
- [ ] User dogfood on Windows 11 with Microsoft Pinyin: confirm candidate window anchors at caret, not one row below.