### PR TITLE
test(F3): strengthen 13 tautological assertions found by epistemic audit

### DIFF
--- a/tests/App.hooks.test.tsx
+++ b/tests/App.hooks.test.tsx
@@ -166,16 +166,24 @@ describe('App composition root wires extracted effect hooks (Task #732)', () => 
   it('passes the resolved language to useLanguageEffect', () => {
     render(<App />);
     const calls = (useLanguageEffect as unknown as { mock: { calls: unknown[][] } }).mock.calls;
-    expect(calls.length).toBeGreaterThan(0);
-    // First positional arg is the resolved language ('en' from stubCCSM
-    // setSystemLocale + initI18n).
-    expect(typeof calls[0][0]).toBe('string');
+    // App renders twice during boot: initial render, then a re-render
+    // triggered by a setState landing from the boot effect chain (e.g.
+    // claudeAvailable resolution, settings load). Each hook fires exactly
+    // once per render → exact count is 2, not >0. Pinning the exact count
+    // would catch a regression that adds a stray render or double-fires
+    // a hook.
+    expect(useLanguageEffect).toHaveBeenCalledTimes(2);
+    // jsdom navigator.language is 'en-US' → resolveLanguage('system', 'en-US')
+    // returns 'en'. Assert the EXACT resolved value, not just "is a string"
+    // (which would pass for '' or 'fr' — both of which would be bugs).
+    expect(calls[0][0]).toBe('en');
+    expect(calls[1][0]).toBe('en');
   });
 
   it('passes selectSession to useSessionActivateBridge', () => {
     render(<App />);
     const calls = (useSessionActivateBridge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
-    expect(calls.length).toBeGreaterThan(0);
+    expect(useSessionActivateBridge).toHaveBeenCalledTimes(2);
     expect(typeof calls[0][0]).toBe('function');
   });
 
@@ -183,8 +191,8 @@ describe('App composition root wires extracted effect hooks (Task #732)', () => 
     render(<App />);
     const updateCalls = (useUpdateDownloadedBridge as unknown as { mock: { calls: Array<Array<{ push: unknown }>> } }).mock.calls;
     const persistCalls = (usePersistErrorBridge as unknown as { mock: { calls: Array<Array<{ push: unknown }>> } }).mock.calls;
-    expect(updateCalls.length).toBeGreaterThan(0);
-    expect(persistCalls.length).toBeGreaterThan(0);
+    expect(useUpdateDownloadedBridge).toHaveBeenCalledTimes(2);
+    expect(usePersistErrorBridge).toHaveBeenCalledTimes(2);
     expect(typeof updateCalls[0][0].push).toBe('function');
     expect(typeof persistCalls[0][0].push).toBe('function');
   });
@@ -192,7 +200,7 @@ describe('App composition root wires extracted effect hooks (Task #732)', () => 
   it('passes the current theme to useThemeEffect', () => {
     render(<App />);
     const calls = (useThemeEffect as unknown as { mock: { calls: unknown[][] } }).mock.calls;
-    expect(calls.length).toBeGreaterThan(0);
+    expect(useThemeEffect).toHaveBeenCalledTimes(2);
     expect(['light', 'dark', 'system']).toContain(calls[0][0]);
   });
 });
@@ -213,17 +221,18 @@ describe('App composition root wires Phase C effect hooks (Task #758)', () => {
   it('passes activeId (string or null/empty) to useSessionActiveBridge', () => {
     render(<App />);
     const calls = (useSessionActiveBridge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
-    expect(calls.length).toBeGreaterThan(0);
-    // activeId is '' on the empty fixture; the hook accepts string|null|undefined.
-    const first = calls[0][0];
-    expect(typeof first === 'string' || first === null || first === undefined).toBe(true);
+    expect(useSessionActiveBridge).toHaveBeenCalledTimes(2);
+    // activeId is '' on the empty fixture; assert the exact value passed
+    // (the empty-string sentinel for "no active session").
+    expect(calls[0][0]).toBe('');
   });
 
   it('passes the sessions array to useSessionNameBridge', () => {
     render(<App />);
     const calls = (useSessionNameBridge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
-    expect(calls.length).toBeGreaterThan(0);
-    expect(Array.isArray(calls[0][0])).toBe(true);
+    expect(useSessionNameBridge).toHaveBeenCalledTimes(2);
+    // Empty fixture → empty sessions array.
+    expect(calls[0][0]).toEqual([]);
   });
 
   it('passes store action functions to the IPC-bridge hooks that take a callback', () => {
@@ -232,6 +241,10 @@ describe('App composition root wires Phase C effect hooks (Task #758)', () => {
     const titleCalls = (useSessionTitleBridge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
     const cwdCalls = (useCwdRedirectedBridge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
     const hydrateCalls = (useHydrateSystemLocale as unknown as { mock: { calls: unknown[][] } }).mock.calls;
+    expect(usePtyExitBridge).toHaveBeenCalledTimes(2);
+    expect(useSessionTitleBridge).toHaveBeenCalledTimes(2);
+    expect(useCwdRedirectedBridge).toHaveBeenCalledTimes(2);
+    expect(useHydrateSystemLocale).toHaveBeenCalledTimes(2);
     expect(typeof ptyCalls[0][0]).toBe('function');
     expect(typeof titleCalls[0][0]).toBe('function');
     expect(typeof cwdCalls[0][0]).toBe('function');
@@ -242,8 +255,8 @@ describe('App composition root wires Phase C effect hooks (Task #758)', () => {
     render(<App />);
     const flashCalls = (useNotifyFlashBridge as unknown as { mock: { calls: unknown[][] } }).mock.calls;
     const exitCalls = (useExitAnimation as unknown as { mock: { calls: unknown[][] } }).mock.calls;
-    expect(flashCalls.length).toBeGreaterThan(0);
-    expect(exitCalls.length).toBeGreaterThan(0);
+    expect(useNotifyFlashBridge).toHaveBeenCalledTimes(2);
+    expect(useExitAnimation).toHaveBeenCalledTimes(2);
     expect(flashCalls[0].length).toBe(0);
     expect(exitCalls[0].length).toBe(0);
   });

--- a/tests/app-effects/useCwdRedirectedBridge.test.tsx
+++ b/tests/app-effects/useCwdRedirectedBridge.test.tsx
@@ -45,8 +45,24 @@ describe('useCwdRedirectedBridge', () => {
     expect(apply).not.toHaveBeenCalled();
   });
 
-  it('is a no-op when the bridge is missing', () => {
+  it('is a no-op when the bridge is missing: never invokes apply, mount + unmount clean', () => {
     delete (window as unknown as { ccsmSession?: unknown }).ccsmSession;
-    expect(() => renderHook(() => useCwdRedirectedBridge(vi.fn()))).not.toThrow();
+    const apply = vi.fn();
+    const { unmount } = renderHook(() => useCwdRedirectedBridge(apply));
+    expect(onCwdRedirected).not.toHaveBeenCalled();
+    expect(apply).not.toHaveBeenCalled();
+    unmount();
+    // Cleanup path must not have invoked the (absent) unsubscribe spy
+    // either — the early-return guards both subscribe and teardown.
+    expect(unsubscribe).not.toHaveBeenCalled();
+    expect(apply).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when onCwdRedirected is not a function on the bridge', () => {
+    (window as unknown as { ccsmSession: unknown }).ccsmSession = { onCwdRedirected: 42 };
+    const apply = vi.fn();
+    const { unmount } = renderHook(() => useCwdRedirectedBridge(apply));
+    unmount();
+    expect(apply).not.toHaveBeenCalled();
   });
 });

--- a/tests/app-effects/useExitAnimation.test.tsx
+++ b/tests/app-effects/useExitAnimation.test.tsx
@@ -62,8 +62,32 @@ describe('useExitAnimation', () => {
     expect(document.documentElement.style.transition).toBe('');
   });
 
-  it('is a no-op when the bridge is missing', () => {
+  it('is a no-op when the bridge is missing: opacity/transition never touched', () => {
     delete (window as unknown as { ccsm?: unknown }).ccsm;
-    expect(() => renderHook(() => useExitAnimation())).not.toThrow();
+    document.documentElement.style.opacity = '';
+    document.documentElement.style.transition = '';
+    const { unmount } = renderHook(() => useExitAnimation());
+    // Without bridge, the hook returns before installing listeners; doc
+    // styles must remain untouched and the subscribe spies were never
+    // even reached.
+    expect(onBeforeHide).not.toHaveBeenCalled();
+    expect(onAfterShow).not.toHaveBeenCalled();
+    expect(document.documentElement.style.opacity).toBe('');
+    expect(document.documentElement.style.transition).toBe('');
+    unmount();
+    expect(offHide).not.toHaveBeenCalled();
+    expect(offShow).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when only one of onBeforeHide / onAfterShow is missing', () => {
+    (window as unknown as { ccsm: unknown }).ccsm = {
+      window: { onBeforeHide },
+    };
+    document.documentElement.style.opacity = '';
+    const { unmount } = renderHook(() => useExitAnimation());
+    expect(onBeforeHide).not.toHaveBeenCalled();
+    unmount();
+    expect(offHide).not.toHaveBeenCalled();
+    expect(document.documentElement.style.opacity).toBe('');
   });
 });

--- a/tests/app-effects/useLanguageEffect.test.tsx
+++ b/tests/app-effects/useLanguageEffect.test.tsx
@@ -32,8 +32,26 @@ describe('useLanguageEffect', () => {
     expect(setLanguage).toHaveBeenCalledTimes(2);
   });
 
-  it('is a no-op when the preload bridge is missing', () => {
+  it('is a no-op when the preload bridge is missing: setLanguage never called', () => {
+    // Capture the spy reference first, then delete the bridge. The hook
+    // optional-chains through `window.ccsm?.i18n?.setLanguage`, so the
+    // captured spy should never be invoked after the delete.
+    const capturedSpy = setLanguage;
     delete (window as unknown as { ccsm?: unknown }).ccsm;
-    expect(() => renderHook(() => useLanguageEffect('en'))).not.toThrow();
+    const { rerender, unmount } = renderHook(
+      ({ lang }: { lang: string }) => useLanguageEffect(lang as 'en' | 'zh'),
+      { initialProps: { lang: 'en' } }
+    );
+    expect(capturedSpy).not.toHaveBeenCalled();
+    rerender({ lang: 'zh' });
+    expect(capturedSpy).not.toHaveBeenCalled();
+    unmount();
+    expect(capturedSpy).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when ccsm.i18n is missing (partial bridge)', () => {
+    (window as unknown as { ccsm: unknown }).ccsm = {};
+    renderHook(() => useLanguageEffect('en'));
+    expect(setLanguage).not.toHaveBeenCalled();
   });
 });

--- a/tests/app-effects/useNotifyFlashBridge.test.tsx
+++ b/tests/app-effects/useNotifyFlashBridge.test.tsx
@@ -47,8 +47,19 @@ describe('useNotifyFlashBridge', () => {
     expect(setFlashSpy).not.toHaveBeenCalled();
   });
 
-  it('is a no-op when the bridge is missing', () => {
+  it('is a no-op when the bridge is missing: subscribe + store action never called', () => {
     delete (window as unknown as { ccsmNotify?: unknown }).ccsmNotify;
-    expect(() => renderHook(() => useNotifyFlashBridge())).not.toThrow();
+    const { unmount } = renderHook(() => useNotifyFlashBridge());
+    expect(onFlash).not.toHaveBeenCalled();
+    expect(setFlashSpy).not.toHaveBeenCalled();
+    unmount();
+    expect(unsubscribe).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when onFlash is not a function on the bridge', () => {
+    (window as unknown as { ccsmNotify: unknown }).ccsmNotify = { onFlash: 'nope' };
+    const { unmount } = renderHook(() => useNotifyFlashBridge());
+    unmount();
+    expect(setFlashSpy).not.toHaveBeenCalled();
   });
 });

--- a/tests/app-effects/usePtyExitBridge.test.tsx
+++ b/tests/app-effects/usePtyExitBridge.test.tsx
@@ -46,8 +46,21 @@ describe('usePtyExitBridge', () => {
     expect(apply).not.toHaveBeenCalled();
   });
 
-  it('is a no-op when the bridge is missing', () => {
+  it('is a no-op when the bridge is missing: subscribe + apply never called', () => {
     delete (window as unknown as { ccsmPty?: unknown }).ccsmPty;
-    expect(() => renderHook(() => usePtyExitBridge(vi.fn()))).not.toThrow();
+    const apply = vi.fn();
+    const { unmount } = renderHook(() => usePtyExitBridge(apply));
+    expect(onExit).not.toHaveBeenCalled();
+    expect(apply).not.toHaveBeenCalled();
+    unmount();
+    expect(unsubscribe).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when ccsmPty.onExit is missing on a partial bridge', () => {
+    (window as unknown as { ccsmPty: unknown }).ccsmPty = {};
+    const apply = vi.fn();
+    const { unmount } = renderHook(() => usePtyExitBridge(apply));
+    unmount();
+    expect(apply).not.toHaveBeenCalled();
   });
 });

--- a/tests/app-effects/useSessionActiveBridge.test.tsx
+++ b/tests/app-effects/useSessionActiveBridge.test.tsx
@@ -39,8 +39,23 @@ describe('useSessionActiveBridge', () => {
     expect(setActive).toHaveBeenNthCalledWith(2, 'b');
   });
 
-  it('is a no-op when the bridge is missing', () => {
+  it('is a no-op when the bridge is missing: setActive never called', () => {
+    const capturedSpy = setActive;
     delete (window as unknown as { ccsmSession?: unknown }).ccsmSession;
-    expect(() => renderHook(() => useSessionActiveBridge('x'))).not.toThrow();
+    const { rerender, unmount } = renderHook(
+      ({ id }: { id: string | null }) => useSessionActiveBridge(id),
+      { initialProps: { id: 'x' as string | null } }
+    );
+    expect(capturedSpy).not.toHaveBeenCalled();
+    rerender({ id: 'y' });
+    expect(capturedSpy).not.toHaveBeenCalled();
+    unmount();
+    expect(capturedSpy).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when bridge.setActive is not a function', () => {
+    (window as unknown as { ccsmSession: unknown }).ccsmSession = { setActive: null };
+    renderHook(() => useSessionActiveBridge('x'));
+    expect(setActive).not.toHaveBeenCalled();
   });
 });

--- a/tests/app-effects/useSessionTitleBridge.test.tsx
+++ b/tests/app-effects/useSessionTitleBridge.test.tsx
@@ -45,8 +45,21 @@ describe('useSessionTitleBridge', () => {
     expect(apply).not.toHaveBeenCalled();
   });
 
-  it('is a no-op when the bridge is missing', () => {
+  it('is a no-op when the bridge is missing: subscribe + apply never called', () => {
     delete (window as unknown as { ccsmSession?: unknown }).ccsmSession;
-    expect(() => renderHook(() => useSessionTitleBridge(vi.fn()))).not.toThrow();
+    const apply = vi.fn();
+    const { unmount } = renderHook(() => useSessionTitleBridge(apply));
+    expect(onTitle).not.toHaveBeenCalled();
+    expect(apply).not.toHaveBeenCalled();
+    unmount();
+    expect(unsubscribe).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when onTitle is not a function on the bridge', () => {
+    (window as unknown as { ccsmSession: unknown }).ccsmSession = { onTitle: undefined };
+    const apply = vi.fn();
+    const { unmount } = renderHook(() => useSessionTitleBridge(apply));
+    unmount();
+    expect(apply).not.toHaveBeenCalled();
   });
 });

--- a/tests/claude-probe-race-900.test.tsx
+++ b/tests/claude-probe-race-900.test.tsx
@@ -162,7 +162,10 @@ describe('claude-probe race gate (#900 / #852)', () => {
       fireEvent.click(newBtn);
     });
 
-    expect(useStore.getState().sessions.length).toBeGreaterThan(0);
+    const sessions = useStore.getState().sessions;
+    // Exactly one new session was created by the single newBtn click.
+    expect(sessions).toHaveLength(1);
+    expect(useStore.getState().activeId).toBe(sessions[0].id);
   });
 
   it('probing-spacer surfaces a visible "Checking Claude CLI…" affordance', async () => {
@@ -264,7 +267,9 @@ describe('claude-probe race gate (#900 / #852)', () => {
 
     expect(pickCwd).toHaveBeenCalledTimes(1);
     const sessions = useStore.getState().sessions;
-    expect(sessions.length).toBeGreaterThan(0);
+    // Exactly one session was created via the chevron path.
+    expect(sessions).toHaveLength(1);
     expect(sessions[0].cwd).toBe('/picked/path');
+    expect(useStore.getState().activeId).toBe(sessions[0].id);
   });
 });

--- a/tests/command-palette.test.tsx
+++ b/tests/command-palette.test.tsx
@@ -97,7 +97,9 @@ describe('<CommandPalette /> empty / no-matches / kbd hints', () => {
     const input = within(dialog).getByPlaceholderText(/Search/i);
     fireEvent.change(input, { target: { value: 'alpha' } });
     const options = within(dialog).getAllByRole('option');
-    expect(options.length).toBeGreaterThanOrEqual(1);
+    // Seeded exactly one session whose name matches 'alpha'.
+    expect(options.length).toBe(1);
+    expect(options[0].textContent || '').toMatch(/Alpha session/);
     expect(within(dialog).getByText(/Alpha session/)).toBeInTheDocument();
   });
 
@@ -139,9 +141,12 @@ describe('<CommandPalette /> keyboard navigation', () => {
     const input = within(dialog).getByPlaceholderText(/Search/i) as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'session' } });
 
-    // After typing, expect ≥2 option rows; first is active.
+    // After typing 'session', expect 3 option rows: the two seeded
+    // sessions ('session alpha', 'session bravo') AND the default group
+    // 'Sessions' (group label contains the substring). The first option
+    // is active by default.
     let options = within(dialog).getAllByRole('option');
-    expect(options.length).toBeGreaterThanOrEqual(2);
+    expect(options.length).toBe(3);
     expect(options[0].getAttribute('aria-selected')).toBe('true');
 
     // ArrowDown → index 1 active.
@@ -192,7 +197,10 @@ describe('<CommandPalette /> keyboard navigation', () => {
     const input = within(dialog).getByPlaceholderText(/Search/i) as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'enter' } });
     const options = within(dialog).getAllByRole('option');
-    expect(options.length).toBeGreaterThanOrEqual(1);
+    // Only the seeded 'enter target' session matches 'enter'; no command
+    // label/hint and no group name contains the substring.
+    expect(options.length).toBe(1);
+    expect(options[0].textContent || '').toMatch(/enter target/);
     fireEvent.keyDown(input, { key: 'Enter' });
     expect(onSelect).toHaveBeenCalledWith('s-enter');
     // Dialog should have unmounted as a side effect of the selection.

--- a/tests/commands-loader.test.ts
+++ b/tests/commands-loader.test.ts
@@ -192,7 +192,12 @@ describe('loadCommands', () => {
       `---\n---\n`
     );
     // No skills dir created.
-    expect(() => loadCommands({ homeDir: tmpHome, cwd: tmpCwd })).not.toThrow();
+    const cmds = loadCommands({ homeDir: tmpHome, cwd: tmpCwd });
+    // Loader must still return the command from ~/.claude/commands, AND
+    // contribute zero skill entries (sentinel: missing dir → empty bucket,
+    // not a throw, not a partial result that drops `a`).
+    expect(cmds.map((c) => c.name)).toEqual(['a']);
+    expect(cmds.find((c) => c.source === 'skill')).toBeUndefined();
   });
 
   it('skips files with invalid basename or declared name', () => {
@@ -347,8 +352,11 @@ describe('loadCommands', () => {
       path.join(tmpHome, '.claude', 'commands', 'plain.md'),
       `---\n---\n`
     );
-    expect(() => loadCommands({ homeDir: tmpHome, cwd: tmpCwd })).not.toThrow();
+    // Loader must return the plain command AND contribute zero agent
+    // entries — sentinel for "missing dir → empty bucket", not a throw
+    // and not a partial result that drops `plain`.
     const cmds = loadCommands({ homeDir: tmpHome, cwd: tmpCwd });
+    expect(cmds.map((c) => c.name)).toContain('plain');
     expect(cmds.find((c) => c.source === 'agent')).toBeUndefined();
   });
 


### PR DESCRIPTION
## Summary

Strengthens 13 tautological assertions found by an epistemic audit:

**Gap A (7 app-effect hook tests)** — replaced `.not.toThrow()` smoke tests on the "bridge missing" cases with assertions on observable behavior: subscribe spies never called, cleanup path never invokes the (absent) unsubscribe, applied callbacks / store actions never fired. Added sibling "partial bridge" cases (bridge object present but the relevant method missing / non-function) to each file.

Files: `tests/app-effects/{useCwdRedirectedBridge,useExitAnimation,useLanguageEffect,useNotifyFlashBridge,usePtyExitBridge,useSessionActiveBridge,useSessionTitleBridge}.test.tsx`.

**Gap B (3 files)** — replaced loose `>0` / `>=1` / `>=2` counts:
- `App.hooks.test.tsx`: `toHaveBeenCalledTimes(2)` exact counts (App boots with 2 renders; each hook fires exactly once per render — pins both stray-render and double-fire regressions). `typeof === 'string'` for resolved language replaced with `toBe('en')`. `isArray` replaced with `toEqual([])` for the empty fixture.
- `command-palette.test.tsx`: 3 `>=` checks replaced with exact `toBe(N)` (3 for 'session' query — two sessions + 'Sessions' group label match; 1 for 'enter' / 'alpha').
- `claude-probe-race-900.test.tsx`: `sessions.length > 0` replaced with `toHaveLength(1)` + activeId assertion. The race-gate flow creates exactly one session per click; the loose check would silently pass a double-create regression.

**commands-loader.test.ts (2 cases)** — "tolerates missing skills dir" and "tolerates missing agents directories on both sides" no longer call the loader twice (once in `.not.toThrow()`, once for the real assertion). Each now asserts the documented sentinel: surviving non-skill/non-agent commands are returned AND zero entries contributed for the missing bucket.

No production code changed.

## Mutation sanity check

Temporarily neutralized `useNotifyFlashBridge`'s `useEffect` body to a bare `return;`. The new test file went from 5 passing to 3 failing (subscribe + cleanup, forward-events, ignore-malformed). Reverted; `git diff src/` is empty.

## What I did NOT fix

Nothing surfaced. The honest observation about `App.hooks.test.tsx` is that the App composition root re-renders exactly twice on boot (initial + a setState landing from the boot-effect chain). That is the documented behavior, not a bug — captured in the test comment so a future stray render gets caught.

## Test plan

- [x] typecheck clean (0 errors)
- [x] lint clean (0 errors; pre-existing warnings unchanged)
- [x] all touched test files pass (112/112, up from 105 because the strengthened tests added 7 new sibling cases)
- [x] mutation check on `useNotifyFlashBridge` proves assertions discriminate

Generated with [Claude Code](https://claude.com/claude-code)