### PR TITLE
test(e2e): run harness-real-cli-ci in CI against fake Anthropic API

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -99,16 +99,24 @@ jobs:
         run: npx electron-rebuild
       - name: Build
         run: npm run build
+      # Install the real `claude` binary so `harness-real-cli-ci` can drive
+      # it (the full `harness-real-cli` stays skipped — only the curated CI
+      # subset runs here). The full harness asserts on LLM-generated reply
+      # content and would need real Anthropic credentials; the CI subset is
+      # picked to avoid that and points the binary at a localhost fake
+      # Anthropic Messages API that the CI harness spins up in-process.
+      - name: Install claude CLI globally
+        run: npm i -g @anthropic-ai/claude-code
+      - name: Verify claude binary
+        run: claude --version
       - name: Run e2e (Linux with xvfb)
         if: runner.os == 'Linux'
-        # E2E_SKIP=harness-real-cli,harness-ime-overflow — public CI runners
-        # have no `claude` CLI installed AND no Anthropic auth tokens, so
-        # every harness that calls waitForTerminalReady deterministically
-        # times out (the renderer falls through to ClaudeMissingGuide and
-        # never mounts <TerminalPane>). Both harnesses stay runnable locally
-        # via `node scripts/harness-*.mjs` (or `npm run probe:e2e` without
-        # the env var) for the dev / dogfood loop, where the user's
-        # ~/.claude is real. (#726, #1324)
+        # E2E_SKIP=harness-real-cli,harness-ime-overflow — the full real-cli
+        # harness stays skipped because its remaining cases assert on real
+        # LLM reply content (ALPHA / PONG / 180s notify waits etc.) which
+        # the CI fake API cannot satisfy deterministically. The CI subset
+        # in `harness-real-cli-ci.mjs` runs the cases that don't need real
+        # model responses. `harness-ime-overflow` stays skipped per #1324.
         run: xvfb-run -a npm run probe:e2e
         env:
           E2E_SKIP: harness-real-cli,harness-ime-overflow

--- a/scripts/fixtures/fake-anthropic-api.mjs
+++ b/scripts/fixtures/fake-anthropic-api.mjs
@@ -1,0 +1,293 @@
+// Fake Anthropic Messages API server for CI.
+//
+// Why this exists:
+//   `scripts/harness-real-cli-ci.mjs` runs a subset of the real-CLI harness
+//   against the real `claude` binary in CI. We can't fake the binary (the
+//   harness reads claude's TUI byte-for-byte), but we MUST fake the network
+//   so CI doesn't need Anthropic credentials.
+//
+//   The CI subset is curated to AVOID assertions on LLM-generated content
+//   (so we don't depend on the fake's reply quality), but `claude` may
+//   still hit the API for auth probes, model availability, or stray chat
+//   requests when the harness types Enter into the TUI. This server
+//   handles all of those:
+//
+//   - POST /v1/messages           : streaming SSE chat completion. Content
+//                                   chosen from the prompt: if the user's
+//                                   last message asks for "ALPHA" we reply
+//                                   ALPHA; for "PONG" we reply PONG; for
+//                                   "ack" we reply ack; otherwise "ok".
+//   - GET  /v1/models             : minimal models list (some claude code
+//                                   builds probe this to enumerate available
+//                                   models on cold start).
+//   - any other path              : 200 OK + empty JSON, logged to stderr
+//                                   so a future case extension knows what
+//                                   to add.
+//
+// Wire format reference:
+//   https://docs.anthropic.com/en/api/messages-streaming
+//   Events: message_start, content_block_start, content_block_delta
+//           (text_delta), content_block_stop, message_delta, message_stop.
+//   Each event is `event: <name>\ndata: <json>\n\n`.
+//
+// Usage (standalone, e.g. for local repro):
+//   node scripts/fixtures/fake-anthropic-api.mjs --port=11434
+//   ANTHROPIC_BASE_URL=http://127.0.0.1:11434 \
+//     ANTHROPIC_API_KEY=fake-ci-key claude
+//
+// Usage (programmatic — used by harness-real-cli-ci.mjs):
+//   import { startFakeAnthropicApi } from './fixtures/fake-anthropic-api.mjs';
+//   const { url, port, stop } = await startFakeAnthropicApi({ port: 0 });
+//
+// Implementation notes:
+//   - Node stdlib only (`http`, `crypto`). No new deps.
+//   - Binds 127.0.0.1, never 0.0.0.0 — safer on CI hosts.
+//   - Port 0 = OS-assigned (use the returned `port`); fixed port is for
+//     the standalone mode only.
+//   - All responses log to stderr with a `[fake-anthropic]` prefix so they
+//     don't contaminate harness stdout.
+
+import { createServer } from 'node:http';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * Pick a reply text from the last user message. Content-aware so the
+ * harness can assert on specific tokens without us needing to extend the
+ * server every time a new probe asks for a new word. The matchers are
+ * case-insensitive and look at the LAST user message (which is what
+ * claude code sends — earlier turns are history).
+ */
+function chooseReply(messages) {
+  const last = Array.isArray(messages)
+    ? [...messages].reverse().find((m) => m && m.role === 'user')
+    : null;
+  const raw = last
+    ? (typeof last.content === 'string'
+        ? last.content
+        : Array.isArray(last.content)
+          ? last.content.map((c) => (c && typeof c.text === 'string' ? c.text : '')).join(' ')
+          : '')
+    : '';
+  const text = raw.toLowerCase();
+  // Order matters: longer / more specific tokens first.
+  if (text.includes('alpha')) return 'ALPHA';
+  if (text.includes('pong')) return 'PONG';
+  if (text.includes('pineapple')) return 'PROBE_IMPORT_PINEAPPLE acknowledged';
+  if (/\back\b/.test(text) || text.includes('reply with: ack')) return 'ack';
+  if (text.includes('beta')) return 'BETA';
+  if (text.includes('omega')) return 'OMEGA';
+  return 'ok';
+}
+
+function sseLine(event, data) {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+function writeSSEResponse(res, replyText, model) {
+  const messageId = `msg_${randomUUID().replace(/-/g, '').slice(0, 24)}`;
+  const usage = { input_tokens: 1, output_tokens: Math.max(1, replyText.length) };
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+  });
+  res.write(sseLine('message_start', {
+    type: 'message_start',
+    message: {
+      id: messageId,
+      type: 'message',
+      role: 'assistant',
+      model: model || 'claude-sonnet-4-5-20250929',
+      content: [],
+      stop_reason: null,
+      stop_sequence: null,
+      usage: { input_tokens: usage.input_tokens, output_tokens: 0 },
+    },
+  }));
+  res.write(sseLine('content_block_start', {
+    type: 'content_block_start',
+    index: 0,
+    content_block: { type: 'text', text: '' },
+  }));
+  // Single-chunk delta is the minimum viable streaming output. claude code's
+  // SSE parser handles single-chunk OR multi-chunk deltas identically; we
+  // pick single-chunk for determinism.
+  res.write(sseLine('content_block_delta', {
+    type: 'content_block_delta',
+    index: 0,
+    delta: { type: 'text_delta', text: replyText },
+  }));
+  res.write(sseLine('content_block_stop', {
+    type: 'content_block_stop',
+    index: 0,
+  }));
+  res.write(sseLine('message_delta', {
+    type: 'message_delta',
+    delta: { stop_reason: 'end_turn', stop_sequence: null },
+    usage: { output_tokens: usage.output_tokens },
+  }));
+  res.write(sseLine('message_stop', { type: 'message_stop' }));
+  res.end();
+}
+
+function jsonResponse(res, status, body) {
+  const buf = Buffer.from(JSON.stringify(body));
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Content-Length': buf.length,
+  });
+  res.end(buf);
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let total = 0;
+    req.on('data', (c) => {
+      chunks.push(c);
+      total += c.length;
+      // Sanity cap so a misbehaving client can't OOM the server.
+      if (total > 4 * 1024 * 1024) {
+        req.destroy(new Error('request body too large'));
+      }
+    });
+    req.on('end', () => {
+      try {
+        const raw = Buffer.concat(chunks).toString('utf8');
+        resolve(raw.length === 0 ? {} : JSON.parse(raw));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+/**
+ * Start the fake server. Returns { url, port, stop }.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.port=0]    Port to bind (0 = OS-assigned).
+ * @param {string} [opts.host='127.0.0.1']
+ * @param {boolean} [opts.verbose=false]  Log every request.
+ */
+export async function startFakeAnthropicApi(opts = {}) {
+  const { port = 0, host = '127.0.0.1', verbose = false } = opts;
+
+  const server = createServer(async (req, res) => {
+    const reqUrl = req.url || '/';
+    // Strip query string for routing — `?beta=...` etc.
+    const pathname = reqUrl.split('?')[0];
+    const method = req.method || 'GET';
+    if (verbose) {
+      process.stderr.write(`[fake-anthropic] ${method} ${reqUrl}\n`);
+    }
+
+    try {
+      // Streaming chat completion.
+      if (method === 'POST' && pathname === '/v1/messages') {
+        const body = await readBody(req).catch(() => ({}));
+        const stream = body && body.stream !== false; // claude code always streams
+        const reply = chooseReply(body && body.messages);
+        const model = body && typeof body.model === 'string' ? body.model : null;
+        if (verbose) {
+          process.stderr.write(`[fake-anthropic]   reply=${JSON.stringify(reply)}\n`);
+        }
+        if (stream) {
+          writeSSEResponse(res, reply, model);
+        } else {
+          // Non-streaming fallback. Matches the Anthropic non-stream shape.
+          jsonResponse(res, 200, {
+            id: `msg_${randomUUID().replace(/-/g, '').slice(0, 24)}`,
+            type: 'message',
+            role: 'assistant',
+            model: model || 'claude-sonnet-4-5-20250929',
+            content: [{ type: 'text', text: reply }],
+            stop_reason: 'end_turn',
+            stop_sequence: null,
+            usage: { input_tokens: 1, output_tokens: reply.length },
+          });
+        }
+        return;
+      }
+
+      // Minimal models list. Some claude code builds enumerate models on
+      // first launch; returning an empty data array is enough to satisfy
+      // the parser without us guessing the full per-model shape.
+      if (method === 'GET' && pathname === '/v1/models') {
+        jsonResponse(res, 200, { data: [], has_more: false, first_id: null, last_id: null });
+        return;
+      }
+
+      // Default catch-all: 200 + {} so the CLI never crashes on an unknown
+      // probe path. Log so a future case extension can grep the CI logs
+      // and add a real handler. NOT 404 because some clients treat 404 as
+      // fatal even when the body is well-formed.
+      process.stderr.write(`[fake-anthropic] UNKNOWN ${method} ${reqUrl} -> 200 {}\n`);
+      jsonResponse(res, 200, {});
+    } catch (err) {
+      process.stderr.write(`[fake-anthropic] error handling ${method} ${reqUrl}: ${err?.stack || err}\n`);
+      try {
+        jsonResponse(res, 500, { type: 'error', error: { type: 'fake_internal', message: String(err) } });
+      } catch (_) { /* socket may already be dead */ }
+    }
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, () => resolve());
+  });
+  const addr = server.address();
+  const actualPort = typeof addr === 'object' && addr ? addr.port : port;
+  const url = `http://${host}:${actualPort}`;
+
+  let stopped = false;
+  const stop = () => {
+    if (stopped) return Promise.resolve();
+    stopped = true;
+    return new Promise((resolve) => {
+      try {
+        server.closeAllConnections?.();
+      } catch (_) { /* node <18.2 */ }
+      server.close(() => resolve());
+    });
+  };
+
+  process.stderr.write(`[fake-anthropic] listening at ${url}\n`);
+  return { url, port: actualPort, stop, server };
+}
+
+// Standalone entry point: `node scripts/fixtures/fake-anthropic-api.mjs --port=11434 --verbose`
+// Only auto-run if argv[1] is present AND resolves to this file. When the
+// module is imported (e.g. by `harness-real-cli-ci.mjs`) argv[1] is the
+// importer's path, not ours, so the standalone block stays dormant.
+const _entry = process.argv[1];
+const _isMain = !!_entry && (() => {
+  try {
+    return new URL(`file://${_entry.replace(/\\/g, '/')}`).href === import.meta.url;
+  } catch {
+    return false;
+  }
+})();
+if (_isMain) {
+  const args = process.argv.slice(2);
+  let port = 11434;
+  let verbose = false;
+  for (const a of args) {
+    if (a.startsWith('--port=')) port = Number(a.slice('--port='.length));
+    else if (a === '--verbose') verbose = true;
+  }
+  startFakeAnthropicApi({ port, verbose }).then(({ url, stop }) => {
+    process.stderr.write(`[fake-anthropic] ready at ${url}\n`);
+    const onSignal = async (sig) => {
+      process.stderr.write(`[fake-anthropic] received ${sig}, shutting down\n`);
+      await stop();
+      process.exit(0);
+    };
+    process.on('SIGINT', () => onSignal('SIGINT'));
+    process.on('SIGTERM', () => onSignal('SIGTERM'));
+  }).catch((err) => {
+    process.stderr.write(`[fake-anthropic] failed to start: ${err?.stack || err}\n`);
+    process.exit(1);
+  });
+}

--- a/scripts/harness-real-cli-ci.mjs
+++ b/scripts/harness-real-cli-ci.mjs
@@ -1,0 +1,306 @@
+// CI-runnable subset of `scripts/harness-real-cli.mjs`.
+//
+// Background:
+//   The full `harness-real-cli.mjs` runs ~27 cases against a real `claude`
+//   binary. About half of them depend on the LLM producing a real assistant
+//   reply (the harness asserts on tokens like ALPHA / PONG / specific
+//   counter signals from notify-pipeline waits of 180s+ etc.). Running
+//   those in CI against any fake API is fragile, and the cumulative
+//   wall-clock blows past `run-all-e2e.mjs`'s `HARNESS_TIMEOUT_MS = 5min`.
+//
+//   This file runs ONLY the cases that:
+//     (a) never assert on LLM-generated content, AND
+//     (b) finish within ~5min total against a stubbed Anthropic API.
+//
+//   The full harness stays unchanged and dogfood-only (still in
+//   `E2E_SKIP=harness-real-cli` in `.github/workflows/e2e.yml`). Cases
+//   excluded from CI keep running locally via the full harness — the
+//   dev / dogfood loop does not change.
+//
+// What this file does:
+//   1. Starts the fake Anthropic API server (`scripts/fixtures/fake-anthropic-api.mjs`).
+//   2. Imports `CASE_REGISTRY` from the full harness — NO copy-paste of
+//      case logic. Filters to the CI subset by name; standalone cases
+//      (reopen-resume, pty-subtree-killed-on-quit) are NOT in the subset.
+//   3. Calls `createIsolatedClaudeDir` + pre-seeds a minimal onboarding
+//      `.claude.json` so claude does not block at the trust dialog.
+//   4. Calls `launchCcsmIsolated` with `ANTHROPIC_BASE_URL` /
+//      `ANTHROPIC_API_KEY` pointed at the fake server, so any stray API
+//      probe (auth check, model list, accidentally-submitted prompt)
+//      lands on our stub instead of a real outbound network call.
+//   5. Runs each selected case against the shared launch, summarizes,
+//      exits non-zero on any failure.
+//
+// Subset (11 cases):
+//   - agent-icon-active-session-no-halo
+//   - cwd-picker-no-shortcut
+//   - sidebar-group-no-newsession-cluster
+//   - notify-name-cleared-on-session-delete
+//   - cwd-picker-top-default
+//   - cwd-picker-top-chevron
+//   - cwd-picker-browse
+//   - caseSpacesInCwdSpawnsCorrectly
+//   - pty-pid-stable-across-switch
+//   - new-session-focus-cli
+//   - attach-replay-from-headless-buffer
+//
+// Excluded cases (with reason):
+//   - new-session-chat                : asserts on LLM reply content
+//   - switch-session-keeps-chat       : asserts on "ALPHA" reply
+//   - cwd-projects-claude             : asserts on "PONG" reply
+//   - session-rename-writes-jsonl     : needs real chat → JSONL writeback
+//   - session-title-syncs-from-jsonl  : 210s wait for SDK title derivation
+//   - session-state-becomes-idle      : depends on real running→idle transition
+//   - notify-fires-on-idle            : 180s notify wait
+//   - notify-shows-session-name       : 180s notify wait
+//   - notify-pipeline-foreground      : 180s notify wait
+//   - notify-pipeline-background      : 180s notify wait
+//   - caseBadgeFiresAndClearsOnFocus  : 180s notify wait
+//   - import-resume                   : asserts on PROBE_FOLLOWUP reply
+//   - import-lands-in-focused-group   : depends on `import-resume` running
+//                                       first to warm the `scanImportable`
+//                                       cache. Without that primer, the
+//                                       10s in-case poll loop times out
+//                                       on cold cache (verified locally
+//                                       2026-05-23 — failed with "cache
+//                                       never reflected seeded JSONLs").
+//                                       Not a real regression; covered by
+//                                       the full harness in dogfood.
+//   - alt-screen-fits-visible-viewport: asserts on claude's Welcome /
+//                                       trust panel rendering at the
+//                                       resized viewport width; with
+//                                       `hasCompletedOnboarding: true`
+//                                       the welcome panel may not render
+//                                       and the case fails the border
+//                                       detection. Tied to onboarding
+//                                       visual state, not a CCSM bug.
+//   - reopen-resume                   : standalone, asserts on SECRET_TOKEN
+//                                       cross-restart reply
+//   - pty-subtree-killed-on-quit      : standalone (own Electron launch);
+//                                       could fit time-wise but its
+//                                       second Electron boot exceeds the
+//                                       shared-launch budget structure
+//
+// Run locally:
+//   node scripts/harness-real-cli-ci.mjs                # all CI subset
+//   node scripts/harness-real-cli-ci.mjs --only=agent-icon-active-session-no-halo
+
+import { existsSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+import { CASE_REGISTRY } from './harness-real-cli.mjs';
+import { createIsolatedClaudeDir, launchCcsmIsolated } from './probe-utils-real-cli.mjs';
+import { startFakeAnthropicApi } from './fixtures/fake-anthropic-api.mjs';
+
+// ============================================================================
+// Subset selection
+// ============================================================================
+
+const CI_SUBSET = new Set([
+  'agent-icon-active-session-no-halo',
+  'cwd-picker-no-shortcut',
+  'sidebar-group-no-newsession-cluster',
+  'notify-name-cleared-on-session-delete',
+  'cwd-picker-top-default',
+  'cwd-picker-top-chevron',
+  'cwd-picker-browse',
+  'caseSpacesInCwdSpawnsCorrectly',
+  'pty-pid-stable-across-switch',
+  'new-session-focus-cli',
+  'attach-replay-from-headless-buffer',
+]);
+
+// ============================================================================
+// Args
+// ============================================================================
+
+function parseArgs(argv) {
+  const out = { only: null, skip: null };
+  for (const arg of argv.slice(2)) {
+    if (arg.startsWith('--only=')) {
+      out.only = arg.slice('--only='.length).split(',').map((s) => s.trim()).filter(Boolean);
+    } else if (arg.startsWith('--skip=')) {
+      out.skip = arg.slice('--skip='.length).split(',').map((s) => s.trim()).filter(Boolean);
+    } else if (arg === '--help' || arg === '-h') {
+      console.log('Usage: node scripts/harness-real-cli-ci.mjs [--only=...] [--skip=...]');
+      console.log('CI subset cases:');
+      for (const n of CI_SUBSET) console.log('  -', n);
+      process.exit(0);
+    }
+  }
+  return out;
+}
+
+// ============================================================================
+// Onboarding pre-seed
+// ============================================================================
+
+/**
+ * Drop a minimal `.claude.json` into the isolated tempdir so claude does
+ * NOT block at the first-run trust dialog when it spawns in CI.
+ *
+ * Empirically (claude v2.x), the keys that matter are:
+ *   - `hasCompletedOnboarding` : skips the welcome / onboarding flow
+ *   - `bypassPermissionsModeAccepted` : skips bypass-permissions notice
+ *   - `projects[<cwd>].hasTrustDialogAccepted` : skips per-folder trust
+ *
+ * The per-folder trust list is dynamic — probes spawn sessions in various
+ * tempdirs / project subdirs we cannot enumerate up-front. We therefore
+ * pre-seed only the global flags here; cases that need to trust a specific
+ * directory (e.g. `caseImportResume`, not in the CI subset) extend the
+ * file themselves. The cases in the CI subset either:
+ *   - never spawn a pty (pure UI/store cases), OR
+ *   - spawn a pty but rely on `dismissFirstRunModals` (probe-utils:583) to
+ *     handle whatever trust prompt is left. With the global flags set,
+ *     claude's trust prompt for unknown folders appears once per cwd and
+ *     `dismissFirstRunModals` clears it within its 12-iteration budget.
+ */
+function seedMinimalOnboarding(tempDir) {
+  const claudeJsonPath = path.join(tempDir, '.claude.json');
+  const cfg = {
+    hasCompletedOnboarding: true,
+    bypassPermissionsModeAccepted: true,
+    // `projects` is keyed by cwd; cases that need a specific entry add
+    // it themselves. Empty object is a safe default.
+    projects: {},
+  };
+  writeFileSync(claudeJsonPath, JSON.stringify(cfg, null, 2));
+  // ALWAYS overwrite `settings.json` with `{}` so any inherited `env` block
+  // (e.g. the local dev's Agent Maestro proxy `ANTHROPIC_BASE_URL` that
+  // `createIsolatedClaudeDir` helpfully copied from `~/.claude/settings.json`)
+  // does not shadow the process-level env vars we set in `launchCcsmIsolated`.
+  // CI runners don't have a settings.json so the copy step is a no-op there;
+  // this matters only for local repros where the harness is run from a
+  // developer machine.
+  const settingsPath = path.join(tempDir, 'settings.json');
+  writeFileSync(settingsPath, JSON.stringify({}, null, 2));
+  // Same story for `settings.local.json` — `createIsolatedClaudeDir`
+  // copies it too, and it can contain its own `env` block.
+  const localSettingsPath = path.join(tempDir, 'settings.local.json');
+  writeFileSync(localSettingsPath, JSON.stringify({}, null, 2));
+}
+
+// ============================================================================
+// Runner
+// ============================================================================
+
+async function main() {
+  const { only, skip } = parseArgs(process.argv);
+
+  // Sanity: every entry in CI_SUBSET must exist in the full registry.
+  const registryByName = new Map(CASE_REGISTRY.map((c) => [c.name, c]));
+  const missing = [...CI_SUBSET].filter((n) => !registryByName.has(n));
+  if (missing.length > 0) {
+    console.error(`[HARNESS-CI] CI subset references unknown cases: ${missing.join(', ')}`);
+    console.error(`[HARNESS-CI] Known cases: ${[...registryByName.keys()].join(', ')}`);
+    process.exit(2);
+  }
+
+  // Build the run list. Standalone cases are not in CI_SUBSET (yet), so we
+  // only run shared cases.
+  const selected = CASE_REGISTRY.filter((c) => {
+    if (!CI_SUBSET.has(c.name)) return false;
+    if (c.group !== 'shared') return false; // safety: subset is shared-only
+    if (only && !only.includes(c.name)) return false;
+    if (skip && skip.includes(c.name)) return false;
+    return true;
+  });
+  if (selected.length === 0) {
+    console.error('[HARNESS-CI] no cases selected after filters');
+    process.exit(2);
+  }
+
+  // Verify the prod bundle exists. The harness needs `dist/renderer/index.html`.
+  if (!existsSync(path.resolve('dist/renderer/index.html'))) {
+    console.error('[HARNESS-CI] dist/renderer/index.html missing — run `npm run build` first');
+    process.exit(2);
+  }
+
+  // ---- start fake API ----
+  const fakeApi = await startFakeAnthropicApi({ port: 0, verbose: false });
+  console.log(`[HARNESS-CI] fake Anthropic API listening at ${fakeApi.url}`);
+
+  const results = [];
+  let isolated = null;
+  let launched = null;
+  const harnessStart = Date.now();
+  try {
+    isolated = await createIsolatedClaudeDir();
+    seedMinimalOnboarding(isolated.tempDir);
+    console.log(`[HARNESS-CI] isolated tempDir + onboarding seed: ${isolated.tempDir}`);
+
+    launched = await launchCcsmIsolated({
+      tempDir: isolated.tempDir,
+      env: {
+        // Point claude (and any in-process Anthropic SDK calls from the main
+        // process) at the fake server. Without these the binary either
+        // refuses to start ("no auth") or makes real outbound calls.
+        ANTHROPIC_BASE_URL: fakeApi.url,
+        ANTHROPIC_API_KEY: 'fake-ci-key',
+        // Enable the harness debug seams that several of the CI-subset cases
+        // assert against (e.g. `notify-name-cleared-on-session-delete` reads
+        // `__ccsmSessionNamesFromRenderer`).
+        CCSM_NOTIFY_TEST_HOOK: '1',
+        // Hidden mode: position the window offscreen (-32000,-32000) and
+        // strip it from the taskbar. `run-all-e2e.mjs` defaults this to '1'
+        // for child probes; when this harness is invoked directly (e.g.
+        // `node scripts/harness-real-cli-ci.mjs` for local repro), the
+        // parent env may not have it set. Forcing it here keeps the user's
+        // desktop free of strobing windows during a local debug session
+        // AND lets the CI Windows runner host the harness without rendering
+        // to a real display. See electron/window/createWindow.ts:230-250.
+        CCSM_E2E_HIDDEN: '1',
+      },
+    });
+    const ctx = {
+      electronApp: launched.electronApp,
+      win: launched.win,
+      tempDir: isolated.tempDir,
+    };
+    console.log(`[HARNESS-CI] shared launch ready, running ${selected.length} case(s)`);
+
+    for (const c of selected) {
+      const t0 = Date.now();
+      console.log(`\n[HARNESS-CI] >>> ${c.name}`);
+      try {
+        await c.run(ctx);
+        const ms = Date.now() - t0;
+        results.push({ name: c.name, ok: true, ms });
+        console.log(`[HARNESS-CI] <<< PASS ${c.name} (${ms}ms)`);
+      } catch (err) {
+        const ms = Date.now() - t0;
+        results.push({ name: c.name, ok: false, ms, error: String(err?.stack || err) });
+        console.error(`[HARNESS-CI] <<< FAIL ${c.name} (${ms}ms): ${err?.message || err}`);
+      }
+    }
+  } finally {
+    if (launched?.electronApp) {
+      try { await launched.electronApp.close(); } catch (_) { /* ignore */ }
+    }
+    launched?.cleanup?.();
+    isolated?.cleanup?.();
+    try { await fakeApi.stop(); } catch (_) { /* ignore */ }
+  }
+
+  // ---- summary ----
+  const totalMs = Date.now() - harnessStart;
+  const passed = results.filter((r) => r.ok).length;
+  const failed = results.length - passed;
+  console.log('\n===== HARNESS-CI SUMMARY =====');
+  for (const r of results) {
+    console.log(`  ${r.ok ? 'PASS' : 'FAIL'}  ${r.name.padEnd(40)} ${r.ms}ms`);
+  }
+  console.log(`  total: ${passed}/${results.length} passed, ${(totalMs / 1000).toFixed(1)}s wall`);
+  if (failed > 0) {
+    console.log('\n--- failures ---');
+    for (const r of results.filter((x) => !x.ok)) {
+      console.log(`\n[${r.name}]\n${r.error}`);
+    }
+  }
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error('[HARNESS-CI] unhandled top-level error:', err?.stack || err);
+  process.exit(1);
+});

--- a/scripts/harness-real-cli.mjs
+++ b/scripts/harness-real-cli.mjs
@@ -3323,7 +3323,11 @@ async function caseAltScreenFitsVisibleViewport({ electronApp, win, tempDir }) {
 // Registry
 // ============================================================================
 
-const CASE_REGISTRY = [
+// Exported so `harness-real-cli-ci.mjs` (the CI subset runner) can import
+// the case table without copy-pasting case functions or the registry.
+// Imports of this module are gated by the `isMain` guard at the bottom so
+// importing does not auto-run `main()`.
+export const CASE_REGISTRY = [
   { name: 'new-session-chat',            group: 'shared', run: caseNewSessionChat },
   { name: 'attach-replay-from-headless-buffer', group: 'shared', run: caseAttachReplayFromHeadlessBuffer },
   { name: 'alt-screen-fits-visible-viewport', group: 'shared', run: caseAltScreenFitsVisibleViewport },
@@ -3446,7 +3450,15 @@ async function main() {
   process.exit(failed === 0 ? 0 : 1);
 }
 
-main().catch((err) => {
-  console.error('[HARNESS] unhandled top-level error:', err?.stack || err);
-  process.exit(1);
-});
+// Only run `main()` when this file is the entry point. When imported by
+// `harness-real-cli-ci.mjs` for CASE_REGISTRY access, we skip auto-run.
+// `import.meta.url` is a `file://` URL; `process.argv[1]` is an absolute
+// path. Normalize both sides for the comparison (Windows path separators).
+const _entryUrlMain =
+  process.argv[1] && new URL(`file://${process.argv[1].replace(/\\/g, '/')}`).href;
+if (_entryUrlMain && import.meta.url === _entryUrlMain) {
+  main().catch((err) => {
+    console.error('[HARNESS] unhandled top-level error:', err?.stack || err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

CI now runs a curated subset of the real-CLI harness (`scripts/harness-real-cli-ci.mjs`) against the real \`claude\` binary by faking the Anthropic Messages API at localhost. The full \`harness-real-cli\` stays dogfood-only — its remaining cases assert on real LLM reply content which a fake cannot satisfy deterministically.

## How it works

- **\`scripts/fixtures/fake-anthropic-api.mjs\`** — Node-stdlib HTTP server implementing the Anthropic Messages streaming SSE wire format (\`message_start\` → \`content_block_delta\` → \`message_stop\`). Picks reply content from the prompt (\"ALPHA\"/\"PONG\"/\"ack\"/etc) so cases that type into the TUI before asserting see a sensible canned response. Logs unknown paths to stderr so future cases can extend it.
- **\`scripts/harness-real-cli-ci.mjs\`** — imports \`CASE_REGISTRY\` from the full harness (no copy-paste), filters to 11 cases, starts the fake API, pre-seeds a minimal onboarding \`.claude.json\` (\`hasCompletedOnboarding: true\`), and points \`ANTHROPIC_BASE_URL\` + \`ANTHROPIC_API_KEY\` at the local fake. Forces \`CCSM_E2E_HIDDEN=1\` so windows do not appear on Windows runners.
- **\`scripts/harness-real-cli.mjs\`** — only change is \`export\` on \`CASE_REGISTRY\` + a small \`isMain\` guard around the \`main()\` call so the file is importable without auto-running. No case logic changed.
- **\`.github/workflows/e2e.yml\`** — installs \`@anthropic-ai/claude-code\` globally, verifies \`claude --version\`, leaves \`harness-real-cli\` in \`E2E_SKIP\`, lets \`harness-real-cli-ci\` (auto-discovered by \`run-all-e2e.mjs\`) run.

Env-var override used: \`ANTHROPIC_BASE_URL\` + \`ANTHROPIC_API_KEY\`. Confirmed in the \`claude\` CLI docs and verified locally that the binary respects them when pointed at the fake.

## Cases included (11)

Local run: 11/11 PASS, ~50s wall clock against the fake (well under the 5min harness ceiling in \`run-all-e2e.mjs\`).

- \`attach-replay-from-headless-buffer\`
- \`agent-icon-active-session-no-halo\`
- \`notify-name-cleared-on-session-delete\`
- \`caseSpacesInCwdSpawnsCorrectly\`
- \`new-session-focus-cli\`
- \`pty-pid-stable-across-switch\`
- \`cwd-picker-top-default\`
- \`cwd-picker-top-chevron\`
- \`cwd-picker-browse\`
- \`cwd-picker-no-shortcut\`
- \`sidebar-group-no-newsession-cluster\`

## Cases excluded (per-case reasons)

LLM-reply-content dependent (the fake cannot satisfy these deterministically):
- \`new-session-chat\`, \`switch-session-keeps-chat\`, \`cwd-projects-claude\` — assert on ALPHA/PONG/etc reply
- \`session-rename-writes-jsonl\` — needs real chat to flush JSONL
- \`session-title-syncs-from-jsonl\` — 210s SDK summary derivation wait
- \`session-state-becomes-idle\` — needs real running→idle transition
- \`notify-fires-on-idle\`, \`notify-shows-session-name\`, \`notify-pipeline-foreground\`, \`notify-pipeline-background\`, \`caseBadgeFiresAndClearsOnFocus\` — 180s notify waits each
- \`import-resume\` — asserts on PROBE_FOLLOWUP reply
- \`reopen-resume\` — standalone, asserts on SECRET_TOKEN cross-restart reply

Other excludes:
- \`import-lands-in-focused-group\` — depends on \`import-resume\` running first to warm the \`scanImportable\` cache. Without that primer, the case's own 10s in-case poll times out cold. Not a real regression; covered by the full harness in dogfood. Diagnosed locally 2026-05-23: \"cache never reflected seeded JSONLs\".
- \`alt-screen-fits-visible-viewport\` — asserts on claude's Welcome / trust panel border widths after viewport resize. With \`hasCompletedOnboarding: true\` the welcome panel may not render, failing the border detection. Tied to onboarding visual state, not a CCSM bug.
- \`pty-subtree-killed-on-quit\` — standalone (own Electron launch); fits time-wise but doesn't slot into the shared-launch structure.

All excluded cases continue to run in the full \`harness-real-cli\` for local dogfood / dev (\`node scripts/harness-real-cli.mjs\`).

## How to run locally

\`\`\`bash
# Standalone fake server (e.g. to manually drive claude against it):
node scripts/fixtures/fake-anthropic-api.mjs --port=11434 --verbose
ANTHROPIC_BASE_URL=http://127.0.0.1:11434 ANTHROPIC_API_KEY=fake-ci-key claude

# Full CI harness, all 11 cases:
node scripts/harness-real-cli-ci.mjs

# Single case:
node scripts/harness-real-cli-ci.mjs --only=cwd-picker-browse
\`\`\`

## Test plan

- [ ] CI green on ubuntu / macos / windows for the new \`harness-real-cli-ci\` run
- [ ] Existing probes / harnesses unchanged in behavior (the \`isMain\` guard on the full harness was sanity-checked with \`node scripts/harness-real-cli.mjs --help\` — registry of 27 cases still listed)
- [ ] No new dependencies added (fake server is Node stdlib only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)