### PR TITLE
test(coverage): paste normalizer + renderer crash-net (PR-B2)

### DIFF
--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -181,11 +181,27 @@ export function setSnapshotReplay(fn: (() => Promise<void>) | null): void {
  * the parser as the app sends DECSET 2004 h/l). Falls back to "no wrap" if
  * the singleton hasn't been constructed yet (e.g. paste fired before the
  * terminal mounted — shouldn't happen, but the early-return is cheap).
+ *
+ * Exported as a pure 2-arg function so the contract property test
+ * (`tests/contract/paste-normalization.property.test.ts`) can exercise the
+ * production normalizer directly instead of mirroring the algorithm. The
+ * production call site reads `bracketed` from the live singleton (see
+ * `getCurrentBracketedPasteMode` below) immediately before invocation, so
+ * extracting the read keeps behaviour identical while breaking the
+ * implicit module-state dependency for testing.
  */
-function preparePastePayload(text: string): string {
+export function preparePastePayload(text: string, bracketed: boolean): string {
   const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-  const bracketed = term?.modes?.bracketedPasteMode === true;
   return bracketed ? `\x1b[200~${normalized}\x1b[201~` : normalized;
+}
+
+/**
+ * Read the live bracketed-paste mode from the singleton Terminal. Returns
+ * `false` when the singleton hasn't been constructed yet (paste fired
+ * before mount — shouldn't happen, but cheap to guard).
+ */
+function getCurrentBracketedPasteMode(): boolean {
+  return term?.modes?.bracketedPasteMode === true;
 }
 
 export async function pasteIntoActivePty(fallbackText: string | undefined): Promise<void> {
@@ -205,13 +221,13 @@ export async function pasteIntoActivePty(fallbackText: string | undefined): Prom
       // the same prep so bracketed-paste wrapping applies — claude must see
       // the path as one atomic paste, not as keystrokes that could collide
       // with TUI keybindings while the path streams in.
-      window.ccsmPty.input(sid, preparePastePayload(imagePath));
+      window.ccsmPty.input(sid, preparePastePayload(imagePath, getCurrentBracketedPasteMode()));
       return;
     }
   } catch {
     // best-effort — fall through to text paste on IPC failure.
   }
-  if (fallbackText) window.ccsmPty.input(sid, preparePastePayload(fallbackText));
+  if (fallbackText) window.ccsmPty.input(sid, preparePastePayload(fallbackText, getCurrentBracketedPasteMode()));
 }
 
 /**

--- a/tests/app-effects/useRendererCrashNet.test.tsx
+++ b/tests/app-effects/useRendererCrashNet.test.tsx
@@ -48,6 +48,21 @@ describe('useRendererCrashNet', () => {
     // Re-import the hook in isolation and confirm that merely importing
     // the module does not register a 'error' or 'unhandledrejection'
     // listener on window. The contract: listeners go in useEffect.
+    //
+    // CRITICAL: vitest's ESM module cache short-circuits a second
+    // `await import(...)` to the cached module record, so the module's
+    // top-level code does NOT re-execute and `addSpy` (cleared in
+    // beforeEach) sees zero calls regardless of where the install
+    // lives. Without `vi.resetModules()` this assertion is a tautology.
+    // Reset is scoped to THIS test only — other tests rely on the
+    // cached module so their addSpy records reflect the useEffect
+    // install, not a re-eval.
+    //
+    // Mutation check (performed locally before commit): moving
+    // `window.addEventListener` calls from inside useEffect to the
+    // module top level causes this test to fail with both 'error' and
+    // 'unhandledrejection' showing up in `installed`.
+    vi.resetModules();
     addSpy.mockClear();
     await import('../../src/app-effects/useRendererCrashNet');
     const installed = addSpy.mock.calls
@@ -151,6 +166,14 @@ describe('useRendererCrashNet', () => {
   it('after unmount, dispatched events no longer reach logError', async () => {
     const { useRendererCrashNet } = await import('../../src/app-effects/useRendererCrashNet');
     const { unmount } = renderHook(() => useRendererCrashNet());
+
+    // Strong form: first prove the listener IS wired by dispatching
+    // pre-unmount and asserting logError fires. Without this, the
+    // negative-only assertion below would also pass for a hook that
+    // simply never installed the listener.
+    window.dispatchEvent(new ErrorEvent('error', { error: new Error('pre-unmount') }));
+    expect(logErrorSpy).toHaveBeenCalledTimes(1);
+
     unmount();
     logErrorSpy.mockClear();
 

--- a/tests/app-effects/useRendererCrashNet.test.tsx
+++ b/tests/app-effects/useRendererCrashNet.test.tsx
@@ -1,0 +1,164 @@
+// Tests for `useRendererCrashNet` (PR-B2 / audit gap from PR #1320).
+//
+// The hook installs window-level 'error' and 'unhandledrejection' listeners
+// inside a `useEffect` and removes them in cleanup. Per memory
+// `feedback_pre_react_mount_listeners.md`, the listeners MUST be installed
+// in useEffect, NEVER at module-eval time — installing them before
+// `createRoot` breaks dnd-kit synthetic pointer events under Linux/xvfb
+// (confirmed via the bisect that produced #1320).
+//
+// Coverage here:
+//   - subscribe on mount via addEventListener spy
+//   - unsubscribe on unmount via removeEventListener spy (with the SAME
+//     handler reference — listeners actually removable, not leaked)
+//   - 'error' event forwards to the shared `error()` logger sink
+//   - 'unhandledrejection' event forwards to the same sink
+//   - no listener installation happens at module-eval (memory contract)
+//
+// jsdom provides a real `window`; we spy on add/removeEventListener to
+// avoid asserting via side-effects on a global the hook also dispatches
+// to (race-prone).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const logErrorSpy = vi.fn();
+
+vi.mock('../../src/shared/log', () => ({
+  error: (...args: unknown[]) => logErrorSpy(...args),
+  warn: vi.fn(),
+}));
+
+describe('useRendererCrashNet', () => {
+  let addSpy: ReturnType<typeof vi.spyOn>;
+  let removeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logErrorSpy.mockClear();
+    addSpy = vi.spyOn(window, 'addEventListener');
+    removeSpy = vi.spyOn(window, 'removeEventListener');
+  });
+
+  afterEach(() => {
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+
+  it('does NOT install listeners at module-eval time (memory: pre-React-mount listeners ban)', async () => {
+    // Re-import the hook in isolation and confirm that merely importing
+    // the module does not register a 'error' or 'unhandledrejection'
+    // listener on window. The contract: listeners go in useEffect.
+    addSpy.mockClear();
+    await import('../../src/app-effects/useRendererCrashNet');
+    const installed = addSpy.mock.calls
+      .map((c) => c[0])
+      .filter((t) => t === 'error' || t === 'unhandledrejection');
+    expect(installed).toEqual([]);
+  });
+
+  it('installs error + unhandledrejection listeners on mount', async () => {
+    const { useRendererCrashNet } = await import('../../src/app-effects/useRendererCrashNet');
+    addSpy.mockClear();
+    renderHook(() => useRendererCrashNet());
+
+    const types = addSpy.mock.calls.map((c) => c[0]);
+    expect(types).toContain('error');
+    expect(types).toContain('unhandledrejection');
+  });
+
+  it('removes BOTH listeners with the same handler refs on unmount', async () => {
+    const { useRendererCrashNet } = await import('../../src/app-effects/useRendererCrashNet');
+    addSpy.mockClear();
+    removeSpy.mockClear();
+    const { unmount } = renderHook(() => useRendererCrashNet());
+
+    // Capture the (type → handler) pairs that were added.
+    const added = new Map<string, EventListenerOrEventListenerObject>();
+    for (const call of addSpy.mock.calls) {
+      const [type, handler] = call as [string, EventListenerOrEventListenerObject];
+      if (type === 'error' || type === 'unhandledrejection') {
+        added.set(type, handler);
+      }
+    }
+    expect(added.size).toBe(2);
+
+    unmount();
+
+    // After unmount, both types should be removed with the IDENTICAL
+    // handler reference — anything else would be a leak.
+    const removed = new Map<string, EventListenerOrEventListenerObject>();
+    for (const call of removeSpy.mock.calls) {
+      const [type, handler] = call as [string, EventListenerOrEventListenerObject];
+      if (type === 'error' || type === 'unhandledrejection') {
+        removed.set(type, handler);
+      }
+    }
+    expect(removed.get('error')).toBe(added.get('error'));
+    expect(removed.get('unhandledrejection')).toBe(added.get('unhandledrejection'));
+  });
+
+  it('forwards window "error" event to logError("renderer", "uncaught error", ...)', async () => {
+    const { useRendererCrashNet } = await import('../../src/app-effects/useRendererCrashNet');
+    renderHook(() => useRendererCrashNet());
+
+    const boom = new Error('boom');
+    const evt = new ErrorEvent('error', { error: boom, message: 'boom-msg' });
+    window.dispatchEvent(evt);
+
+    expect(logErrorSpy).toHaveBeenCalledWith('renderer', 'uncaught error', boom);
+  });
+
+  it('falls back to event.message when event.error is missing', async () => {
+    const { useRendererCrashNet } = await import('../../src/app-effects/useRendererCrashNet');
+    renderHook(() => useRendererCrashNet());
+
+    // Some Chromium error events (cross-origin script errors) only populate
+    // `message`. The hook documents `e.error ?? e.message`; assert that fallback.
+    const evt = new ErrorEvent('error', { message: 'cross-origin-script-error' });
+    // Manually clear .error (jsdom may set it to null by default; ensure):
+    Object.defineProperty(evt, 'error', { value: undefined, configurable: true });
+    window.dispatchEvent(evt);
+
+    expect(logErrorSpy).toHaveBeenCalledWith(
+      'renderer',
+      'uncaught error',
+      'cross-origin-script-error',
+    );
+  });
+
+  it('forwards window "unhandledrejection" event to logError with the reason', async () => {
+    const { useRendererCrashNet } = await import('../../src/app-effects/useRendererCrashNet');
+    renderHook(() => useRendererCrashNet());
+
+    const reason = new Error('async-boom');
+    // jsdom's PromiseRejectionEvent constructor exists; if not, fall back.
+    const PRE: typeof PromiseRejectionEvent | undefined = (globalThis as any).PromiseRejectionEvent;
+    let evt: Event;
+    if (typeof PRE === 'function') {
+      evt = new PRE('unhandledrejection', {
+        promise: Promise.reject(reason).catch(() => undefined) as unknown as Promise<unknown>,
+        reason,
+      });
+    } else {
+      evt = new Event('unhandledrejection');
+      (evt as unknown as { reason: unknown }).reason = reason;
+    }
+    window.dispatchEvent(evt);
+
+    expect(logErrorSpy).toHaveBeenCalledWith('renderer', 'unhandled rejection', reason);
+  });
+
+  it('after unmount, dispatched events no longer reach logError', async () => {
+    const { useRendererCrashNet } = await import('../../src/app-effects/useRendererCrashNet');
+    const { unmount } = renderHook(() => useRendererCrashNet());
+    unmount();
+    logErrorSpy.mockClear();
+
+    // jsdom re-raises ErrorEvent.error as an uncaught error on dispatch,
+    // which would fail the suite even after our handler is gone. Use a
+    // bare Event of type 'error' instead — the listener (if still
+    // attached) would still receive it, and that's what we're checking.
+    window.dispatchEvent(new Event('error'));
+    expect(logErrorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/contract/paste-normalization.property.test.ts
+++ b/tests/contract/paste-normalization.property.test.ts
@@ -1,12 +1,9 @@
 // Property test for paste normalization (audit finding 6).
 //
-// Mirrors `preparePastePayload` from `src/terminal/xtermSingleton.ts`
-// (introduced in PR #1303 — "fix(paste): wrap in bracketed-paste when
-// active + normalize CRLF"). The production function is module-local
-// (not exported), so this test re-declares the contract algorithm and
-// asserts the properties the production code claims to provide. If a
-// future refactor changes the algorithm in `xtermSingleton.ts`, this
-// file is the executable spec and must be updated in lockstep.
+// Imports the real `preparePastePayload` from `src/terminal/xtermSingleton.ts`
+// (exported in PR-B2 specifically so this test can exercise production
+// instead of a mirror). The function was introduced in PR #1303 —
+// "fix(paste): wrap in bracketed-paste when active + normalize CRLF".
 //
 // ccsm is a transparent transport (memory:
 // project_ccsm_transparent_transport.md): the terminal pane forwards
@@ -31,17 +28,20 @@
 // catch a shift in CRLF handling but cheap enough to keep the suite
 // fast.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
-// ── Reference implementation ──────────────────────────────────────────
-// VERBATIM mirror of `preparePastePayload` in
-// `src/terminal/xtermSingleton.ts`. Keep these two in sync; the
-// production source is the source of truth for behavior, this file is
-// the source of truth for the *properties* that behavior must satisfy.
-function preparePastePayload(text: string, bracketed: boolean): string {
-  const normalized = text.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
-  return bracketed ? `\x1b[200~${normalized}\x1b[201~` : normalized;
-}
+// The singleton module touches xterm constructors only inside
+// `ensureTerminal()`, which we never call here — but importing it still
+// pulls in `@xterm/xterm` as a transitive load. Stub the addons with
+// minimal mocks so the import is cheap even in a node-only test env.
+vi.mock('@xterm/xterm', () => ({ Terminal: vi.fn() }));
+vi.mock('@xterm/addon-fit', () => ({ FitAddon: vi.fn() }));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: vi.fn() }));
+vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: vi.fn() }));
+vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: vi.fn() }));
+vi.mock('@xterm/addon-canvas', () => ({ CanvasAddon: vi.fn() }));
+
+import { preparePastePayload } from '../../src/terminal/xtermSingleton';
 
 // ── Hand-rolled generator ─────────────────────────────────────────────
 // Deterministic mulberry32 PRNG so failures are reproducible. Seeded

--- a/tests/terminal/xtermSingleton.paste.test.ts
+++ b/tests/terminal/xtermSingleton.paste.test.ts
@@ -1,0 +1,119 @@
+// Focused unit tests for `preparePastePayload` (PR-B2 / audit gap from PR #1303).
+//
+// Complements the property suite in `tests/contract/paste-normalization.property.test.ts`
+// with explicit, narrative test cases for each branch — the bracketed-paste
+// on/off split, every line-ending variant, NUL pass-through, and the
+// "no length cap" transport invariant from `project_ccsm_transparent_transport.md`.
+//
+// xterm constructors are mocked because the function lives in a module that
+// imports `@xterm/xterm` at top level; we never call `ensureTerminal()` here,
+// so a stub mock is sufficient.
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@xterm/xterm', () => ({ Terminal: vi.fn() }));
+vi.mock('@xterm/addon-fit', () => ({ FitAddon: vi.fn() }));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: vi.fn() }));
+vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: vi.fn() }));
+vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: vi.fn() }));
+vi.mock('@xterm/addon-canvas', () => ({ CanvasAddon: vi.fn() }));
+
+import { preparePastePayload } from '../../src/terminal/xtermSingleton';
+
+const SOH = '\x1b[200~';
+const EOH = '\x1b[201~';
+
+describe('preparePastePayload — bracketed-paste branching', () => {
+  it('wraps with sentinels when bracketed=true', () => {
+    expect(preparePastePayload('hello', true)).toBe(`${SOH}hello${EOH}`);
+  });
+
+  it('does not wrap when bracketed=false', () => {
+    expect(preparePastePayload('hello', false)).toBe('hello');
+  });
+
+  it('emits sentinels for empty input when bracketed=true (paste boundary still visible)', () => {
+    // Ink-based TUIs (claude) rely on the boundary to detect "paste end";
+    // an empty paste should still be marked, never collapse to "".
+    expect(preparePastePayload('', true)).toBe(`${SOH}${EOH}`);
+  });
+
+  it('returns empty string for empty input when bracketed=false', () => {
+    expect(preparePastePayload('', false)).toBe('');
+  });
+});
+
+describe('preparePastePayload — line-ending normalization', () => {
+  it('normalizes CRLF to LF', () => {
+    expect(preparePastePayload('a\r\nb', false)).toBe('a\nb');
+    expect(preparePastePayload('a\r\nb', true)).toBe(`${SOH}a\nb${EOH}`);
+  });
+
+  it('normalizes lone CR to LF', () => {
+    expect(preparePastePayload('a\rb', false)).toBe('a\nb');
+  });
+
+  it('passes LF through unchanged', () => {
+    expect(preparePastePayload('a\nb', false)).toBe('a\nb');
+  });
+
+  it('handles mixed line endings (CRLF, lone CR, LF) consistently', () => {
+    const mixed = 'one\r\ntwo\rthree\nfour';
+    expect(preparePastePayload(mixed, false)).toBe('one\ntwo\nthree\nfour');
+  });
+
+  it('produces no CR bytes in the output, ever', () => {
+    const out = preparePastePayload('\r\r\n\r\n\r', false);
+    expect(out.includes('\r')).toBe(false);
+  });
+
+  it('preserves consecutive line-break runs (\\r\\r → \\n\\n, not collapsed)', () => {
+    // Regression guard: a careless regex like /(\r\n|\r|\n)+/g would
+    // collapse runs into one LF, breaking visible blank lines in pastes.
+    expect(preparePastePayload('\r\r', false)).toBe('\n\n');
+    expect(preparePastePayload('\r\n\r\n', false)).toBe('\n\n');
+  });
+});
+
+describe('preparePastePayload — transparent transport', () => {
+  it('passes NUL bytes through unchanged in both modes', () => {
+    const input = 'before\x00middle\x00after';
+    expect(preparePastePayload(input, false)).toBe(input);
+    expect(preparePastePayload(input, true)).toBe(`${SOH}${input}${EOH}`);
+  });
+
+  it('passes ESC and other control bytes through unchanged', () => {
+    const input = '\x07\x03\x1b\x1f';
+    expect(preparePastePayload(input, false)).toBe(input);
+  });
+
+  it('passes high-bit / multi-byte characters through unchanged', () => {
+    const input = 'café 中文 🙂';
+    expect(preparePastePayload(input, false)).toBe(input);
+    expect(preparePastePayload(input, true)).toBe(`${SOH}${input}${EOH}`);
+  });
+
+  it('does NOT escape embedded bracketed-paste sentinels (transport invariant)', () => {
+    // If production ever started escaping these, it would silently corrupt
+    // any paste that happens to contain the byte sequence. The transport
+    // contract says only CR is touched.
+    const input = `before${SOH}middle${EOH}after`;
+    expect(preparePastePayload(input, false)).toBe(input);
+    expect(preparePastePayload(input, true)).toBe(`${SOH}${input}${EOH}`);
+  });
+
+  it('applies no length cap — 1 MB paste flows through (bracketed=false)', () => {
+    const big = 'x'.repeat(1024 * 1024);
+    const out = preparePastePayload(big, false);
+    expect(out.length).toBe(big.length);
+    expect(out).toBe(big);
+  });
+
+  it('applies no length cap — 1 MB paste flows through (bracketed=true)', () => {
+    const big = 'x'.repeat(1024 * 1024);
+    const out = preparePastePayload(big, true);
+    expect(out.length).toBe(big.length + SOH.length + EOH.length);
+    expect(out.startsWith(SOH)).toBe(true);
+    expect(out.endsWith(EOH)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes two audit gaps surfaced in the PR-B1 review:

1. **Paste normalizer (#1303)** — the contract property test in PR #1332 had to mirror `preparePastePayload` because it was module-local. This PR exports it as a pure `(text, bracketed)` function and switches the contract test to import the real one. The live `term.modes.bracketedPasteMode` read moves to a tiny `getCurrentBracketedPasteMode()` helper invoked by the two existing call sites in `pasteIntoActivePty` — production behaviour is unchanged.
2. **Renderer crash net (#1320)** — `useRendererCrashNet` was shallow-tested. Adds full coverage of the contract: no install at module-eval time (memory: `feedback_pre_react_mount_listeners.md`), mount installs both listeners, unmount removes them with the same handler refs, error / rejection events forward to `shared/log.error`, post-unmount events drop on the floor.

## File list

- `src/terminal/xtermSingleton.ts` — export `preparePastePayload`; extract `getCurrentBracketedPasteMode()` helper. No behaviour change.
- `tests/contract/paste-normalization.property.test.ts` — replace mirrored impl with real import; keep all 8 properties.
- `tests/terminal/xtermSingleton.paste.test.ts` — NEW, 16 focused cases.
- `tests/app-effects/useRendererCrashNet.test.tsx` — NEW, 7 cases.

## No bugs surfaced

The mirror in PR-B1 was a true verbatim copy of the production algorithm; switching to the real import did not change a single assertion outcome. NUL bytes, embedded `\x1b[200~` sentinels, lone CR, mixed line endings, and 1 MB pastes all flow through as the transport invariant requires (memory: `project_ccsm_transparent_transport.md`).

## Constraints honored

- File scope: only `src/terminal/xtermSingleton.ts`, `tests/contract/paste-normalization.property.test.ts`, and two new test files. No `electron/**`, no `src/components/**`, no other src trees.
- No new deps (`fast-check` not added; existing hand-rolled mulberry32 generator in the contract test continues to drive properties).
- No Electron harness runs. Validated via `npm test -- tests/terminal/ tests/app-effects/ tests/contract/ --run` (184 tests pass), plus `npm run typecheck` and `npm run lint` (no new errors / warnings).

## Test plan

- [ ] CI: `npm test` passes
- [ ] CI: `npm run typecheck` passes
- [ ] CI: `npm run lint` passes
- [ ] Manual sanity: paste path still works in dev (out of scope for this PR — verified locally by reading the unchanged `pasteIntoActivePty` call sites)

Generated with Claude Code