### PR TITLE
test(coverage): mobileRemoteServer + db schema-downgrade tests (PR-B5)

### DIFF
--- a/electron/__tests__/db-hardening.test.ts
+++ b/electron/__tests__/db-hardening.test.ts
@@ -60,6 +60,87 @@ describe('db hardening: schema versioning', () => {
     const v = handle.pragma('user_version', { simple: true }) as number;
     expect(v).toBe(1);
   });
+
+  it('preserves a future-newer on-disk schema and proceeds read-as-is', async () => {
+    // Pre-seed a DB file stamped with user_version=99 (a hypothetical future
+    // release). Current policy (see comment in db.ts ~ stored > SCHEMA_VERSION
+    // branch) is: warn loudly but do NOT refuse to boot, do NOT silently
+    // re-stamp the version backwards (that would lose the breadcrumb a
+    // post-mortem needs). Pin both behaviors here so a future "refuse on
+    // downgrade" change is a deliberate, reviewed swap.
+    const mod = await freshDb();
+    mod.closeDb();
+
+    const file = path.join(tmpDir, 'ccsm.db');
+    // Manually create a healthy SQLite file with a far-future user_version.
+    const Database = (await import('better-sqlite3')).default;
+    const seed = new Database(file);
+    seed.exec(`
+      CREATE TABLE app_state (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      INSERT INTO app_state (key, value, updated_at) VALUES ('preExisting', 'keepme', 0);
+    `);
+    seed.pragma('user_version = 99');
+    seed.close();
+
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { initDb, loadState, saveState } = mod;
+    const handle = initDb();
+
+    // The stored version must NOT be rewritten — the breadcrumb has to
+    // survive across boots so a bug report can include it.
+    expect(handle.pragma('user_version', { simple: true })).toBe(99);
+
+    // Existing user rows must not be wiped (no silent data loss on
+    // perceived-newer files).
+    expect(loadState('preExisting')).toBe('keepme');
+
+    // App stays writable: future schemas are assumed to be additive, and
+    // refusing to boot is worse than a stale read per the in-tree comment.
+    saveState('hello', 'world');
+    expect(loadState('hello')).toBe('world');
+
+    // Loud log so the incident is discoverable post-hoc.
+    expect(warn).toHaveBeenCalled();
+    const msg = warn.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(msg).toMatch(/newer than/);
+    warn.mockRestore();
+  });
+
+  it('migrates an older on-disk schema (stored < current) and stamps current', async () => {
+    // Pre-seed a "v0" DB (stored=0 means "fresh", so simulate a legacy v1-
+    // minus-one by stamping 0 explicitly after creating the table). On boot,
+    // initDb must stamp user_version up to SCHEMA_VERSION without trashing
+    // existing rows.
+    const mod = await freshDb();
+    mod.closeDb();
+
+    const file = path.join(tmpDir, 'ccsm.db');
+    const Database = (await import('better-sqlite3')).default;
+    const seed = new Database(file);
+    seed.exec(`
+      CREATE TABLE app_state (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL,
+        updated_at INTEGER NOT NULL
+      );
+      INSERT INTO app_state (key, value, updated_at) VALUES ('legacy', 'survives', 0);
+    `);
+    // user_version defaults to 0 here — that's the "fresh DB" branch in
+    // initDb. The stored<current branch is unreachable while SCHEMA_VERSION
+    // is 1; this test pins the fresh-stamp path end-to-end with pre-existing
+    // rows so the policy ("don't wipe legacy rows on first stamp") is locked.
+    seed.close();
+
+    const { initDb, loadState } = mod;
+    const handle = initDb();
+
+    expect(handle.pragma('user_version', { simple: true })).toBe(1);
+    expect(loadState('legacy')).toBe('survives');
+  });
 });
 
 describe('db hardening: prepared statement cache', () => {

--- a/electron/__tests__/mobileRemoteServer.test.ts
+++ b/electron/__tests__/mobileRemoteServer.test.ts
@@ -1,0 +1,431 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as http from 'http';
+import * as crypto from 'crypto';
+import type { AddressInfo } from 'net';
+import type { Socket } from 'net';
+
+// Mock the ptyHost surface the server consumes. We don't want a real PTY,
+// and pulling in ../ptyHost would drag node-pty + electron transitively.
+vi.mock('../ptyHost', () => {
+  const listeners: Array<(sid: string, chunk: string) => void> = [];
+  return {
+    listPtySessions: vi.fn(() => [{ sid: 'mock-sid', cols: 80, rows: 24 }]),
+    getPtySession: vi.fn((sid: string) =>
+      sid === 'mock-sid' ? { sid, cols: 80, rows: 24 } : null
+    ),
+    inputPtySession: vi.fn(),
+    getBufferSnapshot: vi.fn(async (_sid: string) => ({ snapshot: 'hello\r\n' })),
+    onPtyData: vi.fn((cb: (sid: string, chunk: string) => void) => {
+      listeners.push(cb);
+      return () => {
+        const i = listeners.indexOf(cb);
+        if (i >= 0) listeners.splice(i, 1);
+      };
+    }),
+  };
+});
+
+type Started = {
+  port: number;
+  token: string;
+  close: () => void;
+};
+
+async function startServer(): Promise<Started> {
+  // Capture the random token from the server's startup console.log line.
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+  process.env.CCSM_MOBILE_REMOTE = '1';
+  // Pick a port deterministically by asking the OS for a free one, then
+  // freeing it before the server binds. Cheap-and-cheerful for tests.
+  const probe = http.createServer();
+  await new Promise<void>((resolve) => probe.listen(0, '127.0.0.1', () => resolve()));
+  const port = (probe.address() as AddressInfo).port;
+  await new Promise<void>((resolve) => probe.close(() => resolve()));
+  process.env.CCSM_MOBILE_REMOTE_PORT = String(port);
+
+  // Fresh module so the token is regenerated per test.
+  vi.resetModules();
+  const { startMobileRemoteServer } = await import('../remote/mobileRemoteServer');
+  const handle = startMobileRemoteServer();
+  if (!handle) throw new Error('server did not start');
+
+  // Wait for the "listening at" log line that contains the token.
+  let token: string | null = null;
+  for (let i = 0; i < 50 && !token; i += 1) {
+    for (const call of logSpy.mock.calls) {
+      const line = String(call[0] ?? '');
+      const m = line.match(/token=([A-Za-z0-9_-]+)/);
+      if (m) {
+        token = m[1]!;
+        break;
+      }
+    }
+    if (!token) await new Promise((r) => setTimeout(r, 10));
+  }
+  logSpy.mockRestore();
+  if (!token) throw new Error('could not capture token from startup log');
+
+  return {
+    port,
+    token,
+    close: () => handle.close(),
+  };
+}
+
+function httpGet(port: number, path: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: '127.0.0.1', port, path, method: 'GET' },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () =>
+          resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8') })
+        );
+      }
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+// Minimal client-side WebSocket handshake + framing helpers. We deliberately
+// avoid pulling in `ws` so this stays a zero-dep test.
+type WsHandle = {
+  socket: Socket;
+  recvText: Promise<string[]>;
+  /** Returns the next not-yet-consumed text message, waiting up to `timeoutMs`. */
+  nextMessage: (timeoutMs?: number) => Promise<string>;
+  closeCode: Promise<number | null>;
+};
+
+function wsConnect(port: number, path: string): Promise<WsHandle> {
+  return new Promise((resolve, reject) => {
+    const key = crypto.randomBytes(16).toString('base64');
+    const req = http.request({
+      host: '127.0.0.1',
+      port,
+      path,
+      method: 'GET',
+      headers: {
+        Connection: 'Upgrade',
+        Upgrade: 'websocket',
+        'Sec-WebSocket-Key': key,
+        'Sec-WebSocket-Version': '13',
+      },
+    });
+    req.on('error', reject);
+    req.on('response', (res) => {
+      // Server rejected (401 etc.) — surface the status for the caller.
+      const status = res.statusCode ?? 0;
+      reject(new Error(`upgrade rejected: ${status}`));
+    });
+    req.on('upgrade', (_res, socket, head) => {
+      const messages: string[] = [];
+      let cursor = 0;
+      const waiters: Array<(m: string) => void> = [];
+      let closeCode: number | null = null;
+      let buffer = Buffer.from(head);
+      let resolveText: ((m: string[]) => void) | null = null;
+      let resolveClose: ((c: number | null) => void) | null = null;
+      const recvText = new Promise<string[]>((r) => {
+        resolveText = r;
+      });
+      const closePromise = new Promise<number | null>((r) => {
+        resolveClose = r;
+      });
+
+      const tryDrain = () => {
+        let offset = 0;
+        while (offset + 2 <= buffer.length) {
+          const first = buffer[offset]!;
+          const second = buffer[offset + 1]!;
+          const opcode = first & 0x0f;
+          let length = second & 0x7f;
+          let headerLen = 2;
+          if (length === 126) {
+            if (offset + 4 > buffer.length) break;
+            length = buffer.readUInt16BE(offset + 2);
+            headerLen = 4;
+          } else if (length === 127) {
+            if (offset + 10 > buffer.length) break;
+            length = Number(buffer.readBigUInt64BE(offset + 2));
+            headerLen = 10;
+          }
+          if (offset + headerLen + length > buffer.length) break;
+          const payload = buffer.subarray(offset + headerLen, offset + headerLen + length);
+          if (opcode === 0x1) {
+            messages.push(payload.toString('utf8'));
+            const w = waiters.shift();
+            if (w) w(messages[messages.length - 1]!);
+          } else if (opcode === 0x8) {
+            closeCode = payload.length >= 2 ? payload.readUInt16BE(0) : null;
+          }
+          offset += headerLen + length;
+        }
+        buffer = buffer.subarray(offset);
+      };
+
+      socket.on('data', (chunk) => {
+        buffer = Buffer.concat([buffer, chunk]);
+        tryDrain();
+        if (messages.length >= 2 && resolveText) {
+          resolveText(messages.slice());
+          cursor = messages.length;
+          resolveText = null;
+        }
+      });
+      socket.on('close', () => {
+        if (resolveClose) resolveClose(closeCode);
+      });
+      socket.on('error', () => {
+        if (resolveClose) resolveClose(closeCode);
+      });
+
+      const nextMessage = (timeoutMs = 2000): Promise<string> => {
+        if (cursor < messages.length) {
+          return Promise.resolve(messages[cursor++]!);
+        }
+        return new Promise<string>((res, rej) => {
+          const t = setTimeout(() => rej(new Error('nextMessage timed out')), timeoutMs);
+          waiters.push((m) => {
+            clearTimeout(t);
+            cursor = messages.length;
+            res(m);
+          });
+        });
+      };
+
+      resolve({ socket: socket as Socket, recvText, nextMessage, closeCode: closePromise });
+      // The upgrade response may carry initial server frames in `head` —
+      // drain synchronously so auth.ok / sessions.list don't wait for a
+      // later 'data' event that may never come if the server has nothing
+      // more to send.
+      tryDrain();
+      if (messages.length >= 2 && resolveText) {
+        resolveText(messages.slice());
+        cursor = messages.length;
+        resolveText = null;
+      }
+    });
+    req.end();
+  });
+}
+
+/** Encode a client (masked) WebSocket text frame. */
+function encodeClientText(payload: string, opts: { fin?: boolean; opcode?: number } = {}): Buffer {
+  const body = Buffer.from(payload, 'utf8');
+  return encodeClientFrame(body, opts);
+}
+
+function encodeClientFrame(
+  body: Buffer,
+  opts: { fin?: boolean; opcode?: number } = {}
+): Buffer {
+  const fin = opts.fin ?? true;
+  const opcode = opts.opcode ?? 0x1;
+  const firstByte = (fin ? 0x80 : 0x00) | (opcode & 0x0f);
+  const mask = crypto.randomBytes(4);
+  const masked = Buffer.allocUnsafe(body.length);
+  for (let i = 0; i < body.length; i += 1) masked[i] = body[i]! ^ mask[i % 4]!;
+
+  let header: Buffer;
+  if (body.length < 126) {
+    header = Buffer.from([firstByte, 0x80 | body.length]);
+  } else if (body.length <= 0xffff) {
+    header = Buffer.alloc(4);
+    header[0] = firstByte;
+    header[1] = 0x80 | 126;
+    header.writeUInt16BE(body.length, 2);
+  } else {
+    header = Buffer.alloc(10);
+    header[0] = firstByte;
+    header[1] = 0x80 | 127;
+    header.writeBigUInt64BE(BigInt(body.length), 2);
+  }
+  return Buffer.concat([header, mask, masked]);
+}
+
+let active: Started | null = null;
+beforeEach(() => {
+  active = null;
+});
+afterEach(async () => {
+  if (active) {
+    active.close();
+    active = null;
+  }
+  delete process.env.CCSM_MOBILE_REMOTE;
+  delete process.env.CCSM_MOBILE_REMOTE_PORT;
+  // Let the OS reclaim the listening socket between tests.
+  await new Promise((r) => setTimeout(r, 10));
+});
+
+describe('mobileRemoteServer: env gate', () => {
+  it('returns null when CCSM_MOBILE_REMOTE is unset', async () => {
+    delete process.env.CCSM_MOBILE_REMOTE;
+    vi.resetModules();
+    const { startMobileRemoteServer } = await import('../remote/mobileRemoteServer');
+    expect(startMobileRemoteServer()).toBeNull();
+  });
+});
+
+describe('mobileRemoteServer: HTTP token auth', () => {
+  it('rejects unauthenticated GET / with 401', async () => {
+    active = await startServer();
+    const res = await httpGet(active.port, '/');
+    expect(res.status).toBe(401);
+    expect(res.body).toMatch(/Unauthorized/);
+  });
+
+  it('rejects wrong-token GET / with 401', async () => {
+    active = await startServer();
+    const res = await httpGet(active.port, '/?token=not-the-token');
+    expect(res.status).toBe(401);
+  });
+
+  it('serves the mobile page on correct token', async () => {
+    active = await startServer();
+    const res = await httpGet(active.port, `/?token=${active.token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toMatch(/CCSM Mobile Remote/);
+  });
+
+  it('returns 404 for unknown paths even with valid token', async () => {
+    active = await startServer();
+    const res = await httpGet(active.port, `/nope?token=${active.token}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('mobileRemoteServer: WebSocket token auth', () => {
+  it('rejects upgrade without a token', async () => {
+    active = await startServer();
+    await expect(wsConnect(active.port, '/ws')).rejects.toThrow(/401/);
+  });
+
+  it('rejects upgrade with a wrong token', async () => {
+    active = await startServer();
+    await expect(wsConnect(active.port, '/ws?token=bogus')).rejects.toThrow(/401/);
+  });
+
+  it('rejects upgrade to a non-/ws path with valid token', async () => {
+    active = await startServer();
+    await expect(
+      wsConnect(active.port, `/notws?token=${active.token}`)
+    ).rejects.toThrow(/401/);
+  });
+
+  it('accepts upgrade with valid token and emits auth.ok + sessions.list', async () => {
+    active = await startServer();
+    const ws = await wsConnect(active.port, `/ws?token=${active.token}`);
+    const msgs = await ws.recvText;
+    const parsed = msgs.map((m) => JSON.parse(m));
+    expect(parsed[0]).toEqual({ type: 'auth.ok' });
+    expect(parsed[1].type).toBe('sessions.list');
+    expect(Array.isArray(parsed[1].sessions)).toBe(true);
+    ws.socket.destroy();
+  });
+});
+
+describe('mobileRemoteServer: 1 MiB message cap', () => {
+  const CAP = 1 << 20;
+
+  it('accepts a text message just under 1 MiB', async () => {
+    active = await startServer();
+    const ws = await wsConnect(active.port, `/ws?token=${active.token}`);
+    // Drain initial auth.ok + sessions.list.
+    await ws.recvText;
+
+    // Send a session.input frame with a data payload sized so the *whole*
+    // JSON message is just under the cap (CAP - 1 bytes after framing).
+    const overhead = JSON.stringify({ type: 'session.input', sid: 'mock-sid', data: '' }).length;
+    const fillLen = CAP - overhead - 1;
+    const msg = JSON.stringify({
+      type: 'session.input',
+      sid: 'mock-sid',
+      data: 'a'.repeat(fillLen),
+    });
+    expect(msg.length).toBe(CAP - 1);
+
+    ws.socket.write(encodeClientText(msg));
+    // No close frame should arrive — give it a moment, then check.
+    const raced = await Promise.race([
+      ws.closeCode,
+      new Promise<'still-open'>((r) => setTimeout(() => r('still-open'), 150)),
+    ]);
+    expect(raced).toBe('still-open');
+    ws.socket.destroy();
+  });
+
+  it('rejects a text message just over 1 MiB with close code 1009', async () => {
+    active = await startServer();
+    const ws = await wsConnect(active.port, `/ws?token=${active.token}`);
+    await ws.recvText;
+
+    // One byte past the cap — server should close with 1009 (message too big).
+    const payload = 'x'.repeat(CAP + 1);
+    ws.socket.write(encodeClientText(payload));
+
+    const code = await Promise.race([
+      ws.closeCode,
+      new Promise<number>((_, rej) => setTimeout(() => rej(new Error('no close')), 2000)),
+    ]);
+    // On a clean shutdown the server writes the close frame (code 1009) and
+    // then destroys; on Windows the FIN occasionally races the framed body
+    // so we accept either the exact code or a hard socket close as evidence
+    // the cap was enforced. The crucial assertion is "didn't get parsed and
+    // routed as a normal text message", which a hard close demonstrates.
+    expect(code === 1009 || code === null).toBe(true);
+  });
+});
+
+describe('mobileRemoteServer: message handling', () => {
+  it('replies with sessions.list on demand', async () => {
+    active = await startServer();
+    const ws = await wsConnect(active.port, `/ws?token=${active.token}`);
+    await ws.recvText;
+
+    ws.socket.write(encodeClientText(JSON.stringify({ type: 'sessions.list' })));
+    const text = await ws.nextMessage();
+    expect(JSON.parse(text).type).toBe('sessions.list');
+    ws.socket.destroy();
+  });
+
+  it('responds with error on invalid JSON', async () => {
+    active = await startServer();
+    const ws = await wsConnect(active.port, `/ws?token=${active.token}`);
+    await ws.recvText;
+
+    ws.socket.write(encodeClientText('{not json'));
+    const parsed = JSON.parse(await ws.nextMessage());
+    expect(parsed).toEqual({ type: 'error', message: 'invalid_json' });
+    ws.socket.destroy();
+  });
+
+  it('responds with error on unknown message type', async () => {
+    active = await startServer();
+    const ws = await wsConnect(active.port, `/ws?token=${active.token}`);
+    await ws.recvText;
+
+    ws.socket.write(encodeClientText(JSON.stringify({ type: 'totally.unknown' })));
+    const parsed = JSON.parse(await ws.nextMessage());
+    expect(parsed).toEqual({ type: 'error', message: 'unknown_type' });
+    ws.socket.destroy();
+  });
+
+  it('closes with 1003 on binary data frame (text-only protocol)', async () => {
+    active = await startServer();
+    const ws = await wsConnect(active.port, `/ws?token=${active.token}`);
+    await ws.recvText;
+
+    // Opcode 0x2 = binary; server protocol is text-only.
+    ws.socket.write(encodeClientFrame(Buffer.from([0, 1, 2, 3]), { opcode: 0x2 }));
+    const code = await Promise.race([
+      ws.closeCode,
+      new Promise<number>((_, rej) => setTimeout(() => rej(new Error('no close')), 1000)),
+    ]);
+    expect(code).toBe(1003);
+  });
+});


### PR DESCRIPTION
## Summary

Two coverage gaps from the audit, tests only — no production code touched.

- **`electron/__tests__/mobileRemoteServer.test.ts`** (new, 15 tests): drives `electron/remote/mobileRemoteServer.ts` via Node's built-in `http` module. Mocks `../ptyHost` at the import boundary. Captures the random token from the server's startup `console.log` line; no source change needed.
  - Env gate (`CCSM_MOBILE_REMOTE=1`)
  - HTTP token auth on `/`: unauth -> 401, wrong token -> 401, correct -> 200, unknown path -> 404
  - WebSocket upgrade auth on `/ws`: same matrix plus non-`/ws` path -> 401
  - 1 MiB cap boundary: `CAP-1` accepted, `CAP+1` -> hard close (server emits 1009)
  - Message dispatch: `sessions.list`, `invalid_json`, `unknown_type`, binary frame -> close 1003

- **`electron/__tests__/db-hardening.test.ts`** (extended, +2 tests): pins the schema-version downgrade path in `electron/db.ts`.
  - Future-newer DB (`user_version=99`): proceeds read-as-is, does NOT re-stamp version backwards, does NOT wipe existing rows, emits `console.warn` breadcrumb.
  - Legacy rows survive the initial `user_version` stamp on first boot.

## Bugs / risks surfaced (NOT fixed in this PR)

- **None functional.** Token auth and the 1 MiB cap both work as designed.
- **Design observation (downgrade policy, not a bug today):** `db.ts` deliberately proceeds on `stored > SCHEMA_VERSION` rather than refusing. The in-tree comment justifies this ("worse than risking a stale read"), and the new tests pin the choice. Latent risk for a future schema v2: if v2 adds a `NOT NULL` column or removes one v1 reads, a v1 client opening a v2-stamped file could either crash on writes or silently truncate. Worth revisiting when SCHEMA_VERSION bumps.
- **Token logged to stdout:** `startMobileRemoteServer` logs the full token in the `[mobile-remote] listening at ...?token=...` line. Acceptable for a localhost-only dev opt-in feature (`CCSM_MOBILE_REMOTE=1`), but worth a follow-up if this surface ever ships enabled-by-default.
- **1009 close-frame race on Windows:** server writes the close frame then `socket.destroy()`s; on Windows the FIN occasionally races the framed body. Test accepts either the explicit `1009` payload or a hard close as proof the cap was enforced. This is a test-side accommodation, not a server bug.

## Test plan

- [x] `npm test -- electron/__tests__ --run` — 131 passed, 9 files
- [x] `npm run typecheck` — clean
- [x] `npx eslint electron/__tests__/mobileRemoteServer.test.ts electron/__tests__/db-hardening.test.ts` — clean
- [x] No new dependencies
- [x] No production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)