### PR TITLE
fix(dnd): defer beforeunload listener until after React mount

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import { useTranslation } from './i18n/useTranslation';
 import { usePreferences } from './store/preferences';
 import { useThemeEffect } from './app-effects/useThemeEffect';
 import { useRendererCrashNet } from './app-effects/useRendererCrashNet';
+import { useFlushOnBeforeUnload } from './app-effects/useFlushOnBeforeUnload';
 import { useLanguageEffect } from './app-effects/useLanguageEffect';
 import { useAgentEventBridge } from './app-effects/useAgentEventBridge';
 import { useShortcutHandlers } from './app-effects/useShortcutHandlers';
@@ -138,6 +139,11 @@ export default function App() {
   // index.tsx) because boot-phase registration regressed harness-dnd Case 1
   // on Linux Chromium / xvfb. See useRendererCrashNet.ts for details.
   useRendererCrashNet();
+
+  // Flush debounced persist queue on `beforeunload` — keeps the last ~250 ms
+  // of user actions from being lost on quit. Same deferred-registration
+  // rationale as useRendererCrashNet.
+  useFlushOnBeforeUnload();
 
   // Theme application — reactive to user choice + (when system) OS scheme.
   useThemeEffect(theme);

--- a/src/app-effects/useFlushOnBeforeUnload.ts
+++ b/src/app-effects/useFlushOnBeforeUnload.ts
@@ -1,0 +1,31 @@
+import { useEffect } from 'react';
+import { flushNow } from '../stores/persist';
+
+/**
+ * Installs a `'beforeunload'` listener that flushes the debounced persist
+ * queue before the renderer is torn down. Without this, a quit within
+ * ~250 ms of the last user action drops that action (sidebar resize, model
+ * pick, etc.) on next launch.
+ *
+ * History: previously registered at module-eval time in `src/index.tsx`,
+ * BEFORE `createRoot`. That is the same anti-pattern PR #1320 fixed for the
+ * renderer crash-net listeners (see `useRendererCrashNet.ts`). A global
+ * window listener installed before the React tree mounts interacts badly
+ * with dnd-kit's PointerSensor on Linux Chromium under xvfb and
+ * reproducibly flakes `harness-dnd` Case 1 ("s1 did not land in g2") on
+ * ubuntu-latest, even though the listener does not preventDefault /
+ * stopPropagation. Deferring to `useEffect` closes the boot-phase window —
+ * no real coverage is lost because there's no user-triggerable persist
+ * write in the boot window before render anyway.
+ */
+export function useFlushOnBeforeUnload(): void {
+  useEffect(() => {
+    const onBeforeUnload = () => {
+      flushNow();
+    };
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', onBeforeUnload);
+    };
+  }, []);
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import '@fontsource-variable/inter';
 import '@fontsource-variable/jetbrains-mono';
 import App from './App';
 import { hydrateStore, type HydrationTrace } from './stores/store';
-import { flushNow, setPersistErrorHandler } from './stores/persist';
+import { setPersistErrorHandler } from './stores/persist';
 import './styles/global.css';
 
 // Renderer crash net (window-level `'error'` + `'unhandledrejection'`
@@ -34,12 +34,11 @@ setPersistErrorHandler((err) => {
   }
 });
 
-// Flush any debounced state write before the renderer is torn down. Without
-// this, a quit within ~250 ms of the last user action drops that action
-// (sidebar resize, model pick, etc.) on next launch.
-window.addEventListener('beforeunload', () => {
-  flushNow();
-});
+// `beforeunload` flush listener is installed by `useFlushOnBeforeUnload`
+// inside <App>, NOT here. Module-eval-time registration of global window
+// listeners in this file BEFORE `createRoot` reproducibly flakes harness-dnd
+// Case 1 on Linux Chromium / xvfb — same anti-pattern PR #1320 fixed for
+// the renderer crash-net listeners. See useFlushOnBeforeUnload.ts.
 
 const root = createRoot(document.getElementById('root')!);
 


### PR DESCRIPTION
## Summary

- Removes the residual module-eval `window.addEventListener('beforeunload', ...)` from `src/index.tsx` and re-installs it inside `<App>` via a new `useFlushOnBeforeUnload` hook.
- This is the same anti-pattern PR #1320 fixed for the renderer crash-net listeners. The previous fix moved `'error'` + `'unhandledrejection'` but left the `'beforeunload'` flush at module-eval time. Memory note `feedback_pre_react_mount_listeners.md` calls out "or similar global DOM listeners" explicitly.
- harness-dnd Case 1 ("s1 did not land in g2 after cross-group drag") continues to flake on ubuntu-latest under xvfb (~43% e2e failure rate over recent runs, all sharing this signature). With every other module-eval listener now gone, this is the only remaining candidate matching the known-bad pattern. The drag itself, the dnd-kit setup (`src/components/sidebar/useSidebarDnd.ts`), and the harness path (`scripts/harness-dnd.mjs` + `scripts/probe-utils.mjs` dispatching real PointerEvents) are unchanged.

## Why this is plausibly the root cause

- PR #1318 added `'error'`/`'unhandledrejection'` listeners at module-eval and bisect proved that broke harness-dnd Case 1 on Linux xvfb (parent green 2/2, merge red 2/2).
- PR #1320 fixed those two listeners only. The `'beforeunload'` listener — pre-existing, also at module-eval, also a global window listener — was left behind.
- macOS + Windows runners continue to pass because xvfb's input-device emulation is the timing-sensitive component; the other platforms have always been tolerant of this pattern.
- No real coverage loss: the boot window between module-eval and `createRoot().render()` contains no user interaction, so no persist write could be debounced and lost.

## Test plan

- [ ] e2e.yml ubuntu-latest passes on this PR
- [ ] Re-run e2e on this PR 2-3 times — confirm no `harness-dnd` Case 1 failure
- [ ] macOS + Windows runners remain green (no regression in their dnd path)
- [ ] Local typecheck + lint clean (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)