### PR TITLE
fix(reload): graceful shutdown before kill so claude flushes JSONL

### DIFF
--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -1,15 +1,27 @@
 import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 import type { App } from 'electron';
 
-// Mock electron — appLifecycle.ts top-level imports `Menu`, which would
-// trigger "Electron failed to install correctly" on the lint+test runner
-// (no electron binary on CI). We control the spies via the mock factory
-// and read them back via vi.mocked() in tests.
+// Mock electron — appLifecycle.ts top-level imports `Menu` and
+// `BrowserWindow`, which would trigger "Electron failed to install
+// correctly" on the lint+test runner (no electron binary on CI). We
+// control the spies via the mock factory and read them back via
+// vi.mocked() / the module-level handles in tests.
 vi.mock('electron', () => {
   const buildFromTemplate = vi.fn(() => ({ items: [] }));
   const setApplicationMenu = vi.fn();
+  // Mutable window list — tests push fake windows in via __setWindows.
+  // Each fake exposes a `hide` spy so we can assert the graceful quit
+  // path hid every live window before kicking off the flush.
+  const windows: Array<{ hide: ReturnType<typeof vi.fn> }> = [];
   return {
     Menu: { buildFromTemplate, setApplicationMenu },
+    BrowserWindow: {
+      getAllWindows: () => windows,
+      __setWindows: (list: Array<{ hide: ReturnType<typeof vi.fn> }>) => {
+        windows.length = 0;
+        windows.push(...list);
+      },
+    },
   };
 });
 
@@ -38,35 +50,56 @@ afterAll(() => {
   ModuleProto.require = originalRequire;
 });
 
-import { Menu } from 'electron';
+import { Menu, BrowserWindow } from 'electron';
 import {
   applyAppMenuLocale,
   registerLifecycleHandlers,
+  __resetFlushingForQuitForTests,
   type LifecycleDeps,
 } from '../appLifecycle';
+
+// Test-only handle on the BrowserWindow mock for pushing fake windows in.
+const setMockWindows = (
+  list: Array<{ hide: ReturnType<typeof vi.fn> }>,
+): void => {
+  (BrowserWindow as unknown as {
+    __setWindows: (l: Array<{ hide: ReturnType<typeof vi.fn> }>) => void;
+  }).__setWindows(list);
+};
 
 type EventName = 'before-quit' | 'window-all-closed' | 'activate';
 
 interface FakeApp {
   on: ReturnType<typeof vi.fn>;
   quit: ReturnType<typeof vi.fn>;
-  /** invoke a registered listener for a given event */
-  fire: (event: EventName) => void;
+  /** invoke a registered listener for a given event. Returns the synthetic
+   *  event object so tests can inspect preventDefault state. */
+  fire: (event: EventName) => { defaultPrevented: boolean };
 }
 
 function createFakeApp(): FakeApp {
-  const handlers = new Map<EventName, () => void>();
-  const on = vi.fn((event: EventName, cb: () => void) => {
+  const handlers = new Map<EventName, (ev: { preventDefault: () => void }) => void>();
+  const on = vi.fn((event: EventName, cb: (ev: { preventDefault: () => void }) => void) => {
     handlers.set(event, cb);
   });
-  const quit = vi.fn();
+  // `quit()` re-fires `before-quit` (mirrors Electron's real behavior so
+  // the second-pass / `flushingForQuit` latch test is faithful).
+  const quit = vi.fn(() => {
+    const cb = handlers.get('before-quit');
+    if (cb) {
+      const ev = { defaultPrevented: false, preventDefault() { this.defaultPrevented = true; } };
+      cb(ev);
+    }
+  });
   return {
     on,
     quit,
     fire: (event) => {
       const cb = handlers.get(event);
       if (!cb) throw new Error(`no handler registered for ${event}`);
-      cb();
+      const ev = { defaultPrevented: false, preventDefault() { this.defaultPrevented = true; } };
+      cb(ev);
+      return ev;
     },
   };
 }
@@ -88,7 +121,7 @@ function buildDeps(overrides: Partial<LifecycleDeps> = {}): {
   const setIsQuitting = vi.fn((v: boolean) => {
     state.isQuitting = v;
   });
-  const killAllPtySessions = vi.fn();
+  const killAllPtySessions = vi.fn(() => Promise.resolve());
   const closeDb = vi.fn();
   const createWindow = vi.fn();
   const disposeNotifyPipeline = vi.fn();
@@ -168,6 +201,11 @@ describe('registerLifecycleHandlers', () => {
   });
 
   describe('before-quit', () => {
+    beforeEach(() => {
+      __resetFlushingForQuitForTests();
+      setMockWindows([]);
+    });
+
     it('flips isQuitting to true', () => {
       const { deps, fakeApp, spies, state } = buildDeps();
       registerLifecycleHandlers(deps);
@@ -176,39 +214,106 @@ describe('registerLifecycleHandlers', () => {
       expect(state.isQuitting).toBe(true);
     });
 
-    it('reaps pty sessions', () => {
-      const { deps, fakeApp, spies } = buildDeps();
+    it('hides every live BrowserWindow immediately (UX: app appears to quit instantly)', () => {
+      const w1 = { hide: vi.fn() };
+      const w2 = { hide: vi.fn() };
+      setMockWindows([w1, w2]);
+      const { deps, fakeApp } = buildDeps();
       registerLifecycleHandlers(deps);
       fakeApp.fire('before-quit');
+      expect(w1.hide).toHaveBeenCalledTimes(1);
+      expect(w2.hide).toHaveBeenCalledTimes(1);
+    });
+
+    it('preventDefaults the first before-quit so the async flush can run', () => {
+      const { deps, fakeApp } = buildDeps();
+      registerLifecycleHandlers(deps);
+      const ev = fakeApp.fire('before-quit');
+      expect(ev.defaultPrevented).toBe(true);
+    });
+
+    it('awaits killAllPtySessions then re-fires app.quit() to complete the quit', async () => {
+      let resolveKill!: () => void;
+      const killAllPtySessions = vi.fn(
+        () => new Promise<void>((r) => { resolveKill = r; }),
+      );
+      const { deps, fakeApp, spies } = buildDeps({ killAllPtySessions });
+      registerLifecycleHandlers(deps);
+
+      fakeApp.fire('before-quit');
+      expect(killAllPtySessions).toHaveBeenCalledTimes(1);
+      // disposeNotifyPipeline + app.quit() must NOT have fired yet — the
+      // flush is still in flight.
+      expect(spies.disposeNotifyPipeline).not.toHaveBeenCalled();
+      expect(fakeApp.quit).not.toHaveBeenCalled();
+
+      // Resolve the kill and let the async chain drain.
+      resolveKill();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      expect(spies.disposeNotifyPipeline).toHaveBeenCalledTimes(1);
+      // app.quit() re-fired — our fake re-enters before-quit, which now
+      // takes the flushingForQuit=true fast path and does NOT re-invoke
+      // killAllPtySessions.
+      expect(fakeApp.quit).toHaveBeenCalledTimes(1);
+      expect(killAllPtySessions).toHaveBeenCalledTimes(1);
+    });
+
+    it('second before-quit (flushingForQuit=true) does NOT preventDefault, does NOT re-invoke killAll', async () => {
+      const { deps, fakeApp, spies } = buildDeps();
+      registerLifecycleHandlers(deps);
+
+      // First pass: kicks off async flush.
+      fakeApp.fire('before-quit');
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      // First pass + re-fired pass from app.quit() inside the async chain.
+      expect(spies.killAllPtySessions).toHaveBeenCalledTimes(1);
+      expect(fakeApp.quit).toHaveBeenCalledTimes(1);
+
+      // A user-triggered third before-quit (e.g. tray Quit pressed twice)
+      // should pass through without re-running the graceful path.
+      const ev = fakeApp.fire('before-quit');
+      expect(ev.defaultPrevented).toBe(false);
       expect(spies.killAllPtySessions).toHaveBeenCalledTimes(1);
     });
 
-    it('disposes the notify pipeline when present', () => {
+    it('disposes the notify pipeline after killAll resolves', async () => {
       const { deps, fakeApp, spies } = buildDeps();
       registerLifecycleHandlers(deps);
       fakeApp.fire('before-quit');
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
       expect(spies.disposeNotifyPipeline).toHaveBeenCalledTimes(1);
     });
 
-    it('does not throw when disposeNotifyPipeline is omitted (early-failure path)', () => {
+    it('does not throw when disposeNotifyPipeline is omitted (early-failure path)', async () => {
       const { deps, fakeApp } = buildDeps({ disposeNotifyPipeline: undefined });
       registerLifecycleHandlers(deps);
       expect(() => fakeApp.fire('before-quit')).not.toThrow();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
     });
 
-    it('swallows killAllPtySessions errors (best-effort cleanup)', () => {
+    it('swallows killAllPtySessions rejections (best-effort cleanup) and still disposes + quits', async () => {
       const { deps, fakeApp, spies } = buildDeps({
-        killAllPtySessions: vi.fn(() => {
-          throw new Error('pty reap blew up');
-        }),
+        killAllPtySessions: vi.fn(() => Promise.reject(new Error('pty reap blew up'))),
       });
       registerLifecycleHandlers(deps);
       expect(() => fakeApp.fire('before-quit')).not.toThrow();
-      // disposeNotifyPipeline still runs even if kill threw
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
       expect(spies.disposeNotifyPipeline).toHaveBeenCalledTimes(1);
+      expect(fakeApp.quit).toHaveBeenCalledTimes(1);
     });
 
-    it('swallows disposeNotifyPipeline errors', () => {
+    it('swallows disposeNotifyPipeline errors and still quits', async () => {
       const { deps, fakeApp } = buildDeps({
         disposeNotifyPipeline: vi.fn(() => {
           throw new Error('dispose blew up');
@@ -216,6 +321,25 @@ describe('registerLifecycleHandlers', () => {
       });
       registerLifecycleHandlers(deps);
       expect(() => fakeApp.fire('before-quit')).not.toThrow();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(fakeApp.quit).toHaveBeenCalledTimes(1);
+    });
+
+    it('survives a throwing BrowserWindow.hide() — flush still runs', async () => {
+      const wOK = { hide: vi.fn() };
+      const wBad = { hide: vi.fn(() => { throw new Error('detached'); }) };
+      setMockWindows([wBad, wOK]);
+      const { deps, fakeApp, spies } = buildDeps();
+      registerLifecycleHandlers(deps);
+      expect(() => fakeApp.fire('before-quit')).not.toThrow();
+      // OK window still hidden even though the bad one threw.
+      expect(wOK.hide).toHaveBeenCalledTimes(1);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(spies.killAllPtySessions).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -17,7 +17,7 @@
 // Extracting it would just create a giant deps bag with no real win.
 
 import type { App } from 'electron';
-import { Menu } from 'electron';
+import { BrowserWindow, Menu } from 'electron';
 
 /** Build + install the hidden app accelerator menu. We don't want a visible
  *  File/Edit/View menu bar — CCSM is a single-window tool and those menus
@@ -76,8 +76,12 @@ export interface LifecycleDeps {
   setIsQuitting: (v: boolean) => void;
   /** Best-effort reap of any live node-pty children spawned through
    *  ptyHost. Idempotent; critical on Windows where conpty can otherwise
-   *  leak the claude child past Electron quit. */
-  killAllPtySessions: () => void;
+   *  leak the claude child past Electron quit. Returns a Promise that
+   *  resolves after every session's graceful-flush + kill settles (or
+   *  the 3 s wedged-fallback fires) — `before-quit` awaits this so claude
+   *  has time to drain its 100 ms-buffered JSONL writer before the
+   *  Electron process exits. See `ptyHost/lifecycle.ts:killAll`. */
+  killAllPtySessions: () => Promise<void>;
   /** Tear down the notify pipeline + its app-level listeners (focus/blur,
    *  sessionWatcher 'unwatched') and any pending flash timers. Optional
    *  because `before-quit` may fire before the pipeline is constructed
@@ -93,6 +97,20 @@ export interface LifecycleDeps {
   getWindowCount: () => number;
 }
 
+// Quit-after-flush latch. Set on the FIRST `before-quit` we intercept so
+// the SECOND `before-quit` (re-fired via `app.quit()` after the async
+// flush settles) falls through without re-running the graceful path.
+// Module-level (like the now-unused `isQuitting` pattern in main.ts) so
+// the handler closure reads the live value.
+let flushingForQuit = false;
+
+/** Test hook — reset the quit latch between tests. NOT exported on the
+ *  public surface (no entry in the barrel); imported only by the unit
+ *  test file via the relative path. */
+export function __resetFlushingForQuitForTests(): void {
+  flushingForQuit = false;
+}
+
 export function registerLifecycleHandlers(deps: LifecycleDeps): void {
   const {
     app,
@@ -105,20 +123,58 @@ export function registerLifecycleHandlers(deps: LifecycleDeps): void {
     disposeNotifyPipeline,
   } = deps;
 
-  app.on('before-quit', () => {
+  app.on('before-quit', (event) => {
     setIsQuitting(true);
+
+    // Second-pass: we already ran the graceful flush and re-fired
+    // `app.quit()`. Let Electron tear down normally.
+    if (flushingForQuit) return;
+
+    // First-pass: the graceful kill path in `ptyHost/lifecycle.ts` writes
+    // `\x03` and waits up to 3 s per session for claude to drain its
+    // 100 ms-buffered JSONL writer. If we let Electron exit synchronously
+    // here, the OS would reap claude before the flush completed — worse
+    // than the pre-graceful hard-kill path. So:
+    //   1. Hide every window immediately so the user sees the app "quit"
+    //      with zero perceptible latency. We DON'T `close()` them — close
+    //      would re-enter the tray-resident hide-to-tray logic and other
+    //      window listeners; hide is a pure visibility flip.
+    //   2. `event.preventDefault()` to abort THIS quit pass.
+    //   3. Latch `flushingForQuit = true`.
+    //   4. Await `killAllPtySessions()` (now Promise-returning) and
+    //      `disposeNotifyPipeline()`.
+    //   5. Re-fire `app.quit()`; the handler re-enters with the latch set
+    //      and falls through, Electron walks `window-all-closed` →
+    //      `closeDb()` → process exit.
     try {
-      killAllPtySessions();
+      for (const w of BrowserWindow.getAllWindows()) {
+        try { w.hide(); } catch { /* window may already be destroyed */ }
+      }
     } catch {
-      /* ignore — best-effort cleanup on quit */
+      /* getAllWindows itself can throw on partial-init paths; flush
+         must still run even if the UI hide failed. */
     }
-    if (disposeNotifyPipeline) {
+
+    event.preventDefault();
+    flushingForQuit = true;
+
+    void (async () => {
       try {
-        disposeNotifyPipeline();
+        await killAllPtySessions();
       } catch {
         /* ignore — best-effort cleanup on quit */
       }
-    }
+      if (disposeNotifyPipeline) {
+        try {
+          disposeNotifyPipeline();
+        } catch {
+          /* ignore — best-effort cleanup on quit */
+        }
+      }
+      // Re-fire quit. The handler closure reads `flushingForQuit` live
+      // (module-level) and returns early on this second pass.
+      app.quit();
+    })();
   });
 
   app.on('window-all-closed', () => {

--- a/electron/ptyHost/__tests__/lifecycle.test.ts
+++ b/electron/ptyHost/__tests__/lifecycle.test.ts
@@ -415,6 +415,35 @@ describe('lifecycle.kill', () => {
     expect(bus().watcherStopCalls).toEqual(['s']);
   });
 
+  it('registers pty.onExit BEFORE writing \\x03 — regression guard for sync-onExit mocks', async () => {
+    // If a future refactor swaps the order, a synchronous onExit fired
+    // from inside pty.write (test fakes do this; the real binding can do
+    // similar tricks under fast-exit races) would land before the
+    // listener was registered → settle never runs → the kill promise
+    // either times out (3 s wedge) or worse, the renderer hangs. Lock
+    // the order with an explicit call-order assertion.
+    const sessions = new Map<string, FakeEntry>();
+    const calls: string[] = [];
+    const entry = makeFakeEntry();
+    entry.pty.pid = 800;
+    // Wrap onExit so we record registration order alongside writes.
+    const realOnExit = entry.pty.onExit;
+    entry.pty.onExit = (cb: () => void) => {
+      calls.push('onExit');
+      return realOnExit(cb);
+    };
+    entry.pty.write = vi.fn(() => {
+      calls.push('write');
+      entry.pty.__fireExit!();
+    });
+    sessions.set('s', entry);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(L.kill(sessions as any, 's')).resolves.toBe(true);
+    expect(calls[0]).toBe('onExit');
+    expect(calls[1]).toBe('write');
+  });
+
   // ─── #1277 review race fix ─────────────────────────────────────────────
 
   it('awaits pty.onExit before resolving — renderer-attach race fix', async () => {
@@ -578,42 +607,77 @@ describe('lifecycle.kill', () => {
 });
 
 describe('lifecycle.killAll', () => {
-  it('sends the soft signal to every entry via the kill op', () => {
+  it('sends the soft signal to every entry and returns a Promise that resolves when all kills settle', async () => {
     const sessions = new Map<string, FakeEntry>();
     const a = makeFakeEntry({ pty: makeFakePty({ pid: 1 }) });
     const b = makeFakeEntry({ pty: makeFakePty({ pid: 2 }) });
     const c = makeFakeEntry({ pty: makeFakePty({ pid: 3 }) });
+    // Fire onExit synchronously inside the soft-signal write so every per-sid
+    // kill resolves promptly — the killAll Promise should resolve after
+    // ALL of them settle.
+    a.pty.write = vi.fn(() => a.pty.__fireExit!());
+    b.pty.write = vi.fn(() => b.pty.__fireExit!());
+    c.pty.write = vi.fn(() => c.pty.__fireExit!());
     sessions.set('a', a);
     sessions.set('b', b);
     sessions.set('c', c);
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    L.killAll(sessions as any);
-    // Each pty received the Ctrl+C soft signal synchronously.
+    const result = L.killAll(sessions as any);
+    // killAll must return a Promise (before-quit awaits it to give claude
+    // time to flush before Electron tears down — see appLifecycle.ts).
+    expect(result).toBeInstanceOf(Promise);
+    await expect(result).resolves.toBeUndefined();
+
+    // Each pty received the Ctrl+C soft signal.
     expect(a.pty.write).toHaveBeenCalledWith('\x03');
     expect(b.pty.write).toHaveBeenCalledWith('\x03');
     expect(c.pty.write).toHaveBeenCalledWith('\x03');
     // Watcher stopped synchronously for each sid.
     expect(bus().watcherStopCalls.sort()).toEqual(['a', 'b', 'c']);
-    // No hard kill / subtree walk yet — those only fire on the wedged
-    // timeout fallback.
+    // No hard kill / subtree walk — graceful path completed for all.
     expect(bus().killCalls).toEqual([]);
   });
 
-  it('snapshots the keys before iterating — safe against concurrent mutation', () => {
+  it('killAll Promise does NOT resolve until every per-session kill settles', async () => {
     const sessions = new Map<string, FakeEntry>();
-    sessions.set('a', makeFakeEntry());
-    sessions.set('b', makeFakeEntry());
-    // killAll calls kill() which doesn't itself mutate the map (the onExit
-    // hook does, but it isn't wired in this test). The contract under test
-    // is "iterates over a snapshot of keys".
+    const fast = makeFakeEntry({ pty: makeFakePty({ pid: 10 }) });
+    const slow = makeFakeEntry({ pty: makeFakePty({ pid: 11 }) });
+    // fast exits immediately; slow stays wedged until we manually fire onExit.
+    fast.pty.write = vi.fn(() => fast.pty.__fireExit!());
+    slow.pty.write = vi.fn();
+    sessions.set('fast', fast);
+    sessions.set('slow', slow);
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    L.killAll(sessions as any);
+    const p = L.killAll(sessions as any);
+    let resolved: 'pending' | 'done' = 'pending';
+    void p.then(() => { resolved = 'done'; });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe('pending');
+
+    slow.pty.__fireExit!();
+    await expect(p).resolves.toBeUndefined();
+    expect(resolved).toBe('done');
+  });
+
+  it('snapshots the keys before iterating — safe against concurrent mutation', async () => {
+    const sessions = new Map<string, FakeEntry>();
+    const a = makeFakeEntry();
+    const b = makeFakeEntry();
+    a.pty.write = vi.fn(() => a.pty.__fireExit!());
+    b.pty.write = vi.fn(() => b.pty.__fireExit!());
+    sessions.set('a', a);
+    sessions.set('b', b);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await L.killAll(sessions as any);
     expect(bus().watcherStopCalls).toHaveLength(2);
   });
 
-  it('killAll over an empty map is a no-op', () => {
+  it('killAll over an empty map resolves immediately with no side effects', async () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    L.killAll(new Map() as any);
+    await expect(L.killAll(new Map() as any)).resolves.toBeUndefined();
     expect(bus().killCalls).toEqual([]);
     expect(bus().watcherStopCalls).toEqual([]);
   });

--- a/electron/ptyHost/__tests__/lifecycle.test.ts
+++ b/electron/ptyHost/__tests__/lifecycle.test.ts
@@ -347,41 +347,67 @@ describe('lifecycle.kill', () => {
     expect(bus().watcherStopCalls).toEqual([]);
   });
 
-  it('captures pid BEFORE pty.kill (binding may zero pid post-kill)', async () => {
+  it('writes \\x03 (Ctrl+C) to the pty as the soft signal — NOT pty.kill() on the graceful path', async () => {
+    // Root-cause fix for context-loss on reload: on Windows ConPTY,
+    // `pty.kill()` becomes TerminateProcess and claude never runs its
+    // SIGINT handler → 100 ms buffered JSONL writes are lost. We send
+    // `\x03` instead, which ConPTY translates to CTRL_C_EVENT → SIGINT,
+    // letting claude's flush (2 s budget) drain before exit.
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
-    entry.pty.pid = 4242;
-    // simulate the binding zeroing pid on kill, then firing onExit (the
-    // production race-fix path: kill() awaits onExit before resolving).
-    entry.pty.kill = vi.fn(() => { entry.pty.pid = 0; entry.pty.__fireExit!(); });
+    entry.pty.pid = 111;
+    // Fire onExit synchronously to simulate claude exiting promptly after SIGINT.
+    entry.pty.write = vi.fn(() => entry.pty.__fireExit!());
     sessions.set('s', entry);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await expect(L.kill(sessions as any, 's')).resolves.toBe(true);
-    expect(bus().killCalls).toEqual([4242]);
+    expect(entry.pty.write).toHaveBeenCalledWith('\x03');
+    // Hard kill MUST NOT have been called on the graceful path — that
+    // defeats the soft-signal strategy and tears down claude mid-flush.
+    expect(entry.pty.kill).not.toHaveBeenCalled();
   });
 
-  it('always invokes killProcessSubtree even if pty.kill throws', async () => {
+  it('graceful path: onExit before timeout — processKiller NOT called, subtree left alone', async () => {
+    // The whole point of the soft signal: if claude exits cleanly within
+    // the flush budget, we MUST NOT walk the process tree (killing it
+    // mid-flush would defeat the purpose).
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    entry.pty.pid = 4242;
+    entry.pty.write = vi.fn(() => { entry.pty.__fireExit!(); });
+    sessions.set('s', entry);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await expect(L.kill(sessions as any, 's')).resolves.toBe(true);
+    expect(bus().killCalls).toEqual([]);
+    // Watcher still stopped (idempotent, doesn't interfere with claude's writes).
+    expect(bus().watcherStopCalls).toEqual(['s']);
+  });
+
+  it('still resolves cleanly when pty.write throws (already-exited race)', async () => {
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
     entry.pty.pid = 7;
-    entry.pty.kill = vi.fn(() => { throw new Error('already dead'); });
+    entry.pty.write = vi.fn(() => { throw new Error('EPIPE'); });
     sessions.set('s', entry);
-    // pty.kill threw, no onExit fired → resolves false via timeout
+    // write threw, no onExit fired → resolves false via timeout (and
+    // escalates to hard kill in the timer branch).
     vi.useFakeTimers();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const p = L.kill(sessions as any, 's');
-    expect(bus().killCalls).toEqual([7]);
     await vi.advanceTimersByTimeAsync(L.KILL_EXIT_TIMEOUT_MS + 10);
     await expect(p).resolves.toBe(false);
+    // Hard fallback fired the subtree walk.
+    expect(bus().killCalls).toEqual([7]);
     vi.useRealTimers();
   });
 
   it('always invokes sessionWatcher.stopWatching (belt-and-braces, swallows throws)', async () => {
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
-    // Fire onExit synchronously inside kill so the promise resolves promptly.
-    entry.pty.kill = vi.fn(() => entry.pty.__fireExit!());
+    // Fire onExit synchronously on the soft signal so the promise resolves promptly.
+    entry.pty.write = vi.fn(() => entry.pty.__fireExit!());
     sessions.set('s', entry);
     bus().watcherStopShouldThrow = true;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -395,18 +421,20 @@ describe('lifecycle.kill', () => {
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
     entry.pty.pid = 100;
-    // pty.kill() does NOT auto-fire onExit (the production node-pty contract:
-    // kill dispatches a signal; onExit fires when the OS reaps the process).
-    entry.pty.kill = vi.fn();
+    // pty.write dispatches the soft signal but does NOT auto-fire onExit
+    // (claude is still flushing).
+    entry.pty.write = vi.fn();
     sessions.set('s', entry);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const p = L.kill(sessions as any, 's');
-    // pty.kill + processKiller already ran synchronously (kill signal dispatched).
-    expect(entry.pty.kill).toHaveBeenCalled();
-    expect(bus().killCalls).toEqual([100]);
+    // Soft signal sent synchronously, watcher stopped — but the hard
+    // kill / subtree walk MUST NOT have run yet (graceful path).
+    expect(entry.pty.write).toHaveBeenCalledWith('\x03');
+    expect(entry.pty.kill).not.toHaveBeenCalled();
+    expect(bus().killCalls).toEqual([]);
 
-    // But the promise must NOT have resolved yet — the renderer awaits this
+    // The promise must NOT have resolved yet — the renderer awaits this
     // before bumping reloadNonce, and the entry hasn't been removed.
     let resolved: boolean | 'pending' = 'pending';
     void p.then((v) => { resolved = v; });
@@ -424,10 +452,10 @@ describe('lifecycle.kill', () => {
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
     entry.pty.pid = 200;
-    // Simulates a wedged pty: kill signal dispatched but the process never
-    // exits (onExit silent). Without the timeout the renderer would hang
-    // forever on `await ccsmPty.kill(sid)`.
-    entry.pty.kill = vi.fn();
+    // Simulates a wedged pty: soft signal sent but the process never exits
+    // (claude hung in flush, or the SIGINT was lost). Without the timeout
+    // the renderer would hang forever on `await ccsmPty.kill(sid)`.
+    entry.pty.write = vi.fn();
     sessions.set('s', entry);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -446,30 +474,31 @@ describe('lifecycle.kill', () => {
     vi.useRealTimers();
   });
 
-  it('evicts the zombie entry on timeout so subsequent attach returns null (spawn-on-null unblocked)', async () => {
-    // #1277 follow-up: when KILL_EXIT_TIMEOUT_MS fires, kill() resolves false
-    // but the entry was still in the map — a subsequent pty:attach would
-    // return the zombie and bypass the spawn-on-null fallback, leaving the
-    // renderer registered on a dead pty (crash overlay → manual Retry).
-    // Fix: force SIGKILL + delete from map on timeout.
+  it('wedged fallback: timeout escalates to pty.kill(SIGKILL) + killProcessSubtree', async () => {
+    // When the graceful flush budget elapses without onExit, we escalate
+    // to the hard kill path: pty.kill('SIGKILL') AND processKiller subtree
+    // walk (ConPTY emulates signals, so the subtree walk is what actually
+    // reaps claude.exe + its grandchildren on Windows).
     vi.useFakeTimers();
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
     entry.pty.pid = 500;
-    // Track SIGKILL escalation — pty.kill called twice (first signal-less in
-    // production code, second with 'SIGKILL' on timeout).
-    entry.pty.kill = vi.fn();
+    entry.pty.write = vi.fn();
     sessions.set('s', entry);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const p = L.kill(sessions as any, 's');
 
-    // Cross the timeout — SIGKILL escalation + zombie eviction.
+    // Before timeout: no hard kill yet, no subtree walk.
+    expect(entry.pty.kill).not.toHaveBeenCalled();
+    expect(bus().killCalls).toEqual([]);
+
     await vi.advanceTimersByTimeAsync(L.KILL_EXIT_TIMEOUT_MS + 10);
     await expect(p).resolves.toBe(false);
 
-    // SIGKILL escalation attempted on the wedged pty.
+    // Hard escalation fired.
     expect(entry.pty.kill).toHaveBeenCalledWith('SIGKILL');
+    expect(bus().killCalls).toEqual([500]);
     // Zombie removed from registry — attach now returns null, letting the
     // renderer's reloadNonce → spawn-on-null fallback create a fresh PTY.
     expect(sessions.has('s')).toBe(false);
@@ -478,18 +507,16 @@ describe('lifecycle.kill', () => {
     vi.useRealTimers();
   });
 
-  it('swallows SIGKILL throws on timeout (still evicts the zombie + logs)', async () => {
+  it('swallows SIGKILL throws on timeout (still evicts the zombie + walks subtree + logs)', async () => {
     // On Windows node-pty emulates signals; SIGKILL may throw. The timeout
     // path must still delete the entry from the map (else the zombie blocks
-    // spawn-on-null forever) and must not propagate the throw.
+    // spawn-on-null forever), still walk the subtree, and not propagate.
     vi.useFakeTimers();
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
     entry.pty.pid = 600;
-    let calls = 0;
+    entry.pty.write = vi.fn();
     entry.pty.kill = vi.fn((signal?: string) => {
-      calls += 1;
-      // First call (signal-less production kill) succeeds; SIGKILL throws.
       if (signal === 'SIGKILL') throw new Error('signal not supported');
     });
     sessions.set('s', entry);
@@ -499,7 +526,9 @@ describe('lifecycle.kill', () => {
     await vi.advanceTimersByTimeAsync(L.KILL_EXIT_TIMEOUT_MS + 10);
     await expect(p).resolves.toBe(false);
 
-    expect(calls).toBe(2); // initial kill + SIGKILL escalation
+    expect(entry.pty.kill).toHaveBeenCalledWith('SIGKILL');
+    // Subtree walk still happens — it's what actually reaps the tree on Windows.
+    expect(bus().killCalls).toEqual([600]);
     expect(sessions.has('s')).toBe(false);
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining('SIGKILL also failed'),
@@ -511,7 +540,7 @@ describe('lifecycle.kill', () => {
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
     entry.pty.pid = 300;
-    entry.pty.kill = vi.fn();
+    entry.pty.write = vi.fn();
     sessions.set('s', entry);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -519,10 +548,10 @@ describe('lifecycle.kill', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const p2 = L.kill(sessions as any, 's');
     // Same promise — second call is a no-op short-circuit, no extra
-    // pty.kill / processKiller / stopWatching invocations.
+    // soft-signal writes or watcher-stop calls.
     expect(p1).toBe(p2);
-    expect(entry.pty.kill).toHaveBeenCalledTimes(1);
-    expect(bus().killCalls).toEqual([300]);
+    expect(entry.pty.write).toHaveBeenCalledTimes(1);
+    expect(entry.pty.write).toHaveBeenCalledWith('\x03');
     expect(bus().watcherStopCalls).toEqual(['s']);
 
     // Drain.
@@ -534,7 +563,7 @@ describe('lifecycle.kill', () => {
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
     entry.pty.pid = 400;
-    entry.pty.kill = vi.fn(() => entry.pty.__fireExit!());
+    entry.pty.write = vi.fn(() => entry.pty.__fireExit!());
     sessions.set('s', entry);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -544,20 +573,30 @@ describe('lifecycle.kill', () => {
     sessions.set('s', entry);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await L.kill(sessions as any, 's');
-    expect(entry.pty.kill).toHaveBeenCalledTimes(2);
+    expect(entry.pty.write).toHaveBeenCalledTimes(2);
   });
 });
 
 describe('lifecycle.killAll', () => {
-  it('kills every entry via the kill op', () => {
+  it('sends the soft signal to every entry via the kill op', () => {
     const sessions = new Map<string, FakeEntry>();
-    sessions.set('a', makeFakeEntry({ pty: makeFakePty({ pid: 1 }) }));
-    sessions.set('b', makeFakeEntry({ pty: makeFakePty({ pid: 2 }) }));
-    sessions.set('c', makeFakeEntry({ pty: makeFakePty({ pid: 3 }) }));
+    const a = makeFakeEntry({ pty: makeFakePty({ pid: 1 }) });
+    const b = makeFakeEntry({ pty: makeFakePty({ pid: 2 }) });
+    const c = makeFakeEntry({ pty: makeFakePty({ pid: 3 }) });
+    sessions.set('a', a);
+    sessions.set('b', b);
+    sessions.set('c', c);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     L.killAll(sessions as any);
-    expect(bus().killCalls.sort()).toEqual([1, 2, 3]);
+    // Each pty received the Ctrl+C soft signal synchronously.
+    expect(a.pty.write).toHaveBeenCalledWith('\x03');
+    expect(b.pty.write).toHaveBeenCalledWith('\x03');
+    expect(c.pty.write).toHaveBeenCalledWith('\x03');
+    // Watcher stopped synchronously for each sid.
     expect(bus().watcherStopCalls.sort()).toEqual(['a', 'b', 'c']);
+    // No hard kill / subtree walk yet — those only fire on the wedged
+    // timeout fallback.
+    expect(bus().killCalls).toEqual([]);
   });
 
   it('snapshots the keys before iterating — safe against concurrent mutation', () => {
@@ -569,12 +608,13 @@ describe('lifecycle.killAll', () => {
     // is "iterates over a snapshot of keys".
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     L.killAll(sessions as any);
-    expect(bus().killCalls).toHaveLength(2);
+    expect(bus().watcherStopCalls).toHaveLength(2);
   });
 
   it('killAll over an empty map is a no-op', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     L.killAll(new Map() as any);
     expect(bus().killCalls).toEqual([]);
+    expect(bus().watcherStopCalls).toEqual([]);
   });
 });

--- a/electron/ptyHost/index.ts
+++ b/electron/ptyHost/index.ts
@@ -86,7 +86,7 @@ export const killPtySession = (sid: string): Promise<boolean> => L.kill(sessions
 export const getPtySession = (sid: string): L.PtySessionInfo | null =>
   L.get(sessions, sid);
 
-export const killAllPtySessions = (): void => L.killAll(sessions);
+export const killAllPtySessions = (): Promise<void> => L.killAll(sessions);
 
 // L4 PR-A (#861) + PR-B (#865): async chunked snapshot of the per-session
 // authoritative headless buffer paired with the per-entry chunk seq.

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -178,7 +178,8 @@ export function kill(sessions: Map<string, Entry>, sid: string): Promise<boolean
   const entry = sessions.get(sid);
   if (!entry) return Promise.resolve(false);
 
-  // Capture pid BEFORE pty.kill() — the binding may zero it after kill.
+  // Capture pid BEFORE pty.write/kill — the binding may zero it after either
+  // (signal dispatch and explicit kill both can clear pid in node-pty).
   const pid = entry.pty.pid;
 
   // Race fix (#1277 review): pty.kill() returns synchronously but the entry
@@ -268,6 +269,12 @@ export function kill(sessions: Map<string, Entry>, sid: string): Promise<boolean
   // (2 s internal budget), so this is the signal that lets the 100 ms
   // buffered transcript writer drain before exit. If the process is already
   // dead the write throws — the onExit listener or the timer covers us.
+  //
+  // NOTE: this assumes interactive claude. Claude's `-p` / `--print`
+  // non-interactive mode ignores SIGINT (it's designed to run to completion
+  // for scripting). CCSM never spawns claude in print mode — every PTY
+  // session is a fully interactive REPL — but if that ever changes the
+  // graceful path here needs to be reconsidered.
   try {
     entry.pty.write('\x03');
   } catch {
@@ -357,14 +364,19 @@ export async function getBufferSnapshot(
   return { snapshot: out.join('\n'), seq };
 }
 
-// Kill every running pty. Call from app `before-quit` so renderer-side
-// claude processes don't leak past Electron exit. Fire-and-forget — we don't
-// block app teardown on the per-pty graceful-flush dance. Each `kill()`
-// writes `\x03` synchronously; if claude doesn't drain within the 3 s
-// budget the per-session timer escalates to SIGKILL + processKiller subtree
-// walk, which is what reaps any survivors.
-export function killAll(sessions: Map<string, Entry>): void {
-  for (const sid of [...sessions.keys()]) {
-    void kill(sessions, sid);
-  }
+// Kill every running pty. Returns a Promise that resolves after every
+// per-session `kill()` has settled (graceful onExit or 3 s wedged-fallback).
+// Callers that need to block app teardown on the flush (e.g. `before-quit`)
+// MUST `await` this; legacy fire-and-forget call sites can `void killAll(...)`.
+//
+// Rationale: `kill()` now writes `\x03` and waits up to KILL_EXIT_TIMEOUT_MS
+// for claude to drain its 100 ms-buffered JSONL writer. If `before-quit`
+// returned synchronously the way the pre-graceful code did, the Electron
+// process would exit before the timer ran and claude would be killed by
+// process teardown without ever flushing — worse than the old hard-kill
+// path. The hide-the-window-then-await-quit dance in `appLifecycle.ts`
+// keeps the UX instant while honoring the flush budget in the background.
+export function killAll(sessions: Map<string, Entry>): Promise<void> {
+  const sids = [...sessions.keys()];
+  return Promise.all(sids.map((sid) => kill(sessions, sid))).then(() => undefined);
 }

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -139,12 +139,22 @@ export function resize(
   }
 }
 
-// Max wait for pty.onExit to fire after kill() before we give up and resolve
-// the kill promise anyway. The renderer awaits `kill(sid)` before bumping
-// reloadNonce; if the pty is wedged we still want the renderer to fall through
-// to the spawn-on-null fallback rather than hanging the UI. 3s comfortably
-// covers ConPTY teardown + processKiller subtree walk on slow Windows boxes
-// while staying short enough that a stuck kill doesn't feel broken.
+// Graceful-flush + teardown budget. Reload now sends a soft signal (Ctrl+C
+// via PTY — see `\x03` write in `kill()`) instead of going straight to
+// `pty.kill()`, which on Windows ConPTY translates to `TerminateProcess` and
+// delivers no signal to the child. The claude CLI's transcript writer
+// (`Km_`) buffers JSONL entries with a 100 ms `setTimeout` → `appendFile`
+// (no fsync), and its SIGINT/SIGTERM/SIGBREAK/SIGHUP handlers each await a
+// flush with a ~2 s internal budget. Without a graceful signal those queued
+// entries (plus any mid-stream tokens) are lost — after respawn
+// `claude --resume <sid>` reads JSONL from disk, so the missing tail is gone
+// permanently.
+//
+// 3 s comfortably covers claude's 2 s flush window plus margin for OS
+// write-back / processKiller subtree walk on slow Windows boxes, while
+// staying short enough that a wedged kill doesn't feel broken (renderer
+// still falls through to the spawn-on-null fallback via the timer-branch
+// hard-kill below).
 export const KILL_EXIT_TIMEOUT_MS = 3000;
 
 // Dedupe re-entrant kills for the same sid (e.g. user spam-clicks Reload).
@@ -225,10 +235,11 @@ export function kill(sessions: Map<string, Entry>, sid: string): Promise<boolean
     // register the viewer on a dead pty → crash overlay, manual Retry.
     //
     // Force-evict the entry so attach returns null and the renderer gets
-    // a transparent fresh PTY. The process is still live (kill signal
-    // was sent but the OS never reaped it); attempt SIGKILL as a last
-    // resort. On Windows node-pty emulates signals so SIGKILL may be a
-    // no-op — at minimum we've logged the leak so it's visible.
+    // a transparent fresh PTY. The soft `\x03` signal didn't reap the
+    // process inside the flush budget — escalate to hard kill + subtree
+    // walk. On Windows node-pty emulates signals so SIGKILL may be a
+    // no-op, in which case `killProcessSubtree` (platform-native: taskkill
+    // /T /F on Windows, killpg on Unix) is what actually reaps the tree.
     try {
       entry.pty.kill('SIGKILL');
     } catch (e) {
@@ -236,23 +247,37 @@ export function kill(sessions: Map<string, Entry>, sid: string): Promise<boolean
         `[ptyHost] kill ${sid} wedged: SIGKILL also failed (${e instanceof Error ? e.message : String(e)}); pid ${pid} may leak`,
       );
     }
+    // ConPTY's kill only terminates the cmd.exe / OpenConsole wrapper; on
+    // Windows the claude.exe child (and its grandchildren) survive as
+    // orphans. On mac/linux the pgid may also have stragglers. Walk the
+    // tree via a platform-native call to guarantee a clean shutdown.
+    // Deferred to the hard-fallback branch ONLY — running this on the
+    // graceful path would kill claude mid-flush and defeat the soft-signal
+    // strategy.
+    killProcessSubtree(pid);
     if (sessions.get(sid) === entry) sessions.delete(sid);
     settle(false);
   }, KILL_EXIT_TIMEOUT_MS);
 
+  // Soft signal: write Ctrl+C (`\x03`) to the PTY. On Windows ConPTY this is
+  // translated on stdin into a console CTRL_C_EVENT → SIGINT to the child;
+  // on Unix the terminal line discipline converts `\x03` to SIGINT for the
+  // foreground process group. One code path, both platforms — no FFI, no
+  // `process.kill` differences. claude registers SIGINT/SIGTERM/SIGBREAK/
+  // SIGHUP handlers that all funnel into `nK(code)` → awaits `dWH.flush()`
+  // (2 s internal budget), so this is the signal that lets the 100 ms
+  // buffered transcript writer drain before exit. If the process is already
+  // dead the write throws — the onExit listener or the timer covers us.
   try {
-    entry.pty.kill();
+    entry.pty.write('\x03');
   } catch {
     /* already dead — onExit may or may not fire; timeout covers us */
   }
-  // ConPTY's kill only terminates the cmd.exe / OpenConsole wrapper; on Windows
-  // the claude.exe child (and its grandchildren) survive as orphans. On
-  // mac/linux the pgid may also have stragglers. Walk the tree via a
-  // platform-native call to guarantee a clean shutdown.
-  killProcessSubtree(pid);
-  // Belt-and-braces: also stop the watcher synchronously here so a
-  // pty.kill that races with onExit can't leak the fs.watch handle.
-  // sessionWatcher.stopWatching is idempotent.
+  // Belt-and-braces: stop the watcher synchronously here so a write that
+  // races with onExit can't leak the fs.watch handle.
+  // sessionWatcher.stopWatching is idempotent. Stopping the JSONL watcher
+  // does not interfere with claude's own writes — it just closes our
+  // observer-side fs.watch handle.
   try { sessionWatcher.stopWatching(sid); } catch { /* never throws */ }
 
   return promise;
@@ -334,9 +359,10 @@ export async function getBufferSnapshot(
 
 // Kill every running pty. Call from app `before-quit` so renderer-side
 // claude processes don't leak past Electron exit. Fire-and-forget — we don't
-// block app teardown on the per-pty onExit/timeout dance; the kill signal +
-// processKiller subtree walk dispatch synchronously inside `kill()` before
-// the awaited onExit, which is what actually reaps the children.
+// block app teardown on the per-pty graceful-flush dance. Each `kill()`
+// writes `\x03` synchronously; if claude doesn't drain within the 3 s
+// budget the per-session timer escalates to SIGKILL + processKiller subtree
+// walk, which is what reaps any survivors.
 export function killAll(sessions: Map<string, Entry>): void {
   for (const sid of [...sessions.keys()]) {
     void kill(sessions, sid);


### PR DESCRIPTION
## Root cause

Right-click **Reload session** calls `lifecycle.kill()` → `pty.kill()`. On Windows ConPTY, `pty.kill()` translates to `TerminateProcess` — the claude CLI gets no signal, never runs its graceful-shutdown handler, and the tail of buffered JSONL writes is lost. After respawn `claude --resume <sid>` reads JSONL from disk, so the missing messages are gone permanently.

Empirical claude behavior:
- Transcript writer `Km_` buffers entries with a 100 ms `setTimeout` → `appendFile` (no `fsync`).
- claude installs handlers for `SIGINT` / `SIGTERM` / `SIGBREAK` / `SIGHUP`, each calling `nK(code)` which awaits `dWH.flush()` (~2 s budget).
- On hard kill, queued (≤100 ms) entries and any mid-stream tokens are lost.

## Fix

In `lifecycle.kill()`, send a soft signal **before** any hard kill: write `\x03` (Ctrl+C) to the PTY.

- **Windows:** ConPTY converts `\x03` on stdin to a console CTRL_C_EVENT, delivered to claude as SIGINT.
- **Unix:** the terminal line discipline turns `\x03` into SIGINT for the foreground process group.

One code path, both platforms. Matches what a user pressing Ctrl+C in a real terminal would do (protocol-correct, not content-altering).

Then wait up to `KILL_EXIT_TIMEOUT_MS = 3000` (claude's 2 s flush + margin for OS write-back) for `pty.onExit`. If it fires we settle clean. If the timer fires we escalate to the existing hard-kill path: `pty.kill('SIGKILL')` + `killProcessSubtree(pid)` + force-evict from the registry.

Critically, `killProcessSubtree` is now in the **timeout branch only** — running it synchronously on the graceful path would reap claude mid-flush and defeat the whole point. `sessionWatcher.stopWatching` stays synchronous (it just closes our observer-side `fs.watch` handle; does not touch claude's writes).

Re-entrant `kill(sid)` dedup via `pendingKills` is unchanged.

## Review-round-2 fixes (commit 4eef634)

Cold reviewer caught a **regression in the app-Quit path** (finding #5) plus three nits (#6 #7 #8). All addressed in the second commit on this branch.

### Finding #5 — `before-quit` regression (FIXED)

Before this PR, `before-quit` was synchronous fire-and-forget — `killAll` did `pty.kill()` + `killProcessSubtree` inline, so children were dead before Electron exited. After turning `kill()` into a 3 s `\x03` + onExit wait, fire-and-forget meant the main process exited before the per-session timers ran, and claude got reaped by process teardown without ever flushing — strictly worse than the pre-graceful path.

Decision: **front window hides immediately; flush awaits silently in the background; then re-fire `app.quit()`**.

- `lifecycle.killAll` now returns `Promise<void>` (`Promise.all(...)`).
- `ptyHost/index.ts:killAllPtySessions` propagates the Promise.
- `appLifecycle.LifecycleDeps.killAllPtySessions` typed `() => Promise<void>`.
- `before-quit` handler:
  1. `BrowserWindow.getAllWindows().forEach(w => w.hide())` — UX: instant. We use `hide()` not `close()` to avoid re-entering the tray-resident hide-to-tray path or other window listeners.
  2. `event.preventDefault()` to abort the first quit pass.
  3. Latches a module-level `flushingForQuit` flag.
  4. Awaits `killAllPtySessions()` + `disposeNotifyPipeline()` in the background.
  5. Re-fires `app.quit()`; handler re-enters with the latch set and falls through, Electron walks `window-all-closed` → `closeDb()` → process exit.

### Nit #6 (FIXED)

`lifecycle.ts` pid-capture comment now reads "BEFORE pty.write/kill — binding may zero it after either" (since `pty.write` of `\x03` also dispatches a signal).

### Nit #7 (FIXED)

Added a comment at the `\x03` write site noting that the graceful path assumes interactive claude; claude's `-p` / `--print` mode ignores SIGINT but CCSM never spawns claude in print mode.

### Nit #8 (FIXED)

Added an explicit ordering test in `lifecycle.test.ts`: asserts `pty.onExit` is registered **before** the `\x03` write. Guards against a future reorder that would drop the exit notification under sync-onExit fakes (or real fast-exit races).

## Tests

- `electron/ptyHost/__tests__/lifecycle.test.ts`: graceful path writes `\x03`, no `pty.kill()` on the graceful path; wedged-timeout escalates to SIGKILL + subtree walk; ordering guard (onExit before write); `killAll` returns a Promise that resolves only after all per-session kills settle.
- `electron/lifecycle/__tests__/appLifecycle.test.ts`: windows hidden on first `before-quit`; `preventDefault` on first pass; `killAllPtySessions` awaited before `app.quit()` re-fires; second pass takes the `flushingForQuit` fast-path (no re-invoke); rejected `killAll`/throwing `disposeNotifyPipeline`/throwing `window.hide()` all still complete the quit.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm test` — 1771 / 1771 pass (after `tsc -p tsconfig.electron.json` to populate `dist/electron/` for the load-smoke test, which is required for any electron-related change and is unrelated to this PR)
- [ ] Manual: right-click Reload mid-conversation, confirm last assistant message survives (Windows + macOS)
- [ ] Manual: tray Quit / Ctrl-Q mid-conversation, confirm window vanishes instantly AND the JSONL tail is present on next launch

## Do not merge

Awaiting reviewer.