### PR TITLE
fix(mobile-remote): flush close frame before FIN so peer sees 1009

### DIFF
--- a/electron/__tests__/mobileRemoteServer.test.ts
+++ b/electron/__tests__/mobileRemoteServer.test.ts
@@ -372,12 +372,9 @@ describe('mobileRemoteServer: 1 MiB message cap', () => {
       ws.closeCode,
       new Promise<number>((_, rej) => setTimeout(() => rej(new Error('no close')), 2000)),
     ]);
-    // On a clean shutdown the server writes the close frame (code 1009) and
-    // then destroys; on Windows the FIN occasionally races the framed body
-    // so we accept either the exact code or a hard socket close as evidence
-    // the cap was enforced. The crucial assertion is "didn't get parsed and
-    // routed as a normal text message", which a hard close demonstrates.
-    expect(code === 1009 || code === null).toBe(true);
+    // Server flushes the close frame (via socket.end) before FIN, so the peer
+    // must observe the exact 1009 reason on every OS.
+    expect(code).toBe(1009);
   });
 });
 

--- a/electron/remote/mobileRemoteServer.ts
+++ b/electron/remote/mobileRemoteServer.ts
@@ -258,15 +258,24 @@ function encodeFrameBytes(firstByte: number, body: Buffer): Buffer {
 }
 
 function closeSocket(socket: Duplex, code: number): void {
-  if (socket.destroyed) return;
+  // `writableEnded` guards re-entry: when the client streams a payload that
+  // arrives in multiple TCP chunks, each chunk re-enters the 'data' handler
+  // and may trip the same fatal limit again. Without this guard the second
+  // call would `socket.end()` again, throw "write after end", and the catch
+  // would `destroy()` the socket — losing the framed close payload we just
+  // queued. Checking `writableEnded` keeps the first close frame intact.
+  if (socket.destroyed || socket.writableEnded) return;
   const body = Buffer.allocUnsafe(2);
   body.writeUInt16BE(code, 0);
   try {
-    socket.write(encodeControlFrame(0x8, body));
+    // Use `end()` so the close frame is flushed before FIN. `destroy()` does
+    // not wait for pending writes, so on Windows the framed close payload can
+    // be dropped and the peer never sees the close reason.
+    socket.end(encodeControlFrame(0x8, body));
   } catch {
     /* socket already gone */
+    socket.destroy();
   }
-  socket.destroy();
 }
 
 type DecodeResult =


### PR DESCRIPTION
## Summary

- `closeSocket()` in `electron/remote/mobileRemoteServer.ts` called `socket.write(closeFrame); socket.destroy()`. `destroy()` does not flush pending writes, so on Windows the framed close payload could be lost before the TCP FIN — well-behaved clients never saw the 1009 (message-too-big) reason. Switched to `socket.end(closeFrame)` which flushes then half-closes.
- Added a `socket.writableEnded` re-entry guard. When an over-cap client streams its payload across multiple TCP chunks, each chunk re-enters the `'data'` handler and re-trips the fatal limit. Without the guard the second `closeSocket()` call would `end()` again, throw "write after end", and the `catch` would `destroy()` the socket — undoing the flushed close frame. With the guard the first close frame stays intact.
- Tightened `electron/__tests__/mobileRemoteServer.test.ts`'s 1009 assertion to demand the exact code on every OS. The "1009 OR null close" accommodation from #1336 existed precisely to paper over this bug; it is no longer needed.

## Test plan

- [x] `npm test -- electron/__tests__ --run --reporter=dot` — 139/139 pass locally on Windows (previously, with the tightened assertion but no fix, the 1009 test failed receiving `null`).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — 0 errors (warnings pre-existing, unrelated).
- [ ] CI green on Linux + macOS + Windows.

## Follow-up (not in this PR)

The mobile remote server still `console.log`s the bearer token in clear text on startup. Acceptable while gated by `CCSM_MOBILE_REMOTE=1` dev opt-in, but worth replacing with a fingerprint (first 4 + last 4 chars) in a follow-up to reduce shoulder-surfing / log-leak risk.