### PR TITLE
test(e2e): drop pty-pid-stable-across-switch from CI subset

### DIFF
--- a/scripts/harness-real-cli-ci.mjs
+++ b/scripts/harness-real-cli-ci.mjs
@@ -31,7 +31,7 @@
 //   5. Runs each selected case against the shared launch, summarizes,
 //      exits non-zero on any failure.
 //
-// Subset (11 cases):
+// Subset (10 cases):
 //   - agent-icon-active-session-no-halo
 //   - cwd-picker-no-shortcut
 //   - sidebar-group-no-newsession-cluster
@@ -40,7 +40,6 @@
 //   - cwd-picker-top-chevron
 //   - cwd-picker-browse
 //   - caseSpacesInCwdSpawnsCorrectly
-//   - pty-pid-stable-across-switch
 //   - new-session-focus-cli
 //   - attach-replay-from-headless-buffer
 //
@@ -80,6 +79,17 @@
 //                                       could fit time-wise but its
 //                                       second Electron boot exceeds the
 //                                       shared-launch budget structure
+//   - pty-pid-stable-across-switch    : verifies pty PID stability by writing
+//                                       `echo MARKER\n` into the pty and
+//                                       waiting for the marker in xterm
+//                                       scrollback. The pty hosts the
+//                                       `claude` TUI (not a shell), so the
+//                                       input is consumed by the TUI and
+//                                       never echoed back. Inherently
+//                                       unsatisfiable under the fake-LLM-API
+//                                       CI setup; covered by the full
+//                                       harness in dogfood against a real
+//                                       claude binary.
 //
 // Run locally:
 //   node scripts/harness-real-cli-ci.mjs                # all CI subset
@@ -96,6 +106,11 @@ import { startFakeAnthropicApi } from './fixtures/fake-anthropic-api.mjs';
 // Subset selection
 // ============================================================================
 
+// Note: `pty-pid-stable-across-switch` is intentionally NOT in this subset.
+// It writes `echo MARKER\n` into the pty and waits for the marker in xterm
+// scrollback, but the pty hosts the `claude` TUI (not a shell), which
+// consumes the input instead of echoing it. Unsatisfiable under the
+// fake-LLM-API setup; the full harness still runs it in dogfood.
 const CI_SUBSET = new Set([
   'agent-icon-active-session-no-halo',
   'cwd-picker-no-shortcut',
@@ -105,7 +120,6 @@ const CI_SUBSET = new Set([
   'cwd-picker-top-chevron',
   'cwd-picker-browse',
   'caseSpacesInCwdSpawnsCorrectly',
-  'pty-pid-stable-across-switch',
   'new-session-focus-cli',
   'attach-replay-from-headless-buffer',
 ]);


### PR DESCRIPTION
## Summary

Removes `pty-pid-stable-across-switch` from `scripts/harness-real-cli-ci.mjs`'s `CI_SUBSET`.

**CI subset count: 11 -> 10.**

## Why

The case writes `echo MARKER_xxx\n` into a pty and waits for the marker to appear in xterm scrollback. But the pty hosts the `claude` TUI process itself, not a shell — so the input is consumed by the TUI (as a chat prompt / shortcut) and never echoed back. This is an inherent mismatch between the verification mechanism (assumes shell echo) and the fake-LLM-API CI setup (pty runs `claude`, not bash). The case fails deterministically on both windows and ubuntu runners.

The original case stays in `scripts/harness-real-cli.mjs` and continues to run in dogfood against a real claude binary + real auth, where the pty PID stability invariant is still meaningful and verifiable.

## Scope

- Only `scripts/harness-real-cli-ci.mjs`. No source, no other harness, no workflow changes.
- A brief comment is added next to `CI_SUBSET` and to the excluded-cases block explaining the exclusion.

## Test plan

- [ ] e2e workflow auto-triggers on this PR (paths filter includes `scripts/**`) and the real-cli-ci job passes on both ubuntu and windows with the remaining 10 cases.