### PR TITLE
test(e2e): drop new-session-focus-cli from CI subset

### DIFF
--- a/scripts/harness-real-cli-ci.mjs
+++ b/scripts/harness-real-cli-ci.mjs
@@ -31,7 +31,7 @@
 //   5. Runs each selected case against the shared launch, summarizes,
 //      exits non-zero on any failure.
 //
-// Subset (10 cases):
+// Subset (9 cases):
 //   - agent-icon-active-session-no-halo
 //   - cwd-picker-no-shortcut
 //   - sidebar-group-no-newsession-cluster
@@ -40,7 +40,6 @@
 //   - cwd-picker-top-chevron
 //   - cwd-picker-browse
 //   - caseSpacesInCwdSpawnsCorrectly
-//   - new-session-focus-cli
 //   - attach-replay-from-headless-buffer
 //
 // Excluded cases (with reason):
@@ -90,6 +89,14 @@
 //                                       CI setup; covered by the full
 //                                       harness in dogfood against a real
 //                                       claude binary.
+//   - new-session-focus-cli           : depends on shell-mode pty echo of
+//                                       marker; consumed by TUI on flaky
+//                                       windows runs. Same root cause as
+//                                       `pty-pid-stable-across-switch` —
+//                                       writes `FOCUS_PROBE_xxx` into a pty
+//                                       hosting the claude TUI and waits
+//                                       for it in xterm buffer. Covered by
+//                                       the full harness in dogfood.
 //
 // Run locally:
 //   node scripts/harness-real-cli-ci.mjs                # all CI subset
@@ -120,7 +127,6 @@ const CI_SUBSET = new Set([
   'cwd-picker-top-chevron',
   'cwd-picker-browse',
   'caseSpacesInCwdSpawnsCorrectly',
-  'new-session-focus-cli',
   'attach-replay-from-headless-buffer',
 ]);
 


### PR DESCRIPTION
## Summary

Same root cause as `pty-pid-stable-across-switch` (removed in #1343): drives a marker (`FOCUS_PROBE_xxx`) through a pty that's hosting the `claude` TUI, not a shell, so the input is consumed by the TUI and never echoed back to xterm. Happens to be flaky rather than deterministic — passed on #1342's CI but failed on #1343's `windows-latest` with `waitForXtermBuffer: pattern /FOCUS_PROBE_xxx/ not found within 15000ms`.

Both cases belong only in the dogfood-only `harness-real-cli.mjs` against a real claude + real auth, where the TUI behaves more shell-like (user input flows back as chat content + assistant text echoes the prompt).

- Removed `new-session-focus-cli` from `CI_SUBSET` in `scripts/harness-real-cli-ci.mjs`
- Added it to the excluded-cases comment block next to `pty-pid-stable-across-switch`
- New subset size: 9 (was 10 after #1343)

## Test plan

- [ ] e2e workflow (auto-triggered by `scripts/**` path filter) is green on all 3 OS
- [ ] Subset still runs 9 cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)