### PR TITLE
feat(observability): PR A — structured logger, scrubber, attach probes (Stage 1)

### DIFF
--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -22,8 +22,20 @@ vi.mock('electron', () => {
         windows.push(...list);
       },
     },
+    app: { getPath: vi.fn(() => '/tmp/logs') },
+    shell: { openPath: vi.fn(async () => '') },
   };
 });
+
+// Mock the log module to avoid pulling in electron-log (which requires
+// the electron binary). appLifecycle imports getLogLevel / getLogFilePath
+// to render the Help submenu — stub them with deterministic values.
+vi.mock('../../shared/log', () => ({
+  getLogLevel: () => 'info',
+  setLogLevel: vi.fn(),
+  getLogFilePath: () => '/tmp/logs/main.log',
+  log: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), event: vi.fn() },
+}));
 
 // applyAppMenuLocale uses a dynamic `require('../i18n')` to dodge a
 // circular-import edge in the production graph. vitest's vi.mock only
@@ -156,7 +168,7 @@ describe('applyAppMenuLocale', () => {
     vi.mocked(Menu.setApplicationMenu).mockClear();
   });
 
-  it('builds a hidden Edit-role accelerator menu and installs it', () => {
+  it('builds the menu (Edit accelerators + Help submenu) and installs it', () => {
     applyAppMenuLocale();
     expect(Menu.buildFromTemplate).toHaveBeenCalledTimes(1);
     expect(Menu.setApplicationMenu).toHaveBeenCalledTimes(1);
@@ -165,8 +177,10 @@ describe('applyAppMenuLocale', () => {
   it('uses the localized "Edit" label from i18n.tMenu', () => {
     applyAppMenuLocale();
     const template = vi.mocked(Menu.buildFromTemplate).mock.calls[0][0];
-    expect(template).toHaveLength(1);
+    // Edit + Help → 2 top-level entries.
+    expect(template).toHaveLength(2);
     expect(template[0].label).toBe('MENU_edit');
+    expect(template[1].label).toBe('Help');
   });
 
   it('omits paste from the submenu (terminal pane installs its own handler)', () => {

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -17,7 +17,58 @@
 // Extracting it would just create a giant deps bag with no real win.
 
 import type { App } from 'electron';
-import { BrowserWindow, Menu } from 'electron';
+import { BrowserWindow, Menu, app, shell } from 'electron';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { getLogLevel, setLogLevel, getLogFilePath, log } from '../shared/log';
+
+type LogLevelChoice = 'debug' | 'info' | 'warn' | 'error';
+
+/** "Pin current log" flow used by the Help → Reveal Logs item. Copies the
+ *  live rotating files into `logs/pinned-<ISO-timestamp>/` so subsequent
+ *  rotation can't shred the user's bug-report snapshot, then opens the logs
+ *  folder in the OS file browser.
+ *
+ *  Pinned snapshots are NEVER auto-pruned (parent resolution v2 §7). The
+ *  user can delete them manually if disk pressure becomes an issue. */
+export async function revealLogsAndPin(): Promise<void> {
+  let logsDir: string;
+  try {
+    logsDir = app.getPath('logs');
+  } catch (e) {
+    log.error('menu', 'reveal-logs: getPath failed', e instanceof Error ? e : undefined);
+    return;
+  }
+  try {
+    if (!fs.existsSync(logsDir)) fs.mkdirSync(logsDir, { recursive: true });
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const pinDir = path.join(logsDir, `pinned-${stamp}`);
+    fs.mkdirSync(pinDir, { recursive: true });
+    // Copy every regular file directly under logsDir (NOT subdirs — we don't
+    // want to recurse into prior pinned-* snapshots). `*.log` covers main
+    // + rotated archives; we also pick up any sibling files electron-log
+    // happens to write.
+    for (const name of fs.readdirSync(logsDir)) {
+      const full = path.join(logsDir, name);
+      try {
+        const st = fs.statSync(full);
+        if (st.isFile() && name.endsWith('.log')) {
+          fs.copyFileSync(full, path.join(pinDir, name));
+        }
+      } catch {
+        /* skip individual file failures */
+      }
+    }
+    log.info('menu', 'logs pinned', { stage: 'pin' });
+  } catch (e) {
+    log.error('menu', 'reveal-logs: pin failed', e instanceof Error ? e : undefined);
+  }
+  try {
+    await shell.openPath(logsDir);
+  } catch (e) {
+    log.error('menu', 'reveal-logs: openPath failed', e instanceof Error ? e : undefined);
+  }
+}
 
 /** Build + install the hidden app accelerator menu. We don't want a visible
  *  File/Edit/View menu bar — CCSM is a single-window tool and those menus
@@ -50,6 +101,8 @@ export function applyAppMenuLocale(): void {
   // through means it never reaches DOM keydown at all (the menu consumes
   // it first); removing the menu entry lets the keydown propagate
   // normally to the renderer.
+  const currentLevel = getLogLevel();
+  const levels: LogLevelChoice[] = ['debug', 'info', 'warn', 'error'];
   const accelMenu = Menu.buildFromTemplate([
     {
       label: i18n.tMenu('edit'),
@@ -60,6 +113,40 @@ export function applyAppMenuLocale(): void {
         { role: 'cut' },
         { role: 'copy' },
         { role: 'selectAll' },
+      ],
+    },
+    // Help submenu: Reveal Logs (with pin) + Set Level. Always visible per
+    // parent resolution (v2 §7) — not gated on CCSM_DEV=1. The Set Level
+    // submenu uses radio-style checkmarks reflecting the persisted choice.
+    {
+      label: 'Help',
+      submenu: [
+        {
+          label: 'Reveal Logs in Folder',
+          click: () => {
+            void revealLogsAndPin();
+          },
+        },
+        {
+          label: `Log File: ${getLogFilePath() || '(uninitialized)'}`,
+          enabled: false,
+        },
+        { type: 'separator' },
+        {
+          label: 'Set Log Level',
+          submenu: levels.map((lvl) => ({
+            label: lvl.charAt(0).toUpperCase() + lvl.slice(1),
+            type: 'radio' as const,
+            checked: lvl === currentLevel,
+            click: () => {
+              setLogLevel(lvl);
+              log.info('menu', 'log level changed', { stage: lvl });
+              // Rebuild so the checkmark moves. Cheap; runs at most a few
+              // times per session.
+              applyAppMenuLocale();
+            },
+          })),
+        },
       ],
     },
   ]);

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -29,7 +29,7 @@ import { app, BrowserWindow, ipcMain, type Tray } from 'electron';
 import { initDb, closeDb } from './db';
 import { buildTrayIcon } from './branding/icon';
 import { initSentry } from './sentry/init';
-import { initLog, log, normalizeError } from './shared/log';
+import { initLog, log, normalizeError, syncPersistedLevelFromDb } from './shared/log';
 import { createWindow as createMainWindowFactory, installContextMenuSuppressIpc } from './window/createWindow';
 import { createTray, type TrayController } from './tray/createTray';
 
@@ -188,6 +188,15 @@ app.whenReady().then(() => {
   }
 
   initDb();
+
+  // initLog() ran at module-load (before app.whenReady) when db wasn't yet
+  // open, so it could only see `CCSM_LOG_LEVEL` or the `info` default. Now
+  // that the db is up, re-read the persisted choice and (if it differs)
+  // apply + rebuild the menu so Help → Set Log Level shows the correct
+  // radio checkmark on first paint. Cold review finding #3c / #9.
+  if (syncPersistedLevelFromDb()) {
+    applyAppMenuLocale();
+  }
 
   // ─────────────────────────── IPC registration ──────────────────────────
   // Wire prefs cache invalidation to the stateSavedBus BEFORE registering

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -29,22 +29,27 @@ import { app, BrowserWindow, ipcMain, type Tray } from 'electron';
 import { initDb, closeDb } from './db';
 import { buildTrayIcon } from './branding/icon';
 import { initSentry } from './sentry/init';
+import { initLog, log, normalizeError } from './shared/log';
 import { createWindow as createMainWindowFactory, installContextMenuSuppressIpc } from './window/createWindow';
 import { createTray, type TrayController } from './tray/createTray';
+
+// Initialize structured logger before anything else. Idempotent; safe to
+// call pre-`app.whenReady` because the file path is resolved lazily on the
+// first write (electron-log's `transports.file.resolvePathFn`).
+initLog();
 
 // safety net — escaped main-proc rejections kill app on Node 20+ default
 // (audit tech-debt-03-errors.md risk #2). Registered BEFORE app.whenReady so
 // any throw during bootstrap (initSentry, IPC registration, db open) lands
 // in the logger instead of silently terminating the process. We deliberately
 // do NOT call app.exit() — preserves current default-throw behavior in tests
-// and mirrors the renderer's "log + degrade" stance. TODO: forward to Sentry
-// once main-process Sentry transport is wired (currently renderer-only per
-// audit).
+// and mirrors the renderer's "log + degrade" stance.
 process.on('unhandledRejection', (reason, _promise) => {
-  console.error('[main] unhandledRejection:', reason);
+  const err = reason instanceof Error ? reason : new Error(String(reason));
+  log.error('main', 'unhandledRejection', { error: normalizeError(err) });
 });
 process.on('uncaughtException', (err) => {
-  console.error('[main] uncaughtException:', err);
+  log.error('main', 'uncaughtException', { error: normalizeError(err) });
 });
 
 // Sentry init reads SENTRY_DSN and wires up beforeSend → opt-out check. The

--- a/electron/shared/log.ts
+++ b/electron/shared/log.ts
@@ -12,9 +12,23 @@
 //     the renderer's electron-log instance through the IPC bridge if main
 //     is responsive, AND captured locally so a mid-crash renderer still
 //     has tail evidence on disk
+//
+// TEST / CI SAFETY: this module is `import`-ed by ~80 call sites across the
+// main bundle, including modules that vitest loads under plain Node (with
+// no electron binary installed — the CI lint+typecheck+test job does NOT
+// download the electron binary; only the e2e job does). `electron-log/main`
+// does `require('electron')` at module-eval time, which throws "Electron
+// failed to install correctly" when the binary stub returns no path. To
+// keep vitest under Node from blowing up the moment ANY ptyHost / commands-
+// loader test pulls in `entryFactory.ts → '../shared/log'`, all electron-
+// dependent loads are deferred behind `isElectronRuntime()`:
+//   * `require('electron-log/main')` — lazy, inside `getElog()`
+//   * `require('electron')` for `app.getVersion()` / `app.getPath()` —
+//     lazy, inside `getApp()`
+// Outside Electron, every function in this module falls back to a console-
+// only path. The renderer side (`src/shared/log.ts`) uses a parallel
+// short-circuit keyed on `VITEST`.
 
-import elog from 'electron-log/main';
-import { app } from 'electron';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
@@ -25,9 +39,34 @@ import { scrub, normalizeError, setHomeDir, EVENT_ALLOWED_FIELDS, scrubConsoleAr
 // electron-log's homonymous methods.
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
+// Minimal subset of the electron-log surface we use, so the non-Electron
+// fallback can implement just these. Avoids declaring `any` while still
+// keeping the unknown shape opaque to callers.
+type ElogLike = {
+  initialize: () => void;
+  transports: {
+    console: { level: LogLevel | false; format?: (m: { data: unknown[]; level: string; message: { date: Date } }) => unknown[] };
+    file: {
+      level: LogLevel | false;
+      fileName?: string;
+      maxSize?: number;
+      format?: (params: { data: unknown[]; level: string; message: { date: Date } }) => unknown[];
+      archiveLogFn?: (oldLog: unknown) => void;
+      resolvePathFn?: (vars: unknown, message?: unknown) => string;
+      getFile?: () => { path: string };
+    };
+  };
+  create: (opts: { logId: string }) => ElogLike;
+  debug: (msg: string) => void;
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
 // Setting homedir for the path scrubber. Must happen before any record is
 // emitted; called eagerly at module load so the first uncaughtException
-// during bootstrap is scrubbed too.
+// during bootstrap is scrubbed too. `os.homedir()` is a pure Node API — no
+// electron dep — so it's safe to run at module-eval even on CI vitest.
 try {
   setHomeDir(os.homedir());
 } catch {
@@ -46,6 +85,47 @@ const RENDERER_LOG_MAX_BYTES = 1 * 1024 * 1024;
 
 let _initialized = false;
 let _currentLevel: LogLevel = 'info';
+let _elog: ElogLike | null = null;
+
+/** True when running under Electron (main process with the binary live).
+ *  vitest under plain Node has `process.versions.electron === undefined`,
+ *  so this returns false and every electron-dependent path falls back to
+ *  console-only / no-op. Cheaper than env probing; immune to e2e runs that
+ *  forget to set NODE_ENV / VITEST. */
+function isElectronRuntime(): boolean {
+  return typeof process !== 'undefined' && typeof process.versions?.electron === 'string';
+}
+
+/** Lazily resolve `electron-log/main`. Returns null outside Electron so
+ *  callers can fall back to console-only without crashing on the
+ *  `require('electron')` inside electron-log's own boot. */
+function getElog(): ElogLike | null {
+  if (_elog) return _elog;
+  if (!isElectronRuntime()) return null;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require('electron-log/main') as { default?: ElogLike } & ElogLike;
+    _elog = (mod.default ?? mod) as ElogLike;
+    return _elog;
+  } catch {
+    // electron-log threw on load (e.g. the binary path resolver hit a
+    // corrupt install). Fall back to console-only; logging is best-effort.
+    return null;
+  }
+}
+
+/** Lazily resolve `electron.app`. Same rationale as `getElog`. Returns
+ *  null outside Electron. */
+function getApp(): { getVersion?: () => string; getPath?: (name: string) => string } | null {
+  if (!isElectronRuntime()) return null;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const electron = require('electron') as { app?: { getVersion?: () => string; getPath?: (name: string) => string } };
+    return electron.app ?? null;
+  } catch {
+    return null;
+  }
+}
 
 type EnvFlags = {
   level: LogLevel | null;
@@ -96,7 +176,7 @@ function persistLevel(level: LogLevel): void {
 function buildHeader(): string {
   let appVersion = 'unknown';
   try {
-    appVersion = app.getVersion();
+    appVersion = getApp()?.getVersion?.() ?? 'unknown';
   } catch {
     /* app not ready in tests */
   }
@@ -171,7 +251,10 @@ function jsonlFormat(params: {
   return [JSON.stringify(record)];
 }
 
-/** Configure electron-log transports. Idempotent — re-calling is a no-op. */
+/** Configure electron-log transports. Idempotent — re-calling is a no-op.
+ *  Under non-Electron runtime (vitest on plain Node, CI without binary),
+ *  this is a no-op past the level read — every subsequent `log.*` call
+ *  falls back to the console-only path. */
 export function initLog(): void {
   if (_initialized) return;
   _initialized = true;
@@ -179,6 +262,13 @@ export function initLog(): void {
   const env = readEnvFlags();
   const persisted = loadPersistedLevel();
   _currentLevel = env.level ?? persisted ?? 'info';
+
+  const elog = getElog();
+  if (!elog) {
+    // Non-Electron runtime — no transports to configure. The `emit()`
+    // path below will see `elog === null` and route to console.
+    return;
+  }
 
   // Initialize the IPC bridge so renderer logs flow into main's transports.
   // Per electron-log v5: `initialize()` registers the IPC handlers.
@@ -222,7 +312,7 @@ export function initLog(): void {
     // only keeps ONE rotated archive by default. For 10-file rotation we
     // override to cycle through `main.1.log` … `main.10.log`.
     elog.transports.file.archiveLogFn = (oldLog) => {
-      const file = oldLog.toString();
+      const file = String(oldLog);
       const dir = path.dirname(file);
       const base = path.basename(file, '.log');
       // Shift main.9.log → main.10.log, main.8.log → main.9.log, …
@@ -251,11 +341,13 @@ export function initLog(): void {
     // Header-on-new-file. electron-log resolves the file path lazily via
     // `transports.file.resolvePathFn`; capture it on first write.
     const resolvePath = elog.transports.file.resolvePathFn;
-    elog.transports.file.resolvePathFn = (vars, message) => {
-      const p = resolvePath(vars, message);
-      ensureHeader(p);
-      return p;
-    };
+    if (resolvePath) {
+      elog.transports.file.resolvePathFn = (vars: unknown, message?: unknown) => {
+        const p = resolvePath(vars, message);
+        ensureHeader(p);
+        return p;
+      };
+    }
   }
 
   // Renderer-local fallback transport: a small file at
@@ -265,7 +357,8 @@ export function initLog(): void {
   // evidence if the IPC bridge has died. This transport on the MAIN side
   // captures the IPC-shipped renderer records into a separate file.
   try {
-    const userData = app.getPath('userData');
+    const userData = getApp()?.getPath?.('userData');
+    if (!userData) throw new Error('userData unavailable');
     const rendererLogDir = path.join(userData, 'renderer-logs');
     if (!fs.existsSync(rendererLogDir)) {
       fs.mkdirSync(rendererLogDir, { recursive: true });
@@ -282,7 +375,7 @@ export function initLog(): void {
     rendererLogger.transports.console.level = false;
     // 2-file ring (1MB × 2 = 2MB cap per design v2).
     rendererLogger.transports.file.archiveLogFn = (oldLog) => {
-      const file = oldLog.toString();
+      const file = String(oldLog);
       const dir = path.dirname(file);
       const base = path.basename(file, '.log');
       try {
@@ -303,9 +396,12 @@ export function initLog(): void {
  *  via sqlite app_state so the choice survives restart. */
 export function setLogLevel(level: LogLevel): void {
   _currentLevel = level;
-  elog.transports.console.level = level;
-  if (elog.transports.file.level !== false) {
-    elog.transports.file.level = level;
+  const elog = getElog();
+  if (elog) {
+    elog.transports.console.level = level;
+    if (elog.transports.file.level !== false) {
+      elog.transports.file.level = level;
+    }
   }
   persistLevel(level);
 }
@@ -327,9 +423,12 @@ export function syncPersistedLevelFromDb(): boolean {
   // already came from the db, no write-back needed (would be a no-op
   // anyway, but the avoidance keeps boot off the disk).
   _currentLevel = persisted;
-  elog.transports.console.level = persisted;
-  if (elog.transports.file.level !== false) {
-    elog.transports.file.level = persisted;
+  const elog = getElog();
+  if (elog) {
+    elog.transports.console.level = persisted;
+    if (elog.transports.file.level !== false) {
+      elog.transports.file.level = persisted;
+    }
   }
   return true;
 }
@@ -339,6 +438,8 @@ export function getLogLevel(): LogLevel {
 }
 
 export function getLogFilePath(): string {
+  const elog = getElog();
+  if (!elog?.transports.file.getFile) return '';
   try {
     return elog.transports.file.getFile().path;
   } catch {
@@ -379,7 +480,15 @@ function emit(
     msg,
     ...(payload ?? {}),
   };
-  elog[level](JSON.stringify(record));
+  const json = JSON.stringify(record);
+  const elog = getElog();
+  if (elog) {
+    elog[level](json);
+  }
+  // No console fallback on the structured path — the back-compat shims
+  // below echo to console for the legacy `(tag, msg, ...rest)` callers.
+  // Under non-Electron runtime, structured records simply drop (test
+  // env doesn't need them, and the legacy callers still get console).
 }
 
 function compactRest(rest: unknown[]): Fields {
@@ -429,7 +538,9 @@ export const log = {
       event: name,
       ...(payload ?? {}),
     };
-    elog.info(JSON.stringify(record));
+    const json = JSON.stringify(record);
+    const elog = getElog();
+    if (elog) elog.info(json);
   },
 };
 

--- a/electron/shared/log.ts
+++ b/electron/shared/log.ts
@@ -18,7 +18,7 @@ import { app } from 'electron';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { scrub, normalizeError, setHomeDir, EVENT_ALLOWED_FIELDS } from '../../src/shared/scrub';
+import { scrub, normalizeError, setHomeDir, EVENT_ALLOWED_FIELDS, scrubConsoleArgs } from '../../src/shared/scrub';
 
 // Tighter LogLevel — electron-log's own includes `verbose | silly` which we
 // don't expose at the API layer. The four CCSM levels map straight onto
@@ -144,6 +144,15 @@ function jsonlFormat(params: {
 }): unknown[] {
   const first = params.data[0];
   let payload: Record<string, unknown>;
+  // Convention: every `emit()` / `log.event` call site stringifies a single
+  // JSON object and passes it as `data[0]` (see `emit()` below — it always
+  // calls `elog[level](JSON.stringify(record))` with no trailing newline and
+  // no second arg). The `{…}` shape check is a fast structural filter that
+  // distinguishes our structured records from ad-hoc string args (e.g.
+  // direct `elog.warn('plain text')` from third-party paths). Any payload
+  // that matches `{…}` is parse-and-merged; everything else is wrapped as
+  // `{msg: ...}`. The `JSON.parse` is inside a try/catch so a stray `{json-
+  // shaped} string` doesn't crash the transport.
   if (typeof first === 'string' && first.startsWith('{') && first.endsWith('}')) {
     try {
       payload = JSON.parse(first) as Record<string, unknown>;
@@ -301,6 +310,30 @@ export function setLogLevel(level: LogLevel): void {
   persistLevel(level);
 }
 
+/** Re-read the persisted log level from sqlite and apply it, IF the user
+ *  has not pinned a value via `CCSM_LOG_LEVEL`. Call this exactly once,
+ *  right after `initDb()` lands — `initLog()` runs before `app.whenReady()`
+ *  (so db isn't open yet) and would otherwise fall through to the `info`
+ *  default; the Help → Set Log Level radio would then boot showing the
+ *  wrong checkmark until the user clicked once. Cold review finding #3c /
+ *  #9. Returns `true` if the level actually changed (caller can rebuild
+ *  the app menu so the radio reflects reality). */
+export function syncPersistedLevelFromDb(): boolean {
+  // Env override wins — respect the operator's explicit choice.
+  if (readEnvFlags().level) return false;
+  const persisted = loadPersistedLevel();
+  if (!persisted || persisted === _currentLevel) return false;
+  // Apply to transports + module state. Skip `persistLevel` — the value
+  // already came from the db, no write-back needed (would be a no-op
+  // anyway, but the avoidance keeps boot off the disk).
+  _currentLevel = persisted;
+  elog.transports.console.level = persisted;
+  if (elog.transports.file.level !== false) {
+    elog.transports.file.level = persisted;
+  }
+  return true;
+}
+
 export function getLogLevel(): LogLevel {
   return _currentLevel;
 }
@@ -412,12 +445,19 @@ export const log = {
 // records flow to the file + IPC sinks via `log.warn` / `log.error`. The
 // modern `log.event` / `log.debug` / `log.info` paths do NOT echo to
 // console — only the back-compat shims do.
+//
+// SECURITY: `rest` is scrubbed BEFORE it reaches console — Errors get
+// normalized (stack frames lose absolute paths), plain objects get the same
+// forbidden-field drops + path/env scrubbing the structured sink uses.
+// Without this, a caller doing `warn('foo','bad', err)` would print a raw
+// `C:\Users\<name>\…` stack to dev stderr while the file sink stays clean
+// — a transparent-transport violation flagged by cold review finding #1c.
 export function warn(tag: string, msg: string, ...rest: unknown[]): void {
-  console.warn(`[${tag}] ${msg}`, ...rest);
+  console.warn(`[${tag}] ${msg}`, ...scrubConsoleArgs(rest));
   log.warn(tag, msg, compactRest(rest));
 }
 export function error(tag: string, msg: string, ...rest: unknown[]): void {
-  console.error(`[${tag}] ${msg}`, ...rest);
+  console.error(`[${tag}] ${msg}`, ...scrubConsoleArgs(rest));
   if (rest.length === 1 && rest[0] instanceof Error) {
     log.error(tag, msg, rest[0]);
     return;

--- a/electron/shared/log.ts
+++ b/electron/shared/log.ts
@@ -1,14 +1,429 @@
-// Single seam for main-process logging. Format: "[tag] msg", same args as console.
-// Wire Sentry/file logging here later — call sites already speak this shape.
+// Main-process structured logger.
 //
-// Kept separate from `src/shared/log.ts` (renderer) because main and renderer
-// can't share modules across the contextBridge boundary, and a future Sentry
-// wiring will differ between processes (main: `@sentry/electron/main`,
-// renderer: `@sentry/electron/renderer`).
-export function warn(tag: string, msg: string, ...rest: unknown[]): void {
-  console.warn(`[${tag}] ${msg}`, ...rest);
+// Replaces the legacy console-only stub. Owns:
+//   * the electron-log file transport (10MB × 10 = 100MB cap, JSONL format,
+//     per-file header with version/platform metadata)
+//   * the IPC sink that catches renderer logs (electron-log's built-in
+//     `ipc` transport — wired by `log.initialize()` in main.ts)
+//   * runtime log-level changes (`setLevel` persisted via sqlite app_state)
+//   * `CCSM_LOG_LEVEL` / `CCSM_LOG_DISABLE_FILE` env overrides
+//   * a tiny ring file for renderer-local fallback at
+//     `app.getPath('userData')/renderer-logs/` (1MB × 2 = 2MB) — written by
+//     the renderer's electron-log instance through the IPC bridge if main
+//     is responsive, AND captured locally so a mid-crash renderer still
+//     has tail evidence on disk
+
+import elog from 'electron-log/main';
+import { app } from 'electron';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { scrub, normalizeError, setHomeDir, EVENT_ALLOWED_FIELDS } from '../../src/shared/scrub';
+
+// Tighter LogLevel — electron-log's own includes `verbose | silly` which we
+// don't expose at the API layer. The four CCSM levels map straight onto
+// electron-log's homonymous methods.
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+// Setting homedir for the path scrubber. Must happen before any record is
+// emitted; called eagerly at module load so the first uncaughtException
+// during bootstrap is scrubbed too.
+try {
+  setHomeDir(os.homedir());
+} catch {
+  // homedir unavailable in some sandboxed test envs — scrub falls back to
+  // regex-only path handling.
 }
 
+const LOG_SCHEMA_VERSION = 1;
+const LOG_LEVEL_KEY = 'ccsm.logLevel';
+
+// 100MB cap per process (10MB × 10 rotated files) per design v2 §1.
+const MAIN_LOG_MAX_BYTES = 10 * 1024 * 1024;
+// Renderer-local ring is much smaller — it's a fallback for the IPC bridge
+// only, not the source of truth.
+const RENDERER_LOG_MAX_BYTES = 1 * 1024 * 1024;
+
+let _initialized = false;
+let _currentLevel: LogLevel = 'info';
+
+type EnvFlags = {
+  level: LogLevel | null;
+  disableFile: boolean;
+};
+
+function readEnvFlags(): EnvFlags {
+  const raw = process.env.CCSM_LOG_LEVEL?.toLowerCase();
+  const valid: LogLevel[] = ['debug', 'info', 'warn', 'error'];
+  const level = raw && (valid as string[]).includes(raw) ? (raw as LogLevel) : null;
+  const disableFile = process.env.CCSM_LOG_DISABLE_FILE === '1';
+  return { level, disableFile };
+}
+
+/** Reads persisted log level from sqlite app_state. Imported lazily to avoid
+ *  a circular dep (db.ts imports nothing from log.ts but the boot order has
+ *  this module loaded before db init). Falls back to `info`. */
+function loadPersistedLevel(): LogLevel | null {
+  try {
+    // Lazy require — db init happens later in app.whenReady; before that
+    // call this returns null and the boot uses the env override or 'info'.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const db = require('../db') as typeof import('../db');
+    const raw = db.loadState(LOG_LEVEL_KEY);
+    if (raw && ['debug', 'info', 'warn', 'error'].includes(raw)) {
+      return raw as LogLevel;
+    }
+  } catch {
+    // db not initialized yet — fall through.
+  }
+  return null;
+}
+
+function persistLevel(level: LogLevel): void {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const db = require('../db') as typeof import('../db');
+    db.saveState(LOG_LEVEL_KEY, level);
+  } catch {
+    // db not ready — runtime change still applies in-memory; next boot
+    // re-derives from env / default.
+  }
+}
+
+/** Per-file header written as the FIRST line of every new (or rotated) log
+ *  file. Makes attached logs self-describing — no need to ask the user
+ *  "what version were you on". */
+function buildHeader(): string {
+  let appVersion = 'unknown';
+  try {
+    appVersion = app.getVersion();
+  } catch {
+    /* app not ready in tests */
+  }
+  return (
+    JSON.stringify({
+      schemaV: LOG_SCHEMA_VERSION,
+      app: 'ccsm',
+      version: appVersion,
+      electron: process.versions.electron ?? 'unknown',
+      node: process.versions.node ?? 'unknown',
+      os: process.platform,
+      arch: process.arch,
+      level: _currentLevel,
+      sessionStart: new Date().toISOString(),
+    }) + os.EOL
+  );
+}
+
+/** Write the header to the live file if it's empty (fresh boot or
+ *  immediately post-rotation). electron-log's `archiveLog` hook fires AFTER
+ *  the rotation; this function is idempotent so calling it on every record
+ *  costs at most one stat call (handled by the size check). */
+function ensureHeader(filePath: string): void {
+  try {
+    const st = fs.statSync(filePath);
+    if (st.size === 0) {
+      fs.writeFileSync(filePath, buildHeader(), { flag: 'a' });
+    }
+  } catch {
+    // file does not yet exist — electron-log will create it on first write
+    // and we'll header it on the next call. No-op here.
+  }
+}
+
+/** electron-log message formatter → JSONL. electron-log's transform chain
+ *  treats `format` as `(params: FormatParams) => any[]`; we return a
+ *  1-element array containing the JSONL string and the downstream `toString`
+ *  transform serializes it as-is. We accept already-structured payloads from
+ *  our `log.api.emit()` in `data[0]` and augment with timestamp/level;
+ *  ad-hoc string args are wrapped. */
+function jsonlFormat(params: {
+  data: unknown[];
+  level: string;
+  message: { date: Date };
+}): unknown[] {
+  const first = params.data[0];
+  let payload: Record<string, unknown>;
+  if (typeof first === 'string' && first.startsWith('{') && first.endsWith('}')) {
+    try {
+      payload = JSON.parse(first) as Record<string, unknown>;
+    } catch {
+      payload = { msg: first };
+    }
+  } else {
+    payload = { msg: params.data.map((d) => String(d)).join(' ') };
+  }
+  const record = {
+    t: params.message.date.toISOString(),
+    level: params.level,
+    pid: process.pid,
+    ...payload,
+  };
+  return [JSON.stringify(record)];
+}
+
+/** Configure electron-log transports. Idempotent — re-calling is a no-op. */
+export function initLog(): void {
+  if (_initialized) return;
+  _initialized = true;
+
+  const env = readEnvFlags();
+  const persisted = loadPersistedLevel();
+  _currentLevel = env.level ?? persisted ?? 'info';
+
+  // Initialize the IPC bridge so renderer logs flow into main's transports.
+  // Per electron-log v5: `initialize()` registers the IPC handlers.
+  try {
+    elog.initialize();
+  } catch {
+    // initialize() can throw in test envs where `ipcMain` is mocked. The
+    // file + console transports still work; renderer-shipped records are
+    // the only loss.
+  }
+
+  // Console transport: minimal one-liner. JSONL is hostile to terminal eyes,
+  // so for the console we keep the existing `[tag] msg` shape readable.
+  // electron-log's `format` returns `any[]` — return a 1-element array so
+  // the downstream `toString` transform prints it verbatim.
+  elog.transports.console.level = _currentLevel;
+  elog.transports.console.format = (m) => {
+    const first = m.data[0];
+    if (typeof first === 'string' && first.startsWith('{')) {
+      try {
+        const p = JSON.parse(first) as Record<string, unknown>;
+        const tag = p.tag ?? p.event ?? '';
+        const msg = p.msg ?? '';
+        return [`[${m.level}] ${tag ? `[${String(tag)}] ` : ''}${String(msg)}`];
+      } catch {
+        /* fall through */
+      }
+    }
+    return [`[${m.level}] ${m.data.map((d) => String(d)).join(' ')}`];
+  };
+
+  // File transport.
+  if (env.disableFile) {
+    elog.transports.file.level = false;
+  } else {
+    elog.transports.file.level = _currentLevel;
+    elog.transports.file.format = jsonlFormat;
+    elog.transports.file.maxSize = MAIN_LOG_MAX_BYTES;
+    // `archiveLogFn` runs synchronously when the current file hits maxSize.
+    // Default behavior renames `main.log` → `main.old.log`; electron-log v5
+    // only keeps ONE rotated archive by default. For 10-file rotation we
+    // override to cycle through `main.1.log` … `main.10.log`.
+    elog.transports.file.archiveLogFn = (oldLog) => {
+      const file = oldLog.toString();
+      const dir = path.dirname(file);
+      const base = path.basename(file, '.log');
+      // Shift main.9.log → main.10.log, main.8.log → main.9.log, …
+      try {
+        for (let i = 9; i >= 1; i--) {
+          const from = path.join(dir, `${base}.${i}.log`);
+          const to = path.join(dir, `${base}.${i + 1}.log`);
+          if (fs.existsSync(from)) {
+            if (i + 1 > 10) {
+              fs.unlinkSync(from);
+            } else {
+              fs.renameSync(from, to);
+            }
+          }
+        }
+        const renamed = path.join(dir, `${base}.1.log`);
+        fs.renameSync(file, renamed);
+      } catch (e) {
+        // Best-effort: if rotation fails (locked file on Windows etc.) we
+        // emit a console.error but keep logging — the live file is the
+        // bigger concern than the archive chain.
+        console.error('[log] rotation failed:', e);
+      }
+    };
+
+    // Header-on-new-file. electron-log resolves the file path lazily via
+    // `transports.file.resolvePathFn`; capture it on first write.
+    const resolvePath = elog.transports.file.resolvePathFn;
+    elog.transports.file.resolvePathFn = (vars, message) => {
+      const p = resolvePath(vars, message);
+      ensureHeader(p);
+      return p;
+    };
+  }
+
+  // Renderer-local fallback transport: a small file at
+  // `userData/renderer-logs/renderer.log`. The renderer's electron-log
+  // instance ships records over IPC to main (handled by `transports.ipc`);
+  // we ALSO want a local file so a mid-crash renderer still has tail
+  // evidence if the IPC bridge has died. This transport on the MAIN side
+  // captures the IPC-shipped renderer records into a separate file.
+  try {
+    const userData = app.getPath('userData');
+    const rendererLogDir = path.join(userData, 'renderer-logs');
+    if (!fs.existsSync(rendererLogDir)) {
+      fs.mkdirSync(rendererLogDir, { recursive: true });
+    }
+    // Use the secondary scoped logger so renderer records land in a
+    // separate file from main records (cleaner triage when one process
+    // misbehaves but the other is fine).
+    const rendererLogger = elog.create({ logId: 'renderer-mirror' });
+    rendererLogger.transports.file.fileName = 'renderer.log';
+    rendererLogger.transports.file.resolvePathFn = () =>
+      path.join(rendererLogDir, 'renderer.log');
+    rendererLogger.transports.file.maxSize = RENDERER_LOG_MAX_BYTES;
+    rendererLogger.transports.file.format = jsonlFormat;
+    rendererLogger.transports.console.level = false;
+    // 2-file ring (1MB × 2 = 2MB cap per design v2).
+    rendererLogger.transports.file.archiveLogFn = (oldLog) => {
+      const file = oldLog.toString();
+      const dir = path.dirname(file);
+      const base = path.basename(file, '.log');
+      try {
+        const archive = path.join(dir, `${base}.1.log`);
+        if (fs.existsSync(archive)) fs.unlinkSync(archive);
+        fs.renameSync(file, archive);
+      } catch {
+        /* best-effort */
+      }
+    };
+  } catch {
+    // userData unavailable (tests) — renderer-mirror disabled, IPC still
+    // routes renderer records into main's primary transports.
+  }
+}
+
+/** Runtime log-level change. Applies to console + file transports. Persists
+ *  via sqlite app_state so the choice survives restart. */
+export function setLogLevel(level: LogLevel): void {
+  _currentLevel = level;
+  elog.transports.console.level = level;
+  if (elog.transports.file.level !== false) {
+    elog.transports.file.level = level;
+  }
+  persistLevel(level);
+}
+
+export function getLogLevel(): LogLevel {
+  return _currentLevel;
+}
+
+export function getLogFilePath(): string {
+  try {
+    return elog.transports.file.getFile().path;
+  } catch {
+    return '';
+  }
+}
+
+type Tag = string;
+type Msg = string;
+type Fields = Record<string, unknown> | undefined;
+
+function scrubFields(fields: Fields): Record<string, unknown> | undefined {
+  if (!fields) return undefined;
+  return scrub(fields) as Record<string, unknown> | undefined;
+}
+
+function normalizeErrorFields(fields: Fields): Fields {
+  if (!fields) return undefined;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(fields)) {
+    if (v instanceof Error) out[k] = normalizeError(v);
+    else out[k] = v;
+  }
+  return out;
+}
+
+function emit(
+  level: 'debug' | 'info' | 'warn' | 'error',
+  tag: Tag,
+  msg: Msg,
+  fields?: Fields,
+): void {
+  if (!_initialized) initLog();
+  const payload = scrubFields(normalizeErrorFields(fields));
+  const record = {
+    schemaV: LOG_SCHEMA_VERSION,
+    tag,
+    msg,
+    ...(payload ?? {}),
+  };
+  elog[level](JSON.stringify(record));
+}
+
+function compactRest(rest: unknown[]): Fields {
+  if (rest.length === 0) return undefined;
+  if (rest.length === 1) {
+    const r = rest[0];
+    if (r instanceof Error) return { error: normalizeError(r) };
+    if (r && typeof r === 'object' && !Array.isArray(r)) return r as Record<string, unknown>;
+    return { detail: r };
+  }
+  return { detail: rest };
+}
+
+export const log = {
+  debug(tag: Tag, msg: Msg, fields?: Fields): void {
+    emit('debug', tag, msg, fields);
+  },
+  info(tag: Tag, msg: Msg, fields?: Fields): void {
+    emit('info', tag, msg, fields);
+  },
+  warn(tag: Tag, msg: Msg, fields?: Fields): void {
+    emit('warn', tag, msg, fields);
+  },
+  error(tag: Tag, msg: Msg, fieldsOrErr?: Fields | Error): void {
+    if (fieldsOrErr instanceof Error) {
+      emit('error', tag, msg, { error: normalizeError(fieldsOrErr) });
+      return;
+    }
+    emit('error', tag, msg, fieldsOrErr);
+  },
+  /** Structured probe. Unknown top-level keys in `fields` trigger a dev-only
+   *  console warn (never throws in prod). */
+  event(name: string, fields?: Fields): void {
+    if (fields && process.env.NODE_ENV !== 'production') {
+      for (const k of Object.keys(fields)) {
+        if (!EVENT_ALLOWED_FIELDS.has(k)) {
+          console.warn(
+            `[log.event] unknown field '${k}' in event '${name}' — add to EVENT_ALLOWED_FIELDS or rename`,
+          );
+        }
+      }
+    }
+    if (!_initialized) initLog();
+    const payload = scrubFields(fields);
+    const record = {
+      schemaV: LOG_SCHEMA_VERSION,
+      event: name,
+      ...(payload ?? {}),
+    };
+    elog.info(JSON.stringify(record));
+  },
+};
+
+// Back-compat shims preserved verbatim from the legacy stub.
+//
+// These ALSO call `console.warn` / `console.error` directly (matching the
+// original stub's observable behavior). Reason: electron-log's node console
+// transport captures `console.warn` / `console.error` references at module-
+// load time, so a later `vi.spyOn(console, 'warn')` does not intercept
+// records routed solely through electron-log. ~80 call sites + their tests
+// already assert `console.warn` was called with `[tag] msg`; preserving the
+// direct call keeps every legacy test contract intact while structured
+// records flow to the file + IPC sinks via `log.warn` / `log.error`. The
+// modern `log.event` / `log.debug` / `log.info` paths do NOT echo to
+// console — only the back-compat shims do.
+export function warn(tag: string, msg: string, ...rest: unknown[]): void {
+  console.warn(`[${tag}] ${msg}`, ...rest);
+  log.warn(tag, msg, compactRest(rest));
+}
 export function error(tag: string, msg: string, ...rest: unknown[]): void {
   console.error(`[${tag}] ${msg}`, ...rest);
+  if (rest.length === 1 && rest[0] instanceof Error) {
+    log.error(tag, msg, rest[0]);
+    return;
+  }
+  log.error(tag, msg, compactRest(rest));
 }
+
+// Re-export normalizeError for callers (main.ts uncaughtException etc.).
+export { normalizeError };

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "better-sqlite3": "^12.9.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "electron-log": "^5.4.4",
         "electron-updater": "^6.8.3",
         "framer-motion": "^12.38.0",
         "fuse.js": "^7.0.0",
@@ -8306,6 +8307,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmmirror.com/electron-log/-/electron-log-5.4.4.tgz",
+      "integrity": "sha512-istWgaXjBfURBSS8LWVW9C3jsc6+ac+tY1lXrQEOTp0lVj+a4OlO1Tmqb36GgnEUDv92DGC9VI1HNXwJinWpgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-publish": {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "better-sqlite3": "^12.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "electron-log": "^5.4.4",
     "electron-updater": "^6.8.3",
     "framer-motion": "^12.38.0",
     "fuse.js": "^7.0.0",

--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -1,14 +1,180 @@
-// Single seam for renderer logging. Format: "[tag] msg", same args as console.
-// Wire Sentry/file logging here later — call sites already speak this shape.
+// Renderer-side structured logger.
 //
-// Kept separate from `electron/shared/log.ts` (main) because main and renderer
-// can't share modules across the contextBridge boundary, and a future Sentry
-// wiring will differ between processes (main: `@sentry/electron/main`,
-// renderer: `@sentry/electron/renderer`).
-export function warn(tag: string, msg: string, ...rest: unknown[]): void {
-  console.warn(`[${tag}] ${msg}`, ...rest);
+// Replaces the legacy console-only stub. Wraps `electron-log/renderer` so
+// every record:
+//   1. flows to main via electron-log's IPC bridge (single source of truth
+//      for cross-process correlation by sid)
+//   2. ALSO writes to a small local ring file under
+//      `app.getPath('userData')/renderer-logs/` (1MB × 2 = 2MB cap) — so if
+//      the IPC bridge dies mid-crash the renderer still has tail evidence
+//   3. passes through `scrub` before serialization so the transparent-
+//      transport invariant holds even if a caller accidentally passes a
+//      stringified clipboard chunk
+//
+// Back-compat: existing call sites use `warn(tag, msg, ...rest)` and
+// `error(tag, msg, ...rest)` — both signatures are preserved. New code
+// should prefer `log.event(name, fields)` for structured probes.
+//
+// Test environment: under vitest (`process.env.VITEST` set), we skip the
+// electron-log import and use a console-only stub. Reason: electron-log's
+// renderer entry installs a `RendererErrorHandler` that hooks window
+// 'error' / 'unhandledrejection' listeners and tries to ship records over
+// IPC to a main process that doesn't exist in jsdom — leading to either
+// noisy stderr ("logger isn't initialized in the main process") on every
+// jsdom-emitted error or, in the worst case, a hang when the IPC transport
+// retries. The stub preserves the public API and the console-direct calls
+// in the back-compat shims so all existing test contracts (~80 sites using
+// `vi.spyOn(console, 'warn')`) keep working without behavior drift.
+
+import { scrub, normalizeError, EVENT_ALLOWED_FIELDS, setHomeDir } from './scrub';
+
+type ElogLike = {
+  debug: (msg: string) => void;
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  error: (msg: string) => void;
+};
+
+const isVitest =
+  typeof process !== 'undefined' &&
+  (process.env?.VITEST === 'true' || process.env?.NODE_ENV === 'test');
+
+function loadElog(): ElogLike {
+  if (isVitest) {
+    // jsdom test environment — write to console only. The back-compat shims
+    // already do that; here we provide a thin pass-through so the structured
+    // paths (`log.event`) don't crash if a test exercises them.
+    return {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    };
+  }
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, no-undef
+  const mod = require('electron-log/renderer');
+  return (mod.default ?? mod) as ElogLike;
 }
 
+const log: ElogLike = loadElog();
+
+// Renderer doesn't have a homedir to scrub (sandboxed), but we still hook
+// the setter so any future preload bridge can hand one over.
+setHomeDir(null);
+
+const LOG_SCHEMA_VERSION = 1;
+type Tag = string;
+type Msg = string;
+type Fields = Record<string, unknown> | undefined;
+
+function scrubFields(fields: Fields): Record<string, unknown> | undefined {
+  if (!fields) return undefined;
+  const scrubbed = scrub(fields) as Record<string, unknown> | undefined;
+  return scrubbed;
+}
+
+function maybeNormalizeError(fields: Fields): Fields {
+  if (!fields) return undefined;
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(fields)) {
+    if (v instanceof Error) {
+      out[k] = normalizeError(v);
+    } else {
+      out[k] = v;
+    }
+  }
+  return out;
+}
+
+// Back-compat shim: existing call sites pass `(tag, msg, ...rest)` where
+// `rest` is often a single Error or a string. Roll them into a `fields`
+// object so the structured form below works uniformly.
+function compactRest(rest: unknown[]): Fields {
+  if (rest.length === 0) return undefined;
+  if (rest.length === 1) {
+    const r = rest[0];
+    if (r instanceof Error) return { error: normalizeError(r) };
+    if (r && typeof r === 'object' && !Array.isArray(r)) return r as Record<string, unknown>;
+    return { detail: r };
+  }
+  return { detail: rest };
+}
+
+function emit(
+  level: 'debug' | 'info' | 'warn' | 'error',
+  tag: Tag,
+  msg: Msg,
+  fields?: Fields,
+): void {
+  const scrubbed = scrubFields(maybeNormalizeError(fields));
+  const record = {
+    schemaV: LOG_SCHEMA_VERSION,
+    tag,
+    msg,
+    ...(scrubbed ?? {}),
+  };
+  log[level](JSON.stringify(record));
+}
+
+export const log_api = {
+  debug(tag: Tag, msg: Msg, fields?: Fields): void {
+    emit('debug', tag, msg, fields);
+  },
+  info(tag: Tag, msg: Msg, fields?: Fields): void {
+    emit('info', tag, msg, fields);
+  },
+  warn(tag: Tag, msg: Msg, fields?: Fields): void {
+    emit('warn', tag, msg, fields);
+  },
+  error(tag: Tag, msg: Msg, fieldsOrErr?: Fields | Error): void {
+    if (fieldsOrErr instanceof Error) {
+      emit('error', tag, msg, { error: normalizeError(fieldsOrErr) });
+      return;
+    }
+    emit('error', tag, msg, fieldsOrErr);
+  },
+  /** Structured probe. `name` is a dotted event name (e.g. `attach.snapshot.applied`).
+   *  Unknown top-level keys in `fields` trigger a dev-only assertion (visible in
+   *  console) so accidental content leakage is caught early — never throws in prod. */
+  event(name: string, fields?: Fields): void {
+    if (fields && process.env.NODE_ENV !== 'production') {
+      for (const k of Object.keys(fields)) {
+        if (!EVENT_ALLOWED_FIELDS.has(k)) {
+          console.warn(
+            `[log.event] unknown field '${k}' in event '${name}' — add to EVENT_ALLOWED_FIELDS or rename`,
+          );
+        }
+      }
+    }
+    const scrubbed = scrubFields(fields);
+    const record = {
+      schemaV: LOG_SCHEMA_VERSION,
+      event: name,
+      ...(scrubbed ?? {}),
+    };
+    log.info(JSON.stringify(record));
+  },
+};
+
+// Public namespace export — new code uses `log.debug(...)` / `log.event(...)`.
+export { log_api as log };
+
+// Back-compat top-level exports — ~80 call sites already speak this shape.
+// Signature preserved: `(tag, msg, ...rest)`. ALSO call console directly
+// because electron-log captures `console.warn`/`console.error` references
+// at module-load time, so vitest's `vi.spyOn(console, 'warn')` won't see
+// records routed solely through electron-log. Legacy test contracts assert
+// against the direct console call; preserving it keeps them intact while
+// structured records still flow to the file/IPC sinks via `log_api.warn`.
+export function warn(tag: string, msg: string, ...rest: unknown[]): void {
+  console.warn(`[${tag}] ${msg}`, ...rest);
+  log_api.warn(tag, msg, compactRest(rest));
+}
 export function error(tag: string, msg: string, ...rest: unknown[]): void {
   console.error(`[${tag}] ${msg}`, ...rest);
+  if (rest.length === 1 && rest[0] instanceof Error) {
+    log_api.error(tag, msg, rest[0]);
+    return;
+  }
+  log_api.error(tag, msg, compactRest(rest));
 }

--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -35,15 +35,28 @@ type ElogLike = {
   error: (msg: string) => void;
 };
 
+// Detect a non-Electron runtime (vitest under plain Node OR webpack
+// dev-server's SSR shim) and short-circuit electron-log entirely. We check
+// BOTH the Electron-runtime flag (`process.versions.electron`) AND the
+// `VITEST` env so that:
+//   * `isElectronRuntime === false` covers any non-Electron host (CI vitest
+//     on Node with no binary, future SSR experiments) — most robust signal.
+//   * `isVitest === true` covers the renderer-test case where webpack/jsdom
+//     does set up a `window.process` polyfill that DOES claim
+//     `versions.electron` (vite-plugin-electron emulates it). Belt and
+//     suspenders, mirroring the cold-review recommendation.
+const isElectronRuntime =
+  typeof process !== 'undefined' && typeof process.versions?.electron === 'string';
 const isVitest =
   typeof process !== 'undefined' &&
   (process.env?.VITEST === 'true' || process.env?.NODE_ENV === 'test');
 
 function loadElog(): ElogLike {
-  if (isVitest) {
-    // jsdom test environment — write to console only. The back-compat shims
-    // already do that; here we provide a thin pass-through so the structured
-    // paths (`log.event`) don't crash if a test exercises them.
+  if (!isElectronRuntime || isVitest) {
+    // Non-Electron or test environment — write to console only. The back-
+    // compat shims already do that; here we provide a thin pass-through so
+    // the structured paths (`log.event`) don't crash if a test exercises
+    // them.
     return {
       debug: () => {},
       info: () => {},

--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -26,7 +26,7 @@
 // in the back-compat shims so all existing test contracts (~80 sites using
 // `vi.spyOn(console, 'warn')`) keep working without behavior drift.
 
-import { scrub, normalizeError, EVENT_ALLOWED_FIELDS, setHomeDir } from './scrub';
+import { scrub, normalizeError, EVENT_ALLOWED_FIELDS, setHomeDir, scrubConsoleArgs } from './scrub';
 
 type ElogLike = {
   debug: (msg: string) => void;
@@ -166,12 +166,16 @@ export { log_api as log };
 // records routed solely through electron-log. Legacy test contracts assert
 // against the direct console call; preserving it keeps them intact while
 // structured records still flow to the file/IPC sinks via `log_api.warn`.
+//
+// SECURITY: `rest` is scrubbed BEFORE it reaches console — Errors get
+// normalized, objects get forbidden-field drops + path/env scrubbing.
+// See finding #1c in cold review of PR #1345.
 export function warn(tag: string, msg: string, ...rest: unknown[]): void {
-  console.warn(`[${tag}] ${msg}`, ...rest);
+  console.warn(`[${tag}] ${msg}`, ...scrubConsoleArgs(rest));
   log_api.warn(tag, msg, compactRest(rest));
 }
 export function error(tag: string, msg: string, ...rest: unknown[]): void {
-  console.error(`[${tag}] ${msg}`, ...rest);
+  console.error(`[${tag}] ${msg}`, ...scrubConsoleArgs(rest));
   if (rest.length === 1 && rest[0] instanceof Error) {
     log_api.error(tag, msg, rest[0]);
     return;

--- a/src/shared/scrub.ts
+++ b/src/shared/scrub.ts
@@ -1,0 +1,228 @@
+// Shared PII / secret scrubber + error normalizer.
+//
+// Used by both main and renderer log transports. Per the transparent-transport
+// memo, we MUST NOT log byte content of clipboard, IME composition strings,
+// pty stdout, pty stdin, or env values. The scrubber is the last line of
+// defense for that contract: any field that smells like content is dropped
+// entirely, any field with a path/secret-shaped string is rewritten.
+//
+// Design notes:
+//  * `electron/` tsconfig includes `src/shared/**/*` so this single file is
+//    consumed by both the main bundle (commonjs) and the renderer bundle
+//    (webpack). Keep it dependency-free: no `electron`, no `node:fs`, no
+//    DOM. `os.homedir()` is read lazily via a setter — the renderer can pass
+//    its own value (or omit it).
+//  * Recursion is depth-limited (default 4). Beyond that depth the value is
+//    replaced with `'[depth-limit]'` rather than throwing — logging must
+//    never crash the host.
+
+// Env-var key regexes (v2 §3 + design doc step 2 expansion).
+const ENV_KEY_PREFIX = /^(ANTHROPIC_|CLAUDE_|AWS_)/i;
+const ENV_KEY_SUFFIX =
+  /(_ID|_PASS|_URI|_URL|_CREDENTIALS|TOKEN|KEY|SECRET|PASSWORD|AUTH|COOKIE)$/i;
+
+// Connection-string detector. Order matters only for readability — any match
+// short-circuits.
+const CONN_STRING_RES: readonly RegExp[] = [
+  /^mongodb(\+srv)?:\/\//i,
+  /^postgres(ql)?:\/\//i,
+  /^mysql:\/\//i,
+  /^redis:\/\//i,
+  // userinfo-bearing http(s) URL — matches `https://user:pw@host/...`
+  /^https?:\/\/[^/\s@]+@/i,
+];
+
+// Path detector. Catches Windows drive paths, UNC `\\?\C:\…`, WSL `/mnt/c/…`,
+// POSIX home/system dirs. Applied as a global replace inside any string field
+// AND inside `Error.stack` (stack frames have paths embedded mid-line).
+const PATH_RE =
+  /([A-Za-z]:\\|\\\\\?\\[A-Za-z]:\\|\\\\[^\s'"\\]+\\|\/Users\/|\/home\/|\/mnt\/[a-z]\/|\/root\/|\/var\/|\/tmp\/)[^\s'"]*/g;
+
+// Forbidden field names — dropped entirely from any object before serialization.
+// `name` covers session names; `message` is dropped because user-supplied
+// content commonly lands there (ad-hoc `{message: '...'}`). Error.message is
+// re-injected via `normalizeError` *after* scrub, so the legitimate error
+// path still works.
+const FORBIDDEN_FIELDS = new Set<string>([
+  'content',
+  'data',
+  'buffer',
+  'text',
+  'clipboard',
+  'composition',
+  'name',
+  'env',
+  'body',
+  'payload',
+  'raw',
+  'input',
+  'output',
+  'stdin',
+  'stdout',
+  'stderr',
+  'args',
+  'argv',
+  'cmdline',
+  'command',
+  'query',
+  'params',
+  'headers',
+  'cookies',
+  'authorization',
+  'message',
+  'url',
+  'title',
+  'value',
+  'prompt',
+  'arg',
+  'cmd',
+]);
+
+// Allowlist of metadata keys legal at `log.event(...)` payload level. Unknown
+// keys at the top level of an event payload trigger a dev-only assertion (see
+// log.ts). NOT used to drop fields at runtime — the scrubber's forbidden-list
+// + path/secret regexes already cover the leak surface.
+export const EVENT_ALLOWED_FIELDS = new Set<string>([
+  'sid',
+  'bytes',
+  'durationMs',
+  'cols',
+  'rows',
+  'viewportY',
+  'viewportYBefore',
+  'viewportYAfter',
+  'baseY',
+  'from',
+  'to',
+  'reason',
+  'stage',
+  'callsite',
+  'count',
+  'chunks',
+  'bracketed',
+  'crlfFound',
+  'ptyResized',
+  // Additional fields used by attach probes and `term.firstWrite.afterAttach`.
+  'msSinceAttach',
+  'durationMsSinceAttach',
+  'kind',
+  'bufferedChunks',
+  'bufferedBytes',
+  'bytesBefore',
+  'bytesAfter',
+  'updateCount',
+  'elapsedMs',
+]);
+
+const DEFAULT_DEPTH = 4;
+const REDACTED = '[redacted]';
+const CONN_STRING = '[connection-string]';
+const PATH_TOKEN = '[path]';
+
+// Home-dir prefix replacement. `os.homedir()` resolution is lazy + injectable:
+// node-side calls `setHomeDir(os.homedir())` once at boot; renderer calls
+// `setHomeDir(window.process?.env?.HOME ?? null)` (usually null in sandbox).
+let _homeDir: string | null = null;
+export function setHomeDir(dir: string | null): void {
+  _homeDir = dir && dir.length > 0 ? dir : null;
+}
+export function getHomeDir(): string | null {
+  return _homeDir;
+}
+
+function scrubString(s: string): string {
+  if (!s) return s;
+  // Connection-string first: a Postgres URL is also "path-like" (contains
+  // slashes) and we don't want a partial scrub.
+  for (const re of CONN_STRING_RES) {
+    if (re.test(s)) return CONN_STRING;
+  }
+  let out = s;
+  // Home-dir prefix → `~`. Must run BEFORE the path regex, otherwise the
+  // path regex would replace the whole path with `[path]` and we'd lose the
+  // information that the path was rooted in homedir vs. /tmp.
+  if (_homeDir && out.includes(_homeDir)) {
+    // Use split/join to avoid regex-escaping the homedir (which can contain
+    // backslashes on Windows that would be interpreted as regex escapes).
+    out = out.split(_homeDir).join('~');
+  }
+  // Path-like substrings → `[path]`. Global replace handles multiple matches
+  // per line (common in stack traces).
+  out = out.replace(PATH_RE, PATH_TOKEN);
+  return out;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  if (v === null || typeof v !== 'object') return false;
+  const proto = Object.getPrototypeOf(v);
+  return proto === Object.prototype || proto === null;
+}
+
+function shouldRedactEnvKey(key: string): boolean {
+  return ENV_KEY_PREFIX.test(key) || ENV_KEY_SUFFIX.test(key);
+}
+
+/**
+ * Recursive scrubber. Returns a NEW value — never mutates input. Handles:
+ *   * strings: connection-string detection → path/homedir rewrite.
+ *   * objects: drops forbidden keys, redacts env-shaped keys, recurses on
+ *     remaining values (depth-limited).
+ *   * arrays: recursed elementwise.
+ *   * everything else: passthrough.
+ */
+export function scrub(value: unknown, depth: number = DEFAULT_DEPTH): unknown {
+  if (depth <= 0) return '[depth-limit]';
+  if (value == null) return value;
+  if (typeof value === 'string') return scrubString(value);
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+  if (Array.isArray(value)) return value.map((v) => scrub(v, depth - 1));
+  if (isPlainObject(value)) {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      if (FORBIDDEN_FIELDS.has(k)) continue; // drop entirely
+      if (shouldRedactEnvKey(k)) {
+        out[k] = REDACTED;
+        continue;
+      }
+      out[k] = scrub(v, depth - 1);
+    }
+    return out;
+  }
+  // Non-plain object (class instance etc.) — fall back to string form so we
+  // never accidentally serialize a `Buffer.toJSON()` or similar.
+  try {
+    return scrubString(String(value));
+  } catch {
+    return '[unserializable]';
+  }
+}
+
+/** Normalize an Error for JSON-safe logging. Both `message` and `stack` are
+ *  scrubbed (stack frames are where `C:\Users\<username>\…` leaks happen
+ *  most). `cause` chains are walked recursively.
+ *
+ *  IMPORTANT: the `name` field here intentionally bypasses the forbidden-
+ *  fields drop. Error class names (`TypeError`, `RangeError`, custom subclass
+ *  names like `ClaudeSpawnError`) are NOT PII — they're structural metadata
+ *  needed to triage logs. The forbidden list catches `name` to block session
+ *  names (which are user-supplied free text); error class names live on a
+ *  separate axis and are safe to keep. */
+export function normalizeError(e: unknown): {
+  name: string;
+  message: string;
+  stack: string;
+  cause?: ReturnType<typeof normalizeError>;
+} {
+  if (!(e instanceof Error)) {
+    return { name: 'NonError', message: scrubString(String(e)), stack: '' };
+  }
+  return {
+    name: e.name,
+    message: scrubString(e.message ?? ''),
+    stack: scrubString(e.stack ?? ''),
+    cause:
+      (e as Error & { cause?: unknown }).cause != null
+        ? normalizeError((e as Error & { cause?: unknown }).cause)
+        : undefined,
+  };
+}

--- a/src/shared/scrub.ts
+++ b/src/shared/scrub.ts
@@ -197,6 +197,31 @@ export function scrub(value: unknown, depth: number = DEFAULT_DEPTH): unknown {
   }
 }
 
+/** Per-element scrubber for the back-compat `warn(tag, msg, ...rest)` /
+ *  `error(...)` shims' direct-to-console path. Each `rest` element is one
+ *  positional arg to `console.warn` / `console.error`; we must NOT collapse
+ *  them into a single fields object (that would change the observable shape
+ *  for ~80 call sites + their tests that assert against the spread args).
+ *
+ *  Strategy per element:
+ *    * Error → `normalizeError` (scrubs message + stack, walks cause chain).
+ *    * plain object → `scrub` (forbidden-field drops + env-key redaction +
+ *      string scrubbing on every leaf, depth-limited to 4).
+ *    * string → `scrubString` via `scrub` (connection-string + homedir +
+ *      path regexes).
+ *    * scalar / null / undefined → passthrough.
+ *
+ *  This is the last-line defense for the transparent-transport invariant on
+ *  the dev console path. Without it, callers like `warn('foo','bad', e)`
+ *  would leak `e.stack` with absolute paths into stderr even though the
+ *  structured file/IPC sink already runs the same scrubber. */
+export function scrubConsoleArgs(rest: unknown[]): unknown[] {
+  return rest.map((v) => {
+    if (v instanceof Error) return normalizeError(v);
+    return scrub(v);
+  });
+}
+
 /** Normalize an Error for JSON-safe logging. Both `message` and `stack` are
  *  scrubbed (stack frames are where `C:\Users\<username>\…` leaks happen
  *  most). `cause` chains are walked recursively.

--- a/src/terminal/usePtyAttach.ts
+++ b/src/terminal/usePtyAttach.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useStore } from '../stores/store';
 import { classifyPtyExit } from '../lib/ptyExitClassifier';
-import { warn } from '../shared/log';
+import { warn, log } from '../shared/log';
 import {
   getTerm,
   getFit,
@@ -63,7 +63,31 @@ export type UsePtyAttachResult = {
  * appropriate overlay (attaching / error / exit) and Retry button.
  */
 export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult {
-  const [state, setState] = useState<PtyAttachState>({ kind: 'attaching' });
+  const [state, _setState] = useState<PtyAttachState>({ kind: 'attaching' });
+  // Wrap setState so every state edge emits an `attach.state.transition`
+  // probe. The `kind` of the prev + next state plus an optional reason are
+  // structured-only — no message text leaks. We read the current sessionId
+  // from `requestedSidRef` (declared below) inside the updater so this
+  // callback can be `useCallback([])` — stable identity across renders,
+  // safe to capture in the pty:exit effect's `[]` deps array.
+  const setState = useCallback(
+    (next: PtyAttachState, reason?: string): void => {
+      _setState((prev) => {
+        try {
+          log.event('attach.state.transition', {
+            sid: requestedSidRef.current,
+            from: prev.kind,
+            to: next.kind,
+            reason: reason ?? next.kind,
+          });
+        } catch {
+          /* logging must never break the state machine */
+        }
+        return next;
+      });
+    },
+    [],
+  );
   // Store action — clear the disconnect entry on respawn success so the
   // sidebar red dot disappears the moment the pty is back. Routed through
   // a ref so the attach effect doesn't depend on it (and re-run unnecessarily).
@@ -87,12 +111,18 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
   useEffect(() => {
     requestedSidRef.current = sessionId;
     let cancelled = false;
-    setState({ kind: 'attaching' });
+    // Probe state — `attachStartedAt` anchors `term.firstWrite.afterAttach`
+    // so we can disambiguate "first paint visible to user" vs the attach
+    // transition. `firstWriteSeen` ensures the probe fires exactly once per
+    // attach. Both reset on every effect run (new sid / Retry / reload).
+    const attachStartedAt = Date.now();
+    let firstWriteSeen = false;
+    setState({ kind: 'attaching' }, 'effect-start');
 
     (async () => {
       const pty = window.ccsmPty;
       if (!pty) {
-        if (!cancelled) setState({ kind: 'error', message: 'ccsmPty unavailable' });
+        if (!cancelled) setState({ kind: 'error', message: 'ccsmPty unavailable' }, 'no-bridge');
         return;
       }
 
@@ -271,6 +301,22 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
         setUnsubscribeData(
           pty.onData((payload: { sid: string; chunk: string; seq: number }) => {
             if (payload.sid !== getActiveSid()) return;
+            // `term.firstWrite.afterAttach` probe (design v2): fires once
+            // per attach on the first pty→xterm chunk we observe for the
+            // active sid. Disambiguates the post-attach viewport jump —
+            // was it driven by snapshot, fit, or the first live chunk?
+            if (!firstWriteSeen) {
+              firstWriteSeen = true;
+              try {
+                log.event('term.firstWrite.afterAttach', {
+                  sid: sessionId,
+                  bytes: payload.chunk.length,
+                  durationMsSinceAttach: Date.now() - attachStartedAt,
+                });
+              } catch {
+                /* probe must not block write */
+              }
+            }
             if (snapSeq === null) {
               buffered.push({ seq: payload.seq, chunk: payload.chunk });
               return;
@@ -294,7 +340,25 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
 
         // Step 4: write snapshot to the visible terminal.
         const tSnap = getTerm();
+        const snapBytes = snap.snapshot?.length ?? 0;
+        const viewportYBeforeSnap = tSnap?.buffer?.active?.viewportY ?? 0;
+        const snapWriteStart = Date.now();
         if (tSnap && snap.snapshot) await writeAsync(tSnap, snap.snapshot);
+        const snapWriteEnd = Date.now();
+        const viewportYAfterSnap = tSnap?.buffer?.active?.viewportY ?? 0;
+        const baseYAfterSnap = tSnap?.buffer?.active?.baseY ?? 0;
+        try {
+          log.event('attach.snapshot.applied', {
+            sid: sessionId,
+            bytes: snapBytes,
+            durationMs: snapWriteEnd - snapWriteStart,
+            viewportYBefore: viewportYBeforeSnap,
+            viewportYAfter: viewportYAfterSnap,
+            baseY: baseYAfterSnap,
+          });
+        } catch {
+          /* probe failure must not block attach */
+        }
 
         // Step 5: drain buffered chunks with seq > snapSeq, in order.
         // Anything with seq <= snapSeq is already represented in the
@@ -323,6 +387,16 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
         // the snapshot+drain content.
         const tAfterSnap = getTerm();
         if (tAfterSnap) {
+          try {
+            log.event('attach.scrollToBottom.invoked', {
+              sid: sessionId,
+              callsite: 'post-snap',
+              viewportY: tAfterSnap.buffer?.active?.viewportY ?? 0,
+              baseY: tAfterSnap.buffer?.active?.baseY ?? 0,
+            });
+          } catch {
+            /* probe must not block scroll */
+          }
           try {
             tAfterSnap.scrollToBottom();
           } catch {
@@ -416,6 +490,16 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
           const tBottom = getTerm();
           if (tBottom) {
             try {
+              log.event('attach.scrollToBottom.invoked', {
+                sid: sessionId,
+                callsite: 'post-fit',
+                viewportY: tBottom.buffer?.active?.viewportY ?? 0,
+                baseY: tBottom.buffer?.active?.baseY ?? 0,
+              });
+            } catch {
+              /* probe must not block scroll */
+            }
+            try {
               tBottom.scrollToBottom();
             } catch {
               // best-effort.
@@ -487,7 +571,18 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
             fit.fit();
             const newCols = t4.cols;
             const newRows = t4.rows;
-            if (newCols !== cols || newRows !== rows) {
+            const ptyResized = newCols !== cols || newRows !== rows;
+            try {
+              log.event('attach.fit.applied', {
+                sid: sessionId,
+                cols: newCols,
+                rows: newRows,
+                ptyResized,
+              });
+            } catch {
+              /* probe must not block fit */
+            }
+            if (ptyResized) {
               const resizePromise = window.ccsmPty.resize(sid4, newCols, newRows);
               const p = resizePromise && typeof (resizePromise as Promise<void>).then === 'function'
                 ? (resizePromise as Promise<void>)
@@ -514,6 +609,20 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
             }
           } catch (e) {
             warn('attach', 'post-attach fit failed', e);
+            try {
+              log.event('attach.fit.skipped', { sid: sessionId, reason: 'exception' });
+            } catch {
+              /* probe must not block recovery */
+            }
+          }
+        } else {
+          try {
+            log.event('attach.fit.skipped', {
+              sid: sessionId,
+              reason: !fit ? 'no-fit-addon' : !t4 ? 'no-term' : 'no-sid',
+            });
+          } catch {
+            /* probe must not block control flow */
           }
         }
 
@@ -535,7 +644,7 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
           }
         }
 
-        if (!cancelled) setState({ kind: 'ready' });
+        if (!cancelled) setState({ kind: 'ready' }, 'attach-complete');
         // Successful (re-)attach means whatever pty is running for this
         // sid is healthy — drop any stale disconnect entry so the
         // sidebar red dot clears and a future crash starts from a clean
@@ -544,7 +653,7 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
       } catch (err) {
         if (cancelled || requestedSidRef.current !== sessionId) return;
         const message = err instanceof Error ? err.message : String(err);
-        setState({ kind: 'error', message });
+        setState({ kind: 'error', message }, 'attach-threw');
       }
     })();
 
@@ -581,7 +690,7 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
     // reloadNonce is intentional: bumping it (via `reloadSession` after a
     // pty.kill) re-runs the attach so the spawn-on-null fallback brings
     // up a fresh pty for the same sid (env / config refresh).
-  }, [sessionId, attachNonce, reloadNonce, cwd]);
+  }, [sessionId, attachNonce, reloadNonce, cwd, setState]);
 
   // pty:exit subscription for the active session → flip to exit state with
   // a classification (clean vs crashed) shared with the store via
@@ -602,7 +711,7 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
             : code != null
               ? `exit code ${code}`
               : 'unknown';
-        setState({ kind: 'exit', exitKind, detail });
+        setState({ kind: 'exit', exitKind, detail }, 'pty-exit');
       },
     );
     return () => {
@@ -612,7 +721,7 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
         // already torn down — safe to ignore.
       }
     };
-  }, []);
+  }, [setState]);
 
   const onRetry = useCallback(() => {
     setAttachNonce((n) => n + 1);

--- a/tests/scrub.test.ts
+++ b/tests/scrub.test.ts
@@ -9,11 +9,12 @@
 // test is non-tautological, comment out the corresponding regex in
 // `src/shared/scrub.ts` and run the suite — those tests should fail.
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import {
   scrub,
   normalizeError,
   setHomeDir,
+  scrubConsoleArgs,
 } from '../src/shared/scrub';
 
 describe('scrub: env-var key masking', () => {
@@ -223,5 +224,90 @@ describe('scrub: passthrough of allowed scalars + booleans', () => {
     const out = scrub({ items: ['/Users/x/a', 'plain'] }) as { items: string[] };
     expect(out.items[0]).toBe('[path]');
     expect(out.items[1]).toBe('plain');
+  });
+});
+
+describe('scrubConsoleArgs: back-compat shim leak regression', () => {
+  // Cold review finding #1c: the back-compat `warn(tag, msg, ...rest)` /
+  // `error(...)` shims call `console.warn` / `console.error` directly so
+  // legacy `vi.spyOn(console, …)` test contracts keep working. Without
+  // `scrubConsoleArgs`, an `Error` passed in `rest` would leak its raw
+  // `stack` (with absolute paths) to dev stderr while the structured file
+  // sink stayed clean — a transparent-transport violation.
+  //
+  // These tests exercise the shim end-to-end: spy console, call `warn` /
+  // `error` with an Error containing a path-bearing stack, assert the spy
+  // received a NORMALIZED Error object (stack scrubbed, message scrubbed,
+  // class name preserved).
+  beforeEach(() => setHomeDir(null));
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('scrubConsoleArgs replaces an Error with normalized form (stack scrubbed)', () => {
+    const e = new Error('failed at /Users/jiahui/secret/file.ts');
+    e.stack =
+      'Error: failed at /Users/jiahui/secret/file.ts\n' +
+      '    at fn (C:\\Users\\Jiahui\\repos\\ccsm\\src\\foo.ts:10:5)';
+    const [scrubbed] = scrubConsoleArgs([e]) as [
+      { name: string; message: string; stack: string },
+    ];
+    expect(scrubbed.name).toBe('Error');
+    expect(scrubbed.message).toBe('failed at [path]');
+    expect(scrubbed.stack).not.toContain('/Users/jiahui');
+    expect(scrubbed.stack).not.toContain('C:\\Users\\Jiahui');
+    expect(scrubbed.stack).toContain('[path]');
+  });
+
+  it('scrubConsoleArgs scrubs plain objects (forbidden fields, paths)', () => {
+    const out = scrubConsoleArgs([
+      { sid: 'abc', cwd: '/Users/jiahui/x', content: 'leak me', cols: 80 },
+    ]) as [{ sid: string; cwd: string; content?: string; cols: number }];
+    expect(out[0].sid).toBe('abc');
+    expect(out[0].cols).toBe(80);
+    expect(out[0].content).toBeUndefined(); // forbidden field dropped
+    expect(out[0].cwd).toBe('[path]');
+  });
+
+  it('back-compat warn() shim does NOT leak Error.stack absolute paths to console', async () => {
+    // Import via dynamic require so we exercise the actual production shim,
+    // not a re-derived copy. The shim's `electron-log/renderer` import
+    // short-circuits to a no-op stub under VITEST=true (see src/shared/log.ts),
+    // so the test isolates the direct-to-console path we care about.
+    const { warn } = await import('../src/shared/log');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const e = new Error('boom at /Users/jiahui/repos/ccsm/src/leak.ts:42');
+    e.stack =
+      'Error: boom at /Users/jiahui/repos/ccsm/src/leak.ts:42\n' +
+      '    at fn (C:\\Users\\Jiahui\\repos\\ccsm\\src\\leak.ts:42:7)';
+    warn('test', 'something bad', e);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const args = warnSpy.mock.calls[0];
+    // First arg is the formatted `[tag] msg` string — must NOT contain the
+    // raw path (msg itself is scalar, no leak there, but defensively check).
+    expect(args[0]).toBe('[test] something bad');
+    // Second arg is the scrubbed error. The whole serialized form must not
+    // mention either the POSIX or the Windows absolute path. Stringifying
+    // covers both `stack` and `message` regardless of object shape.
+    const serialized = JSON.stringify(args[1]);
+    expect(serialized).not.toContain('/Users/jiahui');
+    expect(serialized).not.toContain('C:\\\\Users\\\\Jiahui'); // JSON-escaped
+    expect(serialized).toContain('[path]');
+  });
+
+  it('back-compat error() shim normalizes Error before console.error', async () => {
+    const { error } = await import('../src/shared/log');
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const e = new TypeError('bad arg at /home/x/file.ts');
+    e.stack = 'TypeError: bad arg at /home/x/file.ts\n    at f (/home/x/file.ts:1:1)';
+    error('test', 'oh no', e);
+
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    const args = errSpy.mock.calls[0];
+    const serialized = JSON.stringify(args[1]);
+    expect(serialized).not.toContain('/home/x');
+    // Class name preserved per normalizeError contract.
+    expect(serialized).toContain('TypeError');
   });
 });

--- a/tests/scrub.test.ts
+++ b/tests/scrub.test.ts
@@ -1,0 +1,227 @@
+// Unit tests for the shared PII / secret scrubber.
+//
+// Lives under `tests/` per project convention (renderer-side tests are not
+// colocated with src files). The design doc specifies
+// `src/shared/__tests__/log.scrub.test.ts` "or equivalent" — `tests/` is the
+// equivalent here and matches vitest.config.ts's include glob.
+//
+// Reverse-verify: each branch has positive + negative cases. To confirm a
+// test is non-tautological, comment out the corresponding regex in
+// `src/shared/scrub.ts` and run the suite — those tests should fail.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  scrub,
+  normalizeError,
+  setHomeDir,
+} from '../src/shared/scrub';
+
+describe('scrub: env-var key masking', () => {
+  beforeEach(() => setHomeDir(null));
+
+  it('redacts ANTHROPIC_* prefix (case-insensitive)', () => {
+    expect(scrub({ ANTHROPIC_API_KEY: 'sk-abc' })).toEqual({ ANTHROPIC_API_KEY: '[redacted]' });
+    expect(scrub({ anthropic_secret: 'x' })).toEqual({ anthropic_secret: '[redacted]' });
+  });
+  it('redacts CLAUDE_* prefix', () => {
+    expect(scrub({ CLAUDE_MODEL_OVERRIDE: 'x' })).toEqual({ CLAUDE_MODEL_OVERRIDE: '[redacted]' });
+  });
+  it('redacts AWS_* prefix', () => {
+    expect(scrub({ AWS_ACCESS_KEY_ID: 'AKIA...' })).toEqual({
+      AWS_ACCESS_KEY_ID: '[redacted]',
+    });
+    expect(scrub({ AWS_REGION: 'us-east-1' })).toEqual({ AWS_REGION: '[redacted]' });
+  });
+  it('redacts TOKEN / KEY / SECRET / PASSWORD / AUTH / COOKIE suffixes', () => {
+    expect(scrub({ GITHUB_TOKEN: 'ghp_x' })).toEqual({ GITHUB_TOKEN: '[redacted]' });
+    expect(scrub({ OPENAI_API_KEY: 'sk-x' })).toEqual({ OPENAI_API_KEY: '[redacted]' });
+    expect(scrub({ MY_SECRET: 's' })).toEqual({ MY_SECRET: '[redacted]' });
+    expect(scrub({ DB_PASSWORD: 'p' })).toEqual({ DB_PASSWORD: '[redacted]' });
+    expect(scrub({ BASIC_AUTH: 'u:p' })).toEqual({ BASIC_AUTH: '[redacted]' });
+    expect(scrub({ SESSION_COOKIE: 'c' })).toEqual({ SESSION_COOKIE: '[redacted]' });
+  });
+  it('redacts _PASS / _URI / _URL / _CREDENTIALS suffixes', () => {
+    expect(scrub({ DB_PASS: 'x' })).toEqual({ DB_PASS: '[redacted]' });
+    expect(scrub({ REDIS_URI: 'x' })).toEqual({ REDIS_URI: '[redacted]' });
+    expect(scrub({ REDIS_URL: 'redis://localhost' })).toEqual({
+      REDIS_URL: '[redacted]',
+    });
+    expect(scrub({ GCP_CREDENTIALS: '{}' })).toEqual({ GCP_CREDENTIALS: '[redacted]' });
+  });
+  it('does NOT redact unrelated keys', () => {
+    expect(scrub({ sid: 'abc-123', count: 5 })).toEqual({ sid: 'abc-123', count: 5 });
+    expect(scrub({ debug: true })).toEqual({ debug: true });
+  });
+});
+
+describe('scrub: home-dir replacement', () => {
+  it('replaces Windows-style homedir with ~', () => {
+    setHomeDir('C:\\Users\\Jiahui');
+    const out = scrub({ reason: 'C:\\Users\\Jiahui\\projects\\ccsm' });
+    // Path regex *also* matches `C:\Users\…`, so the leading drive prefix
+    // ends up as `[path]`. The home-dir scrub runs first → leaves `~\…`.
+    // The `~\…` no longer matches the path regex (no drive letter / system
+    // dir prefix). End state: `~\projects\ccsm`.
+    expect(out).toEqual({ reason: '~\\projects\\ccsm' });
+  });
+  it('replaces POSIX homedir with ~', () => {
+    setHomeDir('/Users/jiahui');
+    expect(scrub({ reason: '/Users/jiahui/repo/file.ts' })).toEqual({
+      reason: '~/repo/file.ts',
+    });
+  });
+  it('handles WSL paths via the path regex (no homedir match needed)', () => {
+    setHomeDir(null);
+    const out = scrub({ reason: '/mnt/c/Users/jiahui/repo' }) as { reason: string };
+    expect(out.reason).toBe('[path]');
+  });
+  it('handles UNC paths', () => {
+    setHomeDir(null);
+    const out = scrub({ reason: '\\\\?\\C:\\Users\\j\\file' }) as { reason: string };
+    expect(out.reason).toBe('[path]');
+  });
+});
+
+describe('scrub: connection-string detection', () => {
+  it('catches mongodb / mongodb+srv', () => {
+    expect(scrub({ conn: 'mongodb://u:p@host:27017/db' })).toEqual({
+      conn: '[connection-string]',
+    });
+    expect(scrub({ conn: 'mongodb+srv://u:p@cluster.example.com/db' })).toEqual({
+      conn: '[connection-string]',
+    });
+  });
+  it('catches postgres / postgresql', () => {
+    expect(scrub({ conn: 'postgres://u:p@host/db' })).toEqual({
+      conn: '[connection-string]',
+    });
+    expect(scrub({ conn: 'postgresql://u:p@host/db' })).toEqual({
+      conn: '[connection-string]',
+    });
+  });
+  it('catches mysql / redis', () => {
+    expect(scrub({ conn: 'mysql://u:p@host/db' })).toEqual({
+      conn: '[connection-string]',
+    });
+    expect(scrub({ conn: 'redis://localhost:6379' })).toEqual({
+      conn: '[connection-string]',
+    });
+  });
+  it('catches userinfo-bearing http(s) URLs', () => {
+    expect(scrub({ conn: 'https://user:pw@example.com/x' })).toEqual({
+      conn: '[connection-string]',
+    });
+    expect(scrub({ conn: 'http://api_user:secret@internal.local/' })).toEqual({
+      conn: '[connection-string]',
+    });
+  });
+  it('does NOT catch plain https URLs without userinfo', () => {
+    const out = scrub({ conn: 'https://example.com/path' });
+    expect(out).toEqual({ conn: 'https://example.com/path' });
+  });
+});
+
+describe('scrub: forbidden field drops', () => {
+  it('drops every forbidden key, keeps allowlisted scalars', () => {
+    const input = {
+      sid: 'abc',
+      bytes: 42,
+      content: 'this is the actual clipboard content',
+      data: 'whatever',
+      buffer: Buffer.from('x').toString(),
+      text: 'pasted text',
+      clipboard: 'clip',
+      composition: 'こん',
+      name: 'My Session',
+      env: { ANTHROPIC_API_KEY: 'x' },
+      body: 'http body',
+      payload: 'p',
+      raw: 'r',
+      input: 'i',
+      output: 'o',
+      stdin: 's',
+      stdout: 's',
+      stderr: 's',
+      args: ['claude', '--resume'],
+      argv: [],
+      cmdline: 'claude --resume',
+      command: 'claude',
+      query: 'select 1',
+      params: { a: 1 },
+      headers: { auth: 'x' },
+      cookies: 'k=v',
+      authorization: 'Bearer x',
+      message: 'user-supplied content',
+    };
+    const out = scrub(input) as Record<string, unknown>;
+    expect(out).toEqual({ sid: 'abc', bytes: 42 });
+  });
+});
+
+describe('scrub: recursion depth limit', () => {
+  it('terminates at depth 4 with a sentinel', () => {
+    const deep: Record<string, unknown> = { sid: 'a' };
+    deep.next = { sid: 'b', next: { sid: 'c', next: { sid: 'd', next: { sid: 'e' } } } };
+    const out = scrub(deep) as { next: { next: { next: { next: unknown } } } };
+    // Each level decrements depth by 1; the 5th level should hit the sentinel.
+    expect(out.next.next.next.next).toBe('[depth-limit]');
+  });
+});
+
+describe('scrub: Error.stack scrubbing', () => {
+  beforeEach(() => setHomeDir('C:\\Users\\Jiahui'));
+
+  it('scrubs paths from a multi-frame stack', () => {
+    const e = new Error('boom');
+    e.stack =
+      'Error: boom\n' +
+      '    at fn (C:\\Users\\Jiahui\\repos\\ccsm\\src\\foo.ts:10:5)\n' +
+      '    at other (/Users/jiahui/x.ts:1:1)';
+    const norm = normalizeError(e);
+    expect(norm.name).toBe('Error');
+    expect(norm.message).toBe('boom');
+    expect(norm.stack).toContain('~');
+    expect(norm.stack).not.toContain('C:\\Users\\Jiahui\\repos');
+    expect(norm.stack).not.toContain('/Users/jiahui');
+  });
+
+  it('preserves error class name (TypeError etc.) — NOT treated as PII', () => {
+    const e = new TypeError('bad');
+    const norm = normalizeError(e);
+    expect(norm.name).toBe('TypeError');
+  });
+});
+
+describe('normalizeError: cause chains', () => {
+  it('walks `cause` recursively', () => {
+    const inner = new Error('inner-cause');
+    const outer = new Error('outer');
+    (outer as Error & { cause?: unknown }).cause = inner;
+    const norm = normalizeError(outer);
+    expect(norm.cause?.message).toBe('inner-cause');
+    expect(norm.cause?.name).toBe('Error');
+  });
+  it('handles non-Error inputs gracefully', () => {
+    const norm = normalizeError('a string');
+    expect(norm.name).toBe('NonError');
+    expect(norm.message).toBe('a string');
+  });
+});
+
+describe('scrub: passthrough of allowed scalars + booleans', () => {
+  it('keeps numbers, booleans, null, undefined', () => {
+    expect(scrub({ cols: 80, rows: 24, ok: true, bad: false, n: null })).toEqual({
+      cols: 80,
+      rows: 24,
+      ok: true,
+      bad: false,
+      n: null,
+    });
+  });
+  it('recurses through arrays', () => {
+    setHomeDir(null);
+    const out = scrub({ items: ['/Users/x/a', 'plain'] }) as { items: string[] };
+    expect(out.items[0]).toBe('[path]');
+    expect(out.items[1]).toBe('plain');
+  });
+});


### PR DESCRIPTION
## Summary

Stage 1 of the ccsm observability rollout per design doc `scratch/observability-design-v2.md`. Replaces the stub console-only logger with an electron-log-backed structured logger, adds the shared PII / secret scrubber, attach-pane probes (excluding IME / paste — those are PR B), `app.getPath('logs')` init, Help → Reveal Logs (with pin) + Set Level menus, renderer-local fallback sink, and unit tests for the scrubber.

## Cold-review follow-up (commit `35bb14f`)

Both required findings addressed plus both nice-to-haves:

- **Required #1 (finding #1c) — console direct-write path now scrubbed.** Back-compat `warn`/`error` shims used to spread `...rest` straight into `console.warn`/`console.error`; an Error passed by a caller would leak `stack` with absolute paths to dev stderr while the structured sink stayed clean. Added `scrubConsoleArgs` in `src/shared/scrub.ts` (per-element: `Error`→`normalizeError`, plain object→`scrub`) and route both shims through it. Dual-write to console is preserved so `vi.spyOn(console, 'warn')` test contracts keep working — only the leak is sealed.
- **Required #2 (findings #3c / #9) — Help → Set Log Level boots on the persisted level.** `initLog()` + the initial `applyAppMenuLocale()` both run before `initDb()`, so the persisted `ccsm.logLevel` couldn't be read at module-load and the radio always booted on `info`. Added `syncPersistedLevelFromDb()` (env override wins; otherwise applies the persisted value to electron-log transports, returns whether the menu needs rebuild) and call it once in main.ts immediately after `initDb()`. Single rebuild on boot — no per-`setLevel` rebuild churn.
- **Nice-to-have #6** — added a comment on `jsonlFormat` documenting the `{…}` JSON-shape detection convention (single stringified record per emit, no trailing newline, no second arg).
- **Nice-to-have regression test** — four new tests in `tests/scrub.test.ts` proving the shim leak is closed: `scrubConsoleArgs` on Error / plain object, plus end-to-end `warn()` / `error()` shim calls with path-bearing Errors and assertions that the spied console args contain no `/Users/jiahui` / `C:\Users\Jiahui` and DO contain the `[path]` token.

## Scope of this PR

- Replace stub `src/shared/log.ts` + `electron/shared/log.ts` with electron-log-backed real logger. New API: `log.debug | info | warn | error | event`. Back-compat `warn`/`error` exports preserved — ~80 call sites unchanged.
- File transport: JSONL, **10MB × 10 files (100MB cap)**, per-file header line carrying app version / platform / electron version / node version / log schema version. `CCSM_LOG_LEVEL` + `CCSM_LOG_DISABLE_FILE` env overrides.
- PII scrubber (`src/shared/scrub.ts`) per v2 §3: env-key regexes (`ANTHROPIC_|CLAUDE_|AWS_` + `_ID|_PASS|_URI|_URL|_CREDENTIALS|TOKEN|KEY|SECRET|PASSWORD|AUTH|COOKIE`), connection-string detection (mongodb/postgres/mysql/redis + userinfo URLs), path regex (Windows / UNC / WSL / POSIX `/Users` / `/home` / `/root` / `/var` / `/tmp`), forbidden-field drops, allowed-field whitelist for `log.event`, depth-limited recursion (4), homedir prefix → `~`, **`Error.stack` scrubbing**, **`scrubConsoleArgs` for the dev-console direct-write path**.
- `normalizeError(e)` returns `{name, message, stack, cause}`. **Code comment added: `name` field intentionally bypasses the forbidden-fields drop because error class names (TypeError, etc.) are structural metadata, not PII.**
- Renderer-local fallback: 1MB × 2 ring at `userData/renderer-logs/` so a mid-crash renderer still has tail evidence if the IPC bridge dies.
- Scrubber unit tests (27 cases) in `tests/scrub.test.ts`: env-key positive/negative branches, home-dir scrub (Win / POSIX / WSL / UNC), connection-string per scheme + embedded creds, forbidden-field drops, recursion depth, `Error.stack`, `normalizeError` cause chains, plus the 4 cold-review regression tests on `scrubConsoleArgs` + back-compat shim leak.
- Attach probes in `src/terminal/usePtyAttach.ts`: `attach.state.transition`, `attach.snapshot.applied`, `attach.scrollToBottom.invoked` (post-snap + post-fit callsites), `attach.fit.applied`, `attach.fit.skipped`, `term.firstWrite.afterAttach`.
- `electron/main.ts`: `initLog()` at boot, `uncaughtException` + `unhandledRejection` now route through `log.error` with normalized errors, `syncPersistedLevelFromDb()` + menu rebuild after `initDb()`.
- Help menu: **Reveal Logs in Folder** (copies live `*.log` files into `pinned-<ISO-timestamp>/` before `shell.openPath`) + **Set Log Level** submenu (radio, persisted via existing sqlite `app_state` since project doesn't use `electron-store`).

## Parent resolutions applied (no re-raise)

- Default prod log level: **`info`**.
- Pinned-log retention: **never auto-pruned** (user-initiated only).
- `Help → Set Log Level` menu: **always visible** (not gated on `CCSM_DEV=1`).

## Out of scope (PR B)

- IME probes (`ime.*`)
- Paste probes (`paste.*`)
- Main-process Sentry wiring + scrubber on `beforeSend` / `beforeBreadcrumb`

`electron/sentry/init.ts` untouched.

## Implementation notes

- Back-compat `warn` / `error` shims also call `console.warn` / `console.error` directly (rest args scrubbed via `scrubConsoleArgs`). electron-log's node console transport captures console refs at module-load time, so a later `vi.spyOn(console, 'warn')` doesn't intercept records routed solely through electron-log — this preserves every legacy test contract (~80 call sites already asserting against the direct console call) while structured records still flow to the file / IPC sinks. The cold-review finding #1c (rest leak) is sealed by the new scrubber.
- Renderer log module short-circuits to a console-only stub under `process.env.VITEST === 'true'` to avoid electron-log/renderer's `RendererErrorHandler` triggering IPC retries in jsdom (which leads to hangs / noisy stderr in the renderer test suite).
- Log-level persistence reuses the existing sqlite `app_state` table (matches the pattern of other prefs modules like `electron/prefs/notifyEnabled.ts`) — `electron-store` was not added.

## Test plan

- [x] `npm run typecheck` — clean (main + electron tsconfigs).
- [x] `npm run lint` — 0 errors (112 warnings, same as baseline).
- [x] `npm test` — scrubber suite (27 tests) green; pre-existing tests still pass with identical pass/fail counts vs baseline modulo the +4 new tests (1727 vs baseline 1723; same 18 build-required smoke failures pre-existing in `tests/electron-load-smoke.test.ts`).
- [ ] Manual: launch app, confirm Help → Reveal Logs opens the logs folder with a pinned snapshot subdirectory; flip Set Level → Debug and confirm subsequent records include debug lines in `main.log`.
- [ ] Manual: trigger an attach (sidebar click on existing session) and confirm `attach.snapshot.applied`, `attach.scrollToBottom.invoked`, `attach.fit.applied|skipped`, and `term.firstWrite.afterAttach` JSONL lines appear in `main.log`.
- [ ] Manual: kill app, set `ccsm.logLevel = 'debug'` in DB, relaunch, confirm Help → Set Log Level radio shows Debug checked on first paint (not Info).

🤖 Generated with [Claude Code](https://claude.com/claude-code)