### PR TITLE
fix(lifecycle,mobile-remote): close two anti-patterns missed by #1329 / #1341

### DIFF
--- a/electron/__tests__/appLifecycle.test.ts
+++ b/electron/__tests__/appLifecycle.test.ts
@@ -1,0 +1,226 @@
+// Regression test for the `window-all-closed` quit path in
+// electron/lifecycle/appLifecycle.ts.
+//
+// Background: the handler ran `closeDb()` then `app.quit()` as plain
+// sequential statements. A throw from closeDb() (SQLite busy, lock
+// contention, schema-corruption) silently skipped app.quit(), leaving
+// Electron alive with no windows — a process leak.
+//
+// Mirrors the audit pattern from dispose-notify-pipeline.test.ts:
+//   1) Source-level: the literal window-all-closed handler body in
+//      appLifecycle.ts must wrap each disposer in its own try/catch.
+//   2) Behavior-level: drive registerLifecycleHandlers with a fake App,
+//      inject a throwing closeDb, and assert app.quit STILL gets called.
+//
+// Mutation check: removing the try/catch around closeDb() makes the
+// behavior test fail (closeDb throws, app.quit is never invoked).
+
+import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'fs';
+import * as path from 'path';
+
+// Avoid loading the real electron binary; we only need BrowserWindow.getAllWindows
+// to be callable from the before-quit handler.
+vi.mock('electron', () => ({
+  app: {},
+  Menu: { buildFromTemplate: () => ({}), setApplicationMenu: () => {} },
+  BrowserWindow: { getAllWindows: () => [] },
+}));
+
+const LIFECYCLE_TS = path.resolve(__dirname, '..', 'lifecycle', 'appLifecycle.ts');
+
+function readLiveSource(): string {
+  const source = fs.readFileSync(LIFECYCLE_TS, 'utf8');
+  return source
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('//'))
+    .join('\n');
+}
+
+/** Extract the body of the `app.on('window-all-closed', () => { ... })` block. */
+function extractWindowAllClosedBlock(live: string): string {
+  const startMarker = "app.on('window-all-closed', () => {";
+  const startIdx = live.indexOf(startMarker);
+  expect(startIdx).toBeGreaterThan(-1);
+  let depth = 0;
+  let i = startIdx + startMarker.length - 1; // position at the opening '{'
+  for (; i < live.length; i++) {
+    const ch = live[i];
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) return live.slice(startIdx, i + 1);
+    }
+  }
+  throw new Error('unterminated window-all-closed block in appLifecycle.ts');
+}
+
+describe('window-all-closed cleanup chain (source wiring)', () => {
+  const live = readLiveSource();
+  const block = extractWindowAllClosedBlock(live);
+
+  it('wraps closeDb() in its own try/catch', () => {
+    const closeIdx = block.indexOf('closeDb()');
+    expect(closeIdx).toBeGreaterThan(-1);
+    const tryBefore = block.lastIndexOf('try {', closeIdx);
+    expect(tryBefore).toBeGreaterThan(-1);
+    const nextDisposerIdx = block.indexOf('app.quit()', closeIdx);
+    const catchBetween = block.indexOf('catch', closeIdx);
+    expect(catchBetween).toBeGreaterThan(closeIdx);
+    expect(catchBetween).toBeLessThan(nextDisposerIdx);
+  });
+
+  it('wraps app.quit() in its own try/catch', () => {
+    const quitIdx = block.indexOf('app.quit()');
+    expect(quitIdx).toBeGreaterThan(-1);
+    const tryBefore = block.lastIndexOf('try {', quitIdx);
+    expect(tryBefore).toBeGreaterThan(-1);
+    const between = block.slice(tryBefore, quitIdx);
+    expect(between).not.toMatch(/closeDb\(\)/);
+    const catchAfter = block.indexOf('catch', quitIdx);
+    expect(catchAfter).toBeGreaterThan(quitIdx);
+  });
+
+  it('preserves disposer order: closeDb → app.quit', () => {
+    const closeIdx = block.indexOf('closeDb()');
+    const quitIdx = block.indexOf('app.quit()');
+    expect(closeIdx).toBeGreaterThan(-1);
+    expect(quitIdx).toBeGreaterThan(closeIdx);
+  });
+
+  it('logs each disposer failure via console.warn with the [appLifecycle] tag', () => {
+    expect(block).toMatch(/console\.warn\(\s*'\[appLifecycle\] disposer/);
+  });
+});
+
+type Handler = (...args: unknown[]) => void;
+
+function makeFakeApp(): {
+  on: (event: string, cb: Handler) => void;
+  emit: (event: string, ...args: unknown[]) => void;
+  handlers: Map<string, Handler>;
+} {
+  const handlers = new Map<string, Handler>();
+  return {
+    handlers,
+    on(event, cb) {
+      handlers.set(event, cb);
+    },
+    emit(event, ...args) {
+      const cb = handlers.get(event);
+      if (cb) cb(...args);
+    },
+  };
+}
+
+describe('window-all-closed cleanup chain (behavior contract)', () => {
+  it('still calls app.quit when closeDb throws', async () => {
+    const fakeApp = makeFakeApp();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const closeDb = vi.fn(() => {
+      throw new Error('sqlite busy');
+    });
+    const appQuit = vi.fn();
+    // Build an App-shaped object: on() + quit().
+    const appLike = {
+      on: fakeApp.on.bind(fakeApp),
+      quit: appQuit,
+    };
+
+    const { registerLifecycleHandlers } = await import('../lifecycle/appLifecycle');
+    registerLifecycleHandlers({
+      // Cast through unknown — we only exercise on() and quit().
+      app: appLike as unknown as import('electron').App,
+      getIsQuitting: () => true,
+      setIsQuitting: () => {},
+      killAllPtySessions: async () => {},
+      closeDb,
+      createWindow: () => {},
+      getWindowCount: () => 0,
+    });
+
+    fakeApp.emit('window-all-closed');
+
+    expect(closeDb).toHaveBeenCalledTimes(1);
+    // The critical invariant: quit MUST still run even when closeDb threw.
+    expect(appQuit).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[appLifecycle] disposer closeDb threw'),
+      expect.any(Error),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('runs both disposers on the happy path', async () => {
+    const fakeApp = makeFakeApp();
+    const closeDb = vi.fn();
+    const appQuit = vi.fn();
+    const appLike = { on: fakeApp.on.bind(fakeApp), quit: appQuit };
+
+    const { registerLifecycleHandlers } = await import('../lifecycle/appLifecycle');
+    registerLifecycleHandlers({
+      app: appLike as unknown as import('electron').App,
+      getIsQuitting: () => true,
+      setIsQuitting: () => {},
+      killAllPtySessions: async () => {},
+      closeDb,
+      createWindow: () => {},
+      getWindowCount: () => 0,
+    });
+
+    fakeApp.emit('window-all-closed');
+    expect(closeDb).toHaveBeenCalledTimes(1);
+    expect(appQuit).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips disposers entirely when not in a real-quit pass', async () => {
+    const fakeApp = makeFakeApp();
+    const closeDb = vi.fn();
+    const appQuit = vi.fn();
+    const appLike = { on: fakeApp.on.bind(fakeApp), quit: appQuit };
+
+    const { registerLifecycleHandlers } = await import('../lifecycle/appLifecycle');
+    registerLifecycleHandlers({
+      app: appLike as unknown as import('electron').App,
+      // Hide-to-tray: not quitting.
+      getIsQuitting: () => false,
+      setIsQuitting: () => {},
+      killAllPtySessions: async () => {},
+      closeDb,
+      createWindow: () => {},
+      getWindowCount: () => 0,
+    });
+
+    fakeApp.emit('window-all-closed');
+    expect(closeDb).not.toHaveBeenCalled();
+    expect(appQuit).not.toHaveBeenCalled();
+  });
+
+  it('does not rethrow when app.quit throws', async () => {
+    const fakeApp = makeFakeApp();
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const closeDb = vi.fn();
+    const appQuit = vi.fn(() => {
+      throw new Error('quit blew up');
+    });
+    const appLike = { on: fakeApp.on.bind(fakeApp), quit: appQuit };
+
+    const { registerLifecycleHandlers } = await import('../lifecycle/appLifecycle');
+    registerLifecycleHandlers({
+      app: appLike as unknown as import('electron').App,
+      getIsQuitting: () => true,
+      setIsQuitting: () => {},
+      killAllPtySessions: async () => {},
+      closeDb,
+      createWindow: () => {},
+      getWindowCount: () => 0,
+    });
+
+    expect(() => fakeApp.emit('window-all-closed')).not.toThrow();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[appLifecycle] disposer app.quit threw'),
+      expect.any(Error),
+    );
+    warnSpy.mockRestore();
+  });
+});

--- a/electron/__tests__/mobileRemoteServer.test.ts
+++ b/electron/__tests__/mobileRemoteServer.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as http from 'http';
 import * as crypto from 'crypto';
+import * as net from 'net';
 import type { AddressInfo } from 'net';
 import type { Socket } from 'net';
 
@@ -436,7 +437,6 @@ function rawUpgradeProbe(
   path: string
 ): Promise<{ status: number; raw: string }> {
   return new Promise((resolve, reject) => {
-    const net = require('net') as typeof import('net');
     const socket = net.connect(port, '127.0.0.1', () => {
       socket.write(
         [

--- a/electron/__tests__/mobileRemoteServer.test.ts
+++ b/electron/__tests__/mobileRemoteServer.test.ts
@@ -426,3 +426,80 @@ describe('mobileRemoteServer: message handling', () => {
     expect(code).toBe(1003);
   });
 });
+
+// Raw upgrade probe that, unlike wsConnect(), returns the literal HTTP
+// reject response the server wrote. Lets us assert the peer actually
+// receives the 401/400 status line + body — the bug a bare destroy()
+// would have hidden on Windows.
+function rawUpgradeProbe(
+  port: number,
+  path: string
+): Promise<{ status: number; raw: string }> {
+  return new Promise((resolve, reject) => {
+    const net = require('net') as typeof import('net');
+    const socket = net.connect(port, '127.0.0.1', () => {
+      socket.write(
+        [
+          `GET ${path} HTTP/1.1`,
+          'Host: 127.0.0.1',
+          'Connection: Upgrade',
+          'Upgrade: websocket',
+          'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==',
+          'Sec-WebSocket-Version: 13',
+          '',
+          '',
+        ].join('\r\n')
+      );
+    });
+    const chunks: Buffer[] = [];
+    socket.on('data', (c) => chunks.push(c));
+    socket.on('end', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      const m = raw.match(/^HTTP\/1\.1 (\d+)/);
+      resolve({ status: m ? Number(m[1]) : 0, raw });
+    });
+    socket.on('close', () => {
+      const raw = Buffer.concat(chunks).toString('utf8');
+      const m = raw.match(/^HTTP\/1\.1 (\d+)/);
+      resolve({ status: m ? Number(m[1]) : 0, raw });
+    });
+    socket.on('error', reject);
+  });
+}
+
+describe('mobileRemoteServer: upgrade reject delivery', () => {
+  it('peer receives the 401 status line on bad token (socket.end flush)', async () => {
+    active = await startServer();
+    const result = await rawUpgradeProbe(active.port, '/ws?token=wrong');
+    expect(result.status).toBe(401);
+    expect(result.raw).toMatch(/401 Unauthorized/);
+  });
+
+  it('peer receives the 401 status line on non-/ws path', async () => {
+    active = await startServer();
+    const result = await rawUpgradeProbe(active.port, `/elsewhere?token=${active.token}`);
+    expect(result.status).toBe(401);
+    expect(result.raw).toMatch(/401 Unauthorized/);
+  });
+});
+
+describe('mobileRemoteServer: server shutdown', () => {
+  it('sends a 1001 close frame to live clients on close() (no raw RST)', async () => {
+    active = await startServer();
+    const ws = await wsConnect(active.port, `/ws?token=${active.token}`);
+    await ws.recvText;
+
+    // Trigger server shutdown; live clients should receive a 1001 close
+    // frame followed by a normal FIN, not a bare TCP RST.
+    active.close();
+    active = null;
+
+    const code = await Promise.race([
+      ws.closeCode,
+      new Promise<number>((_, rej) => setTimeout(() => rej(new Error('no close')), 2000)),
+    ]);
+    // 1001 = going-away. A bare destroy() would have surfaced as null
+    // (no close frame parsed).
+    expect(code).toBe(1001);
+  });
+});

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -269,8 +269,21 @@ export function registerLifecycleHandlers(deps: LifecycleDeps): void {
     // user explicitly chose minimize-to-tray. Real quit goes through tray
     // Quit / Ctrl-Q.
     if (getIsQuitting()) {
-      closeDb();
-      app.quit();
+      // Each disposer is wrapped in its own try/catch so a throw from one
+      // (e.g. closeDb() on a busy/locked SQLite handle, or a schema-corruption
+      // throw) does NOT skip the rest. `app.quit()` MUST run unconditionally
+      // — without it Electron stays alive with no windows. Mirrors the
+      // pattern PR #1329 used for disposeNotifyPipeline in main.ts.
+      try {
+        closeDb();
+      } catch (err) {
+        console.warn('[appLifecycle] disposer closeDb threw', err);
+      }
+      try {
+        app.quit();
+      } catch (err) {
+        console.warn('[appLifecycle] disposer app.quit threw', err);
+      }
     }
   });
 

--- a/electron/remote/mobileRemoteServer.ts
+++ b/electron/remote/mobileRemoteServer.ts
@@ -60,15 +60,17 @@ export function startMobileRemoteServer(): MobileRemoteServer | null {
   server.on('upgrade', (req, socket) => {
     const url = parseRequestUrl(req.url);
     if (!url || url.pathname !== '/ws' || url.searchParams.get('token') !== token) {
-      socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
-      socket.destroy();
+      // socket.end() flushes the HTTP response before sending FIN; a bare
+      // destroy() would race the kernel and the peer may miss the 401 body
+      // on Windows. Same pattern PR #1341 applied to closeSocket().
+      socket.end('HTTP/1.1 401 Unauthorized\r\n\r\n');
       return;
     }
 
     const key = req.headers['sec-websocket-key'];
     if (typeof key !== 'string') {
-      socket.write('HTTP/1.1 400 Bad Request\r\n\r\n');
-      socket.destroy();
+      // See 401 path above — flush before FIN so the peer sees the 400 body.
+      socket.end('HTTP/1.1 400 Bad Request\r\n\r\n');
       return;
     }
 
@@ -129,7 +131,12 @@ export function startMobileRemoteServer(): MobileRemoteServer | null {
   return {
     close: () => {
       offPtyData();
-      for (const client of clients) client.socket.destroy();
+      // Send a 1001 (going-away) close frame per client and let the FIN
+      // follow naturally via socket.end() inside closeSocket(). A bare
+      // destroy() would emit a raw TCP RST and peers would never see the
+      // close reason — same anti-pattern PR #1341 fixed in the fatal-frame
+      // path.
+      for (const client of clients) closeSocket(client.socket, 1001);
       clients.clear();
       server.close();
     },


### PR DESCRIPTION
## Summary

Code-archaeology audit found two recurrences of patterns the recent PRs #1329 (isolate quit-time disposers) and #1341 (flush close frame before FIN) thought they had eliminated. Both are fixed here with the same patterns those PRs established.

### Bug A — \`electron/lifecycle/appLifecycle.ts:184-187\` \`closeDb()\` not isolated from \`app.quit()\`

The \`window-all-closed\` handler ran:

\`\`\`ts
closeDb();
app.quit();
\`\`\`

A throw from \`closeDb()\` (SQLite busy, lock contention, schema corruption) would silently skip \`app.quit()\`, leaving Electron alive with no windows — exactly the failure mode PR #1329 fixed for \`disposeNotifyPipeline\`. Each disposer is now wrapped in its own try/catch + \`console.warn\` with the \`[appLifecycle]\` tag.

### Bug B — \`electron/remote/mobileRemoteServer.ts\` three remaining write+destroy paths

PR #1341 fixed \`closeSocket\` (fatal-frame path). Three more callers had the same anti-pattern:

- **Upgrade reject 401** (bad token / non-/ws path): \`socket.write('HTTP/1.1 401 ...'); socket.destroy()\`. Peer could miss the body on Windows because destroy() does not wait for pending writes.
- **Upgrade reject 400** (missing Sec-WebSocket-Key): same pattern.
- **Server \`close()\` loop**: \`for (const client of clients) client.socket.destroy()\`. Peers got a raw TCP RST instead of a WebSocket close frame.

Fix:
- 401/400 paths switch to \`socket.end(body)\` (same fix as #1341).
- Server shutdown loop now routes each client through \`closeSocket(client.socket, 1001)\` so peers see a proper 1001 going-away close frame, then a natural FIN.

## Tests

- New \`electron/__tests__/appLifecycle.test.ts\` (8 tests):
  - Source-level: literal handler body must wrap each disposer in its own try/catch.
  - Behavior: throwing \`closeDb\` does NOT prevent \`app.quit\`; throwing \`app.quit\` does not rethrow; hide-to-tray path still skips disposers; happy path runs both.
- Extends \`electron/__tests__/mobileRemoteServer.test.ts\` (+3 tests):
  - Raw-socket upgrade probe asserts the peer receives the literal 401 status line on bad token AND on non-/ws path (the bug a bare destroy() would have hidden).
  - Asserts \`active.close()\` delivers a 1001 close frame to live clients (not a raw RST).

Result: 150 passed (was 139 on origin/main, delta +11).

## Mutation check

Reverting either source fix while keeping the tests fails 6 tests. Confirmed locally by stashing only the source files and re-running the two test files: 6 failed / 20 passed.

## Test plan

- [x] \`npm test -- electron/__tests__ --run\` → 150 passed.
- [x] Mutation check: revert source, tests fail.
- [ ] CI hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)