### PR TITLE
fix(sessionTitles): close cache write-back-after-invalidation race (follow-up to #1340)

### DIFF
--- a/electron/sessionTitles/__tests__/noDataLoss.test.ts
+++ b/electron/sessionTitles/__tests__/noDataLoss.test.ts
@@ -464,3 +464,86 @@ describe('listProjectSummaries returns [] on SDK throw', () => {
     ]);
   });
 });
+
+// ─────────────────────── I10: cache write-back-after-invalidation ───────
+//
+// Follow-up to PR #1340: `getSessionTitle` performs an unconditional
+// `titleCache.set` after awaiting the SDK. If state was invalidated during
+// that await window (by `forgetSid` or a concurrent `renameSessionTitle`),
+// the post-await write re-introduces a value that should not be in the
+// cache — either repopulating a forgotten sid (S1, cache leak bounded by
+// TTL) or shadowing a fresh value with the pre-rename one (S2, user-visible
+// stale read window). Both tests below would fail if the guards in
+// `getSessionTitle` were removed (mutation check).
+
+describe('getSessionTitle does not write back to cache after invalidation', () => {
+  it('does not repopulate cache after forgetSid during await (S1)', async () => {
+    // Hold the SDK on a deferred promise so we can force `forgetSid` to
+    // run strictly between chain entry and the post-await write.
+    let resolveSdk!: (v: unknown) => void;
+    sdkMocks.getSessionInfo.mockReturnValue(
+      new Promise((res) => {
+        resolveSdk = res;
+      })
+    );
+
+    const sid = 'sid-i10a';
+    const inFlight = getSessionTitle(sid);
+    // Yield once to let `getSessionTitle` enter `chain()` and start the
+    // SDK await (it's `await loadSdk()` then `await getSessionInfo(...)`;
+    // two microtasks is enough on Node).
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Forget the sid while the SDK is still in flight.
+    forgetSid(sid);
+    expect(__hasSidStateForTests(sid)).toBe(false);
+
+    // Now let the SDK resolve. The post-await write must NOT repopulate
+    // titleCache for a forgotten sid.
+    resolveSdk({ sessionId: sid, summary: 'late', lastModified: 1 });
+    await inFlight;
+
+    expect(__hasSidStateForTests(sid)).toBe(false);
+  });
+
+  it('does not overwrite a freshly-cleared cache after a concurrent rename (S2)', async () => {
+    // S2 variant: while `getSessionTitle` is mid-await on the SDK, the
+    // renderer enqueues a pending rename for the same sid (user typed a
+    // new title in the sidebar before the JSONL flushed). Once the SDK
+    // returns, the read's post-await cache write would otherwise stash
+    // the pre-rename value — but the pending rename means that value is
+    // already known-stale. The guard skips the write so the next read
+    // re-fetches fresh after the pending rename flushes.
+    let resolveSdk!: (v: unknown) => void;
+    sdkMocks.getSessionInfo.mockReturnValue(
+      new Promise((res) => {
+        resolveSdk = res;
+      })
+    );
+
+    const sid = 'sid-i10b';
+    const inFlight = getSessionTitle(sid);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Pending rename arrives during the await window.
+    enqueuePendingRename(sid, 'new-title');
+
+    // SDK resolves with the now-stale pre-rename summary.
+    resolveSdk({ sessionId: sid, summary: 'old-summary', lastModified: 100 });
+    const result = await inFlight;
+    expect(result.summary).toBe('old-summary'); // the in-flight read still returns what it got
+
+    // But the cache must NOT have been repopulated — a fresh read must
+    // go back to the SDK (which will now serve post-rename data).
+    sdkMocks.getSessionInfo.mockResolvedValueOnce({
+      sessionId: sid,
+      summary: 'new-summary',
+      lastModified: 200,
+    });
+    const fresh = await getSessionTitle(sid);
+    expect(fresh.summary).toBe('new-summary');
+    expect(sdkMocks.getSessionInfo).toHaveBeenCalledTimes(2);
+  });
+});

--- a/electron/sessionTitles/index.ts
+++ b/electron/sessionTitles/index.ts
@@ -133,6 +133,15 @@ function chain<T>(sid: string, fn: () => Promise<T>): Promise<T> {
 type PendingRename = { title: string; dir?: string; attempts: number };
 const pendingRenames = new Map<string, PendingRename>();
 
+// Per-sid generation counter. Bumped by `forgetSid` so a `getSessionTitle`
+// call that started before the forget can detect it happened during its
+// await window and skip the cache write-back. Without this, the post-await
+// `titleCache.set` would repopulate the map for a sid the rest of the
+// module considers forgotten (S1 in the concurrency audit). Generations
+// are never recycled — an absent key reads as 0 via `?? 0`, and forgetting
+// then re-querying a sid just starts a fresh count from 1.
+const sidGenerations = new Map<string, number>();
+
 // Bound for non-ENOENT replays. 2 = initial attempt + 1 retry. Rationale:
 // the realistic transient causes (file briefly locked by the SDK's own
 // write, antivirus scan, momentary EACCES on Windows) clear within a
@@ -164,6 +173,11 @@ export async function getSessionTitle(
     return cached.result;
   }
 
+  // Capture the sid's generation before we enter the chain. If `forgetSid`
+  // bumps it during our await, we'll detect it post-await and skip the
+  // cache write-back (S1 guard).
+  const genAtEntry = sidGenerations.get(sid) ?? 0;
+
   const result = await chain(sid, async (): Promise<SummaryResult> => {
     try {
       const { getSessionInfo } = await loadSdk();
@@ -184,7 +198,37 @@ export async function getSessionTitle(
     }
   });
 
-  titleCache.set(sid, { result, expiresAt: Date.now() + CACHE_TTL_MS });
+  // Write-back-after-invalidation guard (follow-up to #1340).
+  //
+  // Between chain entry and here we awaited the SDK; concurrent operations
+  // on the same sid can have completed in the meantime and invalidated the
+  // result we are about to cache:
+  //
+  //   S1 (cache leak): `forgetSid(sid)` ran during the await. It cleared
+  //   titleCache; an unconditional write here would repopulate the map for
+  //   a sid the rest of the module considers forgotten, surviving until
+  //   the TTL expires.
+  //
+  //   S2 (stale read window): a `renameSessionTitle(sid, "new")` queued
+  //   behind us in the chain ran second, succeeded, and deleted
+  //   titleCache. Our `result` was captured BEFORE the rename and carries
+  //   the pre-rename summary; writing it back here would serve a stale
+  //   value for up to CACHE_TTL_MS.
+  //
+  // Both cases are covered by a single invariant: only write if the cache
+  // is STILL absent (nobody invalidated it), no pending rename is queued
+  // (nothing that would imminently invalidate it again), AND the sid's
+  // generation hasn't been bumped by `forgetSid` since we entered. If any
+  // guard trips we leave the cache cleared; the next caller pays for a
+  // fresh SDK read, which is the correct behavior.
+  const genNow = sidGenerations.get(sid) ?? 0;
+  if (
+    genNow === genAtEntry &&
+    !titleCache.has(sid) &&
+    !pendingRenames.has(sid)
+  ) {
+    titleCache.set(sid, { result, expiresAt: Date.now() + CACHE_TTL_MS });
+  }
   return result;
 }
 
@@ -328,6 +372,11 @@ export function forgetSid(sid: string): void {
   titleCache.delete(sid);
   opChains.delete(sid);
   pendingRenames.delete(sid);
+  // Bump generation so any in-flight `getSessionTitle` for this sid
+  // (currently awaiting the SDK inside its chain) skips its post-await
+  // cache write-back instead of repopulating titleCache for a sid that's
+  // supposed to be forgotten. Closes S1 in the concurrency audit.
+  sidGenerations.set(sid, (sidGenerations.get(sid) ?? 0) + 1);
   if (!pending) return;
   void (async () => {
     // Defer to a microtask so the synchronous caller observes a fully
@@ -383,6 +432,7 @@ export function __resetForTests(): void {
   titleCache.clear();
   opChains.clear();
   pendingRenames.clear();
+  sidGenerations.clear();
   sdkPromise = null;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1340, which explicitly deferred the `getSessionTitle` cache write-back issue at `index.ts:~167`. This closes it.

`getSessionTitle` performed an unconditional `titleCache.set` after awaiting the SDK inside `chain`. Concurrent operations could invalidate state during the await window, leaving the post-await write to re-introduce values that should not live in the cache:

- **S1 (cache leak):** `forgetSid(sid)` runs during the await and clears `titleCache`. The unconditional write then repopulates the map for a sid the rest of the module considers forgotten — survives ~2s TTL.
- **S2 (stale-read window via pending rename):** a `pendingRename` is enqueued while the SDK read is in flight. The captured `result` is pre-rename; writing it back stashes a known-stale value into the cache.

## Fix

Post-await, only write the cache when ALL of these hold:

1. `sidGenerations[sid]` matches what was captured pre-chain. `forgetSid` now bumps this counter — a mismatch means the sid was forgotten mid-await; skip the write. (Closes S1.)
2. `titleCache` is still absent for the sid (nobody else wrote a value we'd shadow).
3. `pendingRenames` is empty for the sid (no known-imminent invalidation). (Closes S2.)

If any guard trips, the cache stays cleared. The next caller pays for a fresh SDK read — better than serving stale/post-forget data.

Bug B (forgetSid post-SDK race / S4) is already fixed on `main` by #1340 (bail-before-SDK in the deferred microtask), so it is **not** re-done here.

## Test plan

- [x] Two new tests appended to `noDataLoss.test.ts` under new I10 describe block:
  - `does not repopulate cache after forgetSid during await (S1)`
  - `does not overwrite a freshly-cleared cache after a concurrent rename (S2)`
- [x] All 55 tests in `electron/sessionTitles/__tests__` pass with the fix in place.
- [x] **Mutation check:** replacing the guard with `if (true || (...))` causes BOTH new tests to fail (verified locally). Each new test pins exactly one side of the guard.
- [ ] CI green on this PR.

## Scope

- `electron/sessionTitles/index.ts` — add `sidGenerations` Map; bump it in `forgetSid`; clear it in `__resetForTests`; capture pre-chain in `getSessionTitle`; guard the cache write.
- `electron/sessionTitles/__tests__/noDataLoss.test.ts` — two new tests, new I10 section.

No other files touched. No deps changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)