### PR TITLE
fix(lint): convert ATTENTION_PRIORITY const to type alias

### DIFF
--- a/src/components/AgentIcon.tsx
+++ b/src/components/AgentIcon.tsx
@@ -50,7 +50,7 @@ function ClaudeAsterisk({ size }: { size: number }) {
 //   1. crashed       → no halo (red dot in SessionRow is the signal)
 //   2. waiting/flash → amber breathing halo
 //   3. idle          → neutral
-const ATTENTION_PRIORITY = ['crashed', 'waiting-or-flashing', 'idle'] as const;
+type AttentionPriority = 'crashed' | 'waiting-or-flashing' | 'idle';
 
 export function AgentIcon({
   agentType,
@@ -67,12 +67,12 @@ export function AgentIcon({
 }) {
   const px = SIZE_PX[size];
   const glyph = GLYPH_PX[size];
-  // Explicit priority resolution — see ATTENTION_PRIORITY above. crashed
+  // Explicit priority resolution — see comment block above. crashed
   // short-circuits the halo even if state==='waiting' or flashing===true.
   const isWaiting = !crashed && (state === 'waiting' || flashing);
   // Resolved attention bucket — exposed as `data-attention` so visual /
   // unit tests can pin the priority contract without measuring animation.
-  const attention: (typeof ATTENTION_PRIORITY)[number] = crashed
+  const attention: AttentionPriority = crashed
     ? 'crashed'
     : state === 'waiting' || flashing
       ? 'waiting-or-flashing'


### PR DESCRIPTION
## Summary
- `AgentIcon.tsx:53` defined `ATTENTION_PRIORITY` as a `const` array but only used it as `(typeof ATTENTION_PRIORITY)[number]` to derive a string-literal union.
- `@typescript-eslint/no-unused-vars` flags this as an unused value binding because the runtime array is never read.
- Replaced with a proper `type AttentionPriority = ...` declaration. Same union, no runtime cost, lint clean.

## Why now
Pre-existing on main but never surfaced because the CI workflow only runs on PRs and `workflow_dispatch`, not on main pushes. Currently blocks the lint+typecheck+test job on every in-flight PR (#1346, #1347, #1348, #1349).

## Test plan
- [x] \`npx eslint src/components/AgentIcon.tsx\` → exit 0
- [x] \`npx tsc --noEmit\` → exit 0
- [ ] CI lint+typecheck+test green on all 3 OS

🤖 Generated with [Claude Code](https://claude.com/claude-code)