### PR TITLE
feat(observability): PR B — IME + paste probes + Sentry hardening

### DIFF
--- a/electron/sentry/init.ts
+++ b/electron/sentry/init.ts
@@ -9,10 +9,122 @@
 // `beforeSend` consults the user's opt-out preference at every send so the
 // Settings toggle takes effect immediately (the cache is invalidated by the
 // `db:save` IPC handler in main.ts when the renderer writes the key).
+//
+// PR B Stage 2 hardening (observability-design-v2 §3):
+//  * `defaultIntegrations: false` — `@sentry/electron/main` defaults pull in
+//    the entire Node SDK default set (httpIntegration, consoleIntegration,
+//    onUnhandledRejectionIntegration, electronBreadcrumbsIntegration with
+//    webContents/browserWindow event capture, etc). Several of those grab
+//    URLs, console arguments, and IPC payloads verbatim — pre-scrub. We
+//    strip the lot and only add back `electronMinidumpIntegration()` so
+//    native crash dumps still ship.
+//  * `sendDefaultPii: false` ONLY controls IP / cookies / user-id
+//    inference; it does NOT cover HTTP bodies, console args, or DOM events.
+//    Those leak via the default integration set — hence the `false` above.
+//  * `beforeSend` and `beforeBreadcrumb` both run the shared scrubber over
+//    every string-bearing field (`message`, `exception.values[].value`,
+//    stacktrace frame paths, `extra`, `contexts`, `tags`, `request`,
+//    `crumb.message`, `crumb.data`). Forbidden field names → dropped;
+//    paths → `[path]`; connection strings → `[connection-string]`;
+//    env-secret keys → `[redacted]`. Recursive, depth-capped.
+//  * `release: ccsm@<version>` — reads from `app.getVersion()`, which in
+//    a packaged build is the version from `package.json`. Prefix matches
+//    the design doc's `ccsm@${packageJson.version}` format so Sentry's
+//    "version" facet groups correctly across SDK/platform shards.
 
 import * as Sentry from '@sentry/electron/main';
+import { electronMinidumpIntegration } from '@sentry/electron/main';
 import { app } from 'electron';
 import { loadCrashReportingOptOut } from '../prefs/crashReporting';
+import { scrub } from '../../src/shared/scrub';
+
+/**
+ * Scrub a Sentry event in place. Every string-valued field that could carry
+ * user content or paths is rewritten via the shared scrubber. We walk:
+ *   * `event.message`
+ *   * `event.exception.values[*].value` + `stacktrace.frames[*].filename / module / abs_path / function`
+ *   * `event.breadcrumbs[*]` (handled separately by `beforeBreadcrumb` for live crumbs;
+ *     scrubbed here too defensively in case the event arrives with frozen crumbs attached)
+ *   * `event.extra`, `event.contexts`, `event.tags`, `event.request`
+ *
+ * Implementation: lean on `scrub()` for objects (forbidden-field drop +
+ * env-key redaction + path/conn-string rewriting on every leaf string).
+ * Stack-frame filename/module fields use `scrub(string)` directly because
+ * those are top-level string slots that the recursive scrubber would
+ * normally only reach via parent-object traversal.
+ */
+type AnyRecord = Record<string, unknown>;
+
+function scrubSentryEvent(event: AnyRecord): AnyRecord | null {
+  try {
+    if (typeof event.message === 'string') {
+      event.message = scrub(event.message) as string;
+    }
+    const ex = event.exception as
+      | { values?: Array<AnyRecord> }
+      | undefined;
+    if (ex?.values) {
+      for (const v of ex.values) {
+        if (typeof v.value === 'string') v.value = scrub(v.value) as string;
+        if (typeof v.type === 'string') v.type = scrub(v.type) as string;
+        const st = v.stacktrace as { frames?: Array<AnyRecord> } | undefined;
+        if (st?.frames) {
+          for (const f of st.frames) {
+            for (const k of ['filename', 'abs_path', 'module', 'function'] as const) {
+              if (typeof f[k] === 'string') f[k] = scrub(f[k] as string) as string;
+            }
+          }
+        }
+      }
+    }
+    for (const k of ['extra', 'contexts', 'tags', 'request', 'user'] as const) {
+      if (event[k] != null && typeof event[k] === 'object') {
+        event[k] = scrub(event[k]);
+      }
+    }
+    const crumbs = event.breadcrumbs as Array<AnyRecord> | undefined;
+    if (Array.isArray(crumbs)) {
+      event.breadcrumbs = crumbs
+        .map((c) => scrubBreadcrumb(c))
+        .filter((c): c is AnyRecord => c != null);
+    }
+  } catch {
+    // Logging must never crash the host. If scrub itself throws, the safer
+    // failure mode is to drop the event entirely.
+    return null;
+  }
+  return event;
+}
+
+/**
+ * Scrub a Sentry breadcrumb. Returns `null` to drop the crumb when post-scrub
+ * it's effectively empty (every meaningful field was a forbidden-field that
+ * got removed). Drop-on-empty matters because Sentry's default breadcrumb
+ * shapes (`{category, message, data}`) become useless when `message` AND all
+ * of `data`'s keys are forbidden — better to drop than ship a structurally-
+ * valid but information-free entry that still leaks the category timing.
+ */
+function scrubBreadcrumb(crumb: AnyRecord): AnyRecord | null {
+  try {
+    if (typeof crumb.message === 'string') {
+      crumb.message = scrub(crumb.message) as string;
+    }
+    if (crumb.data != null && typeof crumb.data === 'object') {
+      crumb.data = scrub(crumb.data);
+    }
+    // Drop the crumb when it carries no message AND no surviving data fields.
+    const hasMsg = typeof crumb.message === 'string' && crumb.message.length > 0;
+    const dataObj = crumb.data as AnyRecord | null | undefined;
+    const hasData = dataObj != null && Object.keys(dataObj).length > 0;
+    if (!hasMsg && !hasData) return null;
+  } catch {
+    return null;
+  }
+  return crumb;
+}
+
+// Exported for unit tests.
+export { scrubSentryEvent, scrubBreadcrumb };
 
 export function initSentry(): void {
   const dsn = process.env.SENTRY_DSN?.trim() || undefined;
@@ -22,9 +134,18 @@ export function initSentry(): void {
   }
   Sentry.init({
     dsn,
-    release: app.getVersion(),
+    release: `ccsm@${app.getVersion()}`,
     environment: app.isPackaged ? 'prod' : 'dev',
     sendDefaultPii: false,
+    // Strip the default integration set entirely. See the file-level comment
+    // for the rationale: the Node SDK defaults capture HTTP URLs, console
+    // arguments, and Electron IPC payloads pre-scrub.
+    defaultIntegrations: false,
+    integrations: [
+      // Native crash dumps via Electron's built-in minidump uploader. No
+      // application-level data captured; this just ships the crash file.
+      electronMinidumpIntegration(),
+    ],
     beforeSend(event) {
       try {
         const optOut = loadCrashReportingOptOut();
@@ -32,7 +153,10 @@ export function initSentry(): void {
       } catch {
         /* fall through, send anyway */
       }
-      return event;
+      return scrubSentryEvent(event as unknown as AnyRecord) as unknown as typeof event;
+    },
+    beforeBreadcrumb(crumb) {
+      return scrubBreadcrumb(crumb as unknown as AnyRecord) as unknown as typeof crumb;
     },
   });
 }

--- a/src/shared/scrub.ts
+++ b/src/shared/scrub.ts
@@ -112,6 +112,10 @@ export const EVENT_ALLOWED_FIELDS = new Set<string>([
   'bytesAfter',
   'updateCount',
   'elapsedMs',
+  // PR B Stage 2 additions:
+  //  - `branch`: discrete code-path tag for paste entry-points
+  //    ('ctrl-v' | 'right-click' | 'capture-dom'). Scalar string, no content.
+  'branch',
 ]);
 
 const DEFAULT_DEPTH = 4;

--- a/src/terminal/xtermSingleton.ts
+++ b/src/terminal/xtermSingleton.ts
@@ -6,7 +6,8 @@ import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { CanvasAddon } from '@xterm/addon-canvas';
 import { useStore } from '../stores/store';
 import { SCROLLBACK_LINES_DEFAULT } from '../stores/slices/types';
-import { warn } from '../shared/log';
+import { warn, log } from '../shared/log';
+import { normalizeError } from '../shared/scrub';
 
 // Module-scope singleton state for the renderer's xterm view.
 //
@@ -43,10 +44,26 @@ let keyboardPasteHandled = false;
 // composition preview box jump around. Buffer pty chunks until compositionend.
 let isComposing = false;
 let imeBuffer = '';
+// PR B Stage 2 IME probes: count buffered chunks/bytes per composition so
+// the `ime.composition.end` event can report buffer pressure. We track
+// chunk count separately from `imeBuffer.length` because the buffer is a
+// concatenated string — without a counter we couldn't reconstruct how many
+// PTY chunks arrived while the IME was composing. Reset on each
+// compositionstart.
+let imeBufferedChunks = 0;
+let imeBufferedBytes = 0;
+// `compositionupdate` fires once per IME edit; we sample every 10 to bound
+// log volume for long pinyin sessions (the v2 design addition). Reset on
+// compositionstart so each composition has its own counter.
+let imeUpdateCount = 0;
+let imeCompositionStartedAt = 0;
+const IME_UPDATE_SAMPLE_N = 10;
 
 export function writeOrBuffer(chunk: string): void {
   if (isComposing) {
     imeBuffer += chunk;
+    imeBufferedChunks += 1;
+    imeBufferedBytes += chunk.length;
     return;
   }
   term?.write(chunk);
@@ -214,6 +231,15 @@ export async function pasteIntoActivePty(fallbackText: string | undefined): Prom
   // looking at when they hit paste.
   const sid = activeSid;
   if (!sid) return;
+  // PR B Stage 2 probe: paste capture stage. Boundary metadata only —
+  // no clipboard content fields. `bytes` is the inbound text length
+  // (fallback path; image path is unknown at this point).
+  log.event('paste.hop', {
+    sid,
+    stage: 'capture',
+    bytes: fallbackText?.length ?? 0,
+    bracketed: getCurrentBracketedPasteMode(),
+  });
   try {
     const imagePath = await window.ccsmPty?.saveClipboardImage?.();
     if (imagePath) {
@@ -221,13 +247,53 @@ export async function pasteIntoActivePty(fallbackText: string | undefined): Prom
       // the same prep so bracketed-paste wrapping applies — claude must see
       // the path as one atomic paste, not as keystrokes that could collide
       // with TUI keybindings while the path streams in.
-      window.ccsmPty.input(sid, preparePastePayload(imagePath, getCurrentBracketedPasteMode()));
+      const bracketed = getCurrentBracketedPasteMode();
+      const payload = preparePastePayload(imagePath, bracketed);
+      log.event('paste.branch', { sid, branch: 'image' });
+      log.event('paste.hop', { sid, stage: 'prepare', bytes: payload.length, bracketed });
+      log.event('paste.hop', { sid, stage: 'ipc-send', bytes: payload.length, bracketed });
+      try {
+        window.ccsmPty.input(sid, payload);
+        log.event('paste.hop', { sid, stage: 'pty-write', bytes: payload.length, bracketed });
+      } catch (e) {
+        log.error('paste', 'pty-write failed', { sid, stage: 'pty-write', error: normalizeError(e) });
+      }
       return;
     }
-  } catch {
+  } catch (e) {
     // best-effort — fall through to text paste on IPC failure.
+    log.error('paste', 'saveClipboardImage failed', {
+      sid,
+      stage: 'ipc-send',
+      error: normalizeError(e),
+    });
   }
-  if (fallbackText) window.ccsmPty.input(sid, preparePastePayload(fallbackText, getCurrentBracketedPasteMode()));
+  if (fallbackText) {
+    const bracketed = getCurrentBracketedPasteMode();
+    const bytesBefore = fallbackText.length;
+    const crlfFound = /\r\n|\r/.test(fallbackText);
+    const payload = preparePastePayload(fallbackText, bracketed);
+    // bytesAfter is the post-normalize length BEFORE bracketed-paste wrapping.
+    // We can derive it by stripping the wrapper bytes when bracketed is true.
+    const bytesAfter = bracketed ? payload.length - '\x1b[200~'.length - '\x1b[201~'.length : payload.length;
+    log.event('paste.normalized', {
+      sid,
+      bytesBefore,
+      bytesAfter,
+      crlfFound,
+    });
+    log.event('paste.branch', { sid, branch: 'text' });
+    log.event('paste.hop', { sid, stage: 'prepare', bytes: payload.length, bracketed });
+    log.event('paste.hop', { sid, stage: 'ipc-send', bytes: payload.length, bracketed });
+    try {
+      window.ccsmPty.input(sid, payload);
+      log.event('paste.hop', { sid, stage: 'pty-write', bytes: payload.length, bracketed });
+    } catch (e) {
+      log.error('paste', 'pty-write failed', { sid, stage: 'pty-write', error: normalizeError(e) });
+    }
+  } else {
+    log.event('paste.branch', { sid, branch: 'empty' });
+  }
 }
 
 /**
@@ -348,13 +414,52 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
   if (ta) {
     ta.addEventListener('compositionstart', () => {
       isComposing = true;
+      imeBufferedChunks = 0;
+      imeBufferedBytes = 0;
+      imeUpdateCount = 0;
+      imeCompositionStartedAt = Date.now();
+      log.event('ime.composition.start', { sid: activeSid ?? undefined });
+    });
+    // `compositionupdate` fires per IME edit. Sample every Nth so a long
+    // pinyin session doesn't flood the log. We never read `event.data` —
+    // that's the in-flight composed string, which is content. Only the
+    // integer counter goes into the event.
+    ta.addEventListener('compositionupdate', () => {
+      imeUpdateCount += 1;
+      if (imeUpdateCount % IME_UPDATE_SAMPLE_N === 0) {
+        log.event('ime.composition.progress', {
+          sid: activeSid ?? undefined,
+          count: imeUpdateCount,
+        });
+      }
     });
     ta.addEventListener('compositionend', () => {
       isComposing = false;
+      const durationMs = imeCompositionStartedAt
+        ? Date.now() - imeCompositionStartedAt
+        : 0;
+      const chunks = imeBufferedChunks;
+      const bytes = imeBufferedBytes;
+      log.event('ime.composition.end', {
+        sid: activeSid ?? undefined,
+        durationMs,
+        bufferedChunks: chunks,
+        bufferedBytes: bytes,
+      });
       if (imeBuffer) {
         const pending = imeBuffer;
         imeBuffer = '';
+        imeBufferedChunks = 0;
+        imeBufferedBytes = 0;
         term?.write(pending);
+        log.event('ime.buffer.flush', {
+          sid: activeSid ?? undefined,
+          bytes: pending.length,
+          chunks,
+        });
+      } else {
+        imeBufferedChunks = 0;
+        imeBufferedBytes = 0;
       }
     });
   }
@@ -417,6 +522,7 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
     // Read text synchronously: clipboardData is only valid during the
     // event dispatch, so we can't await before reading it.
     const text = e.clipboardData?.getData('text/plain') ?? '';
+    if (activeSid) log.event('paste.branch', { sid: activeSid, branch: 'capture-dom' });
     void pasteIntoActivePty(text || undefined);
   };
   host.addEventListener('paste', onPasteCapture, { capture: true });
@@ -456,6 +562,7 @@ export function ensureTerminal(host: HTMLDivElement): Terminal {
     }
     // Task #42 — route through the image-first helper so a copied
     // screenshot lands as a file path rather than empty text.
+    if (activeSid) log.event('paste.branch', { sid: activeSid, branch: 'ctrl-v' });
     void pasteIntoActivePty(text);
   };
 
@@ -549,6 +656,10 @@ export function __resetSingletonForTests(): void {
   keyboardPasteHandled = false;
   isComposing = false;
   imeBuffer = '';
+  imeBufferedChunks = 0;
+  imeBufferedBytes = 0;
+  imeUpdateCount = 0;
+  imeCompositionStartedAt = 0;
   if (typeof window !== 'undefined') {
     delete window.__ccsmTerm;
   }
@@ -609,5 +720,6 @@ export function terminalPaste(): void {
   }
   // Task #42 — route through the image-first helper so right-click on a
   // copied screenshot lands as a file path rather than empty text.
+  if (activeSid) log.event('paste.branch', { sid: activeSid, branch: 'right-click' });
   void pasteIntoActivePty(text);
 }

--- a/tests/sentry-scrub.test.ts
+++ b/tests/sentry-scrub.test.ts
@@ -1,0 +1,160 @@
+// PR B Stage 2 — Sentry beforeSend / beforeBreadcrumb scrubber.
+//
+// Tests the pure scrubber helpers exported from `electron/sentry/init.ts`.
+// We do NOT call `Sentry.init` — that requires a real Sentry/Electron
+// runtime. Instead we exercise the exported scrubbing functions directly,
+// which is what `Sentry.init`'s `beforeSend` / `beforeBreadcrumb` hooks
+// invoke at send-time.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock heavy native deps so we can import the production init module without
+// pulling Electron or the real Sentry SDK into jsdom. The scrubber helpers
+// we're testing are pure functions that don't touch either.
+vi.mock('@sentry/electron/main', () => ({
+  init: vi.fn(),
+  electronMinidumpIntegration: vi.fn(() => ({ name: 'ElectronMinidump' })),
+}));
+vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0-test', isPackaged: false } }));
+vi.mock('../electron/prefs/crashReporting', () => ({ loadCrashReportingOptOut: () => false }));
+
+import { scrubSentryEvent, scrubBreadcrumb } from '../electron/sentry/init';
+import { setHomeDir } from '../src/shared/scrub';
+
+beforeEach(() => setHomeDir(null));
+
+describe('scrubSentryEvent — exception stacktrace paths', () => {
+  it('rewrites POSIX home paths in stack frame filename/abs_path', () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            type: 'TypeError',
+            value: 'bad call at /Users/jiahui/secret/foo.ts',
+            stacktrace: {
+              frames: [
+                {
+                  filename: '/Users/jiahui/secret/foo.ts',
+                  abs_path: '/Users/jiahui/secret/foo.ts',
+                  module: 'foo',
+                  function: 'doStuff',
+                  lineno: 42,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const out = scrubSentryEvent(event) as typeof event;
+    const frame = out.exception.values[0].stacktrace.frames[0];
+    expect(frame.filename).toBe('[path]');
+    expect(frame.abs_path).toBe('[path]');
+    // Message-level path → [path].
+    expect(out.exception.values[0].value).toBe('bad call at [path]');
+    // lineno (non-string) untouched.
+    expect(frame.lineno).toBe(42);
+  });
+
+  it('rewrites Windows drive paths in stack frames', () => {
+    const event = {
+      exception: {
+        values: [
+          {
+            value: 'crash',
+            stacktrace: {
+              frames: [
+                { filename: 'C:\\Users\\Jiahui\\app\\main.js', lineno: 1 },
+              ],
+            },
+          },
+        ],
+      },
+    };
+    const out = scrubSentryEvent(event) as typeof event;
+    expect(out.exception.values[0].stacktrace.frames[0].filename).toBe('[path]');
+  });
+
+  it('scrubs event.message', () => {
+    const event = { message: 'failed reading /home/user/.config' };
+    const out = scrubSentryEvent(event) as typeof event;
+    expect(out.message).toBe('failed reading [path]');
+  });
+
+  it('scrubs forbidden fields from event.extra / contexts / tags', () => {
+    const event = {
+      extra: { sid: 'abc', text: 'leak me', cwd: '/Users/x/file.ts' },
+      contexts: { runtime: { name: 'node', cmd: 'claude --resume' } },
+      tags: { url: 'https://user:pw@host/x', sid: 'abc' },
+    };
+    const out = scrubSentryEvent(event) as typeof event;
+    expect((out.extra as Record<string, unknown>).text).toBeUndefined();
+    expect((out.extra as Record<string, unknown>).sid).toBe('abc');
+    expect((out.extra as Record<string, unknown>).cwd).toBe('[path]');
+    expect((out.contexts.runtime as Record<string, unknown>).cmd).toBeUndefined();
+    expect((out.tags as Record<string, unknown>).url).toBeUndefined();
+    expect((out.tags as Record<string, unknown>).sid).toBe('abc');
+  });
+});
+
+describe('scrubBreadcrumb — drop on forbidden-only content', () => {
+  it('drops a breadcrumb whose only data field was forbidden', () => {
+    const crumb = {
+      category: 'paste',
+      data: { text: 'secret content' },
+    };
+    const out = scrubBreadcrumb(crumb);
+    // After scrub, `data` is empty {} and there's no message → drop.
+    expect(out).toBeNull();
+  });
+
+  it('keeps a breadcrumb whose message scrubs to a non-empty path token', () => {
+    const crumb = {
+      category: 'navigation',
+      message: 'opened /Users/x/foo',
+    };
+    const out = scrubBreadcrumb(crumb);
+    expect(out).not.toBeNull();
+    expect(out!.message).toBe('opened [path]');
+  });
+
+  it('keeps a breadcrumb with surviving allowlisted data fields', () => {
+    const crumb = {
+      category: 'paste',
+      data: { sid: 'abc', bytes: 42, text: 'secret' },
+    };
+    const out = scrubBreadcrumb(crumb) as Record<string, unknown> & {
+      data: Record<string, unknown>;
+    };
+    expect(out).not.toBeNull();
+    expect(out.data.sid).toBe('abc');
+    expect(out.data.bytes).toBe(42);
+    expect(out.data.text).toBeUndefined();
+  });
+
+  it('scrubs env-secret keys inside data', () => {
+    const crumb = {
+      message: 'env loaded',
+      data: { ANTHROPIC_API_KEY: 'sk-leak', sid: 'abc' },
+    };
+    const out = scrubBreadcrumb(crumb) as Record<string, unknown> & {
+      data: Record<string, unknown>;
+    };
+    expect(out!.data.ANTHROPIC_API_KEY).toBe('[redacted]');
+    expect(out!.data.sid).toBe('abc');
+  });
+});
+
+describe('scrubSentryEvent — defensive: never throws', () => {
+  it('returns null when the input is structurally broken (drops the event)', () => {
+    // Pass a getter that throws so the try/catch inside scrubSentryEvent trips.
+    const bad: Record<string, unknown> = {};
+    Object.defineProperty(bad, 'message', {
+      get() {
+        throw new Error('boom');
+      },
+    });
+    const out = scrubSentryEvent(bad);
+    expect(out).toBeNull();
+  });
+});

--- a/tests/terminal/imeProbes.test.ts
+++ b/tests/terminal/imeProbes.test.ts
@@ -1,0 +1,194 @@
+// PR B Stage 2 — IME composition probes.
+//
+// Verifies the structured `log.event` calls emitted by the compositionstart /
+// compositionupdate / compositionend listeners in `xtermSingleton.ts`.
+// Particularly: `ime.composition.progress` is sampled every 10th update so
+// long pinyin sessions don't flood the log. The 1st-through-9th, 11th-
+// through-19th, etc. updates must NOT fire `progress`.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Same hoisted-ctor pattern as imeBuffering.test.ts so the singleton wires
+// real DOM compositionstart/update/end listeners to a real <textarea>.
+const { writeSpy, textareaRef, terminalCtor } = vi.hoisted(() => {
+  const writeSpy = vi.fn();
+  const textareaRef: { current: HTMLTextAreaElement } = {
+    current: (globalThis as unknown as { document: Document }).document.createElement('textarea'),
+  };
+  const terminalCtor = vi.fn(function () {
+    // Fresh textarea per Terminal so leftover listeners from a prior test
+    // don't double-fire compositionupdate handlers on subsequent tests.
+    textareaRef.current = (globalThis as unknown as { document: Document }).document.createElement('textarea');
+    return {
+      open: vi.fn(),
+      loadAddon: vi.fn(),
+      onSelectionChange: vi.fn(),
+      attachCustomKeyEventHandler: vi.fn(),
+      getSelection: vi.fn(() => ''),
+      clearSelection: vi.fn(),
+      selectAll: vi.fn(),
+      unicode: { activeVersion: '6' },
+      modes: { bracketedPasteMode: false },
+      _core: { _parent: null },
+      textarea: textareaRef.current,
+      write: writeSpy,
+    };
+  });
+  return { writeSpy, textareaRef, terminalCtor };
+});
+
+vi.mock('@xterm/xterm', () => ({ Terminal: terminalCtor }));
+vi.mock('@xterm/addon-fit', () => ({ FitAddon: vi.fn(function () { return { fit: vi.fn() }; }) }));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-canvas', () => ({ CanvasAddon: vi.fn(function () { return {}; }) }));
+
+// Mock the shared log so we can assert on `log.event(...)` payloads without
+// the real electron-log path firing. We keep `warn` (and `error`) as real
+// no-op spies so the back-compat shim used inside xtermSingleton for addon-
+// load failures doesn't blow up.
+const eventSpy = vi.fn();
+vi.mock('../../src/shared/log', () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    event: (...args: unknown[]) => eventSpy(...args),
+  },
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+import {
+  __resetSingletonForTests,
+  ensureTerminal,
+  setActiveSid,
+  writeOrBuffer,
+} from '../../src/terminal/xtermSingleton';
+
+function eventNames(): string[] {
+  return eventSpy.mock.calls.map((c) => c[0] as string);
+}
+
+function fieldsFor(name: string): Array<Record<string, unknown>> {
+  return eventSpy.mock.calls
+    .filter((c) => c[0] === name)
+    .map((c) => (c[1] ?? {}) as Record<string, unknown>);
+}
+
+describe('IME probes — composition lifecycle events', () => {
+  beforeEach(() => {
+    __resetSingletonForTests();
+    writeSpy.mockClear();
+    terminalCtor.mockClear();
+    eventSpy.mockClear();
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    ensureTerminal(host as HTMLDivElement);
+    setActiveSid('sid-1');
+  });
+
+  afterEach(() => {
+    __resetSingletonForTests();
+    document.body.innerHTML = '';
+    setActiveSid(null);
+  });
+
+  it('fires ime.composition.start on compositionstart', () => {
+    textareaRef.current.dispatchEvent(new CompositionEvent('compositionstart'));
+    expect(eventNames()).toContain('ime.composition.start');
+    expect(fieldsFor('ime.composition.start')[0]).toMatchObject({ sid: 'sid-1' });
+  });
+
+  it('does NOT fire progress for updates 1..9', () => {
+    textareaRef.current.dispatchEvent(new CompositionEvent('compositionstart'));
+    for (let i = 0; i < 9; i++) {
+      textareaRef.current.dispatchEvent(new CompositionEvent('compositionupdate'));
+    }
+    expect(eventNames()).not.toContain('ime.composition.progress');
+  });
+
+  it('fires progress on the 10th update with count=10', () => {
+    textareaRef.current.dispatchEvent(new CompositionEvent('compositionstart'));
+    for (let i = 0; i < 10; i++) {
+      textareaRef.current.dispatchEvent(new CompositionEvent('compositionupdate'));
+    }
+    const progress = fieldsFor('ime.composition.progress');
+    expect(progress).toHaveLength(1);
+    expect(progress[0]).toMatchObject({ sid: 'sid-1', count: 10 });
+  });
+
+  it('does NOT fire progress for updates 11..19, fires again at 20', () => {
+    textareaRef.current.dispatchEvent(new CompositionEvent('compositionstart'));
+    for (let i = 0; i < 19; i++) {
+      textareaRef.current.dispatchEvent(new CompositionEvent('compositionupdate'));
+    }
+    expect(fieldsFor('ime.composition.progress')).toHaveLength(1); // only at 10
+    textareaRef.current.dispatchEvent(new CompositionEvent('compositionupdate')); // 20th
+    const progress = fieldsFor('ime.composition.progress');
+    expect(progress).toHaveLength(2);
+    expect(progress[1]).toMatchObject({ count: 20 });
+  });
+
+  it('progress payload contains NO content/data fields', () => {
+    textareaRef.current.dispatchEvent(new CompositionEvent('compositionstart'));
+    for (let i = 0; i < 10; i++) {
+      textareaRef.current.dispatchEvent(
+        new CompositionEvent('compositionupdate', { data: 'secret-pinyin' }),
+      );
+    }
+    const fields = fieldsFor('ime.composition.progress')[0];
+    expect(fields).not.toHaveProperty('data');
+    expect(fields).not.toHaveProperty('content');
+    expect(fields).not.toHaveProperty('text');
+    expect(fields).not.toHaveProperty('composition');
+    // Only sid + integer count.
+    expect(Object.keys(fields).sort()).toEqual(['count', 'sid']);
+  });
+
+  it('resets update counter on a fresh compositionstart', () => {
+    textareaRef.current.dispatchEvent(new CompositionEvent('compositionstart'));
+    for (let i = 0; i < 5; i++) {
+      textareaRef.current.dispatchEvent(new CompositionEvent('compositionupdate'));
+    }
+    textareaRef.current.dispatchEvent(new CompositionEvent('compositionend'));
+    eventSpy.mockClear();
+
+    // Second composition: only 5 updates → still no progress event.
+    textareaRef.current.dispatchEvent(new CompositionEvent('compositionstart'));
+    for (let i = 0; i < 5; i++) {
+      textareaRef.current.dispatchEvent(new CompositionEvent('compositionupdate'));
+    }
+    expect(eventNames()).not.toContain('ime.composition.progress');
+  });
+
+  it('fires composition.end with bufferedChunks/bufferedBytes from writeOrBuffer', () => {
+    textareaRef.current.dispatchEvent(new CompositionEvent('compositionstart'));
+    writeOrBuffer('abc'); // 3 bytes, 1 chunk
+    writeOrBuffer('de'); // 2 bytes, 2 chunks total
+    textareaRef.current.dispatchEvent(new CompositionEvent('compositionend'));
+    const end = fieldsFor('ime.composition.end')[0];
+    expect(end).toMatchObject({
+      sid: 'sid-1',
+      bufferedChunks: 2,
+      bufferedBytes: 5,
+    });
+    expect(typeof end.durationMs).toBe('number');
+  });
+
+  it('fires ime.buffer.flush when end drains a non-empty buffer', () => {
+    textareaRef.current.dispatchEvent(new CompositionEvent('compositionstart'));
+    writeOrBuffer('xyz');
+    textareaRef.current.dispatchEvent(new CompositionEvent('compositionend'));
+    const flush = fieldsFor('ime.buffer.flush')[0];
+    expect(flush).toMatchObject({ sid: 'sid-1', bytes: 3, chunks: 1 });
+  });
+
+  it('does NOT fire ime.buffer.flush when buffer is empty at end', () => {
+    textareaRef.current.dispatchEvent(new CompositionEvent('compositionstart'));
+    textareaRef.current.dispatchEvent(new CompositionEvent('compositionend'));
+    expect(eventNames()).not.toContain('ime.buffer.flush');
+  });
+});

--- a/tests/terminal/pasteProbes.test.ts
+++ b/tests/terminal/pasteProbes.test.ts
@@ -1,0 +1,201 @@
+// PR B Stage 2 — paste probe events.
+//
+// Verifies `paste.branch`, `paste.normalized`, `paste.hop` events fire with
+// the expected entry-point tags and metadata. We exercise the three paste
+// entry-points (capture-DOM listener, Ctrl/Cmd+V keydown, right-click
+// `terminalPaste`) via the public API, mocking `window.ccsmPty` so the IPC
+// hops are observable without a real preload bridge.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const { writeSpy, textarea, keyHandlerRef, terminalCtor } = vi.hoisted(() => {
+  const writeSpy = vi.fn();
+  const textarea = (globalThis as unknown as { document: Document }).document.createElement('textarea');
+  const keyHandlerRef: { current: ((ev: KeyboardEvent) => boolean) | null } = { current: null };
+  const terminalCtor = vi.fn(function () {
+    return {
+      open: vi.fn(),
+      loadAddon: vi.fn(),
+      onSelectionChange: vi.fn(),
+      attachCustomKeyEventHandler: vi.fn((cb: (ev: KeyboardEvent) => boolean) => {
+        keyHandlerRef.current = cb;
+      }),
+      getSelection: vi.fn(() => ''),
+      clearSelection: vi.fn(),
+      selectAll: vi.fn(),
+      unicode: { activeVersion: '6' },
+      modes: { bracketedPasteMode: false },
+      _core: { _parent: null },
+      textarea,
+      write: writeSpy,
+    };
+  });
+  return { writeSpy, textarea, keyHandlerRef, terminalCtor };
+});
+
+vi.mock('@xterm/xterm', () => ({ Terminal: terminalCtor }));
+vi.mock('@xterm/addon-fit', () => ({ FitAddon: vi.fn(function () { return { fit: vi.fn() }; }) }));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-canvas', () => ({ CanvasAddon: vi.fn(function () { return {}; }) }));
+
+const eventSpy = vi.fn();
+vi.mock('../../src/shared/log', () => ({
+  log: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    event: (...args: unknown[]) => eventSpy(...args),
+  },
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+import {
+  __resetSingletonForTests,
+  ensureTerminal,
+  setActiveSid,
+  terminalPaste,
+} from '../../src/terminal/xtermSingleton';
+
+function fieldsFor(name: string): Array<Record<string, unknown>> {
+  return eventSpy.mock.calls
+    .filter((c) => c[0] === name)
+    .map((c) => (c[1] ?? {}) as Record<string, unknown>);
+}
+
+function lastBranch(): string | undefined {
+  const calls = fieldsFor('paste.branch');
+  return calls[calls.length - 1]?.branch as string | undefined;
+}
+
+describe('paste probes — entry-point branch dispatch', () => {
+  let host: HTMLDivElement;
+  let inputSpy: ReturnType<typeof vi.fn>;
+  let saveImageSpy: ReturnType<typeof vi.fn>;
+  let readTextSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    __resetSingletonForTests();
+    writeSpy.mockClear();
+    terminalCtor.mockClear();
+    eventSpy.mockClear();
+    keyHandlerRef.current = null;
+    inputSpy = vi.fn();
+    saveImageSpy = vi.fn(async () => null); // no image by default
+    readTextSpy = vi.fn(() => 'pasted-text');
+    (window as unknown as { ccsmPty: unknown }).ccsmPty = {
+      input: inputSpy,
+      saveClipboardImage: saveImageSpy,
+      clipboard: { writeText: vi.fn(), readText: readTextSpy },
+    };
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    ensureTerminal(host as HTMLDivElement);
+    setActiveSid('sid-paste');
+  });
+
+  afterEach(() => {
+    __resetSingletonForTests();
+    document.body.innerHTML = '';
+    setActiveSid(null);
+    delete (window as unknown as { ccsmPty?: unknown }).ccsmPty;
+  });
+
+  it('capture-DOM paste fires paste.branch with branch="capture-dom"', async () => {
+    const e = new Event('paste', { bubbles: true }) as ClipboardEvent;
+    Object.defineProperty(e, 'clipboardData', {
+      value: { getData: () => 'hello-clip' },
+    });
+    host.dispatchEvent(e);
+    // pasteIntoActivePty is async — wait a tick for the saveClipboardImage promise.
+    await new Promise((r) => setTimeout(r, 0));
+    const branches = fieldsFor('paste.branch').map((f) => f.branch);
+    expect(branches).toContain('capture-dom');
+    expect(branches).toContain('text'); // inner image-vs-text branch
+  });
+
+  it('Ctrl+V keyboard paste fires paste.branch with branch="ctrl-v"', async () => {
+    expect(keyHandlerRef.current).toBeTypeOf('function');
+    const ev = {
+      type: 'keydown',
+      ctrlKey: true,
+      metaKey: false,
+      altKey: false,
+      shiftKey: false,
+      key: 'v',
+    } as unknown as KeyboardEvent;
+    keyHandlerRef.current!(ev);
+    await new Promise((r) => setTimeout(r, 0));
+    const branches = fieldsFor('paste.branch').map((f) => f.branch);
+    expect(branches).toContain('ctrl-v');
+  });
+
+  it('right-click terminalPaste fires paste.branch with branch="right-click"', async () => {
+    terminalPaste();
+    await new Promise((r) => setTimeout(r, 0));
+    const branches = fieldsFor('paste.branch').map((f) => f.branch);
+    expect(branches).toContain('right-click');
+  });
+
+  it('image-branch paste fires paste.branch with branch="image" instead of "text"', async () => {
+    saveImageSpy.mockResolvedValueOnce('C:\\tmp\\img.png');
+    terminalPaste();
+    await new Promise((r) => setTimeout(r, 0));
+    const branches = fieldsFor('paste.branch').map((f) => f.branch);
+    expect(branches).toContain('image');
+    expect(branches).not.toContain('text');
+  });
+
+  it('paste.normalized reports byte counts + crlfFound, no content', async () => {
+    readTextSpy.mockReturnValueOnce('line1\r\nline2\r\nline3');
+    terminalPaste();
+    await new Promise((r) => setTimeout(r, 0));
+    const norm = fieldsFor('paste.normalized')[0];
+    expect(norm).toBeDefined();
+    expect(norm.crlfFound).toBe(true);
+    expect(norm.bytesBefore).toBe('line1\r\nline2\r\nline3'.length);
+    expect(norm.bytesAfter).toBe('line1\nline2\nline3'.length);
+    // Critical: no content field leaks.
+    expect(norm).not.toHaveProperty('text');
+    expect(norm).not.toHaveProperty('content');
+    expect(norm).not.toHaveProperty('data');
+  });
+
+  it('paste.hop stages cover capture → prepare → ipc-send → pty-write', async () => {
+    terminalPaste();
+    await new Promise((r) => setTimeout(r, 0));
+    const stages = fieldsFor('paste.hop').map((f) => f.stage);
+    expect(stages).toContain('capture');
+    expect(stages).toContain('prepare');
+    expect(stages).toContain('ipc-send');
+    expect(stages).toContain('pty-write');
+  });
+
+  it('every paste event carries the snapshotted sid (no leaks)', async () => {
+    terminalPaste();
+    await new Promise((r) => setTimeout(r, 0));
+    for (const call of eventSpy.mock.calls) {
+      const name = call[0] as string;
+      if (!name.startsWith('paste.')) continue;
+      const fields = (call[1] ?? {}) as Record<string, unknown>;
+      expect(fields.sid).toBe('sid-paste');
+      // No content-shaped fields anywhere.
+      for (const forbidden of ['text', 'content', 'data', 'clipboard', 'composition', 'payload']) {
+        expect(fields).not.toHaveProperty(forbidden);
+      }
+    }
+  });
+
+  it('does nothing (no events) when activeSid is null', async () => {
+    setActiveSid(null);
+    eventSpy.mockClear();
+    terminalPaste();
+    await new Promise((r) => setTimeout(r, 0));
+    // pasteIntoActivePty early-returns; the `paste.branch` at the entry
+    // point is also gated on activeSid, so zero events fire.
+    expect(eventSpy.mock.calls.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Stage 2 of the observability rollout. Builds on PR A (#1345 / commit aa8c22c).

## Events added

| Event | Fields | Where |
|---|---|---|
| `ime.composition.start` | `sid` | compositionstart listener |
| `ime.composition.progress` | `sid, count` — sampled every 10 updates | compositionupdate listener |
| `ime.composition.end` | `sid, durationMs, bufferedChunks, bufferedBytes` | compositionend listener |
| `ime.buffer.flush` | `sid, bytes, chunks` | compositionend drain |
| `paste.branch` | `sid, branch: 'capture-dom'\|'ctrl-v'\|'right-click'\|'image'\|'text'\|'empty'` | each entry point + image/text split |
| `paste.normalized` | `sid, bytesBefore, bytesAfter, crlfFound` | text-paste branch |
| `paste.hop` | `sid, stage: 'capture'\|'prepare'\|'ipc-send'\|'pty-write', bytes, bracketed` | along the paste pipeline |
| `paste.error` | `sid, stage, error: normalizeError(e)` via `log.error` | pty-write / saveClipboardImage failures |

## EVENT_ALLOWED_FIELDS additions

- **`branch`** — discrete code-path tag for paste entry-points (string scalar). Justification: paste has six legitimately-discrete branches we want to disambiguate in logs; reusing `kind` (already on list, semantically image/text/empty) would conflate entry-point with content-kind.

All other event fields (`count`, `bufferedChunks`, `bufferedBytes`, `bytesBefore`, `bytesAfter`, `crlfFound`, `chunks`, `bytes`, `sid`, `stage`, `bracketed`, `durationMs`) are already on the allowlist from PR A.

## Sentry hardening summary

- `defaultIntegrations: false` — strips the Node SDK defaults (`httpIntegration`, `consoleIntegration`, `electronBreadcrumbsIntegration` with webContents capture, `nodeContextIntegration`, etc.) that grab URLs / console args / IPC payloads pre-scrub. `sendDefaultPii: false` alone does NOT cover those — it only blocks IP / user-id / cookies.
- Only `electronMinidumpIntegration()` added back so native crash dumps still upload via Electron's built-in uploader.
- `beforeSend` scrubs `event.message`, `exception.values[].value/type`, stacktrace frames (`filename`, `abs_path`, `module`, `function`), `extra`, `contexts`, `tags`, `request`, `user`, and any attached breadcrumbs. Returns `null` on internal throw (fail-closed).
- `beforeBreadcrumb` scrubs `message` + `data`, drops crumbs that become empty after forbidden-field removal.
- `release: ccsm@<version>` via `app.getVersion()` (was bare `app.getVersion()` before).

## Scope NOT touched (per task)

- Attach probes / `usePtyAttach.ts` — PR A territory, already shipped at aa8c22c.
- Renderer log forwarding — PR A.
- Help → Reveal Logs / Set Log Level menu items — PR A.
- Scrubber regexes / forbidden-field list — PR A. Only `EVENT_ALLOWED_FIELDS` got the `branch` addition.
- Reload/quit shutdown path — #1338 territory.

## Test plan

- [x] `npm run typecheck` — passes
- [x] `npm run lint` — 0 errors (pre-existing warnings only)
- [x] `npm test` — 1848 pass, 18 failures all in pre-existing `tests/electron-load-smoke.test.ts` which requires `npm run build` (no dist in this worktree). New suites: 24 cases, all green.
- [ ] Manual: trigger IME composition + paste, eyeball JSONL log to confirm no content fields leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)