### PR TITLE
fix(attach): viewport-pinning invariant — eliminate scroll-to-top race on idle re-attach

### DIFF
--- a/src/shared/scrub.ts
+++ b/src/shared/scrub.ts
@@ -116,6 +116,16 @@ export const EVENT_ALLOWED_FIELDS = new Set<string>([
   //  - `branch`: discrete code-path tag for paste entry-points
   //    ('ctrl-v' | 'right-click' | 'capture-dom'). Scalar string, no content.
   'branch',
+  // Attach viewport-pinning invariant probes (`attach.invariant.pinned` +
+  // augmented `attach.scrollToBottom.invoked`).
+  //  - `bufferType`: xterm buffer mode — 'normal' | 'alternate'. Bounded enum.
+  //  - `cursorY`: row index of cursor within the active buffer (small int).
+  //  - `length`: total line count of the active buffer (small int).
+  //  - `atBottom`: boolean — viewportY === baseY after the rendezvous.
+  'bufferType',
+  'cursorY',
+  'length',
+  'atBottom',
 ]);
 
 const DEFAULT_DEPTH = 4;

--- a/src/terminal/usePtyAttach.ts
+++ b/src/terminal/usePtyAttach.ts
@@ -13,7 +13,6 @@ import {
   setInputDisposable,
   setSnapshotReplay,
   getSnapshotReplay,
-  writeAndScrollToBottom,
   writeOrBuffer,
 } from './xtermSingleton';
 
@@ -29,6 +28,71 @@ const writeAsync = (
   t: { write: (s: string, cb?: () => void) => void },
   s: string,
 ): Promise<void> => new Promise((resolve) => t.write(s, resolve));
+
+// Structural shape we need from xterm.Terminal at the attach-complete
+// rendezvous. Kept narrow so the unit test can drive the helper with a
+// fake. The real `Terminal` from xterm satisfies this.
+type PinnableTerminal = {
+  write: (s: string, cb?: () => void) => void;
+  scrollToBottom: () => void;
+  buffer: {
+    active: {
+      viewportY: number;
+      baseY: number;
+      cursorY: number;
+      length: number;
+      type: 'normal' | 'alternate';
+    };
+  };
+};
+
+// Attach-complete rendezvous. Single source of truth for the invariant
+// "when `usePtyAttach` reports state:ready, the visible xterm viewport
+// equals baseY (view pinned at bottom of scrollback)".
+//
+// Anything that runs AFTER the snapshot write — xterm parsing buffered
+// ANSI, claude's first chunks landing on `pty.onData`, cursor moves, a
+// late `fit.fit()` reflow, alt-screen transitions — can move the viewport
+// off bottom. Nothing else in the flow brings it back unconditionally:
+// the prior code only scrolled inside `runReplay()` (gated on
+// `ptyResized=true`) and inside the post-snap scroll which fires BEFORE
+// the fit. So an idle-target attach (small `firstWrite`, no resize)
+// landed with the viewport stranded at the top.
+//
+// Sync primitive: `writeAsync(term, '')` drains xterm's parser queue —
+// the same drain primitive used inside `runReplay()`. NO timers, NO
+// requestAnimationFrame; xterm's `write` callback is the documented
+// synchronization point and resolves once everything queued before it
+// has been processed.
+async function pinViewportToBottom(
+  term: PinnableTerminal,
+  sid: string,
+): Promise<void> {
+  try {
+    await writeAsync(term, '');
+  } catch {
+    /* drain best-effort — fall through to scroll anyway */
+  }
+  try {
+    term.scrollToBottom();
+  } catch {
+    /* best-effort — scrollToBottom rarely throws */
+  }
+  try {
+    const buf = term.buffer.active;
+    log.event('attach.invariant.pinned', {
+      sid,
+      viewportY: buf.viewportY,
+      baseY: buf.baseY,
+      bufferType: buf.type,
+      cursorY: buf.cursorY,
+      length: buf.length,
+      atBottom: buf.viewportY === buf.baseY,
+    });
+  } catch {
+    /* probe failure must not break attach */
+  }
+}
 
 export type PtyAttachState =
   | { kind: 'attaching' }
@@ -388,11 +452,16 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
         const tAfterSnap = getTerm();
         if (tAfterSnap) {
           try {
+            const bufA = tAfterSnap.buffer?.active;
             log.event('attach.scrollToBottom.invoked', {
               sid: sessionId,
               callsite: 'post-snap',
-              viewportY: tAfterSnap.buffer?.active?.viewportY ?? 0,
-              baseY: tAfterSnap.buffer?.active?.baseY ?? 0,
+              viewportY: bufA?.viewportY ?? 0,
+              baseY: bufA?.baseY ?? 0,
+              bufferType: bufA?.type ?? 'normal',
+              cursorY: bufA?.cursorY ?? 0,
+              length: bufA?.length ?? 0,
+              atBottom: (bufA?.viewportY ?? 0) === (bufA?.baseY ?? 0),
             });
           } catch {
             /* probe must not block scroll */
@@ -490,11 +559,16 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
           const tBottom = getTerm();
           if (tBottom) {
             try {
+              const bufB = tBottom.buffer?.active;
               log.event('attach.scrollToBottom.invoked', {
                 sid: sessionId,
                 callsite: 'post-fit',
-                viewportY: tBottom.buffer?.active?.viewportY ?? 0,
-                baseY: tBottom.buffer?.active?.baseY ?? 0,
+                viewportY: bufB?.viewportY ?? 0,
+                baseY: bufB?.baseY ?? 0,
+                bufferType: bufB?.type ?? 'normal',
+                cursorY: bufB?.cursorY ?? 0,
+                length: bufB?.length ?? 0,
+                atBottom: (bufB?.viewportY ?? 0) === (bufB?.baseY ?? 0),
               });
             } catch {
               /* probe must not block scroll */
@@ -583,29 +657,24 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
               /* probe must not block fit */
             }
             if (ptyResized) {
-              const resizePromise = window.ccsmPty.resize(sid4, newCols, newRows);
-              const p = resizePromise && typeof (resizePromise as Promise<void>).then === 'function'
-                ? (resizePromise as Promise<void>)
-                : Promise.resolve();
-              void p
-                .then(() => {
-                  const replay = getSnapshotReplay();
-                  return replay ? replay() : undefined;
-                })
-                .then(() => {
-                  // Post-attach fit branch: even though the replay
-                  // handler itself scrolls to bottom after its drain,
-                  // we re-assert here as a defensive rendezvous. The
-                  // replay queues writes against the live xterm and
-                  // its internal scroll happens once THAT WriteBuffer
-                  // drains; an unrelated chunk that landed between the
-                  // fit and the replay (e.g. claude reacting to the
-                  // resize) could otherwise leave baseY advanced past
-                  // viewportY again. Cheap empty-write rendezvous.
-                  const tFit = getTerm();
-                  if (tFit) writeAndScrollToBottom(tFit);
-                })
-                .catch((e) => warn('attach', 'post-attach replay failed', e));
+              // Awaited (not fire-and-forget) so the attach-complete
+              // rendezvous below truly runs LAST. Previously this branch
+              // was `void p.then(...)`, which meant the `state:ready`
+              // transition could fire before the replay's scrollToBottom
+              // had run — and when ptyResized=false, the replay branch
+              // didn't run at all, leaving viewport pinning to chance.
+              try {
+                const resizePromise = window.ccsmPty.resize(sid4, newCols, newRows);
+                const p =
+                  resizePromise && typeof (resizePromise as Promise<void>).then === 'function'
+                    ? (resizePromise as Promise<void>)
+                    : Promise.resolve();
+                await p;
+                const replay = getSnapshotReplay();
+                if (replay) await replay();
+              } catch (e) {
+                warn('attach', 'post-attach replay failed', e);
+              }
             }
           } catch (e) {
             warn('attach', 'post-attach fit failed', e);
@@ -644,7 +713,23 @@ export function usePtyAttach(sessionId: string, cwd: string): UsePtyAttachResult
           }
         }
 
-        if (!cancelled) setState({ kind: 'ready' }, 'attach-complete');
+        if (!cancelled) {
+          // Attach-complete rendezvous: invariant — viewport pinned to
+          // baseY at the moment we report `state:ready`. Runs AFTER
+          // snapshot+drain, AFTER fit, AFTER the awaited ptyResized
+          // resize+replay branch. This is the single source of truth
+          // for bottom-pinning; the scattered scroll calls in
+          // `runReplay` and the post-snap callsite are defensive only.
+          //
+          // Rationale: the prior code only re-scrolled inside
+          // `runReplay()`, which was gated on ptyResized=true. An
+          // idle-target re-attach (no resize, tiny firstWrite) had no
+          // unconditional post-fit scroll and landed with viewport
+          // stranded at scroll-top.
+          const tPin = getTerm();
+          if (tPin) await pinViewportToBottom(tPin as unknown as PinnableTerminal, sessionId);
+          if (!cancelled) setState({ kind: 'ready' }, 'attach-complete');
+        }
         // Successful (re-)attach means whatever pty is running for this
         // sid is healthy — drop any stale disconnect entry so the
         // sidebar red dot clears and a future crash starts from a clean

--- a/tests/terminal/attachInvariant.test.tsx
+++ b/tests/terminal/attachInvariant.test.tsx
@@ -1,0 +1,304 @@
+// Attach-complete viewport-pinning invariant.
+//
+// Contract (see `pinViewportToBottom` in src/terminal/usePtyAttach.ts):
+//   At the point where `usePtyAttach` reports `state:'ready'`, the visible
+//   xterm viewport MUST equal baseY (view pinned at bottom of scrollback).
+//
+// History: the prior code only re-scrolled inside `runReplay()`, which was
+// gated on `ptyResized=true`. An idle-target re-attach (no resize, tiny
+// post-attach firstWrite) had no unconditional post-fit scroll and landed
+// with viewport stranded at scroll-top. The rendezvous step before
+// `state:ready` enforces the invariant unconditionally and emits the
+// `attach.invariant.pinned` event so a future regression of this class is
+// visible without re-diagnosis.
+//
+// This file asserts the rendezvous fires (and emits with atBottom:true) on
+// every attach path: first-attach, switch-attach, retry, reload,
+// ptyResized=true, ptyResized=false, and the fit-throw recovery path.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  createFakeTerminal,
+  createFakeFit,
+  createXtermSingletonMock,
+  createPtyBridge,
+  installCcsmPty,
+  uninstallCcsmPty,
+  resetFakeTerminalSpies,
+  settleAttach,
+} from '../util/terminalHarness';
+
+const fakeTerm = createFakeTerminal();
+const fakeFit = createFakeFit({ cols: 134, rows: 51 });
+
+vi.mock('../../src/terminal/xtermSingleton', () =>
+  createXtermSingletonMock(() => fakeTerm, () => fakeFit),
+);
+
+// Capture `log.event` calls so we can assert the rendezvous fired and the
+// `attach.invariant.pinned` payload reports atBottom:true. The real logger
+// scrubs + writes to disk; the contract we care about here is "the event
+// was emitted with atBottom:true at attach-complete".
+const eventSpy = vi.fn();
+vi.mock('../../src/shared/log', () => ({
+  log: { event: (name: string, fields: Record<string, unknown>) => eventSpy(name, fields) },
+  warn: vi.fn(),
+}));
+
+// Mock store — see tests/terminal/usePtyAttach.test.tsx for shape rationale.
+const clearPtyExitSpy = vi.fn();
+const mockStoreState: { pendingForkSource: Record<string, string>; reloadNonce: Record<string, number> } = {
+  pendingForkSource: {},
+  reloadNonce: {},
+};
+vi.mock('../../src/stores/store', () => {
+  const useStore = ((selector: (s: any) => any) =>
+    selector({ _clearPtyExit: clearPtyExitSpy, ...mockStoreState })) as any;
+  useStore.getState = () => ({ _clearPtyExit: clearPtyExitSpy, ...mockStoreState });
+  useStore.setState = (
+    patch:
+      | { pendingForkSource?: Record<string, string> }
+      | ((s: typeof mockStoreState) => { pendingForkSource?: Record<string, string> } | {}),
+  ) => {
+    const next = typeof patch === 'function' ? patch({ ...mockStoreState }) : patch;
+    if (next && 'pendingForkSource' in next && next.pendingForkSource) {
+      mockStoreState.pendingForkSource = next.pendingForkSource;
+    }
+  };
+  return { useStore };
+});
+
+import { usePtyAttach } from '../../src/terminal/usePtyAttach';
+import { __resetSingletonForTests } from '../../src/terminal/xtermSingleton';
+
+const makePtyBridge = createPtyBridge;
+const flushAll = (): Promise<void> => settleAttach({ wrap: act });
+const flush = (): Promise<void> => new Promise((r) => setTimeout(r, 0));
+
+// Last `attach.invariant.pinned` event payload from the spy, or undefined.
+function lastPinnedEvent(): Record<string, unknown> | undefined {
+  for (let i = eventSpy.mock.calls.length - 1; i >= 0; i -= 1) {
+    const [name, fields] = eventSpy.mock.calls[i];
+    if (name === 'attach.invariant.pinned') return fields as Record<string, unknown>;
+  }
+  return undefined;
+}
+
+// Count `attach.invariant.pinned` emissions so we can detect multi-attach.
+function countPinned(): number {
+  return eventSpy.mock.calls.filter((c) => c[0] === 'attach.invariant.pinned').length;
+}
+
+// Model "viewport drifted off bottom" so the test would FAIL without the
+// pin: every `write(non-empty)` advances baseY past viewportY, mimicking
+// xterm appending lines while the user-scrolled latch is set.
+function installDriftingWrite(): void {
+  fakeTerm.write.mockImplementation((data: string, cb?: () => void) => {
+    fakeTerm.callLog.push(`write:${data}`);
+    if (data.length > 0) {
+      // Snapshot wrote N rows; pretend baseY advanced but viewportY didn't.
+      fakeTerm.buffer.active.baseY = 72;
+      fakeTerm.buffer.active.length = 145;
+      fakeTerm.buffer.active.cursorY = 50;
+    }
+    if (cb) cb();
+  });
+  // The single source of truth for "follow live output": scrollToBottom
+  // sets viewportY := baseY. Without the rendezvous step, baseY stays at
+  // 72 while viewportY remains 0 — atBottom would be false.
+  fakeTerm.scrollToBottom.mockImplementation(() => {
+    fakeTerm.callLog.push('scrollToBottom');
+    fakeTerm.buffer.active.viewportY = fakeTerm.buffer.active.baseY;
+  });
+}
+
+describe('attach viewport-pinning invariant', () => {
+  beforeEach(() => {
+    __resetSingletonForTests();
+    resetFakeTerminalSpies(fakeTerm);
+    fakeTerm.cols = 80;
+    fakeTerm.rows = 24;
+    fakeFit.fit.mockClear();
+    fakeFit.proposeDimensions.mockClear();
+    fakeFit.proposeDimensions.mockReturnValue({ cols: 134, rows: 51 });
+    eventSpy.mockClear();
+    clearPtyExitSpy.mockClear();
+    mockStoreState.pendingForkSource = {};
+    mockStoreState.reloadNonce = {};
+    installDriftingWrite();
+  });
+
+  afterEach(() => {
+    uninstallCcsmPty();
+    __resetSingletonForTests();
+  });
+
+  it('first-attach path: emits attach.invariant.pinned with atBottom:true (ptyResized=false)', async () => {
+    const { bridge } = makePtyBridge();
+    installCcsmPty(bridge);
+
+    const { result } = renderHook(() => usePtyAttach('sid-first', '/tmp'));
+    await flushAll();
+
+    expect(result.current.state.kind).toBe('ready');
+    const ev = lastPinnedEvent();
+    expect(ev).toBeDefined();
+    expect(ev?.sid).toBe('sid-first');
+    expect(ev?.atBottom).toBe(true);
+    expect(ev?.viewportY).toBe(72);
+    expect(ev?.baseY).toBe(72);
+    // Bounded-enum + scalar shape for the new fields.
+    expect(['normal', 'alternate']).toContain(ev?.bufferType);
+    expect(typeof ev?.cursorY).toBe('number');
+    expect(typeof ev?.length).toBe('number');
+  });
+
+  it('switch-attach path (prev sid existed): rendezvous fires for new sid', async () => {
+    const { bridge } = makePtyBridge();
+    installCcsmPty(bridge);
+
+    const { rerender, result } = renderHook(({ sid }) => usePtyAttach(sid, '/tmp'), {
+      initialProps: { sid: 'sid-A' },
+    });
+    await flushAll();
+    expect(countPinned()).toBe(1);
+    expect(lastPinnedEvent()?.sid).toBe('sid-A');
+
+    await act(async () => {
+      rerender({ sid: 'sid-B' });
+      await flush();
+      await flush();
+      await flush();
+    });
+    expect(result.current.state.kind).toBe('ready');
+    expect(countPinned()).toBe(2);
+    expect(lastPinnedEvent()?.sid).toBe('sid-B');
+    expect(lastPinnedEvent()?.atBottom).toBe(true);
+  });
+
+  it('retry path (same sid, attachNonce bumped via onRetry): rendezvous fires again', async () => {
+    const { bridge } = makePtyBridge();
+    installCcsmPty(bridge);
+
+    const { result } = renderHook(() => usePtyAttach('sid-retry', '/tmp'));
+    await flushAll();
+    expect(countPinned()).toBe(1);
+
+    await act(async () => {
+      result.current.onRetry();
+      await flush();
+      await flush();
+      await flush();
+    });
+    expect(countPinned()).toBe(2);
+    expect(lastPinnedEvent()?.atBottom).toBe(true);
+  });
+
+  it('reload path (reloadNonce bumped): rendezvous fires again', async () => {
+    const { bridge } = makePtyBridge();
+    installCcsmPty(bridge);
+
+    const { rerender } = renderHook(({ nonce }) => {
+      mockStoreState.reloadNonce = { 'sid-reload': nonce };
+      return usePtyAttach('sid-reload', '/tmp');
+    }, { initialProps: { nonce: 0 } });
+    await flushAll();
+    expect(countPinned()).toBe(1);
+
+    await act(async () => {
+      rerender({ nonce: 1 });
+      await flush();
+      await flush();
+      await flush();
+    });
+    expect(countPinned()).toBe(2);
+    expect(lastPinnedEvent()?.atBottom).toBe(true);
+  });
+
+  it('ptyResized=true path: rendezvous fires AFTER the resize+replay branch', async () => {
+    const { bridge } = makePtyBridge({ snapshot: { snapshot: 'snap', seq: 0 } });
+    installCcsmPty(bridge);
+    // Force a size delta — fit.fit() reflows the term, so newCols/newRows
+    // diverge from the attach.cols/rows and the ptyResized branch runs.
+    fakeFit.fit.mockImplementation(() => {
+      fakeTerm.cols = 134;
+      fakeTerm.rows = 51;
+    });
+
+    try {
+      renderHook(() => usePtyAttach('sid-resized', '/tmp'));
+      await flushAll();
+      const ev = lastPinnedEvent();
+      expect(ev).toBeDefined();
+      expect(ev?.atBottom).toBe(true);
+      // The rendezvous emits AFTER the post-fit replay's scrollToBottom.
+      // We use the event-call index as a coarse ordering check.
+      const replayScrollIdx = eventSpy.mock.calls.findIndex(
+        (c) => c[0] === 'attach.scrollToBottom.invoked' && (c[1] as any).callsite === 'post-fit',
+      );
+      const pinIdx = eventSpy.mock.calls.findIndex(
+        (c) => c[0] === 'attach.invariant.pinned',
+      );
+      expect(replayScrollIdx).toBeGreaterThanOrEqual(0);
+      expect(pinIdx).toBeGreaterThan(replayScrollIdx);
+    } finally {
+      fakeTerm.cols = 80;
+      fakeTerm.rows = 24;
+      fakeFit.fit.mockReset();
+    }
+  });
+
+  it('ptyResized=false path (the empirical user repro): rendezvous fires unconditionally', async () => {
+    // This is the bad attach from the bug report: snapshot applied, post-
+    // snap scroll, fit applied with ptyResized=false, then state:ready —
+    // and historically no post-fit scrollToBottom emission. The fix makes
+    // the rendezvous unconditional. Assert it ran AND atBottom:true.
+    const { bridge } = makePtyBridge();
+    installCcsmPty(bridge);
+    // fakeFit.fit default does NOT mutate cols/rows → ptyResized=false.
+
+    renderHook(() => usePtyAttach('sid-idle', '/tmp'));
+    await flushAll();
+
+    // Pre-fix behavior: only the post-snap scrollToBottom would have
+    // fired, and any subsequent baseY advance (a 12-byte cursor chunk
+    // landing post-attach) would leave atBottom=false. The unconditional
+    // rendezvous emits the invariant event regardless.
+    const ev = lastPinnedEvent();
+    expect(ev).toBeDefined();
+    expect(ev?.sid).toBe('sid-idle');
+    expect(ev?.atBottom).toBe(true);
+
+    // No post-fit attach.scrollToBottom.invoked is expected (that
+    // emission lives inside runReplay, gated on ptyResized=true).
+    const postFitScroll = eventSpy.mock.calls.find(
+      (c) => c[0] === 'attach.scrollToBottom.invoked' && (c[1] as any).callsite === 'post-fit',
+    );
+    expect(postFitScroll).toBeUndefined();
+  });
+
+  it('fit.fit() throws: rendezvous still pins viewport before state:ready', async () => {
+    // Contract choice (see spec): on fit throw, the attach state still
+    // transitions to ready (the visible terminal is still attached and
+    // can render content), but the pinning rendezvous MUST run so the
+    // user doesn't land on a stranded viewport.
+    const { bridge } = makePtyBridge();
+    installCcsmPty(bridge);
+    fakeFit.fit.mockImplementation(() => {
+      throw new Error('fit boom');
+    });
+
+    try {
+      const { result } = renderHook(() => usePtyAttach('sid-fitthrow', '/tmp'));
+      await flushAll();
+      // Recovery path: still reaches ready.
+      expect(result.current.state.kind).toBe('ready');
+      const ev = lastPinnedEvent();
+      expect(ev).toBeDefined();
+      expect(ev?.sid).toBe('sid-fitthrow');
+      expect(ev?.atBottom).toBe(true);
+    } finally {
+      fakeFit.fit.mockReset();
+    }
+  });
+});

--- a/tests/util/terminalHarness.ts
+++ b/tests/util/terminalHarness.ts
@@ -37,7 +37,13 @@ export interface FakeTerminalSpies {
 }
 
 export interface FakeBuffer {
-  active: { baseY: number; viewportY: number };
+  active: {
+    baseY: number;
+    viewportY: number;
+    cursorY: number;
+    length: number;
+    type: 'normal' | 'alternate';
+  };
 }
 
 export interface FakeTerminal extends FakeTerminalSpies {
@@ -72,7 +78,7 @@ export function createFakeTerminal(opts: { cols?: number; rows?: number } = {}):
     inputDisposableDispose,
     cols: opts.cols ?? 80,
     rows: opts.rows ?? 24,
-    buffer: { active: { baseY: 0, viewportY: 0 } },
+    buffer: { active: { baseY: 0, viewportY: 0, cursorY: 0, length: 0, type: 'normal' } },
     callLog,
   };
 }
@@ -103,6 +109,9 @@ export function resetFakeTerminalSpies(t: FakeTerminal): void {
   t.callLog.length = 0;
   t.buffer.active.baseY = 0;
   t.buffer.active.viewportY = 0;
+  t.buffer.active.cursorY = 0;
+  t.buffer.active.length = 0;
+  t.buffer.active.type = 'normal';
   // Restore default implementations — individual tests may have called
   // `mockImplementation(...)` to capture async-schedule / event-ordering
   // semantics for the specific assertion they need. Without restoring,


### PR DESCRIPTION
## Bug

A re-attach to an **idle** session (no new output since last attach) occasionally landed with the visible viewport stranded at scroll-top instead of pinned at the prompt. Empirical user-side log lines:

```
L9  attach.state.transition  sid=f5a98a93 from=ready to=attaching reason=effect-start
L10 attach.snapshot.applied  sid=f5a98a93 bytes=4011 viewportYAfter=72 baseY=72
L11 attach.scrollToBottom.invoked  sid=f5a98a93 callsite=post-snap viewportY=72 baseY=72
L12 attach.fit.applied        sid=f5a98a93 cols=143 rows=51 ptyResized=false
L13 attach.state.transition  sid=f5a98a93 from=attaching to=ready reason=attach-complete
L14 term.firstWrite.afterAttach  sid=f5a98a93 bytes=12 durationMsSinceAttach=34
(nothing else — user sees viewport at TOP, not at baseY=72)
```

A healthy attach immediately prior had `ptyResized=true` and emitted a post-fit `scrollToBottom` 48ms after `state:ready`; the bad attach with `ptyResized=false` and a 12-byte `firstWrite` had no such emission and landed stranded.

## Root cause

The `usePtyAttach` flow had an **implicit, unenforced invariant**: "attach completes → viewport at bottom". The only post-fit scroll lived inside `runReplay()`, which was gated on `ptyResized=true`. The post-snap scroll ran BEFORE the fit and before any post-attach chunks could land. On the idle re-attach path nothing brought the viewport back to baseY.

## Fix

Architectural: define an explicit, code-enforced contract.

> **Invariant**: at the point where `usePtyAttach` reports `state:'ready'`, the visible xterm viewport MUST equal `baseY` (pinned at bottom of scrollback). Any path that completes attach without satisfying this is a bug.

Implemented as a single `pinViewportToBottom(term, sid)` rendezvous that runs unconditionally just before `setState({kind:'ready'},'attach-complete')`:

1. `await writeAsync(term, '')` — drains xterm's parser queue (same drain primitive already used in `runReplay`; xterm's `write` callback is the documented synchronization point — **no** `requestAnimationFrame` / `setTimeout` retries).
2. `term.scrollToBottom()` — re-engages follow-output, pins `viewportY := baseY`.
3. `log.event('attach.invariant.pinned', { sid, viewportY, baseY, bufferType, cursorY, length, atBottom })` — exposes the invariant to future diagnostics so a regression of this class is visible without re-diagnosis.

The post-attach `ptyResized=true` branch is now `await`-ed (was `void p.then(...)`) so the rendezvous truly runs last. The scattered `scrollToBottom` calls in `runReplay` and at the post-snap callsite become defensive only — the rendezvous is the single source of truth.

## Diagnostics

Extended the two existing `attach.scrollToBottom.invoked` events (post-snap and post-fit callsites) with `bufferType` (`normal | alternate`), `cursorY`, `length`, and `atBottom` — so a future "bottom pinning is wrong" bug surfaces alt-screen state + cursor position immediately. New scalar/enum fields added to `EVENT_ALLOWED_FIELDS` in `src/shared/scrub.ts`.

## Tests

`tests/terminal/attachInvariant.test.tsx` drives `usePtyAttach` through all attach paths and asserts the rendezvous emits with `atBottom: true`:

- first-attach (no prev sid)
- switch-attach (prev sid existed)
- retry (attachNonce bumped)
- reload (reloadNonce bumped)
- `ptyResized=true` (rendezvous fires AFTER replay's scroll — ordering check)
- `ptyResized=false` (the user's actual repro case)
- `fit.fit()` throws (recovery — still pins before ready)

**Sensitivity verified**: reverting only the production change makes all 7 tests fail with `expected undefined to be defined` on the `attach.invariant.pinned` lookup. The fakes model the actual drift (write advances baseY past viewportY) so a missing rendezvous shows as `atBottom: false`.

## Test plan

- [x] `npx vitest run tests/terminal/` — 102/102 pass (15 existing usePtyAttach + 7 new attachInvariant + others)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [ ] Empirical: reproduce the user's idle-target attach repro, confirm `attach.invariant.pinned` in `.dev-userdata/logs/main.log` with `atBottom: true`. (Skipped in CI worktree — please verify locally before merge.)

## DO NOT MERGE

Per spec instructions: this PR is for review only. Please verify the empirical reproduction locally before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)