### PR TITLE
fix(observability): renderer log silent-drop — use UA for Electron detection under contextIsolation

### DIFF
--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -36,17 +36,45 @@ type ElogLike = {
 };
 
 // Detect a non-Electron runtime (vitest under plain Node OR webpack
-// dev-server's SSR shim) and short-circuit electron-log entirely. We check
-// BOTH the Electron-runtime flag (`process.versions.electron`) AND the
-// `VITEST` env so that:
-//   * `isElectronRuntime === false` covers any non-Electron host (CI vitest
-//     on Node with no binary, future SSR experiments) — most robust signal.
-//   * `isVitest === true` covers the renderer-test case where webpack/jsdom
-//     does set up a `window.process` polyfill that DOES claim
-//     `versions.electron` (vite-plugin-electron emulates it). Belt and
-//     suspenders, mirroring the cold-review recommendation.
-const isElectronRuntime =
-  typeof process !== 'undefined' && typeof process.versions?.electron === 'string';
+// dev-server's SSR shim) and short-circuit electron-log entirely.
+//
+// Detection note: under contextIsolation:true (ccsm's setting, see
+// electron/window/createWindow.ts), the renderer has NO `window.process`
+// and the webpack-bundled module-scope `process` is a polyfill that has
+// `process.env` (via DefinePlugin) but LACKS `process.versions.electron`.
+// So the old `process.versions.electron` check returned false for every
+// renderer build, causing `loadElog()` to return the no-op stub and every
+// renderer-side `log.event(...)` call to be silently discarded.
+//
+// The robust signal that survives both contextIsolation and webpack
+// polyfilling is `navigator.userAgent` — Electron always appends
+// `Electron/<version>` to the renderer's UA string regardless of
+// isolation/sandbox flags. We probe UA first, then fall through to the
+// module process for the main-process path (electron/shared/log.ts has
+// its own detection that uses module process; this fallback covers
+// shared-code reuse).
+export function detectElectronRuntime(deps: {
+  navigator?: { userAgent?: string } | undefined;
+  process?: { versions?: { electron?: string } } | undefined;
+}): boolean {
+  const nav = deps.navigator;
+  if (nav && typeof nav.userAgent === 'string' && /Electron\//.test(nav.userAgent)) {
+    return true;
+  }
+  const proc = deps.process;
+  return !!proc && typeof proc.versions?.electron === 'string';
+}
+
+const isElectronRuntime = detectElectronRuntime({
+  navigator: typeof navigator !== 'undefined' ? navigator : undefined,
+  // Node's `Process` type and the renderer's webpack-polyfilled process are
+  // structurally different from our narrow inline shape; cast to the helper's
+  // expected dep type at the boundary.
+  process:
+    typeof process !== 'undefined'
+      ? (process as unknown as { versions?: { electron?: string } })
+      : undefined,
+});
 const isVitest =
   typeof process !== 'undefined' &&
   (process.env?.VITEST === 'true' || process.env?.NODE_ENV === 'test');

--- a/tests/log-runtime-detection.test.ts
+++ b/tests/log-runtime-detection.test.ts
@@ -1,0 +1,140 @@
+// Regression test for the renderer-logger silent-drop bug.
+//
+// Bug: under contextIsolation:true + nodeIntegration:false (ccsm's config),
+// the renderer has no `window.process` and webpack's polyfilled module-scope
+// `process` lacks `process.versions.electron`. The old detection therefore
+// returned `false` for every renderer build, `loadElog()` short-circuited to
+// a no-op stub, and every `log.event(...)` / `log.warn(...)` call was silently
+// discarded — empirically confirmed by an extended dogfood session producing
+// a logs/main.log containing only the per-file header.
+//
+// Fix: probe `navigator.userAgent` for `Electron/<version>` first (the UA
+// substring is appended unconditionally by Electron regardless of isolation/
+// sandbox flags), then fall through to `process.versions.electron` for the
+// main-process path. `detectElectronRuntime` is exported as a pure helper
+// taking injectable deps so we can exercise all four runtime quadrants here.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { detectElectronRuntime } from '../src/shared/log';
+
+describe('detectElectronRuntime', () => {
+  it('returns true when navigator.userAgent contains "Electron/<version>"', () => {
+    expect(
+      detectElectronRuntime({
+        navigator: {
+          userAgent:
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) ccsm/0.2.7 Chrome/130.0.0.0 Electron/41.3.0 Safari/537.36',
+        },
+        process: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it('falls through to process.versions.electron when UA does not contain Electron/', () => {
+    // Plain Chrome UA — no "Electron/" substring. Falls through to module process.
+    const plainChromeUA =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36';
+    expect(
+      detectElectronRuntime({
+        navigator: { userAgent: plainChromeUA },
+        process: { versions: {} },
+      }),
+    ).toBe(false);
+    expect(
+      detectElectronRuntime({
+        navigator: { userAgent: plainChromeUA },
+        process: { versions: { electron: '41.3.0' } },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true when process.versions.electron is set but navigator is absent (main-process path)', () => {
+    expect(
+      detectElectronRuntime({
+        navigator: undefined,
+        process: { versions: { electron: '41.3.0' } },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when neither signal is present (plain Node, no UA)', () => {
+    expect(
+      detectElectronRuntime({
+        navigator: undefined,
+        process: { versions: {} },
+      }),
+    ).toBe(false);
+    expect(
+      detectElectronRuntime({
+        navigator: undefined,
+        process: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it('treats a non-string userAgent as absent and falls through to process', () => {
+    // Defensive: some embedded contexts expose navigator without userAgent.
+    expect(
+      detectElectronRuntime({
+        navigator: {} as { userAgent?: string },
+        process: { versions: { electron: '41.3.0' } },
+      }),
+    ).toBe(true);
+    expect(
+      detectElectronRuntime({
+        navigator: {} as { userAgent?: string },
+        process: { versions: {} },
+      }),
+    ).toBe(false);
+  });
+});
+
+// `loadElog` is module-private, so we verify the VITEST short-circuit by its
+// observable effect: under VITEST=true the back-compat shims still console-
+// log, but `log.event` / `log.info` route through the no-op stub and produce
+// no thrown errors even when called repeatedly. The structured paths must
+// remain inert in tests regardless of UA, preserving the test-isolation
+// contract documented at the top of src/shared/log.ts.
+describe('loadElog under VITEST', () => {
+  const originalUA = globalThis.navigator?.userAgent;
+  const originalVitest = process.env.VITEST;
+
+  beforeEach(() => {
+    process.env.VITEST = 'true';
+  });
+
+  afterEach(() => {
+    if (originalVitest === undefined) {
+      delete process.env.VITEST;
+    } else {
+      process.env.VITEST = originalVitest;
+    }
+    // Restore UA if a test overrode it.
+    if (originalUA !== undefined && globalThis.navigator) {
+      Object.defineProperty(globalThis.navigator, 'userAgent', {
+        value: originalUA,
+        configurable: true,
+      });
+    }
+  });
+
+  it('returns the no-op stub regardless of UA (preserves test isolation)', async () => {
+    // Force an Electron-looking UA — detection should still be true, but
+    // the VITEST short-circuit must prevent electron-log from being loaded.
+    if (globalThis.navigator) {
+      Object.defineProperty(globalThis.navigator, 'userAgent', {
+        value: 'jsdom Electron/41.3.0 vitest',
+        configurable: true,
+      });
+    }
+    // Re-import with a fresh module registry so module-load-time detection
+    // sees the patched UA. The structured `event` call must not throw and
+    // must not attempt to load electron-log/renderer (which would crash
+    // under jsdom — see the module header comment).
+    vi.resetModules();
+    const mod = await import('../src/shared/log');
+    expect(() => mod.log.event('test.probe', { detail: 'inert' })).not.toThrow();
+    expect(() => mod.log.warn('test', 'msg')).not.toThrow();
+    expect(() => mod.log.error('test', 'msg')).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Root cause

`src/shared/log.ts` detected Electron via `process.versions.electron`. In ccsm's renderer process — `contextIsolation:true` + `nodeIntegration:false` (see `electron/window/createWindow.ts`) — that check fails:

- `window.process` does NOT exist in the renderer's main world under contextIsolation.
- The module-scope `process` reached by `src/shared/log.ts` is webpack's polyfill. It has `process.env` (because of `DefinePlugin`) but does NOT have `process.versions.electron`.

So `isElectronRuntime === false` for every renderer build, `loadElog()` returned the no-op stub, and EVERY renderer-side `log.event(...)` / `log.info/warn/error/debug` call was silently discarded.

## Empirical evidence

After an extended dogfood session of PRs A + B (the attach / IME / paste probes), the file at `app.getPath('logs')/main.log` contained ONLY the per-file header line — zero probe records. The bug was confirmed locally; flipping detection to `navigator.userAgent` made the file start receiving records immediately.

## Why `navigator.userAgent` is the robust signal

Electron unconditionally appends `Electron/<version>` to the renderer's UA string regardless of `contextIsolation` / `sandbox` flags. It survives both contextIsolation (which hides `window.process`) and webpack's process polyfill (which lacks `versions.electron`). We probe UA first, then fall through to `process.versions.electron` for the main-process path / shared-code reuse.

Detection is factored into an exported `detectElectronRuntime(deps)` helper taking injectable `navigator` / `process` deps so all four runtime quadrants are unit-testable without globals-mutation at module load.

The vitest short-circuit (`isVitest`) is left unchanged — belt-and-suspenders for the test environment.

## Test coverage

New file `tests/log-runtime-detection.test.ts`:
- UA contains `Electron/<version>` → `true`
- Plain Chrome UA falls through to `process.versions.electron`
- Main-process scenario (process only, no navigator) → `true`
- Neither signal present → `false`
- Defensive: non-string `userAgent` falls through to process
- VITEST short-circuit keeps `loadElog` returning the no-op stub regardless of UA (preserves test-isolation contract documented in `log.ts` header)

## Verification

- `npm run typecheck` — clean
- `npm run lint` — 0 errors (warnings unchanged from main)
- `npm test` — all suites pass except `tests/electron-load-smoke.test.ts` (pre-existing environmental failure — requires a built `dist/electron/**`, unrelated to this change)
- New `log-runtime-detection.test.ts` — 6/6 pass
- E2E verification skipped per task scope (user has empirically confirmed UA-based detection causes records to flow to disk)

## Out of scope

- `electron/shared/log.ts` main-process detection (works correctly via real Node `process`, not touched)
- Scrubber, probes, menu, lifecycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)