### PR TITLE
feat(observability): file sink off in production by default — dev-only diagnostic logging

### DIFF
--- a/electron/lifecycle/__tests__/appLifecycle.test.ts
+++ b/electron/lifecycle/__tests__/appLifecycle.test.ts
@@ -30,10 +30,14 @@ vi.mock('electron', () => {
 // Mock the log module to avoid pulling in electron-log (which requires
 // the electron binary). appLifecycle imports getLogLevel / getLogFilePath
 // to render the Help submenu — stub them with deterministic values.
+// Mutable backing for the file-sink-enabled gate so individual tests can
+// flip it without rebuilding the whole mock module.
+let _logFileEnabled = true;
 vi.mock('../../shared/log', () => ({
   getLogLevel: () => 'info',
   setLogLevel: vi.fn(),
   getLogFilePath: () => '/tmp/logs/main.log',
+  getLogFileEnabled: () => _logFileEnabled,
   log: { info: vi.fn(), error: vi.fn(), warn: vi.fn(), debug: vi.fn(), event: vi.fn() },
 }));
 
@@ -200,6 +204,57 @@ describe('applyAppMenuLocale', () => {
     applyAppMenuLocale();
     expect(Menu.buildFromTemplate).toHaveBeenCalledTimes(2);
     expect(Menu.setApplicationMenu).toHaveBeenCalledTimes(2);
+  });
+
+  describe('file-sink gate', () => {
+    afterAll(() => {
+      _logFileEnabled = true;
+    });
+
+    it('enables Reveal Logs + Set Log Level when file sink is on (dev runtime)', () => {
+      _logFileEnabled = true;
+      applyAppMenuLocale();
+      const template = vi.mocked(Menu.buildFromTemplate).mock.calls.at(-1)![0];
+      const help = template[1].submenu as Array<{
+        label?: string;
+        enabled?: boolean;
+        submenu?: unknown;
+      }>;
+      const reveal = help.find((it) => typeof it.label === 'string' && it.label.startsWith('Reveal'));
+      const setLevel = help.find((it) => it.label === 'Set Log Level');
+      expect(reveal?.enabled).toBe(true);
+      expect(setLevel?.enabled).toBe(true);
+    });
+
+    it('disables Reveal Logs + Set Log Level when file sink is off (packaged default)', () => {
+      _logFileEnabled = false;
+      applyAppMenuLocale();
+      const template = vi.mocked(Menu.buildFromTemplate).mock.calls.at(-1)![0];
+      const help = template[1].submenu as Array<{
+        label?: string;
+        enabled?: boolean;
+        toolTip?: string;
+        submenu?: Array<{ enabled?: boolean }>;
+      }>;
+      const reveal = help.find((it) => typeof it.label === 'string' && it.label.startsWith('Reveal'));
+      const setLevel = help.find((it) => it.label === 'Set Log Level');
+      expect(reveal?.enabled).toBe(false);
+      expect(reveal?.toolTip).toMatch(/CCSM_LOG_ENABLE_FILE/);
+      expect(setLevel?.enabled).toBe(false);
+      expect(setLevel?.toolTip).toMatch(/CCSM_LOG_ENABLE_FILE/);
+      // Each radio child must ALSO be disabled — Electron renders the
+      // submenu parent state, but child enabled=true could still allow
+      // keyboard navigation on some platforms.
+      for (const child of setLevel?.submenu ?? []) {
+        expect(child.enabled).toBe(false);
+      }
+      // Log File label should hint at the opt-in env var instead of an
+      // uninitialized path.
+      const logFileLabel = help.find(
+        (it) => typeof it.label === 'string' && it.label.startsWith('Log File'),
+      );
+      expect(logFileLabel?.label).toMatch(/CCSM_LOG_ENABLE_FILE/);
+    });
   });
 });
 

--- a/electron/lifecycle/appLifecycle.ts
+++ b/electron/lifecycle/appLifecycle.ts
@@ -20,7 +20,7 @@ import type { App } from 'electron';
 import { BrowserWindow, Menu, app, shell } from 'electron';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { getLogLevel, setLogLevel, getLogFilePath, log } from '../shared/log';
+import { getLogLevel, setLogLevel, getLogFilePath, getLogFileEnabled, log } from '../shared/log';
 
 type LogLevelChoice = 'debug' | 'info' | 'warn' | 'error';
 
@@ -103,6 +103,13 @@ export function applyAppMenuLocale(): void {
   // normally to the renderer.
   const currentLevel = getLogLevel();
   const levels: LogLevelChoice[] = ['debug', 'info', 'warn', 'error'];
+  // File sink may be off in packaged builds (default) — the Reveal Logs +
+  // Set Log Level items have nothing to act on in that case. Disable them
+  // (greyed out) and surface a tooltip pointing at the opt-in env var, so
+  // the menu doesn't silently no-op. See `electron/shared/log.ts` for the
+  // gating logic. The Edit submenu + log-file path readout are unchanged.
+  const fileSinkEnabled = getLogFileEnabled();
+  const disabledTooltip = 'Enable diagnostic logging via CCSM_LOG_ENABLE_FILE=1';
   const accelMenu = Menu.buildFromTemplate([
     {
       label: i18n.tMenu('edit'),
@@ -118,26 +125,35 @@ export function applyAppMenuLocale(): void {
     // Help submenu: Reveal Logs (with pin) + Set Level. Always visible per
     // parent resolution (v2 §7) — not gated on CCSM_DEV=1. The Set Level
     // submenu uses radio-style checkmarks reflecting the persisted choice.
+    // When the file sink is disabled (production default), both items are
+    // greyed out — no files to reveal, no file-level to change.
     {
       label: 'Help',
       submenu: [
         {
           label: 'Reveal Logs in Folder',
+          enabled: fileSinkEnabled,
+          toolTip: fileSinkEnabled ? undefined : disabledTooltip,
           click: () => {
             void revealLogsAndPin();
           },
         },
         {
-          label: `Log File: ${getLogFilePath() || '(uninitialized)'}`,
+          label: fileSinkEnabled
+            ? `Log File: ${getLogFilePath() || '(uninitialized)'}`
+            : 'Log File: (disabled — set CCSM_LOG_ENABLE_FILE=1)',
           enabled: false,
         },
         { type: 'separator' },
         {
           label: 'Set Log Level',
+          enabled: fileSinkEnabled,
+          toolTip: fileSinkEnabled ? undefined : disabledTooltip,
           submenu: levels.map((lvl) => ({
             label: lvl.charAt(0).toUpperCase() + lvl.slice(1),
             type: 'radio' as const,
             checked: lvl === currentLevel,
+            enabled: fileSinkEnabled,
             click: () => {
               setLogLevel(lvl);
               log.info('menu', 'log level changed', { stage: lvl });

--- a/electron/shared/__tests__/log.test.ts
+++ b/electron/shared/__tests__/log.test.ts
@@ -1,0 +1,166 @@
+// Tests for `electron/shared/log.ts` initLog file-sink gating.
+//
+// log.ts decides whether to wire the electron-log file transport based on
+//   1. `app.isPackaged === false` (dev runtime — `npm run dev`), OR
+//   2. `CCSM_LOG_ENABLE_FILE === '1'` (explicit opt-in).
+// Anything else (packaged build, no env opt-in, no electron at all) silences
+// the file transport (`elog.transports.file.level = false`) — production
+// users don't accumulate diagnostic JSONL on disk.
+//
+// The module short-circuits when `process.versions.electron === undefined`,
+// so we have to fake that AND intercept the dynamic `require('electron-log/
+// main')` + `require('electron')` calls that happen inside `getElog()` /
+// `getApp()`. Mirrors the pattern in `electron/lifecycle/__tests__/
+// appLifecycle.test.ts` for `require('../i18n')`.
+
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
+
+// Fake `electron-log/main` instance with just the transports surface our
+// code touches. Re-built fresh per test so leaked state from a prior call
+// doesn't bleed (`_initialized` guard inside log.ts is reset by re-importing
+// via vi.resetModules).
+function makeFakeElog(): {
+  initialize: () => void;
+  transports: {
+    console: { level: string | false; format?: unknown };
+    file: { level: string | false; format?: unknown; maxSize?: number; archiveLogFn?: unknown; resolvePathFn?: unknown; getFile?: () => { path: string }; fileName?: string };
+  };
+  create: () => ReturnType<typeof makeFakeElog>;
+  debug: () => void;
+  info: () => void;
+  warn: () => void;
+  error: () => void;
+} {
+  return {
+    initialize: () => {},
+    transports: {
+      console: { level: 'info' as string | false },
+      file: {
+        level: 'info' as string | false,
+        resolvePathFn: () => '/tmp/main.log',
+      },
+    },
+    create: () => makeFakeElog(),
+    debug: () => {},
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+}
+
+// State knobs the require-patch reads.
+let currentElog: ReturnType<typeof makeFakeElog>;
+let isPackaged = false;
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Module = require('node:module') as typeof import('node:module');
+const ModuleProto = (Module as unknown as { prototype: { require: (id: string) => unknown } })
+  .prototype;
+const originalRequire = ModuleProto.require;
+ModuleProto.require = function patchedRequire(this: NodeJS.Module, id: string) {
+  if (id === 'electron-log/main') {
+    return { default: currentElog };
+  }
+  if (id === 'electron') {
+    return {
+      app: {
+        getVersion: () => '0.0.0-test',
+        getPath: (name: string) => `/tmp/${name}`,
+        isPackaged,
+      },
+    };
+  }
+  // log.ts also lazily requires '../db' (loadPersistedLevel / persistLevel).
+  // Stub it as no-op so we don't drag the real sqlite handle in.
+  if (id === '../db') {
+    return { loadState: () => null, saveState: () => {} };
+  }
+  return originalRequire.call(this, id);
+};
+
+afterAll(() => {
+  ModuleProto.require = originalRequire;
+});
+
+// `isElectronRuntime()` checks `process.versions.electron`. Override and
+// restore around the suite so plain-Node vitest sees a fake Electron.
+const originalElectronVersion = process.versions.electron;
+beforeEach(() => {
+  // Re-fake every test so we observe the post-initLog mutations cleanly.
+  currentElog = makeFakeElog();
+  // process.versions is read-only on its prototype; assign via defineProperty.
+  Object.defineProperty(process.versions, 'electron', {
+    value: '30.0.0-fake',
+    configurable: true,
+    writable: true,
+  });
+  delete process.env.CCSM_LOG_ENABLE_FILE;
+  delete process.env.CCSM_LOG_DISABLE_FILE; // ensure stale value can't sneak in
+});
+
+afterAll(() => {
+  if (originalElectronVersion === undefined) {
+    delete (process.versions as { electron?: string }).electron;
+  } else {
+    Object.defineProperty(process.versions, 'electron', {
+      value: originalElectronVersion,
+      configurable: true,
+      writable: true,
+    });
+  }
+});
+
+/** Re-import log.ts with a fresh module registry so `_initialized` is reset
+ *  between tests. vitest's `vi.resetModules()` clears the ESM cache; the
+ *  dynamic `require()`s inside log.ts re-resolve through our patched
+ *  Module.prototype.require. */
+async function freshLog(): Promise<typeof import('../log')> {
+  vi.resetModules();
+  return import('../log');
+}
+
+describe('initLog file-sink gate', () => {
+  it('dev runtime (app.isPackaged === false): file transport enabled', async () => {
+    isPackaged = false;
+    const { initLog, getLogFileEnabled } = await freshLog();
+    initLog();
+    expect(currentElog.transports.file.level).not.toBe(false);
+    expect(getLogFileEnabled()).toBe(true);
+  });
+
+  it('packaged + no opt-in: file transport silenced', async () => {
+    isPackaged = true;
+    const { initLog, getLogFileEnabled } = await freshLog();
+    initLog();
+    expect(currentElog.transports.file.level).toBe(false);
+    expect(getLogFileEnabled()).toBe(false);
+  });
+
+  it('packaged + CCSM_LOG_ENABLE_FILE=1: file transport enabled', async () => {
+    isPackaged = true;
+    process.env.CCSM_LOG_ENABLE_FILE = '1';
+    const { initLog, getLogFileEnabled } = await freshLog();
+    initLog();
+    expect(currentElog.transports.file.level).not.toBe(false);
+    expect(getLogFileEnabled()).toBe(true);
+  });
+
+  it('packaged + CCSM_LOG_ENABLE_FILE=anything-else: file transport silenced (only "1" opts in)', async () => {
+    isPackaged = true;
+    process.env.CCSM_LOG_ENABLE_FILE = 'true'; // not the exact opt-in token
+    const { initLog, getLogFileEnabled } = await freshLog();
+    initLog();
+    expect(currentElog.transports.file.level).toBe(false);
+    expect(getLogFileEnabled()).toBe(false);
+  });
+
+  it('legacy CCSM_LOG_DISABLE_FILE is REMOVED — setting it does nothing in dev', async () => {
+    isPackaged = false;
+    process.env.CCSM_LOG_DISABLE_FILE = '1';
+    const { initLog, getLogFileEnabled } = await freshLog();
+    initLog();
+    // Dev gate still wins; the old opt-out var is dead.
+    expect(currentElog.transports.file.level).not.toBe(false);
+    expect(getLogFileEnabled()).toBe(true);
+  });
+});

--- a/electron/shared/log.ts
+++ b/electron/shared/log.ts
@@ -6,7 +6,17 @@
 //   * the IPC sink that catches renderer logs (electron-log's built-in
 //     `ipc` transport — wired by `log.initialize()` in main.ts)
 //   * runtime log-level changes (`setLevel` persisted via sqlite app_state)
-//   * `CCSM_LOG_LEVEL` / `CCSM_LOG_DISABLE_FILE` env overrides
+//   * `CCSM_LOG_LEVEL` / `CCSM_LOG_ENABLE_FILE` env overrides
+//
+// FILE SINK DEFAULT: the file transport is gated on `app.isPackaged === false`
+// (i.e. dev runs `npm run dev` get full JSONL on disk automatically) OR an
+// explicit opt-in via `CCSM_LOG_ENABLE_FILE=1`. In packaged production builds
+// with no env opt-in, the file transport is silenced (`elog.transports.file
+// .level = false`) and the renderer-mirror file ring is skipped. Production
+// users don't want diagnostic JSONL accumulating on disk for sessions they
+// never asked to record; only the developer (dogfooding) needs it. Console +
+// Sentry sinks are unchanged — console is free in production (no attached
+// terminal) and Sentry init is governed separately.
 //   * a tiny ring file for renderer-local fallback at
 //     `app.getPath('userData')/renderer-logs/` (1MB × 2 = 2MB) — written by
 //     the renderer's electron-log instance through the IPC bridge if main
@@ -116,11 +126,21 @@ function getElog(): ElogLike | null {
 
 /** Lazily resolve `electron.app`. Same rationale as `getElog`. Returns
  *  null outside Electron. */
-function getApp(): { getVersion?: () => string; getPath?: (name: string) => string } | null {
+function getApp(): {
+  getVersion?: () => string;
+  getPath?: (name: string) => string;
+  isPackaged?: boolean;
+} | null {
   if (!isElectronRuntime()) return null;
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const electron = require('electron') as { app?: { getVersion?: () => string; getPath?: (name: string) => string } };
+    const electron = require('electron') as {
+      app?: {
+        getVersion?: () => string;
+        getPath?: (name: string) => string;
+        isPackaged?: boolean;
+      };
+    };
     return electron.app ?? null;
   } catch {
     return null;
@@ -129,15 +149,43 @@ function getApp(): { getVersion?: () => string; getPath?: (name: string) => stri
 
 type EnvFlags = {
   level: LogLevel | null;
-  disableFile: boolean;
+  enableFile: boolean;
 };
 
 function readEnvFlags(): EnvFlags {
   const raw = process.env.CCSM_LOG_LEVEL?.toLowerCase();
   const valid: LogLevel[] = ['debug', 'info', 'warn', 'error'];
   const level = raw && (valid as string[]).includes(raw) ? (raw as LogLevel) : null;
-  const disableFile = process.env.CCSM_LOG_DISABLE_FILE === '1';
-  return { level, disableFile };
+  const enableFile = process.env.CCSM_LOG_ENABLE_FILE === '1';
+  return { level, enableFile };
+}
+
+/** Module-level latch tracking whether the file sink actually got wired in
+ *  `initLog()`. The menu builder reads this via `getLogFileEnabled()` to grey
+ *  out the Reveal Logs / Set Log Level items in packaged builds with no opt-
+ *  in — there are no log files to reveal and no file-level to change. */
+let _fileSinkEnabled = false;
+
+/** True iff the file transport is active (dev runtime, or production with
+ *  `CCSM_LOG_ENABLE_FILE=1`). Called by `electron/lifecycle/appLifecycle.ts`
+ *  to gate the Help submenu items. Returns false before `initLog()` runs. */
+export function getLogFileEnabled(): boolean {
+  return _fileSinkEnabled;
+}
+
+/** Decide whether to wire the file sink. Dev (unpackaged) always gets it;
+ *  packaged builds need explicit opt-in via `CCSM_LOG_ENABLE_FILE=1`. If we
+ *  can't even resolve `app.isPackaged` (e.g. mid-vitest with the electron
+ *  binary stubbed), default to disabled — vitest doesn't need on-disk JSONL
+ *  and the IPC + Sentry sinks already gracefully no-op. */
+function shouldEnableFileSink(env: EnvFlags): boolean {
+  if (env.enableFile) return true;
+  const a = getApp();
+  // `app.isPackaged === false` is dev runtime; true (or unresolvable) is
+  // packaged. We explicitly check `=== false` rather than `!a.isPackaged`
+  // so the unresolvable case (null app, undefined isPackaged) defaults to
+  // disabled — safer for tests + paranoid prod fallback.
+  return a?.isPackaged === false;
 }
 
 /** Reads persisted log level from sqlite app_state. Imported lazily to avoid
@@ -300,8 +348,13 @@ export function initLog(): void {
     return [`[${m.level}] ${m.data.map((d) => String(d)).join(' ')}`];
   };
 
-  // File transport.
-  if (env.disableFile) {
+  // File transport. Gated on dev-runtime (`app.isPackaged === false`) OR
+  // explicit `CCSM_LOG_ENABLE_FILE=1` opt-in. Packaged builds with no opt-in
+  // silence the file transport entirely — no rotation, no header, no on-disk
+  // JSONL. The IPC bridge for renderer records stays wired (it's cheap) but
+  // electron-log silently drops records routed to a level=false transport.
+  _fileSinkEnabled = shouldEnableFileSink(env);
+  if (!_fileSinkEnabled) {
     elog.transports.file.level = false;
   } else {
     elog.transports.file.level = _currentLevel;
@@ -356,7 +409,11 @@ export function initLog(): void {
   // we ALSO want a local file so a mid-crash renderer still has tail
   // evidence if the IPC bridge has died. This transport on the MAIN side
   // captures the IPC-shipped renderer records into a separate file.
-  try {
+  //
+  // Follows the same dev-vs-packaged gate as the primary file transport —
+  // production users without `CCSM_LOG_ENABLE_FILE=1` get no on-disk JSONL
+  // anywhere.
+  if (_fileSinkEnabled) try {
     const userData = getApp()?.getPath?.('userData');
     if (!userData) throw new Error('userData unavailable');
     const rendererLogDir = path.join(userData, 'renderer-logs');


### PR DESCRIPTION
## Summary

Flip the electron-log file transport from opt-out to opt-in. The file sink is now ON by default only in dev (`app.isPackaged === false`, e.g. `npm run dev`), and OFF in packaged builds unless the user sets `CCSM_LOG_ENABLE_FILE=1`. Console + Sentry sinks unchanged.

## Why

Previously, every packaged run wrote tens of JSONL events per session to `app.getPath('logs')/main.log`, with rotation up to a 100MB cap, forever. Users never asked for diagnostic logging on disk; only the developer (dogfooding) needs it. The console sink is free in production (no attached terminal), and Sentry is governed separately.

## Design changes

- `electron/shared/log.ts` `initLog()` gates the file transport on `app.isPackaged === false || CCSM_LOG_ENABLE_FILE === '1'`. Otherwise sets `elog.transports.file.level = false` and skips the rotation / header / resolvePathFn wiring. The `userData/renderer-logs/` mirror ring follows the same gate.
- Env var: `CCSM_LOG_DISABLE_FILE` (opt-out) removed. New `CCSM_LOG_ENABLE_FILE` (opt-in) takes its place. No back-compat shim — small project, no external users.
- New export `getLogFileEnabled()` for the menu builder.
- Detection uses `app.isPackaged` (Electron's canonical API). `process.env.NODE_ENV` is set by webpack only for the renderer bundle; not reliable in the main process where log.ts lives.

## Menu UX

When the file sink is OFF (packaged default), both Help submenu items that depend on it are disabled with a tooltip:

> Enable diagnostic logging via CCSM_LOG_ENABLE_FILE=1

- **Reveal Logs in Folder** — disabled (no log files to reveal).
- **Set Log Level** — disabled (no file-level to change; runtime mutation would be invisible).
- **Log File: …** readout now reads `Log File: (disabled — set CCSM_LOG_ENABLE_FILE=1)` instead of `(uninitialized)` so the state is self-explanatory.

This prevents silent no-ops and tells the user exactly which env var to flip.

## Dev experience

`npm run dev` → `app.isPackaged === false` → file sink wired automatically, identical behavior to before. `.dev-userdata/logs/main.log` still receives events.

## Renderer side

`src/shared/log.ts` is untouched. electron-log silently drops records arriving over IPC for a `level=false` transport, so gating at main is sufficient. The IPC bridge stays wired (cheap).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors
- [x] New `electron/shared/__tests__/log.test.ts` covers all four cells:
  - dev (unpackaged) → file enabled
  - packaged + no env → file silenced (level === false)
  - packaged + `CCSM_LOG_ENABLE_FILE=1` → file enabled
  - packaged + `CCSM_LOG_ENABLE_FILE=true` (wrong token) → still silenced
  - dead `CCSM_LOG_DISABLE_FILE=1` no longer affects anything
- [x] Updated `electron/lifecycle/__tests__/appLifecycle.test.ts` asserts Reveal Logs + Set Log Level (and each radio child) are disabled with the env-var tooltip when the gate is off; enabled when on.
- [x] Full vitest suite: only pre-existing failures remain (better-sqlite3 native binding ABI mismatch in this worktree's `node_modules`, unrelated to logging).

## Out of scope

- Renderer log silent-drop bug (UA detection) — separate PR in flight.
- Attach-viewport invariant — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)