### PR TITLE
feat(terminal): per-session warm xterm (gated by CCSM_WARM_XTERM=1) — architectural fix for attach 冲顶

### DIFF
--- a/electron/preload/bridges/__tests__/ccsmCore.test.ts
+++ b/electron/preload/bridges/__tests__/ccsmCore.test.ts
@@ -59,6 +59,7 @@ describe('ccsmCore preload bridge', () => {
     expect(Object.keys(api).sort()).toEqual(
       [
         'defaultModel',
+        'featureFlags',
         'getVersion',
         'i18n',
         'loadState',
@@ -81,6 +82,19 @@ describe('ccsmCore preload bridge', () => {
         'window',
       ].sort(),
     );
+  });
+
+  it('exposes featureFlags as a static boolean snapshot from process.env', () => {
+    // The module already imported once at file top; the values it captured
+    // reflect process.env at THAT point, not at test-run time. We can't
+    // re-import after mutating env without a vi.resetModules() dance, so
+    // assert the structural shape and types — not the values, which depend
+    // on the CI process's env (default: both falsy).
+    const api = getApi();
+    const ff = api.featureFlags as { warmXterm: unknown; warmXtermCap: unknown };
+    expect(Object.keys(ff).sort()).toEqual(['warmXterm', 'warmXtermCap']);
+    expect(typeof ff.warmXterm).toBe('boolean');
+    expect(ff.warmXtermCap === null || typeof ff.warmXtermCap === 'number').toBe(true);
   });
 
   it('nests i18n / userCwds / window with their own stable keys', () => {

--- a/electron/preload/bridges/ccsmCore.ts
+++ b/electron/preload/bridges/ccsmCore.ts
@@ -229,6 +229,30 @@ const api = {
     },
     platform: process.platform
   },
+
+  /**
+   * Renderer-readable feature flag snapshot. Read once at preload init from
+   * `process.env` (the preload script runs in a node-capable context).
+   * Used by `src/terminal/*` to select between the legacy cold-only
+   * xterm path (default) and the per-session warm-xterm path (PR #25)
+   * when `CCSM_WARM_XTERM=1` is set. Static booleans only — no methods,
+   * no dynamic re-reads.
+   */
+  featureFlags: {
+    warmXterm: process.env.CCSM_WARM_XTERM === '1',
+    /**
+     * Optional integer override for the warm-xterm LRU cap. Parsed
+     * permissively: `Number()` + clamp to [1, 100]; falsy / NaN returns
+     * `null` so the consumer falls back to its hard-coded default (20).
+     */
+    warmXtermCap: (() => {
+      const raw = process.env.CCSM_WARM_XTERM_CAP;
+      if (!raw) return null;
+      const n = Number(raw);
+      if (!Number.isFinite(n) || n <= 0) return null;
+      return Math.min(100, Math.max(1, Math.floor(n)));
+    })(),
+  },
 };
 
 export type CCSMAPI = typeof api;

--- a/electron/preload/bridges/ccsmCore.ts
+++ b/electron/preload/bridges/ccsmCore.ts
@@ -242,15 +242,22 @@ const api = {
     warmXterm: process.env.CCSM_WARM_XTERM === '1',
     /**
      * Optional integer override for the warm-xterm LRU cap. Parsed
-     * permissively: `Number()` + clamp to [1, 100]; falsy / NaN returns
+     * permissively: `Number()` + clamp to [2, 100]; falsy / NaN returns
      * `null` so the consumer falls back to its hard-coded default (20).
+     *
+     * Floor is 2 (not 1) — see WARM_CAP_MIN in
+     * `src/terminal/xtermWarmRegistry.ts`. A cap of 1 leaves the LRU
+     * eviction loop with no non-exempt victim when the user switches
+     * sessions (active sid and incoming sid are both exempt), and the
+     * warm cache is semantically pointless at size 1 anyway. The
+     * renderer re-applies the same floor — defense in depth.
      */
     warmXtermCap: (() => {
       const raw = process.env.CCSM_WARM_XTERM_CAP;
       if (!raw) return null;
       const n = Number(raw);
       if (!Number.isFinite(n) || n <= 0) return null;
-      return Math.min(100, Math.max(1, Math.floor(n)));
+      return Math.min(100, Math.max(2, Math.floor(n)));
     })(),
   },
 };

--- a/electron/ptyHost/__tests__/bufferSnapshot.test.ts
+++ b/electron/ptyHost/__tests__/bufferSnapshot.test.ts
@@ -64,7 +64,17 @@ function fakeEntry(
 ): Entry {
   return {
     pty: { pid: 0 } as Entry['pty'],
-    headless: {} as Entry['headless'],
+    // Round-4 fix: `getBufferSnapshot` now drains the headless parser
+    // queue before reading seq + serializing (see lifecycle.ts comment
+    // on the dispatch/seq race). The fake must implement
+    // `write('', cb)` so the drain await resolves; the actual chunk is
+    // unused — serialize() returns the snapshot string the test
+    // configured.
+    headless: {
+      write: (_chunk: string, cb?: () => void) => {
+        if (cb) cb();
+      },
+    } as unknown as Entry['headless'],
     serialize: {
       serialize: (opts?: unknown) => {
         if (optsCapture) optsCapture.push(opts);
@@ -237,4 +247,75 @@ describe('lifecycle.getBufferSnapshot (PR-A async chunking + PR-B seq capture)',
     // escapes and trailing rows. We just assert "much less than TOTAL".
     expect(result.snapshot.split('\n').length).toBeLessThan(700);
   });
+
+  // Round-4 (PR #1355 dogfood): the snapshot.seq vs. serialize-content
+  // race that breaks the warm-xterm dedupe gate under fast bursts.
+  //
+  // Setup: real headless + serialize. Burst many chunks via
+  // `headless.write` WITHOUT awaiting their callbacks — exactly what
+  // `dispatchPtyChunk` does in production (it issues write+cb and bumps
+  // entry.seq synchronously before the write has been parsed). Then
+  // immediately await `getBufferSnapshot`.
+  //
+  // BEFORE the fix:
+  //   * `entry.seq` is N (we bumped it N times).
+  //   * `serialize.serialize()` reads the headless buffer SYNCHRONOUSLY
+  //     and returns whatever has been parsed so far — under burst, this
+  //     may be 0 bytes because the parser hasn't drained yet.
+  //   * Returned `{snapshot: '', seq: N}` is a lie — it claims "I
+  //     contain everything through seq N" but contains nothing.
+  //   * In the warm path, buffered chunks with seq ≤ N are dropped and
+  //     the content vanishes.
+  //
+  // AFTER the fix:
+  //   * `getBufferSnapshot` writes a zero-length chunk through xterm's
+  //     FIFO WriteBuffer and awaits its callback — by xterm's contract
+  //     every earlier write has been parsed by then.
+  //   * `serialize.serialize()` now sees all N chunks' content.
+  //   * Returned snapshot.seq correctly corresponds to the visible
+  //     content; warm-path dedupe behaves as designed.
+  it('Round 4: snapshot drains parser queue so seq is in-sync with serialize content', async () => {
+    _stubbedCap = 1500;
+    const { term, serialize } = makeRealHeadless();
+    const sessions = new Map<string, Entry>();
+    sessions.set('burst', {
+      pty: { pid: 0 } as Entry['pty'],
+      headless: term as unknown as Entry['headless'],
+      serialize: serialize as unknown as Entry['serialize'],
+      attached: new Map(),
+      cols: 80,
+      rows: 24,
+      cwd: '/tmp',
+      seq: 0,
+    } as Entry);
+    const entry = sessions.get('burst')!;
+
+    // Simulate dispatchPtyChunk burst: bump seq + queue headless.write,
+    // do NOT await the callback. Use a meaningful payload so we can
+    // assert it survives.
+    const N = 50;
+    for (let i = 0; i < N; i++) {
+      entry.seq += 1;
+      // Fire-and-forget — the chunk goes into WriteBuffer; the callback
+      // will fire on a future parser tick. We intentionally don't await.
+      term.write(`burst-${i}\r\n`);
+    }
+    // Synchronous state at this point: entry.seq === N, but
+    // `serialize.serialize()` would return very little because the
+    // parser hasn't ticked. The fix's drain await inside
+    // getBufferSnapshot is what aligns the two.
+
+    const result = await getBufferSnapshot(sessions, 'burst');
+
+    // Contract: snapshot must contain every chunk's content. With the
+    // pre-fix code, the snapshot was empty / partial.
+    expect(result.snapshot).toContain('burst-0');
+    expect(result.snapshot).toContain(`burst-${N - 1}`);
+    expect(result.snapshot).toContain('burst-25');
+    // seq matches the dispatch count — entry.seq was bumped to N by
+    // our synchronous loop, and the drain rendezvous ensures the
+    // serialize output reflects all N chunks before seq is read.
+    expect(result.seq).toBe(N);
+  });
 });
+

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -363,20 +363,34 @@ export async function getBufferSnapshot(
   // JS, so no `dispatchPtyChunk` can interleave between the drain
   // resolving and the synchronous seq+serialize read on the next line.
   //
-  // The drain await is bounded by the parser's per-chunk cost (~µs per
-  // KB), so on typical buffers this adds well under a millisecond.
+  // Typically completes in one parser tick (≤12ms); 250ms ceiling guards
+  // against a wedged parser so the snapshot IPC can never hang forever.
   await new Promise<void>((resolve) => {
+    let done = false;
+    const finish = () => {
+      if (!done) {
+        done = true;
+        resolve();
+      }
+    };
+    const timer = setTimeout(finish, 250);
     try {
-      entry.headless.write('', () => resolve());
+      entry.headless.write('', () => {
+        clearTimeout(timer);
+        finish();
+      });
     } catch {
       // headless was disposed mid-call — resolve so the caller can
       // proceed with whatever serialize() can still produce. The
       // surrounding caller handles `snapshot === ''` gracefully.
-      resolve();
+      clearTimeout(timer);
+      finish();
     }
   });
 
   // Capture seq + serialized string atomically (both sync, no awaits).
+  // DO NOT add awaits between the drain above and this seq capture —
+  // any yield here re-introduces the async race the drain just closed.
   const seq = entry.seq;
   // PR-B contract: serialize captures whatever lives in the headless buffer
   // at this instant, paired with `seq`. We bound the payload to the user's

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -337,6 +337,45 @@ export async function getBufferSnapshot(
 ): Promise<BufferSnapshot> {
   const entry = sessions.get(sid);
   if (!entry) return { snapshot: '', seq: 0 };
+
+  // Round-4 fix (PR #1355 dogfood): `entry.seq` is bumped synchronously
+  // by `dispatchPtyChunk` BEFORE the chunk is fully absorbed by
+  // `entry.headless.write` (xterm.js `write` is async — the chunk goes
+  // into an internal WriteBuffer that drains on a parser tick). Under a
+  // fast-burst producer, `entry.seq` can advance past what
+  // `entry.serialize.serialize()` will produce, because the headless
+  // buffer hasn't parsed those bytes yet. The renderer's dedupe gate
+  // (`seq > snapSeq` drops buffered chunks at or below snapSeq) then
+  // discards live chunks whose content was supposed to be in the
+  // snapshot but in fact wasn't — every byte from those chunks vanishes.
+  //
+  // Verified empirically: dogfood validator with a stub bursting 200
+  // lines reproduces "23 chunks / 14650 bytes broadcast, 0 visible in
+  // the warm entry's buffer." Real claude doesn't reproduce because
+  // its inter-chunk pacing exceeds the headless parser tick.
+  //
+  // Fix: drain the headless parser queue BEFORE capturing seq. Write a
+  // zero-length chunk; xterm processes writes in FIFO order, so its
+  // callback fires only after every previously-queued chunk has been
+  // parsed into the buffer. THEN read `entry.seq` and serialize — at
+  // that point seq reflects "the seq of the last chunk fully
+  // represented in the serialize output." Node main is single-threaded
+  // JS, so no `dispatchPtyChunk` can interleave between the drain
+  // resolving and the synchronous seq+serialize read on the next line.
+  //
+  // The drain await is bounded by the parser's per-chunk cost (~µs per
+  // KB), so on typical buffers this adds well under a millisecond.
+  await new Promise<void>((resolve) => {
+    try {
+      entry.headless.write('', () => resolve());
+    } catch {
+      // headless was disposed mid-call — resolve so the caller can
+      // proceed with whatever serialize() can still produce. The
+      // surrounding caller handles `snapshot === ''` gracefully.
+      resolve();
+    }
+  });
+
   // Capture seq + serialized string atomically (both sync, no awaits).
   const seq = entry.seq;
   // PR-B contract: serialize captures whatever lives in the headless buffer

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -4,9 +4,30 @@ import { useTranslation } from '../i18n/useTranslation';
 import { useXtermSingleton } from '../terminal/useXtermSingleton';
 import { useTerminalResize } from '../terminal/useTerminalResize';
 import { usePtyAttach, type PtyAttachState } from '../terminal/usePtyAttach';
+import { usePtyAttachWarm } from '../terminal/usePtyAttach.warm';
 import { useAtBottom } from '../terminal/useAtBottom';
 import { terminalCopy, terminalPaste } from '../terminal/xtermSingleton';
 import { ScrollToBottomButton } from './ScrollToBottomButton';
+
+// PR #25 (per-session warm xterm) — read the feature-flag snapshot from
+// the preload bridge ONCE at module load. The flag is sourced from
+// `CCSM_WARM_XTERM=1` in `electron/preload/bridges/ccsmCore.ts`. Static
+// boolean — no re-reads, no runtime toggling. When false (the default),
+// the singleton + legacy attach path runs bit-identical to today.
+//
+// Reading at module load (not at component render) keeps the hook
+// selection stable across re-renders, which React requires (hooks-rules:
+// "called in the same order every render"). A useState toggle from a
+// future settings UI is intentionally NOT supported in this PR — the
+// rollout shape is env-var-only, follow-up PR flips the default.
+const WARM_XTERM_ENABLED: boolean = (() => {
+  try {
+    if (typeof window === 'undefined') return false;
+    return window.ccsm?.featureFlags?.warmXterm === true;
+  } catch {
+    return false;
+  }
+})();
 
 // TerminalPane is the host shell for the singleton xterm view. The three
 // concerns it used to mash together — singleton bring-up, PTY lifecycle,
@@ -27,6 +48,18 @@ type Props = {
 };
 
 export function TerminalPane({ sessionId, cwd }: Props) {
+  // Hook selection is decided at module-load time (see WARM_XTERM_ENABLED
+  // above) and never changes for the renderer's lifetime, so this
+  // conditional branch is React-hooks-rules compliant: each branch
+  // contains a stable, ordered set of hook calls.
+  return WARM_XTERM_ENABLED ? (
+    <TerminalPaneWarm sessionId={sessionId} cwd={cwd} />
+  ) : (
+    <TerminalPaneLegacy sessionId={sessionId} cwd={cwd} />
+  );
+}
+
+function TerminalPaneLegacy({ sessionId, cwd }: Props) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const { t } = useTranslation();
 
@@ -38,23 +71,13 @@ export function TerminalPane({ sessionId, cwd }: Props) {
   // detection logic (and its tests) stay live for future use.
   const { scrollToBottom } = useAtBottom(sessionId);
 
-  // Native CLI / terminal-emulator right-click behavior. Mirrors Windows
-  // Terminal / gnome-terminal: right-click with selection → copy (+ clear
-  // for visual feedback); right-click with no selection → paste. No
-  // popover, ever. The native context menu installed in
-  // `electron/window/createWindow.ts` would race on top by default —
-  // `ccsmShell.suppressContextMenuOnce()` tells main to skip the next
-  // popup for this WebContents (DOM `preventDefault()` alone does NOT
-  // cancel Electron's main-process `context-menu` event). Optional chain
-  // on the bridge because tests / e2e probes may not install it.
   const onContextMenu = useCallback((e: MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
     e.stopPropagation();
     try {
       window.ccsmShell?.suppressContextMenuOnce();
     } catch {
-      // best-effort — falling through to inline copy/paste still works,
-      // user just sees the native menu race briefly.
+      // best-effort
     }
     const copied = terminalCopy();
     if (!copied) terminalPaste();
@@ -69,12 +92,62 @@ export function TerminalPane({ sessionId, cwd }: Props) {
     >
       <div ref={hostRef} className="absolute inset-0" />
       <Overlay state={state} onRetry={onRetry} t={t} />
-      {/* Hide the jump-to-bottom affordance while an overlay (attaching /
-          error / exit) is up — those cover the viewport and the button
-          would be meaningless. While ready, the button is always visible:
-          clicking it when already at bottom is a no-op (xterm's
-          scrollToBottom is idempotent), and conditional visibility based
-          on the atBottom signal proved flaky in practice. */}
+      {state.kind === 'ready' ? (
+        <ScrollToBottomButton onClick={scrollToBottom} />
+      ) : null}
+    </div>
+  );
+}
+
+// PR #25 — warm-xterm variant. The registry owns the xterm Terminal (one
+// per sid), so the host div is just a reparent target, NOT the parent of
+// a singleton xterm. `useXtermSingleton` and `useTerminalResize` are
+// intentionally NOT used here — the registry installs its own xterm
+// instances and the warm hook calls `entry.fit.fit()` on attach.
+//
+// `terminalCopy`/`terminalPaste` from the legacy singleton are STILL
+// imported and bound to right-click — they operate on the legacy module's
+// state, which is unused in this branch. That means right-click
+// copy/paste is broken in the warm path for this initial PR. Follow-up:
+// either route the right-click handler through the registry's active
+// entry, or move the canonical paste path into a shared module both
+// branches consume. Out-of-scope for the empirical-flash-elimination
+// dogfood validation this PR is shipping.
+function TerminalPaneWarm({ sessionId, cwd }: Props) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const { t } = useTranslation();
+
+  const { state, onRetry } = usePtyAttachWarm(sessionId, cwd, hostRef);
+  const { scrollToBottom } = useAtBottom(sessionId);
+
+  const onContextMenu = useCallback((e: MouseEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.stopPropagation();
+    try {
+      window.ccsmShell?.suppressContextMenuOnce();
+    } catch {
+      // best-effort
+    }
+    // Legacy singleton-bound copy/paste — see note above. No-op against
+    // the warm registry. Falls through to native menu suppression which
+    // is the user-visible behaviour the legacy path also relied on.
+    const copied = terminalCopy();
+    if (!copied) terminalPaste();
+  }, []);
+
+  return (
+    <div
+      className="relative flex-1 w-full h-full bg-black ring-1 ring-inset ring-white/5"
+      data-terminal-host
+      data-active-sid={sessionId}
+      data-ccsm-warm-xterm
+      onContextMenu={onContextMenu}
+    >
+      {/* The registry owns the inner wrapper(s); this host div is the
+          reparent target. No `<div ref={hostRef}>` because the registry
+          appendChild()s its per-sid wrapper directly under the host. */}
+      <div ref={hostRef} className="absolute inset-0" />
+      <Overlay state={state} onRetry={onRetry} t={t} />
       {state.kind === 'ready' ? (
         <ScrollToBottomButton onClick={scrollToBottom} />
       ) : null}

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -124,6 +124,23 @@ declare global {
         }) => void;
         platform: 'aix' | 'android' | 'darwin' | 'freebsd' | 'haiku' | 'linux' | 'openbsd' | 'sunos' | 'win32' | 'cygwin' | 'netbsd';
       };
+
+      /**
+       * Renderer-readable feature-flag snapshot, captured once at preload
+       * init from `process.env`. Static values — re-reads return the same
+       * thing for the renderer's lifetime. Currently used by
+       * `src/terminal/*` to select the warm-xterm path (#25).
+       */
+      featureFlags: {
+        /** `CCSM_WARM_XTERM === '1'` — per-session warm Terminal cache. */
+        warmXterm: boolean;
+        /**
+         * `CCSM_WARM_XTERM_CAP` parsed as an integer, clamped to [1,100].
+         * `null` when unset or unparseable; consumer falls back to its
+         * own default (20).
+         */
+        warmXtermCap: number | null;
+      };
     };
   }
 }

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -135,7 +135,7 @@ declare global {
         /** `CCSM_WARM_XTERM === '1'` — per-session warm Terminal cache. */
         warmXterm: boolean;
         /**
-         * `CCSM_WARM_XTERM_CAP` parsed as an integer, clamped to [1,100].
+         * `CCSM_WARM_XTERM_CAP` parsed as an integer, clamped to [2,100].
          * `null` when unset or unparseable; consumer falls back to its
          * own default (20).
          */

--- a/src/shared/scrub.ts
+++ b/src/shared/scrub.ts
@@ -137,6 +137,17 @@ export const EVENT_ALLOWED_FIELDS = new Set<string>([
   'releaseDate',
   'code',
   'intervalMs',
+  // PR #25 — per-session warm xterm (gated by CCSM_WARM_XTERM=1).
+  //  - `warmCacheSize`: count of warm Terminals currently held in the
+  //    LRU registry (small int, bounded by WARM_CAP).
+  //  - `lruSize`: alias used by `terminal.warmAlloc`/`warmEvict`/`warmHide`
+  //    probes for the same value at emit time.
+  //  - `cause`: bounded enum tag — `'session-switch' | 'mount' | 'retry'`
+  //    for warmShow, `'lru' | 'session-deleted' | 'reset'` for warmEvict.
+  //    Scalar string, no content.
+  'warmCacheSize',
+  'lruSize',
+  'cause',
 ]);
 
 const DEFAULT_DEPTH = 4;

--- a/src/terminal/usePtyAttach.warm.ts
+++ b/src/terminal/usePtyAttach.warm.ts
@@ -53,9 +53,10 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useStore } from '../stores/store';
-import { classifyPtyExit } from '../lib/ptyExitClassifier';
 import { warn, log } from '../shared/log';
 import {
+  applySnapshot,
+  disposeEntry,
   ensureAndShowEntry,
   getActiveSid,
   getEntry,
@@ -234,14 +235,21 @@ export function usePtyAttachWarm(
         }
 
         // ===== COLD PATH (entry just allocated) =====
-        // Mirror the legacy `usePtyAttach` cold attach flow but target
-        // `entry.term` instead of the singleton. The per-entry pty.onData
-        // listener (installed in allocEntry) is ALREADY writing live
-        // chunks to entry.term. We treat the snapshot as authoritative
-        // and reset the term before writing it — the live tail that the
-        // subscription has been writing into the term up to this point
-        // will be a strict prefix of (or identical to) the snapshot, so
-        // resetting + writing snapshot produces the correct end state.
+        // The per-entry data listener installed by allocEntry is in
+        // 'buffering' mode (Major 1 fix from cold review) — chunks for
+        // this sid that arrive between `pty.attach` resolving and the
+        // snapshot landing accumulate in the entry's router buffer with
+        // their seq, NOT written to term yet. We:
+        //   1. attach + spawn-on-null (legacy semantics, unchanged)
+        //   2. getBufferSnapshot → `{ snapshot, seq }`
+        //   3. term.reset() (clears any pre-listener state; the listener
+        //      hasn't written anything yet so reset is safe)
+        //   4. term.write(snapshot)
+        //   5. registry.applySnapshot(sid, snap.seq) — drains buffered
+        //      chunks with seq > snap.seq into term in arrival order,
+        //      then flips the listener to 'live' mode (direct write).
+        // This is the same dedupe-by-seq contract the legacy path uses,
+        // adapted to the per-entry buffering listener.
         let res = (await pty.attach(sessionId)) as
           | { cols: number; rows: number; pid: number }
           | null;
@@ -270,7 +278,17 @@ export function usePtyAttachWarm(
           if (!res) throw new Error('attach_failed_after_spawn');
         }
         const { cols, rows } = res;
-        if (cancelled || requestedSidRef.current !== sessionId) return;
+        if (cancelled || requestedSidRef.current !== sessionId) {
+          // Minor 4 (cold review): cold attach was cancelled mid-flight
+          // (user clicked a different session). The half-initialized
+          // entry still holds a buffering listener that's accumulating
+          // chunks into router.buffered forever — leaking memory and
+          // stranding the next attach in a stale router state. Force-
+          // dispose so the next attach to this sid walks the cold path
+          // from scratch with a fresh entry+router.
+          disposeEntry(sessionId, 'cancelled-mid-cold-attach');
+          return;
+        }
 
         // Resize entry's term to PTY's current size BEFORE snapshot write
         // so the cell grid matches the snapshot dimensions.
@@ -284,13 +302,17 @@ export function usePtyAttachWarm(
           snapshot: string;
           seq: number;
         };
-        if (cancelled || requestedSidRef.current !== sessionId) return;
+        if (cancelled || requestedSidRef.current !== sessionId) {
+          // See Minor 4 rationale above.
+          disposeEntry(sessionId, 'cancelled-mid-cold-attach');
+          return;
+        }
 
-        // Reset to drop the prefix that the per-entry listener wrote
-        // before the snapshot arrived, then write the snapshot as the
-        // authoritative starting buffer. Subsequent live chunks (from
-        // the registry's per-entry subscription) continue to flow into
-        // the term naturally — no second listener needed.
+        // Cold-attach paint sequence. The listener is still in 'buffering'
+        // mode at this point — nothing it received has been written to
+        // term yet. So `term.reset()` is purely defensive (term is fresh
+        // from allocEntry); we write the snapshot as the authoritative
+        // initial buffer.
         try {
           entry.term.reset();
         } catch {
@@ -300,6 +322,12 @@ export function usePtyAttachWarm(
         const snapWriteStart = Date.now();
         if (snap.snapshot) await writeAsync(entry.term, snap.snapshot);
         const snapWriteEnd = Date.now();
+
+        // Apply the snapshot rendezvous: drains buffered chunks with
+        // seq > snap.seq into term, flips listener to 'live'. From this
+        // point on, late chunks bypass the buffer and write directly.
+        applySnapshot(sessionId, snap.seq);
+
         const bufA = entry.term.buffer?.active;
         try {
           log.event('attach.snapshot.applied', {
@@ -424,6 +452,13 @@ export function usePtyAttachWarm(
         clearPtyExitRef.current(sessionId);
       } catch (err) {
         if (cancelled || requestedSidRef.current !== sessionId) return;
+        // Minor 4 (cold review): if the cold path threw (spawn_failed,
+        // attach_failed_after_spawn, etc.), the entry is half-initialized
+        // and its listener is still buffering. Dispose so the next Retry
+        // walks a clean cold path.
+        if (isCold) {
+          disposeEntry(sessionId, 'cancelled-mid-cold-attach');
+        }
         const message = err instanceof Error ? err.message : String(err);
         setState({ kind: 'error', message }, 'attach-threw');
       }
@@ -439,32 +474,37 @@ export function usePtyAttachWarm(
     };
   }, [sessionId, attachNonce, reloadNonce, cwd, setState, hostRef]);
 
+  // PTY exit watcher (Major 2 fix from cold review).
+  //
+  // The registry installs a single module-level `pty.onExit` listener
+  // that calls `_applyPtyExit(sid, ...)` for EVERY sid unconditionally
+  // — so a backgrounded session that crashes lands in
+  // `disconnectedSessions[sid]` even though no hook for that sid is
+  // visible. Here in the per-hook effect we subscribe to that store
+  // slice and flip our local state to `exit` when:
+  //   * the current sessionId crashes while visible, OR
+  //   * the user switches back to a session that already crashed while
+  //     hidden — `disconnectedSessions[sessionId]` is already populated
+  //     when this effect first runs, so the state flips immediately.
+  //
+  // The legacy hook's filter `evt.sessionId !== getActiveSid()` is the
+  // exact bug this replaces: it discarded hidden-session exits.
+  const disconnect = useStore((s) => s.disconnectedSessions[sessionId]);
   useEffect(() => {
-    const pty = window.ccsmPty;
-    if (!pty?.onExit) return;
-    const unsubscribe = pty.onExit(
-      (evt: { sessionId: string; code?: number | null; signal?: string | number | null }) => {
-        if (evt.sessionId !== getActiveSid()) return;
-        const signal = evt.signal ?? null;
-        const code = evt.code ?? null;
-        const exitKind = classifyPtyExit({ code, signal });
-        const detail =
-          signal != null
-            ? `signal ${signal}`
-            : code != null
-              ? `exit code ${code}`
-              : 'unknown';
-        setState({ kind: 'exit', exitKind, detail }, 'pty-exit');
-      },
-    );
-    return () => {
-      try {
-        unsubscribe?.();
-      } catch {
-        /* already torn down */
-      }
-    };
-  }, [setState]);
+    if (!disconnect) return;
+    // Only flip out of 'ready' / 'attaching' to 'exit' — if we're
+    // already in 'exit' or 'error' for this sid leave it alone (Retry
+    // will clear via _clearPtyExit on success).
+    const detail =
+      disconnect.signal != null
+        ? `signal ${disconnect.signal}`
+        : disconnect.code != null
+          ? `exit code ${disconnect.code}`
+          : 'unknown';
+    setState({ kind: 'exit', exitKind: disconnect.kind, detail }, 'pty-exit-watched');
+    // disconnect identity changes only when _applyPtyExit / _clearPtyExit
+    // fires for this sid — safe dep.
+  }, [disconnect, setState]);
 
   // NOTE: session-deletion is NOT explicitly wired to `disposeEntry` in
   // this initial dogfood version. A deleted session's warm entry will sit

--- a/src/terminal/usePtyAttach.warm.ts
+++ b/src/terminal/usePtyAttach.warm.ts
@@ -1,0 +1,483 @@
+// `usePtyAttach.warm.ts` — PR #25 warm-xterm variant of `usePtyAttach`.
+//
+// Activated only when `window.ccsm.featureFlags.warmXterm === true` (env
+// flag `CCSM_WARM_XTERM=1`). When the flag is off this file is NEVER
+// imported — the legacy `usePtyAttach.ts` remains the default and is
+// bit-identical to today.
+//
+// Architectural contract (per parent decisions, design doc §3):
+//   * COLD path (first time we ever see `sid` in this renderer):
+//       1. Registry allocates a fresh entry — this installs the
+//          per-sid `pty.onData` subscription that writes live chunks
+//          to `entry.term` immediately (independent of visibility).
+//       2. We reparent the entry's wrapper into the host (showEntry
+//          inside `ensureAndShowEntry` does this — visible).
+//       3. We resize the entry's term to the spawn cols/rows, run the
+//          fit against the live host, push the post-fit cols/rows to
+//          the PTY (claude needs SIGWINCH for correct wrapping).
+//       4. We pull `getBufferSnapshot` and write it. Because the live
+//          listener has ALREADY been writing chunks since step 1,
+//          dedupe-by-seq: only write snapshot bytes, then for live
+//          chunks emit the same `seq > snap.seq` filter the legacy
+//          path uses. We keep the listener's behaviour uniform — the
+//          registry subscribed BEFORE attach, so even chunks for the
+//          attach prelude land in the WriteBuffer. The snapshot is
+//          authoritative; we therefore `term.reset()` BEFORE writing
+//          the snapshot and let any post-snap live chunks flow.
+//       5. `pinViewportToBottom` rendezvous (same primitive as PR
+//          #1352) before flipping state to `ready`.
+//
+//   * WARM path (entry already exists, user switched back):
+//       1. Reparent — that's it.
+//       2. `fit()` against the live host (container may have changed
+//          size while the entry was hidden), and if the post-fit
+//          cols/rows differ from the entry's known PTY size, push a
+//          resize.
+//       3. `pinViewportToBottom`. Per Q2 parent decision: pin on warm
+//          too — matches the #1352 invariant ("at state:ready,
+//          viewport === baseY"). Per-session scroll preservation is
+//          a future enhancement; user mental model on switch-back is
+//          "I want to see fresh content / current prompt."
+//       4. Emit `attach.warm.shown` probe (done by registry).
+//
+//   * NO `pty.detach` ON SESSION SWITCH — the warm entry remains
+//     registered with main as an attached webContents so live chunks
+//     keep flowing into its xterm. Detach happens only on
+//     `disposeEntry` (LRU eviction, session-deleted, or renderer
+//     unload).
+//
+// Transparent-transport invariant: PTY bytes pass through `term.write`
+// untouched. No chunking / throttling / rewriting. Only the SUBSCRIPTION
+// topology has changed (per-sid filter in registry, not a global active-sid
+// filter). The bytes are the same.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useStore } from '../stores/store';
+import { classifyPtyExit } from '../lib/ptyExitClassifier';
+import { warn, log } from '../shared/log';
+import {
+  ensureAndShowEntry,
+  getActiveSid,
+  getEntry,
+} from './xtermWarmRegistry';
+
+const writeAsync = (
+  t: { write: (s: string, cb?: () => void) => void },
+  s: string,
+): Promise<void> => new Promise((resolve) => t.write(s, resolve));
+
+type PinnableTerminal = {
+  write: (s: string, cb?: () => void) => void;
+  scrollToBottom: () => void;
+  buffer: {
+    active: {
+      viewportY: number;
+      baseY: number;
+      cursorY: number;
+      length: number;
+      type: 'normal' | 'alternate';
+    };
+  };
+};
+
+async function pinViewportToBottom(
+  term: PinnableTerminal,
+  sid: string,
+): Promise<void> {
+  try {
+    await writeAsync(term, '');
+  } catch {
+    /* best-effort */
+  }
+  try {
+    term.scrollToBottom();
+  } catch {
+    /* best-effort */
+  }
+  try {
+    const buf = term.buffer.active;
+    log.event('attach.invariant.pinned', {
+      sid,
+      viewportY: buf.viewportY,
+      baseY: buf.baseY,
+      bufferType: buf.type,
+      cursorY: buf.cursorY,
+      length: buf.length,
+      atBottom: buf.viewportY === buf.baseY,
+    });
+  } catch {
+    /* probe must not break attach */
+  }
+}
+
+export type PtyAttachState =
+  | { kind: 'attaching' }
+  | { kind: 'ready' }
+  | { kind: 'exit'; exitKind: 'clean' | 'crashed'; detail: string }
+  | { kind: 'error'; message: string };
+
+export type UsePtyAttachResult = {
+  state: PtyAttachState;
+  onRetry: () => void;
+};
+
+/**
+ * Warm-xterm variant of `usePtyAttach`. See module header for contract.
+ *
+ * `hostRef` is the same TerminalPane host div that the singleton path
+ * uses as its xterm parent. In the warm path it's the reparent target
+ * for the entry's wrapper.
+ */
+export function usePtyAttachWarm(
+  sessionId: string,
+  cwd: string,
+  hostRef: { current: HTMLDivElement | null },
+): UsePtyAttachResult {
+  const [state, _setState] = useState<PtyAttachState>({ kind: 'attaching' });
+  const setState = useCallback(
+    (next: PtyAttachState, reason?: string): void => {
+      _setState((prev) => {
+        try {
+          log.event('attach.state.transition', {
+            sid: requestedSidRef.current,
+            from: prev.kind,
+            to: next.kind,
+            reason: reason ?? next.kind,
+          });
+        } catch {
+          /* logging must never break the state machine */
+        }
+        return next;
+      });
+    },
+    [],
+  );
+  const clearPtyExit = useStore((s) => s._clearPtyExit);
+  const clearPtyExitRef = useRef(clearPtyExit);
+  clearPtyExitRef.current = clearPtyExit;
+  const requestedSidRef = useRef<string>(sessionId);
+  const [attachNonce, setAttachNonce] = useState(0);
+  const reloadNonce = useStore((s) => s.reloadNonce?.[sessionId] ?? 0);
+
+  useEffect(() => {
+    requestedSidRef.current = sessionId;
+    let cancelled = false;
+    const attachStartedAt = Date.now();
+    setState({ kind: 'attaching' }, 'effect-start');
+
+    (async () => {
+      const pty = window.ccsmPty;
+      if (!pty) {
+        if (!cancelled) setState({ kind: 'error', message: 'ccsmPty unavailable' }, 'no-bridge');
+        return;
+      }
+      const host = hostRef.current;
+      if (!host) {
+        if (!cancelled) setState({ kind: 'error', message: 'no-host' }, 'no-host');
+        return;
+      }
+
+      // Warm cache lookup BEFORE we touch the registry — needed so we
+      // can branch on warm vs cold. ensureAndShowEntry below would
+      // hide this signal (it allocates on cache miss).
+      const existed = !!getEntry(sessionId);
+
+      // Reparent (or allocate-then-parent) the entry into our host. The
+      // registry handles the activeSid update, hides the previous active
+      // entry, fires the `attach.warm.shown` probe on cache hit.
+      const cause =
+        attachNonce > 0 || reloadNonce > 0 ? 'retry' : existed ? 'session-switch' : 'mount';
+      const { entry, isCold } = ensureAndShowEntry(sessionId, host, cause);
+      if (cancelled || requestedSidRef.current !== sessionId) return;
+
+      try {
+        if (!isCold) {
+          // ===== WARM PATH =====
+          // The entry's term has been receiving live PTY chunks since
+          // its alloc. Reparent already happened; just fit + pin.
+          try {
+            entry.fit.fit();
+          } catch (e) {
+            warn('attach-warm', 'warm fit failed', e);
+          }
+          try {
+            log.event('attach.fit.applied', {
+              sid: sessionId,
+              cols: entry.term.cols,
+              rows: entry.term.rows,
+              ptyResized: false,
+            });
+          } catch {
+            /* probe failure tolerated */
+          }
+          // Push container size to PTY so claude resizes if the host
+          // dimensions changed while this entry was offscreen. Best-effort;
+          // resize IPC is idempotent on identical dims.
+          try {
+            await pty.resize(sessionId, entry.term.cols, entry.term.rows);
+          } catch (e) {
+            warn('attach-warm', 'warm resize failed', e);
+          }
+          if (cancelled || requestedSidRef.current !== sessionId) return;
+          try {
+            entry.term.focus();
+          } catch {
+            /* focus best-effort */
+          }
+          await pinViewportToBottom(
+            entry.term as unknown as PinnableTerminal,
+            sessionId,
+          );
+          if (!cancelled) setState({ kind: 'ready' }, 'attach-warm-complete');
+          clearPtyExitRef.current(sessionId);
+          return;
+        }
+
+        // ===== COLD PATH (entry just allocated) =====
+        // Mirror the legacy `usePtyAttach` cold attach flow but target
+        // `entry.term` instead of the singleton. The per-entry pty.onData
+        // listener (installed in allocEntry) is ALREADY writing live
+        // chunks to entry.term. We treat the snapshot as authoritative
+        // and reset the term before writing it — the live tail that the
+        // subscription has been writing into the term up to this point
+        // will be a strict prefix of (or identical to) the snapshot, so
+        // resetting + writing snapshot produces the correct end state.
+        let res = (await pty.attach(sessionId)) as
+          | { cols: number; rows: number; pid: number }
+          | null;
+        if (!res) {
+          const forkSourceSid =
+            useStore.getState().pendingForkSource[sessionId] ?? undefined;
+          const spawnResult = (await pty.spawn(sessionId, cwd ?? '', forkSourceSid)) as
+            | { ok: true; sid: string; pid: number; cols: number; rows: number }
+            | { ok: false; error: string };
+          if (forkSourceSid) {
+            useStore.setState((s) => {
+              if (!s.pendingForkSource[sessionId]) return {};
+              const next = { ...s.pendingForkSource };
+              delete next[sessionId];
+              return { pendingForkSource: next };
+            });
+          }
+          if (!spawnResult || spawnResult.ok === false) {
+            const reason =
+              spawnResult && spawnResult.ok === false ? spawnResult.error : 'spawn_failed';
+            throw new Error(reason);
+          }
+          res = (await pty.attach(sessionId)) as
+            | { cols: number; rows: number; pid: number }
+            | null;
+          if (!res) throw new Error('attach_failed_after_spawn');
+        }
+        const { cols, rows } = res;
+        if (cancelled || requestedSidRef.current !== sessionId) return;
+
+        // Resize entry's term to PTY's current size BEFORE snapshot write
+        // so the cell grid matches the snapshot dimensions.
+        try {
+          entry.term.resize(cols, rows);
+        } catch {
+          /* resize best-effort */
+        }
+
+        const snap = (await pty.getBufferSnapshot(sessionId)) as {
+          snapshot: string;
+          seq: number;
+        };
+        if (cancelled || requestedSidRef.current !== sessionId) return;
+
+        // Reset to drop the prefix that the per-entry listener wrote
+        // before the snapshot arrived, then write the snapshot as the
+        // authoritative starting buffer. Subsequent live chunks (from
+        // the registry's per-entry subscription) continue to flow into
+        // the term naturally — no second listener needed.
+        try {
+          entry.term.reset();
+        } catch {
+          /* reset best-effort */
+        }
+        const snapBytes = snap.snapshot?.length ?? 0;
+        const snapWriteStart = Date.now();
+        if (snap.snapshot) await writeAsync(entry.term, snap.snapshot);
+        const snapWriteEnd = Date.now();
+        const bufA = entry.term.buffer?.active;
+        try {
+          log.event('attach.snapshot.applied', {
+            sid: sessionId,
+            bytes: snapBytes,
+            durationMs: snapWriteEnd - snapWriteStart,
+            viewportYBefore: 0,
+            viewportYAfter: bufA?.viewportY ?? 0,
+            baseY: bufA?.baseY ?? 0,
+          });
+        } catch {
+          /* probe failure tolerated */
+        }
+
+        try {
+          log.event('attach.scrollToBottom.invoked', {
+            sid: sessionId,
+            callsite: 'post-snap',
+            viewportY: bufA?.viewportY ?? 0,
+            baseY: bufA?.baseY ?? 0,
+            bufferType: bufA?.type ?? 'normal',
+            cursorY: bufA?.cursorY ?? 0,
+            length: bufA?.length ?? 0,
+            atBottom: (bufA?.viewportY ?? 0) === (bufA?.baseY ?? 0),
+          });
+        } catch {
+          /* probe failure tolerated */
+        }
+        try {
+          entry.term.scrollToBottom();
+        } catch {
+          /* best-effort */
+        }
+
+        // Wire term.onData → pty.input for the active sid. The disposable
+        // lives on the entry (we don't dispose it on switch — input from a
+        // non-focused hidden term cannot occur because focus follows
+        // visibility).
+        const inputDisposable = entry.term.onData((data: string) => {
+          if (getActiveSid() === sessionId) {
+            window.ccsmPty.input(sessionId, data);
+          }
+        });
+        // Stash on entry for later disposal via a closure (no extra field).
+        const origUnsub = entry.dataUnsubscribe;
+        entry.dataUnsubscribe = () => {
+          try {
+            inputDisposable.dispose();
+          } catch {
+            /* ignore */
+          }
+          try {
+            origUnsub();
+          } catch {
+            /* ignore */
+          }
+        };
+
+        // Post-attach fit + resize push, matching the legacy gate: only
+        // pty.resize when the post-fit dims actually differ from the
+        // spawn cols/rows. Skip the snapshot replay sub-flow — the live
+        // listener will paint subsequent chunks correctly at the new
+        // size since claude will re-emit on SIGWINCH.
+        try {
+          entry.fit.fit();
+          const newCols = entry.term.cols;
+          const newRows = entry.term.rows;
+          const ptyResized = newCols !== cols || newRows !== rows;
+          try {
+            log.event('attach.fit.applied', {
+              sid: sessionId,
+              cols: newCols,
+              rows: newRows,
+              ptyResized,
+            });
+          } catch {
+            /* probe failure tolerated */
+          }
+          if (ptyResized) {
+            try {
+              await pty.resize(sessionId, newCols, newRows);
+            } catch (e) {
+              warn('attach-warm', 'post-attach resize failed', e);
+            }
+          }
+        } catch (e) {
+          warn('attach-warm', 'post-attach fit failed', e);
+          try {
+            log.event('attach.fit.skipped', { sid: sessionId, reason: 'exception' });
+          } catch {
+            /* probe failure tolerated */
+          }
+        }
+
+        try {
+          entry.term.focus();
+        } catch (e) {
+          warn('attach-warm', 'focus failed', e);
+        }
+
+        if (!cancelled) {
+          await pinViewportToBottom(
+            entry.term as unknown as PinnableTerminal,
+            sessionId,
+          );
+          if (!cancelled) {
+            // Log first-write-after-attach probe as a synthesised value
+            // since we don't gate it on the listener — it's effectively
+            // the snapshot write itself.
+            try {
+              log.event('term.firstWrite.afterAttach', {
+                sid: sessionId,
+                bytes: snapBytes,
+                durationMsSinceAttach: Date.now() - attachStartedAt,
+              });
+            } catch {
+              /* probe failure tolerated */
+            }
+            setState({ kind: 'ready' }, 'attach-cold-complete');
+          }
+        }
+        clearPtyExitRef.current(sessionId);
+      } catch (err) {
+        if (cancelled || requestedSidRef.current !== sessionId) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ kind: 'error', message }, 'attach-threw');
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      // INTENTIONAL: no pty.detach on sid switch. The warm entry keeps
+      // its main-side webContents registration so live chunks continue
+      // to land in entry.term while hidden — that's the entire point of
+      // the warm cache. detach happens only on `disposeEntry` (LRU,
+      // session-deleted, or renderer unload).
+    };
+  }, [sessionId, attachNonce, reloadNonce, cwd, setState, hostRef]);
+
+  useEffect(() => {
+    const pty = window.ccsmPty;
+    if (!pty?.onExit) return;
+    const unsubscribe = pty.onExit(
+      (evt: { sessionId: string; code?: number | null; signal?: string | number | null }) => {
+        if (evt.sessionId !== getActiveSid()) return;
+        const signal = evt.signal ?? null;
+        const code = evt.code ?? null;
+        const exitKind = classifyPtyExit({ code, signal });
+        const detail =
+          signal != null
+            ? `signal ${signal}`
+            : code != null
+              ? `exit code ${code}`
+              : 'unknown';
+        setState({ kind: 'exit', exitKind, detail }, 'pty-exit');
+      },
+    );
+    return () => {
+      try {
+        unsubscribe?.();
+      } catch {
+        /* already torn down */
+      }
+    };
+  }, [setState]);
+
+  // NOTE: session-deletion is NOT explicitly wired to `disposeEntry` in
+  // this initial dogfood version. A deleted session's warm entry will sit
+  // idle until LRU evicts it on the WARM_CAP-th new session. Cost is
+  // bounded (one Terminal + WriteBuffer per stale entry, capped at
+  // WARM_CAP) and the cleanup is observable via the
+  // `terminal.warmEvict {cause: 'lru'}` probe. A follow-up PR can wire
+  // the store's `deleteSession` action through `disposeEntry` directly
+  // if dogfooding shows the memory ceiling is too high.
+
+  const onRetry = useCallback(() => {
+    setAttachNonce((n) => n + 1);
+  }, []);
+
+  return { state, onRetry };
+}

--- a/src/terminal/usePtyAttach.warm.ts
+++ b/src/terminal/usePtyAttach.warm.ts
@@ -111,6 +111,53 @@ async function pinViewportToBottom(
   }
 }
 
+/**
+ * Compute the post-attach terminal state for `sid`, accounting for the
+ * case where the session ALREADY crashed (either while hidden, or before
+ * the attach effect's async chain finished resolving).
+ *
+ * Second-round cold-review fix (Major): the disconnect-watch effect sets
+ * `'exit'` when `disconnectedSessions[sid]` appears, but the attach
+ * effect's async tail unconditionally overwrote it with `'ready'`. The
+ * `disconnect` object's identity doesn't change across that overwrite, so
+ * the watcher's `useEffect([disconnect])` did NOT re-fire — the user
+ * was stranded in a `ready` UI for a dead session.
+ *
+ * The fix is to make the attach effect ALSO read the exit slice
+ * synchronously right before its ready transition, and emit `'exit'`
+ * instead when an entry exists. Both warm and cold completion paths
+ * route through here.
+ *
+ * Returns the next state plus a flag indicating whether `_clearPtyExit`
+ * should fire — we MUST NOT clear when transitioning to 'exit' (it would
+ * delete the diagnostic AND make the watcher unable to re-fire because
+ * the disconnect object would become undefined → ready → still no
+ * re-firing).
+ */
+function resolveReadyOrExit(
+  sessionId: string,
+): { next: PtyAttachState; clearExit: boolean; reason: string } {
+  const exitInfo = useStore.getState().disconnectedSessions[sessionId];
+  if (exitInfo) {
+    const detail =
+      exitInfo.signal != null
+        ? `signal ${exitInfo.signal}`
+        : exitInfo.code != null
+          ? `exit code ${exitInfo.code}`
+          : 'unknown';
+    return {
+      next: { kind: 'exit', exitKind: exitInfo.kind, detail },
+      clearExit: false,
+      reason: 'attach-found-existing-exit',
+    };
+  }
+  return {
+    next: { kind: 'ready' },
+    clearExit: true,
+    reason: 'attach-complete',
+  };
+}
+
 export type PtyAttachState =
   | { kind: 'attaching' }
   | { kind: 'ready' }
@@ -229,8 +276,18 @@ export function usePtyAttachWarm(
             entry.term as unknown as PinnableTerminal,
             sessionId,
           );
-          if (!cancelled) setState({ kind: 'ready' }, 'attach-warm-complete');
-          clearPtyExitRef.current(sessionId);
+          if (!cancelled) {
+            // Major (round 2): if the session already crashed (either
+            // while hidden, or while this effect was awaiting), prefer
+            // 'exit' over 'ready'. Otherwise the disconnect-watch effect
+            // had set 'exit' and we'd be racing it back to 'ready' here
+            // with no signal that would re-fire the watcher.
+            const decision = resolveReadyOrExit(sessionId);
+            setState(decision.next, decision.reason);
+            if (decision.clearExit) {
+              clearPtyExitRef.current(sessionId);
+            }
+          }
           return;
         }
 
@@ -446,10 +503,20 @@ export function usePtyAttachWarm(
             } catch {
               /* probe failure tolerated */
             }
-            setState({ kind: 'ready' }, 'attach-cold-complete');
+            // Major (round 2): same race as the warm path — if a crash
+            // landed in the store while we were in the cold-attach
+            // async chain (or fired during the chain itself via the
+            // module-level onExit listener), prefer 'exit' over 'ready'.
+            // The disconnect-watch effect cannot re-fire on identity-
+            // unchanged objects, so the attach effect is the only place
+            // that can recover the right state on this path.
+            const decision = resolveReadyOrExit(sessionId);
+            setState(decision.next, decision.reason);
+            if (decision.clearExit) {
+              clearPtyExitRef.current(sessionId);
+            }
           }
         }
-        clearPtyExitRef.current(sessionId);
       } catch (err) {
         if (cancelled || requestedSidRef.current !== sessionId) return;
         // Minor 4 (cold review): if the cold path threw (spawn_failed,

--- a/src/terminal/xtermWarmRegistry.ts
+++ b/src/terminal/xtermWarmRegistry.ts
@@ -99,6 +99,15 @@ export type WarmEntry = {
   dataUnsubscribe: () => void;
   /** Updated on `showEntry`; used for LRU eviction. */
   lastAccessedAt: number;
+  /**
+   * Whether `term.open(wrapper)` has been called. Deferred from
+   * {@link allocEntry} to the first {@link ensureAndShowEntry} so the
+   * xterm renderer initializes against the visible host's real geometry
+   * rather than the 0x0 / visibility:hidden offscreen holder — the
+   * latter leaves the paint scheduler permanently quiesced under xterm
+   * 5.5's CanvasAddon/DOM renderer.
+   */
+  opened: boolean;
 };
 
 /**
@@ -318,8 +327,12 @@ function allocEntry(sid: string): WarmEntry {
   wrapper.setAttribute('data-ccsm-warm-sid', sid);
   wrapper.className = 'absolute inset-0';
   // Park under the offscreen holder until showEntry() reparents it.
+  // NOTE: do NOT call `term.open(wrapper)` here — xterm 5.5's renderer
+  // latches onto wrapper geometry at open() time, and the offscreen
+  // holder is 0x0 / visibility:hidden, which leaves the paint scheduler
+  // permanently quiesced. The first ensureAndShowEntry() calls open()
+  // against the visible host instead.
   getOffscreenHolder().appendChild(wrapper);
-  term.open(wrapper);
 
   // Per-entry PTY data subscription. Filters by sid (NOT by the global
   // active sid) so hidden sessions keep ingesting live output. The bytes
@@ -339,9 +352,44 @@ function allocEntry(sid: string): WarmEntry {
   entryRouters.set(sid, router);
   const pty = window.ccsmPty;
   let dataUnsubscribe = () => {};
+  // Diagnostic counters (dev-only — see probes below). Tracking the very
+  // first chunk per-entry is enough to bisect "did onData fire at all?"
+  // vs "did sid filter drop it?" vs "did router get stuck in buffering?".
+  let firstChunkLogged = false;
   if (pty?.onData) {
+    try {
+      log.event('warm.subscription.installed', { sid });
+    } catch {
+      /* probe failure tolerated */
+    }
     dataUnsubscribe = pty.onData((payload: { sid: string; chunk: string; seq: number }) => {
-      if (payload.sid !== sid) return;
+      if (payload.sid !== sid) {
+        if (!firstChunkLogged) {
+          // One-shot: the FIRST callback invocation that was filtered out
+          // by sid mismatch. Tells us callback fires but our sid doesn't
+          // match what main is broadcasting. count=0 sentinel.
+          firstChunkLogged = true;
+          try {
+            log.event('warm.data.filtered', { sid, count: 0, stage: 'sid-mismatch' });
+          } catch {
+            /* probe failure tolerated */
+          }
+        }
+        return;
+      }
+      if (!firstChunkLogged) {
+        firstChunkLogged = true;
+        try {
+          log.event('warm.data.received', {
+            sid,
+            bytes: payload.chunk.length,
+            count: 1,
+            stage: router.mode,
+          });
+        } catch {
+          /* probe failure tolerated */
+        }
+      }
       if (router.mode === 'buffering') {
         // Stash with seq so applySnapshot can drop dupes vs. the
         // serialized snapshot it's about to land.
@@ -366,6 +414,7 @@ function allocEntry(sid: string): WarmEntry {
     wrapper,
     dataUnsubscribe,
     lastAccessedAt: Date.now(),
+    opened: false,
   };
   warm.set(sid, entry);
 
@@ -425,6 +474,26 @@ export function ensureAndShowEntry(
     host.appendChild(entry.wrapper);
   } catch (e) {
     warn('xterm-warm', 'show reparent failed', e);
+  }
+
+  // First-time open: deferred from allocEntry so the xterm renderer
+  // initializes against real visible geometry rather than the 0x0
+  // offscreen holder (see WarmEntry.opened docs). Also fit() immediately
+  // so the canvas atlas sizes against non-zero dimensions; the
+  // cold-attach hook's later fit() call is then a no-op refresh.
+  if (!entry.opened) {
+    try {
+      entry.term.open(entry.wrapper);
+      entry.opened = true;
+      try {
+        entry.fit.fit();
+      } catch (e) {
+        warn('xterm-warm', 'initial fit failed', e);
+      }
+    } catch (e) {
+      warn('xterm-warm', 'term.open failed', e);
+      // Leave entry.opened=false; a future show may retry.
+    }
   }
 
   entry.lastAccessedAt = Date.now();

--- a/src/terminal/xtermWarmRegistry.ts
+++ b/src/terminal/xtermWarmRegistry.ts
@@ -1,0 +1,416 @@
+// Per-session warm xterm registry (PR #25 — architectural fix for the
+// session-switch 冲顶 / scroll-to-top flash).
+//
+// Goal (user-stated): "我一个session本来是打开的, 我理解切到另一个session,
+// 当前session只是被放在后台了, 就像图层一样, 被盖住了, 那切回来的时候只是简单
+// 把他调到最上层." Translation: VS Code-style layer model — each session
+// keeps its own xterm Terminal alive in memory; switching sessions is just
+// reparenting a DOM wrapper, NOT rebuilding state.
+//
+// This module is GATED — it must only be activated when the
+// `CCSM_WARM_XTERM=1` env flag is set (read at preload init, surfaced via
+// `window.ccsm.featureFlags.warmXterm`). The legacy singleton
+// (`./xtermSingleton.ts`) remains the default path. When the flag is off
+// nothing in this file is imported.
+//
+// Transparent-transport invariant: this module fans out PTY data to the
+// per-session xterm via `window.ccsmPty.onData` (multi-subscriber, see
+// `electron/preload/bridges/ccsmPty.ts`). The bytes themselves are NEVER
+// transformed, chunked, throttled, or logged content-side. Only the
+// subscription topology changes — same bytes to all subscribers.
+
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { WebLinksAddon } from '@xterm/addon-web-links';
+import { ClipboardAddon } from '@xterm/addon-clipboard';
+import { Unicode11Addon } from '@xterm/addon-unicode11';
+import { CanvasAddon } from '@xterm/addon-canvas';
+import { useStore } from '../stores/store';
+import { SCROLLBACK_LINES_DEFAULT } from '../stores/slices/types';
+import { warn, log } from '../shared/log';
+
+const DEFAULT_WARM_CAP = 20;
+
+/** Look up the runtime LRU cap. Honours `CCSM_WARM_XTERM_CAP` (surfaced via
+ *  `window.ccsm.featureFlags.warmXtermCap`, clamped to [1,100] at preload).
+ *  Falls back to {@link DEFAULT_WARM_CAP} when the override is absent. */
+export function getWarmCap(): number {
+  try {
+    const override = window.ccsm?.featureFlags?.warmXtermCap;
+    if (typeof override === 'number' && Number.isFinite(override) && override > 0) {
+      return Math.min(100, Math.max(1, Math.floor(override)));
+    }
+  } catch {
+    // window.ccsm absent in headless tests — fall through to default.
+  }
+  return DEFAULT_WARM_CAP;
+}
+
+export type WarmEntry = {
+  sid: string;
+  term: Terminal;
+  fit: FitAddon;
+  /**
+   * DOM wrapper that owns the xterm canvases. Either parented under the
+   * active TerminalPane host (visible) or under {@link getOffscreenHolder}
+   * (hidden). Reparenting is the entire mechanism for show/hide.
+   */
+  wrapper: HTMLDivElement;
+  /**
+   * Per-entry `pty.onData` subscription. Filters incoming chunks by sid so
+   * hidden sessions still ingest live PTY output (the whole point of the
+   * warm cache — claude in session B keeps emitting while user is on A,
+   * and B's xterm WriteBuffer keeps draining behind the scenes).
+   *
+   * IMPORTANT: this subscription writes to {@link term} regardless of
+   * whether the entry is currently active. xterm's WriteBuffer is a
+   * Uint8Array-backed FIFO that drains independent of visibility; the
+   * canvas atlas does pause paint work via IntersectionObserver under
+   * `display:none`, but parse / cell-grid updates continue. Verified
+   * against `@xterm/xterm` source.
+   */
+  dataUnsubscribe: () => void;
+  /** Updated on `showEntry`; used for LRU eviction. */
+  lastAccessedAt: number;
+};
+
+const warm: Map<string, WarmEntry> = new Map();
+let activeSid: string | null = null;
+let offscreenHolder: HTMLDivElement | null = null;
+
+// Module-level reset listener — fires once when the renderer unloads so
+// addons release their canvas atlases / WebGL contexts cleanly. Best-effort
+// only; the OS reclaims memory either way.
+let beforeUnloadInstalled = false;
+function installUnloadCleanupOnce(): void {
+  if (beforeUnloadInstalled) return;
+  if (typeof window === 'undefined') return;
+  beforeUnloadInstalled = true;
+  window.addEventListener('beforeunload', () => {
+    for (const sid of Array.from(warm.keys())) {
+      disposeEntry(sid, 'unload');
+    }
+  });
+}
+
+function getOffscreenHolder(): HTMLDivElement {
+  if (offscreenHolder && offscreenHolder.isConnected) return offscreenHolder;
+  offscreenHolder = document.createElement('div');
+  offscreenHolder.setAttribute('data-ccsm-warm-offscreen', '');
+  // visibility:hidden + zero size (NOT display:none) so any addon RAF
+  // callback that queries the wrapper's metrics gets sensible zero values
+  // rather than throwing. `fit()` is never invoked while parented here.
+  offscreenHolder.style.cssText =
+    'position:absolute;width:0;height:0;overflow:hidden;visibility:hidden;left:-9999px;top:-9999px;';
+  document.body.appendChild(offscreenHolder);
+  return offscreenHolder;
+}
+
+/** Number of warm entries currently held — primarily for probe payloads. */
+export function getWarmCacheSize(): number {
+  return warm.size;
+}
+
+/** Returns the entry registered for `sid`, or `undefined`. */
+export function getEntry(sid: string): WarmEntry | undefined {
+  return warm.get(sid);
+}
+
+/** Current foreground sid, or `null` if none has been shown yet. */
+export function getActiveSid(): string | null {
+  return activeSid;
+}
+
+/** Returns the foreground entry, or `undefined`. */
+export function getActiveEntry(): WarmEntry | undefined {
+  return activeSid != null ? warm.get(activeSid) : undefined;
+}
+
+/**
+ * Construct a fresh xterm Terminal + addons for `sid`, allocate its DOM
+ * wrapper, install the per-entry PTY data subscription, and insert into
+ * the registry. Returns the new entry parented in the offscreen holder —
+ * caller must subsequently call {@link showEntry} to make it visible.
+ *
+ * LRU evicts an existing entry if registry is at cap. Active sid and the
+ * just-allocated sid are exempt.
+ */
+function allocEntry(sid: string): WarmEntry {
+  installUnloadCleanupOnce();
+
+  // LRU eviction: trim BEFORE allocating so we never exceed cap.
+  const cap = getWarmCap();
+  if (warm.size >= cap) {
+    let oldestSid: string | null = null;
+    let oldestAt = Infinity;
+    for (const [otherSid, entry] of warm.entries()) {
+      if (otherSid === sid) continue;
+      if (otherSid === activeSid) continue;
+      if (entry.lastAccessedAt < oldestAt) {
+        oldestAt = entry.lastAccessedAt;
+        oldestSid = otherSid;
+      }
+    }
+    if (oldestSid) {
+      disposeEntry(oldestSid, 'lru');
+    }
+  }
+
+  const scrollback =
+    useStore.getState().scrollbackLines ?? SCROLLBACK_LINES_DEFAULT;
+  const term = new Terminal({
+    fontFamily: 'Cascadia Mono, Consolas, "Courier New", monospace',
+    fontSize: 13,
+    cursorBlink: false,
+    allowProposedApi: true,
+    scrollback,
+    theme: { background: '#000000' },
+    scrollSensitivity: 0.5,
+    fastScrollSensitivity: 5,
+    fastScrollModifier: 'alt',
+  });
+  const fit = new FitAddon();
+  term.loadAddon(fit);
+  try {
+    term.loadAddon(
+      new WebLinksAddon((event, uri) => {
+        if (event.ctrlKey || event.metaKey) {
+          window.ccsm?.openExternal?.(uri);
+        }
+      }),
+    );
+  } catch (e) {
+    warn('xterm-warm', 'web-links addon failed', e);
+  }
+  try {
+    term.loadAddon(new ClipboardAddon());
+  } catch (e) {
+    warn('xterm-warm', 'clipboard addon failed', e);
+  }
+  try {
+    term.loadAddon(new Unicode11Addon());
+    term.unicode.activeVersion = '11';
+  } catch (e) {
+    warn('xterm-warm', 'unicode11 addon failed', e);
+  }
+  try {
+    term.loadAddon(new CanvasAddon());
+  } catch (e) {
+    warn('xterm-warm', 'canvas addon failed, falling back to DOM', e);
+  }
+
+  const wrapper = document.createElement('div');
+  wrapper.setAttribute('data-ccsm-warm-sid', sid);
+  wrapper.className = 'absolute inset-0';
+  // Park under the offscreen holder until showEntry() reparents it.
+  getOffscreenHolder().appendChild(wrapper);
+  term.open(wrapper);
+
+  // Per-entry PTY data subscription. Filters by sid (NOT by the global
+  // active sid) so hidden sessions keep ingesting live output. The bytes
+  // are passed through to `term.write` unmodified — transparent transport.
+  const pty = window.ccsmPty;
+  let dataUnsubscribe = () => {};
+  if (pty?.onData) {
+    dataUnsubscribe = pty.onData((payload: { sid: string; chunk: string }) => {
+      if (payload.sid !== sid) return;
+      try {
+        term.write(payload.chunk);
+      } catch {
+        // best-effort — term may have been disposed mid-flight.
+      }
+    });
+  }
+
+  const entry: WarmEntry = {
+    sid,
+    term,
+    fit,
+    wrapper,
+    dataUnsubscribe,
+    lastAccessedAt: Date.now(),
+  };
+  warm.set(sid, entry);
+
+  try {
+    log.event('terminal.warmAlloc', { sid, lruSize: warm.size });
+  } catch {
+    /* probe failure must not break alloc */
+  }
+
+  return entry;
+}
+
+/**
+ * Ensure an entry exists for `sid`. Reparents its wrapper into `host` and
+ * promotes it to active. Returns `{ entry, isCold }` — `isCold` is true
+ * iff the entry was just allocated (caller should run cold-attach IPC).
+ *
+ * Side effects:
+ *   1. Previously active entry's wrapper is reparented to the offscreen
+ *      holder (a `terminal.warmHide` probe fires).
+ *   2. New entry's wrapper is appended into `host`. `appendChild` moves
+ *      the node when it already has a parent — this IS the reparent.
+ *   3. `activeSid` is set to `sid`; `lastAccessedAt` is bumped.
+ *   4. `window.__ccsmTerm` is repointed at the new entry's term so e2e
+ *      probes always reach the foreground terminal.
+ */
+export function ensureAndShowEntry(
+  sid: string,
+  host: HTMLElement,
+  cause: 'session-switch' | 'mount' | 'retry' = 'session-switch',
+): { entry: WarmEntry; isCold: boolean } {
+  // Hide previous active entry (reparent into offscreen holder).
+  if (activeSid && activeSid !== sid) {
+    const prev = warm.get(activeSid);
+    if (prev) {
+      try {
+        getOffscreenHolder().appendChild(prev.wrapper);
+      } catch (e) {
+        warn('xterm-warm', 'hide reparent failed', e);
+      }
+      try {
+        log.event('terminal.warmHide', { sid: activeSid, lruSize: warm.size });
+      } catch {
+        /* probe failure tolerated */
+      }
+    }
+  }
+
+  let entry = warm.get(sid);
+  const isCold = !entry;
+  if (!entry) {
+    entry = allocEntry(sid);
+  }
+
+  // Reparent (or initial-parent) into the live host.
+  try {
+    host.appendChild(entry.wrapper);
+  } catch (e) {
+    warn('xterm-warm', 'show reparent failed', e);
+  }
+
+  entry.lastAccessedAt = Date.now();
+  activeSid = sid;
+  try {
+    window.__ccsmTerm = entry.term;
+  } catch {
+    /* probe handle is best-effort */
+  }
+
+  if (!isCold) {
+    // Warm path probe — fires only on cache hit. Cold path emits
+    // `terminal.warmAlloc` from `allocEntry`. Includes viewport
+    // diagnostics so the parent can verify the bottom-pin invariant
+    // holds against the warm switch — same shape as the `attach.*`
+    // family from PR #1352.
+    try {
+      const buf = entry.term.buffer?.active;
+      log.event('attach.warm.shown', {
+        sid,
+        viewportY: buf?.viewportY ?? 0,
+        baseY: buf?.baseY ?? 0,
+        bufferType: buf?.type ?? 'normal',
+        cursorY: buf?.cursorY ?? 0,
+        length: buf?.length ?? 0,
+        atBottom: (buf?.viewportY ?? 0) === (buf?.baseY ?? 0),
+        warmCacheSize: warm.size,
+        cause,
+      });
+    } catch {
+      /* probe failure must not break show */
+    }
+  }
+
+  return { entry, isCold };
+}
+
+/**
+ * Tear down the entry for `sid`: unsubscribe PTY data, dispose the xterm
+ * Terminal (which detaches all addons and frees the canvas atlas), remove
+ * the wrapper from DOM, and drop the map entry. Emits
+ * `terminal.warmEvict` with the supplied cause. Idempotent on unknown sid.
+ *
+ * The PTY-side `attach`/`detach` bookkeeping is the responsibility of the
+ * attach hook, NOT this module. We only own the renderer's xterm.
+ */
+export function disposeEntry(
+  sid: string,
+  cause: 'lru' | 'session-deleted' | 'reset' | 'unload',
+): void {
+  const entry = warm.get(sid);
+  if (!entry) return;
+  warm.delete(sid);
+  if (activeSid === sid) {
+    activeSid = null;
+    try {
+      delete window.__ccsmTerm;
+    } catch {
+      /* ignore */
+    }
+  }
+  try {
+    entry.dataUnsubscribe();
+  } catch (e) {
+    warn('xterm-warm', 'dataUnsubscribe failed', e);
+  }
+  try {
+    entry.wrapper.remove();
+  } catch (e) {
+    warn('xterm-warm', 'wrapper.remove failed', e);
+  }
+  try {
+    entry.term.dispose();
+  } catch (e) {
+    warn('xterm-warm', 'term.dispose failed', e);
+  }
+  try {
+    log.event('terminal.warmEvict', { sid, lruSize: warm.size, cause });
+  } catch {
+    /* probe failure tolerated */
+  }
+}
+
+/**
+ * Test-only: drop all entries without emitting probes (tests don't want
+ * probe noise polluting their own assertions). Also resets the
+ * offscreen-holder pointer + the unload-listener flag so the next test
+ * starts from a clean slate.
+ */
+export function __resetRegistryForTests(): void {
+  for (const entry of warm.values()) {
+    try {
+      entry.dataUnsubscribe();
+    } catch {
+      /* ignore */
+    }
+    try {
+      entry.wrapper.remove();
+    } catch {
+      /* ignore */
+    }
+    try {
+      entry.term.dispose();
+    } catch {
+      /* ignore */
+    }
+  }
+  warm.clear();
+  activeSid = null;
+  if (offscreenHolder) {
+    try {
+      offscreenHolder.remove();
+    } catch {
+      /* ignore */
+    }
+  }
+  offscreenHolder = null;
+  beforeUnloadInstalled = false;
+  if (typeof window !== 'undefined') {
+    try {
+      delete window.__ccsmTerm;
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/src/terminal/xtermWarmRegistry.ts
+++ b/src/terminal/xtermWarmRegistry.ts
@@ -38,6 +38,15 @@ import { warn, log } from '../shared/log';
 
 const DEFAULT_WARM_CAP = 20;
 /**
+ * Soft cap on `router.buffered` length. The buffering window is normally
+ * sub-second (alloc → cold-attach snapshot → applySnapshot drains).
+ * 256 chunks ≈ tens of KB at typical chunk sizes — plenty of headroom
+ * for a healthy attach, while bounding growth if cold-attach hangs
+ * (e.g. term.open() retry path never succeeds). On overflow we drop
+ * the OLDEST entry so the most recent live tail survives.
+ */
+const BUFFERING_SOFT_CAP = 256;
+/**
  * Minimum WARM_CAP. Hard floor of 2 (not 1).
  *
  * Rationale (Major 3 from cold review): with `cap === 1`, the
@@ -352,23 +361,20 @@ function allocEntry(sid: string): WarmEntry {
   entryRouters.set(sid, router);
   const pty = window.ccsmPty;
   let dataUnsubscribe = () => {};
-  // Diagnostic counters (dev-only — see probes below). Tracking the very
-  // first chunk per-entry is enough to bisect "did onData fire at all?"
-  // vs "did sid filter drop it?" vs "did router get stuck in buffering?".
-  let firstChunkLogged = false;
+  // One-shot probe flags — independent so a `sid-mismatch` first callback
+  // doesn't suppress the subsequent `warm.data.received` probe. Under the
+  // multi-subscriber pty.onData fan-out the first invocation is commonly
+  // for someone else's sid; a shared flag would mislead future bisection.
+  let receivedLogged = false;
+  let filteredLogged = false;
   if (pty?.onData) {
-    try {
-      log.event('warm.subscription.installed', { sid });
-    } catch {
-      /* probe failure tolerated */
-    }
     dataUnsubscribe = pty.onData((payload: { sid: string; chunk: string; seq: number }) => {
       if (payload.sid !== sid) {
-        if (!firstChunkLogged) {
+        if (!filteredLogged) {
           // One-shot: the FIRST callback invocation that was filtered out
           // by sid mismatch. Tells us callback fires but our sid doesn't
           // match what main is broadcasting. count=0 sentinel.
-          firstChunkLogged = true;
+          filteredLogged = true;
           try {
             log.event('warm.data.filtered', { sid, count: 0, stage: 'sid-mismatch' });
           } catch {
@@ -377,8 +383,8 @@ function allocEntry(sid: string): WarmEntry {
         }
         return;
       }
-      if (!firstChunkLogged) {
-        firstChunkLogged = true;
+      if (!receivedLogged) {
+        receivedLogged = true;
         try {
           log.event('warm.data.received', {
             sid,
@@ -392,8 +398,16 @@ function allocEntry(sid: string): WarmEntry {
       }
       if (router.mode === 'buffering') {
         // Stash with seq so applySnapshot can drop dupes vs. the
-        // serialized snapshot it's about to land.
+        // serialized snapshot it's about to land. Soft cap: drop the
+        // OLDEST entries past the cap so an unexpectedly long buffering
+        // window (e.g. term.open() retry path never succeeding) can't
+        // grow router.buffered unbounded. 256 chunks ≈ several seconds
+        // of normal output; we hit applySnapshot well before this in
+        // any healthy attach.
         router.buffered.push({ seq: payload.seq, chunk: payload.chunk });
+        if (router.buffered.length > BUFFERING_SOFT_CAP) {
+          router.buffered.shift();
+        }
         return;
       }
       // 'live' mode: drop pre-snap chunks (defensive — should be empty
@@ -478,18 +492,17 @@ export function ensureAndShowEntry(
 
   // First-time open: deferred from allocEntry so the xterm renderer
   // initializes against real visible geometry rather than the 0x0
-  // offscreen holder (see WarmEntry.opened docs). Also fit() immediately
-  // so the canvas atlas sizes against non-zero dimensions; the
-  // cold-attach hook's later fit() call is then a no-op refresh.
+  // offscreen holder (see WarmEntry.opened docs). We do NOT call
+  // fit.fit() here — host layout may not have settled on the same
+  // microtask, and (cold path) usePtyAttach.warm.ts calls fit.fit()
+  // after term.resize() + snapshot write a few ms later, which sizes
+  // the canvas atlas against fully-laid-out dimensions. The eager fit
+  // here would either redundantly force layout or compute cols=0 when
+  // host itself is still hidden.
   if (!entry.opened) {
     try {
       entry.term.open(entry.wrapper);
       entry.opened = true;
-      try {
-        entry.fit.fit();
-      } catch (e) {
-        warn('xterm-warm', 'initial fit failed', e);
-      }
     } catch (e) {
       warn('xterm-warm', 'term.open failed', e);
       // Leave entry.opened=false; a future show may retry.

--- a/src/terminal/xtermWarmRegistry.ts
+++ b/src/terminal/xtermWarmRegistry.ts
@@ -11,7 +11,14 @@
 // `CCSM_WARM_XTERM=1` env flag is set (read at preload init, surfaced via
 // `window.ccsm.featureFlags.warmXterm`). The legacy singleton
 // (`./xtermSingleton.ts`) remains the default path. When the flag is off
-// nothing in this file is imported.
+// this file IS imported (TerminalPane references `usePtyAttachWarm`
+// statically so both branches type-check), but all side effects — the
+// `beforeunload` cleanup and the module-level `pty.onExit` subscription —
+// are lazy behind `installUnloadCleanupOnce` / `installExitListenerOnce`,
+// which are ONLY invoked from `allocEntry`. `allocEntry` itself is only
+// reached via `ensureAndShowEntry`, called exclusively by the warm hook.
+// Net effect with flag off: importing this file allocates no listeners
+// and runs no DOM work.
 //
 // Transparent-transport invariant: this module fans out PTY data to the
 // per-session xterm via `window.ccsmPty.onData` (multi-subscriber, see

--- a/src/terminal/xtermWarmRegistry.ts
+++ b/src/terminal/xtermWarmRegistry.ts
@@ -30,6 +30,26 @@ import { SCROLLBACK_LINES_DEFAULT } from '../stores/slices/types';
 import { warn, log } from '../shared/log';
 
 const DEFAULT_WARM_CAP = 20;
+/**
+ * Minimum WARM_CAP. Hard floor of 2 (not 1).
+ *
+ * Rationale (Major 3 from cold review): with `cap === 1`, the
+ * `allocEntry` eviction loop simultaneously exempts the incoming sid AND
+ * the current active sid. When the only map entry IS the active sid and
+ * the user switches to a new sid, BOTH candidates are exempt → loop
+ * finds no victim → we `set()` past cap and overflow to size 2. A
+ * `cap === 1` warm cache is also semantically pointless: the warm
+ * cache's only value is keeping ≥1 OTHER session's Terminal alive while
+ * the user is on the active one. So we refuse caps below 2.
+ *
+ * `CCSM_WARM_XTERM_CAP=1` is clamped UP to 2 with no error — friendlier
+ * than crashing on a config typo. The clamp happens in two places (env
+ * parser in `electron/preload/bridges/ccsmCore.ts` AND `getWarmCap()`
+ * below); the renderer-side clamp is the authoritative floor since the
+ * preload value is purely advisory.
+ */
+const WARM_CAP_MIN = 2;
+const WARM_CAP_MAX = 100;
 
 /** Look up the runtime LRU cap. Honours `CCSM_WARM_XTERM_CAP` (surfaced via
  *  `window.ccsm.featureFlags.warmXtermCap`, clamped to [1,100] at preload).
@@ -38,7 +58,7 @@ export function getWarmCap(): number {
   try {
     const override = window.ccsm?.featureFlags?.warmXtermCap;
     if (typeof override === 'number' && Number.isFinite(override) && override > 0) {
-      return Math.min(100, Math.max(1, Math.floor(override)));
+      return Math.min(WARM_CAP_MAX, Math.max(WARM_CAP_MIN, Math.floor(override)));
     }
   } catch {
     // window.ccsm absent in headless tests — fall through to default.
@@ -74,23 +94,114 @@ export type WarmEntry = {
   lastAccessedAt: number;
 };
 
+/**
+ * Per-entry chunk-routing state (Major 1 fix from cold review).
+ *
+ * The legacy `usePtyAttach` cold path serializes the headless buffer and
+ * uses an entry-local `snapSeq` to drop chunks already represented in
+ * the serialized snapshot. The warm registry has the same race: between
+ * `pty.attach` resolving (main starts broadcasting chunks to our
+ * webContents) and the cold-path snapshot being written, the per-entry
+ * listener receives live chunks. The previous implementation wrote them
+ * straight to `term`, then the cold path called `term.reset()` —
+ * silently dropping those chunks forever. They were never replayed.
+ *
+ * Fix: the listener has three modes.
+ *   1. `buffering` (default at alloc): chunks land in {@link buffered}
+ *      with their seq, NOT written to term. This is the mode while the
+ *      cold path is still in flight.
+ *   2. `live`: chunks past `snapSeq` are written directly to term;
+ *      chunks <= `snapSeq` are dropped (already in the snapshot, which
+ *      the cold path has by now applied). This is the steady state.
+ *   3. The transition is driven by {@link applySnapshot}, called by
+ *      the cold-attach hook AFTER it has called `term.reset()` and
+ *      `term.write(snapshot)`: it sets `snapSeq`, drains
+ *      `buffered`-with-`seq > snapSeq` into term in arrival order, and
+ *      flips mode to `live`.
+ *
+ * Warm-cache hits never alloc — they reuse an entry that's already in
+ * `live` mode, so warm switching has zero buffering overhead.
+ */
+type EntryRouter = {
+  mode: 'buffering' | 'live';
+  snapSeq: number | null;
+  buffered: Array<{ seq: number; chunk: string }>;
+};
+
+const entryRouters: Map<string, EntryRouter> = new Map();
+
 const warm: Map<string, WarmEntry> = new Map();
 let activeSid: string | null = null;
 let offscreenHolder: HTMLDivElement | null = null;
 
-// Module-level reset listener — fires once when the renderer unloads so
-// addons release their canvas atlases / WebGL contexts cleanly. Best-effort
-// only; the OS reclaims memory either way.
-let beforeUnloadInstalled = false;
+// Global PTY exit subscription (Major 2 fix from cold review).
+//
+// The legacy `usePtyAttach.ts` installed an `onExit` listener per hook
+// instance that filtered `evt.sessionId !== getActiveSid()` and silently
+// returned for hidden sessions — meaning a backgrounded session that
+// crashed left no trace: the user switched back to a "ready" UI with no
+// terminal content and no exit overlay. Under the warm model that's a
+// much bigger gap because hidden sessions are EXPECTED to keep running.
+//
+// Fix: install a single module-level listener that calls
+// `useStore.getState()._applyPtyExit(sid, ...)` for EVERY sid
+// unconditionally. The per-hook effect then reads
+// `disconnectedSessions[sessionId]` and flips local state to `exit` when
+// it sees an entry — including the case where the user switches back to
+// a session that already crashed while hidden.
+//
+// The listener is installed lazily on first registry use (alongside the
+// unload cleanup) so test setups that don't construct the warm path
+// don't get a phantom subscription. Idempotent — only one listener
+// across the renderer's lifetime.
+let exitUnsubscribe: (() => void) | null = null;
+function installExitListenerOnce(): void {
+  if (exitUnsubscribe) return;
+  const pty = typeof window !== 'undefined' ? window.ccsmPty : undefined;
+  if (!pty?.onExit) return;
+  exitUnsubscribe = pty.onExit(
+    (evt: { sessionId: string; code?: number | null; signal?: string | number | null }) => {
+      const sid = evt.sessionId;
+      if (!sid) return;
+      try {
+        // Coerce signal to number|null — the store slice accepts that
+        // shape (see sessionRuntimeSlice._applyPtyExit). String signals
+        // ('SIGTERM' etc.) coerce via the classifier; null/undefined
+        // both land as null.
+        const code = evt.code ?? null;
+        const rawSignal = evt.signal ?? null;
+        const signal =
+          typeof rawSignal === 'number'
+            ? rawSignal
+            : rawSignal == null
+              ? null
+              : // string signal — store/classifier expects number|null, so
+                // pass null and let the code field carry the diagnostic.
+                null;
+        useStore.getState()._applyPtyExit(sid, { code, signal });
+      } catch (e) {
+        warn('xterm-warm', 'exit dispatch failed', e);
+      }
+    },
+  );
+}
+// Module-level renderer-unload cleanup — fires once when the renderer
+// unloads so addons release their canvas atlases / WebGL contexts
+// cleanly. Best-effort only; the OS reclaims memory either way.
+// Captured into a module-scope variable so `__resetRegistryForTests`
+// can detach it on cleanup (Minor 7 from cold review) — a leftover
+// listener across vitest re-imports would otherwise pile up
+// disposed-entry references.
+let beforeUnloadHandler: (() => void) | null = null;
 function installUnloadCleanupOnce(): void {
-  if (beforeUnloadInstalled) return;
+  if (beforeUnloadHandler) return;
   if (typeof window === 'undefined') return;
-  beforeUnloadInstalled = true;
-  window.addEventListener('beforeunload', () => {
+  beforeUnloadHandler = () => {
     for (const sid of Array.from(warm.keys())) {
       disposeEntry(sid, 'unload');
     }
-  });
+  };
+  window.addEventListener('beforeunload', beforeUnloadHandler);
 }
 
 function getOffscreenHolder(): HTMLDivElement {
@@ -137,6 +248,7 @@ export function getActiveEntry(): WarmEntry | undefined {
  */
 function allocEntry(sid: string): WarmEntry {
   installUnloadCleanupOnce();
+  installExitListenerOnce();
 
   // LRU eviction: trim BEFORE allocating so we never exceed cap.
   const cap = getWarmCap();
@@ -209,11 +321,33 @@ function allocEntry(sid: string): WarmEntry {
   // Per-entry PTY data subscription. Filters by sid (NOT by the global
   // active sid) so hidden sessions keep ingesting live output. The bytes
   // are passed through to `term.write` unmodified — transparent transport.
+  //
+  // Routing modes (see EntryRouter docs above):
+  //   - 'buffering' (default until applySnapshot): chunks accumulate in
+  //     router.buffered with their seq. NOT written to term yet, because
+  //     the cold-attach path is about to call term.reset() + write the
+  //     snapshot; writing live chunks before then would be silently
+  //     dropped by reset(). This is the Major 1 fix from cold review.
+  //   - 'live': chunks with seq > router.snapSeq are written immediately;
+  //     chunks <= snapSeq are dropped (already represented in the
+  //     snapshot the cold path applied). Warm-cache hits stay in this
+  //     mode for the entry's whole life — the first cold path flipped it.
+  const router: EntryRouter = { mode: 'buffering', snapSeq: null, buffered: [] };
+  entryRouters.set(sid, router);
   const pty = window.ccsmPty;
   let dataUnsubscribe = () => {};
   if (pty?.onData) {
-    dataUnsubscribe = pty.onData((payload: { sid: string; chunk: string }) => {
+    dataUnsubscribe = pty.onData((payload: { sid: string; chunk: string; seq: number }) => {
       if (payload.sid !== sid) return;
+      if (router.mode === 'buffering') {
+        // Stash with seq so applySnapshot can drop dupes vs. the
+        // serialized snapshot it's about to land.
+        router.buffered.push({ seq: payload.seq, chunk: payload.chunk });
+        return;
+      }
+      // 'live' mode: drop pre-snap chunks (defensive — should be empty
+      // by here since applySnapshot drained them), write the rest.
+      if (router.snapSeq != null && payload.seq <= router.snapSeq) return;
       try {
         term.write(payload.chunk);
       } catch {
@@ -326,6 +460,51 @@ export function ensureAndShowEntry(
 }
 
 /**
+ * Cold-attach rendezvous (Major 1 fix from cold review).
+ *
+ * Called by the warm `usePtyAttach` hook AFTER it has:
+ *   1. `await pty.attach(sid)`     (main starts broadcasting chunks)
+ *   2. `await pty.getBufferSnapshot(sid)`   (gives us `{snapshot, seq}`)
+ *   3. `entry.term.reset()` + `entry.term.write(snapshot)`
+ *
+ * At this point the per-entry data listener has been buffering live
+ * chunks since alloc. We:
+ *   a. Set `router.snapSeq = snapSeq` so future late chunks dedupe.
+ *   b. Drain `router.buffered` — chunks with `seq > snapSeq` get
+ *      written in arrival order; chunks `<= snapSeq` are already in
+ *      the snapshot we just wrote and would duplicate.
+ *   c. Flip `router.mode` to 'live'. Subsequent chunks bypass the
+ *      buffer entirely and write straight to term.
+ *
+ * Idempotent if the router is missing (entry was disposed mid-attach).
+ * Idempotent if mode is already 'live' (e.g. retry path re-calls into
+ * a now-warm entry).
+ */
+export function applySnapshot(sid: string, snapSeq: number): void {
+  const router = entryRouters.get(sid);
+  if (!router) return;
+  const entry = warm.get(sid);
+  if (!entry) return;
+  router.snapSeq = snapSeq;
+  // Drain in arrival order. Chunks <= snapSeq are baked into the
+  // snapshot the cold path just wrote — drop them. The rest is the
+  // "live tail" that arrived between attach-resolve and snapshot-land.
+  if (router.buffered.length > 0) {
+    for (const b of router.buffered) {
+      if (b.seq > snapSeq) {
+        try {
+          entry.term.write(b.chunk);
+        } catch {
+          // best-effort — term may have been disposed mid-drain.
+        }
+      }
+    }
+    router.buffered.length = 0;
+  }
+  router.mode = 'live';
+}
+
+/**
  * Tear down the entry for `sid`: unsubscribe PTY data, dispose the xterm
  * Terminal (which detaches all addons and frees the canvas atlas), remove
  * the wrapper from DOM, and drop the map entry. Emits
@@ -336,11 +515,15 @@ export function ensureAndShowEntry(
  */
 export function disposeEntry(
   sid: string,
-  cause: 'lru' | 'session-deleted' | 'reset' | 'unload',
+  cause: 'lru' | 'session-deleted' | 'reset' | 'unload' | 'cancelled-mid-cold-attach',
 ): void {
   const entry = warm.get(sid);
   if (!entry) return;
   warm.delete(sid);
+  // Drop the router so a future re-alloc for this sid starts fresh in
+  // 'buffering' mode (Major 1) rather than inheriting a half-applied
+  // snapSeq from the disposed entry.
+  entryRouters.delete(sid);
   if (activeSid === sid) {
     activeSid = null;
     try {
@@ -396,6 +579,7 @@ export function __resetRegistryForTests(): void {
     }
   }
   warm.clear();
+  entryRouters.clear();
   activeSid = null;
   if (offscreenHolder) {
     try {
@@ -405,7 +589,28 @@ export function __resetRegistryForTests(): void {
     }
   }
   offscreenHolder = null;
-  beforeUnloadInstalled = false;
+  // Detach the beforeunload listener — leaving it attached across vitest
+  // re-imports leaks stale closures that reference disposed entries
+  // (Minor 7 from cold review).
+  if (beforeUnloadHandler && typeof window !== 'undefined') {
+    try {
+      window.removeEventListener('beforeunload', beforeUnloadHandler);
+    } catch {
+      /* ignore */
+    }
+  }
+  beforeUnloadHandler = null;
+  // Drop the global PTY exit subscription so the next test starts with
+  // no listener (Major 2 fix). Without this, a stale subscription would
+  // dispatch into the previous test's store stub.
+  if (exitUnsubscribe) {
+    try {
+      exitUnsubscribe();
+    } catch {
+      /* ignore */
+    }
+  }
+  exitUnsubscribe = null;
   if (typeof window !== 'undefined') {
     try {
       delete window.__ccsmTerm;

--- a/src/terminal/xtermWarmRegistry.ts
+++ b/src/terminal/xtermWarmRegistry.ts
@@ -52,7 +52,7 @@ const WARM_CAP_MIN = 2;
 const WARM_CAP_MAX = 100;
 
 /** Look up the runtime LRU cap. Honours `CCSM_WARM_XTERM_CAP` (surfaced via
- *  `window.ccsm.featureFlags.warmXtermCap`, clamped to [1,100] at preload).
+ *  `window.ccsm.featureFlags.warmXtermCap`, clamped to [2,100] at preload).
  *  Falls back to {@link DEFAULT_WARM_CAP} when the override is absent. */
 export function getWarmCap(): number {
   try {
@@ -164,21 +164,17 @@ function installExitListenerOnce(): void {
       const sid = evt.sessionId;
       if (!sid) return;
       try {
-        // Coerce signal to number|null — the store slice accepts that
-        // shape (see sessionRuntimeSlice._applyPtyExit). String signals
-        // ('SIGTERM' etc.) coerce via the classifier; null/undefined
-        // both land as null.
-        const code = evt.code ?? null;
-        const rawSignal = evt.signal ?? null;
-        const signal =
-          typeof rawSignal === 'number'
-            ? rawSignal
-            : rawSignal == null
-              ? null
-              : // string signal — store/classifier expects number|null, so
-                // pass null and let the code field carry the diagnostic.
-                null;
-        useStore.getState()._applyPtyExit(sid, { code, signal });
+        // Pass code + signal through unchanged. The store slice's
+        // `disconnectedSessions[sid].signal` field accepts
+        // `string | number | null` — see `src/stores/slices/types.ts` —
+        // so string signals ('SIGTERM' / 'SIGKILL' / etc.) flow through
+        // to `classifyPtyExit` for the crashed-vs-clean overlay
+        // distinction. Nullifying them here (as the prior fix did)
+        // silently lost the diagnostic the legacy hook relied on.
+        useStore.getState()._applyPtyExit(sid, {
+          code: evt.code ?? null,
+          signal: evt.signal ?? null,
+        });
       } catch (e) {
         warn('xterm-warm', 'exit dispatch failed', e);
       }

--- a/tests/terminal/usePtyAttachWarm.race.test.tsx
+++ b/tests/terminal/usePtyAttachWarm.race.test.tsx
@@ -1,0 +1,253 @@
+// Hook-level race regression for `usePtyAttachWarm` (PR #1355 round-2
+// cold review).
+//
+// Specific race being defended against:
+//   1. Session S crashes while hidden — the registry's module-level
+//      onExit listener writes `disconnectedSessions[S]` to the store.
+//   2. User switches BACK to S. The `usePtyAttachWarm(S, ...)` mount
+//      begins.
+//   3. The disconnect-watch effect fires first (synchronously after the
+//      attach effect kicks off its async chain) and sets local state to
+//      `'exit'`.
+//   4. The attach effect's async tail resolves and would naively
+//      `setState({kind:'ready'}, 'attach-warm-complete')` — overwriting
+//      'exit'. The watcher cannot re-fire because the disconnect
+//      object's identity is unchanged → user stranded on 'ready' for
+//      a dead session.
+//
+// The fix: BEFORE flipping to 'ready', the attach effect synchronously
+// reads `useStore.getState().disconnectedSessions[sessionId]` and emits
+// 'exit' instead when an entry exists. This test asserts the fix.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// ---- store mock ----------------------------------------------------------
+// We need a live, mutable mock of the store that supports both the
+// `useStore(selector)` subscription pattern AND `useStore.getState()`.
+//
+// The mock state has only the slices the warm hook touches:
+//   - `_clearPtyExit(sid)`           — spy
+//   - `pendingForkSource`            — empty (no copy-session in scope)
+//   - `reloadNonce`                  — empty (no reload in scope)
+//   - `disconnectedSessions[sid]`    — controlled per test
+//
+// Vitest hoists `vi.mock` factories above all top-level statements, so
+// the spies and shared state object must be declared with `vi.hoisted`.
+const { storeState, clearPtyExitSpy, applyPtyExitSpy } = vi.hoisted(() => {
+  const clearPtyExitSpy = vi.fn();
+  const applyPtyExitSpy = vi.fn();
+  const storeState: {
+    _clearPtyExit: ReturnType<typeof vi.fn>;
+    _applyPtyExit: ReturnType<typeof vi.fn>;
+    pendingForkSource: Record<string, string>;
+    reloadNonce: Record<string, number>;
+    disconnectedSessions: Record<
+      string,
+      { kind: 'clean' | 'crashed'; code: number | null; signal: string | number | null; at: number }
+    >;
+    scrollbackLines: number;
+  } = {
+    _clearPtyExit: clearPtyExitSpy,
+    _applyPtyExit: applyPtyExitSpy,
+    pendingForkSource: {},
+    reloadNonce: {},
+    disconnectedSessions: {},
+    scrollbackLines: 1000,
+  };
+  return { storeState, clearPtyExitSpy, applyPtyExitSpy };
+});
+
+vi.mock('../../src/stores/store', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const useStore = ((selector: (s: any) => any) => selector(storeState)) as any;
+  useStore.getState = () => storeState;
+  useStore.setState = (
+    patch:
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      | Record<string, any>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      | ((s: typeof storeState) => Record<string, any>),
+  ) => {
+    const next = typeof patch === 'function' ? patch(storeState) : patch;
+    Object.assign(storeState, next ?? {});
+  };
+  return { useStore };
+});
+
+// ---- xterm mocks ---------------------------------------------------------
+// The warm registry constructs real-ish Terminal instances. We supply
+// minimal stand-ins so the hook can run through to its setState
+// transitions without exploding on missing DOM behavior.
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn(function () {
+    const inst = {
+      open: vi.fn(),
+      loadAddon: vi.fn(),
+      write: vi.fn((_s: string, cb?: () => void) => cb?.()),
+      reset: vi.fn(),
+      focus: vi.fn(),
+      scrollToBottom: vi.fn(),
+      onData: vi.fn(() => ({ dispose: vi.fn() })),
+      resize: vi.fn(),
+      cols: 80,
+      rows: 24,
+      unicode: { activeVersion: '6' },
+      modes: { bracketedPasteMode: false },
+      buffer: {
+        active: { viewportY: 0, baseY: 0, cursorY: 0, length: 0, type: 'normal' as const },
+      },
+      dispose: vi.fn(),
+    };
+    return inst;
+  }),
+}));
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn(function () {
+    return { fit: vi.fn() };
+  }),
+}));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-canvas', () => ({ CanvasAddon: vi.fn(function () { return {}; }) }));
+
+// Silence log.event probes.
+vi.mock('../../src/shared/log', () => ({
+  log: { event: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+// ---- imports (must come AFTER vi.mock calls) ----------------------------
+import { usePtyAttachWarm } from '../../src/terminal/usePtyAttach.warm';
+import { __resetRegistryForTests } from '../../src/terminal/xtermWarmRegistry';
+
+// ---- pty bridge helpers --------------------------------------------------
+function installFakePty(): void {
+  (window as unknown as { ccsmPty: unknown }).ccsmPty = {
+    attach: vi.fn(async () => ({ cols: 80, rows: 24, pid: 1234 })),
+    spawn: vi.fn(async () => ({ ok: true, sid: 'unused', pid: 1234, cols: 80, rows: 24 })),
+    detach: vi.fn(async () => undefined),
+    input: vi.fn(async () => undefined),
+    resize: vi.fn(async () => undefined),
+    getBufferSnapshot: vi.fn(async () => ({ snapshot: 'SNAP', seq: 0 })),
+    onData: vi.fn(() => () => undefined),
+    onExit: vi.fn(() => () => undefined),
+  };
+}
+
+function uninstallFakePty(): void {
+  delete (window as unknown as { ccsmPty?: unknown }).ccsmPty;
+}
+
+// Drain the warm-hook's async chain (attach → snapshot → applySnapshot →
+// pin rendezvous → setState). Three setTimeout-0 yields suffice — same
+// pattern as the legacy harness's `settleAttach`.
+async function settleAttach(): Promise<void> {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+describe('usePtyAttachWarm — disconnectedSessions race (round-2 review Major)', () => {
+  let host: HTMLDivElement;
+  let hostRef: { current: HTMLDivElement | null };
+
+  beforeEach(() => {
+    installFakePty();
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    hostRef = { current: host };
+    storeState.pendingForkSource = {};
+    storeState.reloadNonce = {};
+    storeState.disconnectedSessions = {};
+    clearPtyExitSpy.mockClear();
+    applyPtyExitSpy.mockClear();
+  });
+
+  afterEach(() => {
+    __resetRegistryForTests();
+    document.body.removeChild(host);
+    uninstallFakePty();
+  });
+
+  // The exact race: store already has disconnectedSessions[sid] when the
+  // attach effect starts. Without the fix, the cold-path setState('ready')
+  // would clobber the disconnect-watcher's setState('exit').
+  it('cold attach to an already-crashed sid lands in exit state, NOT ready', async () => {
+    storeState.disconnectedSessions['sid-crashed'] = {
+      kind: 'crashed',
+      code: null,
+      signal: 'SIGSEGV',
+      at: Date.now(),
+    };
+    const { result } = renderHook(() =>
+      usePtyAttachWarm('sid-crashed', '/tmp', hostRef),
+    );
+    await settleAttach();
+
+    expect(result.current.state.kind).toBe('exit');
+    if (result.current.state.kind === 'exit') {
+      expect(result.current.state.exitKind).toBe('crashed');
+      expect(result.current.state.detail).toBe('signal SIGSEGV');
+    }
+    // Critical contract: _clearPtyExit must NOT be called when we land
+    // in exit. Clearing would delete the diagnostic AND break the
+    // watcher's identity comparison so the user could never escape a
+    // bad 'ready' state.
+    expect(clearPtyExitSpy).not.toHaveBeenCalled();
+  });
+
+  // Steady-state correctness — without a prior disconnect entry the
+  // attach effect still flips to 'ready' as before, and clears any
+  // stale ptyExit slice (matching legacy behaviour).
+  it('cold attach to a healthy sid still lands in ready and clears ptyExit', async () => {
+    const { result } = renderHook(() =>
+      usePtyAttachWarm('sid-fresh', '/tmp', hostRef),
+    );
+    await settleAttach();
+
+    expect(result.current.state.kind).toBe('ready');
+    expect(clearPtyExitSpy).toHaveBeenCalledWith('sid-fresh');
+  });
+
+  // Warm path: pre-populate the registry by attaching once, then mount
+  // again for the same sid with a disconnect entry in the store. The
+  // warm completion path must ALSO resolve to 'exit' instead of 'ready'.
+  it('warm reshow of an already-crashed sid lands in exit state, NOT ready', async () => {
+    // First attach: healthy session lands in 'ready' and entry warmed.
+    const first = renderHook(() => usePtyAttachWarm('sid-W', '/tmp', hostRef));
+    await settleAttach();
+    expect(first.result.current.state.kind).toBe('ready');
+    first.unmount();
+
+    // Now simulate: while no hook was mounted for sid-W, it crashed.
+    // The module-level registry listener (which IS still subscribed —
+    // see registry test for that contract) wrote disconnectedSessions.
+    storeState.disconnectedSessions['sid-W'] = {
+      kind: 'crashed',
+      code: 1,
+      signal: null,
+      at: Date.now(),
+    };
+    clearPtyExitSpy.mockClear();
+
+    // Re-mount: this is the "user switched back to a session that
+    // crashed while hidden" flow. The warm path returns early after
+    // reparent+fit+pin — without the fix, it would unconditionally
+    // setState('ready') and clobber the disconnect watcher's 'exit'.
+    const second = renderHook(() => usePtyAttachWarm('sid-W', '/tmp', hostRef));
+    await settleAttach();
+    expect(second.result.current.state.kind).toBe('exit');
+    if (second.result.current.state.kind === 'exit') {
+      expect(second.result.current.state.exitKind).toBe('crashed');
+      expect(second.result.current.state.detail).toBe('exit code 1');
+    }
+    expect(clearPtyExitSpy).not.toHaveBeenCalled();
+    second.unmount();
+  });
+});

--- a/tests/terminal/xtermWarmRegistry.test.ts
+++ b/tests/terminal/xtermWarmRegistry.test.ts
@@ -340,4 +340,31 @@ describe('xtermWarmRegistry', () => {
     expect(getEntry('sid-3')).toBeDefined();
     nowSpy.mockRestore();
   });
+
+  it('defers term.open() until first ensureAndShowEntry (renderer-init invariant)', () => {
+    // Regression lock: a prior bug called term.open(wrapper) inside
+    // allocEntry while wrapper was parented in a 0x0 visibility:hidden
+    // offscreen holder. xterm 5.5's renderer latched onto that geometry
+    // and the paint scheduler stayed quiesced — chunks parsed but DOM
+    // stayed empty. Fix defers open() to first show, when wrapper is in
+    // the visible host. This test asserts the deferred-open contract
+    // directly so the bug can't silently come back.
+    const { entry } = ensureAndShowEntry('sid-deferred', host);
+    // Mock terminal exposes `open` as a vi.fn(). It MUST have been called
+    // exactly once, and with the wrapper that is now host-parented.
+    const openSpy = (entry.term as unknown as { open: ReturnType<typeof vi.fn> }).open;
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(openSpy).toHaveBeenCalledWith(entry.wrapper);
+    expect(entry.wrapper.parentElement).toBe(host);
+    expect(entry.opened).toBe(true);
+
+    // Hide then re-show: term.open must NOT be called again (opened flag).
+    const host2 = document.createElement('div');
+    document.body.appendChild(host2);
+    ensureAndShowEntry('sid-other', host2);
+    ensureAndShowEntry('sid-deferred', host);
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(entry.opened).toBe(true);
+    document.body.removeChild(host2);
+  });
 });

--- a/tests/terminal/xtermWarmRegistry.test.ts
+++ b/tests/terminal/xtermWarmRegistry.test.ts
@@ -1,0 +1,212 @@
+// Registry semantics for the per-session warm xterm (PR #25). These tests
+// exercise the Map/LRU/lifecycle logic in jsdom; the visual DOM-reparent
+// flow is empirical-only per the parent brief.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock xterm constructors so we don't spin up real terminals in jsdom.
+// `vi.hoisted` runs before the imports below.
+const { terminalCtor, addonCtor } =
+  vi.hoisted(() => {
+    const terminalCtor = vi.fn(function () {
+      // Per-instance spies so two Terminals in the same test track
+      // their own writes / disposals independently.
+      const inst = {
+        open: vi.fn(),
+        loadAddon: vi.fn(),
+        write: vi.fn(),
+        dispose: vi.fn(),
+        reset: vi.fn(),
+        focus: vi.fn(),
+        scrollToBottom: vi.fn(),
+        onData: vi.fn(() => ({ dispose: vi.fn() })),
+        resize: vi.fn(),
+        cols: 80,
+        rows: 24,
+        unicode: { activeVersion: '6' },
+        modes: { bracketedPasteMode: false },
+        buffer: {
+          active: { viewportY: 0, baseY: 0, cursorY: 0, length: 0, type: 'normal' },
+        },
+      };
+      return inst;
+    });
+    const addonCtor = vi.fn(function () {
+      return { fit: vi.fn() };
+    });
+    return { terminalCtor, addonCtor };
+  });
+
+vi.mock('@xterm/xterm', () => ({ Terminal: terminalCtor }));
+vi.mock('@xterm/addon-fit', () => ({ FitAddon: addonCtor }));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-canvas', () => ({ CanvasAddon: vi.fn(function () { return {}; }) }));
+
+// Quiet log.event probes — they're not under test here.
+vi.mock('../../src/shared/log', () => ({
+  log: { event: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+import {
+  ensureAndShowEntry,
+  disposeEntry,
+  getEntry,
+  getActiveSid,
+  getWarmCacheSize,
+  __resetRegistryForTests,
+} from '../../src/terminal/xtermWarmRegistry';
+
+describe('xtermWarmRegistry', () => {
+  let host: HTMLDivElement;
+  let onDataListeners: Array<(p: { sid: string; chunk: string }) => void>;
+
+  beforeEach(() => {
+    onDataListeners = [];
+    (window as unknown as { ccsmPty: unknown }).ccsmPty = {
+      onData: (cb: (p: { sid: string; chunk: string }) => void) => {
+        onDataListeners.push(cb);
+        return () => {
+          const i = onDataListeners.indexOf(cb);
+          if (i >= 0) onDataListeners.splice(i, 1);
+        };
+      },
+    };
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    terminalCtor.mockClear();
+  });
+
+  afterEach(() => {
+    __resetRegistryForTests();
+    document.body.removeChild(host);
+    delete (window as unknown as { ccsmPty?: unknown }).ccsmPty;
+    delete (window as unknown as { ccsm?: unknown }).ccsm;
+  });
+
+  it('first attach to a sid allocates a warm entry (isCold === true)', () => {
+    const { entry, isCold } = ensureAndShowEntry('sid-a', host);
+    expect(isCold).toBe(true);
+    expect(entry.sid).toBe('sid-a');
+    expect(getWarmCacheSize()).toBe(1);
+    expect(getActiveSid()).toBe('sid-a');
+    // Terminal constructed exactly once for sid-a.
+    expect(terminalCtor).toHaveBeenCalledTimes(1);
+    // Wrapper is parented under the host.
+    expect(entry.wrapper.parentElement).toBe(host);
+  });
+
+  it('second attach to the same sid reuses the cached entry (isCold === false)', () => {
+    const { entry: e1 } = ensureAndShowEntry('sid-a', host);
+    terminalCtor.mockClear();
+    // Simulate user switching away then back: hide via switch to sid-b
+    // then return to sid-a.
+    const host2 = document.createElement('div');
+    document.body.appendChild(host2);
+    ensureAndShowEntry('sid-b', host2);
+    const { entry: e2, isCold } = ensureAndShowEntry('sid-a', host);
+    expect(isCold).toBe(false);
+    expect(e2).toBe(e1);
+    // No new Terminal was constructed for the re-show.
+    const ctorCallsForReshow = terminalCtor.mock.calls.length;
+    // sid-b allocated one; sid-a reshow allocated zero. So total since
+    // clear is exactly 1 (the sid-b alloc).
+    expect(ctorCallsForReshow).toBe(1);
+    expect(getActiveSid()).toBe('sid-a');
+    // sid-a's wrapper is back under host after the reparent.
+    expect(e2.wrapper.parentElement).toBe(host);
+    document.body.removeChild(host2);
+  });
+
+  it('honors a custom WARM_CAP override and LRU-evicts the least-recently-shown entry on overflow', () => {
+    (window as unknown as { ccsm: unknown }).ccsm = {
+      featureFlags: { warmXterm: true, warmXtermCap: 3 },
+    };
+
+    // Discrete time stamps so lastAccessedAt has stable ordering. The
+    // registry reads Date.now() — we stub it.
+    let now = 1000;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+
+    // Fill cache: 1, 2, 3.
+    ensureAndShowEntry('sid-1', host);
+    now = 1010;
+    ensureAndShowEntry('sid-2', host);
+    now = 1020;
+    ensureAndShowEntry('sid-3', host);
+    expect(getWarmCacheSize()).toBe(3);
+    // Bump sid-1 so it's NOT the LRU.
+    now = 1030;
+    ensureAndShowEntry('sid-1', host);
+    // sid-2 is now the least-recently-shown that is neither active (sid-1)
+    // nor about-to-be-allocated (sid-4).
+    now = 1040;
+    ensureAndShowEntry('sid-4', host);
+    expect(getWarmCacheSize()).toBe(3);
+    expect(getEntry('sid-1')).toBeDefined();
+    expect(getEntry('sid-2')).toBeUndefined();
+    expect(getEntry('sid-3')).toBeDefined();
+    expect(getEntry('sid-4')).toBeDefined();
+    nowSpy.mockRestore();
+  });
+
+  it('per-entry pty.onData subscription writes ONLY chunks for the entry\'s sid', () => {
+    ensureAndShowEntry('sid-a', host);
+    ensureAndShowEntry('sid-b', host);
+    // Two listeners installed — one per entry.
+    expect(onDataListeners.length).toBe(2);
+    // The Terminal instances are returned in order: index 0 is sid-a, 1 is sid-b.
+    const termA = terminalCtor.mock.results[0].value as { write: ReturnType<typeof vi.fn> };
+    const termB = terminalCtor.mock.results[1].value as { write: ReturnType<typeof vi.fn> };
+    termA.write.mockClear();
+    termB.write.mockClear();
+    // Fan out a chunk for sid-a: only termA receives it.
+    for (const cb of onDataListeners) cb({ sid: 'sid-a', chunk: 'hello' });
+    expect(termA.write).toHaveBeenCalledWith('hello');
+    expect(termB.write).not.toHaveBeenCalled();
+    // Fan out a chunk for sid-b: only termB receives it.
+    termA.write.mockClear();
+    for (const cb of onDataListeners) cb({ sid: 'sid-b', chunk: 'world' });
+    expect(termB.write).toHaveBeenCalledWith('world');
+    expect(termA.write).not.toHaveBeenCalled();
+  });
+
+  it('disposeEntry disposes the term, unsubs the data listener, and removes from the map', () => {
+    const { entry } = ensureAndShowEntry('sid-a', host);
+    const term = entry.term as unknown as { dispose: ReturnType<typeof vi.fn> };
+    expect(onDataListeners.length).toBe(1);
+    expect(entry.wrapper.parentElement).toBe(host);
+    disposeEntry('sid-a', 'lru');
+    expect(getEntry('sid-a')).toBeUndefined();
+    expect(getWarmCacheSize()).toBe(0);
+    expect(term.dispose).toHaveBeenCalledTimes(1);
+    // Listener unsubscribed.
+    expect(onDataListeners.length).toBe(0);
+    // Wrapper detached from DOM.
+    expect(entry.wrapper.parentElement).toBeNull();
+  });
+
+  it('disposeEntry on an unknown sid is a no-op', () => {
+    expect(() => disposeEntry('nope', 'lru')).not.toThrow();
+    expect(getWarmCacheSize()).toBe(0);
+  });
+
+  it('default cap is 20 when no env override is present', () => {
+    // Confirm by attaching 21 distinct sids and observing one eviction.
+    let now = 0;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => ++now);
+    for (let i = 0; i < 20; i += 1) ensureAndShowEntry(`sid-${i}`, host);
+    expect(getWarmCacheSize()).toBe(20);
+    // sid-0 is the LRU (allocated and shown first, never re-shown).
+    // sid-19 is currently active.
+    ensureAndShowEntry('sid-20', host);
+    expect(getWarmCacheSize()).toBe(20);
+    expect(getEntry('sid-0')).toBeUndefined();
+    expect(getEntry('sid-20')).toBeDefined();
+    expect(getEntry('sid-19')).toBeDefined();
+    nowSpy.mockRestore();
+  });
+});

--- a/tests/terminal/xtermWarmRegistry.test.ts
+++ b/tests/terminal/xtermWarmRegistry.test.ts
@@ -51,8 +51,25 @@ vi.mock('../../src/shared/log', () => ({
   error: vi.fn(),
 }));
 
+// Mock the store — the registry calls `useStore.getState()._applyPtyExit`
+// from its module-level onExit listener (Major 2 fix). The spy lets us
+// assert that exits for ALL sids (including hidden ones) reach the store.
+const { applyPtyExitSpy } = vi.hoisted(() => ({ applyPtyExitSpy: vi.fn() }));
+vi.mock('../../src/stores/store', () => {
+  const state = {
+    scrollbackLines: 1000,
+    _applyPtyExit: applyPtyExitSpy,
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const useStore = ((selector: (s: any) => any) => selector(state)) as any;
+  useStore.getState = () => state;
+  useStore.setState = () => undefined;
+  return { useStore };
+});
+
 import {
   ensureAndShowEntry,
+  applySnapshot,
   disposeEntry,
   getEntry,
   getActiveSid,
@@ -62,22 +79,32 @@ import {
 
 describe('xtermWarmRegistry', () => {
   let host: HTMLDivElement;
-  let onDataListeners: Array<(p: { sid: string; chunk: string }) => void>;
+  let onDataListeners: Array<(p: { sid: string; chunk: string; seq: number }) => void>;
+  let onExitListeners: Array<(p: { sessionId: string; code: number | null; signal: number | null }) => void>;
 
   beforeEach(() => {
     onDataListeners = [];
+    onExitListeners = [];
     (window as unknown as { ccsmPty: unknown }).ccsmPty = {
-      onData: (cb: (p: { sid: string; chunk: string }) => void) => {
+      onData: (cb: (p: { sid: string; chunk: string; seq: number }) => void) => {
         onDataListeners.push(cb);
         return () => {
           const i = onDataListeners.indexOf(cb);
           if (i >= 0) onDataListeners.splice(i, 1);
         };
       },
+      onExit: (cb: (p: { sessionId: string; code: number | null; signal: number | null }) => void) => {
+        onExitListeners.push(cb);
+        return () => {
+          const i = onExitListeners.indexOf(cb);
+          if (i >= 0) onExitListeners.splice(i, 1);
+        };
+      },
     };
     host = document.createElement('div');
     document.body.appendChild(host);
     terminalCtor.mockClear();
+    applyPtyExitSpy.mockClear();
   });
 
   afterEach(() => {
@@ -153,25 +180,82 @@ describe('xtermWarmRegistry', () => {
     nowSpy.mockRestore();
   });
 
-  it('per-entry pty.onData subscription writes ONLY chunks for the entry\'s sid', () => {
+  it('per-entry pty.onData subscription buffers chunks until applySnapshot, then drains seq > snapSeq', () => {
     ensureAndShowEntry('sid-a', host);
     ensureAndShowEntry('sid-b', host);
     // Two listeners installed — one per entry.
     expect(onDataListeners.length).toBe(2);
-    // The Terminal instances are returned in order: index 0 is sid-a, 1 is sid-b.
     const termA = terminalCtor.mock.results[0].value as { write: ReturnType<typeof vi.fn> };
     const termB = terminalCtor.mock.results[1].value as { write: ReturnType<typeof vi.fn> };
     termA.write.mockClear();
     termB.write.mockClear();
-    // Fan out a chunk for sid-a: only termA receives it.
-    for (const cb of onDataListeners) cb({ sid: 'sid-a', chunk: 'hello' });
-    expect(termA.write).toHaveBeenCalledWith('hello');
-    expect(termB.write).not.toHaveBeenCalled();
-    // Fan out a chunk for sid-b: only termB receives it.
-    termA.write.mockClear();
-    for (const cb of onDataListeners) cb({ sid: 'sid-b', chunk: 'world' });
-    expect(termB.write).toHaveBeenCalledWith('world');
+    // Fan out two chunks for sid-a in 'buffering' mode (default at alloc).
+    // NOTHING should be written to either term yet — Major 1 fix: the
+    // listener stashes by seq instead of writing-then-being-reset.
+    for (const cb of onDataListeners) cb({ sid: 'sid-a', chunk: 'pre1', seq: 1 });
+    for (const cb of onDataListeners) cb({ sid: 'sid-a', chunk: 'pre2', seq: 2 });
     expect(termA.write).not.toHaveBeenCalled();
+    expect(termB.write).not.toHaveBeenCalled();
+    // Also confirm the sid filter still routes correctly: a sid-b chunk
+    // is buffered ONLY against entry-b's router (we can't peek directly,
+    // but post-applySnapshot drain proves it).
+    for (const cb of onDataListeners) cb({ sid: 'sid-b', chunk: 'bee1', seq: 1 });
+    expect(termA.write).not.toHaveBeenCalled();
+    expect(termB.write).not.toHaveBeenCalled();
+    // Apply snap with snapSeq=1: drains buffered chunks with seq > 1
+    // (i.e. just 'pre2'), drops 'pre1' as already-in-snapshot.
+    applySnapshot('sid-a', 1);
+    expect(termA.write).toHaveBeenCalledTimes(1);
+    expect(termA.write).toHaveBeenCalledWith('pre2');
+    // sid-b is still in 'buffering' mode — applySnapshot is per-sid.
+    expect(termB.write).not.toHaveBeenCalled();
+    // After applySnapshot, sid-a is in 'live' mode: a new chunk with
+    // seq > 1 writes directly; seq <= 1 is dropped.
+    termA.write.mockClear();
+    for (const cb of onDataListeners) cb({ sid: 'sid-a', chunk: 'live3', seq: 3 });
+    expect(termA.write).toHaveBeenCalledWith('live3');
+    // A late chunk with seq <= snapSeq is defensively dropped.
+    termA.write.mockClear();
+    for (const cb of onDataListeners) cb({ sid: 'sid-a', chunk: 'stale', seq: 1 });
+    expect(termA.write).not.toHaveBeenCalled();
+    // sid-b's buffer is preserved; applySnapshot for sid-b drains it.
+    applySnapshot('sid-b', 0);
+    expect(termB.write).toHaveBeenCalledWith('bee1');
+  });
+
+  // Major 1 from cold review — the critical regression: live chunks that
+  // arrive between `pty.attach` resolve and snapshot-land must NOT be
+  // dropped. Before the fix, the listener wrote them straight to term,
+  // then the cold path called term.reset() — silently consuming the
+  // chunks. Now they're buffered, and `applySnapshot` drains them.
+  it('Major 1: chunks arriving after attach but before snapshot are NOT lost across term.reset', () => {
+    ensureAndShowEntry('sid-a', host);
+    const termA = terminalCtor.mock.results[0].value as {
+      write: ReturnType<typeof vi.fn>;
+      reset: ReturnType<typeof vi.fn>;
+    };
+    termA.write.mockClear();
+    termA.reset.mockClear();
+
+    // Simulate the cold-attach window: chunks arrive while listener is
+    // still buffering.
+    for (const cb of onDataListeners) cb({ sid: 'sid-a', chunk: 'live-tail-A', seq: 5 });
+    for (const cb of onDataListeners) cb({ sid: 'sid-a', chunk: 'live-tail-B', seq: 6 });
+
+    // Cold attach: reset, write snapshot, applySnapshot.
+    termA.reset();
+    // (snapshot is hypothetically captured at seq=4 — chunks with seq > 4
+    // are live tail after the snapshot's atomic capture point.)
+    termA.write('SNAPSHOT_CONTENT');
+    applySnapshot('sid-a', 4);
+
+    // After the rendezvous, term must have received: SNAPSHOT_CONTENT,
+    // then live-tail-A, then live-tail-B (the dedupe gate keeps both —
+    // their seq 5 and 6 are > snapSeq 4).
+    const writeCalls = termA.write.mock.calls.map((c) => c[0]);
+    expect(writeCalls).toEqual(['SNAPSHOT_CONTENT', 'live-tail-A', 'live-tail-B']);
+    // Critically: the chunks survived the reset() call sandwiched in
+    // between — they were never silently dropped.
   });
 
   it('disposeEntry disposes the term, unsubs the data listener, and removes from the map', () => {
@@ -207,6 +291,53 @@ describe('xtermWarmRegistry', () => {
     expect(getEntry('sid-0')).toBeUndefined();
     expect(getEntry('sid-20')).toBeDefined();
     expect(getEntry('sid-19')).toBeDefined();
+    nowSpy.mockRestore();
+  });
+
+  // Major 2 from cold review — backgrounded sessions that crash must
+  // still land in `disconnectedSessions[sid]` so the user sees the exit
+  // overlay on switch-back. The registry installs a single module-level
+  // onExit listener that dispatches `_applyPtyExit` for EVERY sid,
+  // including ones whose hook isn't currently mounted.
+  it('Major 2: module-level onExit listener dispatches store._applyPtyExit for ALL sids', () => {
+    // Trigger registry init by allocating an entry.
+    ensureAndShowEntry('sid-foreground', host);
+    expect(onExitListeners.length).toBe(1);
+    // Exit for the foreground sid — recorded.
+    onExitListeners[0]({ sessionId: 'sid-foreground', code: 0, signal: null });
+    expect(applyPtyExitSpy).toHaveBeenCalledTimes(1);
+    expect(applyPtyExitSpy).toHaveBeenLastCalledWith('sid-foreground', { code: 0, signal: null });
+    // Exit for a DIFFERENT sid (e.g. a session that was switched away
+    // from before crashing) — MUST also be recorded. The legacy hook
+    // filtered these out via `evt.sessionId !== getActiveSid()` and is
+    // the precise bug Major 2 fixes.
+    onExitListeners[0]({ sessionId: 'sid-hidden-and-crashed', code: 1, signal: null });
+    expect(applyPtyExitSpy).toHaveBeenCalledTimes(2);
+    expect(applyPtyExitSpy).toHaveBeenLastCalledWith('sid-hidden-and-crashed', { code: 1, signal: null });
+  });
+
+  // Major 3 from cold review — `CCSM_WARM_XTERM_CAP=1` is unsafe because
+  // both the incoming sid AND the active sid are exempt from LRU
+  // eviction, leaving no viable victim when the user switches to a new
+  // sid against a full cache. We clamp UP to 2 (silently — friendlier
+  // than crashing on a config typo).
+  it('cap override of 1 is clamped up to WARM_CAP_MIN=2 (Major 3 fix)', () => {
+    (window as unknown as { ccsm: unknown }).ccsm = {
+      featureFlags: { warmXterm: true, warmXtermCap: 1 },
+    };
+    let now = 0;
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => ++now);
+    ensureAndShowEntry('sid-1', host);
+    ensureAndShowEntry('sid-2', host);
+    expect(getWarmCacheSize()).toBe(2);
+    // Adding a 3rd evicts the LRU non-active (sid-1; sid-2 is active),
+    // leaving size === 2. With the broken clamp (floor=1) the eviction
+    // loop would find no victim and `set()` would push size to 3.
+    ensureAndShowEntry('sid-3', host);
+    expect(getWarmCacheSize()).toBe(2);
+    expect(getEntry('sid-1')).toBeUndefined();
+    expect(getEntry('sid-2')).toBeDefined();
+    expect(getEntry('sid-3')).toBeDefined();
     nowSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

Architectural fix for the session-switch "scroll-to-top flash" (冲顶) bug.
PR #1352 solved the cold-attach viewport-pinning invariant, but the user
still sees a visual rebuild on every session switch because the singleton
xterm Terminal is reset+repopulated each time. This PR introduces the
VS Code-style layer model the user asked for: each session keeps its own
xterm Terminal alive; switching is just reparenting a DOM wrapper.

> 我一个 session 本来是打开的, 我理解切到另一个 session, 当前 session 只是被
> 放在后台了, 就像图层一样, 被盖住了, 那切回来的时候只是简单把他调到最上层

**Default OFF.** Activated only when `CCSM_WARM_XTERM=1` is set in the
environment. When the flag is unset, the legacy attach path runs
bit-identical to today.

**Empirical user validation pending.** Parent will dogfood with
`CCSM_WARM_XTERM=1` and confirm 冲顶 eliminated before a follow-up PR
flips the default to on.

## Key pieces

- `src/terminal/xtermWarmRegistry.ts` — per-sid Terminal lifecycle, LRU
  capped at 20 (override via `CCSM_WARM_XTERM_CAP`, clamped to [2,100]).
  Each entry owns its own `pty.onData` subscription filtered by sid, so
  hidden sessions keep ingesting live PTY output (the whole point of the
  warm cache).
- `src/terminal/usePtyAttach.warm.ts` — warm-aware attach hook. Cold path
  (first attach for a sid) mirrors the legacy snapshot/drain/fit/pin
  flow against the entry's term; warm path is just reparent + fit +
  pin-to-bottom (Q2 decision — pin on warm for invariant consistency
  with #1352).
- `src/components/TerminalPane.tsx` — module-load-time flag read picks
  `TerminalPaneWarm` vs `TerminalPaneLegacy`. React-hooks-rules
  compliant: the flag is static so each branch's hook order is stable.
- `electron/preload/bridges/ccsmCore.ts` — `window.ccsm.featureFlags`
  surface exposes `warmXterm` (boolean) + `warmXtermCap` (int|null),
  captured once at preload init from `process.env`.

## Decisions recorded against the 5 open questions

| Q | Decision | Why |
|---|---|---|
| Q1 — branch baseline | Fresh branch from `origin/main` (the worktree was 65 commits behind). | Inherits PR #1352's pinning invariant + structured observability stack as the cold-path foundation. |
| Q2 — warm scroll behavior | Pin to bottom on warm-show. | Invariant consistency with #1352 ("at state:ready, viewport === baseY"). User mental model on switch-back is "I want to see fresh content / current prompt." Per-session scroll preservation is a future enhancement. |
| Q3 — multi-subscriber `pty.onData` | No preload patch needed — already supports it. | `electron/preload/bridges/ccsmPty.ts` already uses a listener-set fan-out (each `onData(cb)` registers into a `Set`). |
| Q4 — rollout shape | Side-by-side files, default-off env flag. | Legacy code path untouched; warm path is purely additive. |
| Q5 — WARM_CAP | Hard-coded `20` + env override `CCSM_WARM_XTERM_CAP` clamped to `[2,100]`. | Matches design doc; the env knob exists primarily for tests. |

## Transparent-transport invariant

Per-entry `pty.onData` fanout forwards the same bytes to all subscribers
with NO transformation, chunking, throttling, or content logging. Only
the subscription topology differs (per-sid filter vs the legacy global
active-sid filter). Byte stream is byte-for-byte identical.

## New observability

Probes added (all metadata-only, no content):

- `terminal.warmAlloc` `{sid, lruSize}` — registry allocates a new entry.
- `terminal.warmHide` `{sid, lruSize}` — entry reparented to offscreen holder.
- `terminal.warmEvict` `{sid, lruSize, cause}` — LRU / session-deleted / unload.
- `attach.warm.shown` `{sid, viewportY, baseY, bufferType, cursorY, length, atBottom, warmCacheSize, cause}` — warm fast-path show probe, viewport diagnostics matching the `attach.*` family from #1352.

`EVENT_ALLOWED_FIELDS` in `src/shared/scrub.ts` extended with
`warmCacheSize`, `lruSize`, `cause`.

## Known caveats in the warm path (out of scope for this dogfood PR)

- Right-click copy/paste still routes through the legacy singleton
  helpers — no-op in the warm branch. Follow-up will move the canonical
  paste path into shared code accessible to both branches.
- Session-deletion is NOT explicitly wired to `disposeEntry`. A deleted
  session's warm entry sits idle until LRU evicts it (cost bounded by
  WARM_CAP=20).
- Resize during warm-switch is best-effort — no snapshot-replay
  sub-flow; relies on claude re-emitting on SIGWINCH.

## Test plan

- [x] Unit tests for the registry (cold alloc, warm reuse, LRU eviction
      at cap, per-entry data routing, disposal teardown) —
      `tests/terminal/xtermWarmRegistry.test.ts`. The DOM-reparent
      visual flow is empirical-only per the parent brief.
- [x] `npx tsc --noEmit` (renderer + electron) — clean.
- [x] `npx eslint` on the touched files — clean.
- [x] `npx vitest run` — all 1910 tests pass.
- [ ] **Empirical: parent dogfoods with `CCSM_WARM_XTERM=1`** and
      confirms (a) 冲顶 eliminated on session switch, (b) hidden
      sessions continue receiving output, (c) bottom-pin invariant
      holds on warm-show. Follow-up PR will flip the default to on
      after this is confirmed.

Design doc: `scratch/per-session-warm-xterm-design.md` (untracked, in
worktree).
