### PR TITLE
fix(updater): 1h poll cadence + structured observability probes

### DIFF
--- a/electron/__tests__/updater.test.ts
+++ b/electron/__tests__/updater.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { EventEmitter } from 'events';
 import { UPDATE_CHANNELS, UPDATES_CHANNELS } from '../shared/ipcChannels';
 
@@ -315,5 +315,74 @@ describe('updater: IPC wiring', () => {
       code: 'ERR_UPDATER_INVALID_UPDATE_INFO',
       currentVersion: '0.1.2',
     });
+  });
+
+  it('emits releaseDate on updater.check.result when electron-updater reports it', async () => {
+    state.checkForUpdatesImpl = async () => ({
+      updateInfo: { version: '9.9.9', releaseDate: '2026-05-24T00:00:00Z' },
+    });
+    const handler = ipcHandlers.get(UPDATES_CHANNELS.check)!;
+    await handler({});
+    const result = [...logEventCalls]
+      .reverse()
+      .find((c) => c.name === 'updater.check.result');
+    expect(result).toBeTruthy();
+    expect(result!.fields).toMatchObject({
+      reason: 'manual',
+      currentVersion: '0.1.2',
+      latestVersion: '9.9.9',
+      releaseDate: '2026-05-24T00:00:00Z',
+      available: true,
+    });
+  });
+});
+
+// Separate describe with fake timers so the wider IPC-wiring suite above
+// doesn't pay the timer-mocking cost. Verifies the recurring poll actually
+// fires at CHECK_INTERVAL_MS — guards against future regressions where the
+// interval value diverges from the call-site or the timer never gets armed.
+describe('updater: periodic poll', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires a fresh updater.check.start { reason: "poll" } every CHECK_INTERVAL_MS', async () => {
+    await freshModule();
+    const mod = await import('../updater');
+
+    // Drain microtasks for the startup `safeCheck('startup')` without
+    // ticking the interval timer (which would loop forever — setInterval
+    // re-arms itself so `runAllTimersAsync` aborts with an infinite-loop
+    // guard). Two microtask flushes cover the await in `safeCheck`.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const startupStarts = logEventCalls.filter(
+      (c) => c.name === 'updater.check.start',
+    );
+    expect(startupStarts).toHaveLength(1);
+    expect(startupStarts[0]!.fields).toMatchObject({ reason: 'startup' });
+
+    // Advance exactly one interval — the setInterval callback fires
+    // `safeCheck('poll')`.
+    await vi.advanceTimersByTimeAsync(mod.CHECK_INTERVAL_MS);
+    let pollStarts = logEventCalls.filter(
+      (c) => c.name === 'updater.check.start' && c.fields?.reason === 'poll',
+    );
+    expect(pollStarts).toHaveLength(1);
+
+    // Second interval — proves it's a recurring setInterval, not a
+    // one-shot setTimeout. This is the regression we care about: a
+    // future refactor that accidentally swaps setInterval for setTimeout
+    // would pass the single-tick assertion but fail here.
+    await vi.advanceTimersByTimeAsync(mod.CHECK_INTERVAL_MS);
+    pollStarts = logEventCalls.filter(
+      (c) => c.name === 'updater.check.start' && c.fields?.reason === 'poll',
+    );
+    expect(pollStarts).toHaveLength(2);
   });
 });

--- a/electron/__tests__/updater.test.ts
+++ b/electron/__tests__/updater.test.ts
@@ -76,11 +76,28 @@ vi.mock('electron-updater', () => {
   return { autoUpdater };
 });
 
+// Stub the structured logger so test runs under plain Node don't try to
+// initialize electron-log (which requires the electron binary). We capture
+// `log.event` calls so the new observability probes can be asserted.
+const logEventCalls: Array<{ name: string; fields: Record<string, unknown> | undefined }> = [];
+vi.mock('../shared/log', () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    event: (name: string, fields?: Record<string, unknown>) => {
+      logEventCalls.push({ name, fields });
+    },
+  },
+}));
+
 function resetState() {
   ipcHandlers.clear();
   webContentsSends.length = 0;
   autoUpdaterEmitter.removeAllListeners();
   quitAndInstallCalls.length = 0;
+  logEventCalls.length = 0;
   state.appIsPackaged = true;
   state.appVersion = '0.1.2';
   state.appName = 'CCSM';
@@ -258,5 +275,45 @@ describe('updater: IPC wiring', () => {
     const handler = ipcHandlers.get(UPDATES_CHANNELS.status)!;
     const res = await handler({});
     expect(res).toEqual({ kind: 'available', version: '9.9.9', releaseDate: undefined });
+  });
+
+  it('exports CHECK_INTERVAL_MS as exactly 1 hour (matches hourly release cadence)', async () => {
+    const mod = await import('../updater');
+    // Match `.github/workflows/hourly-tag-release.yml` cron `0 * * * *`. Going
+    // lower hammers GitHub Releases; going higher (the prior 4h value) leaves
+    // long-running sessions stuck on stale builds. If this constant changes,
+    // double-check the release workflow's cadence still matches.
+    expect(mod.CHECK_INTERVAL_MS).toBe(60 * 60 * 1000);
+  });
+
+  it('emits updater.check.start + updater.check.result probes on startup', async () => {
+    // freshModule() in beforeEach already triggered installUpdaterIpc which
+    // calls safeCheck('startup'). Drain microtasks so the async probe lands.
+    await new Promise((r) => setImmediate(r));
+    const names = logEventCalls.map((c) => c.name);
+    expect(names).toContain('updater.check.start');
+    expect(names).toContain('updater.check.result');
+    expect(names).toContain('updater.poll.scheduled');
+    const start = logEventCalls.find((c) => c.name === 'updater.check.start')!;
+    expect(start.fields).toMatchObject({ reason: 'startup', currentVersion: '0.1.2' });
+    const scheduled = logEventCalls.find((c) => c.name === 'updater.poll.scheduled')!;
+    expect(scheduled.fields).toEqual({ intervalMs: 60 * 60 * 1000 });
+  });
+
+  it('emits updater.error probe when autoUpdater check rejects', async () => {
+    state.checkForUpdatesImpl = async () => {
+      const e = new Error('boom') as Error & { code?: string };
+      e.code = 'ERR_UPDATER_INVALID_UPDATE_INFO';
+      throw e;
+    };
+    const handler = ipcHandlers.get(UPDATES_CHANNELS.check)!;
+    await handler({});
+    const errProbe = logEventCalls.find((c) => c.name === 'updater.error');
+    expect(errProbe).toBeTruthy();
+    expect(errProbe!.fields).toMatchObject({
+      reason: 'manual',
+      code: 'ERR_UPDATER_INVALID_UPDATE_INFO',
+      currentVersion: '0.1.2',
+    });
   });
 });

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, ipcMain } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import { UPDATE_CHANNELS, UPDATES_CHANNELS } from './shared/ipcChannels';
+import { log } from './shared/log';
 
 // All status updates flow through one channel so the renderer doesn't have to
 // subscribe to N separate event names. The shape mirrors electron-updater's
@@ -19,10 +20,14 @@ let installed = false;
 let autoCheckEnabled = true;
 let periodicHandle: ReturnType<typeof setInterval> | null = null;
 
-// 4 hours. Electron-updater recommends not checking more often than hourly;
-// 4h is a reasonable default that keeps users on the latest signed build
-// without hammering GitHub releases.
-const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
+// 1 hour. Matches the hourly release cadence (see
+// `.github/workflows/hourly-tag-release.yml`) so an in-app session picks up
+// a new build within roughly one polling window of publication. Electron-
+// updater docs caution against going below hourly (GitHub Releases is the
+// underlying feed and 60+ checks/hr per client is noisy); 1h is the floor.
+// Prior value was 4h — that is too coarse for a project that ships a new
+// tag every hour, leaving long-running sessions stuck on stale builds.
+export const CHECK_INTERVAL_MS = 60 * 60 * 1000;
 
 // Named event channels — requested in the release infra spec in addition to
 // the aggregated `updates:status` channel. Keeping both channels is cheap and
@@ -53,16 +58,41 @@ function broadcast(status: UpdateStatus): void {
  * Safe wrapper around autoUpdater.checkForUpdates() that handles the three
  * common failure modes without crashing: not packaged (dev), network error,
  * and missing update metadata (running a build before the first release).
+ *
+ * Emits `updater.check.start` and `updater.check.result` / `updater.error`
+ * probes so the auto-update path is debuggable from main.log (when the file
+ * sink is enabled). Without these, a silent "never finds an update" failure
+ * mode is invisible to triage — there's no UI surface that lights up when
+ * the check itself errors before any IPC event fires.
  */
-async function safeCheck(): Promise<void> {
+async function safeCheck(reason: 'startup' | 'poll' | 'manual' | 'toggle'): Promise<void> {
   if (!app.isPackaged) {
     broadcast({ kind: 'not-available', version: app.getVersion() });
     return;
   }
+  const currentVersion = app.getVersion();
+  log.event('updater.check.start', { reason, currentVersion });
   try {
-    await autoUpdater.checkForUpdates();
+    const res = await autoUpdater.checkForUpdates();
+    // electron-updater returns `null` if a check is already in progress; in
+    // that case treat as a no-op result rather than a phantom "no update".
+    const latestVersion = res?.updateInfo?.version;
+    const available =
+      typeof latestVersion === 'string' && latestVersion !== currentVersion;
+    log.event('updater.check.result', {
+      reason,
+      currentVersion,
+      latestVersion: typeof latestVersion === 'string' ? latestVersion : undefined,
+      available,
+    });
   } catch (e) {
-    broadcast({ kind: 'error', message: (e as Error).message });
+    const err = e as Error & { code?: string };
+    log.event('updater.error', {
+      reason,
+      currentVersion,
+      code: err?.code,
+    });
+    broadcast({ kind: 'error', message: err?.message ?? String(err) });
   }
 }
 
@@ -74,9 +104,10 @@ function startPeriodicChecks(): void {
   // premature quit while timers are pending. .unref() so it doesn't keep
   // the event loop alive during shutdown.
   periodicHandle = setInterval(() => {
-    void safeCheck();
+    void safeCheck('poll');
   }, CHECK_INTERVAL_MS);
   (periodicHandle as unknown as { unref?: () => void }).unref?.();
+  log.event('updater.poll.scheduled', { intervalMs: CHECK_INTERVAL_MS });
 }
 
 function stopPeriodicChecks(): void {
@@ -90,11 +121,21 @@ export function installUpdaterIpc(): void {
   if (installed) return;
   installed = true;
 
-  // electron-updater is noisy by default; quiet it down — we surface state
-  // through our own channel.
   autoUpdater.autoDownload = true;
   autoUpdater.autoInstallOnAppQuit = true;
-  autoUpdater.logger = null;
+
+  // electron-updater is noisy on stdout by default; route its internal
+  // diagnostics through our structured logger so the records land in
+  // main.log (when the file sink is enabled) under tag `electron-updater`.
+  // Previously this was set to `null`, which silenced electron-updater
+  // entirely — making "updater not detecting releases" an invisible failure
+  // mode with zero log evidence to triage from.
+  autoUpdater.logger = {
+    info: (m: unknown) => log.info('electron-updater', String(m)),
+    warn: (m: unknown) => log.warn('electron-updater', String(m)),
+    error: (m: unknown) => log.error('electron-updater', String(m)),
+    debug: (m: unknown) => log.debug('electron-updater', String(m)),
+  } as unknown as typeof autoUpdater.logger;
 
   // Dual-install (#891): the dev variant pulls GitHub pre-releases so we can
   // ship release candidates / dogfood builds without affecting prod users
@@ -126,9 +167,19 @@ export function installUpdaterIpc(): void {
   autoUpdater.on('update-downloaded', (info) =>
     broadcast({ kind: 'downloaded', version: info.version })
   );
-  autoUpdater.on('error', (err) =>
-    broadcast({ kind: 'error', message: err?.message ?? String(err) })
-  );
+  autoUpdater.on('error', (err) => {
+    // Mirror the autoUpdater error to a structured probe so main.log shows
+    // the failure. The `electron-updater` logger above ALSO records it, but
+    // that record is a free-form string from the library; the probe gives
+    // us a stable event name to grep for during triage.
+    const e = err as Error & { code?: string };
+    log.event('updater.error', {
+      reason: 'emit',
+      currentVersion: app.getVersion(),
+      code: e?.code,
+    });
+    broadcast({ kind: 'error', message: err?.message ?? String(err) });
+  });
 
   ipcMain.handle(UPDATES_CHANNELS.status, () => lastStatus);
 
@@ -138,15 +189,10 @@ export function installUpdaterIpc(): void {
       broadcast(status);
       return status;
     }
-    try {
-      const res = await autoUpdater.checkForUpdates();
-      void res;
-      return lastStatus;
-    } catch (e) {
-      const status: UpdateStatus = { kind: 'error', message: (e as Error).message };
-      broadcast(status);
-      return status;
-    }
+    // Reuse safeCheck so the manual path emits the same probes as the
+    // periodic / startup paths — one log signature to triage from.
+    await safeCheck('manual');
+    return lastStatus;
   });
 
   ipcMain.handle(UPDATES_CHANNELS.download, async () => {
@@ -185,15 +231,15 @@ export function installUpdaterIpc(): void {
     autoCheckEnabled = !!enabled;
     if (autoCheckEnabled) {
       startPeriodicChecks();
-      void safeCheck();
+      void safeCheck('toggle');
     } else {
       stopPeriodicChecks();
     }
     return autoCheckEnabled;
   });
 
-  // Check once on ready + every 4h thereafter.
-  void safeCheck();
+  // Check once on ready + every hour thereafter.
+  void safeCheck('startup');
   startPeriodicChecks();
 }
 

--- a/electron/updater.ts
+++ b/electron/updater.ts
@@ -77,12 +77,14 @@ async function safeCheck(reason: 'startup' | 'poll' | 'manual' | 'toggle'): Prom
     // electron-updater returns `null` if a check is already in progress; in
     // that case treat as a no-op result rather than a phantom "no update".
     const latestVersion = res?.updateInfo?.version;
+    const releaseDate = res?.updateInfo?.releaseDate;
     const available =
       typeof latestVersion === 'string' && latestVersion !== currentVersion;
     log.event('updater.check.result', {
       reason,
       currentVersion,
       latestVersion: typeof latestVersion === 'string' ? latestVersion : undefined,
+      releaseDate: typeof releaseDate === 'string' ? releaseDate : undefined,
       available,
     });
   } catch (e) {

--- a/src/shared/scrub.ts
+++ b/src/shared/scrub.ts
@@ -126,6 +126,17 @@ export const EVENT_ALLOWED_FIELDS = new Set<string>([
   'cursorY',
   'length',
   'atBottom',
+  // Auto-updater observability probes (`updater.check.start`,
+  // `updater.check.result`, `updater.error`, `updater.poll.scheduled`,
+  // `updater.poll.tick`). All bounded scalars — version strings are user-
+  // visible semver (no paths/PII), `available` is a boolean, `code` is an
+  // electron-updater error code enum, `intervalMs` is our own constant.
+  'available',
+  'currentVersion',
+  'latestVersion',
+  'releaseDate',
+  'code',
+  'intervalMs',
 ]);
 
 const DEFAULT_DEPTH = 4;


### PR DESCRIPTION
## Root cause

The in-app auto-updater isn't *broken* — GitHub Releases v0.2.7 has `latest.yml` / `latest-mac.yml` / `latest-linux.yml`, the release is published (not draft, not prerelease), and the code does call `autoUpdater.checkForUpdates()` on startup and on a recurring timer. Two compounding issues explain why a packaged session goes "long past" a new release without picking it up:

1. **Poll cadence mismatch.** `CHECK_INTERVAL_MS` was `4 * 60 * 60 * 1000` (4h) while releases ship hourly via `.github/workflows/hourly-tag-release.yml` (cron `0 * * * *`). A session that started right after a check could sit 3-4h on a stale build before the next automatic poll.

2. **Zero observability.** `autoUpdater.logger = null` silenced electron-updater entirely, and `electron/updater.ts` made no calls into the shared `log` module — every transition went over IPC only. `C:/Users/Jiahui/AppData/Roaming/ccsm/logs/main.log` has zero updater records across days of activity (grep `updater|update` returns nothing). So when a user reports "updater not detecting releases," there is no evidence to triage from.

Both issues had to be fixed to make this debuggable next time.

## Changes

- `CHECK_INTERVAL_MS`: 4h → 1h, matching the hourly release cadence. Electron-updater docs caution against going below hourly, so 1h is the floor; if release cadence changes, this constant should track it (cross-referenced in the comment).
- Route `electron-updater`'s internal logger through our structured `log` under tag `electron-updater` instead of silencing it. Library-emitted records now land in main.log alongside our own probes.
- Add `log.event` probes covering every check path:
  - `updater.check.start { reason, currentVersion }`
  - `updater.check.result { reason, currentVersion, latestVersion, available }`
  - `updater.error { reason, currentVersion, code }` (both for check-call rejections and for the autoUpdater `error` emitter)
  - `updater.poll.scheduled { intervalMs }` when the periodic timer is armed
  - `reason` is a bounded enum: `'startup' | 'poll' | 'manual' | 'toggle' | 'emit'`
- The manual `updates:check` IPC handler now routes through the same `safeCheck()` helper so it emits the same probe signature as the periodic/startup paths.
- Add allowed fields to `EVENT_ALLOWED_FIELDS` in `src/shared/scrub.ts`: `available`, `currentVersion`, `latestVersion`, `releaseDate`, `code`, `intervalMs`. All bounded scalars; no paths, no PII.

## Why not just "fix the check"

Because nothing was obviously broken. Without observability, the next time a user reports this we'd be in the same place. The probes + library logger give us a stable signature (`updater.check.start` → `updater.check.result` with `available: true/false`, or `updater.error` with a `code`) that survives across future regressions.

## Test plan

- [x] `npx vitest run electron/__tests__/updater.test.ts` — 18 passed (4 new):
  - exports `CHECK_INTERVAL_MS` as exactly `60 * 60 * 1000`
  - startup path emits `updater.check.start` + `updater.check.result` + `updater.poll.scheduled` with expected fields
  - failing `checkForUpdates()` surfaces `updater.error` carrying the electron-updater `code`
- [x] `npx vitest run tests/scrub.test.ts tests/sentry-scrub.test.ts` — 36 passed (EVENT_ALLOWED_FIELDS addition doesn't break scrub contract)
- [x] `npm run typecheck` — clean
- [x] `npx eslint electron/updater.ts electron/__tests__/updater.test.ts src/shared/scrub.ts` — clean
- [ ] CI (pending)
- [ ] Manual verify in next packaged build: open a packaged session, confirm `updater.check.start` / `updater.check.result` appear in `%APPDATA%/ccsm/logs/main.log` when run with `CCSM_LOG_ENABLE_FILE=1` (file sink is off by default in prod per #1354 — that's separate from this fix).