### PR TITLE
fix(terminal): warm-hit session switch is instant — no attaching flash, no scroll-to-bottom

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ export default [
       'scripts/**',
       'tests/**',
       'docs/**',
+      '.claude/**',
       'webpack.config.js',
       'postcss.config.js',
       'eslint.config.js'

--- a/src/terminal/usePtyAttach.warm.ts
+++ b/src/terminal/usePtyAttach.warm.ts
@@ -181,7 +181,14 @@ export function usePtyAttachWarm(
   cwd: string,
   hostRef: { current: HTMLDivElement | null },
 ): UsePtyAttachResult {
-  const [state, _setState] = useState<PtyAttachState>({ kind: 'attaching' });
+  // Initial state: if the warm registry already has an entry for this
+  // sid (e.g. a prior TerminalPane mount for the same sid populated it),
+  // start in 'ready' so the first render doesn't briefly show the
+  // 'Attaching...' overlay over an already-warmed terminal. Cold mounts
+  // start in 'attaching' as before.
+  const [state, _setState] = useState<PtyAttachState>(() =>
+    getEntry(sessionId) ? { kind: 'ready' } : { kind: 'attaching' },
+  );
   const setState = useCallback(
     (next: PtyAttachState, reason?: string): void => {
       _setState((prev) => {
@@ -211,7 +218,14 @@ export function usePtyAttachWarm(
     requestedSidRef.current = sessionId;
     let cancelled = false;
     const attachStartedAt = Date.now();
-    setState({ kind: 'attaching' }, 'effect-start');
+    // NOTE: do NOT setState('attaching') here unconditionally. Warm-cache
+    // hits (the common case — user switching back to an already-open
+    // session) would briefly render the 'Attaching...' overlay over the
+    // already-visible terminal DOM, producing a perceptible flash on
+    // every session switch. We defer the attaching transition into the
+    // cold branch below so warm hits stay in their prior 'ready' state
+    // (or 'exit'/'error' if the prior attach concluded that way) until
+    // the new entry is fully swapped in.
 
     (async () => {
       const pty = window.ccsmPty;
@@ -230,6 +244,13 @@ export function usePtyAttachWarm(
       // hide this signal (it allocates on cache miss).
       const existed = !!getEntry(sessionId);
 
+      // Only flip to 'attaching' for cold attaches (snapshot IPC etc.
+      // genuinely take time). Warm hits are a sync reparent + at most
+      // one IPC and stay visually continuous.
+      if (!existed) {
+        setState({ kind: 'attaching' }, 'effect-start');
+      }
+
       // Reparent (or allocate-then-parent) the entry into our host. The
       // registry handles the activeSid update, hides the previous active
       // entry, fires the `attach.warm.shown` probe on cache hit.
@@ -242,7 +263,27 @@ export function usePtyAttachWarm(
         if (!isCold) {
           // ===== WARM PATH =====
           // The entry's term has been receiving live PTY chunks since
-          // its alloc. Reparent already happened; just fit + pin.
+          // its alloc — DOM is already populated, viewport is wherever
+          // the user last left it. Switch UX contract: visual swap is
+          // instant, no overlay, no scroll, no flash.
+          //
+          // We still need to (a) fit() locally so the canvas atlas
+          // matches the post-reparent host dims, and (b) tell the PTY
+          // about any cols/rows change that happened while this entry
+          // was offscreen — but BOTH are fire-and-forget. We don't
+          // await them before flipping to 'ready'. Reasons:
+          //   - The terminal DOM is already showing the correct content.
+          //     A stale cols/rows for one PTY tick is harmless (claude
+          //     re-wraps on next output).
+          //   - Awaiting pty.resize (1 IPC) kept the UI on whatever
+          //     prior state (typically 'ready' from the previous warm
+          //     hit) for an extra frame, but the cost showed up as a
+          //     perceptible delay between sidebar click and the new
+          //     terminal feeling "interactive".
+          //   - We do NOT call pinViewportToBottom — the entry's
+          //     viewport is preserved across hide/show by virtue of
+          //     xterm's WriteBuffer staying intact under reparent. The
+          //     user expects "where I left it", not "snapped to bottom".
           try {
             entry.fit.fit();
           } catch (e) {
@@ -258,24 +299,17 @@ export function usePtyAttachWarm(
           } catch {
             /* probe failure tolerated */
           }
-          // Push container size to PTY so claude resizes if the host
-          // dimensions changed while this entry was offscreen. Best-effort;
-          // resize IPC is idempotent on identical dims.
-          try {
-            await pty.resize(sessionId, entry.term.cols, entry.term.rows);
-          } catch (e) {
+          // Fire-and-forget: best-effort PTY resize. Idempotent on
+          // identical dims, so common-case (no host resize since hide)
+          // is a cheap main-side no-op.
+          void pty.resize(sessionId, entry.term.cols, entry.term.rows).catch((e) => {
             warn('attach-warm', 'warm resize failed', e);
-          }
-          if (cancelled || requestedSidRef.current !== sessionId) return;
+          });
           try {
             entry.term.focus();
           } catch {
             /* focus best-effort */
           }
-          await pinViewportToBottom(
-            entry.term as unknown as PinnableTerminal,
-            sessionId,
-          );
           if (!cancelled) {
             // Major (round 2): if the session already crashed (either
             // while hidden, or while this effect was awaiting), prefer


### PR DESCRIPTION
## Summary

When switching to a session whose xterm entry is already warm in the registry, the UI no longer flashes the 'Attaching...' overlay and no longer snaps the viewport to the bottom. The visible swap is now a sync reparent — instant, no intermediate state.

Cold attaches (first time opening a session in the current process) keep the prior behavior: attaching overlay + scroll-to-bottom after the snapshot lands.

## What changed (`src/terminal/usePtyAttach.warm.ts`)

1. **`useState` initializer** checks the warm registry — if an entry exists for the sid, start in `'ready'` instead of `'attaching'`. Fixes the first-render paint of the overlay over an already-warmed terminal.
2. **`setState('attaching')` at effect start** is moved inside the cold branch (`if (!existed)`). Warm hits stay in their prior `'ready'` state until the new entry is fully swapped in.
3. **Warm path drops `pinViewportToBottom`** entirely — xterm's WriteBuffer is preserved across display:none/reparent, so the viewport naturally stays where the user left it. The user's expectation is "where I left it", not "snapped to bottom".
4. **`pty.resize` is fire-and-forget** on the warm path — resize IPC is idempotent and the DOM is already showing the correct content, so we don't block the `'ready'` transition on the IPC roundtrip. Stale cols/rows for one PTY tick is harmless; claude re-wraps on next output.

## Also
- `eslint.config.js` adds `.claude/**` to ignores so leftover agent worktrees don't pour 40k+ `no-undef` errors into `npm run lint`.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (was previously polluted by `.claude/worktrees/`)
- [x] `npm test` — 1854 pass, 0 fail
- [x] `node scripts/harness-ui.mjs` — 14/14 pass including `terminal-pane-mounted`
- [ ] Manual: click between two warm sessions — no 'Attaching...' flash, viewport stays where it was
- [ ] Manual: open a brand-new session — 'Attaching...' overlay visible during cold attach, then scrolls to bottom on ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)