### PR TITLE
fix(terminal): remove "Attaching..." overlay on cold attach

### DIFF
--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -10,7 +10,7 @@ import { ScrollToBottomButton } from './ScrollToBottomButton';
 // TerminalPane is the host shell for the per-session warm xterm view.
 // The registry (`src/terminal/xtermWarmRegistry.ts`) owns the actual
 // Terminal instances — this component just provides the reparent target
-// host div, overlays (Attaching / Error / Exit), and wires right-click
+// host div, overlays (Error / Exit), and wires right-click
 // copy/paste. Per-session warm state means switching sessions reparents
 // the wrapper rather than tearing down xterm.
 //
@@ -83,13 +83,11 @@ function Overlay({
   onRetry: () => void;
   t: (key: string, opts?: Record<string, unknown>) => string;
 }) {
-  if (state.kind === 'attaching') {
-    return (
-      <div className="absolute inset-0 z-10 flex items-center justify-center text-neutral-400 text-sm pointer-events-none">
-        Attaching...
-      </div>
-    );
-  }
+  // Intentionally no overlay for `state.kind === 'attaching'`: per user
+  // feedback, cold attaches should leave the pane visually unchanged for
+  // the brief window before the snapshot lands rather than flashing an
+  // "Attaching..." placeholder. State machine still tracks 'attaching'
+  // for focus/IPC guards elsewhere.
   if (state.kind === 'error') {
     // z-10 so the overlay sits above xterm's canvas layers (the canvas
     // renderer stacks its own absolutely-positioned canvases inside the


### PR DESCRIPTION
## Summary

User feedback: the brief "Attaching..." text that flashes while a freshly mounted `TerminalPane` completes its first PTY attach is visual noise. Quote: *"attaching 这个页面还是不要了吧, 冷启动的时候就右面本来是样就是啥样, 反正过几秒就出来了"*.

PR #1358 already silenced this overlay for warm-hit session switches via a lazy-init `useState` in `usePtyAttachWarm`. This PR extends the same "no placeholder" behavior to cold attaches by removing the JSX branch in `TerminalPane.tsx`'s `Overlay` that rendered the overlay when `state.kind === 'attaching'`.

## What changed

- `src/components/TerminalPane.tsx`: `Overlay` now falls through for `state.kind === 'attaching'` (returns nothing). Comment added explaining the intentional no-op.
- Stale doc comment at top of file updated (overlay list no longer mentions "Attaching").

## What did NOT change

- The state machine in `src/terminal/usePtyAttach.warm.ts` still tracks the `'attaching'` kind — other code (focus / IPC guards) may branch on it.
- Other overlays (`error`, `exit` clean/crash) are unchanged.
- The warm path's attach logic from #1358 is untouched.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm test` — only pre-existing local-env `better-sqlite3` NODE_MODULE_VERSION mismatch failures (unrelated to this single-line JSX change); CI runs with clean install where this won't repro
- [x] `npm run build && node scripts/harness-ui.mjs` — all 14 cases pass, including `terminal-pane-mounted` (xterm DOM still present after host mount without the overlay)
- [x] `scratch/dogfood-no-attaching-overlay.mjs` — launches packaged app, seeds a session forcing cold attach, polls pane DOM for 3s, asserts no "Attaching" text ever appears, then confirms `.xterm` DOM mounts. PASS.
- [x] Negative control: re-introducing the overlay JSX makes the dogfood script FAIL with `saw "Attaching" text in pane DOM during cold-attach window` — confirms the assertion is load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)