### PR TITLE
fix(ime): position pre-edit textarea at terminal cursor

### DIFF
--- a/scripts/harness-ime-overflow.mjs
+++ b/scripts/harness-ime-overflow.mjs
@@ -1,9 +1,10 @@
 // IME composition overflow e2e probe.
 //
 // Verifies the architectural fix in src/styles/global.css (.xterm .xterm-helpers
-// containment) + src/components/AppShell.tsx (min-w-0 overflow-hidden) prevents
+// overflow: clip) + src/components/AppShell.tsx (min-w-0 overflow-hidden) prevents
 // long IME composition strings from inflating .app-shell.scrollWidth and pushing
-// the sidebar off-screen.
+// the sidebar off-screen. (Previous incarnation used `contain: layout` — see the
+// comment in global.css for why we moved to `overflow: clip`.)
 //
 // Bug class: xterm.js 5.5.0 inflates .xterm-helper-textarea and .composition-view
 // inline widths to match the composition string (~11200px for 800 chars).
@@ -114,13 +115,17 @@ async function main() {
           appShellClient: appShell?.clientWidth ?? 0,
           sidebarLeft: sidebar ? sidebar.getBoundingClientRect().left : -9999,
           hostRight: host ? host.getBoundingClientRect().right : 0,
-          // .xterm-helpers is the clip box (overflow:hidden + contain:layout
-          // applied by our fix). Its right edge bounds where .composition-view
-          // is actually painted, regardless of the view element's own natural
-          // width (which xterm sets to the composition string's pixel length).
+          // .xterm-helpers is the clip box (overflow:clip applied by our fix
+          // in src/styles/global.css). Its right edge bounds where
+          // .composition-view is actually painted, regardless of the view
+          // element's own natural width (which xterm sets to the composition
+          // string's pixel length). NOTE: we switched from `contain: layout`
+          // to `overflow: clip` because the former established a new
+          // containing block that broke xterm CompositionHelper's per-keystroke
+          // style.left/top updates on .xterm-helper-textarea — that anchored
+          // the OS IME candidate window off-screen for Chinese input.
           helpersRight: helpersRect ? helpersRect.right : 0,
           helpersOverflow: helpers ? getComputedStyle(helpers).overflow : '',
-          helpersContain: helpers ? getComputedStyle(helpers).contain : '',
           viewWidth: view ? view.getBoundingClientRect().width : 0,
           viewActive: view ? view.classList.contains('active') : false,
         };
@@ -146,16 +151,16 @@ async function main() {
         // The clip box (.xterm-helpers) must stay within the terminal host's
         // right edge. The composition-view's own bounding rect can be wider
         // (xterm 5.5.0 sets its inline width to the string's pixel length),
-        // but our overflow:hidden + contain:layout on .xterm-helpers ensures
-        // only the head is painted within the terminal area.
+        // but our overflow:clip on .xterm-helpers ensures only the head is
+        // painted within the terminal area.
         if (metrics.helpersRight > metrics.hostRight + 2) {
           fail(
             `n=${n}: .xterm-helpers clip box right ${metrics.helpersRight} > terminal-host.right ${metrics.hostRight}+2 (clip box escapes terminal)`,
           );
           failures++;
         }
-        if (!/layout/.test(metrics.helpersContain)) {
-          fail(`n=${n}: .xterm-helpers contain=${metrics.helpersContain} (expected layout)`);
+        if (!/^(clip|hidden)/.test(metrics.helpersOverflow)) {
+          fail(`n=${n}: .xterm-helpers overflow=${metrics.helpersOverflow} (expected clip or hidden)`);
           failures++;
         }
       }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -794,17 +794,25 @@ html.theme-light ::-webkit-scrollbar-thumb:hover {
  * overflow propagates up to .app-shell.scrollWidth (measured 1280 -> 12451)
  * and pushes the sidebar off-screen.
  *
- * `contain: layout` severs scrollable-overflow propagation to ancestors per
- * CSS Containment L2 §2.5 (https://www.w3.org/TR/css-contain-2/#containment-layout).
- * That alone restores scrollWidth to viewport width (12451 -> 1280) and is
- * the entire fix. We deliberately do NOT set width/height/overflow: those
- * inflate .xterm-helpers from its xterm.css-default 0x0 box to the terminal
- * footprint, which moves the Windows TSF / OS IME anchor one row below the
- * caret (P2 regression from the previous over-broad rule).
+ * `overflow: clip` severs scrollable-overflow propagation to ancestors
+ * (https://www.w3.org/TR/css-overflow-3/#overflow-clip) without establishing
+ * a new containing block or paint context. This matters for IME: xterm's
+ * CompositionHelper.updateCompositionElements() writes style.left/style.top
+ * on .xterm-helper-textarea every keystroke to track the cursor so the OS
+ * IME candidate window anchors at the caret. The previous fix used
+ * `contain: layout`, which establishes a new containing block — that broke
+ * those per-keystroke offsets, causing the textarea to fall back to its
+ * xterm.css default (left: -9999em) and the Chinese IME pre-edit/candidate
+ * popup to render at the screen corner instead of overlaying the cursor.
+ *
+ * We deliberately do NOT set width/height: that inflates .xterm-helpers
+ * from its xterm.css-default 0x0 box to the terminal footprint, which
+ * moves the Windows TSF / OS IME anchor one row below the caret (P2
+ * regression from an earlier over-broad rule).
  *
  * Delete this rule when bumping @xterm/xterm to a release containing
  * upstream PRs #5747 / #5763 (milestone 7.0.0, unreleased).
  */
 .xterm .xterm-helpers {
-  contain: layout;
+  overflow: clip;
 }


### PR DESCRIPTION
## Symptom

Typing Chinese via IME (e.g. \`nihao\` → 你好) made the OS IME pre-edit string and candidate popup render at the screen corner / off-screen instead of overlaying the terminal cursor like a normal CLI.

## Root cause

\`src/styles/global.css\` had \`contain: layout\` on \`.xterm .xterm-helpers\` (added previously to stop \`.composition-view\` from inflating \`.app-shell.scrollWidth\` and pushing the sidebar off-screen). \`contain: layout\` establishes a new containing block, which neutralises xterm.js \`CompositionHelper.updateCompositionElements()\`'s per-keystroke \`style.left\` / \`style.top\` writes on \`.xterm-helper-textarea\`. The textarea falls back to xterm.css's default \`left: -9999em\`, and the OS IME anchors its candidate window at that off-screen position.

## Fix

Replace \`contain: layout\` with \`overflow: clip\`. \`overflow: clip\` severs scrollable-overflow propagation (the original reason the rule existed) without altering the containing block or paint context CompositionHelper depends on. Chromium 120+ supports it natively; Electron 38+ (ccsm's target) includes it.

Also updates \`scripts/harness-ime-overflow.mjs\` to assert the new property (\`overflow: clip|hidden\`) instead of \`contain: layout\`, and refreshes the comment block in \`global.css\`.

## Test plan

Dogfood probe (\`scratch/dogfood-ime-position.mjs\`, headless via \`launchCcsmIsolated\` + \`CCSM_E2E_HIDDEN=1\`):

- [x] **A. Positioning** — after \`compositionstart\` + \`compositionupdate(data='nihao')\`, \`.xterm-helper-textarea\` boundingRect is within one cell of the logical cursor. Measured 0px x 0px delta on the worktree.
- [x] **B. Overflow regression** — after \`compositionupdate(data='a'.repeat(200))\`, \`.app-shell.scrollWidth === .app-shell.clientWidth\` (1280 == 1280) and \`aside.left === 0\`. Original sidebar-pushed-off bug remains fixed.
- [x] \`npm run typecheck\` — clean
- [x] \`npm run lint\` — 0 errors
- [x] \`node scripts/harness-ui.mjs\` — 14/14 pass
- [x] \`node scripts/harness-ime-overflow.mjs\` — PASS at n ∈ {1, 10, 50, 200, 800}
- [ ] Local \`npm test\` had 36 pre-existing failures from \`better-sqlite3\` NODE_MODULE_VERSION mismatch (137 vs 145) — unrelated to a CSS change. CI runs a properly rebuilt binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)