### PR TITLE
fix(ui): stop dialog flash by removing translate from dialogIn keyframe

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -466,8 +466,8 @@ html.theme-light ::-webkit-scrollbar-thumb:hover {
   to   { opacity: 1; }
 }
 @keyframes dialogIn {
-  from { opacity: 0; transform: translate(-50%, -48%) scale(0.97); }
-  to   { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+  from { opacity: 0; scale: 0.97; }
+  to   { opacity: 1; scale: 1; }
 }
 @keyframes toastIn {
   from { opacity: 0; transform: translateY(8px); }


### PR DESCRIPTION
## Symptom

All dialogs (Settings, Import, ConfirmDialog, etc.) flashed at an offscreen position for ~600ms before snapping to center. Headless frame-by-frame capture showed frame-0 at `top=-85, left=-69` before settling at `top=148, left=280`.

## Root cause

Tailwind v4 compiles the utility classes `-translate-x-1/2 -translate-y-1/2` on `DialogContent` (`src/components/ui/Dialog.tsx`) to the standalone CSS `translate` property — not `transform: translate(...)`. The `dialogIn` keyframe in `src/styles/global.css` set `transform: translate(-50%, -48%) scale(0.97)` → `transform: translate(-50%, -50%) scale(1)`. Per CSS spec, the standalone `translate` property and the `transform` property **compose** (translate first, then transform), so during the animation the total translation was `(-100%, -98%)` → `(-100%, -100%)` — fully offscreen. On animation end (no `fill-mode: forwards`), `transform` reverts to `none` and only the Tailwind translate remains, snapping the dialog to its true center.

## Fix

`dialogIn` now animates only `opacity` and the standalone `scale` property. Both compose cleanly with the Tailwind `translate` and leave centering untouched. System-level — fixes every dialog at once. ~3 LOC, single file.

## Test plan

Headless `_electron.launch` dogfood with `CCSM_E2E_HIDDEN=1` (verified BrowserWindow.isVisible() === false), captures per-rAF DOM geometry for ~800ms after open. Post-fix:

- [x] Settings dialog: frame-0 center `dx=0.0 dy=0.0` from viewport center
- [x] Import dialog: frame-0 center `dx=0.0 dy=0.1` from viewport center
- [x] `getComputedStyle().translate` is `-50% -50%` throughout
- [x] `getComputedStyle().transform` is `none` throughout (no keyframe composition)
- [x] Animation visibly retained: `scale` ramps 0.97 → 1, `opacity` 0 → 1
- [x] `npm run typecheck` clean
- [x] `npm run lint` 0 errors
- [x] `npm run build && node scripts/harness-ui.mjs` — 14/14 pass