### PR TITLE
chore(harness): default to hidden when launched via Playwright

### DIFF
--- a/electron/window/__tests__/createWindow.test.ts
+++ b/electron/window/__tests__/createWindow.test.ts
@@ -36,6 +36,7 @@ interface FakeWin {
 
 let latestWin: FakeWin | null = null;
 let appQuitMock: ReturnType<typeof vi.fn>;
+let hasSwitchMock: ReturnType<typeof vi.fn<[string], boolean>>;
 
 function makeFakeWin(opts: Record<string, unknown>): FakeWin {
   const listeners = new Map<string, (...args: unknown[]) => void>();
@@ -91,6 +92,14 @@ vi.mock('electron', () => {
   const app = {
     quit: (...args: unknown[]) => appQuitMock(...args),
     isPackaged: false,
+    // Chromium command-line switch lookup. The createWindow factory checks
+    // `enable-automation` to auto-enable hidden mode under Playwright; in
+    // these unit tests we want manual control via CCSM_E2E_HIDDEN env, so
+    // default to "no switches set".
+    commandLine: {
+      hasSwitch: (name: string) => hasSwitchMock(name),
+      getSwitchValue: (_name: string) => '',
+    },
   };
   return { BrowserWindow, Menu, app };
 });
@@ -537,12 +546,14 @@ describe('createWindow factory', () => {
     latestWin = null;
     isQuittingFlag = false;
     appQuitMock = vi.fn();
+    hasSwitchMock = vi.fn<[string], boolean>(() => false);
     getCloseActionMock.mockReset().mockReturnValue('tray');
     setCloseActionMock.mockReset();
     ipcHandlers = new Map();
     removedIpcChannels = [];
     // Default env: not e2e-hidden, no dev-quit override, no custom port.
     delete process.env.CCSM_E2E_HIDDEN;
+    delete process.env.CCSM_E2E_VISIBLE;
     delete process.env.CCSM_DEV_QUIT_ON_CLOSE;
     delete process.env.CCSM_DEV_PORT;
     deps = {
@@ -589,6 +600,34 @@ describe('createWindow factory', () => {
     // Hidden mode also primes Chromium-level focus and disables throttling.
     expect(latestWin!.webContents.focus).toHaveBeenCalled();
     expect(latestWin!.webContents.setBackgroundThrottling).toHaveBeenCalledWith(false);
+  });
+
+  it('auto-hides when Chromium --enable-automation switch is set (Playwright/Puppeteer/etc)', () => {
+    // Playwright `_electron.launch` injects this switch unconditionally;
+    // we treat it as "this is a script-driven launch, do not pop a visible
+    // window on the dev's desktop" — independent of CCSM_E2E_HIDDEN.
+    hasSwitchMock.mockImplementation((name) => name === 'enable-automation');
+    createWindow(deps);
+    expect(latestWin!.ctorOpts.x).toBe(-32000);
+    expect(latestWin!.ctorOpts.skipTaskbar).toBe(true);
+  });
+
+  it('CCSM_E2E_VISIBLE=1 forces visible window even under automation', () => {
+    // Manual escape hatch for demos / recording / interactive debugging
+    // of a Playwright-driven session.
+    hasSwitchMock.mockImplementation((name) => name === 'enable-automation');
+    process.env.CCSM_E2E_VISIBLE = '1';
+    createWindow(deps);
+    expect(latestWin!.ctorOpts.x).toBeUndefined();
+    expect(latestWin!.ctorOpts.skipTaskbar).toBe(false);
+  });
+
+  it('CCSM_E2E_HIDDEN=0 overrides automation auto-detect (existing harness-dnd contract)', () => {
+    hasSwitchMock.mockImplementation((name) => name === 'enable-automation');
+    process.env.CCSM_E2E_HIDDEN = '0';
+    createWindow(deps);
+    expect(latestWin!.ctorOpts.x).toBeUndefined();
+    expect(latestWin!.ctorOpts.skipTaskbar).toBe(false);
   });
 
   // ─── dev vs prod renderer load ─────────────────────────────────────────

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -247,7 +247,28 @@ export function createWindow(deps: CreateWindowDeps): BrowserWindow {
   //
   // Devs running a single probe by hand without the env still get
   // a normal centered visible window for debugging.
-  const hiddenForE2E = process.env.CCSM_E2E_HIDDEN === '1';
+  //
+  // Belt-and-braces: also auto-enable hidden mode when Chromium's
+  // `--enable-automation` switch is present. Playwright's
+  // `_electron.launch` (which drives every harness/dogfood/screenshot
+  // script in this repo) injects this switch unconditionally; same
+  // for puppeteer / chromedriver / selenium. This means a dogfood
+  // script that forgets to set CCSM_E2E_HIDDEN=1 STILL gets a
+  // hidden window instead of popping a visible one on the dev's
+  // desktop. Production launches (electron-builder packaged app,
+  // `npm run dev`) never set this switch, so they're unaffected.
+  // Explicit `CCSM_E2E_VISIBLE=1` opts out (for manual driving of
+  // a Playwright session you want to actually watch — e.g. recording
+  // a demo). Explicit `CCSM_E2E_HIDDEN=0` also opts out and takes
+  // precedence over the automation auto-detect, matching the
+  // existing semantics callers like harness-dnd.mjs rely on.
+  const explicitHidden = process.env.CCSM_E2E_HIDDEN;
+  const wantsVisible =
+    process.env.CCSM_E2E_VISIBLE === '1' || explicitHidden === '0';
+  const automationDriven =
+    !!app.commandLine && app.commandLine.hasSwitch('enable-automation');
+  const hiddenForE2E =
+    !wantsVisible && (explicitHidden === '1' || automationDriven);
   const win = new BrowserWindow({
     width: 1280,
     height: 800,

--- a/scripts/probe-utils-real-cli.mjs
+++ b/scripts/probe-utils-real-cli.mjs
@@ -364,6 +364,14 @@ export async function createIsolatedClaudeDir({ keep = false } = {}) {
  *
  * Throws a clear error if `dist/renderer/index.html` doesn't exist (caller
  * forgot to run `npm run build`).
+ *
+ * Defaults `CCSM_E2E_HIDDEN=1` so dogfood scripts don't accidentally pop a
+ * visible Electron window on the developer's desktop. The window is still
+ * fully rendered (Chromium runs un-throttled — see createWindow.ts) just
+ * positioned offscreen and hidden from the taskbar, so screenshots and
+ * animation-sensitive probes keep working. Callers that genuinely need a
+ * visible window (manual debugging, dnd-kit) opt out with
+ * `env: { CCSM_E2E_HIDDEN: '0' }`.
  */
 export async function launchCcsmIsolated({ tempDir, userDataDir, env = {} } = {}) {
   if (!tempDir) throw new Error('launchCcsmIsolated: tempDir is required');
@@ -402,6 +410,11 @@ export async function launchCcsmIsolated({ tempDir, userDataDir, env = {} } = {}
       ELECTRON_DISABLE_GPU: '1',
       NODE_ENV: 'production',
       CCSM_PROD_BUNDLE: '1',
+      // Default to hidden so dogfood scripts don't pop a visible window
+      // on the dev's desktop. Honor parent shell's CCSM_E2E_HIDDEN if set
+      // (e.g. dev exported '0' for manual debugging), and let the caller's
+      // explicit `env: { CCSM_E2E_HIDDEN: '0' }` win via the spread below.
+      CCSM_E2E_HIDDEN: process.env.CCSM_E2E_HIDDEN ?? '1',
       // Main reads CCSM_CLAUDE_CONFIG_DIR; renderer's commands-loader reads
       // bare CLAUDE_CONFIG_DIR; claude binary reads CLAUDE_CONFIG_DIR;
       // ccsm.userHome is derived from HOME / USERPROFILE. Set them all.


### PR DESCRIPTION
## Summary

Two implementers in a row got bitten today by dogfood scripts that called either `launchCcsmIsolated` or raw `_electron.launch` without setting `CCSM_E2E_HIDDEN=1`, which popped visible Electron windows on the dev's desktop mid-task.

Belt-and-braces fix at two layers:

- **`electron/window/createWindow.ts`**: auto-enable hidden mode (offscreen position + `skipTaskbar`) whenever Chromium's `--enable-automation` switch is set. Playwright `_electron.launch` injects this switch unconditionally (verified via `app.commandLine.hasSwitch` probe); so do Puppeteer / chromedriver / Selenium. Production launches (electron-builder packaged app, `npm run dev`) never set it and are unaffected.
- **`scripts/probe-utils-real-cli.mjs` `launchCcsmIsolated`**: default env to `CCSM_E2E_HIDDEN=1`, honoring parent shell + caller spread order. Redundant with the createWindow auto-detect in the normal case, but covers any future drift in the automation marker.

Two escape hatches preserved:
- `CCSM_E2E_VISIBLE=1` -> force visible (manual demos / recording)
- `CCSM_E2E_HIDDEN=0` -> force visible (existing `harness-dnd.mjs` contract for dnd-kit collision detection)

Three new unit tests in `createWindow.test.ts` cover each path (automation auto-hide, `CCSM_E2E_VISIBLE=1` override, `CCSM_E2E_HIDDEN=0` override).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (0 errors)
- [x] `npx vitest run electron/window/__tests__/createWindow.test.ts` -> 60/60 pass (incl. 3 new)
- [x] `npm test` -> pre-existing better-sqlite3 native-binding failures only (verified by stashing the diff and re-running; same 36 failures on `main`); no new regressions
- [x] `npm run build && node scripts/harness-ui.mjs` -> 14/14 pass
- [x] `scratch/dogfood-default-hidden-playwright.mjs` -> both scenarios PASS (raw `_electron.launch` with no env override is hidden; helper with no env arg is hidden)

Co-Authored-By: Claude Opus 4 (1M context) <noreply@anthropic.com>