### PR TITLE
feat(terminal): Ctrl+MouseWheel zoom for terminal font size

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -64,6 +64,8 @@ export default [
         Event: 'readonly',
         EventTarget: 'readonly',
         MouseEvent: 'readonly',
+        WheelEvent: 'readonly',
+        EventListenerOptions: 'readonly',
         PointerEvent: 'readonly',
         FocusEvent: 'readonly',
         DragEvent: 'readonly',

--- a/scratch/dogfood-ctrl-wheel-zoom.mjs
+++ b/scratch/dogfood-ctrl-wheel-zoom.mjs
@@ -1,0 +1,123 @@
+// Headless dogfood for Ctrl+MouseWheel terminal font-size zoom.
+// MUST stay invisible per project policy (no visible window).
+import { _electron as electron } from 'playwright';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.resolve(__dirname, '..');
+
+function log(...a) { console.log('[dogfood]', ...a); }
+
+const app = await electron.launch({
+  args: [repo],
+  cwd: repo,
+  env: {
+    ...process.env,
+    CCSM_E2E_HIDDEN: '1',
+    CCSM_PROD_BUNDLE: '1',
+    NODE_ENV: 'production',
+    ELECTRON_DISABLE_GPU: '1',
+  },
+  timeout: 60000,
+});
+
+try {
+  const isHidden = await app.evaluate(({ BrowserWindow }) =>
+    BrowserWindow.getAllWindows().every((w) => !w.isVisible())
+  );
+  if (!isHidden) throw new Error('Dogfood opened a visible window - violates project policy');
+  log('headless visibility OK');
+
+  const win = await app.firstWindow();
+  await win.waitForLoadState('domcontentloaded');
+  await win.waitForFunction(() => !!window.__ccsmStore?.getState?.()?.hydrated);
+  log('hydrated');
+
+  // Create two sessions via the store API.
+  await win.evaluate(async () => {
+    const st = window.__ccsmStore.getState();
+    // Pre-existing sessions are fine; just make sure we have 2.
+    while (window.__ccsmStore.getState().sessions.length < 2) {
+      window.__ccsmStore.getState().createSession(null);
+      await new Promise((r) => setTimeout(r, 50));
+    }
+  });
+  const sids = await win.evaluate(() =>
+    window.__ccsmStore.getState().sessions.slice(0, 2).map((s) => s.id),
+  );
+  log('sids', sids);
+
+  // Activate session A, wait for warm.
+  await win.evaluate((sid) => window.__ccsmStore.getState().selectSession(sid), sids[0]);
+  await win.waitForFunction(() => !!window.__ccsmTerm);
+  // Quickly warm session B by selecting it then back.
+  await win.evaluate((sid) => window.__ccsmStore.getState().selectSession(sid), sids[1]);
+  await win.waitForFunction((sid) => {
+    return window.__ccsmStore.getState().activeId === sid && !!window.__ccsmTerm;
+  }, sids[1]);
+  await win.evaluate((sid) => window.__ccsmStore.getState().selectSession(sid), sids[0]);
+  await win.waitForFunction((sid) => {
+    return window.__ccsmStore.getState().activeId === sid && !!window.__ccsmTerm;
+  }, sids[0]);
+  await win.waitForTimeout(300);
+
+  const initial = await win.evaluate(() => {
+    const t = window.__ccsmTerm;
+    return { fontSize: t.options.fontSize };
+  });
+  log('initial fontSize', initial.fontSize);
+  if (initial.fontSize !== 13) throw new Error(`expected initial fontSize=13, got ${initial.fontSize}`);
+
+  // Helper: dispatch a wheel on the active host div.
+  async function wheel(deltaY) {
+    await win.evaluate((dy) => {
+      const host = document.querySelector('[data-terminal-host] > div');
+      if (!host) throw new Error('host not found');
+      const evt = new WheelEvent('wheel', { deltaY: dy, ctrlKey: true, bubbles: true, cancelable: true });
+      host.dispatchEvent(evt);
+    }, deltaY);
+    await win.waitForTimeout(60);
+  }
+
+  // Zoom in once.
+  await wheel(-120);
+  await win.waitForTimeout(200);
+  let cur = await win.evaluate(() => window.__ccsmTerm.options.fontSize);
+  log('after zoom-in 1x:', cur);
+  if (cur !== 14) throw new Error(`expected 14, got ${cur}`);
+
+  // Zoom out 3x → 13, 12, 11.
+  await wheel(120);
+  await win.waitForTimeout(200);
+  await wheel(120);
+  await win.waitForTimeout(200);
+  await wheel(120);
+  await win.waitForTimeout(300);
+  cur = await win.evaluate(() => window.__ccsmTerm.options.fontSize);
+  log('after zoom-out 3x:', cur);
+  if (cur !== 11) throw new Error(`expected 11, got ${cur}`);
+
+  // Persisted store value should also be 11.
+  const storeVal = await win.evaluate(() => window.__ccsmStore.getState().terminalFontSizePx);
+  if (storeVal !== 11) throw new Error(`store expected 11, got ${storeVal}`);
+  log('store terminalFontSizePx', storeVal);
+
+  // Switch to session B; assert its term picks up font 11 lazily on show.
+  await win.evaluate((sid) => window.__ccsmStore.getState().selectSession(sid), sids[1]);
+  await win.waitForFunction(
+    (sid) => window.__ccsmStore.getState().activeId === sid,
+    sids[1],
+  );
+  await win.waitForTimeout(400);
+  const sessionBFontSize = await win.evaluate(() => window.__ccsmTerm.options.fontSize);
+  log('session B fontSize after switch:', sessionBFontSize);
+  if (sessionBFontSize !== 11) throw new Error(`session B expected 11, got ${sessionBFontSize}`);
+
+  log('PASS');
+} catch (err) {
+  console.error('[dogfood] FAIL', err);
+  process.exitCode = 1;
+} finally {
+  await app.close();
+}

--- a/scratch/dogfood-ctrl-wheel-zoom.mjs
+++ b/scratch/dogfood-ctrl-wheel-zoom.mjs
@@ -1,3 +1,4 @@
+/* eslint-disable no-undef, no-unused-vars */
 // Headless dogfood for Ctrl+MouseWheel terminal font-size zoom.
 // MUST stay invisible per project policy (no visible window).
 import { _electron as electron } from 'playwright';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { useFlushOnBeforeUnload } from './app-effects/useFlushOnBeforeUnload';
 import { useLanguageEffect } from './app-effects/useLanguageEffect';
 import { useAgentEventBridge } from './app-effects/useAgentEventBridge';
 import { useShortcutHandlers } from './app-effects/useShortcutHandlers';
+import { useTerminalFontSize } from './app-effects/useTerminalFontSize';
 import { useSessionActivateBridge } from './app-effects/useSessionActivateBridge';
 import { useFocusBridge } from './app-effects/useFocusBridge';
 import { useUpdateDownloadedBridge } from './app-effects/useUpdateDownloadedBridge';
@@ -147,6 +148,11 @@ export default function App() {
 
   // Theme application — reactive to user choice + (when system) OS scheme.
   useThemeEffect(theme);
+
+  // Ctrl+MouseWheel terminal zoom bridge — subscribes to `terminalFontSizePx`
+  // store field and dispatches font apply + resize-replay to the warm
+  // xterm registry. The wheel listener itself lives on TerminalPane.
+  useTerminalFontSize();
 
   // Pipe `session:state` IPC events into the store via subscribeAgentEvents.
   // Drives the AgentIcon attention halo for non-active sessions.

--- a/src/app-effects/useTerminalFontSize.ts
+++ b/src/app-effects/useTerminalFontSize.ts
@@ -1,0 +1,43 @@
+import { useEffect } from 'react';
+import { useStore } from '../stores/store';
+import { applyTerminalFontSize } from '../terminal/xtermWarmRegistry';
+
+/**
+ * Bridge the persisted `terminalFontSizePx` store field to the warm xterm
+ * registry. The store action (`setTerminalFontSizePx`) is the source of
+ * truth — driven by Ctrl+MouseWheel over the terminal pane (and by
+ * persistence-rehydrate on boot). This effect listens for changes and
+ * dispatches `applyTerminalFontSize`, which:
+ *
+ *   - applies `term.options.fontSize` + runs resize-replay on the active
+ *     warm entry immediately (so cells resize + buffer reflows now);
+ *   - marks all other warm entries with `pendingFontSize` for lazy apply
+ *     in `ensureAndShowEntry` on next show (prevents N concurrent
+ *     snapshot IPCs across N warmed sessions).
+ *
+ * We do NOT call `applyTerminalFontSize` on first mount with the initial
+ * value — the registry's `allocEntry` reads the store directly when it
+ * constructs each Terminal, so the boot value is already wired in. We
+ * only react to subsequent changes via the subscriber.
+ *
+ * Persistence rehydrate timing: hydration runs once at boot and sets the
+ * field to the persisted value (or default). If that differs from the
+ * default `13`, this effect's subscriber will fire after hydrate — but
+ * no warm entries exist yet (TerminalPane hasn't mounted), so
+ * applyTerminalFontSize is a no-op iteration over an empty map. The
+ * first session mount then alloc's a Terminal with the correct font.
+ */
+export function useTerminalFontSize(): void {
+  useEffect(() => {
+    let prev = useStore.getState().terminalFontSizePx;
+    const unsubscribe = useStore.subscribe((s) => {
+      const next = s.terminalFontSizePx;
+      if (next === prev) return;
+      prev = next;
+      void applyTerminalFontSize(next);
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+}

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, type MouseEvent } from 'react';
+import { useCallback, useEffect, useRef, type MouseEvent } from 'react';
 import '@xterm/xterm/css/xterm.css';
 import { useTranslation } from '../i18n/useTranslation';
 import { usePtyAttachWarm, type PtyAttachState } from '../terminal/usePtyAttach.warm';
@@ -6,6 +6,11 @@ import { useAtBottom } from '../terminal/useAtBottom';
 import { getActiveEntry } from '../terminal/xtermWarmRegistry';
 import { terminalCopy, terminalPaste } from '../terminal/paste';
 import { ScrollToBottomButton } from './ScrollToBottomButton';
+import { useStore } from '../stores/store';
+import {
+  TERMINAL_FONT_SIZE_MAX,
+  TERMINAL_FONT_SIZE_MIN,
+} from '../stores/slices/types';
 
 // TerminalPane is the host shell for the per-session warm xterm view.
 // The registry (`src/terminal/xtermWarmRegistry.ts`) owns the actual
@@ -31,6 +36,54 @@ export function TerminalPane({ sessionId, cwd }: Props) {
   // while ready (see ScrollToBottomButton). We keep the hook subscribed
   // so the detection logic (and its tests) stays live for future use.
   const { scrollToBottom } = useAtBottom(sessionId);
+
+  // Ctrl+MouseWheel zoom for the terminal font size. We attach via
+  // useEffect rather than React's `onWheel` prop because React synthesizes
+  // wheel events as passive on the document root (cannot preventDefault),
+  // and we need to suppress both the page-zoom default AND xterm's own
+  // wheel-to-scroll handler when Ctrl is held. Capture phase + non-passive
+  // is the only way that works across Chromium versions.
+  //
+  // The store action is no-op on equal value (clamped 8–32), and the
+  // app-effect subscriber dedupes and dispatches `applyTerminalFontSize`
+  // to the registry. We RAF-coalesce so a fast scroll fires one resize
+  // per frame instead of per wheel tick.
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    let raf = 0;
+    let pendingDelta = 0;
+    const onWheel = (e: WheelEvent): void => {
+      if (!e.ctrlKey) return;
+      if (e.deltaY === 0) return;
+      e.preventDefault();
+      e.stopPropagation();
+      // Wheel-up (deltaY < 0) zooms IN (larger font); wheel-down zooms
+      // out. Step by 1 per wheel notch regardless of |deltaY| — touchpad
+      // pinch gestures (typically large continuous deltaY) still feel
+      // responsive because we step in the direction's sign only.
+      pendingDelta += e.deltaY < 0 ? 1 : -1;
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        const delta = pendingDelta;
+        pendingDelta = 0;
+        if (delta === 0) return;
+        const cur = useStore.getState().terminalFontSizePx;
+        const next = Math.max(
+          TERMINAL_FONT_SIZE_MIN,
+          Math.min(TERMINAL_FONT_SIZE_MAX, cur + delta),
+        );
+        if (next === cur) return;
+        useStore.getState().setTerminalFontSizePx(next);
+      });
+    };
+    host.addEventListener('wheel', onWheel, { passive: false, capture: true });
+    return () => {
+      host.removeEventListener('wheel', onWheel, { capture: true } as EventListenerOptions);
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, []);
 
   const onContextMenu = useCallback(
     (e: MouseEvent<HTMLDivElement>) => {

--- a/src/stores/persist.ts
+++ b/src/stores/persist.ts
@@ -34,6 +34,7 @@ export const PERSISTED_KEYS = [
   'theme',
   'fontSize',
   'fontSizePx',
+  'terminalFontSizePx',
 ] as const;
 
 export type PersistedKey = typeof PERSISTED_KEYS[number];
@@ -55,6 +56,9 @@ export interface PersistedState {
   fontSize?: FontSize;
   /** Preferred over legacy `fontSize` when present. 12–16 px scale. */
   fontSizePx?: FontSizePx;
+  /** Terminal (xterm) font size in px. Bounds 8–32, default 13. Driven by
+   *  Ctrl+MouseWheel over the terminal pane. Global across sessions. */
+  terminalFontSizePx?: number;
 }
 
 export async function loadPersisted(): Promise<PersistedState | null> {

--- a/src/stores/slices/appearanceSlice.ts
+++ b/src/stores/slices/appearanceSlice.ts
@@ -16,6 +16,9 @@ import {
   SCROLLBACK_LINES_DEFAULT,
   SCROLLBACK_LINES_MAX,
   SCROLLBACK_LINES_MIN,
+  TERMINAL_FONT_SIZE_DEFAULT,
+  TERMINAL_FONT_SIZE_MAX,
+  TERMINAL_FONT_SIZE_MIN,
 } from './types';
 
 /** Map the legacy `sm`/`md`/`lg` enum to the numeric pixel scale. The old
@@ -56,6 +59,20 @@ export function sanitizeScrollbackLines(raw: unknown): number {
   n = Math.round(n);
   if (n < SCROLLBACK_LINES_MIN) return SCROLLBACK_LINES_MIN;
   if (n > SCROLLBACK_LINES_MAX) return SCROLLBACK_LINES_MAX;
+  return n;
+}
+
+/** Clamp + integerize a raw terminal-font-size value into the 8–32 range.
+ *  Used for both Ctrl+wheel updates and persisted-snapshot rehydration. */
+export function sanitizeTerminalFontSizePx(raw: unknown): number {
+  let n: number;
+  if (typeof raw === 'number') n = raw;
+  else if (typeof raw === 'string' && raw.length > 0) n = Number(raw);
+  else return TERMINAL_FONT_SIZE_DEFAULT;
+  if (!Number.isFinite(n)) return TERMINAL_FONT_SIZE_DEFAULT;
+  n = Math.round(n);
+  if (n < TERMINAL_FONT_SIZE_MIN) return TERMINAL_FONT_SIZE_MIN;
+  if (n > TERMINAL_FONT_SIZE_MAX) return TERMINAL_FONT_SIZE_MAX;
   return n;
 }
 
@@ -104,15 +121,17 @@ export type AppearanceSlice = Pick<
   | 'fontSize'
   | 'fontSizePx'
   | 'scrollbackLines'
+  | 'terminalFontSizePx'
   | 'setTheme'
   | 'setFontSize'
   | 'setFontSizePx'
   | 'setScrollbackLines'
+  | 'setTerminalFontSizePx'
   | 'setSidebarWidth'
   | 'resetSidebarWidth'
 >;
 
-export function createAppearanceSlice(set: SetFn, _get: GetFn): AppearanceSlice {
+export function createAppearanceSlice(set: SetFn, get: GetFn): AppearanceSlice {
   return {
     // initial state
     sidebarWidth: SIDEBAR_WIDTH_DEFAULT,
@@ -120,6 +139,7 @@ export function createAppearanceSlice(set: SetFn, _get: GetFn): AppearanceSlice 
     fontSize: 'md',
     fontSizePx: 14,
     scrollbackLines: SCROLLBACK_LINES_DEFAULT,
+    terminalFontSizePx: TERMINAL_FONT_SIZE_DEFAULT,
 
     // actions
     setTheme: (theme) => set({ theme }),
@@ -129,6 +149,13 @@ export function createAppearanceSlice(set: SetFn, _get: GetFn): AppearanceSlice 
       set({ fontSizePx, fontSize: pxToLegacyFontSize(fontSizePx) }),
     setScrollbackLines: (n) =>
       set({ scrollbackLines: sanitizeScrollbackLines(n) }),
+    setTerminalFontSizePx: (px) => {
+      const next = sanitizeTerminalFontSizePx(px);
+      // No-op on equal value — avoids spurious snapshot-replay work
+      // downstream (`applyTerminalFontSize` runs a real resize pipeline).
+      if (get().terminalFontSizePx === next) return;
+      set({ terminalFontSizePx: next });
+    },
     setSidebarWidth: (px) => set({ sidebarWidth: sanitizeSidebarWidth(px) }),
     resetSidebarWidth: () => set({ sidebarWidth: SIDEBAR_WIDTH_DEFAULT }),
   };

--- a/src/stores/slices/types.ts
+++ b/src/stores/slices/types.ts
@@ -25,6 +25,14 @@ export const SCROLLBACK_LINES_DEFAULT = 1500;
 export const SCROLLBACK_LINES_MIN = 100;
 export const SCROLLBACK_LINES_MAX = 50000;
 
+/** Global terminal (xterm) font size in px. Distinct from `fontSizePx`,
+ *  which controls the app's UI font (12–16) — `terminalFontSizePx` is the
+ *  xterm `fontSize` option, driven by Ctrl+MouseWheel, with broader
+ *  bounds. Persisted; single value across all sessions. */
+export const TERMINAL_FONT_SIZE_DEFAULT = 13;
+export const TERMINAL_FONT_SIZE_MIN = 8;
+export const TERMINAL_FONT_SIZE_MAX = 32;
+
 export type EndpointKind =
   | 'anthropic'
   | 'openai-compat'
@@ -70,6 +78,10 @@ export type State = {
   fontSize: FontSize;
   fontSizePx: FontSizePx;
   scrollbackLines: number;
+  /** xterm font size in px. Global, persisted, default 13, bounds 8–32.
+   *  Controlled by Ctrl+MouseWheel over the terminal pane. Applied to the
+   *  active warm entry immediately and lazily to others on next show. */
+  terminalFontSizePx: number;
   flashStates: Record<string, boolean>;
   hydrated: boolean;
   installerCorrupt: boolean;
@@ -159,6 +171,7 @@ export type Actions = {
   setFontSize: (size: FontSize) => void;
   setFontSizePx: (px: FontSizePx) => void;
   setScrollbackLines: (n: number) => void;
+  setTerminalFontSizePx: (px: number) => void;
   setSidebarWidth: (px: number) => void;
   resetSidebarWidth: () => void;
 

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -10,6 +10,7 @@ import {
   legacyFontSizeToPx,
   sanitizeFontSizePx,
   sanitizeScrollbackLines,
+  sanitizeTerminalFontSizePx,
   resolvePersistedSidebarWidth,
 } from './slices/appearanceSlice';
 import { createInstallerSlice } from './slices/installerSlice';
@@ -103,6 +104,9 @@ export async function hydrateStore(): Promise<void> {
       fontSizePx: persisted.fontSizePx !== undefined
         ? sanitizeFontSizePx(persisted.fontSizePx)
         : legacyFontSizeToPx(persisted.fontSize ?? 'md'),
+      ...(persisted.terminalFontSizePx !== undefined
+        ? { terminalFontSizePx: sanitizeTerminalFontSizePx(persisted.terminalFontSizePx) }
+        : {}),
     });
   }
   if (persistedScrollback !== null) {

--- a/src/terminal/usePtyAttach.warm.ts
+++ b/src/terminal/usePtyAttach.warm.ts
@@ -60,6 +60,7 @@ import {
   ensureAndShowEntry,
   getActiveSid,
   getEntry,
+  runResizeReplayForEntry,
 } from './xtermWarmRegistry';
 
 const writeAsync = (
@@ -647,91 +648,6 @@ export function usePtyAttachWarm(
     let replayInFlight = false;
     let replayPending = false;
 
-    const runResizeReplay = async (): Promise<void> => {
-      const pty = window.ccsmPty;
-      const entry = getEntry(sessionId);
-      if (cancelled || !pty || !entry || !entry.opened) return;
-      // Snapshot pre-resize scroll state.
-      let wasAtBottom = true;
-      let savedViewportY = 0;
-      try {
-        const buf = entry.term.buffer.active;
-        wasAtBottom = buf.baseY - buf.viewportY <= 1;
-        savedViewportY = buf.viewportY;
-      } catch {
-        /* default: assume at-bottom */
-      }
-      try {
-        entry.fit.fit();
-      } catch (e) {
-        warn('attach-warm', 'resize fit failed', e);
-        return;
-      }
-      const cols = entry.term.cols;
-      const rows = entry.term.rows;
-      try {
-        const p = pty.resize(sessionId, cols, rows);
-        if (p && typeof (p as Promise<void>).then === 'function') {
-          await (p as Promise<void>);
-        }
-      } catch (e) {
-        warn('attach-warm', 'resize pty.resize failed', e);
-      }
-      if (cancelled) return;
-      // Pull a fresh snapshot from the (now-reflowed) headless buffer
-      // and replay it. Same dedupe contract as the cold-attach path —
-      // applySnapshot drains live chunks with seq > snap.seq and flips
-      // the router back to 'live'.
-      let snap: { snapshot: string; seq: number };
-      try {
-        snap = (await pty.getBufferSnapshot(sessionId)) as {
-          snapshot: string;
-          seq: number;
-        };
-      } catch (e) {
-        warn('attach-warm', 'resize snapshot fetch failed', e);
-        return;
-      }
-      if (cancelled) return;
-      const entry2 = getEntry(sessionId);
-      if (!entry2 || !entry2.opened) return;
-      try {
-        entry2.term.reset();
-      } catch (e) {
-        warn('attach-warm', 'resize reset failed', e);
-      }
-      if (snap.snapshot) {
-        await new Promise<void>((resolve) => {
-          try {
-            entry2.term.write(snap.snapshot, () => resolve());
-          } catch {
-            resolve();
-          }
-        });
-      }
-      applySnapshot(sessionId, snap.seq);
-      // Drain queued writes before reading viewport state, then restore
-      // scroll position.
-      await new Promise<void>((resolve) => {
-        try {
-          entry2.term.write('', () => resolve());
-        } catch {
-          resolve();
-        }
-      });
-      try {
-        if (wasAtBottom) {
-          entry2.term.scrollToBottom();
-        } else {
-          (entry2.term as unknown as {
-            scrollToLine?: (n: number) => void;
-          }).scrollToLine?.(savedViewportY);
-        }
-      } catch {
-        /* best-effort */
-      }
-    };
-
     const scheduleReplay = (): void => {
       if (replayInFlight) {
         replayPending = true;
@@ -740,10 +656,10 @@ export function usePtyAttachWarm(
       replayInFlight = true;
       void (async () => {
         try {
-          await runResizeReplay();
+          await runResizeReplayForEntry(sessionId);
           while (replayPending && !cancelled) {
             replayPending = false;
-            await runResizeReplay();
+            await runResizeReplayForEntry(sessionId);
           }
         } finally {
           replayInFlight = false;

--- a/src/terminal/xtermWarmRegistry.ts
+++ b/src/terminal/xtermWarmRegistry.ts
@@ -30,7 +30,7 @@ import { ClipboardAddon } from '@xterm/addon-clipboard';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { CanvasAddon } from '@xterm/addon-canvas';
 import { useStore } from '../stores/store';
-import { SCROLLBACK_LINES_DEFAULT } from '../stores/slices/types';
+import { SCROLLBACK_LINES_DEFAULT, TERMINAL_FONT_SIZE_DEFAULT } from '../stores/slices/types';
 import { warn, log } from '../shared/log';
 import { pasteIntoActivePty } from './paste';
 
@@ -125,6 +125,16 @@ export type WarmEntry = {
   /** All input-side disposers (composition listeners, capture-paste,
    *  selection-copy, key handler). Drained in {@link disposeEntry}. */
   inputDisposers: Array<() => void>;
+  /**
+   * Pending terminal font-size to apply on next show. Set by
+   * {@link applyTerminalFontSize} for non-active warm entries when the
+   * global Ctrl+wheel zoom changes — applying live to every hidden entry
+   * would fan out N snapshot IPCs concurrently and stutter the UI. We
+   * apply lazily in {@link ensureAndShowEntry} just before reparent, and
+   * run a single resize-replay for the entry being shown. Null means
+   * the entry's current `term.options.fontSize` is already up to date.
+   */
+  pendingFontSize: number | null;
 };
 
 /**
@@ -299,9 +309,11 @@ function allocEntry(sid: string): WarmEntry {
 
   const scrollback =
     useStore.getState().scrollbackLines ?? SCROLLBACK_LINES_DEFAULT;
+  const fontSize =
+    useStore.getState().terminalFontSizePx ?? TERMINAL_FONT_SIZE_DEFAULT;
   const term = new Terminal({
     fontFamily: 'Cascadia Mono, Consolas, "Courier New", monospace',
-    fontSize: 13,
+    fontSize,
     cursorBlink: false,
     allowProposedApi: true,
     scrollback,
@@ -458,6 +470,7 @@ function allocEntry(sid: string): WarmEntry {
     imeCompositionStartedAt: 0,
     keyboardPasteHandled: false,
     inputDisposers: [],
+    pendingFontSize: null,
   };
   warm.set(sid, entry);
 
@@ -824,6 +837,26 @@ export function ensureAndShowEntry(
     /* probe handle is best-effort */
   }
 
+  // Consume pendingFontSize from a previous Ctrl+wheel zoom that landed
+  // while this entry was hidden. Apply the font option synchronously so
+  // the cell metrics change before paint, then fire-and-forget the
+  // resize-replay (snapshot IPC + reflow) — same primitive the active
+  // path runs eagerly. Cold entries (just allocated) read the current
+  // store value at construction, so they never have a pending mismatch.
+  if (entry.pendingFontSize != null) {
+    const px = entry.pendingFontSize;
+    const cur = (entry.term.options as { fontSize?: number }).fontSize;
+    entry.pendingFontSize = null;
+    if (cur !== px) {
+      try {
+        entry.term.options.fontSize = px;
+      } catch (e) {
+        warn('xterm-warm', 'lazy apply fontSize failed', e);
+      }
+      void runResizeReplayForEntry(sid);
+    }
+  }
+
   if (!isCold) {
     // Warm path probe — fires only on cache hit. Cold path emits
     // `terminal.warmAlloc` from `allocEntry`. Includes viewport
@@ -956,6 +989,152 @@ export function disposeEntry(
   } catch {
     /* probe failure tolerated */
   }
+}
+
+/**
+ * Refit the entry's xterm against its host, push the new cols/rows to the
+ * PTY, then pull a fresh snapshot and replay it. Used by:
+ *
+ *   1. The ResizeObserver-driven flow in `usePtyAttach.warm.ts` (host
+ *      container changed size — splitter drag, window resize, etc.).
+ *   2. {@link applyTerminalFontSize} when the Ctrl+wheel zoom changes
+ *      the font size (cells get bigger/smaller → cols/rows change in
+ *      the same way as a container resize would).
+ *
+ * The snapshot replay is non-negotiable for alt-screen TUIs like claude:
+ * SIGWINCH alone doesn't trigger a repaint until the next user input,
+ * so without pulling + replaying the (now-reflowed) headless buffer the
+ * visible terminal looks stale until the user types.
+ *
+ * Caller is responsible for whatever serialization / debouncing it needs
+ * (the RO path debounces 80 ms + uses an inFlight latch; the font-size
+ * path runs immediately because each wheel tick is throttled by RAF).
+ */
+export async function runResizeReplayForEntry(sid: string): Promise<void> {
+  const pty = window.ccsmPty;
+  const entry = getEntry(sid);
+  if (!pty || !entry || !entry.opened) return;
+  // Snapshot pre-resize scroll state — preserves user's reading position
+  // when they were scrolled up; otherwise we snap to bottom.
+  let wasAtBottom = true;
+  let savedViewportY = 0;
+  try {
+    const buf = entry.term.buffer.active;
+    wasAtBottom = buf.baseY - buf.viewportY <= 1;
+    savedViewportY = buf.viewportY;
+  } catch {
+    /* default: assume at-bottom */
+  }
+  try {
+    entry.fit.fit();
+  } catch (e) {
+    warn('xterm-warm', 'resize fit failed', e);
+    return;
+  }
+  const cols = entry.term.cols;
+  const rows = entry.term.rows;
+  try {
+    const p = pty.resize(sid, cols, rows);
+    if (p && typeof (p as Promise<void>).then === 'function') {
+      await (p as Promise<void>);
+    }
+  } catch (e) {
+    warn('xterm-warm', 'resize pty.resize failed', e);
+  }
+  let snap: { snapshot: string; seq: number };
+  try {
+    snap = (await pty.getBufferSnapshot(sid)) as {
+      snapshot: string;
+      seq: number;
+    };
+  } catch (e) {
+    warn('xterm-warm', 'resize snapshot fetch failed', e);
+    return;
+  }
+  const entry2 = getEntry(sid);
+  if (!entry2 || !entry2.opened) return;
+  try {
+    entry2.term.reset();
+  } catch (e) {
+    warn('xterm-warm', 'resize reset failed', e);
+  }
+  if (snap.snapshot) {
+    await new Promise<void>((resolve) => {
+      try {
+        entry2.term.write(snap.snapshot, () => resolve());
+      } catch {
+        resolve();
+      }
+    });
+  }
+  applySnapshot(sid, snap.seq);
+  await new Promise<void>((resolve) => {
+    try {
+      entry2.term.write('', () => resolve());
+    } catch {
+      resolve();
+    }
+  });
+  try {
+    if (wasAtBottom) {
+      entry2.term.scrollToBottom();
+    } else {
+      (entry2.term as unknown as {
+        scrollToLine?: (n: number) => void;
+      }).scrollToLine?.(savedViewportY);
+    }
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
+ * Apply a new terminal font size to the warm registry.
+ *
+ * Strategy (to avoid N concurrent snapshot IPCs when many sessions are
+ * warmed): the ACTIVE entry gets the font applied + resize-replay run
+ * immediately; all OTHER entries record `pendingFontSize`, which
+ * {@link ensureAndShowEntry} consumes on next show.
+ *
+ * IME guard: if the active entry is mid-composition, defer — applying
+ * `term.options.fontSize` reanchors the hidden textarea mid-edit and
+ * makes the CJK preview box jump. We mark it pending instead, and the
+ * next `compositionend` would not naturally trigger a re-apply, so this
+ * is a known minor staleness for IME-heavy sessions. The user will
+ * trigger another wheel event soon enough to retry. Subsequent
+ * `applyTerminalFontSize` calls clear stale pending values automatically.
+ */
+export async function applyTerminalFontSize(px: number): Promise<void> {
+  const active = getActiveEntry();
+  for (const [sid, entry] of warm.entries()) {
+    if (active && sid === active.sid) continue;
+    // Record pending only when the entry's current font differs — saves
+    // a spurious resize-replay on next show when nothing actually changed.
+    const cur = (entry.term.options as { fontSize?: number }).fontSize;
+    if (cur === px) {
+      entry.pendingFontSize = null;
+    } else {
+      entry.pendingFontSize = px;
+    }
+  }
+  if (!active) return;
+  if (active.composing) {
+    active.pendingFontSize = px;
+    return;
+  }
+  try {
+    const cur = (active.term.options as { fontSize?: number }).fontSize;
+    if (cur === px) {
+      active.pendingFontSize = null;
+      return;
+    }
+    active.term.options.fontSize = px;
+    active.pendingFontSize = null;
+  } catch (e) {
+    warn('xterm-warm', 'apply fontSize failed', e);
+    return;
+  }
+  await runResizeReplayForEntry(active.sid);
 }
 
 /**


### PR DESCRIPTION
## Summary

Hold **Ctrl + scroll the mouse wheel** over the terminal pane to zoom the xterm font in/out — like Windows Terminal / iTerm2. Global setting across all sessions, persisted, default 13 px, bounds 8-32.

## Scope (MVP — intentionally narrow)

- Only Ctrl+MouseWheel
- **No** Ctrl+= / Ctrl+- / Ctrl+0 keyboard shortcuts (deferred)
- **No** AppearancePane settings slider (deferred)
- **No** on-screen indicator overlay (deferred)
- **No** per-session zoom — single global value

## Implementation

- New store field `terminalFontSizePx` + `setTerminalFontSizePx` action (clamped 8-32, no-op on equal value). Persisted via existing `PERSISTED_KEYS` allowlist + `PersistedState` type; rehydrated on boot.
- `xtermWarmRegistry` reads the store value at entry alloc instead of the hardcoded 13. New `pendingFontSize` per entry + `applyTerminalFontSize(px)` export: applies font + resize-replay on the ACTIVE entry; marks all OTHER entries pending. Lazy apply in `ensureAndShowEntry` consumes pending on next show — prevents N concurrent snapshot IPCs across N warmed sessions.
- Extracted the inline resize-replay closure from `usePtyAttach.warm.ts` into `runResizeReplayForEntry` on the registry, reused by both the ResizeObserver path and the font-size path. Same primitive: fit → pty.resize → getBufferSnapshot → reset+write → applySnapshot → restore scroll.
- IME guard: skip font apply during composition (queued via `pendingFontSize` on the active entry instead) so the CJK preview box doesn't jump mid-edit.
- Wheel listener on the TerminalPane host div, useEffect + `{ passive: false, capture: true }` so we can preventDefault the page zoom + xterm's wheel-scroll. RAF-coalesced for fast scrolls.
- New `useTerminalFontSize` app-effect bridges store changes → registry.

## Test plan

- [x] `npm run typecheck` (clean)
- [x] `npm run lint` (0 errors)
- [x] `npm test` — 1818 pass, only env-related pre-existing failures (better-sqlite3 NODE_MODULE_VERSION mismatch, missing dist/electron) unrelated to this change
- [x] `npm run build && node scripts/harness-ui.mjs` — 14/14
- [x] Headless dogfood (`scratch/dogfood-ctrl-wheel-zoom.mjs`, asserts `CCSM_E2E_HIDDEN`): fontSize 13 → 14 on Ctrl+wheel-up, → 11 after 3x wheel-down, session B inherits 11 on switch via lazy apply, store value persisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)