### PR TITLE
fix(terminal): only replay on real size change to preserve scrollback across warm switch

### DIFF
--- a/src/terminal/usePtyAttach.warm.ts
+++ b/src/terminal/usePtyAttach.warm.ts
@@ -668,7 +668,41 @@ export function usePtyAttachWarm(
       })();
     };
 
-    const ro = new ResizeObserver(() => {
+    // Gate the replay on actual contentRect dimension change. Warm
+    // session switches reparent the entry's wrapper from the offscreen
+    // holder back to the live host, but this `host` div (per-pane,
+    // observed below) doesn't itself change size — so the offscreen
+    // ↔ live transition fires RO with dims identical to the live
+    // baseline. Without this gate, every warm switch ran the replay
+    // path which calls `entry.term.reset()` and re-applies a snapshot —
+    // wiping ydisp/baseY/scrollback. Dogfood frame log on the bug:
+    // viewportY 294 → 0, baseY 344 → 0, scrollHeight 6015 → 855 within
+    // ~80ms of B→A switch (the RO debounce window). Real user-driven
+    // resizes (window resize, splitter drag) still produce dim deltas
+    // and trigger the replay as before.
+    //
+    // First RO callback after observe() is treated as the live baseline
+    // (record dims, no replay). Subsequent ticks with identical dims
+    // are no-ops; only genuine dim changes schedule the replay.
+    let lastW = 0;
+    let lastH = 0;
+    let roBaseline = false;
+    const ro = new ResizeObserver((entries) => {
+      const r = entries[0]?.contentRect;
+      if (!r) return;
+      const w = Math.round(r.width);
+      const h = Math.round(r.height);
+      if (!roBaseline) {
+        lastW = w;
+        lastH = h;
+        roBaseline = true;
+        return;
+      }
+      if (w === lastW && h === lastH) {
+        return;
+      }
+      lastW = w;
+      lastH = h;
       if (debounce) clearTimeout(debounce);
       debounce = setTimeout(scheduleReplay, 80);
     });


### PR DESCRIPTION
## Symptom

Switching between two warm sessions (A → B → A) wiped session A's xterm scrollback within ~80ms of the switch back. The scrollbar visibly snapped to the top and stayed there; the user's scrolled-up reading position was lost on every switch.

## Root cause (dogfood-confirmed)

`usePtyAttach.warm.ts` attaches a `ResizeObserver` to the per-pane host div and runs `runResizeReplay` (which calls `entry.term.reset()` + re-applies a snapshot) on every RO tick. On warm reparent the entry's wrapper moves between the live host and the offscreen holder, but the host div itself doesn't change size — yet RO still fires once per `observe()` after the cleanup/setup cycle. That single tick was enough to schedule the replay and wipe the buffer.

Pre-fix frame log (A pre-switch: viewportY=294, baseY=344, scrollHeight=6015):
- t=0..65ms: scrollTop=0 (DOM clamped by parked offscreen holder), buffer state intact
- t≈80ms: `term.reset()` fires via `runResizeReplay` → viewportY=0, baseY=0, scrollHeight collapses to clientHeight
- thereafter: scrollback gone, scrollbar stuck at top

A previously-considered fix (`entry.term.scrollLines(0)`) was rejected: per xterm source `Viewport.scrollLines` short-circuits at amount 0, making the call a no-op.

## Fix

Gate the RO callback on actual `contentRect` dimension change. First tick after `observe()` records the live baseline; subsequent identical-dim ticks are no-ops. Genuine user-driven resizes (window resize, splitter drag) still produce deltas and trigger the replay as before.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — clean
- [x] `node scripts/harness-ui.mjs` — 14/14 passed (including `terminal-pane-mounted`)
- [x] `scratch/dogfood-warm-switch-no-scroll-jump.mjs`:
  - Pre-fix: 5 distinct failures (viewportY collapse, baseY collapse, scrollHeight collapse, scroll-gap lost, reset-frame detected)
  - Post-fix: PASS — viewportY 327→294, baseY 377→344, scrollHeight 6015→6015 (the small viewport/base shifts are legitimate fit-driven reflow as the host grows from xterm's default size to the live host size, not buffer loss)
  - Real-resize regression net: viewport resize 1400×900 → 900×600 still triggers fit → rows 57→37, cols 169→98 (gate is not over-corrected)
- [ ] CI: lint+typecheck+test ×3, e2e ×3, no-silent-drops

🤖 Generated with [Claude Code](https://claude.com/claude-code)