### PR TITLE
fix(terminal): Ctrl+wheel zoom is silky — no flash, no scroll jump

### DIFF
--- a/scripts/dogfood-task-41-zoom-smoothness.mjs
+++ b/scripts/dogfood-task-41-zoom-smoothness.mjs
@@ -1,0 +1,247 @@
+// Dogfood validation: Task #41 — Ctrl+wheel zoom should not flash and
+// should not jump the user's scroll position. The reflow-only fix
+// removes term.reset()+term.write(snapshot) from the zoom path; the
+// mouse-anchor in TerminalPane.tsx keeps the line under the cursor
+// approximately stable across the font change.
+//
+// Method:
+//   1. Stand up an isolated ccsm with the stub-claude shim on PATH so
+//      we have a real PTY producing a deterministic burst.
+//   2. Seed a session and wait until the warm terminal is ready.
+//   3. Write 100 numbered lines to the terminal via __ccsmTerm.write,
+//      then scroll to the middle of the buffer.
+//   4. Dispatch 5 Ctrl+wheel-up + 5 Ctrl+wheel-down events at a fixed
+//      clientY anchor. Sample fontSize / viewportY / baseY before and
+//      after each batch.
+//   5. Assertions (best-effort, since exact viewportY depends on
+//      reflow timing) — primary signals:
+//       a. fontSize changed in both directions and ended at the
+//          baseline (zoom in then out is symmetric).
+//       b. viewportY drift after the round-trip is < 5 lines (anchor
+//          held within a few cells of round-trip).
+//       c. No 'reset' / 'snapshot' related warn/error log lines.
+//   6. Offscreen-bounds assert so this probe stays headless-safe.
+
+import {
+  launchCcsmIsolated,
+  createIsolatedClaudeDir,
+  seedSession,
+} from './probe-utils-real-cli.mjs';
+import { mkdtempSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const REPO_ROOT = path.resolve(__dirname, '..');
+const STUB_PATH = path.join(__dirname, 'fixtures', 'stub-claude.mjs');
+const OUT_DIR = path.join(REPO_ROOT, 'scratch');
+const OUT_PATH = path.join(OUT_DIR, 'dogfood-task-41-zoom-smoothness.json');
+
+function sleep(ms) { return new Promise((r) => setTimeout(r, ms)); }
+
+function setupClaudeShim() {
+  const shimDir = mkdtempSync(path.join(tmpdir(), 'ccsm-stub-claude-'));
+  const cmd = `@echo off\r\nnode "${STUB_PATH}" %*\r\n`;
+  const cmdPath = path.join(shimDir, 'claude.cmd');
+  writeFileSync(cmdPath, cmd, 'utf8');
+  return { shimDir, cmdPath };
+}
+
+async function readState(win) {
+  return await win.evaluate(() => {
+    const term = window.__ccsmTerm;
+    if (!term || !term.buffer || !term.buffer.active) return null;
+    const buf = term.buffer.active;
+    return {
+      fontSize: term.options.fontSize,
+      cols: term.cols,
+      rows: term.rows,
+      viewportY: buf.viewportY,
+      baseY: buf.baseY,
+      length: buf.length,
+    };
+  });
+}
+
+async function dispatchCtrlWheel(win, deltaY, count) {
+  // Dispatch WheelEvent at a fixed point inside the host. We pick a
+  // clientY roughly 1/3 down the host so anchor adjustments are
+  // observable (not at viewport top or bottom edges).
+  return await win.evaluate(
+    async ({ deltaY, count }) => {
+      const outer = document.querySelector('[data-terminal-host]');
+      if (!outer) throw new Error('terminal host not found');
+      // The wheel listener is on the inner ref'd div (absolute inset-0).
+      const host = outer.querySelector(':scope > div') || outer;
+      const rect = host.getBoundingClientRect();
+      const clientX = rect.left + rect.width / 2;
+      const clientY = rect.top + Math.floor(rect.height / 3);
+      for (let i = 0; i < count; i++) {
+        const ev = new WheelEvent('wheel', {
+          bubbles: true,
+          cancelable: true,
+          ctrlKey: true,
+          deltaY,
+          clientX,
+          clientY,
+        });
+        host.dispatchEvent(ev);
+        // Wait two frames so the RAF coalesce inside the wheel handler
+        // commits and the registry's fit + pty.resize observably finishes.
+        await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+      }
+      return { clientX, clientY };
+    },
+    { deltaY, count },
+  );
+}
+
+async function main() {
+  mkdirSync(OUT_DIR, { recursive: true });
+  const tempDir = createIsolatedClaudeDir();
+  const { shimDir } = setupClaudeShim();
+  const launchPath = `${shimDir};${process.env.PATH ?? ''}`;
+
+  const { electronApp, win } = await launchCcsmIsolated({
+    tempDir,
+    env: { PATH: launchPath, CCSM_E2E_HIDDEN: '1' },
+  });
+
+  // Offscreen-bounds assert — project policy: headless probes never pop
+  // a visible window on the developer's desktop.
+  const isHidden = await electronApp.evaluate(({ BrowserWindow }) =>
+    BrowserWindow.getAllWindows().every((w) => {
+      const b = w.getBounds();
+      return b.x <= -10000 || b.y <= -10000;
+    }),
+  );
+  if (!isHidden) {
+    throw new Error('Dogfood opened a visible window — violates project policy');
+  }
+
+  const consoleLines = [];
+  win.on('console', (msg) => {
+    consoleLines.push({ type: msg.type(), text: msg.text() });
+  });
+
+  const { sid } = await seedSession(win, { cwd: tempDir, name: 'zoom-probe' });
+  // Wait until the terminal is attached + window.__ccsmTerm wired up.
+  const deadline = Date.now() + 30000;
+  while (Date.now() < deadline) {
+    const ready = await win.evaluate(() => Boolean(window.__ccsmTerm?.buffer?.active));
+    if (ready) break;
+    await sleep(200);
+  }
+  // Give the stub a moment to settle (claude shim emits its own first
+  // bytes before we write into the buffer).
+  await sleep(1500);
+
+  // Push 100 numbered lines into the visible buffer via term.write.
+  // This is the renderer-side buffer only (not PTY input), which is
+  // exactly what we want — the zoom path operates on the xterm buffer.
+  await win.evaluate(() => {
+    const lines = [];
+    for (let i = 1; i <= 100; i++) {
+      lines.push(`line ${String(i).padStart(3, '0')}`);
+    }
+    window.__ccsmTerm.write(lines.join('\r\n') + '\r\n');
+  });
+  // Let the write commit.
+  await sleep(300);
+
+  // Scroll to the middle so the zoom isn't trivially pinned at bottom.
+  await win.evaluate(() => {
+    const term = window.__ccsmTerm;
+    const buf = term.buffer.active;
+    const mid = Math.floor(buf.baseY / 2);
+    term.scrollToLine(mid);
+  });
+  await sleep(200);
+
+  // Warm up the fit: trigger one round-trip wheel pair so cols/rows
+  // reflect the actual host size before we take the baseline. (The
+  // very first fit on a freshly-mounted hostRef can produce stale
+  // cols if the renderer hasn't finished laying out the inner host
+  // div yet; the round-trip flushes it.)
+  await dispatchCtrlWheel(win, -120, 1);
+  await sleep(150);
+  await dispatchCtrlWheel(win, 120, 1);
+  await sleep(300);
+
+  const before = await readState(win);
+
+  // Diagnostic: confirm wheel handler can change the store at all by
+  // calling the store action directly first; if that bumps fontSize and
+  // term.options.fontSize matches, the registry path works.
+  const directProbe = await win.evaluate(() => {
+    const s = window.__ccsmStore?.getState();
+    if (!s) return { ok: false, reason: 'no store' };
+    const before = s.terminalFontSizePx;
+    s.setTerminalFontSizePx(before + 2);
+    return { ok: true, before, after: window.__ccsmStore.getState().terminalFontSizePx, termFont: window.__ccsmTerm?.options?.fontSize };
+  });
+  // Roll the store back so the wheel test starts from the same baseline.
+  await win.evaluate(() => {
+    const s = window.__ccsmStore?.getState();
+    s?.setTerminalFontSizePx(13);
+  });
+  await sleep(100);
+
+  // 5x wheel-up (zoom IN)
+  await dispatchCtrlWheel(win, -120, 5);
+  await sleep(300);
+  const afterIn = await readState(win);
+
+  // 5x wheel-down (zoom OUT) — return to baseline font.
+  await dispatchCtrlWheel(win, 120, 5);
+  await sleep(300);
+  const afterOut = await readState(win);
+
+  // Check console for the smoking-gun signals the old replay path would emit.
+  const resetMentions = consoleLines.filter(
+    (l) => /resize reset failed|resize snapshot fetch failed/i.test(l.text),
+  );
+
+  const verdict = {
+    sid,
+    directProbe,
+    before,
+    afterIn,
+    afterOut,
+    fontDeltaUp: (afterIn?.fontSize ?? 0) - (before?.fontSize ?? 0),
+    fontDeltaRoundTrip: (afterOut?.fontSize ?? 0) - (before?.fontSize ?? 0),
+    viewportDriftRoundTrip: Math.abs(
+      (afterOut?.viewportY ?? 0) - (before?.viewportY ?? 0),
+    ),
+    resetWarnings: resetMentions.length,
+    consoleSample: consoleLines.slice(-20),
+  };
+
+  writeFileSync(OUT_PATH, JSON.stringify(verdict, null, 2), 'utf8');
+  console.log(JSON.stringify(verdict, null, 2));
+
+  // Soft assertions — log failures but don't throw, so the JSON file is
+  // preserved for inspection. The PR body cites these numbers.
+  const errs = [];
+  if (!before || !afterIn || !afterOut) errs.push('readState returned null at one of the checkpoints');
+  if (verdict.fontDeltaUp <= 0) errs.push(`fontDeltaUp expected > 0, got ${verdict.fontDeltaUp}`);
+  if (verdict.fontDeltaRoundTrip !== 0) errs.push(`fontDeltaRoundTrip expected 0, got ${verdict.fontDeltaRoundTrip}`);
+  if (verdict.viewportDriftRoundTrip > 8) errs.push(`viewportDriftRoundTrip too large: ${verdict.viewportDriftRoundTrip}`);
+  if (verdict.resetWarnings > 0) errs.push(`saw ${verdict.resetWarnings} resize-replay warnings (zoom path should not invoke replay)`);
+
+  await electronApp.close();
+
+  if (errs.length) {
+    console.error('VERDICT: FAIL');
+    for (const e of errs) console.error('  - ' + e);
+    process.exit(1);
+  }
+  console.error('VERDICT: PASS');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -48,11 +48,32 @@ export function TerminalPane({ sessionId, cwd }: Props) {
   // app-effect subscriber dedupes and dispatches `applyTerminalFontSize`
   // to the registry. We RAF-coalesce so a fast scroll fires one resize
   // per frame instead of per wheel tick.
+  //
+  // Mouse-anchored scroll: before changing the font, we sample the
+  // logical line under the cursor (anchorLine = viewportY + offsetY/cellH).
+  // After the registry writes `term.options.fontSize` (synchronous reflow
+  // via the zustand subscriber), we read the new cell height and
+  // scrollToLine so the same anchorLine stays at the same screen-Y. This
+  // is what gives WT / iTerm2 their "zoom around the pointer" feel.
+  // Uses xterm internals (`_core._renderService.dimensions.css.cell`) —
+  // best-effort, wrapped in try/catch; on any failure we skip the
+  // re-anchor and the user still gets correct zoom, just without the
+  // pointer-fixing.
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
     let raf = 0;
     let pendingDelta = 0;
+    let pendingClientY = 0;
+    const readCellHeight = (term: unknown): number | null => {
+      try {
+        const core = (term as { _core?: { _renderService?: { dimensions?: { css?: { cell?: { height?: number } } } } } })._core;
+        const h = core?._renderService?.dimensions?.css?.cell?.height;
+        return typeof h === 'number' && h > 0 ? h : null;
+      } catch {
+        return null;
+      }
+    };
     const onWheel = (e: WheelEvent): void => {
       if (!e.ctrlKey) return;
       if (e.deltaY === 0) return;
@@ -63,10 +84,12 @@ export function TerminalPane({ sessionId, cwd }: Props) {
       // pinch gestures (typically large continuous deltaY) still feel
       // responsive because we step in the direction's sign only.
       pendingDelta += e.deltaY < 0 ? 1 : -1;
+      pendingClientY = e.clientY;
       if (raf) return;
       raf = requestAnimationFrame(() => {
         raf = 0;
         const delta = pendingDelta;
+        const clientY = pendingClientY;
         pendingDelta = 0;
         if (delta === 0) return;
         const cur = useStore.getState().terminalFontSizePx;
@@ -75,7 +98,48 @@ export function TerminalPane({ sessionId, cwd }: Props) {
           Math.min(TERMINAL_FONT_SIZE_MAX, cur + delta),
         );
         if (next === cur) return;
+        // Capture anchor before dispatch (cellH still reflects old font).
+        const active = getActiveEntry();
+        const term = active?.term;
+        let anchorLine: number | null = null;
+        let anchorScreenRow: number | null = null;
+        if (term) {
+          try {
+            const rect = host.getBoundingClientRect();
+            const offsetY = clientY - rect.top;
+            const cellHOld = readCellHeight(term);
+            const buf = term.buffer.active;
+            if (cellHOld != null && offsetY >= 0 && offsetY <= rect.height) {
+              anchorScreenRow = Math.floor(offsetY / cellHOld);
+              anchorLine = buf.viewportY + anchorScreenRow;
+            }
+          } catch {
+            /* anchor capture best-effort */
+          }
+        }
         useStore.getState().setTerminalFontSizePx(next);
+        // After dispatch, the registry has synchronously written
+        // term.options.fontSize and called fit.fit(); cell metrics now
+        // reflect the new font. Reposition so anchorLine stays under
+        // the cursor (modulo sub-cell rounding).
+        if (term && anchorLine != null && anchorScreenRow != null) {
+          try {
+            const cellHNew = readCellHeight(term);
+            const buf = term.buffer.active;
+            if (cellHNew != null) {
+              const desiredViewportY = anchorLine - anchorScreenRow;
+              const clamped = Math.max(
+                0,
+                Math.min(buf.baseY, desiredViewportY),
+              );
+              (term as unknown as {
+                scrollToLine?: (n: number) => void;
+              }).scrollToLine?.(clamped);
+            }
+          } catch {
+            /* re-anchor best-effort — skip on failure */
+          }
+        }
       });
     };
     host.addEventListener('wheel', onWheel, { passive: false, capture: true });

--- a/src/terminal/xtermWarmRegistry.ts
+++ b/src/terminal/xtermWarmRegistry.ts
@@ -853,7 +853,29 @@ export function ensureAndShowEntry(
       } catch (e) {
         warn('xterm-warm', 'lazy apply fontSize failed', e);
       }
-      void runResizeReplayForEntry(sid);
+      // Reflow-only path: fit + pty.resize. No snapshot replay — replay
+      // does `term.reset()` + `term.write(snapshot)` which causes the
+      // CanvasAddon to nuke + repaint its texture atlas (visible flash)
+      // and recomputes viewportY against new cols, making the user's
+      // scroll position appear to jump. xterm's internal reflow
+      // (triggered by the fontSize option write above + the fit) keeps
+      // both the buffer and the cursor row stable.
+      try {
+        entry.fit.fit();
+      } catch (e) {
+        warn('xterm-warm', 'lazy apply fit failed', e);
+      }
+      try {
+        const pty = window.ccsmPty;
+        const p = pty?.resize(sid, entry.term.cols, entry.term.rows);
+        if (p && typeof (p as Promise<void>).then === 'function') {
+          void (p as Promise<void>).catch((e) =>
+            warn('xterm-warm', 'lazy apply pty.resize failed', e),
+          );
+        }
+      } catch (e) {
+        warn('xterm-warm', 'lazy apply pty.resize threw', e);
+      }
     }
   }
 
@@ -1004,9 +1026,13 @@ export function disposeEntry(
  *
  *   1. The ResizeObserver-driven flow in `usePtyAttach.warm.ts` (host
  *      container changed size — splitter drag, window resize, etc.).
- *   2. {@link applyTerminalFontSize} when the Ctrl+wheel zoom changes
- *      the font size (cells get bigger/smaller → cols/rows change in
- *      the same way as a container resize would).
+ *
+ * NOTE: NOT used by the Ctrl+wheel font-size zoom path. The snapshot
+ * replay's `term.reset()` + `term.write(snapshot)` causes CanvasAddon
+ * texture-atlas churn (visible flash) and its post-replay
+ * `scrollToLine(savedViewportY)` lands on the wrong row after a cols
+ * change. {@link applyTerminalFontSize} uses a reflow-only path
+ * instead (option write + `fit.fit()` + `pty.resize`).
  *
  * The snapshot replay is non-negotiable for alt-screen TUIs like claude:
  * SIGWINCH alone doesn't trigger a repaint until the next user input,
@@ -1014,8 +1040,7 @@ export function disposeEntry(
  * visible terminal looks stale until the user types.
  *
  * Caller is responsible for whatever serialization / debouncing it needs
- * (the RO path debounces 80 ms + uses an inFlight latch; the font-size
- * path runs immediately because each wheel tick is throttled by RAF).
+ * (the RO path debounces 80 ms + uses an inFlight latch).
  */
 export async function runResizeReplayForEntry(sid: string): Promise<void> {
   const pty = window.ccsmPty;
@@ -1098,25 +1123,38 @@ export async function runResizeReplayForEntry(sid: string): Promise<void> {
 /**
  * Apply a new terminal font size to the warm registry.
  *
- * Strategy (to avoid N concurrent snapshot IPCs when many sessions are
- * warmed): the ACTIVE entry gets the font applied + resize-replay run
- * immediately; all OTHER entries record `pendingFontSize`, which
- * {@link ensureAndShowEntry} consumes on next show.
+ * Strategy: the ACTIVE entry gets the font applied + a reflow-only resize
+ * pushed to its PTY immediately; all OTHER entries record
+ * `pendingFontSize`, which {@link ensureAndShowEntry} consumes on next
+ * show (same reflow-only primitive).
+ *
+ * Reflow-only (no snapshot replay): writing `term.options.fontSize`
+ * changes the cell metric and xterm reflows the existing buffer in
+ * place. We then `fit.fit()` to recompute cols/rows for the new metric
+ * and forward to PTY via `pty.resize` so the child sees SIGWINCH. We
+ * deliberately do NOT call {@link runResizeReplayForEntry} on the zoom
+ * path because:
+ *   1. `term.reset()` + `term.write(snapshot)` makes the CanvasAddon
+ *      drop its texture atlas and full-repaint — visible flash on every
+ *      wheel tick.
+ *   2. The snapshot replay's post-write `scrollToLine(savedViewportY)`
+ *      uses an absolute row number that no longer points to the same
+ *      logical content after cols-change reflow → jumpy scroll position.
+ * xterm's internal reflow preserves both buffer content and cursor row,
+ * so the user's reading position stays where it visually was modulo
+ * sub-cell rounding (the wheel handler in TerminalPane.tsx applies a
+ * mouse-anchor adjustment on top of this for WT/iTerm2-style feel).
  *
  * IME guard: if the active entry is mid-composition, defer — applying
  * `term.options.fontSize` reanchors the hidden textarea mid-edit and
- * makes the CJK preview box jump. We mark it pending instead, and the
- * next `compositionend` would not naturally trigger a re-apply, so this
- * is a known minor staleness for IME-heavy sessions. The user will
- * trigger another wheel event soon enough to retry. Subsequent
- * `applyTerminalFontSize` calls clear stale pending values automatically.
+ * makes the CJK preview box jump. We mark it pending instead.
  */
 export async function applyTerminalFontSize(px: number): Promise<void> {
   const active = getActiveEntry();
   for (const [sid, entry] of warm.entries()) {
     if (active && sid === active.sid) continue;
     // Record pending only when the entry's current font differs — saves
-    // a spurious resize-replay on next show when nothing actually changed.
+    // a spurious resize on next show when nothing actually changed.
     const cur = (entry.term.options as { fontSize?: number }).fontSize;
     if (cur === px) {
       entry.pendingFontSize = null;
@@ -1141,7 +1179,24 @@ export async function applyTerminalFontSize(px: number): Promise<void> {
     warn('xterm-warm', 'apply fontSize failed', e);
     return;
   }
-  await runResizeReplayForEntry(active.sid);
+  // Reflow-only: fit recomputes cols/rows for the new cell metric, then
+  // we forward to PTY. No snapshot replay (see docstring above).
+  try {
+    active.fit.fit();
+  } catch (e) {
+    warn('xterm-warm', 'apply fontSize fit failed', e);
+    return;
+  }
+  try {
+    const pty = window.ccsmPty;
+    if (!pty) return;
+    const p = pty.resize(active.sid, active.term.cols, active.term.rows);
+    if (p && typeof (p as Promise<void>).then === 'function') {
+      await (p as Promise<void>);
+    }
+  } catch (e) {
+    warn('xterm-warm', 'apply fontSize pty.resize failed', e);
+  }
 }
 
 /**


### PR DESCRIPTION
## Root cause

Two defects in the Ctrl+wheel zoom path landed by #1366:

1. **Flash** — `applyTerminalFontSize` called `runResizeReplayForEntry` on every wheel tick. That replay does `term.reset()` + `term.write(snapshot)`. The CanvasAddon drops its texture-atlas and full-repaints on `reset()`, producing a visible flash per tick.
2. **Scroll jump** — the replay's post-write `scrollToLine(savedViewportY)` uses an absolute buffer-row number. After cols-change reflow the same row number points at different logical content, so the user's reading position appears to jump.

CLI native zoom (Windows Terminal, iTerm2) feels silky because it reflows in place and anchors the line under the cursor.

## Diff

- `src/terminal/xtermWarmRegistry.ts`
  - `applyTerminalFontSize`: write `term.options.fontSize`, then `fit.fit()` + `pty.resize`. **No** snapshot replay. xterm's internal reflow preserves buffer + cursor row.
  - `ensureAndShowEntry` lazy-apply for pending font on non-active entries: same reflow-only primitive.
  - `runResizeReplayForEntry` is unchanged and still used by the ResizeObserver path (container size changes).
  - IME `composing` guard preserved.
- `src/components/TerminalPane.tsx` wheel handler:
  - Captures `clientY`-relative `anchorLine = viewportY + Math.floor(offsetY / cellH)` before dispatch.
  - After the zustand subscriber synchronously applies fontSize + fit, recomputes `viewportY` so the same logical line stays under the pointer.
  - Uses `term._core._renderService.dimensions.css.cell.height` (private API), wrapped in try/catch with graceful fallback to no-anchor on failure.

## Dogfood

`scripts/dogfood-task-41-zoom-smoothness.mjs` (headless, offscreen-bounds asserted at top):

| metric | value |
|---|---|
| `before.fontSize` | 13 |
| `afterIn.fontSize` (5x wheel-up) | 18 |
| `afterOut.fontSize` (5x wheel-down) | 13 |
| `before.viewportY` / `afterIn.viewportY` / `afterOut.viewportY` | 38 / 38 / 38 |
| `viewportDriftRoundTrip` | 0 |
| `fontDeltaRoundTrip` | 0 |
| `resetWarnings` (resize reset/snapshot fetch failures) | 0 |

Verdict: **PASS**.

## Local gate

- `npm run typecheck` ✓
- `npm run lint` ✓ (0 errors)
- `npm test` — pre-existing failures only (`better-sqlite3` NODE_MODULE_VERSION mismatch in this dev env + `electron-load-smoke` dist guards), none related to wheel/registry code paths
- `npm run build` ✓

## Not done (intentional)

- WebGL renderer migration — separate PR. Canvas atlas churn is gone from the zoom path now; switching renderers is an independent improvement.
- Gesture-period `transform: scale` preview — would mis-locate the cursor on click during the gesture, rejected.
- `wheelend` throttling — would break tick-by-tick responsiveness, rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)