### PR TITLE
feat(terminal): hot-reload scrollback line cap across warm xterm entries

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,6 +28,7 @@ import { useLanguageEffect } from './app-effects/useLanguageEffect';
 import { useAgentEventBridge } from './app-effects/useAgentEventBridge';
 import { useShortcutHandlers } from './app-effects/useShortcutHandlers';
 import { useTerminalFontSize } from './app-effects/useTerminalFontSize';
+import { useTerminalScrollback } from './app-effects/useTerminalScrollback';
 import { useSessionActivateBridge } from './app-effects/useSessionActivateBridge';
 import { useFocusBridge } from './app-effects/useFocusBridge';
 import { useUpdateDownloadedBridge } from './app-effects/useUpdateDownloadedBridge';
@@ -153,6 +154,12 @@ export default function App() {
   // store field and dispatches font apply + resize-replay to the warm
   // xterm registry. The wheel listener itself lives on TerminalPane.
   useTerminalFontSize();
+
+  // Hot-apply `scrollbackLines` store field to all warm xterm entries when
+  // the user edits it in Settings — no app restart required for the
+  // visible/active terminal. Main-side headless mirror still picks up the
+  // new cap on next session spawn (its buffer is sized at process start).
+  useTerminalScrollback();
 
   // Pipe `session:state` IPC events into the store via subscribeAgentEvents.
   // Drives the AgentIcon attention halo for non-active sessions.

--- a/src/app-effects/useTerminalScrollback.ts
+++ b/src/app-effects/useTerminalScrollback.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import { useStore } from '../stores/store';
+import { applyTerminalScrollback } from '../terminal/xtermWarmRegistry';
+
+/**
+ * Hot-apply the `scrollbackLines` store field to every warm xterm entry.
+ *
+ * The store action (`setScrollbackLines`, dispatched from the Appearance
+ * settings pane on input commit / reset) is the source of truth. This
+ * effect listens for changes and dispatches `applyTerminalScrollback`,
+ * which assigns `term.options.scrollback = n` on each warm entry.
+ *
+ * No first-mount apply: the registry's `allocEntry` reads the store
+ * directly when constructing each Terminal, so the boot value is already
+ * wired in. We only react to subsequent changes via the subscriber.
+ *
+ * Companion knob `useTerminalFontSize` follows the same pattern; the
+ * scrollback variant is simpler because there is no resize-replay,
+ * IME guard, or pending-defer needed — xterm handles cap shrinks
+ * internally (trims oldest rows immediately) and cap grows are a
+ * no-op until new writes arrive.
+ */
+export function useTerminalScrollback(): void {
+  useEffect(() => {
+    let prev = useStore.getState().scrollbackLines;
+    const unsubscribe = useStore.subscribe((s) => {
+      const next = s.scrollbackLines;
+      if (next === prev) return;
+      prev = next;
+      applyTerminalScrollback(next);
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+}

--- a/src/components/settings/AppearancePane.tsx
+++ b/src/components/settings/AppearancePane.tsx
@@ -126,8 +126,9 @@ function CloseBehaviorField() {
 }
 
 // Terminal scrollback line cap. Single user-facing knob that bounds BOTH
-// the visible xterm buffer (next-launch effect — the renderer's xterm
-// singleton reads this once at construction) and the headless
+// the visible xterm buffer (hot-applied — `useTerminalScrollback` subscribes
+// to the store and dispatches `applyTerminalScrollback` across every warm
+// xterm entry, so edits take effect without a restart) and the headless
 // authoritative buffer in main (next-spawn effect — `entryFactory.makeEntry`
 // reads from the same `scrollbackLines` row). Persisted via `db:save` to
 // match the closeBehavior pattern, NOT via the renderer's PERSISTED_KEYS

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -130,7 +130,7 @@ const en = {
     },
     scrollback: 'Terminal scrollback',
     scrollbackHint:
-      'How many lines each terminal keeps in its scrollback buffer. Applies on next attach for the headless mirror and on next launch for the visible terminal.',
+      'How many lines each terminal keeps in its scrollback buffer. The visible terminal updates immediately; the headless mirror applies on next session spawn.',
     scrollbackUnit: 'lines',
     scrollbackAriaLabel: 'Terminal scrollback in lines',
     scrollbackReset: 'Reset to default ({{default}})',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -125,7 +125,7 @@ const zh: EnCatalog = {
     },
     scrollback: '终端回滚行数',
     scrollbackHint:
-      '每个终端在回滚缓冲区中保留的行数。后台镜像缓冲区在下次接入时生效，可见终端在下次启动时生效。',
+      '每个终端在回滚缓冲区中保留的行数。可见终端立即生效；后台镜像缓冲区在下次会话启动时生效。',
     scrollbackUnit: '行',
     scrollbackAriaLabel: '终端回滚行数',
     scrollbackReset: '重置为默认值 ({{default}})',

--- a/src/terminal/xtermWarmRegistry.ts
+++ b/src/terminal/xtermWarmRegistry.ts
@@ -1145,6 +1145,40 @@ export async function applyTerminalFontSize(px: number): Promise<void> {
 }
 
 /**
+ * Apply a new scrollback line cap to every warm entry (active + background).
+ *
+ * Unlike fontSize, scrollback is a pure buffer-capacity setting on xterm's
+ * Terminal:
+ *
+ *   - growing the cap is a no-op on existing rows (new writes will now be
+ *     retained further);
+ *   - shrinking the cap immediately trims the oldest scrollback rows so
+ *     `buffer.active.length` drops to `scrollback + rows` (xterm internal
+ *     behaviour, no replay needed on our side).
+ *
+ * No resize-replay, no IME guard, no `pending*` deferral — assigning
+ * `term.options.scrollback = n` is cheap and side-effect-free with respect
+ * to fontMetrics / cell layout / cursor / IME compositions. Safe to fan
+ * out across all entries (active and offscreen) in one synchronous pass.
+ *
+ * Transparent-transport invariant unchanged: this only resizes the
+ * renderer-side display buffer. The PTY byte stream and the main-side
+ * headless mirror buffer (which uses its own `scrollbackLines` row read
+ * at spawn) are untouched.
+ */
+export function applyTerminalScrollback(n: number): void {
+  for (const entry of warm.values()) {
+    try {
+      const cur = (entry.term.options as { scrollback?: number }).scrollback;
+      if (cur === n) continue;
+      entry.term.options.scrollback = n;
+    } catch (e) {
+      warn('xterm-warm', 'apply scrollback failed', e);
+    }
+  }
+}
+
+/**
  * Test-only: drop all entries without emitting probes (tests don't want
  * probe noise polluting their own assertions). Also resets the
  * offscreen-holder pointer + the unload-listener flag so the next test

--- a/tests/terminal/xtermWarmRegistry.test.ts
+++ b/tests/terminal/xtermWarmRegistry.test.ts
@@ -28,6 +28,7 @@ const { terminalCtor, addonCtor } =
         buffer: {
           active: { viewportY: 0, baseY: 0, cursorY: 0, length: 0, type: 'normal' },
         },
+        options: { scrollback: 1000, fontSize: 13 },
       };
       return inst;
     });
@@ -74,6 +75,7 @@ import {
   getEntry,
   getActiveSid,
   getWarmCacheSize,
+  applyTerminalScrollback,
   __resetRegistryForTests,
 } from '../../src/terminal/xtermWarmRegistry';
 
@@ -339,5 +341,48 @@ describe('xtermWarmRegistry', () => {
     expect(openSpy).toHaveBeenCalledTimes(1);
     expect(entry.opened).toBe(true);
     document.body.removeChild(host2);
+  });
+
+  describe('applyTerminalScrollback', () => {
+    it('fans out new scrollback to every warm entry (active + background)', () => {
+      const { entry: a } = ensureAndShowEntry('sid-a', host);
+      const host2 = document.createElement('div');
+      document.body.appendChild(host2);
+      const { entry: b } = ensureAndShowEntry('sid-b', host2);
+      // sid-b is now active; sid-a is offscreen. Both should still get
+      // the new scrollback — no pending/defer machinery for scrollback.
+      applyTerminalScrollback(7777);
+      expect((a.term.options as { scrollback?: number }).scrollback).toBe(7777);
+      expect((b.term.options as { scrollback?: number }).scrollback).toBe(7777);
+      document.body.removeChild(host2);
+    });
+
+    it('skips entries whose scrollback already matches (no spurious writes)', () => {
+      const { entry } = ensureAndShowEntry('sid-a', host);
+      // Pre-set to the target value via the assignment path we observe.
+      entry.term.options.scrollback = 5000;
+      const proxy = entry.term.options as { scrollback?: number };
+      let writes = 0;
+      Object.defineProperty(entry.term, 'options', {
+        configurable: true,
+        get() {
+          return new Proxy(proxy, {
+            set(target, key, value) {
+              if (key === 'scrollback') writes++;
+              (target as Record<string, unknown>)[key as string] = value;
+              return true;
+            },
+            get(target, key) {
+              return (target as Record<string, unknown>)[key as string];
+            },
+          });
+        },
+      });
+      applyTerminalScrollback(5000);
+      expect(writes).toBe(0);
+      applyTerminalScrollback(6000);
+      expect(writes).toBe(1);
+      expect(proxy.scrollback).toBe(6000);
+    });
   });
 });


### PR DESCRIPTION
## Summary

User report: changing the scrollback line setting in Settings did not take effect until ccsm was restarted.

**Root cause**: the renderer's xterm `Terminal`s only read `scrollbackLines` once at construction (`xtermWarmRegistry.allocEntry`, line ~310). The store field had no subscriber to fan changes out to live `Terminal` instances. The Settings input persisted the value correctly, but no live xterm ever saw the update.

**Fix** mirrors the existing `terminalFontSizePx` hot-apply pattern (PR #1366):

- `applyTerminalScrollback(n)` in `xtermWarmRegistry.ts` — walks every warm entry (active + offscreen) and assigns `term.options.scrollback = n`. No resize-replay / IME guard / pending-defer needed: xterm trims oldest rows internally on cap shrink and grows are no-ops until new writes arrive. Zero impact on cell layout, cursor, or IME composition.
- `useTerminalScrollback` effect in `src/app-effects/` — subscribes to the store field and dispatches the apply on change. Wired into `App.tsx` beside the font-size effect.
- i18n hint text updated: visible terminal applies immediately; main-side headless mirror still requires a fresh session spawn (its buffer is sized at spawn-time in `entryFactory`).

Transparent-transport invariant preserved: this only resizes the renderer-side display buffer. PTY bytes and main-mirror buffer are untouched.

## Diff highlights

```ts
// xtermWarmRegistry.ts (new export)
export function applyTerminalScrollback(n: number): void {
  for (const entry of warm.values()) {
    try {
      const cur = (entry.term.options as { scrollback?: number }).scrollback;
      if (cur === n) continue;
      entry.term.options.scrollback = n;
    } catch (e) { warn('xterm-warm', 'apply scrollback failed', e); }
  }
}
```

```ts
// useTerminalScrollback.ts (new)
let prev = useStore.getState().scrollbackLines;
const unsubscribe = useStore.subscribe((s) => {
  const next = s.scrollbackLines;
  if (next === prev) return;
  prev = next;
  applyTerminalScrollback(next);
});
```

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (no new warnings)
- [x] `npm test` — 2 new unit tests for `applyTerminalScrollback` (fanout + no-op skip) plus existing 19 scrollback/registry tests pass. Pre-existing 36 failures are environment issues (better-sqlite3 ABI mismatch + missing dist for electron-load-smoke) unrelated to this change.
- [x] `npm run build` succeeds
- [x] Headless dogfood (`scratch/dogfood-scrollback-hot-reload.mjs`, `CCSM_E2E_HIDDEN=1`, offscreen-bounds assert):
  - cap=1500 + 3000 writes → `bufLen=1554` (= 1500 + 54 viewport rows) — cap enforced
  - **shrink to 500 (hot)** → `term.options.scrollback === 500`, `bufLen=554` — trimmed immediately
  - background session B also reads `500` after switch — fanout works
  - **grow to 10000 (hot)** + 5000 writes → `bufLen=5555` — uncapped past old 500

PR closes the user request: setting now changes the live terminal immediately, no restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)