### PR TITLE
chore(lint): close --max-warnings 0 gate; drop 114 dead eslint-disable directives

### DIFF
--- a/electron/ptyHost/__tests__/claudeResolver.test.ts
+++ b/electron/ptyHost/__tests__/claudeResolver.test.ts
@@ -29,7 +29,6 @@ interface SpawnFakeBus {
   killed: number;
 }
 function bus(): SpawnFakeBus {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (globalThis as any).__claudeResolverBus as SpawnFakeBus;
 }
 
@@ -81,7 +80,6 @@ function setPlatform(p: NodeJS.Platform) {
 }
 
 beforeEach(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (globalThis as any).__claudeResolverBus = {
     results: new Map(),
     calls: [],
@@ -95,7 +93,6 @@ beforeEach(() => {
 afterEach(() => {
   setPlatform(ORIGINAL_PLATFORM);
   __resetClaudeResolverForTest();
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (globalThis as any).__claudeResolverBus;
   vi.restoreAllMocks();
 });

--- a/electron/ptyHost/__tests__/detachReattach.test.ts
+++ b/electron/ptyHost/__tests__/detachReattach.test.ts
@@ -46,7 +46,6 @@ interface PtyFakeBus {
   pendingCallbacks: Array<() => void>;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function bus(): PtyFakeBus { return (globalThis as any).__pf as PtyFakeBus; }
 
 vi.mock('node-pty', () => ({
@@ -172,14 +171,12 @@ function freshBus(): PtyFakeBus {
 
 describe('L4 PR-E: detach/reattach via headless buffer (#864)', () => {
   beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (globalThis as any).__pf = freshBus();
     vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (globalThis as any).__pf;
   });
 
@@ -218,7 +215,6 @@ describe('L4 PR-E: detach/reattach via headless buffer (#864)', () => {
 
     // Now register a wc (the freshly-mounted visible xterm).
     const wc = makeFakeWc(1);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     entry.attached.set(wc.id, wc as any);
 
     // A live chunk arrives strictly AFTER the snapshot — must be
@@ -245,7 +241,6 @@ describe('L4 PR-E: detach/reattach via headless buffer (#864)', () => {
 
     // Cycle 1 attach.
     const wc1 = makeFakeWc(1);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     entry.attached.set(wc1.id, wc1 as any);
     bus().onData!('A3');
     expect(wc1.received).toEqual([{ chunk: 'A3', seq: 3 }]);
@@ -269,7 +264,6 @@ describe('L4 PR-E: detach/reattach via headless buffer (#864)', () => {
     expect(snap.seq).toBeGreaterThan(3);
 
     const wc2 = makeFakeWc(2);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     entry.attached.set(wc2.id, wc2 as any);
     bus().onData!('C1');
     expect(wc2.received).toEqual([{ chunk: 'C1', seq: 7 }]);
@@ -287,7 +281,6 @@ describe('L4 PR-E: detach/reattach via headless buffer (#864)', () => {
     expect(snap.seq).toBe(9);
 
     const wc3 = makeFakeWc(3);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     entry.attached.set(wc3.id, wc3 as any);
     bus().onData!('E1');
     expect(wc3.received).toEqual([{ chunk: 'E1', seq: 10 }]);
@@ -325,7 +318,6 @@ describe('L4 PR-E: detach/reattach via headless buffer (#864)', () => {
         visibleTerminal.push(payload.chunk);
       }
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     entry.attached.set(wc.id, wc as any);
 
     // A live chunk arrives DURING the snapshot await; PR-B race window.
@@ -381,7 +373,6 @@ describe('L4 PR-E: detach/reattach via headless buffer (#864)', () => {
     // Now the warn MUST fire (visible consumer is present and the lag
     // is real-user-affecting).
     const wc = makeFakeWc(1);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     entry.attached.set(wc.id, wc as any);
     warnSpy.mockClear();
     for (let i = 0; i < threshold + 1; i++) {

--- a/electron/ptyHost/__tests__/entryFactory.test.ts
+++ b/electron/ptyHost/__tests__/entryFactory.test.ts
@@ -29,7 +29,6 @@ interface PtyFakeBus {
   deferHeadlessWrite: boolean;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function bus(): PtyFakeBus { return (globalThis as any).__pf as PtyFakeBus; }
 
 vi.mock('node-pty', () => ({
@@ -53,7 +52,6 @@ vi.mock('@xterm/headless', () => ({
   Terminal: class {
     constructor(opts?: unknown) {
       // Record constructor opts so tests can pin scrollback wiring.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (globalThis as any).__pf_lastHeadlessOpts = opts;
     }
     // Mirror @xterm/headless's `write(data, callback?)` signature so tests
@@ -112,7 +110,6 @@ vi.mock('../dataFanout', () => ({
 // `globalThis.__pf_scrollback` directly.
 vi.mock('../../prefs/scrollback', () => ({
   loadScrollbackLines: () =>
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (((globalThis as any).__pf_scrollback as number | undefined) ?? 1500),
   DEFAULT_SCROLLBACK_LINES: 1500,
 }));
@@ -135,14 +132,12 @@ describe('entryFactory.makeEntry', () => {
       ensureCopied: false,
       deferHeadlessWrite: false,
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (globalThis as any).__pf = b;
     vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (globalThis as any).__pf;
   });
 
@@ -219,10 +214,8 @@ describe('entryFactory.makeEntry', () => {
   });
 
   it('passes the user-configured scrollback cap into the headless Terminal constructor', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (globalThis as any).__pf_scrollback = 2500;
     makeEntry('sid-SCROLL', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const opts = (globalThis as any).__pf_lastHeadlessOpts as
       | { scrollback?: number }
       | undefined;
@@ -230,10 +223,8 @@ describe('entryFactory.makeEntry', () => {
   });
 
   it('falls back to the default cap when the prefs module returns the default', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (globalThis as any).__pf_scrollback;
     makeEntry('sid-DEFAULT', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const opts = (globalThis as any).__pf_lastHeadlessOpts as
       | { scrollback?: number }
       | undefined;
@@ -312,14 +303,12 @@ describe('entryFactory.dispatchPtyChunk', () => {
       ensureCopied: false,
       deferHeadlessWrite: false,
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (globalThis as any).__pf = b;
     vi.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (globalThis as any).__pf;
   });
 
@@ -333,7 +322,6 @@ describe('entryFactory.dispatchPtyChunk', () => {
         sent.push({ chunk: payload.chunk, seq: payload.seq });
       },
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     entry.attached.set(1, wc as any);
 
     mod.dispatchPtyChunk('sid-DW', entry, 'a');
@@ -366,7 +354,6 @@ describe('entryFactory.dispatchPtyChunk', () => {
       isDestroyed: () => false,
       send: vi.fn(),
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     entry.attached.set(1, wc as any);
 
     // Defer write callbacks so writes stay "pending" until we manually drain.
@@ -413,9 +400,7 @@ describe('entryFactory.dispatchPtyChunk', () => {
       isDestroyed: () => false,
       send: (_ch: string, payload: { seq: number }) => aliveSent.push(payload.seq),
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     entry.attached.set(1, dead as any);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     entry.attached.set(2, alive as any);
 
     mod.dispatchPtyChunk('sid-DEAD', entry, 'x');
@@ -430,9 +415,7 @@ describe('entryFactory.dispatchPtyChunk', () => {
     const entry = mod.makeEntry('sid-PRUNE', '/work', '/bin/claude', 80, 24, { onExit: vi.fn() });
     const dead = { isDestroyed: () => true, send: vi.fn() };
     const alive = { isDestroyed: () => false, send: vi.fn() };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     entry.attached.set(1, dead as any);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     entry.attached.set(2, alive as any);
     expect(entry.attached.size).toBe(2);
 

--- a/electron/ptyHost/__tests__/ipcRegistrar.test.ts
+++ b/electron/ptyHost/__tests__/ipcRegistrar.test.ts
@@ -24,7 +24,6 @@ interface RegistrarBus {
   userDataDir: string;
 }
 function bus(): RegistrarBus {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (globalThis as any).__irBus as RegistrarBus;
 }
 
@@ -112,7 +111,6 @@ function makeDeps(over: Partial<PtyIpcDeps> = {}): PtyIpcDeps {
 }
 
 beforeEach(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (globalThis as any).__irBus = {
     resolveClaude: vi.fn(),
     watcherListeners: new Map<string, Array<(evt: unknown) => void>>(),
@@ -124,7 +122,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (globalThis as any).__irBus;
   vi.restoreAllMocks();
 });
@@ -134,7 +131,6 @@ afterEach(() => {
 describe('registerPtyIpc handler registration', () => {
   it('registers all ten pty:* channels (8 legacy + getBufferSnapshot + saveClipboardImage)', () => {
     const ipc = makeFakeIpc();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
     expect(Array.from(ipc.handlers.keys()).sort()).toEqual(
       [
@@ -162,7 +158,6 @@ describe('registerPtyIpc handler registration', () => {
         seq: 7,
       })),
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     const out = await ipc.handlers.get(PTY_CHANNELS.getBufferSnapshot)!({}, 'sid-Z');
     expect(out).toEqual({ snapshot: 'snap-for-sid-Z', seq: 7 });
@@ -176,7 +171,6 @@ describe(PTY_CHANNELS.list, () => {
   it('delegates to deps.listPtySessions', () => {
     const ipc = makeFakeIpc();
     const deps = makeDeps({ listPtySessions: vi.fn(() => [{ sid: 'a', pid: 1, cols: 80, rows: 24, cwd: '/x' }]) });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     const out = ipc.handlers.get(PTY_CHANNELS.list)!({});
     expect(out).toEqual([{ sid: 'a', pid: 1, cols: 80, rows: 24, cwd: '/x' }]);
@@ -188,7 +182,6 @@ describe('pty:input / resize / kill / get pass-through', () => {
   it('input forwards sid+data', () => {
     const ipc = makeFakeIpc();
     const deps = makeDeps();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     ipc.handlers.get(PTY_CHANNELS.input)!({}, 'sid', 'echo\n');
     expect(deps.inputPtySession).toHaveBeenCalledWith('sid', 'echo\n');
@@ -197,7 +190,6 @@ describe('pty:input / resize / kill / get pass-through', () => {
   it('resize forwards sid+cols+rows', () => {
     const ipc = makeFakeIpc();
     const deps = makeDeps();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     ipc.handlers.get(PTY_CHANNELS.resize)!({}, 'sid', 100, 30);
     expect(deps.resizePtySession).toHaveBeenCalledWith('sid', 100, 30);
@@ -206,7 +198,6 @@ describe('pty:input / resize / kill / get pass-through', () => {
   it('kill returns the deps result', async () => {
     const ipc = makeFakeIpc();
     const deps = makeDeps({ killPtySession: vi.fn(async () => false) });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     await expect(ipc.handlers.get(PTY_CHANNELS.kill)!({}, 'sid')).resolves.toBe(false);
     expect(deps.killPtySession).toHaveBeenCalledWith('sid');
@@ -216,7 +207,6 @@ describe('pty:input / resize / kill / get pass-through', () => {
     const info = { sid: 's', pid: 9, cols: 80, rows: 24, cwd: '/' };
     const ipc = makeFakeIpc();
     const deps = makeDeps({ getPtySession: vi.fn(() => info) });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     expect(ipc.handlers.get(PTY_CHANNELS.get)!({}, 's')).toBe(info);
   });
@@ -228,7 +218,6 @@ describe(PTY_CHANNELS.spawn, () => {
   it('returns {ok:false, error:claude_not_found} when resolveClaude returns null', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue(null);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
     expect(await ipc.handlers.get(PTY_CHANNELS.spawn)!({}, 'sid', '/work')).toEqual({
       ok: false,
@@ -242,7 +231,6 @@ describe(PTY_CHANNELS.spawn, () => {
     const deps = makeDeps({
       spawnPtySession: vi.fn(() => ({ sid: 'sid', pid: 1, cols: 80, rows: 24, cwd: '/picked' })),
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     const out = await ipc.handlers.get(PTY_CHANNELS.spawn)!({}, 'sid', '/work');
     expect(out).toEqual({ ok: true, sid: 'sid', pid: 1, cols: 80, rows: 24, cwd: '/picked' });
@@ -265,7 +253,6 @@ describe(PTY_CHANNELS.spawn, () => {
     const deps = makeDeps({
       spawnPtySession: vi.fn(() => ({ sid: 'sid', pid: 1, cols: 120, rows: 30, cwd: '/picked' })),
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     // Even if a (legacy) renderer were to send the third opts argument,
     // the IPC handler ignores it — the only opt threaded into the
@@ -284,7 +271,6 @@ describe(PTY_CHANNELS.spawn, () => {
     const deps = makeDeps({
       spawnPtySession: vi.fn(() => ({ sid: 'sid', pid: 1, cols: 120, rows: 30, cwd: '/picked' })),
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     await ipc.handlers.get(PTY_CHANNELS.spawn)!({}, 'sid', '/work');
     const call = (deps.spawnPtySession as ReturnType<typeof vi.fn>).mock.calls[0];
@@ -300,7 +286,6 @@ describe(PTY_CHANNELS.spawn, () => {
     const deps = makeDeps({
       spawnPtySession: vi.fn(() => { throw new Error('ENOENT'); }),
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     const out = (await ipc.handlers.get(PTY_CHANNELS.spawn)!({}, 'sid', '/work')) as { ok: boolean; error: string };
     expect(out.ok).toBe(false);
@@ -314,14 +299,12 @@ describe(PTY_CHANNELS.spawn, () => {
     const win = makeWin(wc);
     let captured: ((newCwd: string) => void) | null = null;
     const deps = makeDeps({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       getMainWindow: () => win as any,
       spawnPtySession: vi.fn((_sid: string, _cwd: string, _claude: string, opts?: { onCwdRedirect?: (n: string) => void }) => {
         captured = opts?.onCwdRedirect ?? null;
         return { sid: 'sid', pid: 1, cols: 80, rows: 24, cwd: '/picked' };
       }),
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     await ipc.handlers.get(PTY_CHANNELS.spawn)!({}, 'sid', '/work');
     expect(captured).not.toBeNull();
@@ -340,7 +323,6 @@ describe(PTY_CHANNELS.spawn, () => {
         return { sid: 'sid', pid: 1, cols: 80, rows: 24, cwd: '/' };
       }),
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     await ipc.handlers.get(PTY_CHANNELS.spawn)!({}, 'sid', '/work');
     expect(() => captured!('/new')).not.toThrow();
@@ -353,14 +335,12 @@ describe(PTY_CHANNELS.spawn, () => {
     const win = makeWin(wc);
     let captured: ((newCwd: string) => void) | null = null;
     const deps = makeDeps({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       getMainWindow: () => win as any,
       spawnPtySession: vi.fn((_sid, _cwd, _claude, opts?: { onCwdRedirect?: (n: string) => void }) => {
         captured = opts?.onCwdRedirect ?? null;
         return { sid: 'sid', pid: 1, cols: 80, rows: 24, cwd: '/' };
       }),
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     await ipc.handlers.get(PTY_CHANNELS.spawn)!({}, 'sid', '/work');
     expect(() => captured!('/new')).not.toThrow();
@@ -372,7 +352,6 @@ describe(PTY_CHANNELS.spawn, () => {
 describe(PTY_CHANNELS.attach, () => {
   it('returns null when entry is unknown', () => {
     const ipc = makeFakeIpc();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps({ getEntry: () => undefined }));
     expect(ipc.handlers.get(PTY_CHANNELS.attach)!({ sender: makeWc(1) }, 'sid')).toBeNull();
   });
@@ -389,10 +368,8 @@ describe(PTY_CHANNELS.attach, () => {
       attached,
     };
     const deps = makeDeps({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       getEntry: () => entry as any,
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     const wc = makeWc(7);
     const res = ipc.handlers.get(PTY_CHANNELS.attach)!({ sender: wc }, 'sid');
@@ -415,10 +392,8 @@ describe(PTY_CHANNELS.attach, () => {
       attached,
     };
     const deps = makeDeps({
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       getEntry: () => entry as any,
     });
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, deps);
     const wc = makeWc(11);
     ipc.handlers.get(PTY_CHANNELS.attach)!({ sender: wc }, 'sid');
@@ -433,9 +408,7 @@ describe(PTY_CHANNELS.detach, () => {
   it('removes the sender id from entry.attached', () => {
     const ipc = makeFakeIpc();
     const attached = new Map<number, unknown>([[5, makeWc(5)]]);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const entry = { attached } as any;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps({ getEntry: () => entry }));
     ipc.handlers.get(PTY_CHANNELS.detach)!({ sender: makeWc(5) }, 'sid');
     expect(attached.has(5)).toBe(false);
@@ -443,7 +416,6 @@ describe(PTY_CHANNELS.detach, () => {
 
   it('is a no-op when entry is unknown', () => {
     const ipc = makeFakeIpc();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps({ getEntry: () => undefined }));
     expect(() => ipc.handlers.get(PTY_CHANNELS.detach)!({ sender: makeWc(1) }, 'sid')).not.toThrow();
   });
@@ -455,7 +427,6 @@ describe(PTY_CHANNELS.checkClaudeAvailable, () => {
   it('returns {available:true, path} when resolveClaude succeeds', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
     expect(await ipc.handlers.get(PTY_CHANNELS.checkClaudeAvailable)!({}, undefined)).toEqual({
       available: true,
@@ -466,7 +437,6 @@ describe(PTY_CHANNELS.checkClaudeAvailable, () => {
   it('returns {available:false} when resolveClaude returns null', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue(null);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
     expect(await ipc.handlers.get(PTY_CHANNELS.checkClaudeAvailable)!({}, undefined)).toEqual({
       available: false,
@@ -476,7 +446,6 @@ describe(PTY_CHANNELS.checkClaudeAvailable, () => {
   it('passes {force:true} through to resolveClaude when opts.force === true', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
     await ipc.handlers.get(PTY_CHANNELS.checkClaudeAvailable)!({}, { force: true });
     expect(bus().resolveClaude).toHaveBeenCalledWith({ force: true });
@@ -485,7 +454,6 @@ describe(PTY_CHANNELS.checkClaudeAvailable, () => {
   it('does NOT pass force when opts is malformed (string / number / null / no force key)', async () => {
     const ipc = makeFakeIpc();
     bus().resolveClaude.mockReturnValue('/bin/claude');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
     await ipc.handlers.get(PTY_CHANNELS.checkClaudeAvailable)!({}, 'not-an-object');
     await ipc.handlers.get(PTY_CHANNELS.checkClaudeAvailable)!({}, null);
@@ -554,9 +522,7 @@ describe(PTY_CHANNELS.saveClipboardImage, () => {
 describe('sessionWatcher → renderer bridge', () => {
   it('subscribes to state-changed and title-changed exactly once across re-registrations', () => {
     const ipc = makeFakeIpc();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps());
     // The registrar's `stateBridgeInstalled` guard is module-level and may
     // already be true from earlier tests (other test files import this same
@@ -570,7 +536,6 @@ describe('sessionWatcher → renderer bridge', () => {
     const ipc = makeFakeIpc();
     const wc = makeWc(1);
     const win = makeWin(wc);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps({ getMainWindow: () => win as any }));
     const listeners = bus().watcherListeners.get('state-changed') ?? [];
     if (listeners.length === 0) {
@@ -587,7 +552,6 @@ describe('sessionWatcher → renderer bridge', () => {
     const ipc = makeFakeIpc();
     const wc = makeWc(1);
     const win = makeWin(wc);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps({ getMainWindow: () => win as any }));
     const listeners = bus().watcherListeners.get('title-changed') ?? [];
     if (listeners.length === 0) return;
@@ -597,7 +561,6 @@ describe('sessionWatcher → renderer bridge', () => {
 
   it('state-changed forward is a no-op when getMainWindow returns null', () => {
     const ipc = makeFakeIpc();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps({ getMainWindow: () => null }));
     const listeners = bus().watcherListeners.get('state-changed') ?? [];
     if (listeners.length === 0) return;
@@ -608,7 +571,6 @@ describe('sessionWatcher → renderer bridge', () => {
     const ipc = makeFakeIpc();
     const wc = makeWc(1, { sendThrows: true });
     const win = makeWin(wc);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps({ getMainWindow: () => win as any }));
     const listeners = bus().watcherListeners.get('state-changed') ?? [];
     if (listeners.length === 0) return;

--- a/electron/ptyHost/__tests__/ipcRegistrarWcDestroyed.test.ts
+++ b/electron/ptyHost/__tests__/ipcRegistrarWcDestroyed.test.ts
@@ -23,7 +23,6 @@ interface RegistrarBus {
   userDataDir: string;
 }
 function bus(): RegistrarBus {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (globalThis as any).__irBusF6 as RegistrarBus;
 }
 
@@ -90,7 +89,6 @@ function makeDeps(over: Partial<PtyIpcDeps> = {}): PtyIpcDeps {
 }
 
 beforeEach(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (globalThis as any).__irBusF6 = {
     resolveClaude: vi.fn(),
     watcherListeners: new Map(),
@@ -100,7 +98,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (globalThis as any).__irBusF6;
   vi.restoreAllMocks();
 });
@@ -116,7 +113,6 @@ describe('F6: pty:attach destroyed-handler isolates per-wc (PR #1315 follow-up)'
       rows: 24,
       attached,
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     registerPtyIpc(ipc as any, makeDeps({ getEntry: () => entry as any }));
 
     const wcA = makeWc(101);

--- a/electron/ptyHost/__tests__/lifecycle.test.ts
+++ b/electron/ptyHost/__tests__/lifecycle.test.ts
@@ -38,7 +38,6 @@ interface LifecycleBus {
 }
 
 function bus(): LifecycleBus {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   return (globalThis as any).__lcBus as LifecycleBus;
 }
 
@@ -110,7 +109,6 @@ function makeFakeEntry(over: Partial<FakeEntry> = {}): FakeEntry {
 }
 
 beforeEach(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (globalThis as any).__lcBus = {
     killCalls: [],
     watcherStopCalls: [],
@@ -121,7 +119,6 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   delete (globalThis as any).__lcBus;
   vi.restoreAllMocks();
 });
@@ -134,7 +131,6 @@ describe('lifecycle.spawn', () => {
     const entry = makeFakeEntry({ pty: makeFakePty({ pid: 9 }), cwd: '/picked' });
     bus().makeEntry.mockReturnValue(entry);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const info = L.spawn(sessions as any, 'sid-A', '/work', '/bin/claude');
 
     expect(sessions.get('sid-A')).toBe(entry);
@@ -144,7 +140,6 @@ describe('lifecycle.spawn', () => {
   it('uses DEFAULT_COLS/ROWS when opts is omitted', () => {
     const sessions = new Map<string, FakeEntry>();
     bus().makeEntry.mockReturnValue(makeFakeEntry());
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     L.spawn(sessions as any, 'sid', '/work', '/bin/claude');
     const args = bus().makeEntry.mock.calls[0];
     expect(args[3]).toBe(120); // cols
@@ -154,7 +149,6 @@ describe('lifecycle.spawn', () => {
   it('passes through explicit cols/rows opts', () => {
     const sessions = new Map<string, FakeEntry>();
     bus().makeEntry.mockReturnValue(makeFakeEntry());
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     L.spawn(sessions as any, 'sid', '/work', '/bin/claude', { cols: 200, rows: 50 });
     const args = bus().makeEntry.mock.calls[0];
     expect(args[3]).toBe(200);
@@ -166,7 +160,6 @@ describe('lifecycle.spawn', () => {
     const entry = makeFakeEntry({ pty: makeFakePty({ pid: 99 }) });
     sessions.set('sid-A', entry);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const info = L.spawn(sessions as any, 'sid-A', '/work2', '/bin/claude2');
 
     expect(bus().makeEntry).not.toHaveBeenCalled();
@@ -177,7 +170,6 @@ describe('lifecycle.spawn', () => {
     const sessions = new Map<string, FakeEntry>();
     bus().makeEntry.mockReturnValue(makeFakeEntry());
     const onCwdRedirect = vi.fn();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     L.spawn(sessions as any, 'sid', '/work', '/bin/claude', { onCwdRedirect });
     const deps = bus().makeEntry.mock.calls[0][5] as { onCwdRedirect?: unknown };
     expect(deps.onCwdRedirect).toBe(onCwdRedirect);
@@ -186,7 +178,6 @@ describe('lifecycle.spawn', () => {
   it('the onExit deps callback removes the entry from the map', () => {
     const sessions = new Map<string, FakeEntry>();
     bus().makeEntry.mockReturnValue(makeFakeEntry());
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     L.spawn(sessions as any, 'sid-A', '/work', '/bin/claude');
     expect(sessions.has('sid-A')).toBe(true);
     const deps = bus().makeEntry.mock.calls[0][5] as { onExit: (s: string) => void };
@@ -203,7 +194,6 @@ describe('lifecycle.list and get', () => {
     sessions.set('a', makeFakeEntry({ cwd: '/a', pty: makeFakePty({ pid: 1 }) }));
     sessions.set('b', makeFakeEntry({ cwd: '/b', pty: makeFakePty({ pid: 2 }) }));
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const out = L.list(sessions as any);
     expect(out).toHaveLength(2);
     expect(out.map((i) => i.sid).sort()).toEqual(['a', 'b']);
@@ -212,14 +202,12 @@ describe('lifecycle.list and get', () => {
   });
 
   it('get returns null when sid is not in the map', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(L.get(new Map() as any, 'nope')).toBeNull();
   });
 
   it('get returns the info for an existing entry', () => {
     const sessions = new Map<string, FakeEntry>();
     sessions.set('s', makeFakeEntry({ cwd: '/c', pty: makeFakePty({ pid: 7 }) }));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(L.get(sessions as any, 's')).toEqual({ sid: 's', pid: 7, cols: 80, rows: 24, cwd: '/c' });
   });
 });
@@ -228,7 +216,6 @@ describe('lifecycle.list and get', () => {
 
 describe('lifecycle.attach and detach', () => {
   it('attach returns null for an unknown sid', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(L.attach(new Map() as any, 'ghost')).toBeNull();
   });
 
@@ -241,7 +228,6 @@ describe('lifecycle.attach and detach', () => {
       pty: makeFakePty({ pid: 55 }),
       serialize: { serialize: serializeSpy },
     }));
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(L.attach(sessions as any, 's')).toEqual({
       cols: 99,
       rows: 33,
@@ -255,7 +241,6 @@ describe('lifecycle.attach and detach', () => {
   it('detach is a no-op at the lifecycle layer (per-webContents cleanup is IPC concern)', () => {
     const sessions = new Map<string, FakeEntry>();
     sessions.set('s', makeFakeEntry());
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(() => L.detach(sessions as any, 's')).not.toThrow();
     // entry not removed
     expect(sessions.has('s')).toBe(true);
@@ -269,13 +254,11 @@ describe('lifecycle.input', () => {
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
     sessions.set('s', entry);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     L.input(sessions as any, 's', 'echo hi\n');
     expect(entry.pty.write).toHaveBeenCalledWith('echo hi\n');
   });
 
   it('is a silent no-op when sid is unknown', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(() => L.input(new Map() as any, 'ghost', 'x')).not.toThrow();
   });
 
@@ -284,7 +267,6 @@ describe('lifecycle.input', () => {
     const entry = makeFakeEntry();
     entry.pty.write = vi.fn(() => { throw new Error('EPIPE'); });
     sessions.set('s', entry);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(() => L.input(sessions as any, 's', 'x')).not.toThrow();
   });
 });
@@ -296,7 +278,6 @@ describe('lifecycle.resize', () => {
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
     sessions.set('s', entry);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     L.resize(sessions as any, 's', 100, 40);
     expect(entry.pty.resize).toHaveBeenCalledWith(100, 40);
     expect(entry.headless.resize).toHaveBeenCalledWith(100, 40);
@@ -308,9 +289,7 @@ describe('lifecycle.resize', () => {
     const sessions = new Map<string, FakeEntry>();
     const entry = makeFakeEntry();
     sessions.set('s', entry);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     L.resize(sessions as any, 's', 1, 40);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     L.resize(sessions as any, 's', 40, 1);
     expect(entry.pty.resize).not.toHaveBeenCalled();
     expect(entry.headless.resize).not.toHaveBeenCalled();
@@ -324,7 +303,6 @@ describe('lifecycle.resize', () => {
     const entry = makeFakeEntry();
     entry.pty.resize = vi.fn(() => { throw new Error('boom'); });
     sessions.set('s', entry);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(() => L.resize(sessions as any, 's', 100, 40)).not.toThrow();
     expect(console.warn).toHaveBeenCalledWith(
       expect.stringContaining('resize s failed'),
@@ -332,7 +310,6 @@ describe('lifecycle.resize', () => {
   });
 
   it('is a no-op when sid is unknown', () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(L.resize(new Map() as any, 'ghost', 100, 40)).toBeUndefined();
   });
 });
@@ -341,7 +318,6 @@ describe('lifecycle.resize', () => {
 
 describe('lifecycle.kill', () => {
   it('resolves to false for an unknown sid (no side effects)', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await expect(L.kill(new Map() as any, 'ghost')).resolves.toBe(false);
     expect(bus().killCalls).toEqual([]);
     expect(bus().watcherStopCalls).toEqual([]);
@@ -360,7 +336,6 @@ describe('lifecycle.kill', () => {
     entry.pty.write = vi.fn(() => entry.pty.__fireExit!());
     sessions.set('s', entry);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await expect(L.kill(sessions as any, 's')).resolves.toBe(true);
     expect(entry.pty.write).toHaveBeenCalledWith('\x03');
     // Hard kill MUST NOT have been called on the graceful path — that
@@ -378,7 +353,6 @@ describe('lifecycle.kill', () => {
     entry.pty.write = vi.fn(() => { entry.pty.__fireExit!(); });
     sessions.set('s', entry);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await expect(L.kill(sessions as any, 's')).resolves.toBe(true);
     expect(bus().killCalls).toEqual([]);
     // Watcher still stopped (idempotent, doesn't interfere with claude's writes).
@@ -394,7 +368,6 @@ describe('lifecycle.kill', () => {
     // write threw, no onExit fired → resolves false via timeout (and
     // escalates to hard kill in the timer branch).
     vi.useFakeTimers();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const p = L.kill(sessions as any, 's');
     await vi.advanceTimersByTimeAsync(L.KILL_EXIT_TIMEOUT_MS + 10);
     await expect(p).resolves.toBe(false);
@@ -410,7 +383,6 @@ describe('lifecycle.kill', () => {
     entry.pty.write = vi.fn(() => entry.pty.__fireExit!());
     sessions.set('s', entry);
     bus().watcherStopShouldThrow = true;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await expect(L.kill(sessions as any, 's')).resolves.toBe(true);
     expect(bus().watcherStopCalls).toEqual(['s']);
   });
@@ -438,7 +410,6 @@ describe('lifecycle.kill', () => {
     });
     sessions.set('s', entry);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await expect(L.kill(sessions as any, 's')).resolves.toBe(true);
     expect(calls[0]).toBe('onExit');
     expect(calls[1]).toBe('write');
@@ -455,7 +426,6 @@ describe('lifecycle.kill', () => {
     entry.pty.write = vi.fn();
     sessions.set('s', entry);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const p = L.kill(sessions as any, 's');
     // Soft signal sent synchronously, watcher stopped — but the hard
     // kill / subtree walk MUST NOT have run yet (graceful path).
@@ -487,7 +457,6 @@ describe('lifecycle.kill', () => {
     entry.pty.write = vi.fn();
     sessions.set('s', entry);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const p = L.kill(sessions as any, 's');
     let resolved: boolean | 'pending' = 'pending';
     void p.then((v) => { resolved = v; });
@@ -515,7 +484,6 @@ describe('lifecycle.kill', () => {
     entry.pty.write = vi.fn();
     sessions.set('s', entry);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const p = L.kill(sessions as any, 's');
 
     // Before timeout: no hard kill yet, no subtree walk.
@@ -531,7 +499,6 @@ describe('lifecycle.kill', () => {
     // Zombie removed from registry — attach now returns null, letting the
     // renderer's reloadNonce → spawn-on-null fallback create a fresh PTY.
     expect(sessions.has('s')).toBe(false);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(L.attach(sessions as any, 's')).toBeNull();
     vi.useRealTimers();
   });
@@ -550,7 +517,6 @@ describe('lifecycle.kill', () => {
     });
     sessions.set('s', entry);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const p = L.kill(sessions as any, 's');
     await vi.advanceTimersByTimeAsync(L.KILL_EXIT_TIMEOUT_MS + 10);
     await expect(p).resolves.toBe(false);
@@ -572,9 +538,7 @@ describe('lifecycle.kill', () => {
     entry.pty.write = vi.fn();
     sessions.set('s', entry);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const p1 = L.kill(sessions as any, 's');
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const p2 = L.kill(sessions as any, 's');
     // Same promise — second call is a no-op short-circuit, no extra
     // soft-signal writes or watcher-stop calls.
@@ -595,12 +559,10 @@ describe('lifecycle.kill', () => {
     entry.pty.write = vi.fn(() => entry.pty.__fireExit!());
     sessions.set('s', entry);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await L.kill(sessions as any, 's');
     // Re-add the entry (simulating spawn-on-null fallback creating a new pty
     // for the same sid) and kill again — this must NOT short-circuit.
     sessions.set('s', entry);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await L.kill(sessions as any, 's');
     expect(entry.pty.write).toHaveBeenCalledTimes(2);
   });
@@ -622,7 +584,6 @@ describe('lifecycle.killAll', () => {
     sessions.set('b', b);
     sessions.set('c', c);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const result = L.killAll(sessions as any);
     // killAll must return a Promise (before-quit awaits it to give claude
     // time to flush before Electron tears down — see appLifecycle.ts).
@@ -649,7 +610,6 @@ describe('lifecycle.killAll', () => {
     sessions.set('fast', fast);
     sessions.set('slow', slow);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const p = L.killAll(sessions as any);
     let resolved: 'pending' | 'done' = 'pending';
     void p.then(() => { resolved = 'done'; });
@@ -670,13 +630,11 @@ describe('lifecycle.killAll', () => {
     b.pty.write = vi.fn(() => b.pty.__fireExit!());
     sessions.set('a', a);
     sessions.set('b', b);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await L.killAll(sessions as any);
     expect(bus().watcherStopCalls).toHaveLength(2);
   });
 
   it('killAll over an empty map resolves immediately with no side effects', async () => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await expect(L.killAll(new Map() as any)).resolves.toBeUndefined();
     expect(bus().killCalls).toEqual([]);
     expect(bus().watcherStopCalls).toEqual([]);

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -410,7 +410,6 @@ export async function getBufferSnapshot(
   for (let i = 0; i < lines.length; i += SNAPSHOT_CHUNK_LINES) {
     out.push(lines.slice(i, i + SNAPSHOT_CHUNK_LINES).join('\n'));
     if (i + SNAPSHOT_CHUNK_LINES < lines.length) {
-      // eslint-disable-next-line no-await-in-loop
       await new Promise<void>((resolve) => setImmediate(resolve));
     }
   }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "build": "npm run clean && tsc -p tsconfig.electron.json && webpack --mode production && node -e \"const fs=require('fs');const p='dist/renderer/bundle.js';const t=Date.now()/1000;fs.utimesSync(p,t,t)\"",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.electron.json",
-    "lint": "eslint . --ext .ts,.tsx",
+    "lint": "eslint . --ext .ts,.tsx --max-warnings 0",
     "test": "vitest run",
     "test:watch": "vitest",
     "coverage": "vitest run --coverage",


### PR DESCRIPTION
## Summary

- `npm run lint` ran without `--max-warnings`, so 114 `Unused eslint-disable directive` warnings were accumulating in CI logs without ever failing the build (audit caught this as P2 infra debt 2026-05-25).
- All 114 disables targeted two rules already turned **off** in `eslint.config.js:115,116` (`@typescript-eslint/no-explicit-any` and `no-await-in-loop`) — they were dead noise, not load-bearing.
- This PR removes the dead disables and tightens the lint gate so future regressions fail CI instead of piling up.

## What changed

| File | Change |
|---|---|
| `package.json:24` | `eslint . --ext .ts,.tsx` → `eslint . --ext .ts,.tsx --max-warnings 0` |
| `electron/ptyHost/lifecycle.ts:411` | drop `// eslint-disable-next-line no-await-in-loop` (1 line) |
| `electron/ptyHost/__tests__/*.test.ts` (6 files) | drop 113 `// eslint-disable-next-line @typescript-eslint/no-explicit-any` lines |

Net diff: **+1 / -115**, 8 files. No behavior change — only deletes pure-comment lines and adds one CLI flag.

## Why the rules stay off

`eslint.config.js:115` documents `@typescript-eslint/no-explicit-any: 'off'` with a deliberate rationale: *"Lots of legitimate `as unknown as ...` for SDK boundary casts."* This PR does **not** re-enable the rules. It only enforces the existing config and cleans up debris from when the rules used to fire.

## Evidence (local pre-push gate)

Per `feedback_local_pre_push_gate.md`, all 4 gates green on `chore/lint-max-warnings-zero-2026-05`:

- ✅ `npm run typecheck` — 0 errors
- ✅ `npm run lint` — 0 errors, 0 warnings (gate now strict)
- ✅ `npm test` — **1862 passed + 1 todo, 193 files**
- ✅ `node scripts/harness-ui.mjs` — **14/14 passed**, including critical `terminal-pane-mounted` (170ms)

## How the deletion was verified safe

Used a parser script (committed nowhere — temp files cleaned) that for each warning location asserted the target line matched exactly `^\s*//\s*eslint-disable-next-line\s+<rule>\s*$` before deletion. All 114 lines matched; **0 unexpected**. So nothing but pure-comment lines was touched.

## Not in scope

This is independent of PR #1372 (Node engines pin). No file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)