### PR TITLE
fix(terminal): warm session switch preserves scrollbar thumb position

### DIFF
--- a/scripts/dogfood-pr-1374-warm-scroll-preserved.mjs
+++ b/scripts/dogfood-pr-1374-warm-scroll-preserved.mjs
@@ -1,0 +1,145 @@
+// scripts/dogfood-pr-1374-warm-scroll-preserved.mjs
+//
+// PR #1374 regression probe — `.xterm-viewport.scrollTop` must be preserved
+// across A → B → A warm session switch.
+//
+// Background: webkit drops `.xterm-viewport` scrollTop when the warm
+// entry's wrapper is reparented out of the layout tree (offscreen
+// holder). xterm's logical viewportY survives the detour (the canvas
+// keeps painting the right rows), but the DOM scrollbar thumb snaps to
+// the top. User-visible symptom: "右侧的滚动条是永远置顶的" — task #49.
+//
+// Why this lives in its own dogfood script (not in harness-real-cli's
+// switch-session-keeps-chat or in harness-ui terminal-pane-mounted):
+//   * The real-cli case starts claude TUI, which enters alt-screen mode
+//     within ~1s of attach. Alt-buffer has no scrollable scrollback, so
+//     `.xterm-viewport.scrollTop` is pinned at 0 there and the bug is
+//     unobservable. We need a normal-buffer state to exercise the
+//     repro path the user actually saw (their scrollbar implies normal
+//     buffer either pre-alt-switch or post-alt-exit).
+//   * harness-ui keeps the per-case body small; this case needs a
+//     second session + a real PTY pair + write/scroll/switch
+//     choreography that's heavier than a wiring contract.
+//
+// Exit code 0 = PASS, 1 = FAIL (CI / pre-push gate compatible).
+
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+  createIsolatedClaudeDir,
+  dismissWelcomeSplash,
+  launchCcsmIsolated,
+  seedSession,
+  waitForTerminalReady,
+  waitForXtermBuffer,
+} from './probe-utils-real-cli.mjs';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function readScrollState(win) {
+  return await win.evaluate(() => {
+    const t = window.__ccsmTerm;
+    const b = t?.buffer?.active;
+    const vp = document.querySelector('.xterm-viewport');
+    return {
+      viewportY: b?.viewportY ?? null,
+      baseY: b?.baseY ?? null,
+      bufferType: t?.buffer?.active?.type ?? null,
+      scrollTop: vp instanceof HTMLElement ? vp.scrollTop : null,
+      scrollHeight: vp instanceof HTMLElement ? vp.scrollHeight : null,
+    };
+  });
+}
+
+async function main() {
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'ccsm-dogfood-1374-'));
+  createIsolatedClaudeDir(tempDir);
+
+  const { electronApp, win, userDataDir } = await launchCcsmIsolated({ tempDir });
+
+  try {
+    await win.waitForFunction(
+      () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+      null,
+      { timeout: 30000 },
+    );
+
+    const { sid: sidA } = await seedSession(win, { name: 'A', cwd: tempDir });
+    const { sid: sidB } = await seedSession(win, { name: 'B', cwd: tempDir });
+
+    await win.evaluate((id) => window.__ccsmStore.getState().selectSession(id), sidA);
+    await waitForTerminalReady(win, sidA, { timeout: 45000 });
+    await waitForXtermBuffer(win, /claude|welcome|│|╭|\?\sfor\sshortcuts/i, { timeout: 30000 });
+    await dismissWelcomeSplash(win);
+
+    // Drop claude's alt-screen state if it has gone there — we need to
+    // exercise the normal-buffer scrollback path, which is the surface
+    // the bug actually showed up on.
+    await win.evaluate(() => {
+      const t = window.__ccsmTerm;
+      // \x1b[?1049l = leave alt buffer (xterm-defined private mode 1049).
+      // Safe to send even if we're not in alt — it's a no-op there.
+      t.write('\x1b[?1049l');
+      for (let i = 0; i < 200; i++) t.write(`pr1374-filler ${i}\r\n`);
+      t.scrollLines(-40);
+    });
+    await sleep(200);
+
+    const before = await readScrollState(win);
+    if (before.bufferType !== 'normal') {
+      throw new Error(`expected normal buffer for repro, got ${before.bufferType}`);
+    }
+    if (!before.scrollTop || before.scrollTop <= 0) {
+      throw new Error(`pre-switch setup failed: expected scrollTop > 0, got ${before.scrollTop}`);
+    }
+
+    // A → B → A
+    await win.evaluate((id) => window.__ccsmStore.getState().selectSession(id), sidB);
+    await waitForTerminalReady(win, sidB, { timeout: 30000 });
+    await sleep(300);
+
+    await win.evaluate((id) => window.__ccsmStore.getState().selectSession(id), sidA);
+    await waitForTerminalReady(win, sidA, { timeout: 30000 });
+    await sleep(600);
+
+    const after = await readScrollState(win);
+
+    const ok =
+      after.viewportY === before.viewportY &&
+      after.scrollTop === before.scrollTop;
+
+    console.log(`before: ${JSON.stringify(before)}`);
+    console.log(`after:  ${JSON.stringify(after)}`);
+
+    if (!ok) {
+      console.error(
+        `FAIL: warm switch lost scroll state. ` +
+          `viewportY ${before.viewportY}→${after.viewportY}, ` +
+          `scrollTop ${before.scrollTop}→${after.scrollTop}. ` +
+          `PR #1374 regressed — see src/terminal/xtermWarmRegistry.ts ` +
+          `ensureAndShowEntry save/restore of savedScrollTop.`,
+      );
+      // surface log tail for debugging
+      const logPath = path.join(userDataDir, 'logs', 'main.log');
+      if (existsSync(logPath)) {
+        const tail = readFileSync(logPath, 'utf8')
+          .split('\n')
+          .filter((l) => l.includes('warmHide') || l.includes('warmShow') || l.includes('attach.warm.shown'))
+          .slice(-10);
+        console.error('--- main.log tail ---');
+        for (const l of tail) console.error(l);
+      }
+      process.exitCode = 1;
+      return;
+    }
+    console.log('PASS');
+  } finally {
+    await electronApp.close();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exitCode = 1;
+});

--- a/src/terminal/usePtyAttach.warm.ts
+++ b/src/terminal/usePtyAttach.warm.ts
@@ -285,11 +285,34 @@ export function usePtyAttachWarm(
           //     viewport is preserved across hide/show by virtue of
           //     xterm's WriteBuffer staying intact under reparent. The
           //     user expects "where I left it", not "snapped to bottom".
+          // DEBUG (task #49): trace viewportY across show → fit → focus →
+          // next-frame so we can pinpoint which step is recentering the
+          // viewport to the bottom on warm switch.
+          const snapVp = (label: string) => {
+            try {
+              const b = entry.term.buffer?.active;
+              log.event('warm.viewport.trace', {
+                sid: sessionId,
+                step: label,
+                viewportY: b?.viewportY ?? -1,
+                baseY: b?.baseY ?? -1,
+                cursorY: b?.cursorY ?? -1,
+                length: b?.length ?? -1,
+                cols: entry.term.cols,
+                rows: entry.term.rows,
+                atBottom: (b?.viewportY ?? 0) === (b?.baseY ?? 0),
+              });
+            } catch {
+              /* probe best-effort */
+            }
+          };
+          snapVp('before-fit');
           try {
             entry.fit.fit();
           } catch (e) {
             warn('attach-warm', 'warm fit failed', e);
           }
+          snapVp('after-fit');
           try {
             log.event('attach.fit.applied', {
               sid: sessionId,
@@ -311,6 +334,9 @@ export function usePtyAttachWarm(
           } catch {
             /* focus best-effort */
           }
+          snapVp('after-focus');
+          requestAnimationFrame(() => snapVp('next-frame'));
+          setTimeout(() => snapVp('plus-50ms'), 50);
           if (!cancelled) {
             // Major (round 2): if the session already crashed (either
             // while hidden, or while this effect was awaiting), prefer

--- a/src/terminal/xtermWarmRegistry.ts
+++ b/src/terminal/xtermWarmRegistry.ts
@@ -135,6 +135,17 @@ export type WarmEntry = {
    * the entry's current `term.options.fontSize` is already up to date.
    */
   pendingFontSize: number | null;
+  /**
+   * Last `.xterm-viewport.scrollTop` captured at hide time. Webkit drops
+   * scrollTop when an element is reparented out of the layout tree, so
+   * xterm's internal `viewportY` stays at e.g. 148 but the visible
+   * scrollbar thumb snaps back to 0 on show. We snapshot before the hide
+   * reparent and restore after the show reparent — the canvas was already
+   * painting the correct logical rows (viewportY preserved), so the only
+   * thing the user noticed was the thumb jumping to the top.
+   * `null` means "no snapshot yet" (first show) — treated as no-op.
+   */
+  savedScrollTop: number | null;
 };
 
 /**
@@ -471,6 +482,7 @@ function allocEntry(sid: string): WarmEntry {
     keyboardPasteHandled: false,
     inputDisposers: [],
     pendingFontSize: null,
+    savedScrollTop: null,
   };
   warm.set(sid, entry);
 
@@ -773,13 +785,28 @@ export function ensureAndShowEntry(
   if (activeSid && activeSid !== sid) {
     const prev = warm.get(activeSid);
     if (prev) {
+      // Snapshot `.xterm-viewport.scrollTop` BEFORE the reparent.
+      // Webkit drops scrollTop when an element leaves its containing
+      // block (the offscreen holder is display:none / out-of-tree). Read
+      // synchronously to capture the user's current scroll position;
+      // restore in the symmetric show branch below.
+      try {
+        const vp = prev.wrapper.querySelector('.xterm-viewport');
+        if (vp instanceof HTMLElement) prev.savedScrollTop = vp.scrollTop;
+      } catch {
+        /* snapshot best-effort */
+      }
       try {
         getOffscreenHolder().appendChild(prev.wrapper);
       } catch (e) {
         warn('xterm-warm', 'hide reparent failed', e);
       }
       try {
-        log.event('terminal.warmHide', { sid: activeSid, lruSize: warm.size });
+        log.event('terminal.warmHide', {
+          sid: activeSid,
+          lruSize: warm.size,
+          savedScrollTop: prev.savedScrollTop ?? -1,
+        });
       } catch {
         /* probe failure tolerated */
       }
@@ -797,6 +824,39 @@ export function ensureAndShowEntry(
     host.appendChild(entry.wrapper);
   } catch (e) {
     warn('xterm-warm', 'show reparent failed', e);
+  }
+
+  // Restore `.xterm-viewport.scrollTop` captured at the symmetric hide.
+  // xterm's internal `viewportY` survives the offscreen detour (canvas
+  // keeps painting the right rows), but webkit zeroes the DOM scrollTop
+  // when the element leaves the layout tree — so without this the
+  // scrollbar thumb snaps to the top while the canvas content shows
+  // a mid-buffer position. Write AFTER the reparent (element must be
+  // back in the layout tree) and synchronously so the user never
+  // observes a frame at scrollTop=0.
+  if (entry.savedScrollTop != null) {
+    let restoreApplied = -1;
+    let restoreActual = -1;
+    try {
+      const vp = entry.wrapper.querySelector('.xterm-viewport');
+      if (vp instanceof HTMLElement) {
+        vp.scrollTop = entry.savedScrollTop;
+        restoreApplied = entry.savedScrollTop;
+        restoreActual = vp.scrollTop;
+      }
+    } catch {
+      /* restore best-effort */
+    }
+    try {
+      log.event('terminal.warmShow.scrollRestore', {
+        sid,
+        savedScrollTop: entry.savedScrollTop,
+        applied: restoreApplied,
+        actualAfterWrite: restoreActual,
+      });
+    } catch {
+      /* probe failure tolerated */
+    }
   }
 
   // First-time open: deferred from allocEntry so the xterm renderer


### PR DESCRIPTION
## Summary
- Switching session A→B→A snapped the scrollbar thumb to the top even though the canvas painted the correct mid-buffer rows. User: "右侧的滚动条是永远置顶的".
- Root cause: webkit drops `.xterm-viewport.scrollTop` when the warm entry's wrapper is reparented out of the layout tree (offscreen holder). xterm's internal `viewportY` survives, the DOM `scrollTop` does not.
- Fix: snapshot `.xterm-viewport.scrollTop` on hide-side reparent, restore after show-side reparent. New `savedScrollTop` field on `WarmEntry`; two new probes (`savedScrollTop` on `terminal.warmHide`, new `terminal.warmShow.scrollRestore` event).

## Evidence

`scratch/repro-switch-viewport.mjs` against prod bundle + real PTY, sid A scrolled to mid-buffer (`viewportY:148, baseY:188`), switched A→B→A:

| | before fix | after fix |
|---|---|---|
| `.xterm-viewport.scrollTop` after switch-back | **0** (thumb at top) | **2220** (preserved) |
| xterm internal `viewportY` | 148 | 148 |

main.log after fix:
```
terminal.warmHide                savedScrollTop=2220
terminal.warmShow.scrollRestore  saved=2220 applied=2220 actualAfterWrite=2220
attach.warm.shown                viewportY=148 baseY=188 atBottom=false
```

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `node scripts/harness-ui.mjs` — 14/14 passed
- [x] `node scratch/repro-switch-viewport.mjs` — scrollTop preserved
- [ ] dev manual: A 滚到中间 → 切 B → 切回 A,滚动条 thumb 停在原处

## Notes
- Probes from in-flight task #44 IME investigation (`warm.viewport.trace`, `attach.warm.shown` cursor info) are intentionally kept — per user instruction ("探针留着呀,后面别的 debug 可能还用得上"). They are O(1) per session switch and silent in steady state.
- `npm test` has 18 pre-existing failures in `electron/__tests__/db*.test.ts` from a stale `better-sqlite3` native binding; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)