### PR TITLE
chore(infra): make Node engines hard-enforced + fix e2e cache key node20 label

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: node_modules
-          key: nm-e2e-${{ runner.os }}-${{ runner.arch }}-node20-${{ hashFiles('package-lock.json') }}
+          key: nm-e2e-${{ runner.os }}-${{ runner.arch }}-node22-${{ hashFiles('package-lock.json') }}
       - name: Cache Electron binary
         uses: actions/cache@v4
         with:

--- a/.npmrc
+++ b/.npmrc
@@ -4,3 +4,11 @@
 # native build fails with MSB8020 on fresh checkouts. Pin to 0 to use the
 # default MSVC toolset.
 clang=0
+
+# Make package.json's `engines.node: ">=22.0.0"` a hard error during `npm install`
+# instead of an advisory warning. Pairs with PR #1372 — without this, a fresh
+# checkout on Node 20 would install successfully and then fail at runtime with
+# NODE_MODULE_VERSION mismatches, which is far worse than a 5s install-time
+# error. Reviewer of #1372 flagged this as a followup gap.
+engine-strict=true
+


### PR DESCRIPTION
## Summary

Followup to #1372 — the cold reviewer of that PR flagged two loose ends:

1. **engines.node is advisory, not enforced.** `package.json` declares `">=22.0.0"`, but without \`engine-strict=true\` in \`.npmrc\` it's only a warning. A fresh checkout on Node 20 would \`npm install\` successfully, then explode at runtime with NODE_MODULE_VERSION mismatch — much worse than a 5-second install-time error.

2. **e2e cache key labelled \`node20\` after the bump.** \`.github/workflows/e2e.yml:58\`'s cache key still read \`node20-\` even though setup-node now uses Node 22. Functionally fine (lockfile hash invalidates on real changes, \`electron-rebuild\` self-heals any ABI drift), but a misleading label wastes time later when debugging cache-related CI failures.

## What changed

| File | Change |
|---|---|
| \`.npmrc\` | add \`engine-strict=true\` (and a comment explaining why) |
| \`.github/workflows/e2e.yml:58\` | \`node20-\` → \`node22-\` in cache key |

Net diff: **+9 / -1**, 2 files. Config-only, no JS runtime behavior change.

## Evidence (local pre-push gate)

Per \`feedback_local_pre_push_gate.md\`, all 4 gates green on \`chore/node-engines-followup-2026-05\`:

- ✅ \`npm run typecheck\` — 0 errors
- ✅ \`npm run lint\` — 0 errors, 0 warnings (strict gate from #1373)
- ✅ \`npm test\` — **1862 passed + 1 todo, 193 files**
- ✅ \`node scripts/harness-ui.mjs\` — **14/14 passed**, including \`terminal-pane-mounted\` (170ms)

## Risk

\`engine-strict=true\` means anyone on Node <22 will now fail \`npm install\` with a clear error. This is the intended trade-off — declared-but-unenforced floors are worse than no declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)