### PR TITLE
security(pty): runtime typeof + range guards on pty:input/pty:resize

### DIFF
--- a/electron/ptyHost/__tests__/ipcRegistrar.test.ts
+++ b/electron/ptyHost/__tests__/ipcRegistrar.test.ts
@@ -195,6 +195,54 @@ describe('pty:input / resize / kill / get pass-through', () => {
     expect(deps.resizePtySession).toHaveBeenCalledWith('sid', 100, 30);
   });
 
+  // Defense-in-depth — TS signatures are advisory across the IPC boundary.
+  // These guards drop malformed renderer payloads instead of forwarding them
+  // to node-pty / xterm where the failure mode is uglier (truncate, throw
+  // inside the addon, or accept a runaway size).
+  it('input drops non-string data without calling deps', () => {
+    const ipc = makeFakeIpc();
+    const deps = makeDeps();
+    registerPtyIpc(ipc as any, deps);
+    for (const bad of [123, null, undefined, {}, [], true, Buffer.from('x')]) {
+      ipc.handlers.get(PTY_CHANNELS.input)!({}, 'sid', bad as any);
+    }
+    expect(deps.inputPtySession).not.toHaveBeenCalled();
+  });
+
+  it('resize drops non-finite or out-of-range cols/rows without calling deps', () => {
+    const ipc = makeFakeIpc();
+    const deps = makeDeps();
+    registerPtyIpc(ipc as any, deps);
+    const cases: Array<[unknown, unknown]> = [
+      [Number.NaN, 30],
+      [100, Number.NaN],
+      [Number.POSITIVE_INFINITY, 30],
+      [100, Number.NEGATIVE_INFINITY],
+      [0, 30],
+      [100, 0],
+      [-1, 30],
+      [100, -1],
+      [1001, 30],
+      [100, 1001],
+      ['80' as unknown, 30],
+    ];
+    for (const [c, r] of cases) {
+      ipc.handlers.get(PTY_CHANNELS.resize)!({}, 'sid', c as any, r as any);
+    }
+    expect(deps.resizePtySession).not.toHaveBeenCalled();
+  });
+
+  it('resize accepts boundary values 1 and 1000', () => {
+    const ipc = makeFakeIpc();
+    const deps = makeDeps();
+    registerPtyIpc(ipc as any, deps);
+    ipc.handlers.get(PTY_CHANNELS.resize)!({}, 'sid', 1, 1);
+    ipc.handlers.get(PTY_CHANNELS.resize)!({}, 'sid', 1000, 1000);
+    expect(deps.resizePtySession).toHaveBeenCalledTimes(2);
+    expect(deps.resizePtySession).toHaveBeenNthCalledWith(1, 'sid', 1, 1);
+    expect(deps.resizePtySession).toHaveBeenNthCalledWith(2, 'sid', 1000, 1000);
+  });
+
   it('kill returns the deps result', async () => {
     const ipc = makeFakeIpc();
     const deps = makeDeps({ killPtySession: vi.fn(async () => false) });

--- a/electron/ptyHost/ipcRegistrar.ts
+++ b/electron/ptyHost/ipcRegistrar.ts
@@ -202,10 +202,22 @@ export function registerPtyIpc(ipcMain: IpcMain, deps: PtyIpcDeps): void {
   });
 
   ipcMain.handle(PTY_CHANNELS.input, (_event, sid: string, data: string) => {
+    // Defense-in-depth: TypeScript signature is advisory across the IPC
+    // boundary — a compromised renderer (or a buggy preload bridge) can
+    // hand us anything. node-pty's `write` truncates non-strings silently
+    // or throws inside the addon, neither of which we want.
+    if (typeof data !== 'string') return;
     deps.inputPtySession(sid, data);
   });
 
   ipcMain.handle(PTY_CHANNELS.resize, (_event, sid: string, cols: number, rows: number) => {
+    // Same rationale as `pty:input` — guard the numeric channels too.
+    // `Number.isFinite` rejects NaN / Infinity / -Infinity; `>= 1` rejects
+    // zero and negatives. xterm's typical max is ~600 cols × ~600 rows on a
+    // huge monitor; cap at 1000 each to bound the damage from a hostile
+    // renderer asking for a 2^31 × 2^31 resize.
+    if (!Number.isFinite(cols) || !Number.isFinite(rows)) return;
+    if (cols < 1 || rows < 1 || cols > 1000 || rows > 1000) return;
     deps.resizePtySession(sid, cols, rows);
   });
 


### PR DESCRIPTION
## Summary

Audit (technical-debt skill, 2026-05-25) flagged that `pty:input` and `pty:resize` IPC handlers trusted their TypeScript signatures across the IPC boundary. TS annotations on `ipcMain.handle` callbacks are advisory — a compromised renderer (or buggy preload bridge) can hand the handler anything.

This adds runtime guards at the trust boundary. Defense-in-depth, not a fix for a known exploit.

## What changed

**`electron/ptyHost/ipcRegistrar.ts`**:
- `pty:input` — drop the call when `data` is not a string (otherwise reaches node-pty's `write`, which either truncates silently or throws inside the native addon).
- `pty:resize` — drop the call when `cols`/`rows` is not finite (NaN, ±Infinity) or out of `[1, 1000]`. Upper cap is well above any realistic xterm size (4K + 8px font ≈ 480 cols) and bounds a 2^31 × 2^31 resize request.

**`electron/ptyHost/__tests__/ipcRegistrar.test.ts`** — 3 new tests (`+48 lines`):
- `input drops non-string data without calling deps` — number, null, undefined, object, array, boolean, Buffer
- `resize drops non-finite or out-of-range cols/rows ...` — NaN, ±Inf, 0, negatives, 1001, wrong-type string
- `resize accepts boundary values 1 and 1000` — pins the inclusive range so future tightening is intentional

Net: **+60 / -0**, 2 files.

## What's NOT in scope (intentional)

- `sid` is not guarded here — downstream already validates via `VALID_SID_RE` in `jsonlResolver.ts:26`. A duplicate check here would risk drift between the two validators.
- Other PTY channels (`attach`, `detach`, `kill`, `get`) take only `sid`, which is already covered downstream.

## Evidence (local pre-push gate)

Per `feedback_local_pre_push_gate.md`, all 4 gates green on `security/pty-input-resize-validation-2026-05`:

- ✅ `npm run typecheck` — 0 errors
- ✅ `npm run lint` — 0 errors, 0 warnings (strict gate from #1373)
- ✅ `npm test` — **1865 passed + 1 todo, 193 files** (3 new tests added cleanly)
- ✅ `node scripts/harness-ui.mjs` — **14/14 passed**, including `terminal-pane-mounted` (188ms)

## Risk

- Real users hitting the guard means renderer is sending malformed payloads — that's a renderer bug. The guard logs nothing today; if this turns out to fire silently in dogfood we can add an `console.warn`. Not adding it preemptively since the expected hit rate is zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)