### PR TITLE
chore(test): tighten coverage thresholds from ~8pp to ~3pp under baseline

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -47,17 +47,19 @@ export default defineConfig({
         'src/index.tsx',
         'src/components/ScrollToBottomButton.tsx',
       ],
-      // Task #43 — gate is now enforced in CI. Thresholds set ~8pp below
-      // measured post-exclusion baseline (lines 87.08%, statements 84.60%,
-      // functions 84.52%, branches 76.28%) so normal week-to-week churn
-      // doesn't flake the gate, while regressions of >8pp are caught.
+      // Tech-debt R6 (Task #43) — gate is enforced in CI. Thresholds set
+      // ~3pp below the measured post-exclusion baseline (2026-05-25:
+      // lines 84.46%, statements 82.34%, functions 84.84%, branches 73.69%)
+      // so normal week-to-week churn doesn't flake the gate, while
+      // regressions of >3pp are caught — tightened from the earlier ~8pp
+      // buffer per technical-debt audit 2026-05-25.
       // Raise these as suites grow; never lower without a written
       // justification in the PR body.
       thresholds: {
-        lines: 78,
-        functions: 76,
-        branches: 68,
-        statements: 76,
+        lines: 81,
+        functions: 81,
+        branches: 70,
+        statements: 79,
       },
     },
   },


### PR DESCRIPTION
## Summary

Audit (technical-debt skill, 2026-05-25) flagged that `vitest.config.ts` coverage thresholds were set ~8pp below the measured baseline (configured 78/76/68/76 vs cited baseline 87.08/84.60/76.28/84.52). That meant the gate silently tolerated an 8-percentage-point coverage drop before tripping. In practice week-to-week churn is <1pp per release — 8pp is much wider than needed.

This tightens the buffer to ~3pp, catching real regressions while still absorbing normal churn.

## Measured baseline today (2026-05-25, base a2317b4)

| Metric | Today | Comment baseline | Drift |
|---|---|---|---|
| Lines | 84.46% | 87.08% | -2.62pp |
| Statements | 82.34% | 84.60% | -2.26pp |
| Functions | 84.84% | 84.52% | +0.32pp |
| Branches | 73.69% | 76.28% | -2.59pp |

(The drift between cited and measured suggests the 8pp buffer has been silently absorbing coverage decay — exactly the failure mode the audit caught.)

## New thresholds (3pp buffer below today's baseline)

| Metric | Before | After |
|---|---|---|
| lines | 78 | **81** |
| statements | 76 | **79** |
| functions | 76 | **81** |
| branches | 68 | **70** |

A >3pp regression now fails CI. Normal churn (<1pp) passes comfortably.

## What changed

| File | Change |
|---|---|
| `vitest.config.ts:50-61` | thresholds bumped + comment refreshed with today's date and rationale |

Net: **+10 / -8**, 1 file. Comment update + 4 number bumps. No runtime/test code touched.

## Risk

If subsequent PRs introduce uncovered code in `src/` or `electron/`, they will now have a tighter window before the gate trips. This is intended — the alternative is silently accumulating gaps.

## Evidence (local pre-push gate)

Per `feedback_local_pre_push_gate.md`, all 4 gates green on `chore/coverage-thresholds-tighten-2026-05`:

- ✅ `npm run typecheck` — 0 errors
- ✅ `npm run lint` — 0 errors, 0 warnings
- ✅ `npm run coverage` — **1865 tests + 1 todo, all 4 thresholds met** (no violations)
- ✅ `node scripts/harness-ui.mjs` — **14/14 passed**, including `terminal-pane-mounted` (154ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)