### PR TITLE
chore(docs): add CODEOWNERS + DEBT.md (technical-debt audit 2026-05-25)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# CODEOWNERS — single-maintainer repo
+#
+# GitHub uses this file to auto-request reviews when PRs touch matching
+# paths. As of 2026-05-25 the project has one human maintainer; this entry
+# documents that fact so future contributors / agents / CI tools have a
+# discoverable owner without having to grep git log.
+#
+# Note: branch protection on `main` does NOT require approving reviews
+# (`required_approving_review_count: 0`) — single-account repo, see
+# feedback_dev_workflow.md for the rationale. The "no self-merge" rule
+# lives at the agent layer, not GitHub.
+#
+# Update when adding contributors. Move to per-path patterns once the
+# team grows past one person.
+
+* @Jiahui-Gu

--- a/DEBT.md
+++ b/DEBT.md
@@ -1,0 +1,77 @@
+# Technical Debt Register
+
+Living document of known technical debt in ccsm, ranked by impact + effort.
+Refreshed by the `technical-debt` skill audit (see Anthropic harness).
+
+Format:
+- **Status**: `OPEN` / `IN PROGRESS` / `DONE` / `WONTFIX`
+- **Effort**: `S` (<1 day) / `M` (1–5 days) / `L` (>1 week)
+- **Impact**: `LOW` / `MED` / `HIGH` / `CRITICAL`
+- **Priority** is `effort × impact`; cheap+high-impact items first.
+
+Audit history is appended to the bottom — this register reflects current
+state, not history. When a debt item lands a PR, mark it `DONE` with the
+merge SHA and short note rather than deleting the row (so the ledger
+shows what got paid down).
+
+---
+
+## Open debt (as of 2026-05-25 audit)
+
+### P1 — HIGH impact, large
+
+| ID | Item | Status | Effort | Impact | Location |
+|---|---|---|---|---|---|
+| 1 | Electron 41 → 42 (Chromium CVE patches stop arriving on 41) | OPEN | M | HIGH | `package.json:93` |
+| 2 | `@anthropic-ai/claude-agent-sdk` 0.2 → 0.3 | OPEN | M | HIGH | `package.json:38` |
+| 3 | Renderer bundle 1.24 MB single chunk — add `splitChunks` + lazy-load `ImportDialog`/`CommandPalette`/`SettingsDialog` | OPEN | M | HIGH | `webpack.config.js` |
+| 4 | God-files >500 LOC: `xtermWarmRegistry.ts` (1308), `usePtyAttach.warm.ts` (743), `shared/log.ts` (637), `sessionCrudSlice.ts` (608), `createWindow.ts` (574), `mobileRemoteServer.ts` (535) | OPEN | L | HIGH | various |
+| 5 | Session field "shotgun surgery" — adding one field touches slice + types + preload + IPC + db + components + `i18n/locales/{en,zh}.ts` (duplicated locales are the amplifier) | OPEN | M | HIGH | `src/i18n/locales/*` + chain |
+
+### P2 — MED impact, medium-small
+
+| ID | Item | Status | Effort | Impact | Location |
+|---|---|---|---|---|---|
+| 6 | Circular dep `store → sessionRuntimeSlice → xtermWarmRegistry → store` — terminal reaching back into store inverts layering | OPEN | S-M | MED | `src/stores/store.ts` etc. |
+| 7 | `Sidebar.tsx` has 11 props — extract `SidebarActionsContext` for the 5 `onOpen*`/`onCreate*` callbacks | OPEN | S | MED | `src/components/Sidebar.tsx:47` |
+| 8 | `AGENTS.md` + `CLAUDE.md` missing from repo root — new sessions / contributors lack project-level orientation | OPEN | M | MED | repo root |
+| 9 | `docs/README.md:8` references `STATUS.md` that does not exist | OPEN | S | LOW | `docs/README.md` |
+| 10 | `npm audit` blocked by npmmirror registry — CVE state in current deps is **unknown** | OPEN | S | UNKNOWN | npm registry config |
+| 11 | `webpack.config.js` lacks `performance.hints` / size-limit gate — bundle bloat can land silently | OPEN | S | MED | `webpack.config.js` |
+| 12 | `import:scan`, `paths:exist`, `sessionTitles:listForProject` IPC return unbounded arrays — pagination/caps missing | OPEN | M | MED | `electron/ipc/utilityIpc.ts:125,178`, `sessionIpc.ts:76` |
+| 13 | `sandbox: false` on BrowserWindow (Sentry preload `require` path) — known tracked security debt | OPEN | M | MED | `electron/window/createWindow.ts:342` |
+
+### P3 — LOW impact / nice-to-have
+
+| ID | Item | Status | Effort | Impact | Location |
+|---|---|---|---|---|---|
+| 14 | `src/shared/*` exports and preload bridge methods lack consistent JSDoc | OPEN | M | LOW | `src/shared/*`, `electron/preload/bridges/*` |
+| 15 | `electron/__tests__/db-hardening.test.ts:172` has `it.todo` placeholder for SCHEMA_VERSION ≥2 migration test — un-block when v2 lands | OPEN | S | LOW | (file) |
+| 16 | `vitest.config.ts` lacks `retry: 1` — no flake guard. Currently no observed flakes, so leave as nil-debt; revisit if any case starts to flake | OPEN | S | LOW | `vitest.config.ts` |
+
+---
+
+## Done (paid down in audit batch 2026-05-25)
+
+| ID | Item | PR | Merge SHA |
+|---|---|---|---|
+| D1 | `engines.node` field missing + CI on Node 20 (EOL Apr 2026) | [#1372](https://github.com/Jiahui-Gu/ccsm/pull/1372) | `7093869` |
+| D2 | `npm run lint` had no `--max-warnings 0` — 114 dead `eslint-disable` directives accumulated | [#1373](https://github.com/Jiahui-Gu/ccsm/pull/1373) | `a2317b4` |
+| D3 | `engines.node` was advisory only — add `engine-strict=true`; fix `e2e.yml` cache key `node20`→`node22` | [#1375](https://github.com/Jiahui-Gu/ccsm/pull/1375) | (see PR) |
+| D4 | `pty:input` / `pty:resize` IPC handlers trusted TS signatures — added runtime typeof + range guards + 3 tests | [#1376](https://github.com/Jiahui-Gu/ccsm/pull/1376) | `df461a9` |
+| D5 | Coverage thresholds were ~8pp below baseline (silent regression headroom) — tightened to ~3pp | [#1377](https://github.com/Jiahui-Gu/ccsm/pull/1377) | (see PR) |
+| D6 | No `CODEOWNERS` / no debt register | (this PR) | — |
+
+---
+
+## Audit history
+
+- **2026-05-25** — full audit via `technical-debt` skill (Anthropic Claude harness). 42 rules across 10 categories. 6 items paid down in batch (D1–D6); see commits in week of 2026-05-25.
+
+## How to update this file
+
+- When you fix an item: move its row to the "Done" table with PR # + merge SHA. Don't delete the row.
+- When an audit identifies a new item: add to the appropriate priority section. Cite file:line.
+- When an item's impact changes (e.g. a dep becomes abandoned): update the row and add a note in audit history.
+- Keep `Effort` honest. If S items keep growing, downgrade your estimates.
+- This file is for **discoverable, prioritized** debt. Code smells, ad-hoc improvements, and refactor wishes belong in PR comments or issue tracker, not here.

--- a/DEBT.md
+++ b/DEBT.md
@@ -57,9 +57,9 @@ shows what got paid down).
 |---|---|---|---|
 | D1 | `engines.node` field missing + CI on Node 20 (EOL Apr 2026) | [#1372](https://github.com/Jiahui-Gu/ccsm/pull/1372) | `7093869` |
 | D2 | `npm run lint` had no `--max-warnings 0` — 114 dead `eslint-disable` directives accumulated | [#1373](https://github.com/Jiahui-Gu/ccsm/pull/1373) | `a2317b4` |
-| D3 | `engines.node` was advisory only — add `engine-strict=true`; fix `e2e.yml` cache key `node20`→`node22` | [#1375](https://github.com/Jiahui-Gu/ccsm/pull/1375) | (see PR) |
+| D3 | `engines.node` was advisory only — add `engine-strict=true`; fix `e2e.yml` cache key `node20`→`node22` | [#1375](https://github.com/Jiahui-Gu/ccsm/pull/1375) | `f240978` |
 | D4 | `pty:input` / `pty:resize` IPC handlers trusted TS signatures — added runtime typeof + range guards + 3 tests | [#1376](https://github.com/Jiahui-Gu/ccsm/pull/1376) | `df461a9` |
-| D5 | Coverage thresholds were ~8pp below baseline (silent regression headroom) — tightened to ~3pp | [#1377](https://github.com/Jiahui-Gu/ccsm/pull/1377) | (see PR) |
+| D5 | Coverage thresholds were ~8pp below baseline (silent regression headroom) — tightened to ~3pp | [#1377](https://github.com/Jiahui-Gu/ccsm/pull/1377) | `a426f53` |
 | D6 | No `CODEOWNERS` / no debt register | (this PR) | — |
 
 ---


### PR DESCRIPTION
## Summary

Audit (technical-debt skill, 2026-05-25) flagged two process-debt gaps:

1. **No \`CODEOWNERS\`** — GitHub had no auto-discoverable owner.
2. **No \`DEBT.md\` / \`TODO.md\`** — known debt was implicit, tracked only in commit messages and external task IDs (e.g. \"Task #43\", \"Task #802\").

Low-impact individually, but both improve discoverability for future contributors / agents / auditors. Zero runtime change.

## What changed

| File | Lines | Purpose |
|---|---|---|
| \`.github/CODEOWNERS\` | 16 | Single-maintainer fallback \`* @Jiahui-Gu\`. Header explains the branch-protection rationale (single GitHub account → 0 required approvals → \"no self-merge\" enforced at the agent layer per \`feedback_dev_workflow.md\`). |
| \`DEBT.md\` | 77 | Living debt register, ranked P1/P2/P3 by impact+effort, file:line cited. Reflects 2026-05-25 audit: 15 open items + 6 done this week (engines-pin, lint-gate, engine-strict, pty-validation, coverage-thresholds, this PR). Includes a \"how to update\" section so future audits move rows to \"Done\" rather than deleting them. |

Net: **+93 / -0**, 2 new files.

## Why DEBT.md instead of issues

Issues need triage and clutter the issue tracker for active bugs. The register is intended as a **single discoverable snapshot** — what's broken, ranked. Adding/closing rows is a 1-line PR diff, lower-friction than opening/closing issues. If the team grows past one person and starts wanting cross-references / discussion threads, migrate to issues then.

## Evidence (local pre-push gate)

Per \`feedback_local_pre_push_gate.md\`, all 4 gates green on \`chore/codeowners-debt-md-2026-05\`:

- ✅ \`npm run typecheck\` — 0 errors
- ✅ \`npm run lint\` — 0 errors, 0 warnings
- ✅ \`npm test\` — **1865 passed + 1 todo, 193 files** (this PR adds zero JS, so unit count matches base \`df461a9\`)
- ✅ \`node scripts/harness-ui.mjs\` — **14/14 passed**, including \`terminal-pane-mounted\` (179ms)

Gates are arguably redundant for a doc-only PR but ran them per \`feedback_local_pre_push_gate.md\`'s \"all four every time\" rule. Took ~2 minutes; better than special-casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)