### PR TITLE
fix(sessions): unarchive uses ensureUsableGroup fallback (no orphan when g-default deleted)

### DIFF
--- a/src/stores/slices/sessionCrudSlice.ts
+++ b/src/stores/slices/sessionCrudSlice.ts
@@ -512,7 +512,11 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
 
     unarchiveSession: (sessionId) => {
       // Clear `archivedAt`, move back to original source group if it
-      // still exists and is normal — otherwise fall back to g-default.
+      // still exists and is normal — otherwise route through
+      // `ensureUsableGroup` so we either land in another existing normal
+      // group or materialize a fresh one. The earlier `'g-default'`
+      // literal fallback orphaned the session (invisible row) when the
+      // user had deleted both the source group and `g-default`.
       // If the archive container empties after the move, delete it.
       // If the user has no active session (e.g. they just archived the
       // active one and then immediately unarchived it), restore activeId
@@ -529,11 +533,13 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
       if (!container || container.kind !== 'archive' || !container.sourceGroupId) {
         return;
       }
-      const origin = store.groups.find(
-        (g) => g.id === container.sourceGroupId && g.kind === 'normal'
-      );
-      const targetGroupId = origin ? origin.id : 'g-default';
       set((s) => {
+        // Compute the target group on the latest `s` so any group
+        // synthesis lands in the same atomic patch as the session move
+        // and the container cleanup — avoids a second `set` racing the
+        // empty-container removal against a stale `s.groups`.
+        const ensured = ensureUsableGroup(s.groups, container.sourceGroupId);
+        const targetGroupId = ensured.groupId;
         const sessions = s.sessions.map((x) => {
           if (x.id !== sessionId) return x;
           const { archivedAt: _drop, ...rest } = x;
@@ -544,8 +550,8 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
           (x) => x.groupId === containerId
         );
         const groups = remainingInContainer
-          ? s.groups
-          : s.groups.filter((g) => g.id !== containerId);
+          ? ensured.groups
+          : ensured.groups.filter((g) => g.id !== containerId);
         const nextActive = s.activeId === '' ? sessionId : s.activeId;
         return { groups, sessions, activeId: nextActive };
       });

--- a/tests/stores/slices/archiveSession.test.ts
+++ b/tests/stores/slices/archiveSession.test.ts
@@ -227,7 +227,7 @@ describe('archiveSession / unarchiveSession', () => {
     ).toBe(container!.id);
   });
 
-  it('unarchiveSession falls back to g-default when source group was deleted', () => {
+  it('unarchiveSession falls back to another usable normal group when source was deleted', () => {
     const otherGroup: Group = {
       id: 'g-other',
       name: 'Other',
@@ -261,6 +261,46 @@ describe('archiveSession / unarchiveSession', () => {
     const s = h.state();
     expect(s.sessions!.find((x) => x.id === 's1')!.groupId).toBe('g-default');
     // Container deleted (empty).
+    expect(s.groups!.find((g) => g.id === containerId)).toBeUndefined();
+  });
+
+  it('unarchiveSession synthesizes a normal group when none exist (was orphaning into g-default literal)', () => {
+    // Repro for the P1 bug: when the user has deleted both the source
+    // group AND `g-default`, the old code wrote the literal `'g-default'`
+    // as the target groupId. No such group existed → the unarchived
+    // session pointed at a non-existent groupId and never re-appeared
+    // in the sidebar. ensureUsableGroup must materialize a fresh normal
+    // group so the session lands somewhere visible.
+    const h = harness({
+      groups: [{ id: 'g-default', name: 'Sessions', collapsed: false, kind: 'normal' }],
+      sessions: [mkSession('s1', 'g-default')],
+      activeId: 's1',
+    });
+    h.get().archiveSession('s1');
+    const containerId = h.state().groups!.find(
+      (g) => g.kind === 'archive' && g.sourceGroupId === 'g-default'
+    )!.id;
+    // s1 now lives in the archive container, so deleting g-default does
+    // not cascade-delete it. Removing g-default leaves the container as
+    // the only group, with s1 inside.
+    h.get().deleteGroup('g-default');
+    const mid = h.state();
+    expect(mid.groups!.find((g) => g.id === 'g-default')).toBeUndefined();
+    expect(mid.groups!.filter((g) => g.kind === 'normal').length).toBe(0);
+    expect(mid.sessions!.find((x) => x.id === 's1')).toBeDefined();
+
+    h.get().unarchiveSession('s1');
+    const s = h.state();
+    const s1 = s.sessions!.find((x) => x.id === 's1')!;
+    // A fresh normal group exists.
+    const normalGroups = s.groups!.filter((g) => g.kind === 'normal');
+    expect(normalGroups.length).toBe(1);
+    // Session points at the new group's id, NOT the literal 'g-default'.
+    expect(s1.groupId).toBe(normalGroups[0].id);
+    expect(s1.groupId).not.toBe('g-default');
+    // archivedAt cleared.
+    expect(s1.archivedAt).toBeUndefined();
+    // Container removed (was the only archived holder).
     expect(s.groups!.find((g) => g.id === containerId)).toBeUndefined();
   });
 


### PR DESCRIPTION
## Bug (P1)

`unarchiveSession` in `src/stores/slices/sessionCrudSlice.ts` wrote the literal `'g-default'` as the target `groupId` when the original source group no longer existed:

```ts
const targetGroupId = origin ? origin.id : 'g-default';
```

If the user had also deleted `g-default` (the default group is just a seeded normal group — it can be renamed or deleted like any other), the unarchived session pointed at a non-existent group id and **disappeared from the sidebar** (no row renders for a session whose groupId matches no group).

### Repro

1. Delete `g-default` and every other normal group (leave only an archive container with a session in it).
2. Archive a session.
3. Unarchive it.
4. Session has `groupId='g-default'` but no group with that id exists → invisible.

## Fix

Route through `ensureUsableGroup` — the same helper `createSession` / `importSession` already use (defined ~line 103). It either returns an existing usable normal group, or synthesizes a fresh one with the localized default name. The synthesis branch threads its updated `groups` array through the existing `set(s => ...)` so the empty-container cleanup operates on the same patch (no second `set` race).

Computed inside the `set` callback against the latest `s` to avoid staleness against any other concurrent slice writes.

## Test

New case in `tests/stores/slices/archiveSession.test.ts` ("synthesizes a normal group when none exist"): seed only `g-default`, archive `s1`, delete `g-default` (s1 survives the cascade since it lives in the archive container by then), unarchive `s1`, assert:

- A fresh normal group exists (length 1, was 0).
- `s1.groupId` points at that new group's id, NOT at the literal `'g-default'`.
- `s1.archivedAt` cleared.
- Archive container removed (was the only holder).

Renamed the adjacent existing test from "falls back to g-default" to "falls back to another usable normal group when source was deleted" — its assertion still holds since `g-default` is a usable normal group in that fixture, and `ensureUsableGroup` prefers existing usable groups before synthesizing.

## Gates

- `npm run typecheck` clean
- `npm run lint` clean (`--max-warnings 0`)
- `npx vitest run tests/stores/slices/archiveSession.test.ts` → 14 passed (was 13)
- Full `npx vitest run`: 36 failures all in `electron-load-smoke.test.ts` (needs `npm run build` first) and `db.test.ts` / `db-hardening.test.ts` (`better-sqlite3` NODE_MODULE_VERSION 145 vs 127 ABI mismatch on the dev box). Verified identical failure set on baseline `main` with my changes stashed — pre-existing environmental, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)