### PR TITLE
fix(shortcuts): wire Ctrl+Shift+N to create new group

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -97,6 +97,7 @@ export default function App() {
   // toggling a single session's waiting<->idle). See PR #1269.
   const selectSession = useStore((s) => s.selectSession);
   const focusGroup = useStore((s) => s.focusGroup);
+  const createGroup = useStore((s) => s.createGroup);
   const applyExternalTitle = useStore((s) => s._applyExternalTitle);
   const applyCwdRedirect = useStore((s) => s._applyCwdRedirect);
   const applyPtyExit = useStore((s) => s._applyPtyExit);
@@ -184,11 +185,18 @@ export default function App() {
     }));
   }, []));
 
-  // Global keyboard shortcuts (Ctrl+/, "?", Ctrl+F, Ctrl+,).
+  // Global keyboard shortcuts (Ctrl+/, "?", Ctrl+F, Ctrl+,, Ctrl/Cmd+Shift+N).
   useShortcutHandlers({
     toggleShortcuts: React.useCallback(() => setShortcutsOpen((p) => !p), []),
     togglePalette: React.useCallback(() => setPaletteOpen((p) => !p), []),
     openSettings: React.useCallback(() => setSettingsOpen(true), []),
+    // Mirror Sidebar.handleNewGroup minus the inline-rename: create the group
+    // then focus it so a subsequent "New session" lands inside. Auto-rename
+    // is intentionally not replicated here (see useShortcutHandlers note).
+    createNewGroup: React.useCallback(() => {
+      const id = createGroup();
+      focusGroup(id);
+    }, [createGroup, focusGroup]),
   });
 
   // Mirror resolved language to main for OS-level surfaces (tray menu,

--- a/src/app-effects/useShortcutHandlers.ts
+++ b/src/app-effects/useShortcutHandlers.ts
@@ -35,17 +35,25 @@ export interface ShortcutHandlersDeps {
   togglePalette: () => void;
   /** Open the settings dialog. Bound to Ctrl+,. */
   openSettings: () => void;
+  /**
+   * Create a new group and focus it. Bound to Ctrl/Cmd+Shift+N. Mirrors the
+   * Sidebar "+ New group" button and the CommandPalette "new group" entry,
+   * both of which already advertise this combo (ShortcutOverlay row + palette
+   * `MOD+Shift+N` hint).
+   */
+  createNewGroup: () => void;
 }
 
 /**
  * Composite hook that installs all global keyboard shortcuts handled at
  * the App level. Combines what was previously a single inline `keydown`
- * listener in App.tsx covering: Ctrl+/, "?", Ctrl+F, Ctrl+,.
+ * listener in App.tsx covering: Ctrl+/, "?", Ctrl+F, Ctrl+,,
+ * Ctrl/Cmd+Shift+N.
  *
  * Extracted for SRP under Task #724.
  */
 export function useShortcutHandlers(deps: ShortcutHandlersDeps): void {
-  const { toggleShortcuts, togglePalette, openSettings } = deps;
+  const { toggleShortcuts, togglePalette, openSettings, createNewGroup } = deps;
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       const mod = e.metaKey || e.ctrlKey;
@@ -68,9 +76,21 @@ export function useShortcutHandlers(deps: ShortcutHandlersDeps): void {
       } else if (e.key === ',') {
         e.preventDefault();
         openSettings();
+      } else if (k === 'n' && e.shiftKey) {
+        // Ctrl/Cmd+Shift+N: create a new group. Skip when focus is on a
+        // text-editable surface so typing the literal "N" in an input never
+        // hijacks. Parity note: this matches CommandPalette's "new group"
+        // entry (create + focus, no inline-rename). The Sidebar button has an
+        // additional auto-rename-on-create UX driven by component-local state
+        // (`justCreatedGroupId`); replicating it from a global shortcut would
+        // require lifting that state out of Sidebar, so we intentionally
+        // match CommandPalette's simpler behavior here.
+        if (isEditableTarget(e.target)) return;
+        e.preventDefault();
+        createNewGroup();
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [toggleShortcuts, togglePalette, openSettings]);
+  }, [toggleShortcuts, togglePalette, openSettings, createNewGroup]);
 }

--- a/tests/app-effects/useShortcutHandlers.test.tsx
+++ b/tests/app-effects/useShortcutHandlers.test.tsx
@@ -15,11 +15,13 @@ describe('useShortcutHandlers', () => {
   let toggleShortcuts: ReturnType<typeof vi.fn>;
   let togglePalette: ReturnType<typeof vi.fn>;
   let openSettings: ReturnType<typeof vi.fn>;
+  let createNewGroup: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     toggleShortcuts = vi.fn();
     togglePalette = vi.fn();
     openSettings = vi.fn();
+    createNewGroup = vi.fn();
   });
 
   function mount() {
@@ -28,6 +30,7 @@ describe('useShortcutHandlers', () => {
         toggleShortcuts,
         togglePalette,
         openSettings,
+        createNewGroup,
       })
     );
   }
@@ -50,6 +53,7 @@ describe('useShortcutHandlers', () => {
     expect(togglePalette).not.toHaveBeenCalled();
     expect(toggleShortcuts).not.toHaveBeenCalled();
     expect(openSettings).not.toHaveBeenCalled();
+    expect(createNewGroup).not.toHaveBeenCalled();
   });
 
   it('Ctrl+, opens settings', () => {
@@ -83,6 +87,45 @@ describe('useShortcutHandlers', () => {
     expect(togglePalette).not.toHaveBeenCalled();
     expect(toggleShortcuts).not.toHaveBeenCalled();
     expect(openSettings).not.toHaveBeenCalled();
+    expect(createNewGroup).not.toHaveBeenCalled();
+  });
+
+  describe('Ctrl/Cmd+Shift+N (new group)', () => {
+    it('Ctrl+Shift+N fires createNewGroup', () => {
+      mount();
+      dispatchKey({ key: 'N', ctrlKey: true, shiftKey: true });
+      expect(createNewGroup).toHaveBeenCalledTimes(1);
+      expect(toggleShortcuts).not.toHaveBeenCalled();
+      expect(togglePalette).not.toHaveBeenCalled();
+      expect(openSettings).not.toHaveBeenCalled();
+    });
+
+    it('Cmd+Shift+N fires createNewGroup', () => {
+      mount();
+      dispatchKey({ key: 'N', metaKey: true, shiftKey: true });
+      expect(createNewGroup).toHaveBeenCalledTimes(1);
+    });
+
+    it('Ctrl+N alone does NOT fire createNewGroup', () => {
+      mount();
+      dispatchKey({ key: 'n', ctrlKey: true });
+      expect(createNewGroup).not.toHaveBeenCalled();
+    });
+
+    it('Ctrl+Shift+N is suppressed when an input/textarea is focused', () => {
+      mount();
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+      dispatchKey({ key: 'N', ctrlKey: true, shiftKey: true, target: input });
+      expect(createNewGroup).not.toHaveBeenCalled();
+      document.body.removeChild(input);
+
+      const ta = document.createElement('textarea');
+      document.body.appendChild(ta);
+      dispatchKey({ key: 'N', ctrlKey: true, shiftKey: true, target: ta });
+      expect(createNewGroup).not.toHaveBeenCalled();
+      document.body.removeChild(ta);
+    });
   });
 
   it('removes the keydown listener on unmount', () => {


### PR DESCRIPTION
## Bug
`src/components/ShortcutOverlay.tsx` and `src/components/CommandPalette.tsx` both advertise `Ctrl/Cmd+Shift+N → New group`, but `src/app-effects/useShortcutHandlers.ts` never bound the combo. Pressing it was a no-op.

## Fix
- Add `mod && e.shiftKey && k === 'n'` branch to `useShortcutHandlers`.
- New `createNewGroup` dep on the hook's args; wired from `App.tsx` via `createGroup()` + `focusGroup(id)` (matches `CommandPalette`'s "new group" entry).
- Honor the existing `isEditableTarget` guard so typing `N` in inputs/textareas/contenteditable doesn't hijack.

## Tests (`tests/app-effects/useShortcutHandlers.test.tsx`)
- Ctrl+Shift+N fires `createNewGroup`
- Cmd+Shift+N fires `createNewGroup`
- Ctrl+N alone does NOT fire
- Suppressed when input/textarea is focused
- Extended existing Ctrl+B / Ctrl+K negative assertions to include `createNewGroup`

## Parity note: auto-rename-on-create
`Sidebar.handleNewGroup` additionally puts the freshly-created `GroupRow` into inline-rename mode via component-local state (`justCreatedGroupId`). `CommandPalette`'s "new group" entry does **not** do this, and this shortcut intentionally mirrors `CommandPalette` (create + focus, no rename). Replicating the rename UX from a global shortcut would require lifting `justCreatedGroupId` out of `Sidebar`. Keeping the two global entry points (palette + shortcut) behaviorally consistent felt like the cleaner trade.

## Gates
- `npm run typecheck` clean
- `npm run lint` clean (`--max-warnings 0`)
- `npx vitest run tests/app-effects/useShortcutHandlers.test.tsx` -> 11/11 pass
- Pre-existing full-suite failures are unrelated (missing `dist/electron` build artifacts + native sqlite binding) and present on `main`.

## Test plan
- [ ] Launch app, press Ctrl/Cmd+Shift+N anywhere outside an input -> new group appears in sidebar and is focused
- [ ] Focus a text input/textarea, press Ctrl/Cmd+Shift+N -> nothing happens (typing "N" stays in the field)
- [ ] Press Ctrl+N alone -> no group created