### PR TITLE
fix(pty): async taskkill — quit no longer freezes UI on Windows

### DIFF
--- a/electron/ptyHost/__tests__/lifecycle.test.ts
+++ b/electron/ptyHost/__tests__/lifecycle.test.ts
@@ -42,7 +42,10 @@ function bus(): LifecycleBus {
 }
 
 vi.mock('../processKiller', () => ({
-  killProcessSubtree: (pid: number | undefined) => bus().killCalls.push(pid),
+  killProcessSubtree: (pid: number | undefined) => {
+    bus().killCalls.push(pid);
+    return Promise.resolve();
+  },
 }));
 
 vi.mock('../../sessionWatcher', () => ({
@@ -638,5 +641,46 @@ describe('lifecycle.killAll', () => {
     await expect(L.killAll(new Map() as any)).resolves.toBeUndefined();
     expect(bus().killCalls).toEqual([]);
     expect(bus().watcherStopCalls).toEqual([]);
+  });
+
+  it('killAll fans out in parallel — wall time ≈ slowest kill, NOT sum of all', async () => {
+    // Regression guard for #1380: previously `killAll` was serial and each
+    // wedged session blocked the next on `spawnSync('taskkill', ...)` for
+    // 200–2000 ms, freezing the UI on quit. With parallel fanout + async
+    // taskkill the wall clock should track the slowest kill, not the sum.
+    //
+    // We simulate the wedged-fallback branch by NOT firing onExit and
+    // letting each kill ride the KILL_EXIT_TIMEOUT_MS timer to settlement.
+    // Under serial execution wall time would be 3×KILL_EXIT_TIMEOUT_MS;
+    // under parallel fanout it's ~1×.
+    vi.useFakeTimers();
+    try {
+      const sessions = new Map<string, FakeEntry>();
+      const a = makeFakeEntry({ pty: makeFakePty({ pid: 100 }) });
+      const b = makeFakeEntry({ pty: makeFakePty({ pid: 101 }) });
+      const c = makeFakeEntry({ pty: makeFakePty({ pid: 102 }) });
+      // All three writes succeed but no onExit fires — every kill rides
+      // the wedged-fallback timer.
+      sessions.set('a', a);
+      sessions.set('b', b);
+      sessions.set('c', c);
+
+      const p = L.killAll(sessions as any);
+      let resolved = false;
+      void p.then(() => { resolved = true; });
+
+      // Advance ONE KILL_EXIT_TIMEOUT_MS — if the three kills are racing in
+      // parallel they should all settle on this single tick. If they were
+      // serialized this would only settle the first.
+      await vi.advanceTimersByTimeAsync(L.KILL_EXIT_TIMEOUT_MS + 50);
+      await expect(p).resolves.toBeUndefined();
+      expect(resolved).toBe(true);
+
+      // All three subtree walks fired (proves all three escalated, not
+      // just one).
+      expect(bus().killCalls.sort()).toEqual([100, 101, 102]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/electron/ptyHost/__tests__/processKiller.test.ts
+++ b/electron/ptyHost/__tests__/processKiller.test.ts
@@ -1,29 +1,57 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
 
-import { killProcessSubtree } from '../processKiller';
+// Mock node:child_process via vi.hoisted so production code and test
+// assertions share the SAME `vi.fn()` reference. vi.spyOn(ns,'spawn')
+// doesn't work under vitest's ESM module namespace (non-configurable
+// exports), so we intercept at the module-resolution layer instead.
+const cp = vi.hoisted(() => {
+  return { spawn: vi.fn() };
+});
+vi.mock('node:child_process', () => ({
+  default: { spawn: cp.spawn },
+  spawn: cp.spawn,
+}));
+
+import { killProcessSubtree, TASKKILL_TIMEOUT_MS } from '../processKiller';
+
+/** Fake taskkill child with the `.kill()` + 'close'/'error' surface
+ *  killProcessSubtree consumes. Mirrors node `ChildProcess` enough for
+ *  the production code path; not a full implementation. */
+type FakeChild = EventEmitter & { kill: ReturnType<typeof vi.fn> };
+function makeFakeChild(): FakeChild {
+  const ee = new EventEmitter() as FakeChild;
+  ee.kill = vi.fn();
+  return ee;
+}
 
 describe('killProcessSubtree — guards', () => {
+  beforeEach(() => {
+    cp.spawn.mockReset();
+  });
+
   // No spawn / no process.kill should be invoked for invalid pids.
   it.each([
     ['undefined', undefined],
     ['zero', 0],
     ['negative', -1],
-  ])('no-op for %s pid', (_label, pid) => {
+  ])('no-op for %s pid (resolves immediately)', async (_label, pid) => {
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(((..._args: unknown[]) => true) as never);
     try {
-      // Should not throw and not signal anything.
-      expect(() => killProcessSubtree(pid as number | undefined)).not.toThrow();
+      await expect(killProcessSubtree(pid as number | undefined)).resolves.toBeUndefined();
       expect(killSpy).not.toHaveBeenCalled();
+      expect(cp.spawn).not.toHaveBeenCalled();
     } finally {
       killSpy.mockRestore();
     }
   });
 });
 
-describe('killProcessSubtree — windows path', () => {
+describe('killProcessSubtree — windows path (async taskkill)', () => {
   const originalPlatform = process.platform;
 
   beforeEach(() => {
+    cp.spawn.mockReset();
     Object.defineProperty(process, 'platform', { value: 'win32' });
   });
 
@@ -31,17 +59,79 @@ describe('killProcessSubtree — windows path', () => {
     Object.defineProperty(process, 'platform', { value: originalPlatform });
   });
 
-  it('does not throw for a non-existent pid (taskkill swallows)', () => {
-    // 999999 almost certainly does not exist; taskkill returns nonzero
-    // but spawnSync does not throw. Production code wraps in try/catch
-    // anyway.
-    expect(() => killProcessSubtree(999999)).not.toThrow();
+  it('spawns taskkill /F /T /PID asynchronously (does NOT block on spawnSync)', () => {
+    const fake = makeFakeChild();
+    cp.spawn.mockReturnValue(fake);
+    // Don't await — proves the function returns a pending Promise before
+    // taskkill actually exits (the regression spawnSync would have blocked).
+    const p = killProcessSubtree(1234);
+    expect(cp.spawn).toHaveBeenCalledWith(
+      'taskkill',
+      ['/F', '/T', '/PID', '1234'],
+      expect.objectContaining({ windowsHide: true, stdio: 'ignore' }),
+    );
+    expect(p).toBeInstanceOf(Promise);
+    // Drive the fake child to close so the Promise resolves before the
+    // test finishes (otherwise the timer would unref-await for 5s).
+    fake.emit('close', 0);
+    return p;
   });
 
-  it('does not invoke process.kill on win32 (uses taskkill instead)', () => {
+  it('resolves when taskkill emits close', async () => {
+    const fake = makeFakeChild();
+    cp.spawn.mockReturnValue(fake);
+    const p = killProcessSubtree(42);
+    fake.emit('close', 0);
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it('resolves when taskkill emits error (e.g. ENOENT — binary missing)', async () => {
+    const fake = makeFakeChild();
+    cp.spawn.mockReturnValue(fake);
+    const p = killProcessSubtree(42);
+    fake.emit('error', new Error('ENOENT'));
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it('5s ceiling: timer fires child.kill() and resolves if taskkill wedges', async () => {
+    vi.useFakeTimers();
+    try {
+      const fake = makeFakeChild();
+      cp.spawn.mockReturnValue(fake);
+      const p = killProcessSubtree(42);
+
+      // Just before the ceiling, still pending.
+      let resolved = false;
+      void p.then(() => { resolved = true; });
+      await vi.advanceTimersByTimeAsync(TASKKILL_TIMEOUT_MS - 50);
+      expect(resolved).toBe(false);
+      expect(fake.kill).not.toHaveBeenCalled();
+
+      // Cross the ceiling: last-ditch kill fires AND the Promise resolves
+      // so the surrounding quit path can proceed.
+      await vi.advanceTimersByTimeAsync(100);
+      expect(fake.kill).toHaveBeenCalledTimes(1);
+      await expect(p).resolves.toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('swallows synchronous spawn throw (e.g. EACCES) and resolves', async () => {
+    cp.spawn.mockImplementation(() => {
+      throw new Error('EACCES');
+    });
+    await expect(killProcessSubtree(42)).resolves.toBeUndefined();
+  });
+
+  it('does not invoke process.kill on win32 (uses taskkill instead)', async () => {
+    const fake = makeFakeChild();
+    cp.spawn.mockReturnValue(fake);
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(((..._args: unknown[]) => true) as never);
     try {
-      killProcessSubtree(999999);
+      const p = killProcessSubtree(999999);
+      fake.emit('close', 0);
+      await p;
       expect(killSpy).not.toHaveBeenCalled();
     } finally {
       killSpy.mockRestore();
@@ -53,6 +143,7 @@ describe('killProcessSubtree — posix path', () => {
   const originalPlatform = process.platform;
 
   beforeEach(() => {
+    cp.spawn.mockReset();
     Object.defineProperty(process, 'platform', { value: 'linux' });
     vi.useFakeTimers();
   });
@@ -62,14 +153,20 @@ describe('killProcessSubtree — posix path', () => {
     vi.useRealTimers();
   });
 
-  it('signals process group SIGTERM, then SIGKILL after 500ms', () => {
+  it('signals process group SIGTERM, then SIGKILL after 500ms, resolves immediately', async () => {
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(((..._args: unknown[]) => true) as never);
     try {
-      killProcessSubtree(4321);
+      const p = killProcessSubtree(4321);
 
       // Immediate SIGTERM to negative pid (process group)
       expect(killSpy).toHaveBeenCalledWith(-4321, 'SIGTERM');
       expect(killSpy).toHaveBeenCalledTimes(1);
+
+      // The returned Promise resolves immediately (POSIX path doesn't
+      // wait on the SIGKILL escalation — that's a fire-and-forget timer
+      // so the quit path can proceed without sitting on a 500ms delay
+      // for every session).
+      await expect(p).resolves.toBeUndefined();
 
       // Advance timers — SIGKILL should fire
       vi.advanceTimersByTime(500);
@@ -80,12 +177,12 @@ describe('killProcessSubtree — posix path', () => {
     }
   });
 
-  it('swallows SIGTERM throw (group already gone) and still schedules SIGKILL', () => {
+  it('swallows SIGTERM throw (group already gone) and still schedules SIGKILL', async () => {
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(((..._args: unknown[]) => {
       throw new Error('ESRCH');
     }) as never);
     try {
-      expect(() => killProcessSubtree(7)).not.toThrow();
+      await expect(killProcessSubtree(7)).resolves.toBeUndefined();
       // SIGKILL after timeout should also be swallowed
       expect(() => vi.advanceTimersByTime(500)).not.toThrow();
       // Both attempts were made

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -248,6 +248,10 @@ export function kill(sessions: Map<string, Entry>, sid: string): Promise<boolean
         `[ptyHost] kill ${sid} wedged: SIGKILL also failed (${e instanceof Error ? e.message : String(e)}); pid ${pid} may leak`,
       );
     }
+    // Evict the zombie from the registry RIGHT NOW (before awaiting the
+    // subtree walk): renderer attach-after-kill paths only inspect map
+    // membership and must see the entry gone the instant kill() escalates.
+    if (sessions.get(sid) === entry) sessions.delete(sid);
     // ConPTY's kill only terminates the cmd.exe / OpenConsole wrapper; on
     // Windows the claude.exe child (and its grandchildren) survive as
     // orphans. On mac/linux the pgid may also have stragglers. Walk the
@@ -255,9 +259,16 @@ export function kill(sessions: Map<string, Entry>, sid: string): Promise<boolean
     // Deferred to the hard-fallback branch ONLY — running this on the
     // graceful path would kill claude mid-flush and defeat the soft-signal
     // strategy.
-    killProcessSubtree(pid);
-    if (sessions.get(sid) === entry) sessions.delete(sid);
-    settle(false);
+    //
+    // Now async (#1380): we keep `kill()`'s promise pending until the
+    // subtree walk completes so `before-quit`'s `await killAll(...)` knows
+    // every reap finished before re-firing `app.quit()`. `killProcessSubtree`
+    // has its own 5s ceiling, so this can never hang. Errors are
+    // intentionally swallowed — already-dead pids are expected.
+    void killProcessSubtree(pid).then(
+      () => settle(false),
+      () => settle(false),
+    );
   }, KILL_EXIT_TIMEOUT_MS);
 
   // Soft signal: write Ctrl+C (`\x03`) to the PTY. On Windows ConPTY this is

--- a/electron/ptyHost/processKiller.ts
+++ b/electron/ptyHost/processKiller.ts
@@ -6,22 +6,77 @@
 // mac/linux the pgid may also have stragglers. This module walks the tree
 // via a platform-native call to guarantee a clean shutdown. Best-effort —
 // any already-dead pid is swallowed silently.
+//
+// Returns Promise<void> on BOTH platforms (#1380): the historical
+// Windows implementation used `spawnSync('taskkill',...)`, which blocks
+// the Electron main thread for 200–2000 ms per pid (Defender scan + WMI
+// roundtrip for /T tree walk). Quit-time `killAllPtySessions()` fans out
+// `kill()` in parallel, but on the wedged-fallback branch every per-
+// session 3s timer eventually called `killProcessSubtree`, so N sessions
+// produced N serial sync calls on the main thread → multi-second UI
+// freeze on quit. Now async: `spawn` + 'close' event + 5s ceiling fed by
+// `child.kill()` last-ditch, so the main thread never blocks regardless
+// of how many sessions need to reap.
+//
+// POSIX returns Promise<void> for the same uniform shape, but resolves
+// immediately — the SIGTERM-then-SIGKILL escalation already ran on
+// timers under the hood (and the SIGKILL fallback fires via
+// `setTimeout(...).unref()` 500 ms later regardless of whether the
+// caller awaits us).
 
-import { spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 
-export function killProcessSubtree(pid: number | undefined): void {
-  if (!pid || pid <= 0) return;
+/** Hard ceiling on how long we'll wait for `taskkill /F /T` to finish
+ *  before declaring it wedged. taskkill is normally <500 ms even with
+ *  Defender in the loop; 5 s is generous enough to absorb a contended
+ *  Windows host while keeping quit responsive. */
+export const TASKKILL_TIMEOUT_MS = 5000;
+
+export function killProcessSubtree(pid: number | undefined): Promise<void> {
+  if (!pid || pid <= 0) return Promise.resolve();
   if (process.platform === 'win32') {
-    try {
-      // /T walks the entire tree, /F forces termination.
-      spawnSync('taskkill', ['/F', '/T', '/PID', String(pid)], {
-        windowsHide: true,
-        stdio: 'ignore',
-      });
-    } catch {
-      /* already dead or taskkill unavailable */
-    }
-    return;
+    return new Promise<void>((resolve) => {
+      let settled = false;
+      const settle = (): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve();
+      };
+      let child: ReturnType<typeof spawn>;
+      try {
+        // /T walks the entire tree, /F forces termination. `windowsHide`
+        // prevents a console flash; `stdio:'ignore'` discards taskkill's
+        // status lines (we already swallow non-zero exits because dead
+        // pids are expected).
+        child = spawn('taskkill', ['/F', '/T', '/PID', String(pid)], {
+          windowsHide: true,
+          stdio: 'ignore',
+        });
+      } catch {
+        /* taskkill unavailable on PATH — nothing more we can do. */
+        resolve();
+        return;
+      }
+      child.once('close', settle);
+      child.once('error', settle);
+      // Last-ditch: a 5s wedged taskkill (rare: usually means Defender
+      // is mid-scan or WMI is hung) gets SIGKILL'd so we don't strand
+      // the main quit path waiting on it. The orphan tree may survive
+      // until the OS reaps it on logout, but the app exits cleanly.
+      const timer = setTimeout(() => {
+        try {
+          child.kill();
+        } catch {
+          /* taskkill already exited between the timer firing and
+             child.kill() landing */
+        }
+        settle();
+      }, TASKKILL_TIMEOUT_MS);
+      // Don't keep the event loop alive purely to wait for taskkill —
+      // the surrounding quit path resolves the Promise either way.
+      timer.unref?.();
+    });
   }
   // POSIX: signal the process group (negative pid). SIGTERM first; SIGKILL
   // after a short grace period if anything refuses to exit.
@@ -37,4 +92,5 @@ export function killProcessSubtree(pid: number | undefined): void {
       /* already dead */
     }
   }, 500).unref();
+  return Promise.resolve();
 }


### PR DESCRIPTION
## Bug
`electron/ptyHost/processKiller.ts` called `spawnSync('taskkill', ['/F','/T','/PID',pid])` on Windows, which blocks the Electron main thread **200–2000 ms per pid** (Defender scan + WMI roundtrip for the `/T` tree walk).

The quit-time flush already fans out `kill()` in parallel via `killAll` (#1277-series), but every wedged session's 3 s `KILL_EXIT_TIMEOUT_MS` timer eventually called the sync taskkill on the main thread. With N wedged sessions all timing out concurrently, that produced **N × blocking time** and a multi-second UI freeze on quit.

## Symptom
Quit a window with several live claude sessions on Windows → app menu/tray hangs unresponsive for 1–10 s while the OS reaps the trees.

## Fix
1. **`processKiller.ts`**: `spawnSync` → async `spawn` returning `Promise<void>`. 5 s ceiling fed by `child.kill()` last-ditch so a wedged taskkill (Defender mid-scan, WMI hang) can't strand the quit path.
2. **POSIX path**: also returns `Promise<void>` for uniform shape (SIGTERM-then-SIGKILL timer escalation unchanged — still 500 ms via `setTimeout().unref()`).
3. **`lifecycle.ts`**: the wedged-fallback branch in `kill()` now `await`s the subtree walk before resolving, so `before-quit`'s `await killAllPtySessions()` truly waits for every reap. Eviction from the `sessions` map happens BEFORE the await so renderer attach-after-kill sees the entry gone immediately.

With parallel fanout + async taskkill, quit-time wall clock now tracks the **slowest single kill** rather than the sum.

## Already-fixed context (verified on main HEAD `2008c40f`)
- `killAll` is already parallel (`Promise.all`) ✓
- `kill()` already returns `Promise<boolean>` with `===`-identity dedup in `pendingKills` ✓
- `before-quit` already does `preventDefault()` + latch + `await killAllPtySessions()` + `disposeNotifyPipeline()` + re-fires `app.quit()` ✓

The only remaining gap was the sync `spawnSync` inside `killProcessSubtree`. This PR is scoped to that fix.

## Test coverage
**`processKiller.test.ts`** — rewritten using `vi.hoisted` + `vi.mock('node:child_process')` so production and tests share the same `vi.fn()` reference:
- guards: `undefined` / `0` / negative pids resolve immediately with no spawn
- Windows: async `spawn('taskkill', ['/F','/T','/PID', pid], {windowsHide, stdio:'ignore'})` argv shape
- Windows: resolution on `'close'` AND on `'error'` (ENOENT — binary missing)
- Windows: **5 s ceiling** — at `TASKKILL_TIMEOUT_MS - 50` still pending, at `+100` the timer fires `child.kill()` and the Promise resolves
- Windows: synchronous `spawn` throw (EACCES) swallowed → resolves
- Windows: no `process.kill` call on win32 (taskkill is the only path)
- POSIX: SIGTERM immediate + Promise resolves NOW + SIGKILL 500 ms later via the unref'd timer
- POSIX: SIGTERM throw (ESRCH) swallowed, SIGKILL still scheduled

**`lifecycle.test.ts`** — regression test pinning **parallel wall-time**:
- 3 wedged kills (no `onExit` fires; all ride the `KILL_EXIT_TIMEOUT_MS` timer) settle on a single `advanceTimersByTimeAsync(KILL_EXIT_TIMEOUT_MS + 50)` tick. Under serial execution this would only settle the first; under parallel fanout all three resolve and all three `killProcessSubtree` calls fire.

## Hard gates
- `npm run typecheck` ✓
- `npm run lint --max-warnings 0` ✓
- `npx vitest run electron/ptyHost/__tests__/ electron/lifecycle/__tests__/` → **236/236 pass**
- Full `electron/` suite: 18 pre-existing failures in `db.test.ts` / `db-hardening.test.ts` due to local `better-sqlite3` NODE_MODULE_VERSION 145 vs 127 mismatch (verified pre-existing on stock main with `git stash`). Unrelated to this change.

## Test plan
- [ ] CI green on `main`-targeted PR
- [ ] Dogfood: launch CCSM Windows build with 3+ live sessions, quit via tray, verify quit feels instant (no menu hang)

🤖 Generated with [Claude Code](https://claude.com/claude-code)