### PR TITLE
fix(dev): PowerShell CIM fallback for 4100 preflight + tighter parsers

### DIFF
--- a/scripts/dev-electron.mjs
+++ b/scripts/dev-electron.mjs
@@ -104,11 +104,13 @@ function findListenerPidWin(port) {
   const res = spawnSync('netstat', ['-ano', '-p', 'TCP'], { encoding: 'utf8' });
   if (res.status !== 0) return null;
   const lines = res.stdout.split(/\r?\n/);
-  const needle = `:${port}`;
+  // `:4100 ` (with trailing whitespace) discriminates the exact port
+  // from substrings like `:41000`. netstat always pads the local
+  // address column with at least one space before the foreign address.
+  const needle = `:${port} `;
   for (const line of lines) {
     if (!line.includes('LISTENING')) continue;
-    // Local Address column contains "0.0.0.0:4100" or "[::]:4100".
-    if (!new RegExp(`${needle.replace('.', '\\.')}\\b`).test(line)) continue;
+    if (!line.includes(needle)) continue;
     const cols = line.trim().split(/\s+/);
     const pid = Number(cols[cols.length - 1]);
     if (Number.isFinite(pid) && pid > 0) return pid;
@@ -117,9 +119,10 @@ function findListenerPidWin(port) {
 }
 
 function inspectProcessWin(pid) {
-  // wmic is deprecated on Win11 but still present on most systems; if
-  // missing we fall back to tasklist (which doesn't give CommandLine).
-  // CSV output keeps the comma-in-path case parseable.
+  // Try wmic first — fastest and present on Win10 + most Win11 < 24H2.
+  // Win11 24H2 removed wmic by default; CIM via PowerShell is the
+  // documented replacement and ships on every supported Win10/11 SKU.
+  // Final fallback is tasklist for the image name only.
   const wmic = spawnSync(
     'wmic',
     ['process', 'where', `ProcessId=${pid}`, 'get', 'ExecutablePath,CommandLine', '/format:list'],
@@ -131,12 +134,45 @@ function inspectProcessWin(pid) {
     const cmd = /CommandLine=(.*)/i.exec(out)?.[1]?.trim() ?? '';
     if (exe || cmd) return { executablePath: exe, commandLine: cmd };
   }
-  // Fallback: at least surface the image name.
+
+  // PowerShell CIM fallback. ConvertTo-Json keeps quoted strings
+  // unambiguous (Format-List loses newlines inside CommandLine for
+  // some processes). -NoProfile skips user $PROFILE so this is safe
+  // and fast in fresh shells. Property selection is explicit so the
+  // JSON shape doesn't depend on PowerShell version.
+  const ps = spawnSync(
+    'powershell',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      `Get-CimInstance Win32_Process -Filter "ProcessId=${pid}" | ` +
+        `Select-Object ExecutablePath,CommandLine | ConvertTo-Json -Compress`,
+    ],
+    { encoding: 'utf8' },
+  );
+  if (ps.status === 0 && ps.stdout.trim()) {
+    try {
+      const obj = JSON.parse(ps.stdout);
+      const exe = String(obj?.ExecutablePath ?? '').trim();
+      const cmd = String(obj?.CommandLine ?? '').trim();
+      if (exe || cmd) return { executablePath: exe, commandLine: cmd };
+    } catch {
+      /* fall through to tasklist */
+    }
+  }
+
+  // Final fallback: tasklist gives us the image name only (no
+  // CommandLine). With empty commandLine, the preflight rule
+  // `looksLikeOurDev` is guaranteed false → refuse to kill, which
+  // is the safe default. Parse the first CSV field so the bail
+  // message shows just `CCSM.exe`, not the raw 5-column row.
   const tl = spawnSync('tasklist', ['/FI', `PID eq ${pid}`, '/FO', 'CSV', '/NH'], {
     encoding: 'utf8',
   });
   if (tl.status === 0 && tl.stdout.trim()) {
-    return { executablePath: tl.stdout.trim(), commandLine: '' };
+    const firstField = /^"([^"]*)"/.exec(tl.stdout.trim())?.[1] ?? '';
+    if (firstField) return { executablePath: firstField, commandLine: '' };
   }
   return null;
 }

--- a/scripts/dogfood-pr-followup-inspect-process.mjs
+++ b/scripts/dogfood-pr-followup-inspect-process.mjs
@@ -1,0 +1,58 @@
+// scripts/dogfood-pr-followup-inspect-process.mjs
+//
+// Follow-up to #1379 task #51: validate `inspectProcessWin` falls
+// through wmic → PowerShell CIM → tasklist cleanly. We can't simulate
+// Win11 24H2 (where wmic is gone) from a non-24H2 machine, so this
+// probe instead invokes the PowerShell path directly with the current
+// process's PID and asserts the shape we depend on (ExecutablePath +
+// CommandLine present). If the PS contract changes (older PS, locale,
+// etc.) this probe surfaces it before the field reports do.
+//
+// Exit 0 = PASS, 1 = FAIL.
+
+import { spawnSync } from 'node:child_process';
+
+if (process.platform !== 'win32') {
+  console.log('SKIP (non-Windows)');
+  process.exit(0);
+}
+
+const pid = process.pid;
+const ps = spawnSync(
+  'powershell',
+  [
+    '-NoProfile',
+    '-NonInteractive',
+    '-Command',
+    `Get-CimInstance Win32_Process -Filter "ProcessId=${pid}" | ` +
+      `Select-Object ExecutablePath,CommandLine | ConvertTo-Json -Compress`,
+  ],
+  { encoding: 'utf8' },
+);
+
+if (ps.status !== 0) {
+  console.error(`FAIL: powershell exited ${ps.status}`);
+  console.error(`stderr: ${ps.stderr}`);
+  process.exit(1);
+}
+
+let obj;
+try {
+  obj = JSON.parse(ps.stdout);
+} catch (e) {
+  console.error(`FAIL: ConvertTo-Json output did not parse — ${e.message}`);
+  console.error(`stdout: ${ps.stdout.slice(0, 500)}`);
+  process.exit(1);
+}
+
+const exe = String(obj?.ExecutablePath ?? '').trim();
+const cmd = String(obj?.CommandLine ?? '').trim();
+if (!exe || !cmd) {
+  console.error(
+    `FAIL: PS CIM should return both ExecutablePath and CommandLine for current process. Got exe=${JSON.stringify(exe)} cmd=${JSON.stringify(cmd).slice(0, 200)}`,
+  );
+  process.exit(1);
+}
+console.log(`exe = ${exe}`);
+console.log(`cmd = ${cmd.slice(0, 120)}${cmd.length > 120 ? '…' : ''}`);
+console.log('PASS');


### PR DESCRIPTION
## Summary
Three of the six PR #1379 reviewer follow-ups; the rest judged out of scope and tracked below.

- **S2 (real bug on Win11 24H2)**: wmic was removed from the default install. With only the tasklist fallback (image name, no CommandLine), \`looksLikeOurDev\` is always false and the preflight refuses to kill any stale dev forever. Insert PowerShell \`Get-CimInstance Win32_Process\` between wmic and tasklist — ships on every supported Win10/11 SKU, JSON output avoids locale-sensitive parsing.
- **N1**: findListenerPidWin used a misleading single-dot regex escape + \`\b\` matcher. Replaced with \`line.includes(\\`:\\${port} \\`)\` (trailing space disambiguates \`:4100\` vs \`:41000\`).
- **N2**: tasklist fallback was returning the full CSV row as \`executablePath\`. Parse just the quoted image name.

## Evidence
- \`node scripts/dogfood-pr-followup-inspect-process.mjs\` → PASS (exercises PS CIM contract directly with current PID, parses JSON, asserts both fields populated).
- Live preflight against an unrelated 4100 listener: refused to kill, printed node.exe + listener's CommandLine via wmic.
- \`node scripts/dogfood-dev-process-distinguishable.mjs\` → still PASS (no regression in #1379 surface).
- \`npm run typecheck\`, \`npm run lint\`, \`node scripts/harness-ui.mjs\` (14/14), \`npx vitest run electron/window/__tests__/createWindow.test.ts\` (60/60) — all green.

## Out of scope (judged)
- **N4** worktree-vs-worktree false-positive: fix cost (Win32_Process.GetOwner / startsWith cwd comparison) > practical risk; failure mode is \"other dev gets killed\", not \"installed CCSM gets killed\". Documented behavior: run only one dev per machine.
- **S3** AUMID collision packaged-dev ↔ unpackaged-dev: only matters if you run both at once; cosmetic taskbar grouping issue.
- **Renderer-driven title revival**: YAGNI; \`grep -r document.title src/\` is empty today.

## Test plan
- [x] Local typecheck / lint / harness-ui / createWindow unit / both dogfoods
- [x] PS CIM JSON contract verified on current host
- [ ] Field validation on a true Win11 24H2 host (no machine available; PS API guaranteed by docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)