### PR TITLE
feat(dev): random port + per-run userData for npm run dev (#68)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ release/
 .dogfood-userdata-happy/
 .dogfood-userdata-ttyd-debug/
 .dev-userdata/
+.dev-userdata-*/
 docs/screenshots/dogfood-current-ui/
 docs/screenshots/dogfood-happy-path/
 *.exe

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "node": ">=22.0.0"
   },
   "scripts": {
-    "dev": "concurrently -k -n web,app -c blue,magenta \"npm:dev:web\" \"npm:dev:app\"",
+    "dev": "node scripts/dev.mjs",
     "dev:web": "webpack serve --config webpack.config.js --mode development",
-    "dev:app": "wait-on http://localhost:4100 && tsc -p tsconfig.electron.json && node scripts/dev-electron.mjs",
+    "dev:app": "node scripts/dev-wait-web.mjs && tsc -p tsconfig.electron.json && node scripts/dev-electron.mjs",
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "build": "npm run clean && tsc -p tsconfig.electron.json && webpack --mode production && node -e \"const fs=require('fs');const p='dist/renderer/bundle.js';const t=Date.now()/1000;fs.utimesSync(p,t,t)\"",
     "typecheck": "tsc --noEmit && tsc --noEmit -p tsconfig.electron.json",

--- a/scripts/dev-electron.mjs
+++ b/scripts/dev-electron.mjs
@@ -12,8 +12,10 @@
 //      `productName`, which is "CCSM" in both prod and dev. Without an
 //      override, dev runs would read/write the same SQLite DB and prefs as
 //      your installed ccsm — risky even after exit (WAL recovery, schema
-//      migrations). We point the dev instance at `.dev-userdata/` inside the
-//      worktree via Electron's `--user-data-dir` switch.
+//      migrations). The orchestrator (`scripts/dev.mjs`) hands us a
+//      per-run random `.dev-userdata-<hex>/` via the `CCSM_DEV_USERDATA`
+//      env var; standalone invocations fall back to `.dev-userdata/`.
+//      Either way, we pass it to Electron via `--user-data-dir`.
 //
 //   3. Dev vs installed CCSM identity.  Both run as `CCSM.exe` /
 //      `electron.exe`; tasklist / Alt-Tab / Task Manager can't tell them
@@ -22,13 +24,16 @@
 //      rename the app to "CCSM (dev)" and createWindow tag the title
 //      "CCSM [dev]" — see electron/main.ts and electron/window/createWindow.ts.
 //
-//   4. Stale-port detection.  webpack-dev-server (sibling `dev:web`)
-//      listens on :4100. If a previous `npm run dev` left zombie
-//      processes, the new run dies with `EADDRINUSE` mid-bringup. We
-//      probe :4100 BEFORE spawning electron and refuse to kill blindly:
-//      identify the holder, auto-kill only if it's an electron pointed
-//      at THIS repo, otherwise print PID / path / CommandLine and bail.
-//      Rule from feedback_never_blind_kill_ccsm.md: never kill
+//   4. Stale-port detection.  In the orchestrated path (`npm run dev`
+//      via `scripts/dev.mjs`), each run gets a fresh random port via
+//      OS allocation — collisions are vanishingly rare and the
+//      preflight is skipped to avoid false-positives on our own
+//      sibling webpack. When this wrapper is invoked standalone
+//      (legacy fixed port :4100), we probe :4100 BEFORE spawning
+//      electron and refuse to kill blindly: identify the holder,
+//      auto-kill only if its CommandLine references this repo's
+//      node_modules, otherwise print PID / path / CommandLine and
+//      bail. Rule from feedback_never_blind_kill_ccsm.md: never kill
 //      ambiguous CCSM.exe processes.
 //
 // Cross-platform: spawning Node with explicit arg/env propagation works on
@@ -43,21 +48,32 @@ import { createRequire } from 'node:module';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..');
-const userDataDir = resolve(repoRoot, '.dev-userdata');
+// scripts/dev.mjs (the orchestrator) hands us a per-run random userData
+// directory via CCSM_DEV_USERDATA so two concurrent `npm run dev` shells
+// don't share SQLite WAL / prefs. When this wrapper is invoked
+// standalone (e.g. for debugging), fall back to the legacy fixed dir.
+const userDataDir = process.env.CCSM_DEV_USERDATA
+  ? resolve(process.env.CCSM_DEV_USERDATA)
+  : resolve(repoRoot, '.dev-userdata');
 mkdirSync(userDataDir, { recursive: true });
 
-// ─────────────────────── Port :4100 preflight ────────────────────────
-// Goal: catch the leftover-dev-process case BEFORE webpack-dev-server
-// crashes with EADDRINUSE, and never blind-kill an ambiguous CCSM.exe.
-preflightPort4100();
+// ─────────────────────── Port preflight ──────────────────────────────
+// Only useful for standalone runs on the legacy fixed port (4100). When
+// the orchestrator (scripts/dev.mjs) launches us, CCSM_DEV_PORT is a
+// freshly-allocated random port and the only listener is our own sibling
+// webpack-dev-server (we already wait-on'd it). Running preflight in
+// that case false-positives on our own webpack.
+if (!process.env.CCSM_DEV_PORT) {
+  preflightPort('4100');
+}
 
-function preflightPort4100() {
+function preflightPort(port) {
   if (process.platform !== 'win32') {
     // Non-Windows preflight is opt-in; the failure mode that motivated
     // this (taskkill /IM blasting installed CCSM) is Windows-specific.
     return;
   }
-  const holderPid = findListenerPidWin('4100');
+  const holderPid = findListenerPidWin(String(port));
   if (!holderPid) return;
 
   const info = inspectProcessWin(holderPid);
@@ -80,14 +96,14 @@ function preflightPort4100() {
 
   if (looksLikeOurDev) {
     console.error(
-      `[dev-electron] port 4100 held by zombie dev electron PID=${holderPid} (path matches this repo). Killing.`,
+      `[dev-electron] port ${port} held by zombie dev electron PID=${holderPid} (path matches this repo). Killing.`,
     );
     spawnSync('taskkill', ['/F', '/T', '/PID', String(holderPid)]);
     return;
   }
 
   console.error(
-    `\n[dev-electron] port 4100 is in use by PID=${holderPid}, ` +
+    `\n[dev-electron] port ${port} is in use by PID=${holderPid}, ` +
       `and we cannot confirm it's a leftover dev process for THIS repo. ` +
       `Refusing to kill blindly.\n` +
       `  ExecutablePath: ${info?.executablePath ?? '<unknown>'}\n` +

--- a/scripts/dev-lib.mjs
+++ b/scripts/dev-lib.mjs
@@ -1,0 +1,154 @@
+// Helpers for scripts/dev.mjs. Kept separate from the entry point so they
+// can be unit-tested without spawning electron / webpack-dev-server.
+//
+// Designed to be pure-ish: callers pass in the bits we'd otherwise reach
+// for via process / fs globals, so tests can swap fakes.
+
+import { createServer } from 'node:net';
+import { randomBytes } from 'node:crypto';
+import { existsSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Ask the OS for a free TCP port by listening on :0 and reading the
+// assigned port off the socket. We bind to 127.0.0.1 so we never accept
+// from the LAN even for the lifetime of this probe.
+//
+// There's an inherent race: between close() and the time the caller
+// actually re-binds, another process *could* claim the port. In practice
+// the dev orchestrator re-binds within milliseconds and the ephemeral
+// port range is large enough that collisions are vanishingly rare for
+// 1–2 concurrent dev runs. If we ever need stronger guarantees we'd
+// switch to passing the bound socket fd to the child via SO_REUSEADDR,
+// but that's overkill here.
+export function allocateDevPort() {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.unref();
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const addr = srv.address();
+      if (!addr || typeof addr !== 'object') {
+        srv.close();
+        reject(new Error('allocateDevPort: server.address() returned non-object'));
+        return;
+      }
+      const port = addr.port;
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+// `.dev-userdata-<6 hex>` lets two concurrent `npm run dev` runs have
+// independent SQLite WAL / cache / prefs. 6 hex = 16M values; collision
+// risk is negligible for the realistic ceiling of <10 simultaneous runs.
+export function generateUserDataDirName() {
+  return `.dev-userdata-${randomBytes(3).toString('hex')}`;
+}
+
+// Install a cleanup function on the process so it runs on any termination
+// path we can intercept on Node: normal exit, Ctrl-C (SIGINT), SIGTERM,
+// SIGHUP, and uncaught exceptions.
+//
+// On Windows, SIGINT/SIGTERM/SIGHUP work for the orchestrator process
+// itself when invoked via `npm run dev` from a console (Node maps the
+// CTRL_C_EVENT). A force-kill from outside (Stop-Process -Force,
+// taskkill /F /PID) sidesteps Node entirely — 'exit' does NOT fire in
+// that case. Orphan recovery on next start (reapOrphanUserDataDirs) is
+// the safety net for that path; Job Objects would be the proper fix
+// but require a native addon, out of scope.
+//
+// Idempotent: multiple events firing in quick succession (e.g. SIGINT
+// then exit) collapse to a single cleanup invocation.
+export function installCleanupTrap(cleanup, opts = {}) {
+  const proc = opts.proc ?? process;
+  let ran = false;
+  const once = () => {
+    if (ran) return;
+    ran = true;
+    try {
+      cleanup();
+    } catch {
+      // Swallow — we're already on an exit path; surfacing here would
+      // mask the original cause.
+    }
+  };
+  proc.on('exit', once);
+  proc.on('SIGINT', () => {
+    once();
+    // SIGINT default would exit(130); we ran cleanup ourselves so
+    // call exit explicitly to be sure we leave.
+    try {
+      proc.exit(130);
+    } catch {}
+  });
+  proc.on('SIGTERM', () => {
+    once();
+    try {
+      proc.exit(143);
+    } catch {}
+  });
+  proc.on('SIGHUP', () => {
+    once();
+    try {
+      proc.exit(129);
+    } catch {}
+  });
+  proc.on('uncaughtException', (err) => {
+    // eslint-disable-next-line no-console
+    console.error('[dev] uncaughtException:', err);
+    once();
+    try {
+      proc.exit(1);
+    } catch {}
+  });
+  proc.on('unhandledRejection', (err) => {
+    // eslint-disable-next-line no-console
+    console.error('[dev] unhandledRejection:', err);
+    once();
+    try {
+      proc.exit(1);
+    } catch {}
+  });
+}
+
+// Sweep stale `.dev-userdata-XXXXXX` directories at orchestrator start.
+// Strong-kill of a previous run skips the exit hook, leaving the dir on
+// disk; this is the recovery path. We deliberately scope to the hashed
+// dirs (six hex chars) so the legacy `.dev-userdata` (no hash) is
+// untouched — it might still be in use by a developer running an older
+// branch in another shell.
+//
+// Returns the list of removed dir names so callers can log them.
+export function reapOrphanUserDataDirs(repoRoot, opts = {}) {
+  const maxAgeMs = opts.maxAgeMs ?? 60 * 60 * 1000; // 1h
+  const now = Date.now();
+  const pattern = /^\.dev-userdata-[0-9a-f]{6}$/;
+  const removed = [];
+  if (!existsSync(repoRoot)) return removed;
+  let entries;
+  try {
+    entries = readdirSync(repoRoot, { withFileTypes: true });
+  } catch {
+    return removed;
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (!pattern.test(entry.name)) continue;
+    const abs = join(repoRoot, entry.name);
+    let st;
+    try {
+      st = statSync(abs);
+    } catch {
+      continue;
+    }
+    if (now - st.mtimeMs < maxAgeMs) continue;
+    try {
+      rmSync(abs, { recursive: true, force: true });
+      removed.push(entry.name);
+    } catch {
+      // Locked by another running dev instance? Leave it; next sweep
+      // will retry.
+    }
+  }
+  return removed;
+}

--- a/scripts/dev-wait-web.mjs
+++ b/scripts/dev-wait-web.mjs
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+// Tiny wait-on shim for `npm run dev:app`. Resolves the dev server port
+// from CCSM_DEV_PORT (set by scripts/dev.mjs) and falls back to 4100 for
+// the standalone-debug case. Kept as a separate script so the
+// package.json invocation stays readable and doesn't have to fight
+// cross-shell quoting of `node -e`.
+
+import waitOn from 'wait-on';
+
+const port = process.env.CCSM_DEV_PORT || '4100';
+const url = `http://localhost:${port}`;
+
+try {
+  await waitOn({ resources: [url], timeout: 60_000 });
+  process.exit(0);
+} catch (e) {
+  console.error(`[dev-wait-web] timed out waiting for ${url}:`, e?.message ?? e);
+  process.exit(1);
+}

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+// Entry point for `npm run dev`. Replaces the old
+// `concurrently -k -n web,app "npm:dev:web" "npm:dev:app"` with a single
+// Node process that owns the whole dev lifecycle. Two reasons:
+//
+//   1. Random port + random userData per run, so two concurrent
+//      `npm run dev` shells don't collide on :4100 or SQLite WAL. Both
+//      values are env vars, and concurrently can't share dynamic env
+//      between siblings without a temp-file dance.
+//
+//   2. Guaranteed cleanup. Windows is unfriendly to "kill the whole
+//      tree" via signals — `concurrently -k` does not reliably reach
+//      electron's renderer / utility children. We spawn webpack and
+//      electron directly here and `taskkill /F /T /PID` the recorded
+//      PIDs on any exit path. Idempotent so SIGINT + exit don't
+//      double-kill.
+//
+// Out of scope: Job Objects. Node has no native API, and the realistic
+// failure case (force-kill of this orchestrator from outside, no exit
+// hook fires) is covered by orphan-userData sweep on the next dev
+// start.
+
+import { spawn, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, join } from 'node:path';
+import { mkdirSync, rmSync } from 'node:fs';
+
+import {
+  allocateDevPort,
+  generateUserDataDirName,
+  installCleanupTrap,
+  reapOrphanUserDataDirs,
+} from './dev-lib.mjs';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+const isWin = process.platform === 'win32';
+
+// Sweep stragglers from previous runs that died via force-kill.
+const reaped = reapOrphanUserDataDirs(repoRoot);
+if (reaped.length > 0) {
+  console.log(`[dev] reaped ${reaped.length} orphan userData dir(s): ${reaped.join(', ')}`);
+}
+
+const port = await allocateDevPort();
+const userDataName = generateUserDataDirName();
+const userDataDir = join(repoRoot, userDataName);
+mkdirSync(userDataDir, { recursive: true });
+console.log(`[dev] port=${port} userData=${userDataName}`);
+
+const childEnv = {
+  ...process.env,
+  CCSM_DEV_PORT: String(port),
+  CCSM_DEV_USERDATA: userDataDir,
+};
+
+// Windows: `npm` is `npm.cmd`, a batch shim — Node's spawn requires
+// `shell: true` to invoke a .cmd / .bat (otherwise EINVAL). On POSIX
+// we keep shell:false so the child gets its own process group and we
+// can `kill(-pgid)` later for clean tree teardown.
+const useShell = isWin;
+const npmCmd = 'npm';
+
+// `dev:web` — webpack-dev-server. It reads CCSM_DEV_PORT in webpack.config.js.
+const webChild = spawn(npmCmd, ['run', 'dev:web'], {
+  cwd: repoRoot,
+  stdio: 'inherit',
+  env: childEnv,
+  shell: useShell,
+  detached: !isWin,
+});
+
+// `dev:app` — wait for webpack to be ready, then compile TS + spawn
+// electron via dev-electron.mjs. We keep the wait-on + tsc orchestration
+// inside an npm script so anyone debugging can run `npm run dev:app`
+// standalone with CCSM_DEV_PORT/CCSM_DEV_USERDATA set.
+const appChild = spawn(npmCmd, ['run', 'dev:app'], {
+  cwd: repoRoot,
+  stdio: 'inherit',
+  env: childEnv,
+  shell: useShell,
+  detached: !isWin,
+});
+
+const children = [webChild, appChild];
+
+// If either child exits on its own, tear the rest down.
+for (const c of children) {
+  c.on('exit', (code, signal) => {
+    console.log(`[dev] child pid=${c.pid} exited code=${code} signal=${signal}`);
+    cleanup();
+    process.exit(code ?? 0);
+  });
+}
+
+function killPidTree(pid) {
+  if (!pid) return;
+  if (isWin) {
+    // /T = kill the entire process tree (electron's renderer + utility).
+    // /F = force. We don't care about the exit code — the process may
+    // already be gone.
+    spawnSync('taskkill', ['/F', '/T', '/PID', String(pid)], { stdio: 'ignore' });
+  } else {
+    // Best-effort: SIGTERM the process group (negative pid). If we
+    // weren't detached this falls back to the single pid.
+    try {
+      process.kill(-pid, 'SIGTERM');
+    } catch {
+      try {
+        process.kill(pid, 'SIGTERM');
+      } catch {}
+    }
+    // Give it a beat, then SIGKILL if still around. We're in a
+    // synchronous cleanup path, so just try-kill without waiting.
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {}
+  }
+}
+
+function cleanup() {
+  for (const c of children) {
+    try {
+      killPidTree(c.pid);
+    } catch {}
+  }
+  try {
+    rmSync(userDataDir, { recursive: true, force: true });
+  } catch {
+    // Locked file (SQLite WAL on Windows occasionally) — leave for the
+    // next-start orphan reaper.
+  }
+}
+
+installCleanupTrap(cleanup);

--- a/tests/scripts/devOrchestrator.test.ts
+++ b/tests/scripts/devOrchestrator.test.ts
@@ -1,0 +1,131 @@
+// Unit tests for the dev orchestrator helpers (scripts/dev-lib.mjs).
+//
+// We deliberately split the orchestrator's pure helpers (port allocation,
+// userData naming, cleanup-trap installer, orphan-userData reaper) into a
+// loadable module so they're testable without spawning electron/webpack.
+// scripts/dev.mjs is the thin entry point that wires them together.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import * as net from 'node:net';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+import {
+  allocateDevPort,
+  generateUserDataDirName,
+  installCleanupTrap,
+  reapOrphanUserDataDirs,
+} from '../../scripts/dev-lib.mjs';
+
+describe('allocateDevPort', () => {
+  it('returns a free TCP port in the ephemeral range', async () => {
+    const port = await allocateDevPort();
+    expect(port).toBeTypeOf('number');
+    expect(port).toBeGreaterThan(1024);
+    expect(port).toBeLessThan(65536);
+
+    // Verify we can actually listen on the returned port (i.e. it was
+    // free at the time of allocation). There's a tiny race window
+    // between close() and re-listen here, but on a quiet CI host the
+    // port we just got back from OS should still be available.
+    await new Promise<void>((resolve, reject) => {
+      const srv = net.createServer();
+      srv.once('error', reject);
+      srv.listen(port, () => srv.close(() => resolve()));
+    });
+  });
+
+  it('returns different ports across calls (no static cache)', async () => {
+    const a = await allocateDevPort();
+    const b = await allocateDevPort();
+    // Not guaranteed strictly different (OS may recycle), but the
+    // function must not memoize.
+    expect(typeof a).toBe('number');
+    expect(typeof b).toBe('number');
+  });
+});
+
+describe('generateUserDataDirName', () => {
+  it('matches .dev-userdata-<6 hex> pattern', () => {
+    const name = generateUserDataDirName();
+    expect(name).toMatch(/^\.dev-userdata-[0-9a-f]{6}$/);
+  });
+
+  it('is randomized across calls', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 32; i++) seen.add(generateUserDataDirName());
+    // 6 hex = 16M possibilities. 32 draws colliding is < 1e-6.
+    expect(seen.size).toBeGreaterThan(28);
+  });
+});
+
+describe('installCleanupTrap', () => {
+  // We swap process for these tests to avoid leaving stray listeners
+  // on the real one; the EventEmitter surface is what installCleanupTrap
+  // touches.
+  let fakeProc: NodeJS.EventEmitter & {
+    once: (ev: string, fn: () => void) => unknown;
+    on: (ev: string, fn: (...a: unknown[]) => void) => unknown;
+    listeners: (ev: string) => Function[];
+  };
+  beforeEach(() => {
+    const ee = new (require('node:events').EventEmitter)();
+    fakeProc = ee;
+  });
+
+  it('registers handlers for all the expected signals/events', () => {
+    const cleanup = vi.fn();
+    installCleanupTrap(cleanup, { proc: fakeProc });
+    for (const ev of ['exit', 'SIGINT', 'SIGTERM', 'SIGHUP', 'uncaughtException', 'unhandledRejection']) {
+      expect(fakeProc.listeners(ev).length).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('is idempotent — calling cleanup twice runs it once', () => {
+    const cleanup = vi.fn();
+    installCleanupTrap(cleanup, { proc: fakeProc });
+    // Two signals fire in rapid succession (e.g. SIGINT then exit).
+    fakeProc.emit('SIGINT');
+    fakeProc.emit('exit');
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('reapOrphanUserDataDirs', () => {
+  let tmpRoot: string;
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ccsm-dev-reap-'));
+  });
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it('removes stale .dev-userdata-XXXXXX dirs older than the cutoff', () => {
+    const stale = path.join(tmpRoot, '.dev-userdata-aaaaaa');
+    const fresh = path.join(tmpRoot, '.dev-userdata-bbbbbb');
+    const unrelated = path.join(tmpRoot, '.dev-userdata'); // legacy, no hash
+    fs.mkdirSync(stale);
+    fs.mkdirSync(fresh);
+    fs.mkdirSync(unrelated);
+
+    // Backdate `stale` by 2 hours.
+    const twoHoursAgo = (Date.now() - 2 * 60 * 60 * 1000) / 1000;
+    fs.utimesSync(stale, twoHoursAgo, twoHoursAgo);
+
+    const removed = reapOrphanUserDataDirs(tmpRoot, { maxAgeMs: 60 * 60 * 1000 });
+
+    expect(removed).toContain('.dev-userdata-aaaaaa');
+    expect(removed).not.toContain('.dev-userdata-bbbbbb');
+    expect(removed).not.toContain('.dev-userdata'); // legacy untouched
+    expect(fs.existsSync(stale)).toBe(false);
+    expect(fs.existsSync(fresh)).toBe(true);
+    expect(fs.existsSync(unrelated)).toBe(true);
+  });
+
+  it('does not throw when repo root has no orphans', () => {
+    expect(() => reapOrphanUserDataDirs(tmpRoot, { maxAgeMs: 1000 })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

Task #68 — eliminates port-4100 / `.dev-userdata` collisions between concurrent `npm run dev` shells, and tightens zombie cleanup on dev exit. Also folds in Task #67's preflight tightening that's already on main.

- New `scripts/dev.mjs` orchestrator replaces `concurrently -k web,app`. Single Node process owns the dev lifecycle.
- Random free port via `net.createServer().listen(0)`, threaded through `CCSM_DEV_PORT` to webpack-dev-server + electron (existing plumbing in `createWindow.ts`).
- Per-run `.dev-userdata-<6 hex>` via `crypto.randomBytes(3)`, exposed as `CCSM_DEV_USERDATA`; `scripts/dev-electron.mjs` reads it and passes to Electron via `--user-data-dir`.
- Idempotent cleanup trap on `exit` / `SIGINT` / `SIGTERM` / `SIGHUP` / `uncaughtException` / `unhandledRejection` → `taskkill /F /T /PID` per child (Windows) or `kill(-pgid, SIGTERM)` + SIGKILL fallback (POSIX) + `rmSync` userData dir.
- Orphan reaper at orchestrator start: `.dev-userdata-XXXXXX` dirs older than 1h are swept. Covers the force-kill-parent edge case where Node's exit hooks don't fire on Windows.
- `dev-electron.mjs` preflight scoped to standalone runs (env `CCSM_DEV_PORT` unset). In the orchestrated path the only listener on the random port is our own sibling webpack, which the existing `looksLikeOurDev` check false-positives on across worktrees due to npm node_modules hoisting.

## Design choices

- **Method A (replace concurrently) over B (temp-file port handoff)**: a single Node process makes cleanup ordering deterministic and avoids the temp-file teardown race. concurrently's `-k` is unreliable on Windows for electron's renderer/utility tree anyway.
- **No Job Objects**: would require a native addon. The realistic failure case (external `Stop-Process -Force` on the orchestrator, no exit hook fires) is covered by the orphan-userData sweep + orphan electrons being harmless on a no-longer-listening random port.

## Test plan

Unit tests (new): `tests/scripts/devOrchestrator.test.ts` — 8 tests, all passing.
- Red→green: initial run (no `dev-lib.mjs`) failed import; after implementation, 8/8.

Integration evidence (two parallel `npm run dev` shells):
- Shell 1: `[dev] port=56260 userData=.dev-userdata-7090a7`
- Shell 2: `[dev] port=63029 userData=.dev-userdata-0a6ad5`
- Both webpack-dev-servers compiled successfully; 10 electron processes (5 each, full main+renderer+utility trees).
- Orphan reaper verified: backdated `.dev-userdata-7090a7` by 2h, `reapOrphanUserDataDirs` removed it and left the fresh `.dev-userdata-0a6ad5` intact.

Limitations of the headless-agent verification:
- Could not exercise the true Ctrl-C path from this agent context. `process.kill(pid, 'SIGINT')` on Windows is `TerminateProcess`, not a real CTRL_C_EVENT — exit hooks don't fire. The cleanup-trap *logic* is unit-tested; a human in a real terminal needs to confirm Ctrl-C delivers the graceful path with electron + userData cleanup.

## Test plan for reviewer

- [ ] Run two shells: `npm run dev` in each. Confirm distinct random ports + distinct `.dev-userdata-<hex>/` dirs.
- [ ] Ctrl-C shell 1 in a real terminal. Verify shell-1's userData dir is removed and only shell-2's electron tree remains.
- [ ] Ctrl-C shell 2. Verify all electron processes gone, all `.dev-userdata-*` dirs gone.
- [ ] Reverse-verify: stash this PR, run two `npm run dev`, confirm shell 2 EADDRINUSE on 4100. Reapply, confirm no collision.