### PR TITLE
fix(terminal): warm switch uses display toggle, not reparent (bug #69)

### DIFF
--- a/scripts/dogfood-bug-69-no-flicker.mjs
+++ b/scripts/dogfood-bug-69-no-flicker.mjs
@@ -1,0 +1,220 @@
+// scripts/dogfood-bug-69-no-flicker.mjs
+//
+// Bug #69 regression probe — warm session-switch must NOT flicker the
+// scrollbar.
+//
+// Background: PR #1374 (already on origin/main) restores
+// `.xterm-viewport.scrollTop` after the warm reshow's reparent, but the
+// restore happens AFTER webkit has zeroed the scrollTop on layout-tree
+// detach. The user-visible symptom is the scrollbar thumb being at the
+// TOP for the first 1–3 frames after a B → A switch, then jumping to the
+// correct position. Even though the final state is right, the intermediate
+// frames are perceptible as a flash.
+//
+// The fix (this PR) switches the registry from "reparent across hosts" to
+// "display:none / display:'' on a single persistent host" so the wrapper
+// never leaves the layout tree, webkit never zeroes scrollTop, and there
+// is no frame at scrollTop=0 to clobber.
+//
+// This probe asserts the no-flicker invariant per-frame: it hooks
+// requestAnimationFrame on the renderer side BEFORE the B → A click,
+// records the `.xterm-viewport.scrollTop` at every frame for 600ms after
+// the switch, and asserts that NONE of those samples sit at 0 (or any
+// value other than the saved scrollTop). The presence of even one
+// off-target frame fails the probe.
+//
+// Exit code 0 = PASS, 1 = FAIL.
+
+import { mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+  createIsolatedClaudeDir,
+  dismissWelcomeSplash,
+  launchCcsmIsolated,
+  seedSession,
+  waitForTerminalReady,
+  waitForXtermBuffer,
+} from './probe-utils-real-cli.mjs';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function readScrollState(win) {
+  return await win.evaluate(() => {
+    const t = window.__ccsmTerm;
+    const b = t?.buffer?.active;
+    // The active wrapper is the one with display !== 'none'. There can be
+    // multiple .xterm-viewport elements on the page (one per warm wrapper
+    // under the new design) — pick the one whose ancestor wrapper is
+    // visible.
+    const wrappers = Array.from(document.querySelectorAll('[data-ccsm-warm-sid]'));
+    const visible = wrappers.find((w) => w instanceof HTMLElement && w.style.display !== 'none');
+    const vp = (visible ?? document).querySelector('.xterm-viewport');
+    return {
+      viewportY: b?.buffer?.active?.viewportY ?? b?.viewportY ?? null,
+      baseY: b?.buffer?.active?.baseY ?? b?.baseY ?? null,
+      bufferType: t?.buffer?.active?.type ?? null,
+      scrollTop: vp instanceof HTMLElement ? vp.scrollTop : null,
+      scrollHeight: vp instanceof HTMLElement ? vp.scrollHeight : null,
+    };
+  });
+}
+
+async function main() {
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'ccsm-dogfood-69-'));
+  createIsolatedClaudeDir(tempDir);
+
+  const { electronApp, win, userDataDir } = await launchCcsmIsolated({ tempDir });
+
+  try {
+    await win.waitForFunction(
+      () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+      null,
+      { timeout: 30000 },
+    );
+
+    const { sid: sidA } = await seedSession(win, { name: 'A', cwd: tempDir });
+    const { sid: sidB } = await seedSession(win, { name: 'B', cwd: tempDir });
+
+    await win.evaluate((id) => window.__ccsmStore.getState().selectSession(id), sidA);
+    await waitForTerminalReady(win, sidA, { timeout: 45000 });
+    await waitForXtermBuffer(win, /claude|welcome|│|╭|\?\sfor\sshortcuts/i, { timeout: 30000 });
+    await dismissWelcomeSplash(win);
+
+    // Drop claude's alt-screen so we get scrollable normal-buffer (the
+    // surface where the bug is visible). Fill scrollback and scroll up so
+    // .xterm-viewport.scrollTop is well above 0.
+    await win.evaluate(() => {
+      const t = window.__ccsmTerm;
+      t.write('\x1b[?1049l');
+      for (let i = 0; i < 200; i++) t.write(`bug69-filler ${i}\r\n`);
+      t.scrollLines(-40);
+    });
+    await sleep(200);
+
+    const before = await readScrollState(win);
+    if (before.bufferType !== 'normal') {
+      throw new Error(`expected normal buffer for repro, got ${before.bufferType}`);
+    }
+    if (!before.scrollTop || before.scrollTop <= 0) {
+      throw new Error(`pre-switch setup failed: expected scrollTop > 0, got ${before.scrollTop}`);
+    }
+
+    // A → B (let B settle so the next A-show is the warm path)
+    await win.evaluate((id) => window.__ccsmStore.getState().selectSession(id), sidB);
+    await waitForTerminalReady(win, sidB, { timeout: 30000 });
+    await sleep(500);
+
+    // Install per-frame scrollTop sampler in the renderer BEFORE we click A.
+    // Records the .xterm-viewport.scrollTop of sidA's wrapper at every RAF
+    // for the configured duration. Stored on window.__bug69Samples for
+    // post-switch readback.
+    await win.evaluate((expectedSid) => {
+      window.__bug69Samples = [];
+      const startedAt = performance.now();
+      const DURATION_MS = 800;
+      const tick = () => {
+        const wrappers = Array.from(document.querySelectorAll('[data-ccsm-warm-sid]'));
+        // Find sidA's wrapper specifically (by data attr) so we sample the
+        // entry whose scroll position we care about even mid-switch.
+        const target = wrappers.find(
+          (w) => w instanceof HTMLElement && w.getAttribute('data-ccsm-warm-sid') === expectedSid,
+        );
+        let scrollTop = null;
+        let display = null;
+        let connected = null;
+        if (target instanceof HTMLElement) {
+          display = target.style.display || '';
+          connected = target.isConnected;
+          const vp = target.querySelector('.xterm-viewport');
+          if (vp instanceof HTMLElement) scrollTop = vp.scrollTop;
+        }
+        window.__bug69Samples.push({
+          t: Math.round(performance.now() - startedAt),
+          scrollTop,
+          display,
+          connected,
+        });
+        if (performance.now() - startedAt < DURATION_MS) {
+          requestAnimationFrame(tick);
+        }
+      };
+      requestAnimationFrame(tick);
+    }, sidA);
+
+    // Trigger the warm switch back to A.
+    await win.evaluate((id) => window.__ccsmStore.getState().selectSession(id), sidA);
+
+    // Wait long enough for the sampler to finish.
+    await sleep(1200);
+
+    const samples = await win.evaluate(() => window.__bug69Samples || []);
+    const after = await readScrollState(win);
+
+    console.log(`before: ${JSON.stringify(before)}`);
+    console.log(`after:  ${JSON.stringify(after)}`);
+    console.log(`sample count: ${samples.length}`);
+    // Trim the firehose: log first 12 + last 4.
+    const head = samples.slice(0, 12);
+    const tail = samples.slice(-4);
+    console.log('first frames:');
+    for (const s of head) console.log(`  ${JSON.stringify(s)}`);
+    if (samples.length > 16) {
+      console.log('...');
+      console.log('last frames:');
+      for (const s of tail) console.log(`  ${JSON.stringify(s)}`);
+    }
+
+    const expected = before.scrollTop;
+    // Allow ±2px tolerance for sub-pixel rounding from xterm's Viewport
+    // refresh; anything more is a real visible mismatch.
+    const TOLERANCE = 2;
+    const bad = samples.filter(
+      (s) =>
+        s.scrollTop != null &&
+        s.connected !== false &&
+        s.display !== 'none' &&
+        Math.abs(s.scrollTop - expected) > TOLERANCE,
+    );
+
+    // The post-settle position must also match the pre-switch position.
+    const finalOk =
+      after.viewportY === before.viewportY &&
+      Math.abs((after.scrollTop ?? -1) - expected) <= TOLERANCE;
+
+    if (bad.length > 0 || !finalOk) {
+      console.error(
+        `FAIL: bug #69 — warm switch flickers. ` +
+          `${bad.length} frame(s) out of ${samples.length} had ` +
+          `scrollTop != ${expected} (±${TOLERANCE}px). finalOk=${finalOk}.`,
+      );
+      console.error('bad frames (sample):');
+      for (const b of bad.slice(0, 10)) console.error(`  ${JSON.stringify(b)}`);
+      const logPath = path.join(userDataDir, 'logs', 'main.log');
+      if (existsSync(logPath)) {
+        const tail = readFileSync(logPath, 'utf8')
+          .split('\n')
+          .filter(
+            (l) =>
+              l.includes('warmHide') ||
+              l.includes('warmShow') ||
+              l.includes('attach.warm.shown') ||
+              l.includes('terminal.warmDisplay'),
+          )
+          .slice(-12);
+        console.error('--- main.log tail ---');
+        for (const l of tail) console.error(l);
+      }
+      process.exitCode = 1;
+      return;
+    }
+    console.log('PASS: all frames pinned to saved scrollTop.');
+  } finally {
+    await electronApp.close();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exitCode = 1;
+});

--- a/src/terminal/usePtyAttach.warm.ts
+++ b/src/terminal/usePtyAttach.warm.ts
@@ -2,16 +2,17 @@
 //
 // The only PTY-attach path in the renderer: there is no longer a legacy
 // singleton variant or a `CCSM_WARM_XTERM` flag. The warm registry owns
-// one xterm Terminal per sid and switching sessions is a wrapper
-// reparent, not a teardown.
+// one xterm Terminal per sid and switching sessions is a display-toggle
+// on a single persistent host (bug #69 fix — replaces reparent model).
 //
 // Architectural contract (per parent decisions, design doc §3):
 //   * COLD path (first time we ever see `sid` in this renderer):
 //       1. Registry allocates a fresh entry — this installs the
 //          per-sid `pty.onData` subscription that writes live chunks
 //          to `entry.term` immediately (independent of visibility).
-//       2. We reparent the entry's wrapper into the host (showEntry
-//          inside `ensureAndShowEntry` does this — visible).
+//       2. Registry appends the entry's wrapper into the host on its
+//          first show (`ensureAndShowEntry` does this) and flips
+//          `style.display` from 'none' to ''.
 //       3. We resize the entry's term to the spawn cols/rows, run the
 //          fit against the live host, push the post-fit cols/rows to
 //          the PTY (claude needs SIGWINCH for correct wrapping).
@@ -271,7 +272,7 @@ export function usePtyAttachWarm(
           // We still need to (a) fit() locally so the canvas atlas
           // matches the post-reparent host dims, and (b) tell the PTY
           // about any cols/rows change that happened while this entry
-          // was offscreen — but BOTH are fire-and-forget. We don't
+          // was hidden — but BOTH are fire-and-forget. We don't
           // await them before flipping to 'ready'. Reasons:
           //   - The terminal DOM is already showing the correct content.
           //     A stale cols/rows for one PTY tick is harmless (claude
@@ -695,11 +696,12 @@ export function usePtyAttachWarm(
     };
 
     // Gate the replay on actual contentRect dimension change. Warm
-    // session switches reparent the entry's wrapper from the offscreen
-    // holder back to the live host, but this `host` div (per-pane,
-    // observed below) doesn't itself change size — so the offscreen
-    // ↔ live transition fires RO with dims identical to the live
-    // baseline. Without this gate, every warm switch ran the replay
+    // session switches toggle `display:none` / `display:''` on the warm
+    // entry's wrapper under a persistent host; this `host` div (per-pane,
+    // observed below) doesn't itself change size, but the wrapper going
+    // from `display:none` to '' fires xterm's internal ResizeObserver
+    // and Chromium may also fire ours with dims identical to the prior
+    // live baseline. Without this gate, every warm switch ran the replay
     // path which calls `entry.term.reset()` and re-applies a snapshot —
     // wiping ydisp/baseY/scrollback. Dogfood frame log on the bug:
     // viewportY 294 → 0, baseY 344 → 0, scrollHeight 6015 → 855 within

--- a/src/terminal/xtermWarmRegistry.ts
+++ b/src/terminal/xtermWarmRegistry.ts
@@ -6,8 +6,12 @@
 // Goal (user-stated): "我一个session本来是打开的, 我理解切到另一个session,
 // 当前session只是被放在后台了, 就像图层一样, 被盖住了, 那切回来的时候只是简单
 // 把他调到最上层." Translation: VS Code-style layer model — each session
-// keeps its own xterm Terminal alive in memory; switching sessions is just
-// reparenting a DOM wrapper, NOT rebuilding state.
+// keeps its own xterm Terminal alive in memory; switching sessions is a
+// `display:none / display:''` toggle on a single persistent host, NOT a
+// reparent and NOT a rebuild. (The reparent-to-offscreen-holder model used
+// from PR #1355 through #1374 was replaced for bug #69: webkit drops
+// `.xterm-viewport.scrollTop` on layout-tree detach, and no
+// post-show restore can avoid the first-frame scrollbar flash.)
 //
 // The registry owns the per-entry xterm Terminal AND all input-side
 // behaviours that used to live on the legacy singleton: IME composition
@@ -64,9 +68,17 @@ export type WarmEntry = {
   term: Terminal;
   fit: FitAddon;
   /**
-   * DOM wrapper that owns the xterm canvases. Either parented under the
-   * active TerminalPane host (visible) or under {@link getOffscreenHolder}
-   * (hidden). Reparenting is the entire mechanism for show/hide.
+   * DOM wrapper that owns the xterm canvases. Lives under the TerminalPane
+   * host AS A SIBLING of other warm entries' wrappers; visibility is
+   * toggled via `wrapper.style.display` (hidden = 'none', visible = '').
+   *
+   * The wrapper NEVER leaves the layout tree during a session switch —
+   * that's the whole fix for bug #69. Webkit drops `.xterm-viewport
+   * .scrollTop` when an element is reparented out of the layout tree, and
+   * any post-show restore (synchronous write, RAF, scrollToLine) can only
+   * close the gap on frame 2+, leaving frame 1 visibly at scrollTop=0.
+   * Keeping the wrapper in-tree under `display:none` preserves `scrollTop`
+   * across the hide window so the user never sees a 0-scroll frame.
    */
   wrapper: HTMLDivElement;
   /**
@@ -89,9 +101,10 @@ export type WarmEntry = {
    * Whether `term.open(wrapper)` has been called. Deferred from
    * {@link allocEntry} to the first {@link ensureAndShowEntry} so the
    * xterm renderer initializes against the visible host's real geometry
-   * rather than the 0x0 / visibility:hidden offscreen holder — the
-   * latter leaves the paint scheduler permanently quiesced under xterm
-   * 5.5's CanvasAddon/DOM renderer.
+   * rather than the wrapper's pre-attach state (the wrapper is unparented
+   * + `display:none` between alloc and first show, which leaves xterm's
+   * 5.5 CanvasAddon paint scheduler permanently quiesced if open() runs
+   * too early).
    */
   opened: boolean;
   /**
@@ -130,22 +143,12 @@ export type WarmEntry = {
    * {@link applyTerminalFontSize} for non-active warm entries when the
    * global Ctrl+wheel zoom changes — applying live to every hidden entry
    * would fan out N snapshot IPCs concurrently and stutter the UI. We
-   * apply lazily in {@link ensureAndShowEntry} just before reparent, and
-   * run a single resize-replay for the entry being shown. Null means
-   * the entry's current `term.options.fontSize` is already up to date.
+   * apply lazily in {@link ensureAndShowEntry} just before the display
+   * toggle, and run a single resize-replay for the entry being shown.
+   * Null means the entry's current `term.options.fontSize` is already
+   * up to date.
    */
   pendingFontSize: number | null;
-  /**
-   * Last `.xterm-viewport.scrollTop` captured at hide time. Webkit drops
-   * scrollTop when an element is reparented out of the layout tree, so
-   * xterm's internal `viewportY` stays at e.g. 148 but the visible
-   * scrollbar thumb snaps back to 0 on show. We snapshot before the hide
-   * reparent and restore after the show reparent — the canvas was already
-   * painting the correct logical rows (viewportY preserved), so the only
-   * thing the user noticed was the thumb jumping to the top.
-   * `null` means "no snapshot yet" (first show) — treated as no-op.
-   */
-  savedScrollTop: number | null;
 };
 
 /**
@@ -186,7 +189,6 @@ const entryRouters: Map<string, EntryRouter> = new Map();
 
 const warm: Map<string, WarmEntry> = new Map();
 let activeSid: string | null = null;
-let offscreenHolder: HTMLDivElement | null = null;
 
 // Global PTY exit subscription (Major 2 fix from cold review).
 //
@@ -254,19 +256,6 @@ function installUnloadCleanupOnce(): void {
   window.addEventListener('beforeunload', beforeUnloadHandler);
 }
 
-function getOffscreenHolder(): HTMLDivElement {
-  if (offscreenHolder && offscreenHolder.isConnected) return offscreenHolder;
-  offscreenHolder = document.createElement('div');
-  offscreenHolder.setAttribute('data-ccsm-warm-offscreen', '');
-  // visibility:hidden + zero size (NOT display:none) so any addon RAF
-  // callback that queries the wrapper's metrics gets sensible zero values
-  // rather than throwing. `fit()` is never invoked while parented here.
-  offscreenHolder.style.cssText =
-    'position:absolute;width:0;height:0;overflow:hidden;visibility:hidden;left:-9999px;top:-9999px;';
-  document.body.appendChild(offscreenHolder);
-  return offscreenHolder;
-}
-
 /** Number of warm entries currently held — primarily for probe payloads. */
 export function getWarmCacheSize(): number {
   return warm.size;
@@ -290,8 +279,9 @@ export function getActiveEntry(): WarmEntry | undefined {
 /**
  * Construct a fresh xterm Terminal + addons for `sid`, allocate its DOM
  * wrapper, install the per-entry PTY data subscription, and insert into
- * the registry. Returns the new entry parented in the offscreen holder —
- * caller must subsequently call {@link showEntry} to make it visible.
+ * the registry. Returns the new entry with its wrapper unparented and
+ * `display:none` — caller must subsequently call {@link ensureAndShowEntry}
+ * to append it into the live host and make it visible.
  *
  * LRU evicts an existing entry if registry is at cap. Active sid and the
  * just-allocated sid are exempt.
@@ -366,13 +356,21 @@ function allocEntry(sid: string): WarmEntry {
   const wrapper = document.createElement('div');
   wrapper.setAttribute('data-ccsm-warm-sid', sid);
   wrapper.className = 'absolute inset-0';
-  // Park under the offscreen holder until showEntry() reparents it.
+  // Start hidden — the first {@link ensureAndShowEntry} for this sid
+  // will appendChild into the live host and flip display back to ''.
+  // We do NOT parent under any holder here: parking the wrapper under a
+  // hidden offscreen holder (the legacy approach) means subsequent
+  // session switches have to REPARENT the wrapper into the live host,
+  // and webkit drops `.xterm-viewport.scrollTop` on every layout-tree
+  // detach — producing the bug #69 first-frame scrollbar flash. Under
+  // the new design the wrapper, once parented under the host on first
+  // show, NEVER moves; visibility is toggled via `style.display`.
+  wrapper.style.display = 'none';
   // NOTE: do NOT call `term.open(wrapper)` here — xterm 5.5's renderer
-  // latches onto wrapper geometry at open() time, and the offscreen
-  // holder is 0x0 / visibility:hidden, which leaves the paint scheduler
+  // latches onto wrapper geometry at open() time, and an unparented or
+  // `display:none` wrapper has 0x0 dims which leaves the paint scheduler
   // permanently quiesced. The first ensureAndShowEntry() calls open()
-  // against the visible host instead.
-  getOffscreenHolder().appendChild(wrapper);
+  // against the wrapper AFTER it has been parented + made visible.
 
   // Per-entry PTY data subscription. Filters by sid (NOT by the global
   // active sid) so hidden sessions keep ingesting live output. The bytes
@@ -482,7 +480,6 @@ function allocEntry(sid: string): WarmEntry {
     keyboardPasteHandled: false,
     inputDisposers: [],
     pendingFontSize: null,
-    savedScrollTop: null,
   };
   warm.set(sid, entry);
 
@@ -761,51 +758,55 @@ function installInputListeners(entry: WarmEntry): void {
 }
 
 /**
- * Ensure an entry exists for `sid`. Reparents its wrapper into `host` and
- * promotes it to active. Returns `{ entry, isCold }` — `isCold` is true
- * iff the entry was just allocated (caller should run cold-attach IPC).
+ * Ensure an entry exists for `sid`. Toggles visibility so this entry is
+ * the only visible warm wrapper under `host`, and promotes it to active.
+ * Returns `{ entry, isCold }` — `isCold` is true iff the entry was just
+ * allocated (caller should run cold-attach IPC).
  *
  * Side effects:
- *   1. Previously active entry's wrapper is reparented to the offscreen
- *      holder (a `terminal.warmHide` probe fires).
- *   2. New entry's wrapper is appended into `host`. `appendChild` moves
- *      the node when it already has a parent — this IS the reparent.
+ *   1. Previously active entry's wrapper has `style.display = 'none'`
+ *      applied (NO reparent — that's the bug #69 fix). A
+ *      `terminal.warmHide` probe fires.
+ *   2. Target entry's wrapper is parented under `host` if not already
+ *      (only happens on the entry's first show, or if TerminalPane
+ *      remounted and produced a different host node), then has
+ *      `style.display = ''` applied so it paints.
  *   3. `activeSid` is set to `sid`; `lastAccessedAt` is bumped.
  *   4. `window.__ccsmTerm` is repointed at the new entry's term so e2e
  *      probes always reach the foreground terminal.
- *   5. On first show after alloc: `term.open()` runs against the visible
- *      host, then textarea-dependent input listeners are installed.
+ *   5. On first show after alloc: `term.open()` runs against the
+ *      now-parented + visible wrapper, then textarea-dependent input
+ *      listeners are installed.
+ *
+ * Display-switch model (replaces the prior reparent-to-offscreen model):
+ * the same `host` div is the long-lived parent of every warm wrapper for
+ * sessions the user has visited. Hiding is a single property write; the
+ * wrapper never leaves the layout tree, so webkit never zeroes
+ * `.xterm-viewport.scrollTop` and there is no first-frame flicker on
+ * switch-back. TerminalPane is rendered without a `key` keyed on sid in
+ * App.tsx, so the host node is stable across session switches in the
+ * common path.
  */
 export function ensureAndShowEntry(
   sid: string,
   host: HTMLElement,
   cause: 'session-switch' | 'mount' | 'retry' = 'session-switch',
 ): { entry: WarmEntry; isCold: boolean } {
-  // Hide previous active entry (reparent into offscreen holder).
+  // Hide previous active entry — display:none only, no reparent. The
+  // wrapper stays in the layout tree so its `.xterm-viewport.scrollTop`
+  // is preserved across the hide window (bug #69 fix).
   if (activeSid && activeSid !== sid) {
     const prev = warm.get(activeSid);
     if (prev) {
-      // Snapshot `.xterm-viewport.scrollTop` BEFORE the reparent.
-      // Webkit drops scrollTop when an element leaves its containing
-      // block (the offscreen holder is display:none / out-of-tree). Read
-      // synchronously to capture the user's current scroll position;
-      // restore in the symmetric show branch below.
       try {
-        const vp = prev.wrapper.querySelector('.xterm-viewport');
-        if (vp instanceof HTMLElement) prev.savedScrollTop = vp.scrollTop;
-      } catch {
-        /* snapshot best-effort */
-      }
-      try {
-        getOffscreenHolder().appendChild(prev.wrapper);
+        prev.wrapper.style.display = 'none';
       } catch (e) {
-        warn('xterm-warm', 'hide reparent failed', e);
+        warn('xterm-warm', 'hide display toggle failed', e);
       }
       try {
         log.event('terminal.warmHide', {
           sid: activeSid,
           lruSize: warm.size,
-          savedScrollTop: prev.savedScrollTop ?? -1,
         });
       } catch {
         /* probe failure tolerated */
@@ -819,55 +820,41 @@ export function ensureAndShowEntry(
     entry = allocEntry(sid);
   }
 
-  // Reparent (or initial-parent) into the live host.
-  try {
-    host.appendChild(entry.wrapper);
-  } catch (e) {
-    warn('xterm-warm', 'show reparent failed', e);
+  // Parent the wrapper under `host` if needed. In the common path the
+  // wrapper is already a child of `host` (it was appended on first show
+  // and never reparented), so this is just the first-show / host-changed
+  // case. Reparenting in the host-changed case (e.g. TerminalPane remount
+  // for a structural reason) is unavoidable but acceptable: it's the rare
+  // path, not the per-switch path.
+  if (entry.wrapper.parentElement !== host) {
+    try {
+      host.appendChild(entry.wrapper);
+    } catch (e) {
+      warn('xterm-warm', 'show appendChild failed', e);
+    }
   }
 
-  // Restore `.xterm-viewport.scrollTop` captured at the symmetric hide.
-  // xterm's internal `viewportY` survives the offscreen detour (canvas
-  // keeps painting the right rows), but webkit zeroes the DOM scrollTop
-  // when the element leaves the layout tree — so without this the
-  // scrollbar thumb snaps to the top while the canvas content shows
-  // a mid-buffer position. Write AFTER the reparent (element must be
-  // back in the layout tree) and synchronously so the user never
-  // observes a frame at scrollTop=0.
-  if (entry.savedScrollTop != null) {
-    let restoreApplied = -1;
-    let restoreActual = -1;
-    try {
-      const vp = entry.wrapper.querySelector('.xterm-viewport');
-      if (vp instanceof HTMLElement) {
-        vp.scrollTop = entry.savedScrollTop;
-        restoreApplied = entry.savedScrollTop;
-        restoreActual = vp.scrollTop;
-      }
-    } catch {
-      /* restore best-effort */
-    }
-    try {
-      log.event('terminal.warmShow.scrollRestore', {
-        sid,
-        savedScrollTop: entry.savedScrollTop,
-        applied: restoreApplied,
-        actualAfterWrite: restoreActual,
-      });
-    } catch {
-      /* probe failure tolerated */
-    }
+  // Make the wrapper visible. Flipping `display` from 'none' to '' may
+  // fire xterm's internal ResizeObserver (the wrapper's content-box goes
+  // 0x0 → real), which can trigger a Viewport refresh — but ydisp is
+  // stable across the hide window so the refresh re-derives the same
+  // scrollTop and there is no visible jump. Verified empirically by the
+  // `scripts/dogfood-bug-69-no-flicker.mjs` per-frame probe.
+  try {
+    entry.wrapper.style.display = '';
+  } catch (e) {
+    warn('xterm-warm', 'show display toggle failed', e);
   }
 
   // First-time open: deferred from allocEntry so the xterm renderer
-  // initializes against real visible geometry rather than the 0x0
-  // offscreen holder (see WarmEntry.opened docs). We do NOT call
-  // fit.fit() here — host layout may not have settled on the same
-  // microtask, and (cold path) usePtyAttach.warm.ts calls fit.fit()
-  // after term.resize() + snapshot write a few ms later, which sizes
-  // the canvas atlas against fully-laid-out dimensions. The eager fit
-  // here would either redundantly force layout or compute cols=0 when
-  // host itself is still hidden.
+  // initializes against the wrapper's real visible geometry rather than
+  // the 0x0 unparented + display:none state at alloc time (see
+  // WarmEntry.opened docs). We do NOT call fit.fit() here — host layout
+  // may not have settled on the same microtask, and (cold path)
+  // usePtyAttach.warm.ts calls fit.fit() after term.resize() + snapshot
+  // write a few ms later, which sizes the canvas atlas against fully-
+  // laid-out dimensions. The eager fit here would either redundantly
+  // force layout or compute cols=0 when host itself is still hidden.
   if (!entry.opened) {
     try {
       entry.term.open(entry.wrapper);
@@ -1274,7 +1261,7 @@ export async function applyTerminalFontSize(px: number): Promise<void> {
  * No resize-replay, no IME guard, no `pending*` deferral — assigning
  * `term.options.scrollback = n` is cheap and side-effect-free with respect
  * to fontMetrics / cell layout / cursor / IME compositions. Safe to fan
- * out across all entries (active and offscreen) in one synchronous pass.
+ * out across all entries (active and hidden) in one synchronous pass.
  *
  * Transparent-transport invariant unchanged: this only resizes the
  * renderer-side display buffer. The PTY byte stream and the main-side
@@ -1296,8 +1283,7 @@ export function applyTerminalScrollback(n: number): void {
 /**
  * Test-only: drop all entries without emitting probes (tests don't want
  * probe noise polluting their own assertions). Also resets the
- * offscreen-holder pointer + the unload-listener flag so the next test
- * starts from a clean slate.
+ * unload-listener flag so the next test starts from a clean slate.
  */
 export function __resetRegistryForTests(): void {
   for (const entry of warm.values()) {
@@ -1328,14 +1314,6 @@ export function __resetRegistryForTests(): void {
   warm.clear();
   entryRouters.clear();
   activeSid = null;
-  if (offscreenHolder) {
-    try {
-      offscreenHolder.remove();
-    } catch {
-      /* ignore */
-    }
-  }
-  offscreenHolder = null;
   // Detach the beforeunload listener — leaving it attached across vitest
   // re-imports leaks stale closures that reference disposed entries
   // (Minor 7 from cold review).

--- a/tests/terminal/xtermWarmRegistry.test.ts
+++ b/tests/terminal/xtermWarmRegistry.test.ts
@@ -146,9 +146,37 @@ describe('xtermWarmRegistry', () => {
     // clear is exactly 1 (the sid-b alloc).
     expect(ctorCallsForReshow).toBe(1);
     expect(getActiveSid()).toBe('sid-a');
-    // sid-a's wrapper is back under host after the reparent.
+    // sid-a's wrapper is back under host after the show.
     expect(e2.wrapper.parentElement).toBe(host);
     document.body.removeChild(host2);
+  });
+
+  it('hide toggles display:none on previous active wrapper (no reparent — bug #69 fix)', () => {
+    // Switching A→B must NOT detach A's wrapper from the layout tree:
+    // webkit drops `.xterm-viewport.scrollTop` on layout-tree detach, and
+    // that causes the first-frame scrollbar flash users perceive as a
+    // jump-to-top on switch-back. Under the display-switch model the
+    // wrapper stays in the tree; only `style.display` flips.
+    const { entry: a } = ensureAndShowEntry('sid-a', host);
+    expect(a.wrapper.parentElement).toBe(host);
+    expect(a.wrapper.style.display).toBe('');
+    ensureAndShowEntry('sid-b', host);
+    // A's wrapper is still under the SAME host (no reparent), just
+    // hidden. This is the load-bearing assertion for the no-flicker
+    // invariant — if a regression reparents A back to an offscreen
+    // holder, this expectation breaks.
+    expect(a.wrapper.parentElement).toBe(host);
+    expect(a.wrapper.style.display).toBe('none');
+    // B is the visible one now.
+    const b = getEntry('sid-b');
+    expect(b?.wrapper.style.display).toBe('');
+    expect(b?.wrapper.parentElement).toBe(host);
+    // Switch back: A becomes visible again, B hides, neither reparents.
+    ensureAndShowEntry('sid-a', host);
+    expect(a.wrapper.style.display).toBe('');
+    expect(a.wrapper.parentElement).toBe(host);
+    expect(b?.wrapper.style.display).toBe('none');
+    expect(b?.wrapper.parentElement).toBe(host);
   });
 
   it('LRU-evicts the least-recently-shown entry on overflow (active sid + just-allocated sid exempt)', () => {
@@ -319,12 +347,12 @@ describe('xtermWarmRegistry', () => {
 
   it('defers term.open() until first ensureAndShowEntry (renderer-init invariant)', () => {
     // Regression lock: a prior bug called term.open(wrapper) inside
-    // allocEntry while wrapper was parented in a 0x0 visibility:hidden
-    // offscreen holder. xterm 5.5's renderer latched onto that geometry
-    // and the paint scheduler stayed quiesced — chunks parsed but DOM
-    // stayed empty. Fix defers open() to first show, when wrapper is in
-    // the visible host. This test asserts the deferred-open contract
-    // directly so the bug can't silently come back.
+    // allocEntry while wrapper was unparented + display:none (0x0). xterm
+    // 5.5's renderer latched onto that geometry and the paint scheduler
+    // stayed quiesced — chunks parsed but DOM stayed empty. Fix defers
+    // open() to first show, when wrapper is parented in the host AND
+    // display has been flipped back to ''. This test asserts the
+    // deferred-open contract directly so the bug can't silently come back.
     const { entry } = ensureAndShowEntry('sid-deferred', host);
     // Mock terminal exposes `open` as a vi.fn(). It MUST have been called
     // exactly once, and with the wrapper that is now host-parented.


### PR DESCRIPTION
## Real root cause

Webkit drops `.xterm-viewport.scrollTop` whenever the element leaves the layout tree. PR #1374's save/restore writes the captured scrollTop back AFTER the reparent — correct final state, but for one or more frames the user sees the scrollbar at 0 before it jumps to the right position. Take 3 (PR #1385 commit `c631e20d`, direct DOM write + double-RAF) narrowed the gap to a single frame but did not close it: the wrapper still detaches.

The probe `scripts/dogfood-bug-69-no-flicker.mjs` hooks `requestAnimationFrame` in the renderer and samples `.xterm-viewport.scrollTop` for 800ms after a warm switch. On origin/main it shows exactly one bad frame (`t=1ms scrollTop=0`) before recovery at frame 2 — that's the visible flash. PR #1385's c631e20d would behave similarly.

## Fix: display toggle, not reparent

Stop reparenting. Each warm wrapper is appended once to the TerminalPane host and stays there for its whole life; switching sessions flips `wrapper.style.display` between `'none'` and `''`. The wrapper never leaves the layout tree, so webkit never zeroes scrollTop and there is no first-frame flicker.

`TerminalPane` is rendered without a `key` in `App.tsx` (line 430: `<TerminalPane sessionId={active.id} cwd={...} />`), so React keeps the host node stable across session switches — that's the precondition that makes display-toggle work without reparent.

### display:none over visibility:hidden + position:absolute

Empirical per-frame probe (below) shows the show transition produces no scrollTop jump: `ydisp` is stable across the hide window, so xterm's internal ResizeObserver / Viewport refresh re-derives the same scrollTop. `display:none` also lets Chromium fully pause paint work on hidden wrappers — same benefit the offscreen holder gave us, without the layout-tree detach.

## Per-frame probe (red → green)

**On origin/main (red):**
```
sample count: 28
first frames:
  {"t":1,"scrollTop":0,"display":"","connected":true}
  {"t":17,"scrollTop":2314.666748046875,"display":"","connected":true}
  ...
FAIL: bug #69 — warm switch flickers. 1 frame(s) out of 28 had scrollTop != 2314.67 (±2px).
```

**On this PR (green):**
```
sample count: 27
first frames:
  {"t":0,"scrollTop":0,"display":"none","connected":true}   (pre-switch — display none excluded)
  {"t":27,"scrollTop":2314.666748046875,"display":"","connected":true}
  ...
PASS: all frames pinned to saved scrollTop.
```

The lone `t=0` `display:none` sample is the pre-switch baseline (sidA is hidden while user is on sidB); the probe explicitly excludes hidden frames since they can't be visible to the user.

## Changes

- `src/terminal/xtermWarmRegistry.ts`:
  - Drop `offscreenHolder` + `getOffscreenHolder()`.
  - Drop `WarmEntry.savedScrollTop`, the post-reshow scrollTop write, and the `terminal.warmShow.scrollRestore` probe.
  - `allocEntry`: wrapper starts unparented + `display:none`. No appendChild to any holder.
  - `ensureAndShowEntry`: hide branch is `prev.wrapper.style.display = 'none'`; show branch appendChild's only if `parentElement !== host` (covers first-show + rare host-changed remount), then sets `display = ''`. `term.open()` still deferred to first show.
  - `__resetRegistryForTests`: drop offscreenHolder cleanup.
- `src/terminal/usePtyAttach.warm.ts`: header doc + ResizeObserver-gate comment updated to reflect the display-toggle model. No behavioural change in the hook itself.
- `tests/terminal/xtermWarmRegistry.test.ts`: add new `hide toggles display:none on previous active wrapper` assertion that pins the no-reparent invariant; refresh the deferred-`term.open()` test's rationale comment. All 16 tests pass.
- `scripts/dogfood-bug-69-no-flicker.mjs`: new probe (per-frame RAF sampler).

`scripts/dogfood-pr-1374-warm-scroll-preserved.mjs` still passes — its assertion ("scrollTop equal before/after switch") is satisfied by the display-toggle model trivially.

## Replaces PR #1385

PR #1385 (take 3 / c631e20d on `fix/attach-scrollbar-mismatch`) attempted to close the gap with a direct DOM `scrollTop` write + double-RAF after reparent. Empirically still showed a first-frame flash because reparent itself is what zeroes scrollTop. This PR removes the reparent entirely. Closing #1385.

## Test plan

- [ ] Reviewer pulls branch, runs `npm test -- tests/terminal/` (66/66 expected).
- [ ] Reviewer runs `node scripts/dogfood-bug-69-no-flicker.mjs` after `npm run build` — must report PASS with all frames at the saved scrollTop.
- [ ] Reviewer runs `node scripts/dogfood-pr-1374-warm-scroll-preserved.mjs` — must still PASS.
- [ ] User dogfood: in real CLI, open 2+ sessions, claude in session A, scroll up in normal buffer, switch to B and back to A — scrollbar must not flash to top.
- [ ] Reverse-verify: stash the registry/hook changes, rerun bug-69 probe → must FAIL (proves the probe actually catches the regression).