### PR TITLE
docs: attach redesign — from-scratch counter-proposal

### DIFF
--- a/docs/attach-redesign.html
+++ b/docs/attach-redesign.html
@@ -334,9 +334,49 @@
   </div>
 </section>
 
-<!-- ====================== 7. 实现要点 ====================== -->
+<!-- ====================== 7. 并发与取消 ====================== -->
 <section class="s">
-  <h2>7 · 实现要点</h2>
+  <h2>7 · 并发与取消</h2>
+  <p class="lede">用户操作可能踩在一起 —— 比如 reload 中途 delete、冷启动中途切走。下面是统一的处理方式,corner case 一次想清楚。</p>
+
+  <h3 class="sub">机制</h3>
+  <ul style="margin:0 0 12px; padding-left:18px; font-size:13px; color:var(--ink-2);">
+    <li>每个 shell 上挂一个 <code>currentOp: { token, kind }</code>。</li>
+    <li>新操作开始前:先 <code>cancel</code> 同一 sid 的旧操作,await 它的 finally 块(确保遮罩、资源已清理),再启动新的。</li>
+    <li>遮罩的揭开 / shell 的 dispose / 资源释放,<b>永远由当前操作自己在 finally 里负责</b> —— 其他操作不碰。</li>
+  </ul>
+
+  <h3 class="sub">取消语义(谁取消谁、什么时候不取消)</h3>
+  <div class="rules">
+    <div class="rule">
+      <div class="tag">场景表</div>
+      <p>
+        · <b>reload 中途 delete</b> → delete cancel reload,reload finally dispose 收尾,顶层下沉。<br>
+        · <b>reload 中途用户切走</b> → reload <b>不 cancel</b> —— 继续跑完,但完成后<b>不抢顶层</b>(activeSid 已不是它)。<br>
+        · <b>reload 中途用户又 reload</b> → cancel 第一个,启动第二个(用户最后操作 wins)。<br>
+        · <b>冷启动 B 中途切回 A</b> → B 不 cancel,继续 hydrate;activeSid=A;B 完成后<b>不抢顶层</b>。<br>
+        · <b>冷启动 B 中途 delete B</b> → cancel coldStart,移除 wrapper,activeSid 回到下一层。<br>
+        · <b>copy A 中途 delete A</b> → copy 已经产生 newSid(产品行为);原 A 的 delete 正常走。
+      </p>
+    </div>
+  </div>
+
+  <h3 class="sub">关键不变量</h3>
+  <ul style="margin:0 0 12px; padding-left:18px; font-size:13px; color:var(--ink-2);">
+    <li>"活操作" 至多一个 per sid。</li>
+    <li>遮罩的可见性由 ownership 决定:谁开的谁关。</li>
+    <li>z-stack 顶层 = activeSid;操作完成后<b>不一定上顶</b>,只有用户行为或冷启动初次完成才上顶。</li>
+  </ul>
+
+  <h3 class="sub">为什么不用 queue</h3>
+  <p style="margin:0; font-size:13px; color:var(--ink-2);">
+    queue 是 FIFO,但用户后一个操作就是想覆盖前一个 —— FIFO 反而不对。cancellation token + finally 是更轻的方案,没有"卡顿"感。
+  </p>
+</section>
+
+<!-- ====================== 8. 实现要点 ====================== -->
+<section class="s">
+  <h2>8 · 实现要点</h2>
   <p class="lede">给后续 worker 看的落地清单。不是完整方案,只是关键决策。</p>
 
   <h3 class="sub">替换掉的现有代码</h3>

--- a/docs/attach-redesign.html
+++ b/docs/attach-redesign.html
@@ -1,0 +1,500 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Attach redesign — from scratch</title>
+<style>
+  :root {
+    --bg: #f7f7f6;
+    --panel: #ffffff;
+    --ink: #1a1a1a;
+    --ink-2: #4a4a4a;
+    --ink-3: #6b6b6b;
+    --line: #e3e3e0;
+    --line-2: #d4d4d0;
+    --accent: #2962ff;
+    --accent-bg: #eaf0ff;
+    --ok: #1b873f;
+    --ok-bg: #e6f4ec;
+    --warn: #d97706;
+    --warn-bg: #fff3df;
+    --err: #c8281a;
+    --err-bg: #fdecea;
+    --par: #5d3aa0;
+    --par-bg: #f4eefb;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+    --sans: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); font-family: var(--sans); font-size: 14px; line-height: 1.55; }
+  .page { max-width: 1500px; margin: 0 auto; padding: 32px 28px 80px; }
+
+  header.head { margin-bottom: 28px; }
+  header.head h1 { font-size: 22px; font-weight: 600; margin: 0 0 6px; letter-spacing: -0.01em; }
+  header.head .sub { color: var(--ink-3); font-size: 13px; }
+  header.head .meta { color: var(--ink-3); font-family: var(--mono); font-size: 12px; margin-top: 6px; }
+
+  section.s { background: var(--panel); border: 1px solid var(--line); border-radius: 10px; padding: 20px 22px; margin-bottom: 22px; }
+  section.s > h2 { font-size: 16px; font-weight: 600; margin: 0 0 4px; }
+  section.s > .lede { color: var(--ink-3); font-size: 12.5px; margin: 0 0 16px; }
+
+  h3.sub { font-size: 12.5px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: var(--ink-2); margin: 16px 0 8px; }
+
+  code, .mono { font-family: var(--mono); }
+  code { background: #f0efec; padding: 1px 5px; border-radius: 4px; font-size: 12.5px; color: var(--ink); }
+  pre { background: #fafaf8; border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px; overflow-x: auto; font-family: var(--mono); font-size: 12.5px; line-height: 1.55; margin: 8px 0; color: var(--ink); }
+  pre .k { color: var(--par); }
+  pre .s { color: var(--ok); }
+  pre .c { color: var(--ink-3); font-style: italic; }
+  pre .t { color: #006b8f; }
+
+  .principles { display: grid; gap: 10px; }
+  .princ { display: grid; grid-template-columns: 28px 1fr; gap: 12px; align-items: start; padding: 10px 12px; border: 1px solid var(--line); border-radius: 8px; background: #fafaf8; }
+  .princ .n { font-family: var(--mono); font-size: 11px; color: var(--ink-3); padding-top: 1px; }
+  .princ b { font-size: 13.5px; }
+  .princ .body { color: var(--ink-2); font-size: 13px; margin-top: 2px; }
+
+  /* phases */
+  .phases { display: grid; grid-template-columns: repeat(5, 1fr); gap: 10px; margin-top: 8px; }
+  @media (max-width: 1100px) { .phases { grid-template-columns: 1fr 1fr; } }
+  .phase { border: 1px solid var(--line); border-radius: 8px; padding: 12px 12px 10px; background: #fff; position: relative; }
+  .phase .ph { font-family: var(--mono); font-size: 10.5px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.06em; }
+  .phase b { display: block; font-size: 13.5px; margin: 4px 0; }
+  .phase .desc { font-size: 12px; color: var(--ink-2); }
+  .phase.live { border-color: #c5e3ce; background: var(--ok-bg); }
+  .phase.reveal { border-color: #cfdbff; background: var(--accent-bg); }
+
+  /* parallel flow */
+  .flow { background: #fafaf8; border: 1px dashed var(--line-2); border-radius: 10px; padding: 16px; }
+  .lanes { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+  @media (max-width: 1000px) { .lanes { grid-template-columns: 1fr; } }
+  .lane { border: 1.5px dashed #b9a8df; border-radius: 8px; background: #fbf8ff; padding: 10px 12px; }
+  .lane .lh { font-family: var(--mono); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--par); font-weight: 700; margin-bottom: 6px; }
+  .lane .item { font-size: 12.5px; margin: 4px 0; padding-left: 12px; position: relative; color: var(--ink-2); }
+  .lane .item::before { content: "›"; position: absolute; left: 0; color: var(--par); font-weight: 700; }
+  .lane .item b { color: var(--ink); }
+  .arrow { text-align: center; color: #b9a8df; font-size: 18px; line-height: 1; margin: 6px 0; }
+  .barrier { padding: 10px 12px; border: 2px solid var(--ok); background: var(--ok-bg); border-radius: 8px; text-align: center; font-weight: 600; color: #0e4019; font-family: var(--mono); font-size: 13px; }
+  .barrier .sub { display: block; font-weight: 400; font-size: 11.5px; color: var(--ok); margin-top: 3px; font-family: var(--sans); }
+  .serial { border: 1.5px solid #c5e3ce; background: #f4faf6; border-radius: 8px; padding: 10px 12px; }
+  .serial .sh { font-family: var(--mono); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--ok); font-weight: 700; margin-bottom: 6px; }
+  .serial .item { font-size: 12.5px; margin: 4px 0; padding-left: 12px; position: relative; color: var(--ink-2); }
+  .serial .item::before { content: "→"; position: absolute; left: 0; color: var(--ok); font-weight: 700; }
+  .serial .item b { color: var(--ink); }
+  .reveal { margin-top: 6px; padding: 12px; border: 2px solid var(--accent); background: var(--accent-bg); border-radius: 8px; text-align: center; font-weight: 600; color: #15327a; font-family: var(--mono); font-size: 13.5px; }
+  .reveal .sub { display: block; font-weight: 400; font-size: 11.5px; color: var(--accent); margin-top: 3px; font-family: var(--sans); }
+
+  /* scenario two-up */
+  .two { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  @media (max-width: 900px) { .two { grid-template-columns: 1fr; } }
+  .scen { border: 1px solid var(--line); border-radius: 8px; padding: 14px 16px; background: #fafaf8; }
+  .scen h4 { font-size: 13.5px; margin: 0 0 6px; }
+  .scen h4 .tag { font-size: 10.5px; padding: 2px 7px; border-radius: 4px; margin-left: 6px; vertical-align: 2px; background: #fff; border: 1px solid var(--line-2); color: var(--ink-3); font-family: var(--mono); font-weight: 500; }
+  .scen .frame { background: #fff; border: 1px solid var(--line); border-radius: 6px; padding: 10px 12px; font-size: 12.5px; color: var(--ink-2); margin: 8px 0; }
+  .scen ul { padding-left: 18px; margin: 6px 0; font-size: 12.5px; color: var(--ink-2); }
+  .scen ul li { margin: 3px 0; }
+  .scen ul li b { color: var(--ink); }
+  .inv { background: #fff; border-left: 3px solid var(--ok); padding: 6px 10px; font-size: 12px; color: #134d24; border-radius: 0 6px 6px 0; margin: 6px 0; }
+  .inv b { color: #0e4019; }
+
+  /* failure table */
+  table.f { width: 100%; border-collapse: collapse; font-size: 12.5px; margin-top: 4px; }
+  table.f th, table.f td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--line); vertical-align: top; }
+  table.f th { font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--ink-3); font-weight: 600; background: #fafaf8; }
+  table.f td.what { font-family: var(--mono); color: var(--ink); width: 22%; }
+  table.f td.user { color: var(--ink-2); width: 32%; }
+
+  /* compare */
+  .cmp { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  @media (max-width: 900px) { .cmp { grid-template-columns: 1fr; } }
+  .cmp .col { border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px; background: #fafaf8; }
+  .cmp .col h4 { margin: 0 0 6px; font-size: 13px; }
+  .cmp .col.old h4 { color: var(--err); }
+  .cmp .col.new h4 { color: var(--ok); }
+  .cmp ul { padding-left: 18px; margin: 4px 0; font-size: 12.5px; color: var(--ink-2); }
+  .cmp ul li { margin: 4px 0; }
+
+  .kill { text-decoration: line-through; color: var(--err); }
+
+  footer { color: var(--ink-3); font-size: 12px; margin-top: 24px; }
+</style>
+</head>
+<body>
+<div class="page">
+
+<header class="head">
+  <h1>Attach redesign — from scratch</h1>
+  <div class="sub">If we wrote ccsm’s attach path today, what would it look like? Discard the 19-step incumbent and the patches on top of it. Design only.</div>
+  <div class="meta">scope: pty attach + xterm mount + sidebar coupling · companion to docs/attach-timeline-review.html (history)</div>
+</header>
+
+<!-- ====================== 1. PRINCIPLES ====================== -->
+<section class="s">
+  <h2>1 · Design principles</h2>
+  <p class="lede">Five things every later decision answers to.</p>
+  <div class="principles">
+    <div class="princ"><div class="n">P1</div><div>
+      <b>First frame = final frame.</b>
+      <div class="body">Before <code>display:''</code>, the user perceives nothing. After it, the user must see a finished picture: scrolled to the right line, atlas warm, dims final. Step count between mount and reveal is irrelevant; the cut line is what matters.</div>
+    </div></div>
+    <div class="princ"><div class="n">P2</div><div>
+      <b>The Terminal is a long-lived per-sid object, not a per-attach artifact.</b>
+      <div class="body">Allocation, <code>term.open</code>, addon load, atlas warm-up, and the live data subscription happen the first time we have any reason to care about a sid (e.g. it’s in the sidebar). “Attach” is reduced to <i>making one of these visible</i>. Switching sessions never disposes or re-opens xterm.</div>
+    </div></div>
+    <div class="princ"><div class="n">P3</div><div>
+      <b>Data subscription is independent of visibility.</b>
+      <div class="body">Per-sid chunks flow into the per-sid Terminal continuously, from spawn/restore to dispose. There is no “buffering listener” mode that toggles around attach — the listener is always the Terminal itself. Visibility is a DOM concern only.</div>
+    </div></div>
+    <div class="princ"><div class="n">P4</div><div>
+      <b>Sidebar runs on its own data plane.</b>
+      <div class="body">Sidebar state (agent state, title, badge, archived flag) comes from <code>session:state</code> / <code>session:title</code> — already independent of PTY chunks. Redesign keeps it that way; no last-line preview parsing of PTY output anywhere.</div>
+    </div></div>
+    <div class="princ"><div class="n">P5</div><div>
+      <b>Parallel where independent. One barrier. Then serial. Then reveal.</b>
+      <div class="body">Independent work (snapshot fetch, layout commit, addon warm-up) runs concurrently in invisible space. A single <code>await Promise.all</code> meets them. The serial tail does only the bits with real ordering (write snapshot → drain live tail → pin viewport). Reveal is the last instruction.</div>
+    </div></div>
+  </div>
+</section>
+
+<!-- ====================== 2. HIGH-LEVEL PHASES ====================== -->
+<section class="s">
+  <h2>2 · High-level architecture</h2>
+  <p class="lede">Five phases. Read left to right.</p>
+  <div class="phases">
+    <div class="phase">
+      <div class="ph">Phase 0</div>
+      <b>Provision</b>
+      <div class="desc">When a sid enters the sidebar, allocate a renderer-side <code>SessionShell</code>: xterm Terminal in an offscreen container, addons loaded, live stream subscription opened. No user-visible side effect.</div>
+    </div>
+    <div class="phase live">
+      <div class="ph">Phase 1</div>
+      <b>Stream-live</b>
+      <div class="desc">PTY chunks land in the per-sid Terminal continuously. Sidebar receives <code>session:state</code> independently. Both run forever, regardless of which sid is active.</div>
+    </div>
+    <div class="phase">
+      <div class="ph">Phase 2</div>
+      <b>Prepare-visible</b>
+      <div class="desc">User picks a sid. Parallel: reparent the SessionShell into the visible host (still <code>display:'none'</code>), commit layout, fit to real dims, restore last viewport (warm) or snap to bottom (cold).</div>
+    </div>
+    <div class="phase reveal">
+      <div class="ph">Phase 3</div>
+      <b>Reveal</b>
+      <div class="desc">One assignment: <code>display:''</code>. Viewport, atlas, dims, content — all already final. <i>This is the only frame the user sees.</i></div>
+    </div>
+    <div class="phase">
+      <div class="ph">Phase 4</div>
+      <b>Post-reveal</b>
+      <div class="desc">Wire input passthrough (it’s already wired at the Terminal layer; we only flip a routing flag), focus, mark active in store, install/refresh ResizeObserver baseline.</div>
+    </div>
+  </div>
+
+  <h3 class="sub">Why this shape</h3>
+  <p style="margin:0; font-size:13px; color:var(--ink-2);">
+    The current path conflates four orthogonal things — Terminal lifecycle, data subscription, layout, and visibility — into one mega-procedure called “attach.” Untangling them moves all the heavy lifting out of the click path. By the time the user clicks a session, the bytes have already been streaming for seconds; “attach” becomes “show.”
+  </p>
+</section>
+
+<!-- ====================== 3. PARALLEL FLOW ====================== -->
+<section class="s">
+  <h2>3 · Parallel flow inside Phase 2</h2>
+  <p class="lede">What can run concurrently while still in <code>display:'none'</code>, what must serialize, and where reveal sits.</p>
+
+  <div class="flow">
+
+    <div class="lanes">
+      <div class="lane">
+        <div class="lh">Lane A · Data</div>
+        <div class="item"><b>A1.</b> Request <code>pty.snapshotAt(sid, sinceSeq?)</code> if shell hasn’t written a snapshot yet, else skip (already live).</div>
+        <div class="item"><b>A2.</b> Apply <code>writeAsync(snapshot)</code> into the Terminal’s scrollback. Drain.</div>
+        <div class="item"><b>A3.</b> Drain in-flight live chunks up to <i>now</i> (single explicit <code>await term.write('', cb)</code> barrier — only place we use it).</div>
+      </div>
+      <div class="lane">
+        <div class="lh">Lane B · DOM</div>
+        <div class="item"><b>B1.</b> Reparent SessionShell from offscreen pool into visible <code>&lt;TerminalSlot/&gt;</code>, still <code>display:'none'</code>.</div>
+        <div class="item"><b>B2.</b> <code>await rAF</code> — let layout commit. Assert <code>clientWidth/Height &gt; 0</code> (else go to error path F3).</div>
+        <div class="item"><b>B3.</b> <code>fit.fit()</code> → compute final cols/rows from real dims.</div>
+      </div>
+      <div class="lane">
+        <div class="lh">Lane C · Viewport plan</div>
+        <div class="item"><b>C1.</b> Read shell’s <code>lastViewportY</code> (warm) or <code>null</code> (cold).</div>
+        <div class="item"><b>C2.</b> Decide target: warm → restore Y; cold+resume → bottom; cold+empty → bottom (no-op).</div>
+        <div class="item"><b>C3.</b> Precompute via shell’s scrollback line count; no terminal mutation yet.</div>
+      </div>
+    </div>
+
+    <div class="arrow">▼</div>
+    <div class="barrier">
+      await Promise.all([ A, B, C ])
+      <span class="sub">single barrier — three lanes fully settled</span>
+    </div>
+    <div class="arrow">▼</div>
+
+    <div class="serial">
+      <div class="sh">Serial tail · still display:'none'</div>
+      <div class="item"><b>S1.</b> If <code>fit.cols ≠ pty.cols</code>: <code>pty.resize(sid, cols, rows)</code>. The resulting SIGWINCH echo lands in the live stream (already going to this Terminal); we don’t re-fetch a snapshot — the parser will catch up.</div>
+      <div class="item"><b>S2.</b> One <code>await term.write('', cb)</code> drain — catches both the live tail from A3 <i>and</i> any SIGWINCH echo from S1.</div>
+      <div class="item"><b>S3.</b> Apply viewport plan from C: <code>term.scrollToLine(targetY)</code> or <code>term.scrollToBottom()</code>. Once. Exact.</div>
+    </div>
+
+    <div class="arrow">▼</div>
+
+    <div class="reveal">
+      slot.style.display = ''
+      <span class="sub">user’s first frame — already final</span>
+    </div>
+
+    <div class="arrow">▼</div>
+
+    <div class="serial">
+      <div class="sh">Phase 4 · After reveal · order-free</div>
+      <div class="item"><b>P1.</b> Flip <code>activeSid</code> in store → input routing now sends keystrokes for this sid to <code>pty.input</code>.</div>
+      <div class="item"><b>P2.</b> <code>term.focus()</code>.</div>
+      <div class="item"><b>P3.</b> Install ResizeObserver baseline (eat the first spurious tick from display flip, same rationale as today).</div>
+    </div>
+
+  </div>
+
+  <h3 class="sub">Dependency notes</h3>
+  <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
+    <li>A is independent of B/C. A can complete before B reparents — the writes go into a Terminal that just isn’t on screen yet, which is fine (Phase 1 / P3).</li>
+    <li>B2 (rAF) is the only DOM-timed barrier. It is cheap and predictable: at most one frame, typically &lt;16ms.</li>
+    <li>C is pure computation. It exists as its own lane to make the warm-vs-cold decision an explicit data input to S3 rather than a branching mess inside it.</li>
+  </ul>
+</section>
+
+<!-- ====================== 4. FIRST-FRAME SCENARIOS ====================== -->
+<section class="s">
+  <h2>4 · First-frame guarantees per scenario</h2>
+  <p class="lede">The only two scenarios that exist from the user’s point of view. What they see and the invariant that makes it true.</p>
+  <div class="two">
+
+    <div class="scen">
+      <h4>Scenario A — cold + resume<span class="tag">first attach of a session with history</span></h4>
+      <div class="frame">
+        <b>First frame:</b> full xterm canvas at final size, scrollback rendered to the last line of the resume snapshot, scrollbar at bottom, cursor where the CLI left it. No empty frame, no upward drift, no late snap.
+      </div>
+      <ul>
+        <li><b>How:</b> snapshot write (A1–A2) and live-tail drain (A3, S2) complete <i>before</i> reveal. Viewport target is computed in C (bottom) and applied in S3 once. Reveal happens after S3.</li>
+        <li><b>Why no race:</b> there is no fire-and-forget write. The single drain barrier in S2 is the only point where parser queue can be non-empty before reveal, and we wait on it explicitly.</li>
+      </ul>
+      <div class="inv">
+        <b>Invariant:</b> at the moment of <code>display:''</code>, <code>term.buffer.baseY === lastWrittenBaseY</code> and <code>ydisp === baseY</code>. Both follow from S2 (no pending writes) and S3 (exactly one pin).
+      </div>
+    </div>
+
+    <div class="scen">
+      <h4>Scenario B — warm switch<span class="tag">previously attached, switching back</span></h4>
+      <div class="frame">
+        <b>First frame:</b> the exact viewport position the user left, including mid-scrollback positions. Scrollbar aligned. If new chunks arrived while detached, they are in the scrollback below the viewport (not auto-scrolled to).
+      </div>
+      <ul>
+        <li><b>How:</b> the SessionShell was never disposed (P2). Lane A is a no-op — chunks have been streaming into this Terminal the whole time. Lane C reads the persisted <code>lastViewportY</code> (captured on each visibility-loss). S3 calls <code>scrollToLine(targetY)</code>.</li>
+        <li><b>Reparent considerations:</b> reparent (B1) does not reset xterm internal state. We still gate on rAF (B2) to be safe against width changes between hosts.</li>
+      </ul>
+      <div class="inv">
+        <b>Invariant:</b> the renderer state for sid X is identical immediately before deactivation and immediately after reactivation, save for <code>baseY</code> which may have advanced from live chunks (which is correct — they should be in the buffer, just not pulling the viewport).
+      </div>
+    </div>
+
+  </div>
+</section>
+
+<!-- ====================== 5. IPC CONTRACT ====================== -->
+<section class="s">
+  <h2>5 · IPC contract proposal</h2>
+  <p class="lede">Main ↔ renderer surface. Smaller and more explicit than today.</p>
+
+<pre><span class="c">// ─── main → renderer broadcasts ─────────────────────────────────────────</span>
+
+<span class="c">// One channel, per-sid stream. Emits from spawn to dispose. Renderer</span>
+<span class="c">// attaches a Terminal as the sole consumer per sid; main does NOT gate</span>
+<span class="c">// emission on any "viewer count". This is what kills the buffering-mode</span>
+<span class="c">// dance: the consumer is always present.</span>
+<span class="k">channel</span> <span class="s">'pty:chunk'</span>: { sid: string; seq: number; data: <span class="t">Uint8Array</span> }
+
+<span class="c">// Lifecycle. Separate from chunks so consumers don't have to parse them.</span>
+<span class="k">channel</span> <span class="s">'pty:exit'</span>: { sid: string; code: number | null; signal: string | null }
+
+<span class="c">// Sidebar's data plane. Unchanged from today, listed for completeness.</span>
+<span class="k">channel</span> <span class="s">'session:state'</span>: { sid: string; state: SessionState }
+<span class="k">channel</span> <span class="s">'session:title'</span>: { sid: string; title: string }
+
+<span class="c">// ─── renderer → main RPC ────────────────────────────────────────────────</span>
+
+<span class="c">// Open a SessionShell. Idempotent. Called once per sid that enters the</span>
+<span class="c">// sidebar; the renderer treats this as "start streaming to me". Returns</span>
+<span class="c">// the seq cursor the renderer should treat as the live floor.</span>
+<span class="k">rpc</span> <span class="t">pty.open</span>(sid): Promise&lt;{ pid: number; cols: number; rows: number; seq: number }&gt;
+
+<span class="c">// One-shot historical snapshot. Returned snapshot is everything up to</span>
+<span class="c">// `seq` (exclusive). Renderer writes snapshot, then plays chunks with</span>
+<span class="c">// seq &gt;= returned.seq. Replaces the 'buffering listener' indirection.</span>
+<span class="k">rpc</span> <span class="t">pty.snapshotAt</span>(sid, opts?: { sinceSeq?: number }): Promise&lt;{
+  snapshot: <span class="t">Uint8Array</span>;
+  seq: number;     <span class="c">// exclusive upper bound covered by `snapshot`</span>
+  cols: number;
+  rows: number;
+}&gt;
+
+<span class="c">// Resize is a hint; if cols/rows match current, main returns without</span>
+<span class="c">// emitting SIGWINCH. No-op-safe to call after every fit().</span>
+<span class="k">rpc</span> <span class="t">pty.resize</span>(sid, cols, rows): Promise&lt;{ applied: boolean }&gt;
+
+<span class="c">// Input is fire-and-forget, ordered per-sid.</span>
+<span class="k">channel</span> <span class="s">'pty:input'</span>: { sid: string; data: string }   <span class="c">// renderer → main, one-way</span>
+
+<span class="c">// Drop the SessionShell. Main may keep the PTY alive (other windows /</span>
+<span class="c">// background) but stops emitting chunks for this sid to this window.</span>
+<span class="k">rpc</span> <span class="t">pty.close</span>(sid): Promise&lt;void&gt;
+
+<span class="c">// ─── what we deliberately do NOT have ───────────────────────────────────</span>
+<span class="c">// • No pty.attach / pty.detach. Subscription is implicit in pty.open.</span>
+<span class="c">// • No getBufferSnapshot/attach split. Replaced by pty.snapshotAt, which</span>
+<span class="c">//   is callable at any time and returns a self-consistent {snapshot, seq}.</span>
+<span class="c">// • No sidebar preview channel. Sidebar reads agent state only.</span>
+</pre>
+
+  <h3 class="sub">Why these shapes</h3>
+  <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
+    <li><b><code>pty.open</code> instead of <code>pty.attach</code></b> — “open” describes truth: the renderer is committing to consume this sid’s stream until <code>pty.close</code>. There is no transient attach/detach inside a window’s lifetime; switching sids doesn’t touch main.</li>
+    <li><b>Chunks carry <code>seq</code></b> — makes snapshot/live join trivially correct (drop chunks with <code>seq &lt; snapshotSeq</code>, write the rest). No timestamp races, no “did I miss any.”</li>
+    <li><b><code>pty.snapshotAt</code> is decoupled from open</b> — the renderer can call it lazily (first time it actually needs to render history) or eagerly. The IPC is the same. Avoids the “attach implies snapshot” bundling that locks ordering.</li>
+    <li><b><code>resize.applied</code> return</b> — lets the renderer skip the “did SIGWINCH fire” heuristic; main is the source of truth.</li>
+  </ul>
+</section>
+
+<!-- ====================== 6. STATE MACHINE ====================== -->
+<section class="s">
+  <h2>6 · Renderer state per SessionShell</h2>
+  <p class="lede">Discriminated union; transitions are the only places anything can go wrong, so they’re explicit.</p>
+
+<pre><span class="k">type</span> <span class="t">SessionShell</span> = {
+  sid: string;
+  term: <span class="t">Terminal</span>;            <span class="c">// xterm instance, created at provisioning</span>
+  container: <span class="t">HTMLElement</span>;   <span class="c">// offscreen by default; reparented to slot on activate</span>
+  lastViewportY: number | null; <span class="c">// captured on each deactivate; null until first</span>
+  status: <span class="t">ShellStatus</span>;
+};
+
+<span class="k">type</span> <span class="t">ShellStatus</span> =
+  | { kind: <span class="s">'provisioning'</span> }                                   <span class="c">// term created, awaiting pty.open</span>
+  | { kind: <span class="s">'streaming'</span>; seq: number }                         <span class="c">// pty.open done, chunks flowing, no snapshot yet written</span>
+  | { kind: <span class="s">'hydrating'</span>; snapshotSeq: number }                 <span class="c">// snapshot fetched, currently writing</span>
+  | { kind: <span class="s">'live'</span>; baseSeq: number }                          <span class="c">// snapshot drained, live chunks applied directly</span>
+  | { kind: <span class="s">'exited'</span>; code: number | null }                    <span class="c">// pty.onExit received; terminal becomes read-only</span>
+  | { kind: <span class="s">'error'</span>; reason: <span class="t">ShellError</span>; recoverable: boolean };
+
+<span class="k">type</span> <span class="t">ShellError</span> =
+  | <span class="s">'open-failed'</span>             <span class="c">// pty.open rejected (claude binary missing, spawn EPERM, etc.)</span>
+  | <span class="s">'snapshot-failed'</span>         <span class="c">// pty.snapshotAt rejected after retry</span>
+  | <span class="s">'host-zero-size'</span>           <span class="c">// rAF settled and slot is still 0×0 — layout never gave us space</span>
+  | <span class="s">'stream-disconnected'</span>;    <span class="c">// chunk channel went silent without an exit event</span>
+
+<span class="c">// Visibility is OUTSIDE the shell — orthogonal axis:</span>
+<span class="k">type</span> <span class="t">SlotState</span> =
+  | { kind: <span class="s">'empty'</span> }
+  | { kind: <span class="s">'mounting'</span>; sid: string }       <span class="c">// reparented, display:'none', running Phase 2 serial tail</span>
+  | { kind: <span class="s">'visible'</span>; sid: string };       <span class="c">// post-reveal</span>
+</pre>
+  <p style="margin:10px 0 0; font-size:13px; color:var(--ink-2);">
+    The product of <code>ShellStatus × SlotState</code> spells out every situation. Most attach-path bugs today are illegal states in this model (e.g. <i>visible but not yet live</i>), which the redesign makes unrepresentable: the slot transition from <code>mounting → visible</code> is the same call site as <code>display:''</code>, and that call site requires <code>shell.status.kind === 'live'</code>.
+  </p>
+</section>
+
+<!-- ====================== 7. FAILURE PATHS ====================== -->
+<section class="s">
+  <h2>7 · Failure paths</h2>
+  <p class="lede">Every error has a name, a user-visible artifact, and a recovery.</p>
+  <table class="f">
+    <thead>
+      <tr><th>Failure</th><th>What the user sees</th><th>Recovery</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="what">F1 · open-failed</td>
+        <td class="user">Slot stays empty; an inline error card replaces the xterm canvas: <i>“Couldn’t start Claude for this session. [Retry] [View logs]”</i>. Sidebar row gets a small error pip.</td>
+        <td>Retry button calls <code>pty.open</code> again; on third failure we surface the claude-missing guide (existing UI).</td>
+      </tr>
+      <tr>
+        <td class="what">F2 · snapshot-failed</td>
+        <td class="user">If shell never wrote a snapshot: same inline error card as F1. If shell was already live and this was a re-snapshot (rare, e.g. after dropped chunks): no UI change — we continue with current buffer and toast a non-blocking warning.</td>
+        <td>Auto-retry once after 250ms; on second failure escalate to the error card.</td>
+      </tr>
+      <tr>
+        <td class="what">F3 · host-zero-size</td>
+        <td class="user">Slot stays in <code>mounting</code> with a subtle spinner (typically &lt;200ms). If it persists &gt;2s: error card <i>“Terminal area has no space — try resizing the window.”</i></td>
+        <td>Keep re-rAFing on every ResizeObserver tick of the slot. The moment we get nonzero dims, resume Phase 2 at B3.</td>
+      </tr>
+      <tr>
+        <td class="what">F4 · stream-disconnected</td>
+        <td class="user">Banner across the top of the terminal: <i>“Live updates paused — reconnecting…”</i>. Existing scrollback stays readable; input is disabled.</td>
+        <td>Re-subscribe via <code>pty.open</code>; if seq jumped, run a delta snapshot via <code>pty.snapshotAt(sid, {sinceSeq})</code> and apply.</td>
+      </tr>
+      <tr>
+        <td class="what">F5 · exited</td>
+        <td class="user">Terminal goes read-only; ghost cursor; sidebar agent state moves to exited. A footer chip shows the exit code, with a Restart button.</td>
+        <td>Restart spawns a fresh sid (re-uses the SessionShell container with a new Terminal); existing sessions never silently resurrect.</td>
+      </tr>
+    </tbody>
+  </table>
+</section>
+
+<!-- ====================== 8. CONTRAST ====================== -->
+<section class="s">
+  <h2>8 · Contrast with the current 19-step path</h2>
+  <p class="lede">Not a diff — a structural comparison.</p>
+
+  <div class="cmp">
+    <div class="col old">
+      <h4>Current</h4>
+      <ul>
+        <li><b>19 sequential steps</b> in <code>usePtyAttach.warm.ts</code> + <code>xtermWarmRegistry.ts</code>, mixing data, DOM, layout, and ordering decisions.</li>
+        <li><b>Terminal lifecycle tied to attach:</b> <code>allocEntry</code> on cold, <code>display</code> toggle on warm — different code paths.</li>
+        <li><b>Buffering-listener mode</b> exists to bridge the gap between subscribing and being ready to render. It is correct but is a workaround for the deeper coupling.</li>
+        <li><b>Two <code>scrollToBottom</code> calls</b> (L479 + L551) because the first one is structurally too early.</li>
+        <li><b>Fit happens after attach</b>, forcing a SIGWINCH echo that arrives after the first pin (QP-3).</li>
+        <li><b>Live-tail writes are fire-and-forget</b> (QP-1) — the highest-priority bug.</li>
+        <li><b><code>term.open</code> runs in stale-or-zero layout</b> (QP-2), CanvasAddon atlas warms up while visible (QP-4).</li>
+      </ul>
+    </div>
+    <div class="col new">
+      <h4>Redesigned</h4>
+      <ul>
+        <li><b>5 phases</b>, of which only Phase 2 has internal ordering — and that ordering is three independent lanes joined by one barrier.</li>
+        <li><b>One Terminal lifecycle</b>: created at sidebar-provision, disposed at <code>pty.close</code>. Switching sids never touches xterm internals.</li>
+        <li><b>No buffering mode</b>: chunks always flow to a Terminal that exists. The data plane has no “waiting room.”</li>
+        <li><b>One pin</b>: S3. Computed in lane C, applied once, after drain, before reveal.</li>
+        <li><b>Fit runs before any resize negotiation</b> (B3 → S1). SIGWINCH echo, if any, is absorbed in S2’s drain — never a separate event the timeline needs to worry about.</li>
+        <li><b>All writes are awaited</b>. The drain barrier in S2 is structural, not a patched-in <code>writeAsync('')</code>.</li>
+        <li><b><code>term.open</code> runs after rAF + nonzero assert</b>. Reveal is the last instruction, so atlas warm-up is invisible by construction.</li>
+      </ul>
+    </div>
+  </div>
+
+  <h3 class="sub">Races that cannot occur in the new architecture</h3>
+  <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
+    <li><b>QP-1 (live-tail vs pin):</b> there is no fire-and-forget tail. S2 is a single explicit drain; nothing writes between S2 and S3.</li>
+    <li><b>QP-2 (stale-dim open):</b> <code>term.open</code> only runs when the container has live dims (P0 offscreen has fixed dims; B2 rAF guards the visible path).</li>
+    <li><b>QP-3 (fit-after-attach SIGWINCH echo):</b> fit is computed before <code>pty.resize</code> is called, and the resize response is drained by S2.</li>
+    <li><b>QP-4 (atlas-warm in user-visible window):</b> atlas warms up at provisioning (Phase 0) when the Terminal first <code>open</code>s into an offscreen container with real dims. By the time anything reveals, atlas is hot.</li>
+    <li><b>StrictMode double-mount (QP-5):</b> shell provisioning is idempotent (keyed by sid in a renderer registry), so re-running effects is a no-op rather than a re-allocation.</li>
+  </ul>
+
+  <h3 class="sub">Code that can be deleted</h3>
+  <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
+    <li><span class="kill"><code>src/terminal/usePtyAttach.warm.ts</code></span> — the 19-step procedure. Replaced by a small <code>useVisibleShell(sid)</code> hook that toggles <code>SlotState</code>.</li>
+    <li><span class="kill"><code>xtermWarmRegistry.ts::ensureAndShowEntry / applySnapshot / pinViewportToBottom</code></span> — collapse into a <code>shellRegistry</code> with <code>provision/close/getSnapshot</code>.</li>
+    <li><span class="kill">"buffering" listener mode</span> — gone with the data-plane separation.</li>
+    <li><span class="kill"><code>pty:attach</code> and <code>pty:detach</code> IPC channels</span> — replaced by <code>pty.open</code> / <code>pty.close</code>; the per-window stream is implicit.</li>
+    <li><span class="kill">Defensive <code>term.reset()</code> before snapshot</span> — the shell registry guarantees terminals are either fresh or already live; reset has no caller.</li>
+  </ul>
+</section>
+
+<footer>
+  Companion document. The current implementation’s annotated timeline lives in <code>docs/attach-timeline-review.html</code> and remains the historical record — do not edit it. This file is the “if we started today” counter-proposal.
+</footer>
+
+</div>
+</body>
+</html>

--- a/docs/attach-redesign.html
+++ b/docs/attach-redesign.html
@@ -43,7 +43,7 @@
 
   code, .mono { font-family: var(--mono); }
   code { background: #f0efec; padding: 1px 5px; border-radius: 4px; font-size: 12.5px; color: var(--ink); }
-  pre { background: #fafaf8; border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px; overflow-x: auto; font-family: var(--mono); font-size: 12.5px; line-height: 1.55; margin: 8px 0; color: var(--ink); }
+  pre { background: #fafaf8; border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px; overflow-x: auto; font-family: var(--mono); font-size: 12.5px; line-height: 1.55; margin: 8px 0; color: var(--ink); white-space: pre; }
   pre .k { color: var(--par); }
   pre .s { color: var(--ok); }
   pre .c { color: var(--ink-3); font-style: italic; }
@@ -117,6 +117,40 @@
 
   .kill { text-decoration: line-through; color: var(--err); }
 
+  /* callout (rule cards) */
+  .rules { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  @media (max-width: 900px) { .rules { grid-template-columns: 1fr; } }
+  .rule { padding: 14px 16px; border-radius: 10px; border: 2px solid var(--line); background: #fff; }
+  .rule.cold { border-color: var(--accent); background: var(--accent-bg); }
+  .rule.warm { border-color: var(--ok); background: var(--ok-bg); }
+  .rule .tag { font-family: var(--mono); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--ink-3); margin-bottom: 4px; }
+  .rule.cold .tag { color: var(--accent); }
+  .rule.warm .tag { color: var(--ok); }
+  .rule b { font-size: 15px; display: block; margin-bottom: 6px; }
+  .rule p { margin: 0; font-size: 13px; color: var(--ink-2); }
+
+  /* state mock (ascii-ish layout) */
+  .states { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+  @media (max-width: 1100px) { .states { grid-template-columns: 1fr; } }
+  .state { border: 1px solid var(--line); border-radius: 10px; background: #fafaf8; padding: 12px 14px; }
+  .state .stag { font-family: var(--mono); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--ink-3); }
+  .state h4 { margin: 4px 0 8px; font-size: 13.5px; }
+  .state .caption { font-size: 12.5px; color: var(--ink-2); margin-top: 8px; }
+  .mock { display: grid; grid-template-columns: 110px 1fr; gap: 0; border: 1px solid var(--line-2); border-radius: 6px; background: #fff; overflow: hidden; height: 200px; font-family: var(--mono); font-size: 11px; }
+  .mock .side { background: #f4f4f1; border-right: 1px solid var(--line-2); padding: 8px 10px; color: var(--ink-2); }
+  .mock .side .row { padding: 4px 6px; margin: 2px -6px; border-radius: 4px; }
+  .mock .side .row.act { background: var(--accent); color: #fff; }
+  .mock .side .row.dim { color: var(--ink-3); }
+  .mock .right { position: relative; background: #1a1a1a; color: #d8d8d8; padding: 10px 12px; overflow: hidden; }
+  .mock .right .blackout { position: absolute; inset: 0; background: #1a1a1a; display: flex; align-items: center; justify-content: center; color: #6b6b6b; font-size: 11px; }
+  .mock .right .mask { position: absolute; inset: 0; background: rgba(26,26,26,0.94); display: flex; align-items: center; justify-content: center; color: #b9a8df; font-size: 11px; backdrop-filter: blur(2px); border: 1px dashed #5d3aa0; }
+  .mock .right .layer { position: absolute; inset: 6px 8px; padding: 4px 6px; border-radius: 4px; }
+  .mock .right .layer.top { background: #0e0e0e; border: 1px solid #2962ff; z-index: 3; }
+  .mock .right .layer.mid { background: #161616; border: 1px solid #444; z-index: 2; transform: translate(8px, 8px); opacity: 0.55; }
+  .mock .right .layer.bot { background: #1c1c1c; border: 1px solid #333; z-index: 1; transform: translate(16px, 16px); opacity: 0.3; }
+  .mock .right .layer .lh { font-size: 10px; color: var(--ink-3); margin-bottom: 4px; }
+  .mock .right .layer .ln { color: #e0e0e0; margin: 1px 0; font-size: 10.5px; }
+
   footer { color: var(--ink-3); font-size: 12px; margin-top: 24px; }
 </style>
 </head>
@@ -124,382 +158,148 @@
 <div class="page">
 
 <header class="head">
-  <h1>Attach 重新设计 —— 从零开始</h1>
-  <div class="sub">如果今天从头写 ccsm 的 attach,会长成什么样。当前 19 步流程和上面的补丁全不看,只谈设计。</div>
+  <h1>Attach 重新设计 —— UX 模型</h1>
+  <div class="sub">右侧内容区怎么呈现 session,以及背后大致是怎么做到的。3 分钟看完。</div>
   <div class="meta">范围:pty attach + xterm mount + 侧边栏耦合 · 配套文档 docs/attach-timeline-review.html(历史)</div>
 </header>
 
-<!-- ====================== 1. PRINCIPLES ====================== -->
+<!-- ====================== 1. UX 模型 ====================== -->
 <section class="s">
-  <h2>1 · 设计原则</h2>
-  <p class="lede">五条原则,后面所有决策都要回答它们。</p>
-  <div class="principles">
-    <div class="princ"><div class="n">P1</div><div>
-      <b>第一帧 = 最终帧。</b>
-      <div class="body">用户看到画面的那一瞬间,画面就得是最终态:滚到对的行、字体已渲染好、尺寸已就位。当前问题是用户能看见 "空白 → 内容 → 跳一下" 的过程。新设计把所有准备工作藏在 <code>display:'none'</code> 后面,翻成 <code>display:''</code> 就是结果。</div>
-    </div></div>
-    <div class="princ"><div class="n">P2</div><div>
-      <b>Terminal 是 per-sid 的长寿对象,不是 attach 的副产物。</b>
-      <div class="body">xterm 实例、addon、字体预热、PTY 数据订阅 —— 都在我们第一次关心这个 sid 时一次性建好,之后一直留着。当前 "切会话就重新走一遍" 的代价直接消失。"Attach" 退化成 "把已经准备好的东西显示出来"。</div>
-    </div></div>
-    <div class="princ"><div class="n">P3</div><div>
-      <b>数据订阅与可见性无关。</b>
-      <div class="body">PTY chunk 从进程启动到结束一直流进对应的 Terminal,不管它是否在屏幕上。当前为了等 attach 才订阅,中间有个 "buffering listener" 模式做缓冲 —— 这个中间层在新设计里直接没有,因为消费者永远在线。</div>
-    </div></div>
-    <div class="princ"><div class="n">P4</div><div>
-      <b>侧边栏走自己的数据通道。</b>
-      <div class="body">侧边栏要的是 agent 状态、标题、徽标,这些早就由 <code>session:state</code> / <code>session:title</code> 单独推送。它和 PTY chunk 没关系,新设计继续保持这种解耦,绝不去解析 PTY 输出做侧边栏预览。</div>
-    </div></div>
-    <div class="princ"><div class="n">P5</div><div>
-      <b>能并行就并行,一次汇合,然后串行,最后 reveal。</b>
-      <div class="body">独立的事情(拉 snapshot、做布局、算 viewport)同时跑,用一次 <code>await Promise.all</code> 等齐。真正有顺序要求的(写 snapshot → drain → 钉位)再串行。Reveal 是整个流程的最后一条指令。</div>
-    </div></div>
+  <h2>1 · UX 模型 —— 三种状态</h2>
+  <p class="lede">右侧内容区就这三种样子。左边的 sidebar 是固定的。</p>
+
+  <div class="states">
+
+    <div class="state">
+      <div class="stag">State 0</div>
+      <h4>刚打开 ccsm</h4>
+      <div class="mock">
+        <div class="side">
+          <div class="row dim">session A</div>
+          <div class="row dim">session B</div>
+          <div class="row dim">session C</div>
+        </div>
+        <div class="right">
+          <div class="blackout">— 空 —</div>
+        </div>
+      </div>
+      <div class="caption">右侧全黑。还没人 attach 过,什么都没准备。</div>
+    </div>
+
+    <div class="state">
+      <div class="stag">State 1</div>
+      <h4>冷启动中</h4>
+      <div class="mock">
+        <div class="side">
+          <div class="row act">session A</div>
+          <div class="row dim">session B</div>
+          <div class="row dim">session C</div>
+        </div>
+        <div class="right">
+          <div class="layer bot"><div class="lh">(底层旧 shell,被盖住)</div></div>
+          <div class="mask">准备中…</div>
+        </div>
+      </div>
+      <div class="caption">遮罩盖住右侧。后台拉 snapshot、建 xterm、写入、滚到底,好了揭开。</div>
+    </div>
+
+    <div class="state">
+      <div class="stag">State 2</div>
+      <h4>已 attach 切换</h4>
+      <div class="mock">
+        <div class="side">
+          <div class="row act">session A</div>
+          <div class="row dim">session B</div>
+          <div class="row dim">session C</div>
+        </div>
+        <div class="right">
+          <div class="layer bot"><div class="lh">session C</div></div>
+          <div class="layer mid"><div class="lh">session B</div></div>
+          <div class="layer top">
+            <div class="lh">session A · 顶层</div>
+            <div class="ln">$ npm test</div>
+            <div class="ln">PASS  ./foo.test.ts</div>
+            <div class="ln">▍</div>
+          </div>
+        </div>
+      </div>
+      <div class="caption">右侧是 z-stack。点谁谁拉到顶,各自保留上次离开的位置,无遮罩、无冷启动。</div>
+    </div>
+
+  </div>
+
+  <h3 class="sub">状态怎么流转</h3>
+<pre>State 0  ──点第一个 session──▶  State 1  ──准备完──▶  State 2
+                                                       │
+                                                       ├──点已看过──▶ 留在 State 2(秒切)
+                                                       │
+                                                       └──点没看过──▶ State 1(再来一次冷启动)
+</pre>
+</section>
+
+<!-- ====================== 2. 两条规则 ====================== -->
+<section class="s">
+  <h2>2 · 两条规则</h2>
+  <p class="lede">用户行为只分两种,响应也只有两种。</p>
+
+  <div class="rules">
+    <div class="rule cold">
+      <div class="tag">规则 1</div>
+      <b>第一次点 = 冷启动</b>
+      <p>右侧盖一层 "准备中" 的遮罩。背后拉 snapshot、建 xterm、写入、滚到底,全部做完才揭开。用户不会看到半成品。</p>
+    </div>
+    <div class="rule warm">
+      <div class="tag">规则 2</div>
+      <b>再点已看过的 = 秒切</b>
+      <p>右侧 z-stack 里把这个 session 翻到顶,viewport 还停在上次离开的位置。无遮罩,无加载,无重建。</p>
+    </div>
   </div>
 </section>
 
-<!-- ====================== 2. HIGH-LEVEL PHASES ====================== -->
+<!-- ====================== 3. 背后做什么 ====================== -->
 <section class="s">
-  <h2>2 · 总体架构</h2>
-  <p class="lede">五个阶段,从左到右。前两个阶段在用户点会话之前就已经在跑。</p>
-  <div class="phases">
-    <div class="phase">
-      <div class="ph">Phase 0</div>
-      <b>Provision(lazy)</b>
-      <div class="desc">侧边栏里的 session 行<i>进入可视区</i>(IntersectionObserver)才 provision:在 offscreen 容器里建 xterm Terminal、加 addon、订阅 PTY 流。滚出可视区不 dispose,关闭 ccsm 才回收。归档分组里的 session 要<i>展开 + 进入可视区</i>才 provision —— 几百条归档不会一起吃内存。</div>
-    </div>
-    <div class="phase live">
-      <div class="ph">Phase 1</div>
-      <b>持续 stream</b>
-      <div class="desc">已 provision 的 sid,PTY chunk 持续流进它的 Terminal,直到进程退出。侧边栏状态走另一条通道。谁在前台无所谓。</div>
-    </div>
-    <div class="phase">
-      <div class="ph">Phase 2</div>
-      <b>准备可见</b>
-      <div class="desc">用户点了某个 sid。并行做三件事:把 SessionShell reparent 到可见容器(仍 <code>display:'none'</code>)、commit 布局拿到真实尺寸、算好 viewport 要停在哪。</div>
-    </div>
-    <div class="phase reveal">
-      <div class="ph">Phase 3</div>
-      <b>Reveal</b>
-      <div class="desc">一条赋值:<code>display:''</code>。viewport、字体、尺寸、内容全是最终态。<i>用户看到的就是这一帧。</i></div>
-    </div>
-    <div class="phase">
-      <div class="ph">Phase 4</div>
-      <b>Reveal 之后</b>
-      <div class="desc">把输入路由切到这个 sid、focus、装 ResizeObserver 基线。顺序无所谓,因为用户已经看到结果。</div>
-    </div>
-  </div>
+  <h2>3 · 背后做什么(high-level)</h2>
+  <p class="lede">不展开 IPC 和状态机,只说大方向。</p>
 
-  <h3 class="sub">为什么这么分</h3>
+  <ul style="margin:0; padding-left:18px; font-size:13.5px; color:var(--ink-2);">
+    <li>没点过的 session <b>完全不准备</b> —— 不订 PTY,不建 xterm,什么资源都不占。</li>
+    <li>点过一次之后 <b>留住不放</b> —— xterm 实例和 PTY 订阅都不 dispose,所以再切回来是秒级。</li>
+    <li><b>关 ccsm 才回收</b> —— 退出时一次性 dispose 所有留下来的 shell。</li>
+    <li>右侧是 <b>z-stack</b> —— 看过的 shell 都叠在那里,点哪个哪个拉到顶。</li>
+    <li>z-stack 是 LRU 缓存 —— <b>暂不设上限</b>。单人一天用的 session 数远低于内存压力线。</li>
+  </ul>
+</section>
+
+<!-- ====================== 4. 实现要点 ====================== -->
+<section class="s">
+  <h2>4 · 实现要点</h2>
+  <p class="lede">给后续 worker 看的落地清单。不是完整方案,只是关键决策。</p>
+
+  <h3 class="sub">替换掉的现有代码</h3>
+  <ul style="margin:0 0 12px; padding-left:18px; font-size:13px; color:var(--ink-2);">
+    <li><span class="kill"><code>src/terminal/usePtyAttach.warm.ts</code></span> —— 19 步过程整体替换为 "点击 → 翻 z-stack 顶层"。</li>
+    <li><span class="kill"><code>xtermWarmRegistry.ts</code> 里的 cold-vs-warm 分支</span> —— 不再区分,统一走 "shell 不存在就建,存在就拉顶"。</li>
+    <li><span class="kill">buffering listener 模式</span> —— 没用了。点击之前根本不订 PTY,点击之后订一次就一直挂着。</li>
+  </ul>
+
+  <h3 class="sub">z-stack 怎么实现</h3>
+  <p style="margin:0 0 8px; font-size:13px; color:var(--ink-2);">
+    右侧 host 里放 N 个 wrapper div,每个 wrapper 里挂一个 xterm。切换只动 <code>display</code> 和 <code>z-index</code>:目标 shell <code>display:''</code>,其余 <code>display:'none'</code>。xterm 实例从不在 wrapper 之间 reparent。
+  </p>
+
+  <h3 class="sub">遮罩怎么做</h3>
+  <p style="margin:0 0 8px; font-size:13px; color:var(--ink-2);">
+    在右侧 host 上盖一个 <code>position:absolute; inset:0</code> 的遮罩 div。冷启动开始时 <code>display:''</code> 显示 "准备中…",背后建 shell + 写 snapshot + 滚到底全部跑完后 <code>display:'none'</code> 揭开。秒切场景遮罩自始至终 <code>display:'none'</code>。
+  </p>
+
+  <h3 class="sub">PTY 订阅时机</h3>
   <p style="margin:0; font-size:13px; color:var(--ink-2);">
-    当前 attach 把四件事 —— 建 Terminal、订阅数据、做布局、改可见性 —— 揉成一个大过程,所以又慢又容易出 bug。把它们拆开做,重活在用户点之前就跑完了。等用户点会话,字节其实已经流进 Terminal 几秒,所谓的 "attach" 就只剩 "把这个 Terminal 显示出来" 而已。
+    第一次点 session 时调 <code>pty.open(sid)</code> 订上,之后这个订阅一直挂着,直到关 ccsm 调 <code>pty.close</code>。脱离前台不取消订阅,chunk 持续写入对应的 xterm scrollback —— 这样秒切回来时新内容已经在那里了。
   </p>
-</section>
-
-<!-- ====================== 3. PARALLEL FLOW ====================== -->
-<section class="s">
-  <h2>3 · Phase 2 内部的并行流</h2>
-  <p class="lede">用户点会话后到 reveal 之前发生的事。仍 <code>display:'none'</code>,所以做多少步用户都看不到。</p>
-
-  <div class="flow">
-
-    <div class="lanes">
-      <div class="lane">
-        <div class="lh">Lane A · 数据</div>
-        <div class="item"><b>A1.</b> 若 shell 尚未写过 snapshot,调 <code>pty.snapshotAt(sid, sinceSeq?)</code>;否则跳过(已 live)。</div>
-        <div class="item"><b>A2.</b> <code>writeAsync(snapshot)</code> 写入 Terminal scrollback。Drain。</div>
-        <div class="item"><b>A3.</b> Drain 截至<i>当前</i>的 in-flight live chunk(一次显式 <code>await term.write('', cb)</code> barrier —— 全流程唯一使用处)。</div>
-      </div>
-      <div class="lane">
-        <div class="lh">Lane B · DOM</div>
-        <div class="item"><b>B1.</b> 把 SessionShell 从 offscreen pool reparent 到可见 <code>&lt;TerminalSlot/&gt;</code>,仍 <code>display:'none'</code>。</div>
-        <div class="item"><b>B2.</b> <code>await rAF</code> —— 让布局 commit。断言 <code>clientWidth/Height &gt; 0</code>(否则进入错误路径 F3)。</div>
-        <div class="item"><b>B3.</b> <code>fit.fit()</code> → 按真实尺寸算出最终 cols/rows。</div>
-      </div>
-      <div class="lane">
-        <div class="lh">Lane C · Viewport 计划</div>
-        <div class="item"><b>C1.</b> 读 shell 的 <code>lastViewportY</code>(warm)或 <code>null</code>(cold)。</div>
-        <div class="item"><b>C2.</b> 决定目标:warm → 恢复 Y;cold+resume → 贴底;cold+空 → 贴底(no-op)。</div>
-        <div class="item"><b>C3.</b> 借 shell 的 scrollback 行数预算;此时不修改 terminal。</div>
-      </div>
-    </div>
-
-    <div class="arrow">▼</div>
-    <div class="barrier">
-      await Promise.all([ A, B, C ])
-      <span class="sub">单点 barrier —— 三条 lane 全部就绪</span>
-    </div>
-    <div class="arrow">▼</div>
-
-    <div class="serial">
-      <div class="sh">串行尾部 · 仍 display:'none'</div>
-      <div class="item"><b>S1.</b> 若 <code>fit.cols ≠ pty.cols</code>:<code>pty.resize(sid, cols, rows)</code>。引发的 SIGWINCH 回显落在 live 流(已指向该 Terminal);不重新拉 snapshot —— parser 会追上。</div>
-      <div class="item"><b>S2.</b> 一次 <code>await term.write('', cb)</code> drain —— 同时吸收 A3 的 live tail<i>和</i> S1 的 SIGWINCH 回显。</div>
-      <div class="item"><b>S3.</b> 应用 lane C 的 viewport 计划:<code>term.scrollToLine(targetY)</code> 或 <code>term.scrollToBottom()</code>。一次。精确。</div>
-    </div>
-
-    <div class="arrow">▼</div>
-
-    <div class="reveal">
-      slot.style.display = ''
-      <span class="sub">用户看到的第一帧 —— 已是最终态</span>
-    </div>
-
-    <div class="arrow">▼</div>
-
-    <div class="serial">
-      <div class="sh">Phase 4 · reveal 之后 · 无序</div>
-      <div class="item"><b>P1.</b> 在 store 翻转 <code>activeSid</code> → 输入路由开始把击键送到该 sid 的 <code>pty.input</code>。</div>
-      <div class="item"><b>P2.</b> <code>term.focus()</code>。</div>
-      <div class="item"><b>P3.</b> 安装 ResizeObserver 基线(吃掉 display 翻转引起的第一个伪 tick,与当前实现同理)。</div>
-    </div>
-
-  </div>
-
-  <h3 class="sub">依赖说明</h3>
-  <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li>A 和 B、C 互不依赖。A 可以在 B reparent 之前就写完 —— 写入进一个还没上屏的 Terminal,完全没问题。</li>
-    <li>B2(rAF)是唯一一处要等 DOM 的地方。便宜、可预测,通常一帧就够,&lt;16ms。</li>
-    <li>C 是纯计算,单独成一条 lane 是为了让 warm/cold 的决策作为 S3 的明确输入,而不是塞在 S3 里一堆 if/else。</li>
-  </ul>
-</section>
-
-<!-- ====================== 4. FIRST-FRAME SCENARIOS ====================== -->
-<section class="s">
-  <h2>4 · 各场景下的第一帧保证</h2>
-  <p class="lede">从用户角度只有两种情况:第一次点开有历史的会话,或者切回之前看过的会话。下面是各自看到什么、为什么不会出问题。</p>
-  <div class="two">
-
-    <div class="scen">
-      <h4>场景 A —— cold + resume<span class="tag">第一次 attach 有历史的会话</span></h4>
-      <div class="frame">
-        <b>第一帧:</b>完整的 xterm 画布、尺寸最终、scrollback 已渲染到 snapshot 最后一行、滚动条贴底、光标停在 CLI 离开的位置。不会出现空帧、向上漂、迟到的 snap。
-      </div>
-      <ul>
-        <li><b>怎么做到的:</b>snapshot 写入(A1–A2)和 live tail drain(A3、S2)都在 reveal 之前完成。Viewport 位置在 C 算好,在 S3 一次性 scroll 到位。Reveal 排在 S3 后面。</li>
-        <li><b>为什么不会 race:</b>没有 fire-and-forget 的写。S2 是唯一可能有 pending 写的位置,这里我们 await 它。</li>
-      </ul>
-      <div class="inv">
-        <b>不变量:</b><code>display:''</code> 那一刻,<code>term.buffer.baseY === lastWrittenBaseY</code> 且 <code>ydisp === baseY</code>。前者来自 S2(无 pending 写入),后者来自 S3(恰好一次钉位)。
-      </div>
-    </div>
-
-    <div class="scen">
-      <h4>场景 B —— warm 切换<span class="tag">之前 attach 过,再切回来</span></h4>
-      <div class="frame">
-        <b>第一帧:</b>用户离开时的 viewport 位置,包括停在 scrollback 中间。滚动条对齐。脱离期间新到的 chunk 在 viewport 下方,不会自动滚到。
-      </div>
-      <ul>
-        <li><b>怎么做到的:</b>SessionShell 一直没 dispose(P2)。Lane A 完全是 no-op —— chunk 一直在流。Lane C 读上次离开时记的 <code>lastViewportY</code>。S3 调一次 <code>scrollToLine(targetY)</code>。</li>
-        <li><b>关于 reparent:</b>reparent(B1)不会动 xterm 内部状态。仍然走 rAF(B2),防止换宿主后宽度变了。</li>
-      </ul>
-      <div class="inv">
-        <b>不变量:</b>同一个 sid,deactivate 前和 reactivate 后 renderer 状态一致,只有 <code>baseY</code> 可能因为 live chunk 往前涨过 —— 这是对的,新数据应在 buffer 里,只是不应拽动 viewport。
-      </div>
-    </div>
-
-  </div>
-</section>
-
-<!-- ====================== 5. IPC CONTRACT ====================== -->
-<section class="s">
-  <h2>5 · IPC 契约提案</h2>
-  <p class="lede">主进程和 renderer 之间的接口。比现在更少、更明确。</p>
-
-<pre><span class="c">// ─── main → renderer 广播 ───────────────────────────────────────────────</span>
-
-<span class="c">// 单一通道,per-sid 一条流。从进程启动 emit 到 dispose。</span>
-<span class="c">// renderer 让对应的 Terminal 当唯一消费者;主进程不根据 "有没有人在看"</span>
-<span class="c">// 来 gate emit。正因如此,buffering-mode 那一套缓冲层就没必要了 —— </span>
-<span class="c">// 消费者永远在。</span>
-<span class="k">channel</span> <span class="s">'pty:chunk'</span>: { sid: string; seq: number; data: <span class="t">Uint8Array</span> }
-
-<span class="c">// 生命周期。和 chunk 分开,消费者不用解析 chunk 去判断进程是否退出。</span>
-<span class="k">channel</span> <span class="s">'pty:exit'</span>: { sid: string; code: number | null; signal: string | null }
-
-<span class="c">// 侧边栏自己的数据通道,和现状一致,这里列出来求完整。</span>
-<span class="k">channel</span> <span class="s">'session:state'</span>: { sid: string; state: SessionState }
-<span class="k">channel</span> <span class="s">'session:title'</span>: { sid: string; title: string }
-
-<span class="c">// ─── renderer → main RPC ────────────────────────────────────────────────</span>
-
-<span class="c">// 打开 SessionShell。幂等。何时调:</span>
-<span class="c">//   • 普通 session 行进入侧边栏可视区(IntersectionObserver 触发)</span>
-<span class="c">//   • 归档分组被展开 且 行进入可视区</span>
-<span class="c">// 不调:行滚出可视区(保留 shell)、关闭归档分组(保留 shell)。</span>
-<span class="c">// 退出时 close。返回 renderer 应视作 live 起点的 seq 游标。</span>
-<span class="k">rpc</span> <span class="t">pty.open</span>(sid): Promise&lt;{ pid: number; cols: number; rows: number; seq: number }&gt;
-
-<span class="c">// 一次性历史 snapshot。返回的 snapshot 覆盖到 `seq`(不含)之前的全部</span>
-<span class="c">// 内容。renderer 先写 snapshot,再播放 seq &gt;= returned.seq 的 chunk。</span>
-<span class="c">// 替代 'buffering listener' 那层间接。</span>
-<span class="k">rpc</span> <span class="t">pty.snapshotAt</span>(sid, opts?: { sinceSeq?: number }): Promise&lt;{
-  snapshot: <span class="t">Uint8Array</span>;
-  seq: number;     <span class="c">// `snapshot` 覆盖的上界(不含)</span>
-  cols: number;
-  rows: number;
-}&gt;
-
-<span class="c">// Resize 是 hint;若 cols/rows 和当前一致,主进程返回但不 emit SIGWINCH。</span>
-<span class="c">// 所以每次 fit() 后无脑调一下都安全。</span>
-<span class="k">rpc</span> <span class="t">pty.resize</span>(sid, cols, rows): Promise&lt;{ applied: boolean }&gt;
-
-<span class="c">// 输入是 fire-and-forget,per-sid 有序。</span>
-<span class="k">channel</span> <span class="s">'pty:input'</span>: { sid: string; data: string }   <span class="c">// renderer → main,单向</span>
-
-<span class="c">// 丢掉 SessionShell。主进程可能让 PTY 继续活着(给其他窗口或后台),</span>
-<span class="c">// 但不再向本窗口 emit 该 sid 的 chunk。</span>
-<span class="k">rpc</span> <span class="t">pty.close</span>(sid): Promise&lt;void&gt;
-
-<span class="c">// ─── 故意不要的东西 ─────────────────────────────────────────────────────</span>
-<span class="c">// • 没有 pty.attach / pty.detach。订阅就藏在 pty.open 里。</span>
-<span class="c">// • 没有 getBufferSnapshot/attach 拆分。换成 pty.snapshotAt,</span>
-<span class="c">//   任何时候调都行,返回自洽的 {snapshot, seq}。</span>
-<span class="c">// • 没有侧边栏预览通道。侧边栏只读 agent 状态。</span>
-</pre>
-
-  <h3 class="sub">为什么是这些形状</h3>
-  <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li><b>叫 <code>pty.open</code> 不叫 <code>pty.attach</code></b> —— "open" 才符合事实:renderer 承诺一直消费到 <code>pty.close</code>。窗口生命周期里不会有反复 attach/detach,切 sid 完全不打扰主进程。</li>
-    <li><b>chunk 自带 <code>seq</code></b> —— snapshot 和 live 拼接天然对得上(<code>seq &lt; snapshotSeq</code> 的丢掉,其余写)。不靠时间戳,不用问 "我有没有漏接"。</li>
-    <li><b><code>pty.snapshotAt</code> 和 open 分开</b> —— renderer 想懒拉就懒拉(真要渲染历史时再调),想立刻拉也行,IPC 一样。不再绑死 "一 attach 就 snapshot"。</li>
-    <li><b><code>resize.applied</code> 有返回值</b> —— renderer 不用猜 SIGWINCH 有没有发出来,主进程说了算。</li>
-  </ul>
-</section>
-
-<!-- ====================== 6. STATE MACHINE ====================== -->
-<section class="s">
-  <h2>6 · 每个 SessionShell 的 renderer 状态</h2>
-  <p class="lede">用 discriminated union 表达。状态本身不容易出错,出错的都是状态转移,所以把它们写明。</p>
-
-<pre><span class="k">type</span> <span class="t">SessionShell</span> = {
-  sid: string;
-  term: <span class="t">Terminal</span>;            <span class="c">// xterm 实例,在 provision 时创建</span>
-  container: <span class="t">HTMLElement</span>;   <span class="c">// 默认 offscreen;activate 时 reparent 到 slot</span>
-  lastViewportY: number | null; <span class="c">// 每次 deactivate 时记录;首次之前为 null</span>
-  status: <span class="t">ShellStatus</span>;
-};
-
-<span class="k">type</span> <span class="t">ShellStatus</span> =
-  | { kind: <span class="s">'provisioning'</span> }                                   <span class="c">// term 已创建,等待 pty.open</span>
-  | { kind: <span class="s">'streaming'</span>; seq: number }                         <span class="c">// pty.open 完成,chunk 流动,尚未写过 snapshot</span>
-  | { kind: <span class="s">'hydrating'</span>; snapshotSeq: number }                 <span class="c">// snapshot 已拉,正在写入</span>
-  | { kind: <span class="s">'live'</span>; baseSeq: number }                          <span class="c">// snapshot 已 drain,live chunk 直接应用</span>
-  | { kind: <span class="s">'exited'</span>; code: number | null }                    <span class="c">// 收到 pty.onExit;terminal 转为只读</span>
-  | { kind: <span class="s">'error'</span>; reason: <span class="t">ShellError</span>; recoverable: boolean };
-
-<span class="k">type</span> <span class="t">ShellError</span> =
-  | <span class="s">'open-failed'</span>             <span class="c">// pty.open 被拒(claude 二进制缺失、spawn EPERM 等)</span>
-  | <span class="s">'snapshot-failed'</span>         <span class="c">// pty.snapshotAt 重试后仍失败</span>
-  | <span class="s">'host-zero-size'</span>           <span class="c">// rAF 已 settle,slot 仍为 0×0 —— 布局未给空间</span>
-  | <span class="s">'stream-disconnected'</span>;    <span class="c">// chunk 通道静默,但未收到 exit 事件</span>
-
-<span class="c">// 可见性在 shell 之外 —— 正交轴:</span>
-<span class="k">type</span> <span class="t">SlotState</span> =
-  | { kind: <span class="s">'empty'</span> }
-  | { kind: <span class="s">'mounting'</span>; sid: string }       <span class="c">// 已 reparent,display:'none',跑 Phase 2 串行尾部</span>
-  | { kind: <span class="s">'visible'</span>; sid: string };       <span class="c">// reveal 之后</span>
-</pre>
-  <p style="margin:10px 0 0; font-size:13px; color:var(--ink-2);">
-    把 <code>ShellStatus</code> 和 <code>SlotState</code> 两轴叉乘,所有可能的情况都在表里。当前 attach 路径的大多数 bug 在这个模型里是非法态(比如<i>已经可见但还没 live</i>),新设计让这种态写不出来:<code>mounting → visible</code> 的切换和 <code>display:''</code> 是同一个调用点,而这个点要求 <code>shell.status.kind === 'live'</code>,编译器/类型系统就拦住了。
-  </p>
-</section>
-
-<!-- ====================== 7. FAILURE PATHS ====================== -->
-<section class="s">
-  <h2>7 · 失败路径</h2>
-  <p class="lede">每种错误都有名字、用户看到什么、怎么恢复。</p>
-  <table class="f">
-    <thead>
-      <tr><th>失败</th><th>用户看到什么</th><th>恢复</th></tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td class="what">F1 · open-failed</td>
-        <td class="user">Slot 保持空;xterm 画布位置换成内联错误卡:<i>"无法为该会话启动 Claude。[重试] [查看日志]"</i>。侧边栏行带小错误标点。</td>
-        <td>重试按钮再调一次 <code>pty.open</code>;第三次失败时弹出 claude-missing 指引(沿用现有 UI)。</td>
-      </tr>
-      <tr>
-        <td class="what">F2 · snapshot-failed</td>
-        <td class="user">如果 shell 从未写过 snapshot:同 F1 的错误卡。如果 shell 已经 live、这次是补一次 snapshot(罕见,比如 chunk 丢了):UI 不变,继续用当前 buffer,弹一个非阻塞 toast 提醒。</td>
-        <td>250ms 后自动重试一次;第二次失败升级成错误卡。</td>
-      </tr>
-      <tr>
-        <td class="what">F3 · host-zero-size</td>
-        <td class="user">Slot 停在 <code>mounting</code>,显示一个淡 spinner(通常 &lt;200ms)。超过 2s:错误卡 <i>"终端区域没有空间 —— 试着调整窗口大小。"</i></td>
-        <td>每次 slot 的 ResizeObserver tick 都重排 rAF;一拿到非零尺寸,从 B3 继续走 Phase 2。</td>
-      </tr>
-      <tr>
-        <td class="what">F4 · stream-disconnected</td>
-        <td class="user">终端顶部横幅:<i>"实时更新已暂停 —— 重连中…"</i>。已有 scrollback 仍可读;输入禁用。</td>
-        <td>再调 <code>pty.open</code> 重新订阅;若 seq 跳跃,调 <code>pty.snapshotAt(sid, {sinceSeq})</code> 做增量 snapshot 并应用。</td>
-      </tr>
-      <tr>
-        <td class="what">F5 · exited</td>
-        <td class="user">终端只读;光标变灰;侧边栏 agent 状态变 exited。底部 chip 显示退出码,带重启按钮。</td>
-        <td>重启 spawn 一个新 sid(复用 SessionShell 容器,装一个新的 Terminal);已有会话不会静默复活。</td>
-      </tr>
-      <tr>
-        <td class="what">F6 · shell-not-ready</td>
-        <td class="user">边缘情况 —— 用户刚加完 session 立刻点,Phase 0 的 provision 还没跑完。Slot 进入 <code>mounting</code> 显示淡 spinner(典型 &lt;500ms),provision 完成立刻接着走 Phase 2。</td>
-        <td>不用用户操作。如果 provision 本身失败,降级为 F1。</td>
-      </tr>
-    </tbody>
-  </table>
-</section>
-
-<!-- ====================== 8. CONTRAST ====================== -->
-<section class="s">
-  <h2>8 · 与当前 19 步路径的对比</h2>
-  <p class="lede">不是 diff,是结构对比。两栏,一句话一条。</p>
-
-  <div class="cmp">
-    <div class="col old">
-      <h4>当前</h4>
-      <ul>
-        <li>19 个串行步骤,数据、DOM、布局、顺序全混在一起。</li>
-        <li>Terminal 生命周期和 attach 绑死:cold 和 warm 走两条代码路径。</li>
-        <li>有个 buffering-listener 模式专门缓冲 attach 之前的 chunk。</li>
-        <li>调了两次 <code>scrollToBottom</code>(L479 + L551),因为第一次太早。</li>
-        <li>fit 在 attach 之后才做,SIGWINCH 回显追在第一次钉位后面(QP-3)。</li>
-        <li>live-tail 写入是 fire-and-forget(QP-1)—— 最严重的 bug。</li>
-        <li><code>term.open</code> 在过期或零尺寸布局里跑(QP-2),CanvasAddon atlas 当着用户面预热(QP-4)。</li>
-      </ul>
-    </div>
-    <div class="col new">
-      <h4>重设计</h4>
-      <ul>
-        <li>5 个阶段,只有 Phase 2 内部有顺序,而且就是 "三 lane 并行 + 一次汇合"。</li>
-        <li>Terminal 只建一次、关 ccsm 才 dispose。切 sid 完全不动 xterm。</li>
-        <li>没有 buffering 模式,因为 chunk 永远流进一个已存在的 Terminal。</li>
-        <li>只有一次钉位:S3,drain 完之后、reveal 之前。</li>
-        <li>Fit 排在任何 resize 协商之前(B3 → S1),SIGWINCH 回显被 S2 的 drain 顺手吃掉。</li>
-        <li>所有写入都 await,S2 的 drain 是结构性的,不是补丁。</li>
-        <li><code>term.open</code> 在 rAF + 非零尺寸断言之后才跑,reveal 是最后一步,atlas 预热永远在用户看不到的地方。</li>
-      </ul>
-    </div>
-  </div>
-
-  <h3 class="sub">新架构里压根不会发生的 race</h3>
-  <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li><b>QP-1(live tail vs 钉位):</b>没有 fire-and-forget tail,S2 显式 drain,S2 和 S3 之间不写任何东西。</li>
-    <li><b>QP-2(stale-dim open):</b><code>term.open</code> 只在容器有真实尺寸时跑(P0 offscreen 容器有固定尺寸,B2 rAF 保护可见路径)。</li>
-    <li><b>QP-3(fit-after-attach SIGWINCH 回显):</b>fit 在 <code>pty.resize</code> 之前算好,resize 的回响被 S2 吃掉。</li>
-    <li><b>QP-4(用户能看见 atlas 预热):</b>atlas 在 Phase 0 就预热完了 —— 那时容器在 offscreen,用户根本看不见。</li>
-    <li><b>StrictMode 双 mount(QP-5):</b>provision 以 sid 为 key 幂等,effect 重跑就是 no-op。</li>
-  </ul>
-
-  <h3 class="sub">可以删掉的代码</h3>
-  <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li><span class="kill"><code>src/terminal/usePtyAttach.warm.ts</code></span> —— 19 步过程,被一个只翻 <code>SlotState</code> 的小 hook <code>useVisibleShell(sid)</code> 取代。</li>
-    <li><span class="kill"><code>xtermWarmRegistry.ts::ensureAndShowEntry / applySnapshot / pinViewportToBottom</code></span> —— 折成 <code>shellRegistry</code>,只暴露 <code>provision/close/getSnapshot</code>。</li>
-    <li><span class="kill">"buffering" listener 模式</span> —— 数据面解耦之后没人需要它了。</li>
-    <li><span class="kill"><code>pty:attach</code> 和 <code>pty:detach</code> IPC 通道</span> —— 由 <code>pty.open</code> / <code>pty.close</code> 取代,per-window 的流是隐式的。</li>
-    <li><span class="kill">snapshot 前的防御性 <code>term.reset()</code></span> —— shell registry 保证 terminal 要么是新的、要么已 live,reset 没人调。</li>
-  </ul>
 </section>
 
 <footer>
-  配套文档。当前实现的标注时间线在 <code>docs/attach-timeline-review.html</code>,作为历史档案保留 —— 别去改。本文件是 "如果今天从头来" 的对照提案。
+  配套文档。当前实现的标注时间线在 <code>docs/attach-timeline-review.html</code>,作为历史档案保留 —— 别去改。本文件描述目标 UX 模型,实现细节由后续 plan/PR 落地。
 </footer>
 
 </div>

--- a/docs/attach-redesign.html
+++ b/docs/attach-redesign.html
@@ -125,34 +125,34 @@
 
 <header class="head">
   <h1>Attach 重新设计 —— 从零开始</h1>
-  <div class="sub">如果今天从头写 ccsm 的 attach 路径,它会是什么样?抛掉当前 19 步流程,以及打在上面的补丁。只谈设计。</div>
+  <div class="sub">如果今天从头写 ccsm 的 attach,会长成什么样。当前 19 步流程和上面的补丁全不看,只谈设计。</div>
   <div class="meta">范围:pty attach + xterm mount + 侧边栏耦合 · 配套文档 docs/attach-timeline-review.html(历史)</div>
 </header>
 
 <!-- ====================== 1. PRINCIPLES ====================== -->
 <section class="s">
   <h2>1 · 设计原则</h2>
-  <p class="lede">后面每个决策都要回答的五条原则。</p>
+  <p class="lede">五条原则,后面所有决策都要回答它们。</p>
   <div class="principles">
     <div class="princ"><div class="n">P1</div><div>
       <b>第一帧 = 最终帧。</b>
-      <div class="body"><code>display:''</code> 之前,用户什么都感知不到。之后,用户必须看到一张完成的画面:滚到正确的行、atlas 已预热、尺寸为最终值。mount 到 reveal 之间步骤数无所谓;切线在哪才是关键。</div>
+      <div class="body">用户看到画面的那一瞬间,画面就得是最终态:滚到对的行、字体已渲染好、尺寸已就位。当前问题是用户能看见 "空白 → 内容 → 跳一下" 的过程。新设计把所有准备工作藏在 <code>display:'none'</code> 后面,翻成 <code>display:''</code> 就是结果。</div>
     </div></div>
     <div class="princ"><div class="n">P2</div><div>
-      <b>Terminal 是 per-sid 的长寿对象,不是 per-attach 的临时产物。</b>
-      <div class="body">分配、<code>term.open</code>、addon 加载、atlas 预热、live 数据订阅,都在我们第一次有理由关心某个 sid 时发生(例如它进了侧边栏)。"Attach" 退化为<i>让其中之一可见</i>。切换会话从不 dispose 或重新 open xterm。</div>
+      <b>Terminal 是 per-sid 的长寿对象,不是 attach 的副产物。</b>
+      <div class="body">xterm 实例、addon、字体预热、PTY 数据订阅 —— 都在我们第一次关心这个 sid 时一次性建好,之后一直留着。当前 "切会话就重新走一遍" 的代价直接消失。"Attach" 退化成 "把已经准备好的东西显示出来"。</div>
     </div></div>
     <div class="princ"><div class="n">P3</div><div>
-      <b>数据订阅独立于可见性。</b>
-      <div class="body">per-sid chunk 从 spawn/restore 到 dispose 持续流入 per-sid Terminal。不存在围绕 attach 切换的 "buffering listener" 模式 —— listener 永远是 Terminal 自己。可见性纯粹是 DOM 层的事。</div>
+      <b>数据订阅与可见性无关。</b>
+      <div class="body">PTY chunk 从进程启动到结束一直流进对应的 Terminal,不管它是否在屏幕上。当前为了等 attach 才订阅,中间有个 "buffering listener" 模式做缓冲 —— 这个中间层在新设计里直接没有,因为消费者永远在线。</div>
     </div></div>
     <div class="princ"><div class="n">P4</div><div>
-      <b>侧边栏跑在自己的数据面上。</b>
-      <div class="body">侧边栏状态(agent 状态、标题、徽标、归档标志)来自 <code>session:state</code> / <code>session:title</code> —— 本就独立于 PTY chunk。重设计延续这一点;任何地方都不再解析 PTY 输出做最后一行预览。</div>
+      <b>侧边栏走自己的数据通道。</b>
+      <div class="body">侧边栏要的是 agent 状态、标题、徽标,这些早就由 <code>session:state</code> / <code>session:title</code> 单独推送。它和 PTY chunk 没关系,新设计继续保持这种解耦,绝不去解析 PTY 输出做侧边栏预览。</div>
     </div></div>
     <div class="princ"><div class="n">P5</div><div>
-      <b>能并行就并行。一次 barrier。然后串行。然后 reveal。</b>
-      <div class="body">互相独立的工作(snapshot 拉取、布局 commit、addon 预热)在不可见空间内并发跑。一次 <code>await Promise.all</code> 汇合。串行尾部只做真正有顺序约束的事(写 snapshot → drain live tail → 钉住 viewport)。Reveal 是最后一条指令。</div>
+      <b>能并行就并行,一次汇合,然后串行,最后 reveal。</b>
+      <div class="body">独立的事情(拉 snapshot、做布局、算 viewport)同时跑,用一次 <code>await Promise.all</code> 等齐。真正有顺序要求的(写 snapshot → drain → 钉位)再串行。Reveal 是整个流程的最后一条指令。</div>
     </div></div>
   </div>
 </section>
@@ -160,45 +160,45 @@
 <!-- ====================== 2. HIGH-LEVEL PHASES ====================== -->
 <section class="s">
   <h2>2 · 总体架构</h2>
-  <p class="lede">五个阶段。从左往右读。</p>
+  <p class="lede">五个阶段,从左到右。前两个阶段在用户点会话之前就已经在跑。</p>
   <div class="phases">
     <div class="phase">
       <div class="ph">Phase 0</div>
-      <b>Provision</b>
-      <div class="desc">sid 进入侧边栏时,在 renderer 侧分配一个 <code>SessionShell</code>:offscreen 容器里的 xterm Terminal、addon 已加载、live 流订阅已开启。无用户可见副作用。</div>
+      <b>Provision(lazy)</b>
+      <div class="desc">侧边栏里的 session 行<i>进入可视区</i>(IntersectionObserver)才 provision:在 offscreen 容器里建 xterm Terminal、加 addon、订阅 PTY 流。滚出可视区不 dispose,关闭 ccsm 才回收。归档分组里的 session 要<i>展开 + 进入可视区</i>才 provision —— 几百条归档不会一起吃内存。</div>
     </div>
     <div class="phase live">
       <div class="ph">Phase 1</div>
       <b>持续 stream</b>
-      <div class="desc">PTY chunk 持续落入 per-sid Terminal。侧边栏独立接收 <code>session:state</code>。两条线永远在跑,与当前激活的是哪个 sid 无关。</div>
+      <div class="desc">已 provision 的 sid,PTY chunk 持续流进它的 Terminal,直到进程退出。侧边栏状态走另一条通道。谁在前台无所谓。</div>
     </div>
     <div class="phase">
       <div class="ph">Phase 2</div>
       <b>准备可见</b>
-      <div class="desc">用户选中某个 sid。并行:把 SessionShell reparent 到可见宿主(仍 <code>display:'none'</code>)、commit 布局、按真实尺寸 fit、恢复上次 viewport(warm)或贴底(cold)。</div>
+      <div class="desc">用户点了某个 sid。并行做三件事:把 SessionShell reparent 到可见容器(仍 <code>display:'none'</code>)、commit 布局拿到真实尺寸、算好 viewport 要停在哪。</div>
     </div>
     <div class="phase reveal">
       <div class="ph">Phase 3</div>
       <b>Reveal</b>
-      <div class="desc">一条赋值:<code>display:''</code>。viewport、atlas、尺寸、内容 —— 都已为最终态。<i>这是用户看到的唯一一帧。</i></div>
+      <div class="desc">一条赋值:<code>display:''</code>。viewport、字体、尺寸、内容全是最终态。<i>用户看到的就是这一帧。</i></div>
     </div>
     <div class="phase">
       <div class="ph">Phase 4</div>
       <b>Reveal 之后</b>
-      <div class="desc">接通输入路由(在 Terminal 层早已接好,只翻一个路由标志)、focus、在 store 标记 active、安装/刷新 ResizeObserver 基线。</div>
+      <div class="desc">把输入路由切到这个 sid、focus、装 ResizeObserver 基线。顺序无所谓,因为用户已经看到结果。</div>
     </div>
   </div>
 
-  <h3 class="sub">为什么是这个形状</h3>
+  <h3 class="sub">为什么这么分</h3>
   <p style="margin:0; font-size:13px; color:var(--ink-2);">
-    当前路径把四件正交的事 —— Terminal 生命周期、数据订阅、布局、可见性 —— 揉成一个叫 "attach" 的大过程。把它们解耦,所有重活都从点击路径中移走。等用户点会话时,字节已经流了几秒;"attach" 退化为 "show"。
+    当前 attach 把四件事 —— 建 Terminal、订阅数据、做布局、改可见性 —— 揉成一个大过程,所以又慢又容易出 bug。把它们拆开做,重活在用户点之前就跑完了。等用户点会话,字节其实已经流进 Terminal 几秒,所谓的 "attach" 就只剩 "把这个 Terminal 显示出来" 而已。
   </p>
 </section>
 
 <!-- ====================== 3. PARALLEL FLOW ====================== -->
 <section class="s">
   <h2>3 · Phase 2 内部的并行流</h2>
-  <p class="lede">仍在 <code>display:'none'</code> 时可以并发跑什么、什么必须串行、reveal 落在何处。</p>
+  <p class="lede">用户点会话后到 reveal 之前发生的事。仍 <code>display:'none'</code>,所以做多少步用户都看不到。</p>
 
   <div class="flow">
 
@@ -257,43 +257,43 @@
 
   <h3 class="sub">依赖说明</h3>
   <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li>A 与 B/C 独立。A 可以在 B reparent 之前完成 —— 写入会进入一个尚未上屏的 Terminal,没问题(Phase 1 / P3)。</li>
-    <li>B2(rAF)是唯一 DOM 时序 barrier。便宜、可预测:至多一帧,通常 &lt;16ms。</li>
-    <li>C 是纯计算。独立成一条 lane,是为了把 warm/cold 决策作为 S3 的显式数据输入,而非藏在 S3 里的分支泥潭。</li>
+    <li>A 和 B、C 互不依赖。A 可以在 B reparent 之前就写完 —— 写入进一个还没上屏的 Terminal,完全没问题。</li>
+    <li>B2(rAF)是唯一一处要等 DOM 的地方。便宜、可预测,通常一帧就够,&lt;16ms。</li>
+    <li>C 是纯计算,单独成一条 lane 是为了让 warm/cold 的决策作为 S3 的明确输入,而不是塞在 S3 里一堆 if/else。</li>
   </ul>
 </section>
 
 <!-- ====================== 4. FIRST-FRAME SCENARIOS ====================== -->
 <section class="s">
   <h2>4 · 各场景下的第一帧保证</h2>
-  <p class="lede">从用户视角看只存在两种场景。各自看到什么,以及保证它成立的不变量。</p>
+  <p class="lede">从用户角度只有两种情况:第一次点开有历史的会话,或者切回之前看过的会话。下面是各自看到什么、为什么不会出问题。</p>
   <div class="two">
 
     <div class="scen">
-      <h4>场景 A —— cold + resume<span class="tag">有历史的会话首次 attach</span></h4>
+      <h4>场景 A —— cold + resume<span class="tag">第一次 attach 有历史的会话</span></h4>
       <div class="frame">
-        <b>第一帧:</b>最终尺寸的完整 xterm 画布,scrollback 渲染到 resume snapshot 的最后一行,滚动条贴底,光标停在 CLI 离开的位置。无空帧、无向上漂移、无延迟 snap。
+        <b>第一帧:</b>完整的 xterm 画布、尺寸最终、scrollback 已渲染到 snapshot 最后一行、滚动条贴底、光标停在 CLI 离开的位置。不会出现空帧、向上漂、迟到的 snap。
       </div>
       <ul>
-        <li><b>怎么做到:</b>snapshot 写入(A1–A2)和 live-tail drain(A3、S2)都在 reveal <i>之前</i>完成。Viewport 目标在 C 计算(贴底),在 S3 一次性应用。Reveal 在 S3 之后。</li>
-        <li><b>为何无 race:</b>没有 fire-and-forget 的写。S2 的单点 drain barrier 是 reveal 前 parser 队列可能非空的唯一位置,我们显式 await 它。</li>
+        <li><b>怎么做到的:</b>snapshot 写入(A1–A2)和 live tail drain(A3、S2)都在 reveal 之前完成。Viewport 位置在 C 算好,在 S3 一次性 scroll 到位。Reveal 排在 S3 后面。</li>
+        <li><b>为什么不会 race:</b>没有 fire-and-forget 的写。S2 是唯一可能有 pending 写的位置,这里我们 await 它。</li>
       </ul>
       <div class="inv">
-        <b>不变量:</b><code>display:''</code> 那一刻,<code>term.buffer.baseY === lastWrittenBaseY</code> 且 <code>ydisp === baseY</code>。两者由 S2(无 pending 写入)和 S3(恰好一次钉位)共同保证。
+        <b>不变量:</b><code>display:''</code> 那一刻,<code>term.buffer.baseY === lastWrittenBaseY</code> 且 <code>ydisp === baseY</code>。前者来自 S2(无 pending 写入),后者来自 S3(恰好一次钉位)。
       </div>
     </div>
 
     <div class="scen">
-      <h4>场景 B —— warm 切换<span class="tag">之前 attach 过,切回</span></h4>
+      <h4>场景 B —— warm 切换<span class="tag">之前 attach 过,再切回来</span></h4>
       <div class="frame">
-        <b>第一帧:</b>用户离开时的精确 viewport 位置,包括 scrollback 中间位置。滚动条对齐。脱离期间到达的新 chunk 在 viewport 下方的 scrollback 中(不会被自动滚到)。
+        <b>第一帧:</b>用户离开时的 viewport 位置,包括停在 scrollback 中间。滚动条对齐。脱离期间新到的 chunk 在 viewport 下方,不会自动滚到。
       </div>
       <ul>
-        <li><b>怎么做到:</b>SessionShell 从未被 dispose(P2)。Lane A 是 no-op —— chunk 一直流入这个 Terminal。Lane C 读取已持久化的 <code>lastViewportY</code>(每次失去可见性时记下)。S3 调 <code>scrollToLine(targetY)</code>。</li>
-        <li><b>Reparent 考虑:</b>reparent(B1)不会重置 xterm 内部状态。仍走 rAF(B2)gate,以防宿主之间宽度变化。</li>
+        <li><b>怎么做到的:</b>SessionShell 一直没 dispose(P2)。Lane A 完全是 no-op —— chunk 一直在流。Lane C 读上次离开时记的 <code>lastViewportY</code>。S3 调一次 <code>scrollToLine(targetY)</code>。</li>
+        <li><b>关于 reparent:</b>reparent(B1)不会动 xterm 内部状态。仍然走 rAF(B2),防止换宿主后宽度变了。</li>
       </ul>
       <div class="inv">
-        <b>不变量:</b>sid X 的 renderer 状态在 deactivate 之前与 reactivate 之后相同,除了 <code>baseY</code> 可能因 live chunk 前进过(这是正确的 —— 它们应在 buffer 里,只是不拉动 viewport)。
+        <b>不变量:</b>同一个 sid,deactivate 前和 reactivate 后 renderer 状态一致,只有 <code>baseY</code> 可能因为 live chunk 往前涨过 —— 这是对的,新数据应在 buffer 里,只是不应拽动 viewport。
       </div>
     </div>
 
@@ -303,32 +303,35 @@
 <!-- ====================== 5. IPC CONTRACT ====================== -->
 <section class="s">
   <h2>5 · IPC 契约提案</h2>
-  <p class="lede">主进程 ↔ renderer 接口面。比现在更小、更显式。</p>
+  <p class="lede">主进程和 renderer 之间的接口。比现在更少、更明确。</p>
 
 <pre><span class="c">// ─── main → renderer 广播 ───────────────────────────────────────────────</span>
 
-<span class="c">// 单一通道,per-sid 流。从 spawn 到 dispose 都在 emit。renderer 以</span>
-<span class="c">// Terminal 作为该 sid 的唯一消费者;主进程不按 "viewer count" gate</span>
-<span class="c">// emit。这正是杀掉 buffering-mode 把戏的关键:消费者永远在线。</span>
+<span class="c">// 单一通道,per-sid 一条流。从进程启动 emit 到 dispose。</span>
+<span class="c">// renderer 让对应的 Terminal 当唯一消费者;主进程不根据 "有没有人在看"</span>
+<span class="c">// 来 gate emit。正因如此,buffering-mode 那一套缓冲层就没必要了 —— </span>
+<span class="c">// 消费者永远在。</span>
 <span class="k">channel</span> <span class="s">'pty:chunk'</span>: { sid: string; seq: number; data: <span class="t">Uint8Array</span> }
 
-<span class="c">// 生命周期。与 chunk 分开,消费者无需解析 chunk。</span>
+<span class="c">// 生命周期。和 chunk 分开,消费者不用解析 chunk 去判断进程是否退出。</span>
 <span class="k">channel</span> <span class="s">'pty:exit'</span>: { sid: string; code: number | null; signal: string | null }
 
-<span class="c">// 侧边栏数据面。与现状一致,此处列出以求完整。</span>
+<span class="c">// 侧边栏自己的数据通道,和现状一致,这里列出来求完整。</span>
 <span class="k">channel</span> <span class="s">'session:state'</span>: { sid: string; state: SessionState }
 <span class="k">channel</span> <span class="s">'session:title'</span>: { sid: string; title: string }
 
 <span class="c">// ─── renderer → main RPC ────────────────────────────────────────────────</span>
 
-<span class="c">// 打开一个 SessionShell。幂等。每个进入侧边栏的 sid 调用一次;</span>
-<span class="c">// renderer 视其为 "开始 stream 给我"。返回 renderer 应视为 live floor</span>
-<span class="c">// 的 seq 游标。</span>
+<span class="c">// 打开 SessionShell。幂等。何时调:</span>
+<span class="c">//   • 普通 session 行进入侧边栏可视区(IntersectionObserver 触发)</span>
+<span class="c">//   • 归档分组被展开 且 行进入可视区</span>
+<span class="c">// 不调:行滚出可视区(保留 shell)、关闭归档分组(保留 shell)。</span>
+<span class="c">// 退出时 close。返回 renderer 应视作 live 起点的 seq 游标。</span>
 <span class="k">rpc</span> <span class="t">pty.open</span>(sid): Promise&lt;{ pid: number; cols: number; rows: number; seq: number }&gt;
 
 <span class="c">// 一次性历史 snapshot。返回的 snapshot 覆盖到 `seq`(不含)之前的全部</span>
-<span class="c">// 内容。renderer 写入 snapshot,再播放 seq &gt;= returned.seq 的 chunk。</span>
-<span class="c">// 替代 'buffering listener' 这一层间接。</span>
+<span class="c">// 内容。renderer 先写 snapshot,再播放 seq &gt;= returned.seq 的 chunk。</span>
+<span class="c">// 替代 'buffering listener' 那层间接。</span>
 <span class="k">rpc</span> <span class="t">pty.snapshotAt</span>(sid, opts?: { sinceSeq?: number }): Promise&lt;{
   snapshot: <span class="t">Uint8Array</span>;
   seq: number;     <span class="c">// `snapshot` 覆盖的上界(不含)</span>
@@ -336,37 +339,37 @@
   rows: number;
 }&gt;
 
-<span class="c">// Resize 是 hint;若 cols/rows 与当前一致,主进程返回但不 emit SIGWINCH。</span>
-<span class="c">// 每次 fit() 后无副作用地调用都是安全的。</span>
+<span class="c">// Resize 是 hint;若 cols/rows 和当前一致,主进程返回但不 emit SIGWINCH。</span>
+<span class="c">// 所以每次 fit() 后无脑调一下都安全。</span>
 <span class="k">rpc</span> <span class="t">pty.resize</span>(sid, cols, rows): Promise&lt;{ applied: boolean }&gt;
 
 <span class="c">// 输入是 fire-and-forget,per-sid 有序。</span>
 <span class="k">channel</span> <span class="s">'pty:input'</span>: { sid: string; data: string }   <span class="c">// renderer → main,单向</span>
 
-<span class="c">// 丢弃该 SessionShell。主进程可能保留 PTY 存活(其他窗口 / 后台),</span>
-<span class="c">// 但停止向本窗口 emit 该 sid 的 chunk。</span>
+<span class="c">// 丢掉 SessionShell。主进程可能让 PTY 继续活着(给其他窗口或后台),</span>
+<span class="c">// 但不再向本窗口 emit 该 sid 的 chunk。</span>
 <span class="k">rpc</span> <span class="t">pty.close</span>(sid): Promise&lt;void&gt;
 
-<span class="c">// ─── 我们刻意不提供的东西 ───────────────────────────────────────────────</span>
-<span class="c">// • 没有 pty.attach / pty.detach。订阅隐含在 pty.open 里。</span>
-<span class="c">// • 没有 getBufferSnapshot/attach 拆分。由 pty.snapshotAt 替代,</span>
-<span class="c">//   可在任意时刻调用,返回自洽的 {snapshot, seq}。</span>
+<span class="c">// ─── 故意不要的东西 ─────────────────────────────────────────────────────</span>
+<span class="c">// • 没有 pty.attach / pty.detach。订阅就藏在 pty.open 里。</span>
+<span class="c">// • 没有 getBufferSnapshot/attach 拆分。换成 pty.snapshotAt,</span>
+<span class="c">//   任何时候调都行,返回自洽的 {snapshot, seq}。</span>
 <span class="c">// • 没有侧边栏预览通道。侧边栏只读 agent 状态。</span>
 </pre>
 
-  <h3 class="sub">为何是这些形状</h3>
+  <h3 class="sub">为什么是这些形状</h3>
   <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li><b><code>pty.open</code> 而非 <code>pty.attach</code></b> —— "open" 更贴合事实:renderer 承诺消费该 sid 的流直到 <code>pty.close</code>。窗口生命周期内不存在瞬态 attach/detach;切换 sid 不触及主进程。</li>
-    <li><b>chunk 携带 <code>seq</code></b> —— 让 snapshot/live 拼接天然正确(丢弃 <code>seq &lt; snapshotSeq</code> 的 chunk,其余写入)。无时间戳竞争,无 "是否漏了"。</li>
-    <li><b><code>pty.snapshotAt</code> 与 open 解耦</b> —— renderer 可以懒调(首次真正需要渲染历史时)或主动调,IPC 形状一致。避免 "attach 即 snapshot" 的捆绑锁死顺序。</li>
-    <li><b><code>resize.applied</code> 返回值</b> —— 让 renderer 跳过 "SIGWINCH 是否触发了" 的猜测;主进程是事实源。</li>
+    <li><b>叫 <code>pty.open</code> 不叫 <code>pty.attach</code></b> —— "open" 才符合事实:renderer 承诺一直消费到 <code>pty.close</code>。窗口生命周期里不会有反复 attach/detach,切 sid 完全不打扰主进程。</li>
+    <li><b>chunk 自带 <code>seq</code></b> —— snapshot 和 live 拼接天然对得上(<code>seq &lt; snapshotSeq</code> 的丢掉,其余写)。不靠时间戳,不用问 "我有没有漏接"。</li>
+    <li><b><code>pty.snapshotAt</code> 和 open 分开</b> —— renderer 想懒拉就懒拉(真要渲染历史时再调),想立刻拉也行,IPC 一样。不再绑死 "一 attach 就 snapshot"。</li>
+    <li><b><code>resize.applied</code> 有返回值</b> —— renderer 不用猜 SIGWINCH 有没有发出来,主进程说了算。</li>
   </ul>
 </section>
 
 <!-- ====================== 6. STATE MACHINE ====================== -->
 <section class="s">
   <h2>6 · 每个 SessionShell 的 renderer 状态</h2>
-  <p class="lede">Discriminated union;转移是唯一可能出错的地方,所以显式列出。</p>
+  <p class="lede">用 discriminated union 表达。状态本身不容易出错,出错的都是状态转移,所以把它们写明。</p>
 
 <pre><span class="k">type</span> <span class="t">SessionShell</span> = {
   sid: string;
@@ -397,14 +400,14 @@
   | { kind: <span class="s">'visible'</span>; sid: string };       <span class="c">// reveal 之后</span>
 </pre>
   <p style="margin:10px 0 0; font-size:13px; color:var(--ink-2);">
-    <code>ShellStatus × SlotState</code> 的笛卡尔积穷尽了所有情况。当前 attach 路径的多数 bug 在这个模型里都是非法态(例如<i>已可见但还没 live</i>),重设计让它们无法表达:<code>mounting → visible</code> 的 slot 转移与 <code>display:''</code> 是同一个调用点,而该调用点要求 <code>shell.status.kind === 'live'</code>。
+    把 <code>ShellStatus</code> 和 <code>SlotState</code> 两轴叉乘,所有可能的情况都在表里。当前 attach 路径的大多数 bug 在这个模型里是非法态(比如<i>已经可见但还没 live</i>),新设计让这种态写不出来:<code>mounting → visible</code> 的切换和 <code>display:''</code> 是同一个调用点,而这个点要求 <code>shell.status.kind === 'live'</code>,编译器/类型系统就拦住了。
   </p>
 </section>
 
 <!-- ====================== 7. FAILURE PATHS ====================== -->
 <section class="s">
   <h2>7 · 失败路径</h2>
-  <p class="lede">每个错误都有名字、用户可见表现、恢复方式。</p>
+  <p class="lede">每种错误都有名字、用户看到什么、怎么恢复。</p>
   <table class="f">
     <thead>
       <tr><th>失败</th><th>用户看到什么</th><th>恢复</th></tr>
@@ -412,28 +415,33 @@
     <tbody>
       <tr>
         <td class="what">F1 · open-failed</td>
-        <td class="user">Slot 保持空;内联错误卡替代 xterm 画布:<i>"无法为该会话启动 Claude。[重试] [查看日志]"</i>。侧边栏行带小错误标点。</td>
-        <td>重试按钮再次调 <code>pty.open</code>;第三次失败时弹出 claude-missing 指引(沿用现有 UI)。</td>
+        <td class="user">Slot 保持空;xterm 画布位置换成内联错误卡:<i>"无法为该会话启动 Claude。[重试] [查看日志]"</i>。侧边栏行带小错误标点。</td>
+        <td>重试按钮再调一次 <code>pty.open</code>;第三次失败时弹出 claude-missing 指引(沿用现有 UI)。</td>
       </tr>
       <tr>
         <td class="what">F2 · snapshot-failed</td>
-        <td class="user">若 shell 从未写过 snapshot:同 F1 的内联错误卡。若 shell 已 live、这次是重新 snapshot(罕见,如 chunk 丢失之后):无 UI 变化 —— 继续沿用当前 buffer,toast 非阻塞警告。</td>
-        <td>250ms 后自动重试一次;第二次失败升级为错误卡。</td>
+        <td class="user">如果 shell 从未写过 snapshot:同 F1 的错误卡。如果 shell 已经 live、这次是补一次 snapshot(罕见,比如 chunk 丢了):UI 不变,继续用当前 buffer,弹一个非阻塞 toast 提醒。</td>
+        <td>250ms 后自动重试一次;第二次失败升级成错误卡。</td>
       </tr>
       <tr>
         <td class="what">F3 · host-zero-size</td>
-        <td class="user">Slot 停留在 <code>mounting</code> 并显示淡 spinner(通常 &lt;200ms)。若超过 2s:错误卡 <i>"终端区域无空间 —— 试试调整窗口大小。"</i></td>
-        <td>每次 slot 的 ResizeObserver tick 都重排 rAF。一旦拿到非零尺寸,从 B3 恢复 Phase 2。</td>
+        <td class="user">Slot 停在 <code>mounting</code>,显示一个淡 spinner(通常 &lt;200ms)。超过 2s:错误卡 <i>"终端区域没有空间 —— 试着调整窗口大小。"</i></td>
+        <td>每次 slot 的 ResizeObserver tick 都重排 rAF;一拿到非零尺寸,从 B3 继续走 Phase 2。</td>
       </tr>
       <tr>
         <td class="what">F4 · stream-disconnected</td>
         <td class="user">终端顶部横幅:<i>"实时更新已暂停 —— 重连中…"</i>。已有 scrollback 仍可读;输入禁用。</td>
-        <td>通过 <code>pty.open</code> 重新订阅;若 seq 跳跃,调 <code>pty.snapshotAt(sid, {sinceSeq})</code> 做增量 snapshot 并应用。</td>
+        <td>再调 <code>pty.open</code> 重新订阅;若 seq 跳跃,调 <code>pty.snapshotAt(sid, {sinceSeq})</code> 做增量 snapshot 并应用。</td>
       </tr>
       <tr>
         <td class="what">F5 · exited</td>
-        <td class="user">终端转只读;光标变灰;侧边栏 agent 状态变为 exited。底部 chip 显示退出码,带重启按钮。</td>
-        <td>重启 spawn 一个新 sid(复用 SessionShell 容器,搭配新的 Terminal);已有会话不会静默复活。</td>
+        <td class="user">终端只读;光标变灰;侧边栏 agent 状态变 exited。底部 chip 显示退出码,带重启按钮。</td>
+        <td>重启 spawn 一个新 sid(复用 SessionShell 容器,装一个新的 Terminal);已有会话不会静默复活。</td>
+      </tr>
+      <tr>
+        <td class="what">F6 · shell-not-ready</td>
+        <td class="user">边缘情况 —— 用户刚加完 session 立刻点,Phase 0 的 provision 还没跑完。Slot 进入 <code>mounting</code> 显示淡 spinner(典型 &lt;500ms),provision 完成立刻接着走 Phase 2。</td>
+        <td>不用用户操作。如果 provision 本身失败,降级为 F1。</td>
       </tr>
     </tbody>
   </table>
@@ -442,56 +450,56 @@
 <!-- ====================== 8. CONTRAST ====================== -->
 <section class="s">
   <h2>8 · 与当前 19 步路径的对比</h2>
-  <p class="lede">不是 diff,是结构性对比。</p>
+  <p class="lede">不是 diff,是结构对比。两栏,一句话一条。</p>
 
   <div class="cmp">
     <div class="col old">
       <h4>当前</h4>
       <ul>
-        <li><b>19 个串行步骤</b>分布在 <code>usePtyAttach.warm.ts</code> + <code>xtermWarmRegistry.ts</code>,数据、DOM、布局、顺序决策混在一起。</li>
-        <li><b>Terminal 生命周期绑死 attach:</b>cold 走 <code>allocEntry</code>,warm 走 <code>display</code> toggle —— 两条不同代码路径。</li>
-        <li><b>buffering-listener 模式</b>用来弥合订阅与可渲染之间的空档。它是正确的,但本质是更深层耦合的 workaround。</li>
-        <li><b>两次 <code>scrollToBottom</code></b>(L479 + L551),因为第一次结构上太早。</li>
-        <li><b>fit 在 attach 之后发生</b>,导致 SIGWINCH 回显出现在第一次钉位之后(QP-3)。</li>
-        <li><b>live-tail 写入是 fire-and-forget</b>(QP-1)—— 最高优先级的 bug。</li>
-        <li><b><code>term.open</code> 在过期或零尺寸布局中执行</b>(QP-2),CanvasAddon atlas 在可见状态预热(QP-4)。</li>
+        <li>19 个串行步骤,数据、DOM、布局、顺序全混在一起。</li>
+        <li>Terminal 生命周期和 attach 绑死:cold 和 warm 走两条代码路径。</li>
+        <li>有个 buffering-listener 模式专门缓冲 attach 之前的 chunk。</li>
+        <li>调了两次 <code>scrollToBottom</code>(L479 + L551),因为第一次太早。</li>
+        <li>fit 在 attach 之后才做,SIGWINCH 回显追在第一次钉位后面(QP-3)。</li>
+        <li>live-tail 写入是 fire-and-forget(QP-1)—— 最严重的 bug。</li>
+        <li><code>term.open</code> 在过期或零尺寸布局里跑(QP-2),CanvasAddon atlas 当着用户面预热(QP-4)。</li>
       </ul>
     </div>
     <div class="col new">
       <h4>重设计</h4>
       <ul>
-        <li><b>5 个阶段</b>,只有 Phase 2 有内部顺序 —— 且这个顺序是三条独立 lane 加一次 barrier。</li>
-        <li><b>单一 Terminal 生命周期</b>:侧边栏 provision 时创建,<code>pty.close</code> 时 dispose。切换 sid 永远不触碰 xterm 内部。</li>
-        <li><b>无 buffering 模式</b>:chunk 永远流向一个已存在的 Terminal。数据面没有 "等候室"。</li>
-        <li><b>一次钉位</b>:S3。在 lane C 算好,drain 后、reveal 前一次应用。</li>
-        <li><b>Fit 在任何 resize 协商之前发生</b>(B3 → S1)。SIGWINCH 回显(若有)被 S2 的 drain 吸收 —— 时间线不需要单独操心。</li>
-        <li><b>所有写入都被 await</b>。S2 的 drain barrier 是结构性的,不是补丁式的 <code>writeAsync('')</code>。</li>
-        <li><b><code>term.open</code> 在 rAF + 非零尺寸断言之后运行</b>。Reveal 是最后一条指令,所以 atlas 预热在结构上不可见。</li>
+        <li>5 个阶段,只有 Phase 2 内部有顺序,而且就是 "三 lane 并行 + 一次汇合"。</li>
+        <li>Terminal 只建一次、关 ccsm 才 dispose。切 sid 完全不动 xterm。</li>
+        <li>没有 buffering 模式,因为 chunk 永远流进一个已存在的 Terminal。</li>
+        <li>只有一次钉位:S3,drain 完之后、reveal 之前。</li>
+        <li>Fit 排在任何 resize 协商之前(B3 → S1),SIGWINCH 回显被 S2 的 drain 顺手吃掉。</li>
+        <li>所有写入都 await,S2 的 drain 是结构性的,不是补丁。</li>
+        <li><code>term.open</code> 在 rAF + 非零尺寸断言之后才跑,reveal 是最后一步,atlas 预热永远在用户看不到的地方。</li>
       </ul>
     </div>
   </div>
 
-  <h3 class="sub">在新架构下不可能发生的 race</h3>
+  <h3 class="sub">新架构里压根不会发生的 race</h3>
   <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li><b>QP-1(live-tail vs 钉位):</b>不存在 fire-and-forget tail。S2 是单点显式 drain;S2 与 S3 之间无任何写入。</li>
-    <li><b>QP-2(stale-dim open):</b><code>term.open</code> 只在容器有 live 尺寸时运行(P0 offscreen 有固定尺寸;B2 rAF 保护可见路径)。</li>
-    <li><b>QP-3(fit-after-attach SIGWINCH 回显):</b>fit 在 <code>pty.resize</code> 之前算好,resize 的响应被 S2 drain。</li>
-    <li><b>QP-4(用户可见窗口内 atlas 预热):</b>atlas 在 provision(Phase 0)即预热 —— 此时 Terminal 首次 <code>open</code> 到带真实尺寸的 offscreen 容器。等任何东西 reveal 时,atlas 已热。</li>
-    <li><b>StrictMode 双 mount(QP-5):</b>shell provisioning 是幂等的(在 renderer registry 中以 sid 为键),所以 effect 重跑就是 no-op,不会重新分配。</li>
+    <li><b>QP-1(live tail vs 钉位):</b>没有 fire-and-forget tail,S2 显式 drain,S2 和 S3 之间不写任何东西。</li>
+    <li><b>QP-2(stale-dim open):</b><code>term.open</code> 只在容器有真实尺寸时跑(P0 offscreen 容器有固定尺寸,B2 rAF 保护可见路径)。</li>
+    <li><b>QP-3(fit-after-attach SIGWINCH 回显):</b>fit 在 <code>pty.resize</code> 之前算好,resize 的回响被 S2 吃掉。</li>
+    <li><b>QP-4(用户能看见 atlas 预热):</b>atlas 在 Phase 0 就预热完了 —— 那时容器在 offscreen,用户根本看不见。</li>
+    <li><b>StrictMode 双 mount(QP-5):</b>provision 以 sid 为 key 幂等,effect 重跑就是 no-op。</li>
   </ul>
 
   <h3 class="sub">可以删掉的代码</h3>
   <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li><span class="kill"><code>src/terminal/usePtyAttach.warm.ts</code></span> —— 19 步过程。由一个小 <code>useVisibleShell(sid)</code> hook 取代,只翻 <code>SlotState</code>。</li>
-    <li><span class="kill"><code>xtermWarmRegistry.ts::ensureAndShowEntry / applySnapshot / pinViewportToBottom</code></span> —— 折叠成 <code>shellRegistry</code>,只暴露 <code>provision/close/getSnapshot</code>。</li>
-    <li><span class="kill">"buffering" listener 模式</span> —— 随数据面解耦一并消失。</li>
-    <li><span class="kill"><code>pty:attach</code> 与 <code>pty:detach</code> IPC 通道</span> —— 由 <code>pty.open</code> / <code>pty.close</code> 取代;per-window 流是隐式的。</li>
-    <li><span class="kill">snapshot 前的防御性 <code>term.reset()</code></span> —— shell registry 保证 terminal 要么全新,要么已 live;reset 无人调用。</li>
+    <li><span class="kill"><code>src/terminal/usePtyAttach.warm.ts</code></span> —— 19 步过程,被一个只翻 <code>SlotState</code> 的小 hook <code>useVisibleShell(sid)</code> 取代。</li>
+    <li><span class="kill"><code>xtermWarmRegistry.ts::ensureAndShowEntry / applySnapshot / pinViewportToBottom</code></span> —— 折成 <code>shellRegistry</code>,只暴露 <code>provision/close/getSnapshot</code>。</li>
+    <li><span class="kill">"buffering" listener 模式</span> —— 数据面解耦之后没人需要它了。</li>
+    <li><span class="kill"><code>pty:attach</code> 和 <code>pty:detach</code> IPC 通道</span> —— 由 <code>pty.open</code> / <code>pty.close</code> 取代,per-window 的流是隐式的。</li>
+    <li><span class="kill">snapshot 前的防御性 <code>term.reset()</code></span> —— shell registry 保证 terminal 要么是新的、要么已 live,reset 没人调。</li>
   </ul>
 </section>
 
 <footer>
-  配套文档。当前实现的标注时间线在 <code>docs/attach-timeline-review.html</code>,作为历史记录保留 —— 不要编辑。本文件是 "如果今天从头来" 的对立提案。
+  配套文档。当前实现的标注时间线在 <code>docs/attach-timeline-review.html</code>,作为历史档案保留 —— 别去改。本文件是 "如果今天从头来" 的对照提案。
 </footer>
 
 </div>

--- a/docs/attach-redesign.html
+++ b/docs/attach-redesign.html
@@ -44,78 +44,6 @@
   code, .mono { font-family: var(--mono); }
   code { background: #f0efec; padding: 1px 5px; border-radius: 4px; font-size: 12.5px; color: var(--ink); }
   pre { background: #fafaf8; border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px; overflow-x: auto; font-family: var(--mono); font-size: 12.5px; line-height: 1.55; margin: 8px 0; color: var(--ink); white-space: pre; }
-  pre .k { color: var(--par); }
-  pre .s { color: var(--ok); }
-  pre .c { color: var(--ink-3); font-style: italic; }
-  pre .t { color: #006b8f; }
-
-  .principles { display: grid; gap: 10px; }
-  .princ { display: grid; grid-template-columns: 28px 1fr; gap: 12px; align-items: start; padding: 10px 12px; border: 1px solid var(--line); border-radius: 8px; background: #fafaf8; }
-  .princ .n { font-family: var(--mono); font-size: 11px; color: var(--ink-3); padding-top: 1px; }
-  .princ b { font-size: 13.5px; }
-  .princ .body { color: var(--ink-2); font-size: 13px; margin-top: 2px; }
-
-  /* phases */
-  .phases { display: grid; grid-template-columns: repeat(5, 1fr); gap: 10px; margin-top: 8px; }
-  @media (max-width: 1100px) { .phases { grid-template-columns: 1fr 1fr; } }
-  .phase { border: 1px solid var(--line); border-radius: 8px; padding: 12px 12px 10px; background: #fff; position: relative; }
-  .phase .ph { font-family: var(--mono); font-size: 10.5px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.06em; }
-  .phase b { display: block; font-size: 13.5px; margin: 4px 0; }
-  .phase .desc { font-size: 12px; color: var(--ink-2); }
-  .phase.live { border-color: #c5e3ce; background: var(--ok-bg); }
-  .phase.reveal { border-color: #cfdbff; background: var(--accent-bg); }
-
-  /* parallel flow */
-  .flow { background: #fafaf8; border: 1px dashed var(--line-2); border-radius: 10px; padding: 16px; }
-  .lanes { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
-  @media (max-width: 1000px) { .lanes { grid-template-columns: 1fr; } }
-  .lane { border: 1.5px dashed #b9a8df; border-radius: 8px; background: #fbf8ff; padding: 10px 12px; }
-  .lane .lh { font-family: var(--mono); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--par); font-weight: 700; margin-bottom: 6px; }
-  .lane .item { font-size: 12.5px; margin: 4px 0; padding-left: 12px; position: relative; color: var(--ink-2); }
-  .lane .item::before { content: "›"; position: absolute; left: 0; color: var(--par); font-weight: 700; }
-  .lane .item b { color: var(--ink); }
-  .arrow { text-align: center; color: #b9a8df; font-size: 18px; line-height: 1; margin: 6px 0; }
-  .barrier { padding: 10px 12px; border: 2px solid var(--ok); background: var(--ok-bg); border-radius: 8px; text-align: center; font-weight: 600; color: #0e4019; font-family: var(--mono); font-size: 13px; }
-  .barrier .sub { display: block; font-weight: 400; font-size: 11.5px; color: var(--ok); margin-top: 3px; font-family: var(--sans); }
-  .serial { border: 1.5px solid #c5e3ce; background: #f4faf6; border-radius: 8px; padding: 10px 12px; }
-  .serial .sh { font-family: var(--mono); font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--ok); font-weight: 700; margin-bottom: 6px; }
-  .serial .item { font-size: 12.5px; margin: 4px 0; padding-left: 12px; position: relative; color: var(--ink-2); }
-  .serial .item::before { content: "→"; position: absolute; left: 0; color: var(--ok); font-weight: 700; }
-  .serial .item b { color: var(--ink); }
-  .reveal { margin-top: 6px; padding: 12px; border: 2px solid var(--accent); background: var(--accent-bg); border-radius: 8px; text-align: center; font-weight: 600; color: #15327a; font-family: var(--mono); font-size: 13.5px; }
-  .reveal .sub { display: block; font-weight: 400; font-size: 11.5px; color: var(--accent); margin-top: 3px; font-family: var(--sans); }
-
-  /* scenario two-up */
-  .two { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
-  @media (max-width: 900px) { .two { grid-template-columns: 1fr; } }
-  .scen { border: 1px solid var(--line); border-radius: 8px; padding: 14px 16px; background: #fafaf8; }
-  .scen h4 { font-size: 13.5px; margin: 0 0 6px; }
-  .scen h4 .tag { font-size: 10.5px; padding: 2px 7px; border-radius: 4px; margin-left: 6px; vertical-align: 2px; background: #fff; border: 1px solid var(--line-2); color: var(--ink-3); font-family: var(--mono); font-weight: 500; }
-  .scen .frame { background: #fff; border: 1px solid var(--line); border-radius: 6px; padding: 10px 12px; font-size: 12.5px; color: var(--ink-2); margin: 8px 0; }
-  .scen ul { padding-left: 18px; margin: 6px 0; font-size: 12.5px; color: var(--ink-2); }
-  .scen ul li { margin: 3px 0; }
-  .scen ul li b { color: var(--ink); }
-  .inv { background: #fff; border-left: 3px solid var(--ok); padding: 6px 10px; font-size: 12px; color: #134d24; border-radius: 0 6px 6px 0; margin: 6px 0; }
-  .inv b { color: #0e4019; }
-
-  /* failure table */
-  table.f { width: 100%; border-collapse: collapse; font-size: 12.5px; margin-top: 4px; }
-  table.f th, table.f td { text-align: left; padding: 8px 10px; border-bottom: 1px solid var(--line); vertical-align: top; }
-  table.f th { font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; color: var(--ink-3); font-weight: 600; background: #fafaf8; }
-  table.f td.what { font-family: var(--mono); color: var(--ink); width: 22%; }
-  table.f td.user { color: var(--ink-2); width: 32%; }
-
-  /* compare */
-  .cmp { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
-  @media (max-width: 900px) { .cmp { grid-template-columns: 1fr; } }
-  .cmp .col { border: 1px solid var(--line); border-radius: 8px; padding: 12px 14px; background: #fafaf8; }
-  .cmp .col h4 { margin: 0 0 6px; font-size: 13px; }
-  .cmp .col.old h4 { color: var(--err); }
-  .cmp .col.new h4 { color: var(--ok); }
-  .cmp ul { padding-left: 18px; margin: 4px 0; font-size: 12.5px; color: var(--ink-2); }
-  .cmp ul li { margin: 4px 0; }
-
-  .kill { text-decoration: line-through; color: var(--err); }
 
   /* callout (rule cards) */
   .rules { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
@@ -159,14 +87,14 @@
 
 <header class="head">
   <h1>Attach 重新设计 —— UX 模型</h1>
-  <div class="sub">右侧内容区怎么呈现 session,以及背后大致是怎么做到的。3 分钟看完。</div>
-  <div class="meta">范围:pty attach + xterm mount + 侧边栏耦合 · 配套文档 docs/attach-timeline-review.html(历史)</div>
+  <div class="sub">右侧内容区怎么呈现 session。只解两个问题:第一次别 flicker,看过的切回要瞬间。</div>
+  <div class="meta">范围:pty attach + xterm mount · 历史时间线 docs/attach-timeline-review.html</div>
 </header>
 
-<!-- ====================== 1. UX 模型 ====================== -->
+<!-- ====================== 1. UX 三种状态 ====================== -->
 <section class="s">
-  <h2>1 · UX 模型 —— 三种状态</h2>
-  <p class="lede">右侧内容区就这三种样子。左边的 sidebar 是固定的。</p>
+  <h2>1 · UX —— 三种状态</h2>
+  <p class="lede">右侧内容区就这三种样子,sidebar 固定。</p>
 
   <div class="states">
 
@@ -200,7 +128,7 @@
           <div class="mask">准备中…</div>
         </div>
       </div>
-      <div class="caption">遮罩盖住右侧。后台拉 snapshot、建 xterm、写入、滚到底,好了揭开。遮罩是<b>每个 shell wrapper 自己</b>的,不是右侧 host 共用的 —— 切到别的 session 不会把这个遮罩带过去。</div>
+      <div class="caption">遮罩盖住右侧。后台拉 snapshot、建 xterm、写入、滚到底,好了揭开。用户看不到半成品。</div>
     </div>
 
     <div class="state">
@@ -227,254 +155,69 @@
     </div>
 
   </div>
-
-  <h3 class="sub">状态怎么流转</h3>
-<pre>State 0  ──点第一个 session──▶  State 1  ──准备完──▶  State 2
-                                                       │
-                                                       ├──点已看过──▶ 留在 State 2(秒切)
-                                                       │
-                                                       └──点没看过──▶ State 1(再来一次冷启动)
-</pre>
 </section>
 
 <!-- ====================== 2. 两条规则 ====================== -->
 <section class="s">
   <h2>2 · 两条规则</h2>
-  <p class="lede">用户行为只分两种,响应也只有两种。</p>
+  <p class="lede">资源策略,一句话。</p>
 
   <div class="rules">
     <div class="rule cold">
       <div class="tag">规则 1</div>
-      <b>第一次点 = 冷启动</b>
-      <p>右侧盖一层 "准备中" 的遮罩。背后拉 snapshot、建 xterm、写入、滚到底,全部做完才揭开。用户不会看到半成品。</p>
+      <b>没看过 = 零资源</b>
+      <p>没点过的 session 完全不准备 —— 不订 PTY,不建 xterm,什么都不占。</p>
     </div>
     <div class="rule warm">
       <div class="tag">规则 2</div>
-      <b>再点已看过的 = 秒切</b>
-      <p>右侧 z-stack 里把这个 session 翻到顶,viewport 还停在上次离开的位置。无遮罩,无加载,无重建。</p>
+      <b>看过 = 留着不放</b>
+      <p>点过一次之后 xterm 和 PTY 订阅都留住。关 ccsm 才一次性回收。</p>
     </div>
   </div>
 </section>
 
-<!-- ====================== 3. 背后做什么 ====================== -->
+<!-- ====================== 3. 怎么做 ====================== -->
 <section class="s">
-  <h2>3 · 背后做什么(high-level)</h2>
-  <p class="lede">不展开 IPC 和状态机,只说大方向。</p>
+  <h2>3 · 怎么做</h2>
+  <p class="lede">三块东西凑起来,不展开。</p>
 
   <ul style="margin:0; padding-left:18px; font-size:13.5px; color:var(--ink-2);">
-    <li>没点过的 session <b>完全不准备</b> —— 不订 PTY,不建 xterm,什么资源都不占。</li>
-    <li>点过一次之后 <b>留住不放</b> —— xterm 实例和 PTY 订阅都不 dispose,所以再切回来是秒级。</li>
-    <li><b>关 ccsm 才回收</b> —— 退出时一次性 dispose 所有留下来的 shell。</li>
-    <li>右侧是 <b>z-stack</b> —— 看过的 shell 都叠在那里,点哪个哪个拉到顶。</li>
-    <li>看过的 session 一直留着,关 ccsm 才一次性回收。</li>
+    <li><b>z-stack</b> —— 右侧 host 里挂 N 个 wrapper,每个 wrapper 内有自己的 xterm。切换只改 <code>display</code> 和 <code>z-index</code>,xterm 实例<b>从不</b>在 wrapper 之间 reparent。这是"看过的切回瞬间、位置不变"的根本。</li>
+    <li><b>per-shell mask</b> —— 每个 wrapper 自带一个遮罩 div。冷启动期间这个 wrapper 的遮罩亮,其它 wrapper 的遮罩状态各自独立,切走切回都不串。</li>
+    <li><b>服务端 snapshot</b> —— main 进程用 <code>@xterm/headless</code> + <code>SerializeAddon</code> 保留每个 session 的镜像,renderer 冷启动时拉一次写进 xterm 就行。</li>
   </ul>
-
-  <h3 class="sub">为什么留住不放</h3>
-  <p style="margin:0; font-size:13px; color:var(--ink-2);">
-    服务端 (<code>@xterm/headless</code> + <code>SerializeAddon</code>) 一直在 main 进程里保留每个 session 的镜像,renderer 这边理论上随时 dispose 再重建都行。但本设计选择<b>留住</b>,因为切换体感差别明显:z-stack swap 0ms,重建一次大约 ~50ms(还要等 snapshot 往返)。这是有意识的权衡。<b>如果以后内存真成问题再加回收逻辑</b>,目前不做。
-  </p>
 </section>
 
-<!-- ====================== 5. 其他操作的行为 ====================== -->
+<!-- ====================== 4. 其他操作 ====================== -->
 <section class="s">
-  <h2>5 · 其他操作的行为</h2>
-  <p class="lede">sidebar 上的三个操作:删除、重做、复制。都不引入新的 UX 概念,只是套用前面两条规则。</p>
+  <h2>4 · 其他操作</h2>
+  <p class="lede">delete / reload / copy,各一句话,不引入新概念。</p>
 
   <div class="rules" style="grid-template-columns: 1fr 1fr 1fr;">
     <div class="rule">
-      <div class="tag">操作 1</div>
-      <b>删除 (delete)</b>
-      <p>
-        · sidebar 那行消失。<br>
-        · 后台 dispose 这个 session 的 xterm,解订 PTY。<br>
-        · 删的是当前顶层 → 顶层移走,z-stack 下一层自动露出(上次看的那个)。<br>
-        · 删的是 z-stack 里非顶层 → 用户看不到任何变化。<br>
-        · 删的是从没看过的 session → 啥都不发生,本来就没建。<br>
-        · 删的是正在冷启动的 session → cancel,遮罩消失,顶层退回下一层。
-      </p>
+      <div class="tag">delete</div>
+      <b>移除</b>
+      <p>移除 shell + wrapper。删的是顶层 → z-stack 自动塌到下一层;塌到空 → 回 State 0 黑屏。</p>
     </div>
     <div class="rule">
-      <div class="tag">操作 2</div>
-      <b>重做 (reload)</b>
-      <p>
-        · <b>原地重置,不 dispose</b>:同一个 xterm 实例、同一个 wrapper、同一组 listener。只是 <code>term.reset()</code> + 清 buffer + 重拉 snapshot + 写入 + 滚到底。<br>
-        · 重做的是顶层 → 该 wrapper 自己的遮罩亮起来(蓝色"重做中…"),走完揭开。<br>
-        · 重做的是非顶层 → <b>不显示遮罩</b>(用户也看不到),后台静默走完。万一用户中途切过来,看到的就是 reload 当前进行到哪一步的样子 —— 接受这个 corner case,不专门处理。<br>
-        · reload 走的是同一条路径,顶层 / 非顶层的区别只在"要不要显示遮罩"。
-      </p>
+      <div class="tag">reload</div>
+      <b>原地刷</b>
+      <p><code>term.reset()</code> + 重拉 snapshot + 写入,<b>不 dispose</b>。顶层显示遮罩,非顶层静默走完不显示。</p>
     </div>
     <div class="rule">
-      <div class="tag">操作 3</div>
-      <b>复制 (copy session)</b>
-      <p>
-        · 调用方拿到新 sid(已有产品行为,不改)。<br>
-        · 复制的是当前顶层 session → 新 sid 立刻打开,走第一次点击冷启动(顶上来),原 session 下沉。<br>
-        · 复制的是非顶层 → 新 sid 只在 sidebar 出现,不自动抢顶层,等用户主动点才冷启动。<br>
-        · 复制的是从没看过的 session → 新 sid 在 sidebar 出现,不自动打开。
-      </p>
+      <div class="tag">copy</div>
+      <b>新 session</b>
+      <p>调用方拿到新 sid。用户点了才 attach,走正常冷启动。</p>
     </div>
   </div>
 </section>
 
-<!-- ====================== 6. Sidebar 高亮 ====================== -->
+<!-- ====================== 5. 兜底 ====================== -->
 <section class="s">
-  <h2>6 · Sidebar 高亮</h2>
-  <p class="lede">每个 session 行可能有一个蓝色圆点,语义就一条:<b>蓝点 = z-stack 顶层,也就是右侧当前看得见的那个 session</b>。只表示 "现在显示的就是它"。</p>
-
-  <div class="rules">
-    <div class="rule">
-      <div class="tag">规则</div>
-      <b>activeSid = zStack[0]</b>
-      <p>
-        · activeSid = z-stack 顶层 sid。蓝色圆点跟着 activeSid 走。<br>
-        · State 0(右侧全黑):没有任何行有圆点。<br>
-        · State 1(冷启动中):用户点的那行有圆点(因为它即将上顶)。<br>
-        · State 2(秒切):z-stack 顶层 sid 那行有圆点。<br>
-        · 删除顶层 session:顶层 pop,下一层 sid 变成新顶层 → 圆点自动跳到 sidebar 那行。<br>
-        · 非顶层 reload / 非顶层 copy:顶层不变,圆点不动。<br>
-        · 实现一句话:<b>activeSid = zStack[0]</b>,sidebar 订阅这个值。
-      </p>
-    </div>
-  </div>
-</section>
-
-<!-- ====================== 7. 并发与取消 ====================== -->
-<section class="s">
-  <h2>7 · 并发与取消</h2>
-  <p class="lede">长跑 operation(冷启动 / reload)期间用户可能操作其他东西。下面是统一的处理方式 —— 两个 stop 信号,一个 shouldStop 检查点,没有 case-by-case 的 if/else。</p>
-
-  <h3 class="sub">两条规则</h3>
-  <div class="rules">
-    <div class="rule">
-      <div class="tag">规则 1</div>
-      <p><b>Shell 还存在吗?</b><br>
-        长跑 operation 在每个 await 之后检查 <code>shell.disposed</code>。disposed=true 就退出。delete 操作不直接 cancel operation,它只调 <code>disposeShell</code>,operation 自己会发现并退出。
-      </p>
-    </div>
-    <div class="rule">
-      <div class="tag">规则 2</div>
-      <p><b>这个 operation 还是 "最新的" 吗?</b><br>
-        同一 shell 同种 operation 新的覆盖旧的。每个 operation 启动时把自己写到 <code>shell.currentOp</code>。旧的在 await 之后看到 <code>currentOp !== self</code> 就退出。
-      </p>
-    </div>
-  </div>
-
-  <h3 class="sub">实现模式</h3>
-<pre>async function reload(sid) {
-  const shell = getShell(sid);
-  if (!shell) return;
-  const self = (shell.currentOp = {});  <span class="c">// 用对象身份做 token</span>
-
-  if (shell.isTop) shell.showMask();    <span class="c">// 非顶层不显示遮罩</span>
-
-  shell.pausePtySubscription();         if (shouldStop(shell, self)) return;
-  await drain();                        if (shouldStop(shell, self)) return;
-  term.reset();                         if (shouldStop(shell, self)) return;
-  const snap = await fetchSnapshot();   if (shouldStop(shell, self)) return;
-  term.write(snap);                     if (shouldStop(shell, self)) return;
-  term.scrollToBottom();
-  shell.resumePtySubscription();
-
-  if (shell.currentOp === self) {
-    shell.currentOp = null;
-    shell.hideMask();
-  }
-  <span class="c">// 没到这里就 return = 被新 op 顶替或 shell 已 dispose。</span>
-  <span class="c">// 遮罩 / 订阅 / currentOp 都不在这里清理 ——</span>
-  <span class="c">// 下一个 op 接手时会自己 showMask / setCurrentOp,</span>
-  <span class="c">// disposeShell 兜底统一释放。</span>
-}
-
-function shouldStop(shell, self) {
-  return shell.disposed || shell.currentOp !== self;
-}</pre>
-  <p style="margin:6px 0 12px; font-size:13px; color:var(--ink-2);"><b>整个 codebase 只有 shouldStop 一个判断函数。</b>每个 await 后都检查一次,幂等。被打断时直接 return,不做任何清理 —— 清理是下一个 op 或 <code>disposeShell</code> 的事。<b>不要</b>用 try/finally 在 cancel 路径上 hideMask,disposed 的 shell 引用可能已经无效,容易崩。</p>
-
-  <h3 class="sub">关键不变量</h3>
-  <ul style="margin:0 0 12px; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li><b>遮罩是每个 shell wrapper 自己的</b> —— 不是右侧 host 共用一个。被打断的 op 直接 return,不清理遮罩;下一个 op (showMask 或不 show)接手,disposeShell 兜底。</li>
-    <li><b>切 session 不动正在跑的 operation</b> —— 只改 activeSid。operation 完成时<b>一次性判断</b> "我跑完了,activeSid 还是我吗?是 → showShell;不是 → 不抢顶层"。这是完成时的一次判断,不是 cancel 逻辑。</li>
-    <li><b>delete = 调 disposeShell</b> —— operation 自己看到 disposed 退出,delete 不需要知道有哪些 operation 在跑。</li>
-  </ul>
-
-  <h3 class="sub">term.reset() 跟 PTY chunk 怎么不打架</h3>
-  <p style="margin:0 0 8px; font-size:13px; color:var(--ink-2);">
-    每个 shell 一个简单的串行 op 序列(冷启动 / reload / dispose 都是 op)。平时 PTY chunk 直接写进 xterm,跟 op 无关。reload 这个 op 一启动就先 <b>pause PTY 订阅</b>(chunk 暂时不送进 xterm,在 main 端缓冲),然后 reset → fetchSnapshot → write snapshot → <b>resume 订阅</b>(main 把暂存的 chunk 一次性补回来,接上 snapshot 之后的内容)。这样 reset 跟 chunk 不会交错,xterm 看到的永远是 "snapshot + 之后顺序到达的 chunk"。
-  </p>
-
-  <h3 class="sub">冷启动时 chunk 比 xterm 早到怎么办</h3>
-  <p style="margin:0 0 12px; font-size:13px; color:var(--ink-2);">
-    顺序写死成:<b>先建 xterm + open + 写 snapshot,再 subscribe PTY</b>。snapshot 是 main 端某个时间点的镜像,subscribe 启动后 main 会从那个点之后的 chunk 开始往下发(main 一直在缓冲,没丢)。这样根本不存在 "chunk 来了 xterm 还没好" 的窗口,也不需要 renderer 端的 pending 数组。
-  </p>
-
-  <h3 class="sub">为什么不用 queue 处理用户操作</h3>
-  <p style="margin:0; font-size:13px; color:var(--ink-2);">
-    上面说的 "op 序列" 是 shell 内部串行(reload 之间互相 supersede,跟 PTY chunk 的同步用 pause/resume 解决)。<b>但用户连点 reload 时不排队</b> —— 用户后一下就是想覆盖前一下,FIFO 反而不对。新 reload 写入 <code>currentOp</code>,老的 shouldStop 拦下退出。两条规则 + shouldStop,够了。
-  </p>
-
-  <h3 class="sub">corner case 自然推论</h3>
-  <table class="f">
-    <thead>
-      <tr><th>场景</th><th>结果</th><th>为什么</th></tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>reload A 中途 delete A</td>
-        <td>reload 自动退出</td>
-        <td><code>shell.disposed=true</code>,shouldStop 拦下</td>
-      </tr>
-      <tr>
-        <td>reload A 中途用户切走</td>
-        <td>reload 继续跑完,但不抢顶层</td>
-        <td>shell 还在,operation 仍是 currentOp;跑完时检查 activeSid 决定是否 showShell</td>
-      </tr>
-      <tr>
-        <td>reload A 中途又 reload A</td>
-        <td>第一个 reload 退出,第二个跑</td>
-        <td>第二个写入 currentOp,第一个 shouldStop 拦下</td>
-      </tr>
-      <tr>
-        <td>冷启动 B 中途切回 A</td>
-        <td>B 的冷启动继续跑;不抢顶层</td>
-        <td>同 reload 切走 case</td>
-      </tr>
-      <tr>
-        <td>冷启动 B 中途 delete B</td>
-        <td>冷启动自动退出,wrapper 不出现</td>
-        <td><code>shell.disposed=true</code></td>
-      </tr>
-      <tr>
-        <td>copy A 中途 delete A</td>
-        <td>不相干</td>
-        <td>copy 操作的是 newSid,A 的 delete 不影响 newSid</td>
-      </tr>
-    </tbody>
-  </table>
-</section>
-
-<!-- ====================== 8. 实现要点 ====================== -->
-<section class="s">
-  <h2>8 · 实现要点</h2>
-  <p class="lede">给后续 worker 看的落地清单。不是完整方案,只是关键决策。</p>
-
-  <h3 class="sub">每个 shell 的结构</h3>
-  <p style="margin:0 0 8px; font-size:13px; color:var(--ink-2);">
-    每个 visited session 对应一个 <code>Shell</code> 对象:一个 wrapper div、wrapper 里挂一个 xterm 实例、wrapper 里盖一个自己的遮罩 div、一个 PTY 订阅、<code>currentOp</code>、<code>disposed</code> 标志。<b>遮罩跟着 wrapper 走,不在 host 层共享</b> —— 切 session 时遮罩状态留在原 wrapper 里,新顶层 wrapper 自己有自己的遮罩(默认隐藏)。
-  </p>
-
-  <h3 class="sub">z-stack 怎么实现</h3>
-  <p style="margin:0 0 8px; font-size:13px; color:var(--ink-2);">
-    右侧 host 里放 N 个 wrapper div,每个 wrapper 里挂一个 xterm。切换只动 <code>display</code> 和 <code>z-index</code>:目标 shell <code>display:''</code>,其余 <code>display:'none'</code>。xterm 实例从不在 wrapper 之间 reparent。
-  </p>
-
-  <h3 class="sub">遮罩怎么做</h3>
-  <p style="margin:0 0 8px; font-size:13px; color:var(--ink-2);">
-    每个 shell wrapper 里有一个 <code>position:absolute; inset:0</code> 的遮罩 div(<b>不是 host 层共享</b>)。冷启动开始时 <code>display:''</code> 显示 "准备中…",建 xterm + 写 snapshot + 滚到底跑完后 <code>display:'none'</code> 揭开。秒切场景遮罩一直是 <code>display:'none'</code>。reload 顶层时同样亮自己 wrapper 的遮罩;reload 非顶层时不亮 —— 用户看不见,没意义。
-  </p>
-
-  <h3 class="sub">PTY 订阅时机</h3>
-  <p style="margin:0; font-size:13px; color:var(--ink-2);">
-    第一次点 session 的顺序<b>写死</b>:<code>建 xterm</code> → <code>term.open(wrapper)</code> → <code>fetchSnapshot</code> → <code>term.write(snapshot)</code> → <code>pty.open(sid)</code> 开始订阅。snapshot 是 main 端某个时间点的镜像,subscribe 之后 main 把那个点之后缓冲的 chunk 顺序补回来,接上 snapshot。这样 renderer 这边永远不会出现 "chunk 来了 xterm 还没好" 的窗口,不需要在 renderer 端搞 pending buffer。订阅一旦挂上就一直挂着,直到关 ccsm 调 <code>pty.close</code>;脱离前台<b>不</b>取消订阅,后台 session 的输出持续写进 scrollback,秒切回来就在那里。
+  <h2>5 · 兜底</h2>
+  <p class="lede">异常处理的原则。</p>
+  <p style="margin:0; font-size:13.5px; color:var(--ink-2);">
+    <b>任何状态卡住或异常,dispose 这个 shell + 重新 cold start。</b>不在 design 里穷举各种 race / cancellation / ordering 细节,实现者自己想 —— 反正最坏路径就是回到第一次点击那条路径。
   </p>
 </section>
 

--- a/docs/attach-redesign.html
+++ b/docs/attach-redesign.html
@@ -266,7 +266,7 @@
     <li>点过一次之后 <b>留住不放</b> —— xterm 实例和 PTY 订阅都不 dispose,所以再切回来是秒级。</li>
     <li><b>关 ccsm 才回收</b> —— 退出时一次性 dispose 所有留下来的 shell。</li>
     <li>右侧是 <b>z-stack</b> —— 看过的 shell 都叠在那里,点哪个哪个拉到顶。</li>
-    <li>z-stack 是 LRU 缓存 —— <b>暂不设上限</b>。单人一天用的 session 数远低于内存压力线。</li>
+    <li>看过就留,关 ccsm 一次性回收 —— <b>不做缓存上限,不做淘汰</b>。</li>
   </ul>
 </section>
 

--- a/docs/attach-redesign.html
+++ b/docs/attach-redesign.html
@@ -270,9 +270,50 @@
   </ul>
 </section>
 
-<!-- ====================== 4. 实现要点 ====================== -->
+<!-- ====================== 5. 其他操作的行为 ====================== -->
 <section class="s">
-  <h2>4 · 实现要点</h2>
+  <h2>5 · 其他操作的行为</h2>
+  <p class="lede">sidebar 上的三个操作:删除、重做、复制。都不引入新的 UX 概念,只是套用前面两条规则。</p>
+
+  <div class="rules" style="grid-template-columns: 1fr 1fr 1fr;">
+    <div class="rule">
+      <div class="tag">操作 1</div>
+      <b>删除 (delete)</b>
+      <p>
+        · sidebar 那行消失。<br>
+        · 后台 dispose 这个 session 的 xterm,解订 PTY。<br>
+        · 删的是当前顶层 → 顶层移走,z-stack 下一层自动露出(上次看的那个)。<br>
+        · 删的是 z-stack 里非顶层 → 用户看不到任何变化。<br>
+        · 删的是从没看过的 session → 啥都不发生,本来就没建。<br>
+        · 删的是正在冷启动的 session → cancel,遮罩消失,顶层退回下一层。
+      </p>
+    </div>
+    <div class="rule">
+      <div class="tag">操作 2</div>
+      <b>重做 (reload)</b>
+      <p>
+        · sid 不变,xterm 实例复用,不重建,不破坏 z-stack 缓存。<br>
+        · 走和第一次点一样的冷启动流程:盖遮罩 → 清屏 + 重拉 snapshot + 写入 + 滚到底 → 揭开。<br>
+        · 视觉上等于这个 session 当场重做一次冷启动。<br>
+        · z-stack 里其他 shell 不受影响,顺序不变。
+      </p>
+    </div>
+    <div class="rule">
+      <div class="tag">操作 3</div>
+      <b>复制 (copy session)</b>
+      <p>
+        · 调用方拿到新 sid,这部分是已有产品行为,不改。<br>
+        · 新 sid 通常会立刻被打开 → 走第一次点击的冷启动路径。<br>
+        · 原 session 在 z-stack 里照常保留,顺序不变。<br>
+        · 设计上不需要特殊路径,等同于自动 click(newSid)。
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- ====================== 6. 实现要点 ====================== -->
+<section class="s">
+  <h2>6 · 实现要点</h2>
   <p class="lede">给后续 worker 看的落地清单。不是完整方案,只是关键决策。</p>
 
   <h3 class="sub">替换掉的现有代码</h3>

--- a/docs/attach-redesign.html
+++ b/docs/attach-redesign.html
@@ -337,40 +337,97 @@
 <!-- ====================== 7. 并发与取消 ====================== -->
 <section class="s">
   <h2>7 · 并发与取消</h2>
-  <p class="lede">用户操作可能踩在一起 —— 比如 reload 中途 delete、冷启动中途切走。下面是统一的处理方式,corner case 一次想清楚。</p>
+  <p class="lede">长跑 operation(冷启动 / reload)期间用户可能操作其他东西。下面是统一的处理方式 —— 两个 stop 信号,一个 shouldStop 检查点,没有 case-by-case 的 if/else。</p>
 
-  <h3 class="sub">机制</h3>
-  <ul style="margin:0 0 12px; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li>每个 shell 上挂一个 <code>currentOp: { token, kind }</code>。</li>
-    <li>新操作开始前:先 <code>cancel</code> 同一 sid 的旧操作,await 它的 finally 块(确保遮罩、资源已清理),再启动新的。</li>
-    <li>遮罩的揭开 / shell 的 dispose / 资源释放,<b>永远由当前操作自己在 finally 里负责</b> —— 其他操作不碰。</li>
-  </ul>
-
-  <h3 class="sub">取消语义(谁取消谁、什么时候不取消)</h3>
+  <h3 class="sub">两条规则</h3>
   <div class="rules">
     <div class="rule">
-      <div class="tag">场景表</div>
-      <p>
-        · <b>reload 中途 delete</b> → delete cancel reload,reload finally dispose 收尾,顶层下沉。<br>
-        · <b>reload 中途用户切走</b> → reload <b>不 cancel</b> —— 继续跑完,但完成后<b>不抢顶层</b>(activeSid 已不是它)。<br>
-        · <b>reload 中途用户又 reload</b> → cancel 第一个,启动第二个(用户最后操作 wins)。<br>
-        · <b>冷启动 B 中途切回 A</b> → B 不 cancel,继续 hydrate;activeSid=A;B 完成后<b>不抢顶层</b>。<br>
-        · <b>冷启动 B 中途 delete B</b> → cancel coldStart,移除 wrapper,activeSid 回到下一层。<br>
-        · <b>copy A 中途 delete A</b> → copy 已经产生 newSid(产品行为);原 A 的 delete 正常走。
+      <div class="tag">规则 1</div>
+      <p><b>Shell 还存在吗?</b><br>
+        长跑 operation 在每个 await 之后检查 <code>shell.disposed</code>。disposed=true 就退出。delete 操作不直接 cancel operation,它只调 <code>disposeShell</code>,operation 自己会发现并退出。
+      </p>
+    </div>
+    <div class="rule">
+      <div class="tag">规则 2</div>
+      <p><b>这个 operation 还是 "最新的" 吗?</b><br>
+        同一 shell 同种 operation 新的覆盖旧的。每个 operation 启动时把自己写到 <code>shell.currentOp</code>。旧的在 await 之后看到 <code>currentOp !== self</code> 就退出。
       </p>
     </div>
   </div>
 
+  <h3 class="sub">实现模式</h3>
+<pre>async function reload(sid) {
+  const shell = getShell(sid);
+  if (!shell) return;
+  const op = { token: Symbol() };
+  shell.currentOp = op;
+  try {
+    shell.showMask();
+    await drain();           if (shouldStop(shell, op)) return;
+    await term.reset();      if (shouldStop(shell, op)) return;
+    await fetchSnapshot();   if (shouldStop(shell, op)) return;
+    await write(snapshot);   if (shouldStop(shell, op)) return;
+    term.scrollToBottom();
+  } finally {
+    if (shell.currentOp === op) shell.currentOp = null;
+    shell.hideMask();  // 永远揭开,成功 / 失败 / cancel 都揭
+  }
+}
+
+function shouldStop(shell, op) {
+  return shell.disposed || shell.currentOp !== op;
+}</pre>
+  <p style="margin:6px 0 12px; font-size:13px; color:var(--ink-2);"><b>整个 codebase 只有 shouldStop 一个判断函数。</b></p>
+
   <h3 class="sub">关键不变量</h3>
   <ul style="margin:0 0 12px; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li>"活操作" 至多一个 per sid。</li>
-    <li>遮罩的可见性由 ownership 决定:谁开的谁关。</li>
-    <li>z-stack 顶层 = activeSid;操作完成后<b>不一定上顶</b>,只有用户行为或冷启动初次完成才上顶。</li>
+    <li><b>遮罩永远在 finally 里清理</b> —— delete / 切走 / cancel 都不用 carry mask 状态。</li>
+    <li><b>切 session 不动正在跑的 operation</b> —— 只改 activeSid。operation 完成时<b>一次性判断</b> "我跑完了,activeSid 还是我吗?是 → showShell;不是 → 不抢顶层"。这是完成时的一次判断,不是 cancel 逻辑。</li>
+    <li><b>delete = 调 disposeShell</b> —— operation 自己看到 disposed 退出,delete 不需要知道有哪些 operation 在跑。</li>
   </ul>
+
+  <h3 class="sub">corner case 自然推论</h3>
+  <table class="f">
+    <thead>
+      <tr><th>场景</th><th>结果</th><th>为什么</th></tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>reload A 中途 delete A</td>
+        <td>reload 自动退出</td>
+        <td><code>shell.disposed=true</code>,shouldStop 拦下</td>
+      </tr>
+      <tr>
+        <td>reload A 中途用户切走</td>
+        <td>reload 继续跑完,但不抢顶层</td>
+        <td>shell 还在,operation 仍是 currentOp;跑完时检查 activeSid 决定是否 showShell</td>
+      </tr>
+      <tr>
+        <td>reload A 中途又 reload A</td>
+        <td>第一个 reload 退出,第二个跑</td>
+        <td>第二个写入 currentOp,第一个 shouldStop 拦下</td>
+      </tr>
+      <tr>
+        <td>冷启动 B 中途切回 A</td>
+        <td>B 的冷启动继续跑;不抢顶层</td>
+        <td>同 reload 切走 case</td>
+      </tr>
+      <tr>
+        <td>冷启动 B 中途 delete B</td>
+        <td>冷启动自动退出,wrapper 不出现</td>
+        <td><code>shell.disposed=true</code></td>
+      </tr>
+      <tr>
+        <td>copy A 中途 delete A</td>
+        <td>不相干</td>
+        <td>copy 操作的是 newSid,A 的 delete 不影响 newSid</td>
+      </tr>
+    </tbody>
+  </table>
 
   <h3 class="sub">为什么不用 queue</h3>
   <p style="margin:0; font-size:13px; color:var(--ink-2);">
-    queue 是 FIFO,但用户后一个操作就是想覆盖前一个 —— FIFO 反而不对。cancellation token + finally 是更轻的方案,没有"卡顿"感。
+    queue 是 FIFO,但用户后一个操作就是想覆盖前一个,FIFO 反而不对。两条规则 + shouldStop 更轻,没 "卡顿" 感。
   </p>
 </section>
 

--- a/docs/attach-redesign.html
+++ b/docs/attach-redesign.html
@@ -200,7 +200,7 @@
           <div class="mask">准备中…</div>
         </div>
       </div>
-      <div class="caption">遮罩盖住右侧。后台拉 snapshot、建 xterm、写入、滚到底,好了揭开。</div>
+      <div class="caption">遮罩盖住右侧。后台拉 snapshot、建 xterm、写入、滚到底,好了揭开。遮罩是<b>每个 shell wrapper 自己</b>的,不是右侧 host 共用的 —— 切到别的 session 不会把这个遮罩带过去。</div>
     </div>
 
     <div class="state">
@@ -266,8 +266,13 @@
     <li>点过一次之后 <b>留住不放</b> —— xterm 实例和 PTY 订阅都不 dispose,所以再切回来是秒级。</li>
     <li><b>关 ccsm 才回收</b> —— 退出时一次性 dispose 所有留下来的 shell。</li>
     <li>右侧是 <b>z-stack</b> —— 看过的 shell 都叠在那里,点哪个哪个拉到顶。</li>
-    <li>看过就留,关 ccsm 一次性回收 —— <b>不做缓存上限,不做淘汰</b>。</li>
+    <li>看过的 session 一直留着,关 ccsm 才一次性回收。</li>
   </ul>
+
+  <h3 class="sub">为什么留住不放</h3>
+  <p style="margin:0; font-size:13px; color:var(--ink-2);">
+    服务端 (<code>@xterm/headless</code> + <code>SerializeAddon</code>) 一直在 main 进程里保留每个 session 的镜像,renderer 这边理论上随时 dispose 再重建都行。但本设计选择<b>留住</b>,因为切换体感差别明显:z-stack swap 0ms,重建一次大约 ~50ms(还要等 snapshot 往返)。这是有意识的权衡。<b>如果以后内存真成问题再加回收逻辑</b>,目前不做。
+  </p>
 </section>
 
 <!-- ====================== 5. 其他操作的行为 ====================== -->
@@ -292,11 +297,10 @@
       <div class="tag">操作 2</div>
       <b>重做 (reload)</b>
       <p>
-        · sid 不变,xterm 实例复用(不重建,不破坏 z-stack 缓存)。<br>
-        · 该 wrapper 内部盖遮罩 → <code>term.reset()</code> + 重拉 snapshot + 写入 + 滚到底 → 揭开。<br>
-        · 重做的是顶层 → 用户能看到遮罩(蓝色"重做中…")。<br>
-        · 重做的是非顶层 → 遮罩在底下,用户看不到;但万一重做没完用户切过来,顺势看到遮罩走完。<br>
-        · 关键:不管顶层还是非顶层,reload 走的是同一条路径,只是用户是否看见取决于 z-stack 位置。
+        · <b>原地重置,不 dispose</b>:同一个 xterm 实例、同一个 wrapper、同一组 listener。只是 <code>term.reset()</code> + 清 buffer + 重拉 snapshot + 写入 + 滚到底。<br>
+        · 重做的是顶层 → 该 wrapper 自己的遮罩亮起来(蓝色"重做中…"),走完揭开。<br>
+        · 重做的是非顶层 → <b>不显示遮罩</b>(用户也看不到),后台静默走完。万一用户中途切过来,看到的就是 reload 当前进行到哪一步的样子 —— 接受这个 corner case,不专门处理。<br>
+        · reload 走的是同一条路径,顶层 / 非顶层的区别只在"要不要显示遮罩"。
       </p>
     </div>
     <div class="rule">
@@ -315,7 +319,7 @@
 <!-- ====================== 6. Sidebar 高亮 ====================== -->
 <section class="s">
   <h2>6 · Sidebar 高亮</h2>
-  <p class="lede">每个 session 行可能有一个蓝色圆点,表示"右侧 CLI 当前显示的就是它"。</p>
+  <p class="lede">每个 session 行可能有一个蓝色圆点,语义就一条:<b>蓝点 = z-stack 顶层,也就是右侧当前看得见的那个 session</b>。只表示 "现在显示的就是它"。</p>
 
   <div class="rules">
     <div class="rule">
@@ -359,32 +363,54 @@
 <pre>async function reload(sid) {
   const shell = getShell(sid);
   if (!shell) return;
-  const op = { token: Symbol() };
-  shell.currentOp = op;
-  try {
-    shell.showMask();
-    await drain();           if (shouldStop(shell, op)) return;
-    await term.reset();      if (shouldStop(shell, op)) return;
-    await fetchSnapshot();   if (shouldStop(shell, op)) return;
-    await write(snapshot);   if (shouldStop(shell, op)) return;
-    term.scrollToBottom();
-  } finally {
-    if (shell.currentOp === op) shell.currentOp = null;
-    shell.hideMask();  // 永远揭开,成功 / 失败 / cancel 都揭
+  const self = (shell.currentOp = {});  <span class="c">// 用对象身份做 token</span>
+
+  if (shell.isTop) shell.showMask();    <span class="c">// 非顶层不显示遮罩</span>
+
+  shell.pausePtySubscription();         if (shouldStop(shell, self)) return;
+  await drain();                        if (shouldStop(shell, self)) return;
+  term.reset();                         if (shouldStop(shell, self)) return;
+  const snap = await fetchSnapshot();   if (shouldStop(shell, self)) return;
+  term.write(snap);                     if (shouldStop(shell, self)) return;
+  term.scrollToBottom();
+  shell.resumePtySubscription();
+
+  if (shell.currentOp === self) {
+    shell.currentOp = null;
+    shell.hideMask();
   }
+  <span class="c">// 没到这里就 return = 被新 op 顶替或 shell 已 dispose。</span>
+  <span class="c">// 遮罩 / 订阅 / currentOp 都不在这里清理 ——</span>
+  <span class="c">// 下一个 op 接手时会自己 showMask / setCurrentOp,</span>
+  <span class="c">// disposeShell 兜底统一释放。</span>
 }
 
-function shouldStop(shell, op) {
-  return shell.disposed || shell.currentOp !== op;
+function shouldStop(shell, self) {
+  return shell.disposed || shell.currentOp !== self;
 }</pre>
-  <p style="margin:6px 0 12px; font-size:13px; color:var(--ink-2);"><b>整个 codebase 只有 shouldStop 一个判断函数。</b></p>
+  <p style="margin:6px 0 12px; font-size:13px; color:var(--ink-2);"><b>整个 codebase 只有 shouldStop 一个判断函数。</b>每个 await 后都检查一次,幂等。被打断时直接 return,不做任何清理 —— 清理是下一个 op 或 <code>disposeShell</code> 的事。<b>不要</b>用 try/finally 在 cancel 路径上 hideMask,disposed 的 shell 引用可能已经无效,容易崩。</p>
 
   <h3 class="sub">关键不变量</h3>
   <ul style="margin:0 0 12px; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li><b>遮罩永远在 finally 里清理</b> —— delete / 切走 / cancel 都不用 carry mask 状态。</li>
+    <li><b>遮罩是每个 shell wrapper 自己的</b> —— 不是右侧 host 共用一个。被打断的 op 直接 return,不清理遮罩;下一个 op (showMask 或不 show)接手,disposeShell 兜底。</li>
     <li><b>切 session 不动正在跑的 operation</b> —— 只改 activeSid。operation 完成时<b>一次性判断</b> "我跑完了,activeSid 还是我吗?是 → showShell;不是 → 不抢顶层"。这是完成时的一次判断,不是 cancel 逻辑。</li>
     <li><b>delete = 调 disposeShell</b> —— operation 自己看到 disposed 退出,delete 不需要知道有哪些 operation 在跑。</li>
   </ul>
+
+  <h3 class="sub">term.reset() 跟 PTY chunk 怎么不打架</h3>
+  <p style="margin:0 0 8px; font-size:13px; color:var(--ink-2);">
+    每个 shell 一个简单的串行 op 序列(冷启动 / reload / dispose 都是 op)。平时 PTY chunk 直接写进 xterm,跟 op 无关。reload 这个 op 一启动就先 <b>pause PTY 订阅</b>(chunk 暂时不送进 xterm,在 main 端缓冲),然后 reset → fetchSnapshot → write snapshot → <b>resume 订阅</b>(main 把暂存的 chunk 一次性补回来,接上 snapshot 之后的内容)。这样 reset 跟 chunk 不会交错,xterm 看到的永远是 "snapshot + 之后顺序到达的 chunk"。
+  </p>
+
+  <h3 class="sub">冷启动时 chunk 比 xterm 早到怎么办</h3>
+  <p style="margin:0 0 12px; font-size:13px; color:var(--ink-2);">
+    顺序写死成:<b>先建 xterm + open + 写 snapshot,再 subscribe PTY</b>。snapshot 是 main 端某个时间点的镜像,subscribe 启动后 main 会从那个点之后的 chunk 开始往下发(main 一直在缓冲,没丢)。这样根本不存在 "chunk 来了 xterm 还没好" 的窗口,也不需要 renderer 端的 pending 数组。
+  </p>
+
+  <h3 class="sub">为什么不用 queue 处理用户操作</h3>
+  <p style="margin:0; font-size:13px; color:var(--ink-2);">
+    上面说的 "op 序列" 是 shell 内部串行(reload 之间互相 supersede,跟 PTY chunk 的同步用 pause/resume 解决)。<b>但用户连点 reload 时不排队</b> —— 用户后一下就是想覆盖前一下,FIFO 反而不对。新 reload 写入 <code>currentOp</code>,老的 shouldStop 拦下退出。两条规则 + shouldStop,够了。
+  </p>
 
   <h3 class="sub">corner case 自然推论</h3>
   <table class="f">
@@ -424,11 +450,6 @@ function shouldStop(shell, op) {
       </tr>
     </tbody>
   </table>
-
-  <h3 class="sub">为什么不用 queue</h3>
-  <p style="margin:0; font-size:13px; color:var(--ink-2);">
-    queue 是 FIFO,但用户后一个操作就是想覆盖前一个,FIFO 反而不对。两条规则 + shouldStop 更轻,没 "卡顿" 感。
-  </p>
 </section>
 
 <!-- ====================== 8. 实现要点 ====================== -->
@@ -436,12 +457,10 @@ function shouldStop(shell, op) {
   <h2>8 · 实现要点</h2>
   <p class="lede">给后续 worker 看的落地清单。不是完整方案,只是关键决策。</p>
 
-  <h3 class="sub">替换掉的现有代码</h3>
-  <ul style="margin:0 0 12px; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li><span class="kill"><code>src/terminal/usePtyAttach.warm.ts</code></span> —— 19 步过程整体替换为 "点击 → 翻 z-stack 顶层"。</li>
-    <li><span class="kill"><code>xtermWarmRegistry.ts</code> 里的 cold-vs-warm 分支</span> —— 不再区分,统一走 "shell 不存在就建,存在就拉顶"。</li>
-    <li><span class="kill">buffering listener 模式</span> —— 没用了。点击之前根本不订 PTY,点击之后订一次就一直挂着。</li>
-  </ul>
+  <h3 class="sub">每个 shell 的结构</h3>
+  <p style="margin:0 0 8px; font-size:13px; color:var(--ink-2);">
+    每个 visited session 对应一个 <code>Shell</code> 对象:一个 wrapper div、wrapper 里挂一个 xterm 实例、wrapper 里盖一个自己的遮罩 div、一个 PTY 订阅、<code>currentOp</code>、<code>disposed</code> 标志。<b>遮罩跟着 wrapper 走,不在 host 层共享</b> —— 切 session 时遮罩状态留在原 wrapper 里,新顶层 wrapper 自己有自己的遮罩(默认隐藏)。
+  </p>
 
   <h3 class="sub">z-stack 怎么实现</h3>
   <p style="margin:0 0 8px; font-size:13px; color:var(--ink-2);">
@@ -450,12 +469,12 @@ function shouldStop(shell, op) {
 
   <h3 class="sub">遮罩怎么做</h3>
   <p style="margin:0 0 8px; font-size:13px; color:var(--ink-2);">
-    在右侧 host 上盖一个 <code>position:absolute; inset:0</code> 的遮罩 div。冷启动开始时 <code>display:''</code> 显示 "准备中…",背后建 shell + 写 snapshot + 滚到底全部跑完后 <code>display:'none'</code> 揭开。秒切场景遮罩自始至终 <code>display:'none'</code>。
+    每个 shell wrapper 里有一个 <code>position:absolute; inset:0</code> 的遮罩 div(<b>不是 host 层共享</b>)。冷启动开始时 <code>display:''</code> 显示 "准备中…",建 xterm + 写 snapshot + 滚到底跑完后 <code>display:'none'</code> 揭开。秒切场景遮罩一直是 <code>display:'none'</code>。reload 顶层时同样亮自己 wrapper 的遮罩;reload 非顶层时不亮 —— 用户看不见,没意义。
   </p>
 
   <h3 class="sub">PTY 订阅时机</h3>
   <p style="margin:0; font-size:13px; color:var(--ink-2);">
-    第一次点 session 时调 <code>pty.open(sid)</code> 订上,之后这个订阅一直挂着,直到关 ccsm 调 <code>pty.close</code>。脱离前台不取消订阅,chunk 持续写入对应的 xterm scrollback —— 这样秒切回来时新内容已经在那里了。
+    第一次点 session 的顺序<b>写死</b>:<code>建 xterm</code> → <code>term.open(wrapper)</code> → <code>fetchSnapshot</code> → <code>term.write(snapshot)</code> → <code>pty.open(sid)</code> 开始订阅。snapshot 是 main 端某个时间点的镜像,subscribe 之后 main 把那个点之后缓冲的 chunk 顺序补回来,接上 snapshot。这样 renderer 这边永远不会出现 "chunk 来了 xterm 还没好" 的窗口,不需要在 renderer 端搞 pending buffer。订阅一旦挂上就一直挂着,直到关 ccsm 调 <code>pty.close</code>;脱离前台<b>不</b>取消订阅,后台 session 的输出持续写进 scrollback,秒切回来就在那里。
   </p>
 </section>
 

--- a/docs/attach-redesign.html
+++ b/docs/attach-redesign.html
@@ -124,176 +124,176 @@
 <div class="page">
 
 <header class="head">
-  <h1>Attach redesign — from scratch</h1>
-  <div class="sub">If we wrote ccsm’s attach path today, what would it look like? Discard the 19-step incumbent and the patches on top of it. Design only.</div>
-  <div class="meta">scope: pty attach + xterm mount + sidebar coupling · companion to docs/attach-timeline-review.html (history)</div>
+  <h1>Attach 重新设计 —— 从零开始</h1>
+  <div class="sub">如果今天从头写 ccsm 的 attach 路径,它会是什么样?抛掉当前 19 步流程,以及打在上面的补丁。只谈设计。</div>
+  <div class="meta">范围:pty attach + xterm mount + 侧边栏耦合 · 配套文档 docs/attach-timeline-review.html(历史)</div>
 </header>
 
 <!-- ====================== 1. PRINCIPLES ====================== -->
 <section class="s">
-  <h2>1 · Design principles</h2>
-  <p class="lede">Five things every later decision answers to.</p>
+  <h2>1 · 设计原则</h2>
+  <p class="lede">后面每个决策都要回答的五条原则。</p>
   <div class="principles">
     <div class="princ"><div class="n">P1</div><div>
-      <b>First frame = final frame.</b>
-      <div class="body">Before <code>display:''</code>, the user perceives nothing. After it, the user must see a finished picture: scrolled to the right line, atlas warm, dims final. Step count between mount and reveal is irrelevant; the cut line is what matters.</div>
+      <b>第一帧 = 最终帧。</b>
+      <div class="body"><code>display:''</code> 之前,用户什么都感知不到。之后,用户必须看到一张完成的画面:滚到正确的行、atlas 已预热、尺寸为最终值。mount 到 reveal 之间步骤数无所谓;切线在哪才是关键。</div>
     </div></div>
     <div class="princ"><div class="n">P2</div><div>
-      <b>The Terminal is a long-lived per-sid object, not a per-attach artifact.</b>
-      <div class="body">Allocation, <code>term.open</code>, addon load, atlas warm-up, and the live data subscription happen the first time we have any reason to care about a sid (e.g. it’s in the sidebar). “Attach” is reduced to <i>making one of these visible</i>. Switching sessions never disposes or re-opens xterm.</div>
+      <b>Terminal 是 per-sid 的长寿对象,不是 per-attach 的临时产物。</b>
+      <div class="body">分配、<code>term.open</code>、addon 加载、atlas 预热、live 数据订阅,都在我们第一次有理由关心某个 sid 时发生(例如它进了侧边栏)。"Attach" 退化为<i>让其中之一可见</i>。切换会话从不 dispose 或重新 open xterm。</div>
     </div></div>
     <div class="princ"><div class="n">P3</div><div>
-      <b>Data subscription is independent of visibility.</b>
-      <div class="body">Per-sid chunks flow into the per-sid Terminal continuously, from spawn/restore to dispose. There is no “buffering listener” mode that toggles around attach — the listener is always the Terminal itself. Visibility is a DOM concern only.</div>
+      <b>数据订阅独立于可见性。</b>
+      <div class="body">per-sid chunk 从 spawn/restore 到 dispose 持续流入 per-sid Terminal。不存在围绕 attach 切换的 "buffering listener" 模式 —— listener 永远是 Terminal 自己。可见性纯粹是 DOM 层的事。</div>
     </div></div>
     <div class="princ"><div class="n">P4</div><div>
-      <b>Sidebar runs on its own data plane.</b>
-      <div class="body">Sidebar state (agent state, title, badge, archived flag) comes from <code>session:state</code> / <code>session:title</code> — already independent of PTY chunks. Redesign keeps it that way; no last-line preview parsing of PTY output anywhere.</div>
+      <b>侧边栏跑在自己的数据面上。</b>
+      <div class="body">侧边栏状态(agent 状态、标题、徽标、归档标志)来自 <code>session:state</code> / <code>session:title</code> —— 本就独立于 PTY chunk。重设计延续这一点;任何地方都不再解析 PTY 输出做最后一行预览。</div>
     </div></div>
     <div class="princ"><div class="n">P5</div><div>
-      <b>Parallel where independent. One barrier. Then serial. Then reveal.</b>
-      <div class="body">Independent work (snapshot fetch, layout commit, addon warm-up) runs concurrently in invisible space. A single <code>await Promise.all</code> meets them. The serial tail does only the bits with real ordering (write snapshot → drain live tail → pin viewport). Reveal is the last instruction.</div>
+      <b>能并行就并行。一次 barrier。然后串行。然后 reveal。</b>
+      <div class="body">互相独立的工作(snapshot 拉取、布局 commit、addon 预热)在不可见空间内并发跑。一次 <code>await Promise.all</code> 汇合。串行尾部只做真正有顺序约束的事(写 snapshot → drain live tail → 钉住 viewport)。Reveal 是最后一条指令。</div>
     </div></div>
   </div>
 </section>
 
 <!-- ====================== 2. HIGH-LEVEL PHASES ====================== -->
 <section class="s">
-  <h2>2 · High-level architecture</h2>
-  <p class="lede">Five phases. Read left to right.</p>
+  <h2>2 · 总体架构</h2>
+  <p class="lede">五个阶段。从左往右读。</p>
   <div class="phases">
     <div class="phase">
       <div class="ph">Phase 0</div>
       <b>Provision</b>
-      <div class="desc">When a sid enters the sidebar, allocate a renderer-side <code>SessionShell</code>: xterm Terminal in an offscreen container, addons loaded, live stream subscription opened. No user-visible side effect.</div>
+      <div class="desc">sid 进入侧边栏时,在 renderer 侧分配一个 <code>SessionShell</code>:offscreen 容器里的 xterm Terminal、addon 已加载、live 流订阅已开启。无用户可见副作用。</div>
     </div>
     <div class="phase live">
       <div class="ph">Phase 1</div>
-      <b>Stream-live</b>
-      <div class="desc">PTY chunks land in the per-sid Terminal continuously. Sidebar receives <code>session:state</code> independently. Both run forever, regardless of which sid is active.</div>
+      <b>持续 stream</b>
+      <div class="desc">PTY chunk 持续落入 per-sid Terminal。侧边栏独立接收 <code>session:state</code>。两条线永远在跑,与当前激活的是哪个 sid 无关。</div>
     </div>
     <div class="phase">
       <div class="ph">Phase 2</div>
-      <b>Prepare-visible</b>
-      <div class="desc">User picks a sid. Parallel: reparent the SessionShell into the visible host (still <code>display:'none'</code>), commit layout, fit to real dims, restore last viewport (warm) or snap to bottom (cold).</div>
+      <b>准备可见</b>
+      <div class="desc">用户选中某个 sid。并行:把 SessionShell reparent 到可见宿主(仍 <code>display:'none'</code>)、commit 布局、按真实尺寸 fit、恢复上次 viewport(warm)或贴底(cold)。</div>
     </div>
     <div class="phase reveal">
       <div class="ph">Phase 3</div>
       <b>Reveal</b>
-      <div class="desc">One assignment: <code>display:''</code>. Viewport, atlas, dims, content — all already final. <i>This is the only frame the user sees.</i></div>
+      <div class="desc">一条赋值:<code>display:''</code>。viewport、atlas、尺寸、内容 —— 都已为最终态。<i>这是用户看到的唯一一帧。</i></div>
     </div>
     <div class="phase">
       <div class="ph">Phase 4</div>
-      <b>Post-reveal</b>
-      <div class="desc">Wire input passthrough (it’s already wired at the Terminal layer; we only flip a routing flag), focus, mark active in store, install/refresh ResizeObserver baseline.</div>
+      <b>Reveal 之后</b>
+      <div class="desc">接通输入路由(在 Terminal 层早已接好,只翻一个路由标志)、focus、在 store 标记 active、安装/刷新 ResizeObserver 基线。</div>
     </div>
   </div>
 
-  <h3 class="sub">Why this shape</h3>
+  <h3 class="sub">为什么是这个形状</h3>
   <p style="margin:0; font-size:13px; color:var(--ink-2);">
-    The current path conflates four orthogonal things — Terminal lifecycle, data subscription, layout, and visibility — into one mega-procedure called “attach.” Untangling them moves all the heavy lifting out of the click path. By the time the user clicks a session, the bytes have already been streaming for seconds; “attach” becomes “show.”
+    当前路径把四件正交的事 —— Terminal 生命周期、数据订阅、布局、可见性 —— 揉成一个叫 "attach" 的大过程。把它们解耦,所有重活都从点击路径中移走。等用户点会话时,字节已经流了几秒;"attach" 退化为 "show"。
   </p>
 </section>
 
 <!-- ====================== 3. PARALLEL FLOW ====================== -->
 <section class="s">
-  <h2>3 · Parallel flow inside Phase 2</h2>
-  <p class="lede">What can run concurrently while still in <code>display:'none'</code>, what must serialize, and where reveal sits.</p>
+  <h2>3 · Phase 2 内部的并行流</h2>
+  <p class="lede">仍在 <code>display:'none'</code> 时可以并发跑什么、什么必须串行、reveal 落在何处。</p>
 
   <div class="flow">
 
     <div class="lanes">
       <div class="lane">
-        <div class="lh">Lane A · Data</div>
-        <div class="item"><b>A1.</b> Request <code>pty.snapshotAt(sid, sinceSeq?)</code> if shell hasn’t written a snapshot yet, else skip (already live).</div>
-        <div class="item"><b>A2.</b> Apply <code>writeAsync(snapshot)</code> into the Terminal’s scrollback. Drain.</div>
-        <div class="item"><b>A3.</b> Drain in-flight live chunks up to <i>now</i> (single explicit <code>await term.write('', cb)</code> barrier — only place we use it).</div>
+        <div class="lh">Lane A · 数据</div>
+        <div class="item"><b>A1.</b> 若 shell 尚未写过 snapshot,调 <code>pty.snapshotAt(sid, sinceSeq?)</code>;否则跳过(已 live)。</div>
+        <div class="item"><b>A2.</b> <code>writeAsync(snapshot)</code> 写入 Terminal scrollback。Drain。</div>
+        <div class="item"><b>A3.</b> Drain 截至<i>当前</i>的 in-flight live chunk(一次显式 <code>await term.write('', cb)</code> barrier —— 全流程唯一使用处)。</div>
       </div>
       <div class="lane">
         <div class="lh">Lane B · DOM</div>
-        <div class="item"><b>B1.</b> Reparent SessionShell from offscreen pool into visible <code>&lt;TerminalSlot/&gt;</code>, still <code>display:'none'</code>.</div>
-        <div class="item"><b>B2.</b> <code>await rAF</code> — let layout commit. Assert <code>clientWidth/Height &gt; 0</code> (else go to error path F3).</div>
-        <div class="item"><b>B3.</b> <code>fit.fit()</code> → compute final cols/rows from real dims.</div>
+        <div class="item"><b>B1.</b> 把 SessionShell 从 offscreen pool reparent 到可见 <code>&lt;TerminalSlot/&gt;</code>,仍 <code>display:'none'</code>。</div>
+        <div class="item"><b>B2.</b> <code>await rAF</code> —— 让布局 commit。断言 <code>clientWidth/Height &gt; 0</code>(否则进入错误路径 F3)。</div>
+        <div class="item"><b>B3.</b> <code>fit.fit()</code> → 按真实尺寸算出最终 cols/rows。</div>
       </div>
       <div class="lane">
-        <div class="lh">Lane C · Viewport plan</div>
-        <div class="item"><b>C1.</b> Read shell’s <code>lastViewportY</code> (warm) or <code>null</code> (cold).</div>
-        <div class="item"><b>C2.</b> Decide target: warm → restore Y; cold+resume → bottom; cold+empty → bottom (no-op).</div>
-        <div class="item"><b>C3.</b> Precompute via shell’s scrollback line count; no terminal mutation yet.</div>
+        <div class="lh">Lane C · Viewport 计划</div>
+        <div class="item"><b>C1.</b> 读 shell 的 <code>lastViewportY</code>(warm)或 <code>null</code>(cold)。</div>
+        <div class="item"><b>C2.</b> 决定目标:warm → 恢复 Y;cold+resume → 贴底;cold+空 → 贴底(no-op)。</div>
+        <div class="item"><b>C3.</b> 借 shell 的 scrollback 行数预算;此时不修改 terminal。</div>
       </div>
     </div>
 
     <div class="arrow">▼</div>
     <div class="barrier">
       await Promise.all([ A, B, C ])
-      <span class="sub">single barrier — three lanes fully settled</span>
+      <span class="sub">单点 barrier —— 三条 lane 全部就绪</span>
     </div>
     <div class="arrow">▼</div>
 
     <div class="serial">
-      <div class="sh">Serial tail · still display:'none'</div>
-      <div class="item"><b>S1.</b> If <code>fit.cols ≠ pty.cols</code>: <code>pty.resize(sid, cols, rows)</code>. The resulting SIGWINCH echo lands in the live stream (already going to this Terminal); we don’t re-fetch a snapshot — the parser will catch up.</div>
-      <div class="item"><b>S2.</b> One <code>await term.write('', cb)</code> drain — catches both the live tail from A3 <i>and</i> any SIGWINCH echo from S1.</div>
-      <div class="item"><b>S3.</b> Apply viewport plan from C: <code>term.scrollToLine(targetY)</code> or <code>term.scrollToBottom()</code>. Once. Exact.</div>
+      <div class="sh">串行尾部 · 仍 display:'none'</div>
+      <div class="item"><b>S1.</b> 若 <code>fit.cols ≠ pty.cols</code>:<code>pty.resize(sid, cols, rows)</code>。引发的 SIGWINCH 回显落在 live 流(已指向该 Terminal);不重新拉 snapshot —— parser 会追上。</div>
+      <div class="item"><b>S2.</b> 一次 <code>await term.write('', cb)</code> drain —— 同时吸收 A3 的 live tail<i>和</i> S1 的 SIGWINCH 回显。</div>
+      <div class="item"><b>S3.</b> 应用 lane C 的 viewport 计划:<code>term.scrollToLine(targetY)</code> 或 <code>term.scrollToBottom()</code>。一次。精确。</div>
     </div>
 
     <div class="arrow">▼</div>
 
     <div class="reveal">
       slot.style.display = ''
-      <span class="sub">user’s first frame — already final</span>
+      <span class="sub">用户看到的第一帧 —— 已是最终态</span>
     </div>
 
     <div class="arrow">▼</div>
 
     <div class="serial">
-      <div class="sh">Phase 4 · After reveal · order-free</div>
-      <div class="item"><b>P1.</b> Flip <code>activeSid</code> in store → input routing now sends keystrokes for this sid to <code>pty.input</code>.</div>
-      <div class="item"><b>P2.</b> <code>term.focus()</code>.</div>
-      <div class="item"><b>P3.</b> Install ResizeObserver baseline (eat the first spurious tick from display flip, same rationale as today).</div>
+      <div class="sh">Phase 4 · reveal 之后 · 无序</div>
+      <div class="item"><b>P1.</b> 在 store 翻转 <code>activeSid</code> → 输入路由开始把击键送到该 sid 的 <code>pty.input</code>。</div>
+      <div class="item"><b>P2.</b> <code>term.focus()</code>。</div>
+      <div class="item"><b>P3.</b> 安装 ResizeObserver 基线(吃掉 display 翻转引起的第一个伪 tick,与当前实现同理)。</div>
     </div>
 
   </div>
 
-  <h3 class="sub">Dependency notes</h3>
+  <h3 class="sub">依赖说明</h3>
   <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li>A is independent of B/C. A can complete before B reparents — the writes go into a Terminal that just isn’t on screen yet, which is fine (Phase 1 / P3).</li>
-    <li>B2 (rAF) is the only DOM-timed barrier. It is cheap and predictable: at most one frame, typically &lt;16ms.</li>
-    <li>C is pure computation. It exists as its own lane to make the warm-vs-cold decision an explicit data input to S3 rather than a branching mess inside it.</li>
+    <li>A 与 B/C 独立。A 可以在 B reparent 之前完成 —— 写入会进入一个尚未上屏的 Terminal,没问题(Phase 1 / P3)。</li>
+    <li>B2(rAF)是唯一 DOM 时序 barrier。便宜、可预测:至多一帧,通常 &lt;16ms。</li>
+    <li>C 是纯计算。独立成一条 lane,是为了把 warm/cold 决策作为 S3 的显式数据输入,而非藏在 S3 里的分支泥潭。</li>
   </ul>
 </section>
 
 <!-- ====================== 4. FIRST-FRAME SCENARIOS ====================== -->
 <section class="s">
-  <h2>4 · First-frame guarantees per scenario</h2>
-  <p class="lede">The only two scenarios that exist from the user’s point of view. What they see and the invariant that makes it true.</p>
+  <h2>4 · 各场景下的第一帧保证</h2>
+  <p class="lede">从用户视角看只存在两种场景。各自看到什么,以及保证它成立的不变量。</p>
   <div class="two">
 
     <div class="scen">
-      <h4>Scenario A — cold + resume<span class="tag">first attach of a session with history</span></h4>
+      <h4>场景 A —— cold + resume<span class="tag">有历史的会话首次 attach</span></h4>
       <div class="frame">
-        <b>First frame:</b> full xterm canvas at final size, scrollback rendered to the last line of the resume snapshot, scrollbar at bottom, cursor where the CLI left it. No empty frame, no upward drift, no late snap.
+        <b>第一帧:</b>最终尺寸的完整 xterm 画布,scrollback 渲染到 resume snapshot 的最后一行,滚动条贴底,光标停在 CLI 离开的位置。无空帧、无向上漂移、无延迟 snap。
       </div>
       <ul>
-        <li><b>How:</b> snapshot write (A1–A2) and live-tail drain (A3, S2) complete <i>before</i> reveal. Viewport target is computed in C (bottom) and applied in S3 once. Reveal happens after S3.</li>
-        <li><b>Why no race:</b> there is no fire-and-forget write. The single drain barrier in S2 is the only point where parser queue can be non-empty before reveal, and we wait on it explicitly.</li>
+        <li><b>怎么做到:</b>snapshot 写入(A1–A2)和 live-tail drain(A3、S2)都在 reveal <i>之前</i>完成。Viewport 目标在 C 计算(贴底),在 S3 一次性应用。Reveal 在 S3 之后。</li>
+        <li><b>为何无 race:</b>没有 fire-and-forget 的写。S2 的单点 drain barrier 是 reveal 前 parser 队列可能非空的唯一位置,我们显式 await 它。</li>
       </ul>
       <div class="inv">
-        <b>Invariant:</b> at the moment of <code>display:''</code>, <code>term.buffer.baseY === lastWrittenBaseY</code> and <code>ydisp === baseY</code>. Both follow from S2 (no pending writes) and S3 (exactly one pin).
+        <b>不变量:</b><code>display:''</code> 那一刻,<code>term.buffer.baseY === lastWrittenBaseY</code> 且 <code>ydisp === baseY</code>。两者由 S2(无 pending 写入)和 S3(恰好一次钉位)共同保证。
       </div>
     </div>
 
     <div class="scen">
-      <h4>Scenario B — warm switch<span class="tag">previously attached, switching back</span></h4>
+      <h4>场景 B —— warm 切换<span class="tag">之前 attach 过,切回</span></h4>
       <div class="frame">
-        <b>First frame:</b> the exact viewport position the user left, including mid-scrollback positions. Scrollbar aligned. If new chunks arrived while detached, they are in the scrollback below the viewport (not auto-scrolled to).
+        <b>第一帧:</b>用户离开时的精确 viewport 位置,包括 scrollback 中间位置。滚动条对齐。脱离期间到达的新 chunk 在 viewport 下方的 scrollback 中(不会被自动滚到)。
       </div>
       <ul>
-        <li><b>How:</b> the SessionShell was never disposed (P2). Lane A is a no-op — chunks have been streaming into this Terminal the whole time. Lane C reads the persisted <code>lastViewportY</code> (captured on each visibility-loss). S3 calls <code>scrollToLine(targetY)</code>.</li>
-        <li><b>Reparent considerations:</b> reparent (B1) does not reset xterm internal state. We still gate on rAF (B2) to be safe against width changes between hosts.</li>
+        <li><b>怎么做到:</b>SessionShell 从未被 dispose(P2)。Lane A 是 no-op —— chunk 一直流入这个 Terminal。Lane C 读取已持久化的 <code>lastViewportY</code>(每次失去可见性时记下)。S3 调 <code>scrollToLine(targetY)</code>。</li>
+        <li><b>Reparent 考虑:</b>reparent(B1)不会重置 xterm 内部状态。仍走 rAF(B2)gate,以防宿主之间宽度变化。</li>
       </ul>
       <div class="inv">
-        <b>Invariant:</b> the renderer state for sid X is identical immediately before deactivation and immediately after reactivation, save for <code>baseY</code> which may have advanced from live chunks (which is correct — they should be in the buffer, just not pulling the viewport).
+        <b>不变量:</b>sid X 的 renderer 状态在 deactivate 之前与 reactivate 之后相同,除了 <code>baseY</code> 可能因 live chunk 前进过(这是正确的 —— 它们应在 buffer 里,只是不拉动 viewport)。
       </div>
     </div>
 
@@ -302,139 +302,138 @@
 
 <!-- ====================== 5. IPC CONTRACT ====================== -->
 <section class="s">
-  <h2>5 · IPC contract proposal</h2>
-  <p class="lede">Main ↔ renderer surface. Smaller and more explicit than today.</p>
+  <h2>5 · IPC 契约提案</h2>
+  <p class="lede">主进程 ↔ renderer 接口面。比现在更小、更显式。</p>
 
-<pre><span class="c">// ─── main → renderer broadcasts ─────────────────────────────────────────</span>
+<pre><span class="c">// ─── main → renderer 广播 ───────────────────────────────────────────────</span>
 
-<span class="c">// One channel, per-sid stream. Emits from spawn to dispose. Renderer</span>
-<span class="c">// attaches a Terminal as the sole consumer per sid; main does NOT gate</span>
-<span class="c">// emission on any "viewer count". This is what kills the buffering-mode</span>
-<span class="c">// dance: the consumer is always present.</span>
+<span class="c">// 单一通道,per-sid 流。从 spawn 到 dispose 都在 emit。renderer 以</span>
+<span class="c">// Terminal 作为该 sid 的唯一消费者;主进程不按 "viewer count" gate</span>
+<span class="c">// emit。这正是杀掉 buffering-mode 把戏的关键:消费者永远在线。</span>
 <span class="k">channel</span> <span class="s">'pty:chunk'</span>: { sid: string; seq: number; data: <span class="t">Uint8Array</span> }
 
-<span class="c">// Lifecycle. Separate from chunks so consumers don't have to parse them.</span>
+<span class="c">// 生命周期。与 chunk 分开,消费者无需解析 chunk。</span>
 <span class="k">channel</span> <span class="s">'pty:exit'</span>: { sid: string; code: number | null; signal: string | null }
 
-<span class="c">// Sidebar's data plane. Unchanged from today, listed for completeness.</span>
+<span class="c">// 侧边栏数据面。与现状一致,此处列出以求完整。</span>
 <span class="k">channel</span> <span class="s">'session:state'</span>: { sid: string; state: SessionState }
 <span class="k">channel</span> <span class="s">'session:title'</span>: { sid: string; title: string }
 
 <span class="c">// ─── renderer → main RPC ────────────────────────────────────────────────</span>
 
-<span class="c">// Open a SessionShell. Idempotent. Called once per sid that enters the</span>
-<span class="c">// sidebar; the renderer treats this as "start streaming to me". Returns</span>
-<span class="c">// the seq cursor the renderer should treat as the live floor.</span>
+<span class="c">// 打开一个 SessionShell。幂等。每个进入侧边栏的 sid 调用一次;</span>
+<span class="c">// renderer 视其为 "开始 stream 给我"。返回 renderer 应视为 live floor</span>
+<span class="c">// 的 seq 游标。</span>
 <span class="k">rpc</span> <span class="t">pty.open</span>(sid): Promise&lt;{ pid: number; cols: number; rows: number; seq: number }&gt;
 
-<span class="c">// One-shot historical snapshot. Returned snapshot is everything up to</span>
-<span class="c">// `seq` (exclusive). Renderer writes snapshot, then plays chunks with</span>
-<span class="c">// seq &gt;= returned.seq. Replaces the 'buffering listener' indirection.</span>
+<span class="c">// 一次性历史 snapshot。返回的 snapshot 覆盖到 `seq`(不含)之前的全部</span>
+<span class="c">// 内容。renderer 写入 snapshot,再播放 seq &gt;= returned.seq 的 chunk。</span>
+<span class="c">// 替代 'buffering listener' 这一层间接。</span>
 <span class="k">rpc</span> <span class="t">pty.snapshotAt</span>(sid, opts?: { sinceSeq?: number }): Promise&lt;{
   snapshot: <span class="t">Uint8Array</span>;
-  seq: number;     <span class="c">// exclusive upper bound covered by `snapshot`</span>
+  seq: number;     <span class="c">// `snapshot` 覆盖的上界(不含)</span>
   cols: number;
   rows: number;
 }&gt;
 
-<span class="c">// Resize is a hint; if cols/rows match current, main returns without</span>
-<span class="c">// emitting SIGWINCH. No-op-safe to call after every fit().</span>
+<span class="c">// Resize 是 hint;若 cols/rows 与当前一致,主进程返回但不 emit SIGWINCH。</span>
+<span class="c">// 每次 fit() 后无副作用地调用都是安全的。</span>
 <span class="k">rpc</span> <span class="t">pty.resize</span>(sid, cols, rows): Promise&lt;{ applied: boolean }&gt;
 
-<span class="c">// Input is fire-and-forget, ordered per-sid.</span>
-<span class="k">channel</span> <span class="s">'pty:input'</span>: { sid: string; data: string }   <span class="c">// renderer → main, one-way</span>
+<span class="c">// 输入是 fire-and-forget,per-sid 有序。</span>
+<span class="k">channel</span> <span class="s">'pty:input'</span>: { sid: string; data: string }   <span class="c">// renderer → main,单向</span>
 
-<span class="c">// Drop the SessionShell. Main may keep the PTY alive (other windows /</span>
-<span class="c">// background) but stops emitting chunks for this sid to this window.</span>
+<span class="c">// 丢弃该 SessionShell。主进程可能保留 PTY 存活(其他窗口 / 后台),</span>
+<span class="c">// 但停止向本窗口 emit 该 sid 的 chunk。</span>
 <span class="k">rpc</span> <span class="t">pty.close</span>(sid): Promise&lt;void&gt;
 
-<span class="c">// ─── what we deliberately do NOT have ───────────────────────────────────</span>
-<span class="c">// • No pty.attach / pty.detach. Subscription is implicit in pty.open.</span>
-<span class="c">// • No getBufferSnapshot/attach split. Replaced by pty.snapshotAt, which</span>
-<span class="c">//   is callable at any time and returns a self-consistent {snapshot, seq}.</span>
-<span class="c">// • No sidebar preview channel. Sidebar reads agent state only.</span>
+<span class="c">// ─── 我们刻意不提供的东西 ───────────────────────────────────────────────</span>
+<span class="c">// • 没有 pty.attach / pty.detach。订阅隐含在 pty.open 里。</span>
+<span class="c">// • 没有 getBufferSnapshot/attach 拆分。由 pty.snapshotAt 替代,</span>
+<span class="c">//   可在任意时刻调用,返回自洽的 {snapshot, seq}。</span>
+<span class="c">// • 没有侧边栏预览通道。侧边栏只读 agent 状态。</span>
 </pre>
 
-  <h3 class="sub">Why these shapes</h3>
+  <h3 class="sub">为何是这些形状</h3>
   <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li><b><code>pty.open</code> instead of <code>pty.attach</code></b> — “open” describes truth: the renderer is committing to consume this sid’s stream until <code>pty.close</code>. There is no transient attach/detach inside a window’s lifetime; switching sids doesn’t touch main.</li>
-    <li><b>Chunks carry <code>seq</code></b> — makes snapshot/live join trivially correct (drop chunks with <code>seq &lt; snapshotSeq</code>, write the rest). No timestamp races, no “did I miss any.”</li>
-    <li><b><code>pty.snapshotAt</code> is decoupled from open</b> — the renderer can call it lazily (first time it actually needs to render history) or eagerly. The IPC is the same. Avoids the “attach implies snapshot” bundling that locks ordering.</li>
-    <li><b><code>resize.applied</code> return</b> — lets the renderer skip the “did SIGWINCH fire” heuristic; main is the source of truth.</li>
+    <li><b><code>pty.open</code> 而非 <code>pty.attach</code></b> —— "open" 更贴合事实:renderer 承诺消费该 sid 的流直到 <code>pty.close</code>。窗口生命周期内不存在瞬态 attach/detach;切换 sid 不触及主进程。</li>
+    <li><b>chunk 携带 <code>seq</code></b> —— 让 snapshot/live 拼接天然正确(丢弃 <code>seq &lt; snapshotSeq</code> 的 chunk,其余写入)。无时间戳竞争,无 "是否漏了"。</li>
+    <li><b><code>pty.snapshotAt</code> 与 open 解耦</b> —— renderer 可以懒调(首次真正需要渲染历史时)或主动调,IPC 形状一致。避免 "attach 即 snapshot" 的捆绑锁死顺序。</li>
+    <li><b><code>resize.applied</code> 返回值</b> —— 让 renderer 跳过 "SIGWINCH 是否触发了" 的猜测;主进程是事实源。</li>
   </ul>
 </section>
 
 <!-- ====================== 6. STATE MACHINE ====================== -->
 <section class="s">
-  <h2>6 · Renderer state per SessionShell</h2>
-  <p class="lede">Discriminated union; transitions are the only places anything can go wrong, so they’re explicit.</p>
+  <h2>6 · 每个 SessionShell 的 renderer 状态</h2>
+  <p class="lede">Discriminated union;转移是唯一可能出错的地方,所以显式列出。</p>
 
 <pre><span class="k">type</span> <span class="t">SessionShell</span> = {
   sid: string;
-  term: <span class="t">Terminal</span>;            <span class="c">// xterm instance, created at provisioning</span>
-  container: <span class="t">HTMLElement</span>;   <span class="c">// offscreen by default; reparented to slot on activate</span>
-  lastViewportY: number | null; <span class="c">// captured on each deactivate; null until first</span>
+  term: <span class="t">Terminal</span>;            <span class="c">// xterm 实例,在 provision 时创建</span>
+  container: <span class="t">HTMLElement</span>;   <span class="c">// 默认 offscreen;activate 时 reparent 到 slot</span>
+  lastViewportY: number | null; <span class="c">// 每次 deactivate 时记录;首次之前为 null</span>
   status: <span class="t">ShellStatus</span>;
 };
 
 <span class="k">type</span> <span class="t">ShellStatus</span> =
-  | { kind: <span class="s">'provisioning'</span> }                                   <span class="c">// term created, awaiting pty.open</span>
-  | { kind: <span class="s">'streaming'</span>; seq: number }                         <span class="c">// pty.open done, chunks flowing, no snapshot yet written</span>
-  | { kind: <span class="s">'hydrating'</span>; snapshotSeq: number }                 <span class="c">// snapshot fetched, currently writing</span>
-  | { kind: <span class="s">'live'</span>; baseSeq: number }                          <span class="c">// snapshot drained, live chunks applied directly</span>
-  | { kind: <span class="s">'exited'</span>; code: number | null }                    <span class="c">// pty.onExit received; terminal becomes read-only</span>
+  | { kind: <span class="s">'provisioning'</span> }                                   <span class="c">// term 已创建,等待 pty.open</span>
+  | { kind: <span class="s">'streaming'</span>; seq: number }                         <span class="c">// pty.open 完成,chunk 流动,尚未写过 snapshot</span>
+  | { kind: <span class="s">'hydrating'</span>; snapshotSeq: number }                 <span class="c">// snapshot 已拉,正在写入</span>
+  | { kind: <span class="s">'live'</span>; baseSeq: number }                          <span class="c">// snapshot 已 drain,live chunk 直接应用</span>
+  | { kind: <span class="s">'exited'</span>; code: number | null }                    <span class="c">// 收到 pty.onExit;terminal 转为只读</span>
   | { kind: <span class="s">'error'</span>; reason: <span class="t">ShellError</span>; recoverable: boolean };
 
 <span class="k">type</span> <span class="t">ShellError</span> =
-  | <span class="s">'open-failed'</span>             <span class="c">// pty.open rejected (claude binary missing, spawn EPERM, etc.)</span>
-  | <span class="s">'snapshot-failed'</span>         <span class="c">// pty.snapshotAt rejected after retry</span>
-  | <span class="s">'host-zero-size'</span>           <span class="c">// rAF settled and slot is still 0×0 — layout never gave us space</span>
-  | <span class="s">'stream-disconnected'</span>;    <span class="c">// chunk channel went silent without an exit event</span>
+  | <span class="s">'open-failed'</span>             <span class="c">// pty.open 被拒(claude 二进制缺失、spawn EPERM 等)</span>
+  | <span class="s">'snapshot-failed'</span>         <span class="c">// pty.snapshotAt 重试后仍失败</span>
+  | <span class="s">'host-zero-size'</span>           <span class="c">// rAF 已 settle,slot 仍为 0×0 —— 布局未给空间</span>
+  | <span class="s">'stream-disconnected'</span>;    <span class="c">// chunk 通道静默,但未收到 exit 事件</span>
 
-<span class="c">// Visibility is OUTSIDE the shell — orthogonal axis:</span>
+<span class="c">// 可见性在 shell 之外 —— 正交轴:</span>
 <span class="k">type</span> <span class="t">SlotState</span> =
   | { kind: <span class="s">'empty'</span> }
-  | { kind: <span class="s">'mounting'</span>; sid: string }       <span class="c">// reparented, display:'none', running Phase 2 serial tail</span>
-  | { kind: <span class="s">'visible'</span>; sid: string };       <span class="c">// post-reveal</span>
+  | { kind: <span class="s">'mounting'</span>; sid: string }       <span class="c">// 已 reparent,display:'none',跑 Phase 2 串行尾部</span>
+  | { kind: <span class="s">'visible'</span>; sid: string };       <span class="c">// reveal 之后</span>
 </pre>
   <p style="margin:10px 0 0; font-size:13px; color:var(--ink-2);">
-    The product of <code>ShellStatus × SlotState</code> spells out every situation. Most attach-path bugs today are illegal states in this model (e.g. <i>visible but not yet live</i>), which the redesign makes unrepresentable: the slot transition from <code>mounting → visible</code> is the same call site as <code>display:''</code>, and that call site requires <code>shell.status.kind === 'live'</code>.
+    <code>ShellStatus × SlotState</code> 的笛卡尔积穷尽了所有情况。当前 attach 路径的多数 bug 在这个模型里都是非法态(例如<i>已可见但还没 live</i>),重设计让它们无法表达:<code>mounting → visible</code> 的 slot 转移与 <code>display:''</code> 是同一个调用点,而该调用点要求 <code>shell.status.kind === 'live'</code>。
   </p>
 </section>
 
 <!-- ====================== 7. FAILURE PATHS ====================== -->
 <section class="s">
-  <h2>7 · Failure paths</h2>
-  <p class="lede">Every error has a name, a user-visible artifact, and a recovery.</p>
+  <h2>7 · 失败路径</h2>
+  <p class="lede">每个错误都有名字、用户可见表现、恢复方式。</p>
   <table class="f">
     <thead>
-      <tr><th>Failure</th><th>What the user sees</th><th>Recovery</th></tr>
+      <tr><th>失败</th><th>用户看到什么</th><th>恢复</th></tr>
     </thead>
     <tbody>
       <tr>
         <td class="what">F1 · open-failed</td>
-        <td class="user">Slot stays empty; an inline error card replaces the xterm canvas: <i>“Couldn’t start Claude for this session. [Retry] [View logs]”</i>. Sidebar row gets a small error pip.</td>
-        <td>Retry button calls <code>pty.open</code> again; on third failure we surface the claude-missing guide (existing UI).</td>
+        <td class="user">Slot 保持空;内联错误卡替代 xterm 画布:<i>"无法为该会话启动 Claude。[重试] [查看日志]"</i>。侧边栏行带小错误标点。</td>
+        <td>重试按钮再次调 <code>pty.open</code>;第三次失败时弹出 claude-missing 指引(沿用现有 UI)。</td>
       </tr>
       <tr>
         <td class="what">F2 · snapshot-failed</td>
-        <td class="user">If shell never wrote a snapshot: same inline error card as F1. If shell was already live and this was a re-snapshot (rare, e.g. after dropped chunks): no UI change — we continue with current buffer and toast a non-blocking warning.</td>
-        <td>Auto-retry once after 250ms; on second failure escalate to the error card.</td>
+        <td class="user">若 shell 从未写过 snapshot:同 F1 的内联错误卡。若 shell 已 live、这次是重新 snapshot(罕见,如 chunk 丢失之后):无 UI 变化 —— 继续沿用当前 buffer,toast 非阻塞警告。</td>
+        <td>250ms 后自动重试一次;第二次失败升级为错误卡。</td>
       </tr>
       <tr>
         <td class="what">F3 · host-zero-size</td>
-        <td class="user">Slot stays in <code>mounting</code> with a subtle spinner (typically &lt;200ms). If it persists &gt;2s: error card <i>“Terminal area has no space — try resizing the window.”</i></td>
-        <td>Keep re-rAFing on every ResizeObserver tick of the slot. The moment we get nonzero dims, resume Phase 2 at B3.</td>
+        <td class="user">Slot 停留在 <code>mounting</code> 并显示淡 spinner(通常 &lt;200ms)。若超过 2s:错误卡 <i>"终端区域无空间 —— 试试调整窗口大小。"</i></td>
+        <td>每次 slot 的 ResizeObserver tick 都重排 rAF。一旦拿到非零尺寸,从 B3 恢复 Phase 2。</td>
       </tr>
       <tr>
         <td class="what">F4 · stream-disconnected</td>
-        <td class="user">Banner across the top of the terminal: <i>“Live updates paused — reconnecting…”</i>. Existing scrollback stays readable; input is disabled.</td>
-        <td>Re-subscribe via <code>pty.open</code>; if seq jumped, run a delta snapshot via <code>pty.snapshotAt(sid, {sinceSeq})</code> and apply.</td>
+        <td class="user">终端顶部横幅:<i>"实时更新已暂停 —— 重连中…"</i>。已有 scrollback 仍可读;输入禁用。</td>
+        <td>通过 <code>pty.open</code> 重新订阅;若 seq 跳跃,调 <code>pty.snapshotAt(sid, {sinceSeq})</code> 做增量 snapshot 并应用。</td>
       </tr>
       <tr>
         <td class="what">F5 · exited</td>
-        <td class="user">Terminal goes read-only; ghost cursor; sidebar agent state moves to exited. A footer chip shows the exit code, with a Restart button.</td>
-        <td>Restart spawns a fresh sid (re-uses the SessionShell container with a new Terminal); existing sessions never silently resurrect.</td>
+        <td class="user">终端转只读;光标变灰;侧边栏 agent 状态变为 exited。底部 chip 显示退出码,带重启按钮。</td>
+        <td>重启 spawn 一个新 sid(复用 SessionShell 容器,搭配新的 Terminal);已有会话不会静默复活。</td>
       </tr>
     </tbody>
   </table>
@@ -442,57 +441,57 @@
 
 <!-- ====================== 8. CONTRAST ====================== -->
 <section class="s">
-  <h2>8 · Contrast with the current 19-step path</h2>
-  <p class="lede">Not a diff — a structural comparison.</p>
+  <h2>8 · 与当前 19 步路径的对比</h2>
+  <p class="lede">不是 diff,是结构性对比。</p>
 
   <div class="cmp">
     <div class="col old">
-      <h4>Current</h4>
+      <h4>当前</h4>
       <ul>
-        <li><b>19 sequential steps</b> in <code>usePtyAttach.warm.ts</code> + <code>xtermWarmRegistry.ts</code>, mixing data, DOM, layout, and ordering decisions.</li>
-        <li><b>Terminal lifecycle tied to attach:</b> <code>allocEntry</code> on cold, <code>display</code> toggle on warm — different code paths.</li>
-        <li><b>Buffering-listener mode</b> exists to bridge the gap between subscribing and being ready to render. It is correct but is a workaround for the deeper coupling.</li>
-        <li><b>Two <code>scrollToBottom</code> calls</b> (L479 + L551) because the first one is structurally too early.</li>
-        <li><b>Fit happens after attach</b>, forcing a SIGWINCH echo that arrives after the first pin (QP-3).</li>
-        <li><b>Live-tail writes are fire-and-forget</b> (QP-1) — the highest-priority bug.</li>
-        <li><b><code>term.open</code> runs in stale-or-zero layout</b> (QP-2), CanvasAddon atlas warms up while visible (QP-4).</li>
+        <li><b>19 个串行步骤</b>分布在 <code>usePtyAttach.warm.ts</code> + <code>xtermWarmRegistry.ts</code>,数据、DOM、布局、顺序决策混在一起。</li>
+        <li><b>Terminal 生命周期绑死 attach:</b>cold 走 <code>allocEntry</code>,warm 走 <code>display</code> toggle —— 两条不同代码路径。</li>
+        <li><b>buffering-listener 模式</b>用来弥合订阅与可渲染之间的空档。它是正确的,但本质是更深层耦合的 workaround。</li>
+        <li><b>两次 <code>scrollToBottom</code></b>(L479 + L551),因为第一次结构上太早。</li>
+        <li><b>fit 在 attach 之后发生</b>,导致 SIGWINCH 回显出现在第一次钉位之后(QP-3)。</li>
+        <li><b>live-tail 写入是 fire-and-forget</b>(QP-1)—— 最高优先级的 bug。</li>
+        <li><b><code>term.open</code> 在过期或零尺寸布局中执行</b>(QP-2),CanvasAddon atlas 在可见状态预热(QP-4)。</li>
       </ul>
     </div>
     <div class="col new">
-      <h4>Redesigned</h4>
+      <h4>重设计</h4>
       <ul>
-        <li><b>5 phases</b>, of which only Phase 2 has internal ordering — and that ordering is three independent lanes joined by one barrier.</li>
-        <li><b>One Terminal lifecycle</b>: created at sidebar-provision, disposed at <code>pty.close</code>. Switching sids never touches xterm internals.</li>
-        <li><b>No buffering mode</b>: chunks always flow to a Terminal that exists. The data plane has no “waiting room.”</li>
-        <li><b>One pin</b>: S3. Computed in lane C, applied once, after drain, before reveal.</li>
-        <li><b>Fit runs before any resize negotiation</b> (B3 → S1). SIGWINCH echo, if any, is absorbed in S2’s drain — never a separate event the timeline needs to worry about.</li>
-        <li><b>All writes are awaited</b>. The drain barrier in S2 is structural, not a patched-in <code>writeAsync('')</code>.</li>
-        <li><b><code>term.open</code> runs after rAF + nonzero assert</b>. Reveal is the last instruction, so atlas warm-up is invisible by construction.</li>
+        <li><b>5 个阶段</b>,只有 Phase 2 有内部顺序 —— 且这个顺序是三条独立 lane 加一次 barrier。</li>
+        <li><b>单一 Terminal 生命周期</b>:侧边栏 provision 时创建,<code>pty.close</code> 时 dispose。切换 sid 永远不触碰 xterm 内部。</li>
+        <li><b>无 buffering 模式</b>:chunk 永远流向一个已存在的 Terminal。数据面没有 "等候室"。</li>
+        <li><b>一次钉位</b>:S3。在 lane C 算好,drain 后、reveal 前一次应用。</li>
+        <li><b>Fit 在任何 resize 协商之前发生</b>(B3 → S1)。SIGWINCH 回显(若有)被 S2 的 drain 吸收 —— 时间线不需要单独操心。</li>
+        <li><b>所有写入都被 await</b>。S2 的 drain barrier 是结构性的,不是补丁式的 <code>writeAsync('')</code>。</li>
+        <li><b><code>term.open</code> 在 rAF + 非零尺寸断言之后运行</b>。Reveal 是最后一条指令,所以 atlas 预热在结构上不可见。</li>
       </ul>
     </div>
   </div>
 
-  <h3 class="sub">Races that cannot occur in the new architecture</h3>
+  <h3 class="sub">在新架构下不可能发生的 race</h3>
   <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li><b>QP-1 (live-tail vs pin):</b> there is no fire-and-forget tail. S2 is a single explicit drain; nothing writes between S2 and S3.</li>
-    <li><b>QP-2 (stale-dim open):</b> <code>term.open</code> only runs when the container has live dims (P0 offscreen has fixed dims; B2 rAF guards the visible path).</li>
-    <li><b>QP-3 (fit-after-attach SIGWINCH echo):</b> fit is computed before <code>pty.resize</code> is called, and the resize response is drained by S2.</li>
-    <li><b>QP-4 (atlas-warm in user-visible window):</b> atlas warms up at provisioning (Phase 0) when the Terminal first <code>open</code>s into an offscreen container with real dims. By the time anything reveals, atlas is hot.</li>
-    <li><b>StrictMode double-mount (QP-5):</b> shell provisioning is idempotent (keyed by sid in a renderer registry), so re-running effects is a no-op rather than a re-allocation.</li>
+    <li><b>QP-1(live-tail vs 钉位):</b>不存在 fire-and-forget tail。S2 是单点显式 drain;S2 与 S3 之间无任何写入。</li>
+    <li><b>QP-2(stale-dim open):</b><code>term.open</code> 只在容器有 live 尺寸时运行(P0 offscreen 有固定尺寸;B2 rAF 保护可见路径)。</li>
+    <li><b>QP-3(fit-after-attach SIGWINCH 回显):</b>fit 在 <code>pty.resize</code> 之前算好,resize 的响应被 S2 drain。</li>
+    <li><b>QP-4(用户可见窗口内 atlas 预热):</b>atlas 在 provision(Phase 0)即预热 —— 此时 Terminal 首次 <code>open</code> 到带真实尺寸的 offscreen 容器。等任何东西 reveal 时,atlas 已热。</li>
+    <li><b>StrictMode 双 mount(QP-5):</b>shell provisioning 是幂等的(在 renderer registry 中以 sid 为键),所以 effect 重跑就是 no-op,不会重新分配。</li>
   </ul>
 
-  <h3 class="sub">Code that can be deleted</h3>
+  <h3 class="sub">可以删掉的代码</h3>
   <ul style="margin:0; padding-left:18px; font-size:13px; color:var(--ink-2);">
-    <li><span class="kill"><code>src/terminal/usePtyAttach.warm.ts</code></span> — the 19-step procedure. Replaced by a small <code>useVisibleShell(sid)</code> hook that toggles <code>SlotState</code>.</li>
-    <li><span class="kill"><code>xtermWarmRegistry.ts::ensureAndShowEntry / applySnapshot / pinViewportToBottom</code></span> — collapse into a <code>shellRegistry</code> with <code>provision/close/getSnapshot</code>.</li>
-    <li><span class="kill">"buffering" listener mode</span> — gone with the data-plane separation.</li>
-    <li><span class="kill"><code>pty:attach</code> and <code>pty:detach</code> IPC channels</span> — replaced by <code>pty.open</code> / <code>pty.close</code>; the per-window stream is implicit.</li>
-    <li><span class="kill">Defensive <code>term.reset()</code> before snapshot</span> — the shell registry guarantees terminals are either fresh or already live; reset has no caller.</li>
+    <li><span class="kill"><code>src/terminal/usePtyAttach.warm.ts</code></span> —— 19 步过程。由一个小 <code>useVisibleShell(sid)</code> hook 取代,只翻 <code>SlotState</code>。</li>
+    <li><span class="kill"><code>xtermWarmRegistry.ts::ensureAndShowEntry / applySnapshot / pinViewportToBottom</code></span> —— 折叠成 <code>shellRegistry</code>,只暴露 <code>provision/close/getSnapshot</code>。</li>
+    <li><span class="kill">"buffering" listener 模式</span> —— 随数据面解耦一并消失。</li>
+    <li><span class="kill"><code>pty:attach</code> 与 <code>pty:detach</code> IPC 通道</span> —— 由 <code>pty.open</code> / <code>pty.close</code> 取代;per-window 流是隐式的。</li>
+    <li><span class="kill">snapshot 前的防御性 <code>term.reset()</code></span> —— shell registry 保证 terminal 要么全新,要么已 live;reset 无人调用。</li>
   </ul>
 </section>
 
 <footer>
-  Companion document. The current implementation’s annotated timeline lives in <code>docs/attach-timeline-review.html</code> and remains the historical record — do not edit it. This file is the “if we started today” counter-proposal.
+  配套文档。当前实现的标注时间线在 <code>docs/attach-timeline-review.html</code>,作为历史记录保留 —— 不要编辑。本文件是 "如果今天从头来" 的对立提案。
 </footer>
 
 </div>

--- a/docs/attach-redesign.html
+++ b/docs/attach-redesign.html
@@ -292,28 +292,51 @@
       <div class="tag">操作 2</div>
       <b>重做 (reload)</b>
       <p>
-        · sid 不变,xterm 实例复用,不重建,不破坏 z-stack 缓存。<br>
-        · 走和第一次点一样的冷启动流程:盖遮罩 → 清屏 + 重拉 snapshot + 写入 + 滚到底 → 揭开。<br>
-        · 视觉上等于这个 session 当场重做一次冷启动。<br>
-        · z-stack 里其他 shell 不受影响,顺序不变。
+        · sid 不变,xterm 实例复用(不重建,不破坏 z-stack 缓存)。<br>
+        · 该 wrapper 内部盖遮罩 → <code>term.reset()</code> + 重拉 snapshot + 写入 + 滚到底 → 揭开。<br>
+        · 重做的是顶层 → 用户能看到遮罩(蓝色"重做中…")。<br>
+        · 重做的是非顶层 → 遮罩在底下,用户看不到;但万一重做没完用户切过来,顺势看到遮罩走完。<br>
+        · 关键:不管顶层还是非顶层,reload 走的是同一条路径,只是用户是否看见取决于 z-stack 位置。
       </p>
     </div>
     <div class="rule">
       <div class="tag">操作 3</div>
       <b>复制 (copy session)</b>
       <p>
-        · 调用方拿到新 sid,这部分是已有产品行为,不改。<br>
-        · 新 sid 通常会立刻被打开 → 走第一次点击的冷启动路径。<br>
-        · 原 session 在 z-stack 里照常保留,顺序不变。<br>
-        · 设计上不需要特殊路径,等同于自动 click(newSid)。
+        · 调用方拿到新 sid(已有产品行为,不改)。<br>
+        · 复制的是当前顶层 session → 新 sid 立刻打开,走第一次点击冷启动(顶上来),原 session 下沉。<br>
+        · 复制的是非顶层 → 新 sid 只在 sidebar 出现,不自动抢顶层,等用户主动点才冷启动。<br>
+        · 复制的是从没看过的 session → 新 sid 在 sidebar 出现,不自动打开。
       </p>
     </div>
   </div>
 </section>
 
-<!-- ====================== 6. 实现要点 ====================== -->
+<!-- ====================== 6. Sidebar 高亮 ====================== -->
 <section class="s">
-  <h2>6 · 实现要点</h2>
+  <h2>6 · Sidebar 高亮</h2>
+  <p class="lede">每个 session 行可能有一个蓝色圆点,表示"右侧 CLI 当前显示的就是它"。</p>
+
+  <div class="rules">
+    <div class="rule">
+      <div class="tag">规则</div>
+      <b>activeSid = zStack[0]</b>
+      <p>
+        · activeSid = z-stack 顶层 sid。蓝色圆点跟着 activeSid 走。<br>
+        · State 0(右侧全黑):没有任何行有圆点。<br>
+        · State 1(冷启动中):用户点的那行有圆点(因为它即将上顶)。<br>
+        · State 2(秒切):z-stack 顶层 sid 那行有圆点。<br>
+        · 删除顶层 session:顶层 pop,下一层 sid 变成新顶层 → 圆点自动跳到 sidebar 那行。<br>
+        · 非顶层 reload / 非顶层 copy:顶层不变,圆点不动。<br>
+        · 实现一句话:<b>activeSid = zStack[0]</b>,sidebar 订阅这个值。
+      </p>
+    </div>
+  </div>
+</section>
+
+<!-- ====================== 7. 实现要点 ====================== -->
+<section class="s">
+  <h2>7 · 实现要点</h2>
   <p class="lede">给后续 worker 看的落地清单。不是完整方案,只是关键决策。</p>
 
   <h3 class="sub">替换掉的现有代码</h3>


### PR DESCRIPTION
## Summary

Companion to `docs/attach-timeline-review.html` (#1389 — the audit). That doc reviewed the **current** 19-step path and proposed step-by-step fixes. Manager pushback: too many steps, still serial — design itself is wrong.

This PR is the answer to *"forget sunk cost — if we wrote ccsm's attach today, what would it look like?"*

**Core thesis:** the current path conflates four orthogonal axes — Terminal lifecycle, data subscription, layout, visibility — into one mega-procedure called "attach." Untangle them and "attach" becomes "show": all the heavy work has already happened by the time the user clicks a session.

**Structure (5 phases):**

- **Phase 0 · Provision** — when a sid enters the sidebar, allocate a `SessionShell` (Terminal + addons + offscreen container + live subscription). No user-visible side effect.
- **Phase 1 · Stream-live** — PTY chunks flow into the per-sid Terminal forever. Sidebar runs on its own data plane (`session:state`). Both are independent of visibility.
- **Phase 2 · Prepare-visible** — three parallel lanes (data / DOM / viewport-plan) → one `Promise.all` barrier → short serial tail (fit → drain → pin).
- **Phase 3 · Reveal** — single `display:''`. First frame = final frame.
- **Phase 4 · Post-reveal** — input routing flip, focus, RO baseline. Order-free.

**Boldest move:** Terminal is a **long-lived per-sid renderer object**, not a per-attach artifact. Switching sessions never disposes or re-opens xterm — it just reparents an existing Shell into the visible slot. Buffering-listener mode is **deleted**, not refactored — chunks always flow to a Terminal that exists.

**Structural elimination of QP-1..QP-5:** the redesign section explains why each known race becomes architecturally impossible, not just patched.

**IPC contract:** `pty.attach`/`pty.detach` → `pty.open`/`pty.close` (long-lived). Adds `seq` to chunks so snapshot/live join is trivially correct. No code changes in this PR.

## Test plan

- [ ] Manager reads `docs/attach-redesign.html` in 5 minutes
- [ ] Sanity-check the IPC contract against `electron/ptyHost/ipcRegistrar.ts`
- [ ] Compare Section 4 invariants against PR #1388 (warm-switch fix) — should be a strict superset
- [ ] Decide whether Phase 0 (provision-on-sidebar-entry) is acceptable resource-wise for users with many sessions
- [ ] If approved, follow-up task: convert design into an implementation plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)