### PR TITLE
chore(release): disable hourly auto-release cron

### DIFF
--- a/.github/workflows/hourly-tag-release.yml
+++ b/.github/workflows/hourly-tag-release.yml
@@ -39,8 +39,12 @@
 name: hourly tag + release
 
 on:
-  schedule:
-    - cron: '0 * * * *'
+  # Hourly schedule disabled 2026-05-26: recent auto-releases shipped
+  # bugs to users (e.g. the warm-xterm scrollbar regression). Reverting
+  # to manual releases until we have stronger pre-release gates. To
+  # restore, uncomment the schedule below.
+  #   schedule:
+  #     - cron: '0 * * * *'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Comments out the `schedule: '0 * * * *'` trigger in `hourly-tag-release.yml`; keeps `workflow_dispatch` so releases can still be triggered manually from the Actions tab.
- Motivation: recent hourly auto-releases shipped bugs to users (e.g. the warm-xterm scrollbar regression). Going back to manual releases until pre-release gating is stronger.

## Test plan
- [ ] After merge: confirm no `hourly tag + release` run fires at the next top of the hour.
- [ ] Confirm the workflow still appears under Actions → can be dispatched manually when we want to cut a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)