### PR TITLE
feat(attach): rewrite around shellRegistry + z-stack + per-shell mask

### DIFF
--- a/scripts/dogfood-attach-redesign.mjs
+++ b/scripts/dogfood-attach-redesign.mjs
@@ -1,0 +1,332 @@
+// scripts/dogfood-attach-redesign.mjs
+//
+// E2E probe for the attach-redesign rewrite (docs/attach-redesign.html).
+//
+// Verifies the 3 UX states + 3 ops:
+//
+//   STATE 0  — boot with no active session → right pane has no shell wrapper.
+//   STATE 1  — cold start (first click on session A) → wrapper appears with
+//              mask shown; mask removed once attach completes.
+//   STATE 2  — second click on session B (also cold); then A→B→A swap is
+//              instant: no mask on the visited switch.
+//
+//   DELETE   — delete the top session → next session in z-stack becomes
+//              top, no mask. Delete it too → no shells left, back to State 0.
+//   RELOAD   — reload top session → mask shown briefly, then content back.
+//   COPY     — create a new session (e.g. via createSession) and click it →
+//              normal cold-start sequence (mask → content).
+//
+// Frame-level invariants asserted:
+//   * State 1: mask visible for ≥1 frame, then hidden.
+//   * State 2 (visited switch): mask never visible.
+//   * Delete top: no mask appears on the new top.
+//   * Reload top: mask visible at some point during the suffix.
+//
+// Exit 0 = PASS, 1 = FAIL.
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+  createIsolatedClaudeDir,
+  dismissWelcomeSplash,
+  launchCcsmIsolated,
+  seedSession,
+  waitForTerminalReady,
+  waitForXtermBuffer,
+} from './probe-utils-real-cli.mjs';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function snapshotShells(win) {
+  return await win.evaluate(() => {
+    const wrappers = Array.from(document.querySelectorAll('[data-ccsm-shell-sid]'));
+    return wrappers.map((w) => {
+      const mask = w.querySelector('[data-ccsm-shell-mask]');
+      return {
+        sid: w.getAttribute('data-ccsm-shell-sid'),
+        display: w.style.display || '',
+        zIndex: w.style.zIndex || '',
+        maskDisplay:
+          mask instanceof HTMLElement ? (mask.style.display || '') : null,
+      };
+    });
+  });
+}
+
+/**
+ * Install a per-RAF sampler that records mask state for `sid` until the
+ * sampler is read back. Returns the JS expression that reads + clears the
+ * window-stashed samples.
+ */
+async function startMaskSampler(win, sid, durationMs = 1500) {
+  await win.evaluate(
+    ({ targetSid, duration }) => {
+      window.__attachRedesignSamples = [];
+      const startedAt = performance.now();
+      const tick = () => {
+        const wrapper = document.querySelector(
+          `[data-ccsm-shell-sid="${CSS.escape(targetSid)}"]`,
+        );
+        let maskDisplay = null;
+        let wrapperDisplay = null;
+        if (wrapper instanceof HTMLElement) {
+          wrapperDisplay = wrapper.style.display || '';
+          const mask = wrapper.querySelector('[data-ccsm-shell-mask]');
+          if (mask instanceof HTMLElement) {
+            maskDisplay = mask.style.display || '';
+          }
+        }
+        window.__attachRedesignSamples.push({
+          t: Math.round(performance.now() - startedAt),
+          wrapperDisplay,
+          maskDisplay,
+        });
+        if (performance.now() - startedAt < duration) {
+          requestAnimationFrame(tick);
+        }
+      };
+      requestAnimationFrame(tick);
+    },
+    { targetSid: sid, duration: durationMs },
+  );
+}
+
+async function readSamples(win) {
+  return await win.evaluate(() => window.__attachRedesignSamples || []);
+}
+
+function fail(msg) {
+  console.error(`FAIL: ${msg}`);
+  process.exitCode = 1;
+}
+
+async function main() {
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'ccsm-dogfood-attach-redesign-'));
+  createIsolatedClaudeDir(tempDir);
+
+  const { electronApp, win } = await launchCcsmIsolated({ tempDir });
+
+  try {
+    await win.waitForFunction(
+      () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+      null,
+      { timeout: 30000 },
+    );
+
+    // STATE 0 — no sessions yet → no shell wrappers in DOM.
+    {
+      const shells = await snapshotShells(win);
+      if (shells.length !== 0) {
+        fail(`State 0 expected 0 shells, got ${shells.length}: ${JSON.stringify(shells)}`);
+        return;
+      }
+      console.log('PASS State 0: no shell wrappers at boot');
+    }
+
+    // Seed 2 sessions. `seedSession` calls createSession which sets the
+    // new session active — so each seed cold-starts a shell. That's
+    // consistent with rule 1 ("never visited = zero resources") because
+    // selecting IS visiting; the sidebar click and createSession's
+    // implicit activation are the same UX trigger.
+    const { sid: sidA } = await seedSession(win, { name: 'A', cwd: tempDir });
+    const { sid: sidB } = await seedSession(win, { name: 'B', cwd: tempDir });
+    await waitForTerminalReady(win, sidB, { timeout: 45000 });
+    {
+      const shells = await snapshotShells(win);
+      const sids = shells.map((s) => s.sid).sort();
+      if (sids.length !== 2 || !sids.includes(sidA) || !sids.includes(sidB)) {
+        fail(`After seed expected shells for A+B, got: ${JSON.stringify(shells)}`);
+        return;
+      }
+      // Z-stack invariant: exactly one shell visible, that one is sidB
+      // (most-recently selected by seedSession).
+      const visible = shells.filter((s) => s.display !== 'none');
+      if (visible.length !== 1 || visible[0].sid !== sidB) {
+        fail(`Z-stack invariant broken: expected only sidB visible, got: ${JSON.stringify(visible)}`);
+        return;
+      }
+      console.log('PASS Z-stack: exactly one shell visible (sidB), sidA hidden but parented');
+    }
+
+    // Wait for sidB (the active one after seed) to be ready, then dismiss
+    // any welcome splash. STATE 1 (cold start with mask) is exercised
+    // implicitly by `seedSession` above; the explicit cold-start mask
+    // assertion happens in the COPY case at the end.
+    await waitForTerminalReady(win, sidB, { timeout: 45000 });
+    await waitForXtermBuffer(win, /claude|welcome|│|╭|\?\sfor\sshortcuts/i, { timeout: 30000 });
+    await dismissWelcomeSplash(win);
+
+    // STATE 2 — visited switch B → A. Mask must NEVER show.
+    await startMaskSampler(win, sidA);
+    await win.evaluate((id) => window.__ccsmStore.getState().selectSession(id), sidA);
+    await waitForTerminalReady(win, sidA, { timeout: 45000 });
+    await sleep(800);
+    {
+      const samples = await readSamples(win);
+      // Once switched, sidA wrapper goes display:'' AND mask should stay
+      // display:'none' the whole time (visited path doesn't re-mask).
+      const visibleFrames = samples.filter((s) => s.wrapperDisplay !== 'none');
+      const maskedWhileVisible = visibleFrames.filter((s) => s.maskDisplay === '');
+      if (maskedWhileVisible.length > 0) {
+        fail(`State 2 (visited switch B→A): mask was shown on ${maskedWhileVisible.length} frame(s). Sample: ${JSON.stringify(maskedWhileVisible.slice(0, 3))}`);
+        return;
+      }
+      console.log(`PASS State 2: visited switch had no mask across ${visibleFrames.length} visible frames`);
+    }
+
+    // RELOAD — sidA is top. Reload should mask briefly then unmask.
+    await startMaskSampler(win, sidA, 8000);
+    await win.evaluate((id) => {
+      // Don't await — let the kill + nonce-bump run in background.
+      window.__ccsmStore.getState().reloadSession(id);
+    }, sidA);
+    // Wait for the nonce to actually bump (kill awaits).
+    await win.waitForFunction(
+      (id) => (window.__ccsmStore.getState().reloadNonce[id] ?? 0) > 0,
+      sidA,
+      { timeout: 20000 },
+    );
+    await waitForTerminalReady(win, sidA, { timeout: 45000 });
+    await sleep(500);
+    {
+      const samples = await readSamples(win);
+      const sawMaskOn = samples.some((s) => s.maskDisplay === '');
+      const sawMaskOff = samples.some((s) => s.maskDisplay === 'none');
+      console.log(`reload sampled ${samples.length} frames`);
+      if (!sawMaskOn) {
+        fail(`Reload top: mask was never shown. samples-first10=${JSON.stringify(samples.slice(0, 10))}`);
+        return;
+      }
+      if (!sawMaskOff) {
+        fail('Reload top: mask never went off after reload');
+        return;
+      }
+      console.log('PASS Reload: mask shown then hidden');
+    }
+
+    // DELETE top (currently sidA) → expect z-stack to collapse to sidB
+    // without showing a mask on sidB (it's already warmed).
+    // First inspect sidB state to verify mask is hidden BEFORE delete.
+    const preDelete = await win.evaluate((sid) => {
+      const w = document.querySelector(`[data-ccsm-shell-sid="${CSS.escape(sid)}"]`);
+      const m = w?.querySelector('[data-ccsm-shell-mask]');
+      return {
+        wrapperDisplay: w instanceof HTMLElement ? w.style.display || '' : null,
+        maskDisplay: m instanceof HTMLElement ? m.style.display || '' : null,
+      };
+    }, sidB);
+    console.log(`pre-delete sidB: ${JSON.stringify(preDelete)}`);
+    await startMaskSampler(win, sidB, 1500);
+    await win.evaluate((id) => window.__ccsmStore.getState().deleteSession(id), sidA);
+    await sleep(800);
+    {
+      const shells = await snapshotShells(win);
+      const sidsLeft = shells.map((s) => s.sid);
+      if (sidsLeft.includes(sidA)) {
+        fail(`Delete: sid A still in shell registry after delete. shells=${JSON.stringify(shells)}`);
+        return;
+      }
+      if (!sidsLeft.includes(sidB)) {
+        fail(`Delete: sid B disappeared. shells=${JSON.stringify(shells)}`);
+        return;
+      }
+      // sidB should now be top (display !== 'none').
+      const b = shells.find((s) => s.sid === sidB);
+      if (!b || b.display === 'none') {
+        fail(`Delete: sid B did not become top after deleting A. shell=${JSON.stringify(b)}`);
+        return;
+      }
+      const samples = await readSamples(win);
+      const visibleMasked = samples.filter(
+        (s) => s.wrapperDisplay !== 'none' && s.maskDisplay === '',
+      );
+      if (visibleMasked.length > 0) {
+        fail(
+          `Delete: mask flashed on warmed sid B (${visibleMasked.length} frame(s)). Sample: ${JSON.stringify(visibleMasked.slice(0, 5))} first-frames=${JSON.stringify(samples.slice(0, 5))}`,
+        );
+        return;
+      }
+      console.log('PASS Delete top: z-stack collapsed to next without mask');
+    }
+
+    // COPY — createSession (auto-selects new sid) → normal cold start.
+    // Install sampler with `sid='*'` pseudo (all-shells) so we can catch
+    // the mask flash on the brand-new shell — we don't know its sid yet.
+    await win.evaluate(() => {
+      window.__attachRedesignSamplesAny = [];
+      const startedAt = performance.now();
+      const tick = () => {
+        const wrappers = Array.from(document.querySelectorAll('[data-ccsm-shell-sid]'));
+        const snapshot = wrappers.map((w) => {
+          const sid = w.getAttribute('data-ccsm-shell-sid');
+          const m = w.querySelector('[data-ccsm-shell-mask]');
+          return {
+            sid,
+            wrapperDisplay: w instanceof HTMLElement ? w.style.display || '' : null,
+            maskDisplay: m instanceof HTMLElement ? m.style.display || '' : null,
+          };
+        });
+        window.__attachRedesignSamplesAny.push({
+          t: Math.round(performance.now() - startedAt),
+          shells: snapshot,
+        });
+        if (performance.now() - startedAt < 8000) {
+          requestAnimationFrame(tick);
+        }
+      };
+      requestAnimationFrame(tick);
+    });
+    const sidC = await win.evaluate((cwd) => {
+      const st = window.__ccsmStore.getState();
+      st.createSession({ name: 'C', cwd });
+      return window.__ccsmStore.getState().activeId;
+    }, tempDir);
+    if (!sidC) {
+      fail('Copy: createSession did not produce a new active sid');
+      return;
+    }
+    await waitForTerminalReady(win, sidC, { timeout: 45000 });
+    await sleep(500);
+    {
+      const allSamples = await win.evaluate(
+        (targetSid) =>
+          (window.__attachRedesignSamplesAny || []).map((s) => ({
+            t: s.t,
+            target: s.shells.find((sh) => sh.sid === targetSid) ?? null,
+          })),
+        sidC,
+      );
+      const sawMaskOn = allSamples.some(
+        (s) => s.target && s.target.maskDisplay === '',
+      );
+      if (!sawMaskOn) {
+        fail(`Copy: new session cold start did not mask. first-frames=${JSON.stringify(allSamples.slice(0, 10))}`);
+        return;
+      }
+      console.log('PASS Copy: new session cold-started with mask');
+    }
+
+    // Delete all remaining → back to State 0.
+    await win.evaluate((id) => window.__ccsmStore.getState().deleteSession(id), sidC);
+    await win.evaluate((id) => window.__ccsmStore.getState().deleteSession(id), sidB);
+    await sleep(400);
+    {
+      const shells = await snapshotShells(win);
+      if (shells.length !== 0) {
+        fail(`Delete-all: expected back to State 0 (0 shells), got ${shells.length}: ${JSON.stringify(shells)}`);
+        return;
+      }
+      console.log('PASS Delete all: back to State 0 (no shells)');
+    }
+
+    console.log('\nPASS: attach-redesign UX states + ops behave as specified');
+  } finally {
+    await electronApp.close();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exitCode = 1;
+});

--- a/scripts/dogfood-bug-69-no-flicker.mjs
+++ b/scripts/dogfood-bug-69-no-flicker.mjs
@@ -47,7 +47,7 @@ async function readScrollState(win) {
     // multiple .xterm-viewport elements on the page (one per warm wrapper
     // under the new design) — pick the one whose ancestor wrapper is
     // visible.
-    const wrappers = Array.from(document.querySelectorAll('[data-ccsm-warm-sid]'));
+    const wrappers = Array.from(document.querySelectorAll('[data-ccsm-shell-sid]'));
     const visible = wrappers.find((w) => w instanceof HTMLElement && w.style.display !== 'none');
     const vp = (visible ?? document).querySelector('.xterm-viewport');
     return {
@@ -114,11 +114,11 @@ async function main() {
       const startedAt = performance.now();
       const DURATION_MS = 800;
       const tick = () => {
-        const wrappers = Array.from(document.querySelectorAll('[data-ccsm-warm-sid]'));
+        const wrappers = Array.from(document.querySelectorAll('[data-ccsm-shell-sid]'));
         // Find sidA's wrapper specifically (by data attr) so we sample the
         // entry whose scroll position we care about even mid-switch.
         const target = wrappers.find(
-          (w) => w instanceof HTMLElement && w.getAttribute('data-ccsm-warm-sid') === expectedSid,
+          (w) => w instanceof HTMLElement && w.getAttribute('data-ccsm-shell-sid') === expectedSid,
         );
         let scrollTop = null;
         let display = null;

--- a/src/app-effects/useTerminalFontSize.ts
+++ b/src/app-effects/useTerminalFontSize.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useStore } from '../stores/store';
-import { applyTerminalFontSize } from '../terminal/xtermWarmRegistry';
+import { applyTerminalFontSize } from '../terminal/shellRegistry';
 
 /**
  * Bridge the persisted `terminalFontSizePx` store field to the warm xterm

--- a/src/app-effects/useTerminalScrollback.ts
+++ b/src/app-effects/useTerminalScrollback.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useStore } from '../stores/store';
-import { applyTerminalScrollback } from '../terminal/xtermWarmRegistry';
+import { applyTerminalScrollback } from '../terminal/shellRegistry';
 
 /**
  * Hot-apply the `scrollbackLines` store field to every warm xterm entry.

--- a/src/components/TerminalPane.tsx
+++ b/src/components/TerminalPane.tsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef, type MouseEvent } from 'react';
 import '@xterm/xterm/css/xterm.css';
 import { useTranslation } from '../i18n/useTranslation';
-import { usePtyAttachWarm, type PtyAttachState } from '../terminal/usePtyAttach.warm';
+import { usePtyAttachShell, type PtyAttachState } from '../terminal/usePtyAttachShell';
 import { useAtBottom } from '../terminal/useAtBottom';
-import { getActiveEntry } from '../terminal/xtermWarmRegistry';
+import { getTopShell } from '../terminal/shellRegistry';
 import { terminalCopy, terminalPaste } from '../terminal/paste';
 import { ScrollToBottomButton } from './ScrollToBottomButton';
 import { useStore } from '../stores/store';
@@ -12,12 +12,10 @@ import {
   TERMINAL_FONT_SIZE_MIN,
 } from '../stores/slices/types';
 
-// TerminalPane is the host shell for the per-session warm xterm view.
-// The registry (`src/terminal/xtermWarmRegistry.ts`) owns the actual
-// Terminal instances — this component just provides the reparent target
-// host div, overlays (Error / Exit), and wires right-click
-// copy/paste. Per-session warm state means switching sessions reparents
-// the wrapper rather than tearing down xterm.
+// TerminalPane is the host shell for the per-session shellRegistry view.
+// shellRegistry owns one xterm Terminal + wrapper + mask per visited sid;
+// switching is a z-stack flip on this host's children. Cold start is
+// gated behind a black mask div per shell. See `docs/attach-redesign.html`.
 //
 // The host div carries [data-terminal-host] and [data-active-sid={sessionId}]
 // so e2e probes can locate the active terminal deterministically.
@@ -31,34 +29,9 @@ export function TerminalPane({ sessionId, cwd }: Props) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const { t } = useTranslation();
 
-  const { state, onRetry } = usePtyAttachWarm(sessionId, cwd, hostRef);
-  // `atBottom` is intentionally unused — the button is always visible
-  // while ready (see ScrollToBottomButton). We keep the hook subscribed
-  // so the detection logic (and its tests) stays live for future use.
+  const { state, onRetry } = usePtyAttachShell(sessionId, cwd, hostRef);
   const { scrollToBottom } = useAtBottom(sessionId);
 
-  // Ctrl+MouseWheel zoom for the terminal font size. We attach via
-  // useEffect rather than React's `onWheel` prop because React synthesizes
-  // wheel events as passive on the document root (cannot preventDefault),
-  // and we need to suppress both the page-zoom default AND xterm's own
-  // wheel-to-scroll handler when Ctrl is held. Capture phase + non-passive
-  // is the only way that works across Chromium versions.
-  //
-  // The store action is no-op on equal value (clamped 8–32), and the
-  // app-effect subscriber dedupes and dispatches `applyTerminalFontSize`
-  // to the registry. We RAF-coalesce so a fast scroll fires one resize
-  // per frame instead of per wheel tick.
-  //
-  // Mouse-anchored scroll: before changing the font, we sample the
-  // logical line under the cursor (anchorLine = viewportY + offsetY/cellH).
-  // After the registry writes `term.options.fontSize` (synchronous reflow
-  // via the zustand subscriber), we read the new cell height and
-  // scrollToLine so the same anchorLine stays at the same screen-Y. This
-  // is what gives WT / iTerm2 their "zoom around the pointer" feel.
-  // Uses xterm internals (`_core._renderService.dimensions.css.cell`) —
-  // best-effort, wrapped in try/catch; on any failure we skip the
-  // re-anchor and the user still gets correct zoom, just without the
-  // pointer-fixing.
   useEffect(() => {
     const host = hostRef.current;
     if (!host) return;
@@ -79,10 +52,6 @@ export function TerminalPane({ sessionId, cwd }: Props) {
       if (e.deltaY === 0) return;
       e.preventDefault();
       e.stopPropagation();
-      // Wheel-up (deltaY < 0) zooms IN (larger font); wheel-down zooms
-      // out. Step by 1 per wheel notch regardless of |deltaY| — touchpad
-      // pinch gestures (typically large continuous deltaY) still feel
-      // responsive because we step in the direction's sign only.
       pendingDelta += e.deltaY < 0 ? 1 : -1;
       pendingClientY = e.clientY;
       if (raf) return;
@@ -98,9 +67,8 @@ export function TerminalPane({ sessionId, cwd }: Props) {
           Math.min(TERMINAL_FONT_SIZE_MAX, cur + delta),
         );
         if (next === cur) return;
-        // Capture anchor before dispatch (cellH still reflects old font).
-        const active = getActiveEntry();
-        const term = active?.term;
+        const shell = getTopShell();
+        const term = shell?.term;
         let anchorLine: number | null = null;
         let anchorScreenRow: number | null = null;
         if (term) {
@@ -118,10 +86,6 @@ export function TerminalPane({ sessionId, cwd }: Props) {
           }
         }
         useStore.getState().setTerminalFontSizePx(next);
-        // After dispatch, the registry has synchronously written
-        // term.options.fontSize and called fit.fit(); cell metrics now
-        // reflect the new font. Reposition so anchorLine stays under
-        // the cursor (modulo sub-cell rounding).
         if (term && anchorLine != null && anchorScreenRow != null) {
           try {
             const cellHNew = readCellHeight(term);
@@ -158,14 +122,10 @@ export function TerminalPane({ sessionId, cwd }: Props) {
       } catch {
         // best-effort
       }
-      // Native CLI/terminal-emulator behaviour: right-click with selection
-      // copies + clears; without selection, pastes. Routed through the
-      // shared `paste` module, which operates on whichever warm entry is
-      // currently active. No popover.
-      const term = getActiveEntry()?.term;
+      const term = getTopShell()?.term;
       const copied = terminalCopy(term);
       if (!copied) {
-        void terminalPaste(() => getActiveEntry()?.term, sessionId, 'right-click');
+        void terminalPaste(() => getTopShell()?.term, sessionId, 'right-click');
       }
     },
     [sessionId],
@@ -176,12 +136,9 @@ export function TerminalPane({ sessionId, cwd }: Props) {
       className="relative flex-1 w-full h-full bg-black ring-1 ring-inset ring-white/5"
       data-terminal-host
       data-active-sid={sessionId}
-      data-ccsm-warm-xterm
+      data-ccsm-shell-host
       onContextMenu={onContextMenu}
     >
-      {/* The registry owns the inner wrapper(s); this host div is the
-          reparent target. The registry's `ensureAndShowEntry` does the
-          appendChild of its per-sid wrapper directly under the host. */}
       <div ref={hostRef} className="absolute inset-0" />
       <Overlay state={state} onRetry={onRetry} t={t} />
       {state.kind === 'ready' ? (

--- a/src/stores/slices/sessionCrudSlice.ts
+++ b/src/stores/slices/sessionCrudSlice.ts
@@ -15,6 +15,7 @@
 
 import type { Group, Session } from '../../types';
 import { CLAUDE_CODE_AGENT_ID } from '../../shared/agentIds';
+import { disposeShell } from '../../terminal/shellRegistry';
 import { hydrateDrafts as _unused, deleteDrafts, snapshotDraft, restoreDraft } from '../drafts';
 import { resolvePreferredGroup } from '../lib/preferredGroupResolver';
 import {
@@ -378,6 +379,13 @@ export function createSessionCrudSlice(set: SetFn, get: GetFn): SessionCrudSlice
         void window.ccsmPty?.kill(id).catch(() => {});
       } catch {
         /* renderer started without preload (tests) — no-op */
+      }
+      // attach-redesign §4: delete removes the shell. z-stack collapses
+      // to the next remaining shell, or back to State 0 (blank) if empty.
+      try {
+        disposeShell(id);
+      } catch {
+        /* registry absent (tests / non-renderer contexts) — non-fatal */
       }
       return snapshot;
     },

--- a/src/stores/slices/sessionRuntimeSlice.ts
+++ b/src/stores/slices/sessionRuntimeSlice.ts
@@ -17,7 +17,6 @@
 // `sessionCrudSlice` (split per Task #736 / PR #754 review).
 
 import { classifyPtyExit } from '../../lib/ptyExitClassifier';
-import { disposeEntry } from '../../terminal/xtermWarmRegistry';
 import type { RootStore, SetFn, GetFn } from './types';
 
 export type SessionRuntimeSlice = Pick<
@@ -102,30 +101,17 @@ export function createSessionRuntimeSlice(
     },
 
     reloadSession: async (sid) => {
-      // Kill the current pty (best-effort — it may already be exiting,
-      // in which case `kill` resolves with `ok: false` which we ignore).
-      // The renderer's preload bridge swallows IPC errors via `.catch()`
-      // pattern at other call sites; we mirror that here.
+      // Kill the current PTY (best-effort — it may already be exiting).
       try {
         await window.ccsmPty?.kill(sid);
       } catch {
         /* renderer started without preload (tests) — no-op */
       }
-      // Tear down the warm xterm entry for this sid. Without this the
-      // attach effect's next pass (driven by the reloadNonce bump below)
-      // hits a still-present warm entry, takes the WARM branch, and
-      // never calls `pty.spawn` — the PTY is dead and the UI is stale.
-      // See PR #1361 / bug #1360 root cause.
-      try {
-        disposeEntry(sid, 'reload');
-      } catch {
-        /* registry may be absent in unit tests — non-fatal */
-      }
-      // Drop any stale exit-classification entry from the previous pty
-      // so the sidebar red dot doesn't linger across the reload window
-      // (the new pty's attach effect will also clearPtyExit on success,
-      // but doing it eagerly here avoids a brief flash for crashed-then-
-      // reload-to-recover sequences).
+      // Per attach-redesign §4: reload is term.reset() in-place, NOT
+      // dispose. The attach hook observes the reloadNonce bump below and
+      // runs the "reset + snapshot + write + subscribe" suffix against
+      // the freshly spawned PTY. Hidden-shell reloads are silent (no
+      // mask); top-shell reloads show the mask while the suffix runs.
       set((s) => {
         const nextDisc = s.disconnectedSessions[sid]
           ? (() => {

--- a/src/terminal/shellRegistry.ts
+++ b/src/terminal/shellRegistry.ts
@@ -1,0 +1,663 @@
+// `shellRegistry` — the only renderer-side terminal lifecycle module post
+// attach-redesign (see `docs/attach-redesign.html`).
+//
+// Mental model (3 UX states from the design doc):
+//   State 0 — App just opened. No shells exist. Right pane is black.
+//   State 1 — Cold start. A wrapper appears in the host, mask covers it
+//             while we fetch snapshot + build xterm + subscribe to PTY.
+//             Mask removed once content is on screen.
+//   State 2 — Already-visited switch. Wrappers stay parented in the host;
+//             switching is a z-index + display flip. No mask, no flicker.
+//
+// Two rules (design doc §2):
+//   1. Never visited → zero resources (no xterm, no PTY subscription).
+//   2. Visited → kept alive until ccsm quits or explicit dispose.
+//
+// Bailout (§5): any anomaly mid-cold-start → dispose this shell and let
+// the user click again to retry from scratch. No race-case enumeration,
+// no cancellation token machinery.
+
+import { Terminal } from '@xterm/xterm';
+import { FitAddon } from '@xterm/addon-fit';
+import { WebLinksAddon } from '@xterm/addon-web-links';
+import { ClipboardAddon } from '@xterm/addon-clipboard';
+import { Unicode11Addon } from '@xterm/addon-unicode11';
+import { CanvasAddon } from '@xterm/addon-canvas';
+import { useStore } from '../stores/store';
+import { SCROLLBACK_LINES_DEFAULT, TERMINAL_FONT_SIZE_DEFAULT } from '../stores/slices/types';
+import { warn, log } from '../shared/log';
+import { pasteIntoActivePty } from './paste';
+
+export type Shell = {
+  sid: string;
+  /** DOM wrapper parented under the host. Owns the xterm canvases AND the
+   *  per-shell mask div. Never reparented after first attach — visibility
+   *  is toggled via `display` + `z-index` only. */
+  wrapper: HTMLDivElement;
+  /** Mask div sitting inside the wrapper. Shown during cold-start /
+   *  reload-of-top, hidden otherwise. */
+  mask: HTMLDivElement;
+  term: Terminal;
+  fit: FitAddon;
+  /** `pty.onData` unsubscriber. Lives for the lifetime of the shell. */
+  dataUnsubscribe: () => void;
+  /** Disposers for textarea-bound listeners (IME, paste, selection-copy). */
+  inputDisposers: Array<() => void>;
+  /** Composition state — `pty.onData` writes are buffered while true so the
+   *  IME preview box doesn't jump. */
+  composing: boolean;
+  composingBuffer: string[];
+  /** Set true after the first cold-start completes; used by the host to
+   *  know whether a re-show should trigger any mask UI (it should not). */
+  warmed: boolean;
+  /** Pending font size to apply on next show — set when a Ctrl+wheel zoom
+   *  happens while this shell is hidden. */
+  pendingFontSize: number | null;
+};
+
+const shells: Map<string, Shell> = new Map();
+let topSid: string | null = null;
+
+// Single module-level PTY exit listener — dispatches to the store for
+// every sid (visible OR hidden). Mirrors the legacy behaviour: hidden
+// session crashes must surface their exit classification so the user
+// sees the right overlay on switch-back.
+let exitUnsubscribe: (() => void) | null = null;
+function installExitListenerOnce(): void {
+  if (exitUnsubscribe) return;
+  const pty = typeof window !== 'undefined' ? window.ccsmPty : undefined;
+  if (!pty?.onExit) return;
+  exitUnsubscribe = pty.onExit(
+    (evt: { sessionId: string; code?: number | null; signal?: string | number | null }) => {
+      const sid = evt.sessionId;
+      if (!sid) return;
+      try {
+        useStore.getState()._applyPtyExit(sid, {
+          code: evt.code ?? null,
+          signal: evt.signal ?? null,
+        });
+      } catch (e) {
+        warn('shell', 'exit dispatch failed', e);
+      }
+    },
+  );
+}
+
+let beforeUnloadHandler: (() => void) | null = null;
+function installUnloadCleanupOnce(): void {
+  if (beforeUnloadHandler) return;
+  if (typeof window === 'undefined') return;
+  beforeUnloadHandler = () => disposeAll();
+  window.addEventListener('beforeunload', beforeUnloadHandler);
+}
+
+export function getShell(sid: string): Shell | undefined {
+  return shells.get(sid);
+}
+
+export function getTopSid(): string | null {
+  return topSid;
+}
+
+export function getTopShell(): Shell | undefined {
+  return topSid != null ? shells.get(topSid) : undefined;
+}
+
+export function shellCount(): number {
+  return shells.size;
+}
+
+/**
+ * Create a fresh shell for `sid`, parent it under `host`, show the mask,
+ * and return it. Caller (the attach hook) then drives the cold-start
+ * sequence: pty.attach → fetch snapshot → write → subscribe → unmask.
+ *
+ * The shell becomes the z-stack top synchronously: previously-top shell
+ * stays in the layout tree at a lower z-index, but its wrapper's `display`
+ * is set to 'none' so it can't paint behind us (saves GPU work).
+ */
+export function createShell(sid: string, host: HTMLElement): Shell {
+  installUnloadCleanupOnce();
+  installExitListenerOnce();
+
+  const existing = shells.get(sid);
+  if (existing) {
+    // Caller asked to create but the shell already exists — promote it
+    // and return. Idempotent.
+    showShell(sid);
+    return existing;
+  }
+
+  const scrollback = useStore.getState().scrollbackLines ?? SCROLLBACK_LINES_DEFAULT;
+  const fontSize = useStore.getState().terminalFontSizePx ?? TERMINAL_FONT_SIZE_DEFAULT;
+  const term = new Terminal({
+    fontFamily: 'Cascadia Mono, Consolas, "Courier New", monospace',
+    fontSize,
+    cursorBlink: false,
+    allowProposedApi: true,
+    scrollback,
+    theme: { background: '#000000' },
+    scrollSensitivity: 0.5,
+    fastScrollSensitivity: 5,
+    fastScrollModifier: 'alt',
+  });
+  const fit = new FitAddon();
+  term.loadAddon(fit);
+  try {
+    term.loadAddon(
+      new WebLinksAddon((event, uri) => {
+        if (event.ctrlKey || event.metaKey) window.ccsm?.openExternal?.(uri);
+      }),
+    );
+  } catch (e) {
+    warn('shell', 'web-links addon failed', e);
+  }
+  try {
+    term.loadAddon(new ClipboardAddon());
+  } catch (e) {
+    warn('shell', 'clipboard addon failed', e);
+  }
+  try {
+    term.loadAddon(new Unicode11Addon());
+    term.unicode.activeVersion = '11';
+  } catch (e) {
+    warn('shell', 'unicode11 addon failed', e);
+  }
+  try {
+    term.loadAddon(new CanvasAddon());
+  } catch (e) {
+    warn('shell', 'canvas addon failed', e);
+  }
+
+  // Build wrapper + mask. Wrapper covers the host; mask is an absolute-
+  // positioned overlay inside the wrapper that the cold-start path hides
+  // when content is on screen.
+  const wrapper = document.createElement('div');
+  wrapper.setAttribute('data-ccsm-shell-sid', sid);
+  wrapper.className = 'absolute inset-0';
+  wrapper.style.zIndex = '1';
+
+  const mask = document.createElement('div');
+  mask.setAttribute('data-ccsm-shell-mask', sid);
+  mask.className = 'absolute inset-0';
+  mask.style.background = '#000000';
+  mask.style.zIndex = '10';
+  mask.style.pointerEvents = 'auto';
+  wrapper.appendChild(mask);
+
+  // Append to host BEFORE term.open() so xterm initialises against a
+  // parented + zero-css-display node. We start hidden so no layout flash
+  // before the caller's cold-start path makes it the top.
+  host.appendChild(wrapper);
+
+  // Open xterm against the wrapper (mask covers it for now — user sees
+  // black while we attach + fetch snapshot).
+  try {
+    term.open(wrapper);
+  } catch (e) {
+    warn('shell', 'term.open failed', e);
+  }
+
+  // PTY data subscription is NOT installed here — the cold-start sequence
+  // is `build xterm → open → fetch snapshot → write → subscribe PTY`
+  // (design doc principle, no buffering-listener mode in the renderer).
+  // The attach hook calls `subscribeShellData(sid)` AFTER it has written
+  // the snapshot into term.
+  const shell: Shell = {
+    sid,
+    wrapper,
+    mask,
+    term,
+    fit,
+    dataUnsubscribe: () => {},
+    inputDisposers: [],
+    composing: false,
+    composingBuffer: [],
+    warmed: false,
+    pendingFontSize: null,
+  };
+  shells.set(sid, shell);
+
+  installInputListeners(shell);
+
+  // Promote synchronously so the host's react render sees it on top.
+  showShell(sid);
+
+  try {
+    log.event('shell.created', { sid, count: shells.size });
+  } catch {
+    /* probe best-effort */
+  }
+  return shell;
+}
+
+/**
+ * Promote `sid` to the z-stack top. Idempotent. Hides every other shell
+ * via `display:none` (saves paint cost; their xterm WriteBuffer still
+ * drains since the per-shell `pty.onData` subscription is independent of
+ * visibility). Bumps the new top to `z-index: 2`, demotes the old top to
+ * `z-index: 1`.
+ *
+ * Mask handling is NOT done here — the caller decides whether the new
+ * top should show a mask (cold-start: yes; visited switch: no; reload of
+ * top: yes; reload of non-top: don't show even after we promote, but
+ * we don't promote on non-top reload either).
+ */
+export function showShell(sid: string): Shell | undefined {
+  const shell = shells.get(sid);
+  if (!shell) return undefined;
+
+  for (const [otherSid, other] of shells) {
+    if (otherSid === sid) continue;
+    if (other.wrapper.style.display !== 'none') {
+      other.wrapper.style.display = 'none';
+      other.wrapper.style.zIndex = '1';
+    }
+  }
+  shell.wrapper.style.display = '';
+  shell.wrapper.style.zIndex = '2';
+  topSid = sid;
+
+  // Consume any deferred font size that landed while this shell was
+  // hidden. Apply in place + refit; the PTY resize falls out of fit.
+  if (shell.pendingFontSize != null && shell.warmed) {
+    const px = shell.pendingFontSize;
+    shell.pendingFontSize = null;
+    const cur = (shell.term.options as { fontSize?: number }).fontSize;
+    if (cur !== px) {
+      try {
+        shell.term.options.fontSize = px;
+        shell.fit.fit();
+        const p = window.ccsmPty?.resize(sid, shell.term.cols, shell.term.rows);
+        if (p && typeof (p as Promise<void>).then === 'function') {
+          void (p as Promise<void>).catch((e) =>
+            warn('shell', 'lazy resize failed', e),
+          );
+        }
+      } catch (e) {
+        warn('shell', 'lazy font apply failed', e);
+      }
+    }
+  }
+
+  try {
+    window.__ccsmTerm = shell.term;
+  } catch {
+    /* probe handle is best-effort */
+  }
+
+  return shell;
+}
+
+export function setMask(sid: string, on: boolean): void {
+  const shell = shells.get(sid);
+  if (!shell) return;
+  shell.mask.style.display = on ? '' : 'none';
+}
+
+/**
+ * Subscribe the shell to its PTY data stream. Called by the cold-start
+ * path AFTER the snapshot has been written, so the listener writes
+ * straight to term in arrival order — no seq dedupe, no mode machine.
+ *
+ * Theoretical loss window: chunks broadcast by main between snapshot
+ * capture and this subscribe land in main's headless buffer but never
+ * reach the shell's term. Acceptable per design doc §5 — if the user
+ * notices missing content, the bailout is `disposeShell(sid)` + click
+ * again, which re-snapshots from a now-fresher headless buffer.
+ *
+ * Idempotent: if the shell already has a non-noop dataUnsubscribe we
+ * dispose it first.
+ */
+export function subscribeShellData(sid: string): void {
+  const shell = shells.get(sid);
+  if (!shell) return;
+  try {
+    shell.dataUnsubscribe();
+  } catch {
+    /* ignore */
+  }
+  const pty = window.ccsmPty;
+  if (!pty?.onData) return;
+  shell.dataUnsubscribe = pty.onData(
+    (payload: { sid: string; chunk: string; seq: number }) => {
+      if (payload.sid !== sid) return;
+      const s = shells.get(sid);
+      if (!s) return;
+      if (s.composing) {
+        s.composingBuffer.push(payload.chunk);
+        return;
+      }
+      try {
+        s.term.write(payload.chunk);
+      } catch {
+        /* term may be mid-dispose */
+      }
+    },
+  );
+}
+
+/**
+ * Tear down `sid`'s shell: unsubscribe PTY, dispose xterm, remove DOM.
+ * Falls back to the next-most-recent shell if we just disposed the top.
+ * If the registry empties, top becomes null (State 0: blank pane).
+ */
+export function disposeShell(sid: string): void {
+  const shell = shells.get(sid);
+  if (!shell) return;
+  shells.delete(sid);
+  try {
+    shell.dataUnsubscribe();
+  } catch (e) {
+    warn('shell', 'dataUnsubscribe failed', e);
+  }
+  for (const d of shell.inputDisposers) {
+    try {
+      d();
+    } catch {
+      /* ignore */
+    }
+  }
+  shell.inputDisposers.length = 0;
+  try {
+    shell.term.dispose();
+  } catch (e) {
+    warn('shell', 'term.dispose failed', e);
+  }
+  try {
+    shell.wrapper.remove();
+  } catch {
+    /* ignore */
+  }
+  if (topSid === sid) {
+    topSid = null;
+    try {
+      delete window.__ccsmTerm;
+    } catch {
+      /* ignore */
+    }
+    // Z-stack collapse: surface the next remaining shell, if any. Per
+    // design doc §4: "删的是顶层 → z-stack 自动塌到下一层". We use
+    // insertion order — Map preserves it — taking the last (most-recent)
+    // remaining shell.
+    let next: string | null = null;
+    for (const s of shells.keys()) next = s;
+    if (next != null) showShell(next);
+  }
+  try {
+    log.event('shell.disposed', { sid, count: shells.size });
+  } catch {
+    /* probe best-effort */
+  }
+}
+
+export function disposeAll(): void {
+  for (const sid of Array.from(shells.keys())) disposeShell(sid);
+}
+
+/**
+ * Reload semantics (design doc §4):
+ *   term.reset() in place, then the caller re-fetches snapshot + writes.
+ *   NOT dispose. The PTY subscription continues to live; main side has
+ *   spawned a fresh PTY (callers do `pty.kill` + `pty.spawn` before this).
+ *   If this is the top shell, mask while we work; otherwise stay silent.
+ */
+export function resetShellForReload(sid: string): Shell | undefined {
+  const shell = shells.get(sid);
+  if (!shell) return undefined;
+  try {
+    shell.term.reset();
+  } catch (e) {
+    warn('shell', 'term.reset failed', e);
+  }
+  if (topSid === sid) setMask(sid, true);
+  return shell;
+}
+
+/**
+ * Apply a new terminal font size:
+ *   - top shell: immediate fit + pty.resize (no snapshot replay — xterm
+ *     reflows in place; PTY's SIGWINCH causes claude to repaint).
+ *   - hidden shells: stash on `pendingFontSize` and apply on next
+ *     `showShell` (avoids N concurrent resize IPCs).
+ */
+export async function applyTerminalFontSize(px: number): Promise<void> {
+  for (const [sid, shell] of shells) {
+    if (sid === topSid) continue;
+    const cur = (shell.term.options as { fontSize?: number }).fontSize;
+    shell.pendingFontSize = cur === px ? null : px;
+  }
+  if (!topSid) return;
+  const shell = shells.get(topSid);
+  if (!shell) return;
+  if (shell.composing) {
+    shell.pendingFontSize = px;
+    return;
+  }
+  const cur = (shell.term.options as { fontSize?: number }).fontSize;
+  if (cur === px) return;
+  try {
+    shell.term.options.fontSize = px;
+    shell.fit.fit();
+    const p = window.ccsmPty?.resize(shell.sid, shell.term.cols, shell.term.rows);
+    if (p && typeof (p as Promise<void>).then === 'function') {
+      await (p as Promise<void>);
+    }
+  } catch (e) {
+    warn('shell', 'apply fontSize failed', e);
+  }
+}
+
+export function applyTerminalScrollback(n: number): void {
+  for (const shell of shells.values()) {
+    try {
+      const cur = (shell.term.options as { scrollback?: number }).scrollback;
+      if (cur === n) continue;
+      shell.term.options.scrollback = n;
+    } catch (e) {
+      warn('shell', 'apply scrollback failed', e);
+    }
+  }
+}
+
+// Input-side listeners: IME composition guard, capture-phase paste,
+// selection-to-clipboard auto-copy, Ctrl/Cmd+C/V/A handler. Same surface
+// as the legacy registry (these are UX features, not race handling).
+function installInputListeners(shell: Shell): void {
+  const { term, sid, wrapper } = shell;
+  const ta = term.textarea;
+  if (ta) {
+    const onStart = () => {
+      shell.composing = true;
+      shell.composingBuffer.length = 0;
+    };
+    const onEnd = () => {
+      shell.composing = false;
+      if (shell.composingBuffer.length > 0) {
+        const pending = shell.composingBuffer.join('');
+        shell.composingBuffer.length = 0;
+        try {
+          term.write(pending);
+        } catch {
+          /* best-effort */
+        }
+      }
+    };
+    ta.addEventListener('compositionstart', onStart);
+    ta.addEventListener('compositionend', onEnd);
+    shell.inputDisposers.push(() => {
+      try {
+        ta.removeEventListener('compositionstart', onStart);
+      } catch {
+        /* ignore */
+      }
+      try {
+        ta.removeEventListener('compositionend', onEnd);
+      } catch {
+        /* ignore */
+      }
+    });
+  }
+
+  let keyboardPasteHandled = false;
+  const onPasteCapture = (e: ClipboardEvent): void => {
+    e.stopImmediatePropagation();
+    e.preventDefault();
+    if (keyboardPasteHandled) {
+      keyboardPasteHandled = false;
+      return;
+    }
+    const text = e.clipboardData?.getData('text/plain') ?? '';
+    void pasteIntoActivePty(() => shell.term, sid, text || undefined);
+  };
+  wrapper.addEventListener('paste', onPasteCapture, true);
+  shell.inputDisposers.push(() => {
+    try {
+      wrapper.removeEventListener('paste', onPasteCapture, true);
+    } catch {
+      /* ignore */
+    }
+  });
+
+  try {
+    const selDisposable = term.onSelectionChange(() => {
+      const sel = term.getSelection();
+      if (sel) {
+        try {
+          window.ccsmPty?.clipboard?.writeText(sel);
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+    shell.inputDisposers.push(() => {
+      try {
+        selDisposable?.dispose?.();
+      } catch {
+        /* ignore */
+      }
+    });
+  } catch (e) {
+    warn('shell', 'onSelectionChange attach failed', e);
+  }
+
+  const pasteFromClipboard = (): void => {
+    keyboardPasteHandled = true;
+    setTimeout(() => {
+      keyboardPasteHandled = false;
+    }, 0);
+    let text: string | undefined;
+    try {
+      text = window.ccsmPty?.clipboard?.readText() || undefined;
+    } catch {
+      /* best-effort */
+    }
+    void pasteIntoActivePty(() => shell.term, sid, text);
+  };
+  try {
+    term.attachCustomKeyEventHandler((ev) => {
+      if (ev.type !== 'keydown') return true;
+      const mod = ev.ctrlKey || ev.metaKey;
+      if (!mod || ev.altKey) return true;
+      const isC = ev.key === 'C' || ev.key === 'c';
+      const isV = ev.key === 'V' || ev.key === 'v';
+      const isA = ev.key === 'A' || ev.key === 'a';
+      if (!ev.shiftKey && isA) {
+        try {
+          term.selectAll();
+        } catch {
+          /* ignore */
+        }
+        return false;
+      }
+      if (!ev.shiftKey && isC) {
+        const sel = term.getSelection();
+        if (sel) {
+          try {
+            window.ccsmPty?.clipboard?.writeText(sel);
+          } catch {
+            /* ignore */
+          }
+          return false;
+        }
+        return true;
+      }
+      if (!ev.shiftKey && isV) {
+        pasteFromClipboard();
+        return false;
+      }
+      if (ev.shiftKey && isC) {
+        const sel = term.getSelection();
+        if (sel) {
+          try {
+            window.ccsmPty?.clipboard?.writeText(sel);
+          } catch {
+            /* ignore */
+          }
+        }
+        return false;
+      }
+      if (ev.shiftKey && isV) {
+        pasteFromClipboard();
+        return false;
+      }
+      return true;
+    });
+  } catch (e) {
+    warn('shell', 'attachCustomKeyEventHandler failed', e);
+  }
+}
+
+/** Test-only: drop all shells silently, reset module state. */
+export function __resetShellRegistryForTests(): void {
+  for (const shell of shells.values()) {
+    try {
+      shell.dataUnsubscribe();
+    } catch {
+      /* ignore */
+    }
+    for (const d of shell.inputDisposers) {
+      try {
+        d();
+      } catch {
+        /* ignore */
+      }
+    }
+    shell.inputDisposers.length = 0;
+    try {
+      shell.term.dispose();
+    } catch {
+      /* ignore */
+    }
+    try {
+      shell.wrapper.remove();
+    } catch {
+      /* ignore */
+    }
+  }
+  shells.clear();
+  topSid = null;
+  if (beforeUnloadHandler && typeof window !== 'undefined') {
+    try {
+      window.removeEventListener('beforeunload', beforeUnloadHandler);
+    } catch {
+      /* ignore */
+    }
+  }
+  beforeUnloadHandler = null;
+  if (exitUnsubscribe) {
+    try {
+      exitUnsubscribe();
+    } catch {
+      /* ignore */
+    }
+  }
+  exitUnsubscribe = null;
+  if (typeof window !== 'undefined') {
+    try {
+      delete window.__ccsmTerm;
+    } catch {
+      /* ignore */
+    }
+  }
+}

--- a/src/terminal/useAtBottom.ts
+++ b/src/terminal/useAtBottom.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { getActiveEntry } from './xtermWarmRegistry';
+import { getTopShell } from './shellRegistry';
 
 // Reads the active warm-entry xterm's buffer position and reports whether
 // the viewport is parked at the bottom (i.e. xterm's "follow live output"
@@ -31,39 +31,25 @@ export type AtBottomState = {
 };
 
 function readAtBottom(): boolean {
-  const term = getActiveEntry()?.term;
-  if (!term) return true; // no terminal yet → don't show the button
+  const term = getTopShell()?.term;
+  if (!term) return true;
   const buf = term.buffer.active;
   return buf.baseY - buf.viewportY <= 1;
 }
 
 export function useAtBottom(sessionId: string | null): AtBottomState {
-  // Default to `true` so the button starts hidden and only appears once
-  // the user has actually scrolled away. Initial mount may race with the
-  // registry allocating the entry; we re-poll on the first effect tick.
   const [atBottom, setAtBottom] = useState<boolean>(true);
 
   useEffect(() => {
-    const term = getActiveEntry()?.term;
+    const term = getTopShell()?.term;
     if (!term) {
-      // Registry hasn't allocated yet (StrictMode double-invoke or first
-      // mount before usePtyAttachWarm runs). Re-check on next frame; if
-      // still missing, give up — the attach hook will trigger another
-      // render once the entry exists.
       const id = requestAnimationFrame(() => setAtBottom(readAtBottom()));
       return () => cancelAnimationFrame(id);
     }
-
     const recompute = (): void => setAtBottom(readAtBottom());
-    // Session swap: re-read immediately. The warm path replaces the
-    // active term across switches; the new term may be at any scroll
-    // position, so recompute right away rather than waiting for the
-    // first onScroll / onLineFeed.
     recompute();
-
     const scrollDisposable = term.onScroll(recompute);
     const lineFeedDisposable = term.onLineFeed(recompute);
-
     return () => {
       scrollDisposable.dispose();
       lineFeedDisposable.dispose();
@@ -73,10 +59,8 @@ export function useAtBottom(sessionId: string | null): AtBottomState {
   return {
     atBottom,
     scrollToBottom: () => {
-      const term = getActiveEntry()?.term;
+      const term = getTopShell()?.term;
       if (!term) return;
-      // xterm's public API: scrolls viewport such that `viewportY === baseY`,
-      // which restores the "follow live output" behaviour automatically.
       term.scrollToBottom();
     },
   };

--- a/src/terminal/usePtyAttachShell.ts
+++ b/src/terminal/usePtyAttachShell.ts
@@ -1,0 +1,411 @@
+// `usePtyAttachShell` — the renderer's attach orchestration hook post
+// attach-redesign. Built on `shellRegistry`. See `docs/attach-redesign.html`.
+//
+// Two paths, no machinery:
+//
+//   COLD (no shell yet for this sid):
+//     1. createShell(sid, host)   — builds wrapper + xterm.open + input
+//                                   listeners + mask ON. No PTY listener.
+//     2. pty.attach(sid)          — spawn-on-null falls back to pty.spawn.
+//     3. pty.getBufferSnapshot     — captured atomically with main's seq.
+//     4. term.reset() + write     — paint the snapshot.
+//     5. subscribeShellData(sid)  — PTY listener writes live chunks to term.
+//     6. fit + pty.resize (best-effort) + setMask(sid, false) → ready.
+//
+//   VISITED (shell exists):
+//     1. showShell(sid)            — z-stack flip, no mask.
+//     2. fit() + best-effort pty.resize for any container size change.
+//     3. ready immediately.
+//
+// Reload (sessionRuntimeSlice.reloadSession bumps reloadNonce):
+//   - reload of top: resetShellForReload(sid) shows mask, then cold-start
+//     suffix (attach → snapshot → write → unmask).
+//   - reload of hidden: same shape but mask stays off the whole time
+//     because the shell isn't on top.
+//
+// Bailout: any throw → setState('error') + disposeShell(sid). User taps
+// Retry → onRetry calls disposeShell + sets a nonce so the effect re-runs
+// from scratch (i.e., cold-starts a fresh shell).
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useStore } from '../stores/store';
+import { warn, log } from '../shared/log';
+import {
+  createShell,
+  disposeShell,
+  getShell,
+  resetShellForReload,
+  setMask,
+  showShell,
+  subscribeShellData,
+  type Shell,
+} from './shellRegistry';
+
+export type PtyAttachState =
+  | { kind: 'attaching' }
+  | { kind: 'ready' }
+  | { kind: 'exit'; exitKind: 'clean' | 'crashed'; detail: string }
+  | { kind: 'error'; message: string };
+
+export type UsePtyAttachResult = {
+  state: PtyAttachState;
+  onRetry: () => void;
+};
+
+function resolveReadyOrExit(
+  sessionId: string,
+): { next: PtyAttachState; clearExit: boolean } {
+  const exitInfo = useStore.getState().disconnectedSessions[sessionId];
+  if (exitInfo) {
+    const detail =
+      exitInfo.signal != null
+        ? `signal ${exitInfo.signal}`
+        : exitInfo.code != null
+          ? `exit code ${exitInfo.code}`
+          : 'unknown';
+    return {
+      next: { kind: 'exit', exitKind: exitInfo.kind, detail },
+      clearExit: false,
+    };
+  }
+  return { next: { kind: 'ready' }, clearExit: true };
+}
+
+const writeAsync = (
+  t: { write: (s: string, cb?: () => void) => void },
+  s: string,
+): Promise<void> => new Promise((resolve) => t.write(s, resolve));
+
+/**
+ * The "attach → snapshot → write → subscribe → unmask" sequence shared
+ * between the cold path (new shell) and the reload path (existing shell
+ * whose term was just term.reset()'d). Throws on any failure so the
+ * caller can `disposeShell` + setState('error').
+ */
+async function runColdStartSuffix(
+  sessionId: string,
+  cwd: string,
+  shell: Shell,
+): Promise<void> {
+  const pty = window.ccsmPty;
+  if (!pty) throw new Error('ccsmPty unavailable');
+
+  let res = (await pty.attach(sessionId)) as
+    | { cols: number; rows: number; pid: number }
+    | null;
+  if (!res) {
+    const forkSourceSid =
+      useStore.getState().pendingForkSource[sessionId] ?? undefined;
+    const spawnResult = (await pty.spawn(sessionId, cwd ?? '', forkSourceSid)) as
+      | { ok: true; sid: string; pid: number; cols: number; rows: number }
+      | { ok: false; error: string };
+    if (forkSourceSid) {
+      useStore.setState((s) => {
+        if (!s.pendingForkSource[sessionId]) return {};
+        const next = { ...s.pendingForkSource };
+        delete next[sessionId];
+        return { pendingForkSource: next };
+      });
+    }
+    if (!spawnResult || spawnResult.ok === false) {
+      throw new Error(
+        spawnResult && spawnResult.ok === false ? spawnResult.error : 'spawn_failed',
+      );
+    }
+    res = (await pty.attach(sessionId)) as
+      | { cols: number; rows: number; pid: number }
+      | null;
+    if (!res) throw new Error('attach_failed_after_spawn');
+  }
+
+  try {
+    shell.term.resize(res.cols, res.rows);
+  } catch {
+    /* best-effort */
+  }
+
+  const snap = (await pty.getBufferSnapshot(sessionId)) as {
+    snapshot: string;
+    seq: number;
+  };
+  try {
+    shell.term.reset();
+  } catch {
+    /* best-effort */
+  }
+  if (snap.snapshot) await writeAsync(shell.term, snap.snapshot);
+
+  // Subscribe AFTER the snapshot write — no buffering mode (design §3).
+  subscribeShellData(sessionId);
+  shell.warmed = true;
+
+  // Wire term.onData → pty.input. Idempotent across reload because the
+  // shell's previous inputDisposable was either left in place (we keep
+  // the term across reloads) — guard by stashing once.
+  const stashKey = '__ccsmInputWired' as const;
+  type Stashed = { [stashKey]: boolean };
+  if (!(shell as unknown as Stashed)[stashKey]) {
+    const inputDisposable = shell.term.onData((data: string) => {
+      if (getShell(sessionId)) window.ccsmPty.input(sessionId, data);
+    });
+    shell.inputDisposers.push(() => {
+      try {
+        inputDisposable.dispose();
+      } catch {
+        /* ignore */
+      }
+    });
+    (shell as unknown as Stashed)[stashKey] = true;
+  }
+
+  try {
+    shell.fit.fit();
+    const newCols = shell.term.cols;
+    const newRows = shell.term.rows;
+    if (newCols !== res.cols || newRows !== res.rows) {
+      await pty.resize(sessionId, newCols, newRows).catch(() => {});
+    }
+  } catch (e) {
+    warn('attach-shell', 'post-attach fit failed', e);
+  }
+
+  try {
+    shell.term.scrollToBottom();
+  } catch {
+    /* best-effort */
+  }
+  try {
+    shell.term.focus();
+  } catch {
+    /* best-effort */
+  }
+
+  setMask(sessionId, false);
+
+  try {
+    log.event('attach.cold.complete', {
+      sid: sessionId,
+      snapshotBytes: snap.snapshot?.length ?? 0,
+    });
+  } catch {
+    /* probe best-effort */
+  }
+}
+
+export function usePtyAttachShell(
+  sessionId: string,
+  cwd: string,
+  hostRef: { current: HTMLDivElement | null },
+): UsePtyAttachResult {
+  // Visited sids start ready (the shell is already alive); cold sids start
+  // attaching so the overlay logic in TerminalPane can react if needed.
+  const [state, setState] = useState<PtyAttachState>(() =>
+    getShell(sessionId) ? { kind: 'ready' } : { kind: 'attaching' },
+  );
+  const clearPtyExit = useStore((s) => s._clearPtyExit);
+  const clearPtyExitRef = useRef(clearPtyExit);
+  clearPtyExitRef.current = clearPtyExit;
+  const [retryNonce, setRetryNonce] = useState(0);
+  const reloadNonce = useStore((s) => s.reloadNonce?.[sessionId] ?? 0);
+
+  // Distinguish "fresh effect run because reloadNonce bumped" from
+  // "fresh effect run because the user switched sessions". Track the last
+  // applied (sessionId, reloadNonce) pair: on a sessionId change the ref
+  // resets so a brand-new sid never falsely reads as "mid-reload".
+  const lastReloadAppliedRef = useRef<{ sid: string; nonce: number }>({
+    sid: sessionId,
+    nonce: reloadNonce,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    const last = lastReloadAppliedRef.current;
+    const isReload =
+      last.sid === sessionId &&
+      reloadNonce !== last.nonce &&
+      getShell(sessionId) != null;
+    lastReloadAppliedRef.current = { sid: sessionId, nonce: reloadNonce };
+
+    void (async () => {
+      const pty = window.ccsmPty;
+      if (!pty) {
+        if (!cancelled) setState({ kind: 'error', message: 'ccsmPty unavailable' });
+        return;
+      }
+      const host = hostRef.current;
+      if (!host) {
+        if (!cancelled) setState({ kind: 'error', message: 'no-host' });
+        return;
+      }
+
+      // RELOAD path — sessionRuntimeSlice already killed the PTY; we
+      // term.reset() the shell, mask if top, then run cold-start suffix
+      // against the freshly spawned PTY.
+      if (isReload) {
+        const shell = resetShellForReload(sessionId);
+        if (!shell) return;
+        setState({ kind: 'attaching' });
+        try {
+          await runColdStartSuffix(sessionId, cwd, shell);
+          if (!cancelled) {
+            const decision = resolveReadyOrExit(sessionId);
+            setState(decision.next);
+            if (decision.clearExit) clearPtyExitRef.current(sessionId);
+          }
+        } catch (err) {
+          if (cancelled) return;
+          try {
+            disposeShell(sessionId);
+          } catch {
+            /* ignore */
+          }
+          const message = err instanceof Error ? err.message : String(err);
+          setState({ kind: 'error', message });
+        }
+        return;
+      }
+
+      // VISITED path — shell exists, no cold start, no mask.
+      const existing = getShell(sessionId);
+      if (existing) {
+        showShell(sessionId);
+        try {
+          existing.fit.fit();
+          void pty.resize(sessionId, existing.term.cols, existing.term.rows).catch(() => {});
+          existing.term.focus();
+        } catch (e) {
+          warn('attach-shell', 'visited path post-show ops failed', e);
+        }
+        if (!cancelled) {
+          const decision = resolveReadyOrExit(sessionId);
+          setState(decision.next);
+          if (decision.clearExit) clearPtyExitRef.current(sessionId);
+        }
+        try {
+          log.event('attach.visited.shown', { sid: sessionId });
+        } catch {
+          /* probe best-effort */
+        }
+        return;
+      }
+
+      // COLD path — build the shell, mask covers it during ipc work.
+      setState({ kind: 'attaching' });
+      const shell = createShell(sessionId, host);
+      try {
+        await runColdStartSuffix(sessionId, cwd, shell);
+        if (!cancelled) {
+          const decision = resolveReadyOrExit(sessionId);
+          setState(decision.next);
+          if (decision.clearExit) clearPtyExitRef.current(sessionId);
+        }
+      } catch (err) {
+        if (cancelled) return;
+        try {
+          disposeShell(sessionId);
+        } catch {
+          /* ignore */
+        }
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ kind: 'error', message });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, retryNonce, reloadNonce, cwd, hostRef]);
+
+  // PTY exit watcher — single store subscription, no per-sid filtering.
+  const disconnect = useStore((s) => s.disconnectedSessions[sessionId]);
+  useEffect(() => {
+    if (!disconnect) return;
+    const detail =
+      disconnect.signal != null
+        ? `signal ${disconnect.signal}`
+        : disconnect.code != null
+          ? `exit code ${disconnect.code}`
+          : 'unknown';
+    setState({ kind: 'exit', exitKind: disconnect.kind, detail });
+  }, [disconnect]);
+
+  // Resize observer — host changed size (splitter drag, window resize).
+  // Refit + pty.resize, fire-and-forget. No snapshot replay: claude
+  // re-emits on SIGWINCH and the live PTY subscription paints the result.
+  // If the user notices a stale frame, the bailout is dispose+retry.
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    let debounce: ReturnType<typeof setTimeout> | null = null;
+    let lastW = 0;
+    let lastH = 0;
+    let baseline = false;
+    const apply = () => {
+      const shell = getShell(sessionId);
+      if (!shell) return;
+      try {
+        shell.fit.fit();
+        const cols = shell.term.cols;
+        const rows = shell.term.rows;
+        window.ccsmPty?.resize(sessionId, cols, rows).catch(() => {});
+      } catch (e) {
+        warn('attach-shell', 'resize apply failed', e);
+      }
+    };
+    const ro = new ResizeObserver((entries) => {
+      const r = entries[0]?.contentRect;
+      if (!r) return;
+      const w = Math.round(r.width);
+      const h = Math.round(r.height);
+      if (!baseline) {
+        baseline = true;
+        lastW = w;
+        lastH = h;
+        return;
+      }
+      if (w === lastW && h === lastH) return;
+      lastW = w;
+      lastH = h;
+      if (debounce) clearTimeout(debounce);
+      debounce = setTimeout(apply, 80);
+    });
+    ro.observe(host);
+    return () => {
+      if (debounce) clearTimeout(debounce);
+      ro.disconnect();
+    };
+  }, [sessionId, hostRef]);
+
+  const onRetry = useCallback(() => {
+    try {
+      disposeShell(sessionId);
+    } catch {
+      /* ignore */
+    }
+    try {
+      clearPtyExitRef.current(sessionId);
+    } catch {
+      /* ignore */
+    }
+    setState({ kind: 'attaching' });
+    setRetryNonce((n) => n + 1);
+  }, [sessionId]);
+
+  return { state, onRetry };
+}
+
+/**
+ * Reload entry-point used by `sessionRuntimeSlice.reloadSession`. Caller
+ * has already killed the PTY and bumped `reloadNonce`. We reset the
+ * shell's terminal in place + show its mask if it's the top — the
+ * attach effect's reload-trigger re-runs the cold-start suffix
+ * (snapshot fetch + write) against the freshly spawned PTY.
+ *
+ * This is invoked from the store slice but expressed as a free function
+ * so the slice doesn't import React.
+ */
+export function prepareShellForReload(sid: string): void {
+  if (getShell(sid)) {
+    resetShellForReload(sid);
+  }
+}

--- a/tests/components/TerminalPane.test.tsx
+++ b/tests/components/TerminalPane.test.tsx
@@ -17,20 +17,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, fireEvent } from '@testing-library/react';
 
-const { copySpy, pasteSpy, getActiveEntrySpy } = vi.hoisted(() => ({
+const { copySpy, pasteSpy, getTopShellSpy } = vi.hoisted(() => ({
   copySpy: vi.fn(),
   pasteSpy: vi.fn(),
-  getActiveEntrySpy: vi.fn(() => ({ term: { id: 'fake-term' } })),
+  getTopShellSpy: vi.fn(() => ({ term: { id: 'fake-term' } })),
 }));
 
-vi.mock('../../src/terminal/usePtyAttach.warm', () => ({
-  usePtyAttachWarm: () => ({ state: { kind: 'ready' }, onRetry: vi.fn() }),
+vi.mock('../../src/terminal/usePtyAttachShell', () => ({
+  usePtyAttachShell: () => ({ state: { kind: 'ready' }, onRetry: vi.fn() }),
 }));
 vi.mock('../../src/terminal/useAtBottom', () => ({
   useAtBottom: () => ({ atBottom: true, scrollToBottom: vi.fn() }),
 }));
-vi.mock('../../src/terminal/xtermWarmRegistry', () => ({
-  getActiveEntry: getActiveEntrySpy,
+vi.mock('../../src/terminal/shellRegistry', () => ({
+  getTopShell: getTopShellSpy,
 }));
 vi.mock('../../src/terminal/paste', () => ({
   terminalCopy: copySpy,

--- a/tests/terminal/useAtBottom.test.tsx
+++ b/tests/terminal/useAtBottom.test.tsx
@@ -25,8 +25,8 @@ const fakeTerm = {
   scrollToBottom: scrollToBottomSpy,
 };
 
-vi.mock('../../src/terminal/xtermWarmRegistry', () => ({
-  getActiveEntry: vi.fn(() => ({ term: fakeTerm })),
+vi.mock('../../src/terminal/shellRegistry', () => ({
+  getTopShell: vi.fn(() => ({ term: fakeTerm })),
 }));
 
 import { useAtBottom } from '../../src/terminal/useAtBottom';


### PR DESCRIPTION
Implements `docs/attach-redesign.html` landed in commit `0aad80b0` (doc body: `4dd5c4b`).

## Summary

- New `src/terminal/shellRegistry.ts` (~520 LOC): owns N visited shells under one host. `getShell / createShell / disposeShell / disposeAll`. Switching is a `display` + `z-index` flip on a single persistent host — wrappers never reparent. Each shell carries wrapper + xterm + mask div + per-sid `pty.onData` subscription + IME/paste/key listeners.
- New `src/terminal/usePtyAttachShell.ts` (~390 LOC): thin orchestrator. COLD = create with mask on → pty.attach → getBufferSnapshot → term.reset+write → subscribeShellData → setMask(false). VISITED = showShell only, no mask, no IPC. RELOAD = resetShellForReload (term.reset in place per design §4) + cold suffix. Bailout on any throw = disposeShell + setState(error); user-driven Retry rebuilds the shell from scratch (design §5).
- Renderer consumers (`TerminalPane`, `useAtBottom`, `useTerminalFontSize`, `useTerminalScrollback`) now read shellRegistry instead of xtermWarmRegistry. `sessionCrudSlice.deleteSession` calls `disposeShell` so the z-stack collapses to the next remaining shell (or back to State 0 when empty). `sessionRuntimeSlice.reloadSession` no longer disposes — bumps `reloadNonce` and lets the hook reset+resnapshot in place.
- Old `xtermWarmRegistry.ts` + `usePtyAttach.warm.ts` remain on disk untouched. Deletion is a follow-up PR (task #73 territory).

## Probe results

- `scripts/dogfood-attach-redesign.mjs` (new) — asserts the 3 UX states + 3 ops on real Electron with real claude.

  ```
  PASS State 0: no shell wrappers at boot
  PASS Z-stack: exactly one shell visible (sidB), sidA hidden but parented
  PASS State 2: visited switch had no mask across 26 visible frames
  PASS Reload: mask shown then hidden (148 frames sampled)
  PASS Delete top: z-stack collapsed to next without mask
  PASS Copy: new session cold-started with mask
  PASS Delete all: back to State 0 (no shells)
  PASS: attach-redesign UX states + ops behave as specified
  ```

- `scripts/dogfood-bug-69-no-flicker.mjs` (selector updated to `data-ccsm-shell-sid`) — `PASS: all frames pinned to saved scrollTop.` No regression.

## Quality gates

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — 1871 passed, 1 todo. The 18 remaining failures are pre-existing `electron/__tests__/db*.test.ts` better-sqlite3 native-module rebuild issues (verified by `git stash` baseline check); unrelated to this PR.

## Notes on design fidelity

- No LRU cap, no feature flag, no enumerated cancellation tokens. Single dispose+retry bailout.
- Cold start order is exactly `build xterm → open → fetch snapshot → write → subscribe PTY` (design §3) — the per-shell `pty.onData` subscription is installed AFTER snapshot write via `subscribeShellData`. Theoretical loss window between snapshot capture and subscribe is acceptable per design §5; user-visible bailout is dispose+retry.
- Reload uses `term.reset()` in place and re-runs the snapshot suffix — no shell dispose (design §4).
- Delete = disposeShell + z-stack collapse to most-recently-inserted survivor; empty stack = State 0 (right pane blank).