### PR TITLE
fix(main): print full reason+stack on unhandledRejection

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -44,11 +44,23 @@ initLog();
 // in the logger instead of silently terminating the process. We deliberately
 // do NOT call app.exit() — preserves current default-throw behavior in tests
 // and mirrors the renderer's "log + degrade" stance.
+//
+// We ALSO mirror the full reason + stack to stderr directly. The structured
+// `log.error` call routes through electron-log's console transport, which
+// formats records as `[level] [tag] msg` and elides the structured `fields`
+// object — so a real crash showed up in `npm run dev` as a single useless
+// line `[error] [main] unhandledRejection` with no error message, no stack,
+// and no clue what code path threw. Direct console.error keeps the file sink
+// + Sentry pipeline intact while giving the dev terminal the actual stack so
+// the next regression is debuggable in one pass instead of requiring a
+// diagnostic shim to be added by the engineer chasing the bug.
 process.on('unhandledRejection', (reason, _promise) => {
   const err = reason instanceof Error ? reason : new Error(String(reason));
+  console.error('[main] unhandledRejection:', err);
   log.error('main', 'unhandledRejection', { error: normalizeError(err) });
 });
 process.on('uncaughtException', (err) => {
+  console.error('[main] uncaughtException:', err);
   log.error('main', 'uncaughtException', { error: normalizeError(err) });
 });
 


### PR DESCRIPTION
## Why

The existing safety-net handler in `electron/main.ts` routes errors through `log.error()` only. electron-log's console transport formats records as `[level] [tag] msg` and elides the structured fields object, so a real crash showed up in `npm run dev` as one useless line:

```
[error] [main] unhandledRejection
```

No message, no stack, no class name. Engineers debugging the next regression (e.g. the crash that triggered PR #1394's revert of #1393) have to add a temporary `console.error` shim by hand before they can even read what threw. That's friction we don't need at the infrastructure layer.

## What

Mirror `reason` + stack to stderr directly via `console.error` in both the `unhandledRejection` and `uncaughtException` handlers. The structured `log.error` call is unchanged, so the file sink + Sentry pipeline still get the normalized record; only the dev terminal gets the upgrade.

## Verification

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npx vitest run electron/__tests__/error-safety-net.test.ts` — 4/4 pass
  - Source-grep test still finds both `process.on(...)` registrations before `app.whenReady`
  - Behavior test already mirrored the exact `console.error('[main] unhandledRejection:', reason)` shape — no churn
- Reverse-verify: tested locally that throwing in main now prints reason + full stack to dev stderr instead of the single-line elision

## Scope

Single 12-line addition to `electron/main.ts`. Decoupled from any feature work — this is purely diagnostic plumbing so future regressions surface immediately instead of requiring a debug session to even see the error.