### PR TITLE
fix(terminal): pass current session cwd on reload spawn (#79a)

### DIFF
--- a/src/terminal/usePtyAttachShell.ts
+++ b/src/terminal/usePtyAttachShell.ts
@@ -100,7 +100,20 @@ async function runColdStartSuffix(
   if (!res) {
     const forkSourceSid =
       useStore.getState().pendingForkSource[sessionId] ?? undefined;
-    const spawnResult = (await pty.spawn(sessionId, cwd ?? '', forkSourceSid)) as
+    // Resolve cwd from the live store at spawn time. The `cwd` prop can
+    // be stale (a tool-driven `_applyCwdRedirect` updates `session.cwd`
+    // mid-session and the new value may not yet have rendered down to
+    // this hook) or empty (App.tsx falls back to `''` if `active.cwd`
+    // is missing). An empty/missing cwd makes main's `resolveSpawnCwd`
+    // fall back to `homedir()` — that's what was triggering the "trust
+    // this folder?" prompt on reload (#79a). The store is the source of
+    // truth for the session's current cwd; the prop is a render-time
+    // shadow that can lag.
+    const storeCwd = useStore
+      .getState()
+      .sessions.find((x) => x.id === sessionId)?.cwd;
+    const spawnCwd = storeCwd && storeCwd.length > 0 ? storeCwd : (cwd ?? '');
+    const spawnResult = (await pty.spawn(sessionId, spawnCwd, forkSourceSid)) as
       | { ok: true; sid: string; pid: number; cols: number; rows: number }
       | { ok: false; error: string };
     if (forkSourceSid) {

--- a/tests/terminal/usePtyAttachShell.spawnCwd.test.tsx
+++ b/tests/terminal/usePtyAttachShell.spawnCwd.test.tsx
@@ -1,0 +1,210 @@
+// Task #81 / #79a: on reload, `pty.spawn` must receive the session's
+// CURRENT cwd (the value held in the store), not an empty string or a
+// stale prop value. The bug: user reloads a session whose original cwd
+// is a project dir; after reload, claude prints
+// `Accessing workspace: C:\Users\jiahuigu` (HOME) and pops the
+// "trust this folder?" prompt.
+//
+// Root cause: `runColdStartSuffix` in `usePtyAttachShell.ts` was
+// passing `cwd ?? ''` to `pty.spawn`. The `cwd` prop is a render-time
+// shadow that can be empty (App.tsx falls back to '' when
+// `active.cwd` is missing) or stale (a tool-driven `_applyCwdRedirect`
+// mutates `session.cwd` mid-session and the new value may not yet have
+// rendered down to this hook). Main's `resolveSpawnCwd` interprets
+// empty/missing as `homedir()`.
+//
+// Fix: at spawn time, read cwd from the store (`session.cwd`) — the
+// store is the source of truth.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const { storeState, clearPtyExitSpy } = vi.hoisted(() => {
+  const clearPtyExitSpy = vi.fn();
+  const storeState: {
+    _clearPtyExit: ReturnType<typeof vi.fn>;
+    pendingForkSource: Record<string, string>;
+    reloadNonce: Record<string, number>;
+    disconnectedSessions: Record<string, unknown>;
+    sessions: Array<{ id: string; cwd: string }>;
+    scrollbackLines: number;
+    terminalFontSizePx: number;
+  } = {
+    _clearPtyExit: clearPtyExitSpy,
+    pendingForkSource: {},
+    reloadNonce: {},
+    disconnectedSessions: {},
+    sessions: [],
+    scrollbackLines: 1000,
+    terminalFontSizePx: 13,
+  };
+  return { storeState, clearPtyExitSpy };
+});
+
+vi.mock('../../src/stores/store', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const useStore = ((selector: (s: any) => any) => selector(storeState)) as any;
+  useStore.getState = () => storeState;
+  useStore.setState = (
+    patch:
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      | Record<string, any>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      | ((s: typeof storeState) => Record<string, any>),
+  ) => {
+    const next = typeof patch === 'function' ? patch(storeState) : patch;
+    Object.assign(storeState, next ?? {});
+  };
+  return { useStore };
+});
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn(function () {
+    return {
+      open: vi.fn(),
+      loadAddon: vi.fn(),
+      write: vi.fn((_s: string, cb?: () => void) => cb?.()),
+      reset: vi.fn(),
+      focus: vi.fn(),
+      scrollToBottom: vi.fn(),
+      onData: vi.fn(() => ({ dispose: vi.fn() })),
+      resize: vi.fn(),
+      cols: 80,
+      rows: 24,
+      unicode: { activeVersion: '6' },
+      modes: { bracketedPasteMode: false },
+      buffer: {
+        active: { viewportY: 0, baseY: 0, cursorY: 0, length: 0, type: 'normal' as const },
+      },
+      dispose: vi.fn(),
+    };
+  }),
+}));
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn(function () {
+    return { fit: vi.fn() };
+  }),
+}));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-canvas', () => ({ CanvasAddon: vi.fn(function () { return {}; }) }));
+
+vi.mock('../../src/shared/log', () => ({
+  log: { event: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+import { usePtyAttachShell } from '../../src/terminal/usePtyAttachShell';
+import {
+  __resetShellRegistryForTests,
+} from '../../src/terminal/shellRegistry';
+
+type SpawnFn = (sid: string, cwd: string, forkSourceSid?: string) => Promise<unknown>;
+
+function installFakePty(spawnImpl: SpawnFn): { spawn: ReturnType<typeof vi.fn> } {
+  const spawn = vi.fn(spawnImpl);
+  (window as unknown as { ccsmPty: unknown }).ccsmPty = {
+    // attach returns null → forces the spawn branch (cold path).
+    attach: vi.fn(async () => null),
+    spawn,
+    detach: vi.fn(async () => undefined),
+    input: vi.fn(async () => undefined),
+    resize: vi.fn(async () => undefined),
+    kill: vi.fn(async () => undefined),
+    getBufferSnapshot: vi.fn(async () => ({ snapshot: '', seq: 0 })),
+    onData: vi.fn(() => () => undefined),
+    onExit: vi.fn(() => () => undefined),
+  };
+  return { spawn };
+}
+
+function uninstallFakePty(): void {
+  delete (window as unknown as { ccsmPty?: unknown }).ccsmPty;
+}
+
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+describe('usePtyAttachShell — spawn cwd source-of-truth (#79a)', () => {
+  let host: HTMLDivElement;
+  let hostRef: { current: HTMLDivElement | null };
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    hostRef = { current: host };
+    storeState.pendingForkSource = {};
+    storeState.reloadNonce = {};
+    storeState.disconnectedSessions = {};
+    storeState.sessions = [];
+    clearPtyExitSpy.mockClear();
+  });
+
+  afterEach(() => {
+    __resetShellRegistryForTests();
+    document.body.removeChild(host);
+    uninstallFakePty();
+  });
+
+  // The exact bug: prop `cwd` is empty (App.tsx fallback) but the store
+  // holds the real cwd. Without the fix, pty.spawn was called with ''
+  // and main's resolveSpawnCwd defaulted to homedir() → trust prompt.
+  it('uses store session.cwd when prop cwd is empty (reload with stale prop)', async () => {
+    const realCwd = 'C:/Users/jiahuigu/projects/ccsm';
+    storeState.sessions = [{ id: 'sid-A', cwd: realCwd }];
+    const { spawn } = installFakePty(async () => ({
+      ok: true, sid: 'sid-A', pid: 1234, cols: 80, rows: 24,
+    }));
+
+    renderHook(() => usePtyAttachShell('sid-A', '', hostRef));
+    await settle();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    const callArgs = spawn.mock.calls[0]!;
+    expect(callArgs[0]).toBe('sid-A');
+    expect(callArgs[1]).toBe(realCwd);
+    expect(callArgs[1]).not.toBe('');
+  });
+
+  // Prop carries a stale value (e.g. project cwd before a `cd` redirect);
+  // store has the up-to-date cwd. Fix prefers store.
+  it('uses store session.cwd when it differs from prop (cwd redirect race)', async () => {
+    const staleProp = 'C:/Users/jiahuigu/projects/foo';
+    const liveStoreCwd = 'C:/Users/jiahuigu/projects/foo/subdir';
+    storeState.sessions = [{ id: 'sid-B', cwd: liveStoreCwd }];
+    const { spawn } = installFakePty(async () => ({
+      ok: true, sid: 'sid-B', pid: 1234, cols: 80, rows: 24,
+    }));
+
+    renderHook(() => usePtyAttachShell('sid-B', staleProp, hostRef));
+    await settle();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn.mock.calls[0]![1]).toBe(liveStoreCwd);
+  });
+
+  // Defensive: if the session is not in the store (e.g. transient race),
+  // fall back to the prop so we don't regress to '' when the prop is
+  // actually valid.
+  it('falls back to prop cwd when session missing from store', async () => {
+    const propCwd = 'C:/Users/jiahuigu/projects/bar';
+    storeState.sessions = [];
+    const { spawn } = installFakePty(async () => ({
+      ok: true, sid: 'sid-C', pid: 1234, cols: 80, rows: 24,
+    }));
+
+    renderHook(() => usePtyAttachShell('sid-C', propCwd, hostRef));
+    await settle();
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(spawn.mock.calls[0]![1]).toBe(propCwd);
+  });
+});


### PR DESCRIPTION
## Bug repro (from user dogfood)

User reloads a session whose original cwd was a project dir (e.g. `C:\Users\jiahuigu\projects\foo`). After reload, the claude CLI prints `Accessing workspace: C:\Users\jiahuigu` (HOME) and pops the **"trust this folder?"** prompt. Every reload regresses the trust state and forces a confirmation tap.

## Root cause

`runColdStartSuffix` in `src/terminal/usePtyAttachShell.ts` was passing the React `cwd` prop straight to `pty.spawn` as `cwd ?? ''`. Two failure modes converged on the same HOME fallback:

1. `App.tsx:430` threads `active.cwd ?? ''` down to `TerminalPane` -> `usePtyAttachShell`. When the session snapshot's cwd was empty, the prop arrived as `''`.
2. `sessionRuntimeSlice._applyCwdRedirect` mutates `session.cwd` mid-session whenever the SDK reports a tool-driven `cd`. The prop is a render-time shadow that can lag the store across re-renders / reloads.

Either way, empty/missing cwd hits `electron/ptyHost/cwdResolver.ts:resolveSpawnCwd`, which intentionally falls back to `homedir()` for safety. That's the workspace claude sees.

## Fix

Read cwd from the live store at spawn time (same pattern already used 1 line up for `pendingForkSource`):

```ts
const storeCwd = useStore.getState().sessions.find((x) => x.id === sessionId)?.cwd;
const spawnCwd = storeCwd && storeCwd.length > 0 ? storeCwd : (cwd ?? '');
```

The store is the source of truth for `session.cwd`. The prop is kept as a defensive fallback only for the transient case where the session isn't in the store yet.

## Test added

`tests/terminal/usePtyAttachShell.spawnCwd.test.tsx` — three scenarios, RED->GREEN verified:

- Empty prop + populated store -> spawn gets store cwd (the reload bug)
- Prop differs from store -> spawn gets store cwd (cd-redirect race)
- Session missing from store -> spawn gets prop (defensive)

Stash-reverted the fix locally to confirm 2/3 tests fail without it.

## Gates

- `npm run typecheck` PASS
- `npm run lint` PASS
- `npm run test` PASS (only pre-existing `electron/__tests__/db.test.ts` failures from local `better-sqlite3` ABI mismatch; resolved with `npm rebuild better-sqlite3`, unrelated to this fix)

## Manual repro / probe

Automated e2e is infeasible without a real `claude` CLI in CI. Manual repro:

1. Create a session with cwd = some project dir.
2. Reload it.
3. **Before**: claude prints `Accessing workspace: C:\Users\jiahuigu` + trust prompt.
4. **After**: claude prints `Accessing workspace: <project dir>`, no trust prompt.

## Touched files

- `src/terminal/usePtyAttachShell.ts` (only the `pty.spawn` call site, lines 100-110 — does NOT touch the `__ccsmInputWired` block at lines 149-163 which is in flight on another PR).
- `tests/terminal/usePtyAttachShell.spawnCwd.test.tsx` (new).