### PR TITLE
fix(terminal): restore keyboard input after reload (#79b)

### DIFF
--- a/electron/ptyHost/__tests__/lifecycle.test.ts
+++ b/electron/ptyHost/__tests__/lifecycle.test.ts
@@ -187,6 +187,60 @@ describe('lifecycle.spawn', () => {
     deps.onExit('sid-A');
     expect(sessions.has('sid-A')).toBe(false);
   });
+
+  // Regression for Task #79b — "keyboard input dead after reload".
+  // Root cause: on Windows, `pty.kill('SIGKILL')` throws "Signals not
+  // supported on windows" in the kill timeout branch
+  // (KILL_EXIT_TIMEOUT_MS); the entry is then async-reaped via
+  // `killProcessSubtree`. The OLD pty's natural `onExit` fires LATE —
+  // BY THEN `reloadSession`'s fresh `spawn(sid, ...)` has already
+  // registered a NEW entry under the same sid. If the late onExit
+  // unconditionally `sessions.delete(sid)`s, it CLOBBERS the live fresh
+  // entry. Every subsequent `pty:input` IPC then finds nothing under
+  // the sid and is silently dropped — user-visible as "keystrokes
+  // dropped after reload" (the trust-folder prompt the user sees is
+  // painted by the still-running fresh claude, but its tracking entry
+  // is gone from main's `sessions` map so input goes nowhere).
+  //
+  // Fix: the onExit deps callback identity-guards the delete with
+  // `sessions.get(s) === entry` (the closure-captured original entry).
+  // The OLD pty's late onExit then no-ops because `sessions.get(sid)`
+  // returns the FRESH entry, not the old one.
+  it('onExit identity-guards the delete — stale onExit does not clobber a fresh entry under the same sid', () => {
+    const sessions = new Map<string, FakeEntry>();
+    // First spawn — captures its own onExit closure over `entryA`.
+    const entryA = makeFakeEntry({ pty: makeFakePty({ pid: 100 }) });
+    bus().makeEntry.mockReturnValueOnce(entryA);
+    L.spawn(sessions as any, 'sid-X', '/work', '/bin/claude');
+    expect(sessions.get('sid-X')).toBe(entryA);
+    const depsA = bus().makeEntry.mock.calls[0][5] as { onExit: (s: string) => void };
+
+    // Simulate reload: kill timeout branch already evicted entryA (see
+    // lifecycle.ts line 254). reloadSession then spawns FRESH entry under
+    // same sid before entryA's late onExit fires.
+    sessions.delete('sid-X');
+    const entryB = makeFakeEntry({ pty: makeFakePty({ pid: 200 }) });
+    bus().makeEntry.mockReturnValueOnce(entryB);
+    L.spawn(sessions as any, 'sid-X', '/work', '/bin/claude');
+    expect(sessions.get('sid-X')).toBe(entryB);
+
+    // OLD pty's natural onExit fires LATE — must NOT clobber entryB.
+    depsA.onExit('sid-X');
+    expect(sessions.get('sid-X')).toBe(entryB);
+  });
+
+  // Sanity: the OLD entry's onExit still self-cleans when no fresh entry
+  // has replaced it (the common case — pty exits normally, no reload).
+  it('onExit still removes the entry when no replacement has been registered', () => {
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    bus().makeEntry.mockReturnValue(entry);
+    L.spawn(sessions as any, 'sid-Y', '/work', '/bin/claude');
+    const deps = bus().makeEntry.mock.calls[0][5] as { onExit: (s: string) => void };
+    expect(sessions.has('sid-Y')).toBe(true);
+    deps.onExit('sid-Y');
+    expect(sessions.has('sid-Y')).toBe(false);
+  });
 });
 
 // ─── list / get ───────────────────────────────────────────────────────────

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -74,7 +74,19 @@ export function spawn(
     cols,
     rows,
     {
-      onExit: (s) => { sessions.delete(s); },
+      // Identity-guarded delete: when reload races with a wedged-pty
+      // kill (Windows: `pty.kill('SIGKILL')` throws "Signals not supported
+      // on windows", the timeout branch async-reaps via
+      // `killProcessSubtree`, the OLD pty's actual `onExit` fires LATE),
+      // the OLD entry's onExit must not clobber a FRESH entry that
+      // `reloadSession` already registered under the same sid. Without
+      // this guard, sessions.get(sid) returns undefined for the live
+      // fresh pty and every subsequent `pty:input` IPC is silently
+      // dropped — user-visible as "reload made keyboard input dead"
+      // (Task #79b empirical repro).
+      onExit: (s) => {
+        if (sessions.get(s) === entry) sessions.delete(s);
+      },
       onCwdRedirect: opts?.onCwdRedirect,
     },
     opts?.forkSourceSid,

--- a/scripts/dogfood-bug-79b-reload-input.mjs
+++ b/scripts/dogfood-bug-79b-reload-input.mjs
@@ -1,0 +1,145 @@
+// scripts/dogfood-bug-79b-reload-input.mjs
+//
+// Regression probe for Task #79b — "keyboard input dead after reload" on
+// Windows. Asserts the end-to-end contract that survived the empirical
+// root-cause investigation:
+//
+//   1. After `reloadSession(sid)`, main-side `pty.list()` contains the
+//      freshly-spawned entry under the same sid for ≥2s post-reload.
+//      (Pre-fix: the OLD pty's late `onExit` clobbers the fresh entry
+//      because Windows `pty.kill('SIGKILL')` throws "Signals not
+//      supported on windows" → entry async-reaped via `killProcessSubtree`
+//      → OLD pty's natural onExit fires LATE → unconditional
+//      `sessions.delete(sid)` evicts the LIVE fresh entry → every
+//      subsequent `pty:input` IPC silently drops.)
+//
+//   2. After typing into the post-reload xterm via the normal onData →
+//      `ccsmPty.input` IPC path, the xterm buffer reflects the input
+//      (claude echoes / advances past the trust-folder prompt).
+//
+// Exit 0 = both invariants hold. Exit 1 = regression.
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+  createIsolatedClaudeDir,
+  dismissWelcomeSplash,
+  launchCcsmIsolated,
+  seedSession,
+  sendToClaudeTui,
+  waitForTerminalReady,
+  waitForXtermBuffer,
+} from './probe-utils-real-cli.mjs';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let exitCode = 0;
+function fail(msg) { console.error('FAIL:', msg); exitCode = 1; }
+
+async function main() {
+  const { tempDir } = await createIsolatedClaudeDir();
+  const cwd = mkdtempSync(path.join(tmpdir(), 'ccsm-79b-cwd-'));
+
+  const { electronApp, win } = await launchCcsmIsolated({
+    tempDir,
+    env: { CCSM_E2E_HIDDEN: '1' },
+  });
+
+  // Visibility guard — never open a visible window on the user's desktop.
+  const visibilityProbe = await electronApp.evaluate(({ BrowserWindow }) => {
+    return BrowserWindow.getAllWindows().map((w) => {
+      const b = w.getBounds();
+      return { x: b.x, y: b.y, offscreen: b.x <= -10000 && b.y <= -10000 };
+    });
+  });
+  if (!visibilityProbe.every((w) => w.offscreen)) {
+    await electronApp.close().catch(() => {});
+    throw new Error(`window not offscreen: ${JSON.stringify(visibilityProbe)}`);
+  }
+
+  const { sid } = await seedSession(win, { cwd, name: 'bug-79b' });
+  await waitForTerminalReady(win, sid, { timeout: 45000 });
+  await waitForXtermBuffer(win, /claude|welcome|│|╭|\?\sfor\sshortcuts/i, { timeout: 30000 });
+  await dismissWelcomeSplash(win);
+  await sleep(1500);
+
+  // RELOAD.
+  await win.evaluate((s) => window.__ccsmStore.getState().reloadSession(s), sid);
+  await win.waitForFunction(
+    (s) => (window.__ccsmStore.getState().reloadNonce[s] ?? 0) > 0,
+    sid,
+    { timeout: 20000 },
+  );
+  // Wait for mask to go off (cold-suffix complete).
+  await win.waitForFunction(
+    (s) => {
+      const w = document.querySelector(`[data-ccsm-shell-sid="${s}"]`);
+      const mask = w?.querySelector('[data-ccsm-shell-mask]');
+      return mask instanceof HTMLElement && mask.style.display === 'none';
+    },
+    sid,
+    { timeout: 30000 },
+  );
+
+  // INVARIANT 1: fresh pty entry stays in main's sessions map for ≥2s.
+  // Pre-fix: the OLD pty's wedged-kill async-reap fires its natural
+  // onExit LATE, unconditionally deletes the fresh entry under the same
+  // sid. Listen at 0, 1s, 2s.
+  const samples = [];
+  for (const delay of [0, 1000, 2000]) {
+    if (delay > 0) await sleep(delay);
+    const list = await win.evaluate(() => window.ccsmPty.list());
+    samples.push({ at: delay, entry: list.find((e) => e.sid === sid) ?? null });
+  }
+  console.log(`pty.list samples post-reload: ${JSON.stringify(samples)}`);
+  const allPresent = samples.every((s) => s.entry != null);
+  if (!allPresent) {
+    fail(`fresh pty entry vanished from sessions map between mask-off and 2s post-reload: ${JSON.stringify(samples)}`);
+  } else {
+    console.log('PASS invariant 1: fresh pty entry survives in main sessions map');
+  }
+
+  // INVARIANT 2: keystrokes flow through to the fresh pty (claude advances
+  // past the trust-folder prompt). Type "1" + Enter to trust the folder.
+  const beforeBuf = await win.evaluate(() => {
+    const t = window.__ccsmTerm;
+    if (!t) return null;
+    const buf = t.buffer.active;
+    const lines = [];
+    for (let i = 0; i < Math.min(buf.length, t.rows); i++) {
+      const l = buf.getLine(buf.viewportY + i);
+      if (l) lines.push(l.translateToString(true));
+    }
+    return lines.join('\n');
+  });
+  await sendToClaudeTui(win, '1');
+  await sleep(300);
+  await sendToClaudeTui(win, '\r');
+  await sleep(2500);
+  const afterBuf = await win.evaluate(() => {
+    const t = window.__ccsmTerm;
+    if (!t) return null;
+    const buf = t.buffer.active;
+    const lines = [];
+    for (let i = 0; i < Math.min(buf.length, t.rows); i++) {
+      const l = buf.getLine(buf.viewportY + i);
+      if (l) lines.push(l.translateToString(true));
+    }
+    return lines.join('\n');
+  });
+
+  if (afterBuf === beforeBuf) {
+    fail('xterm buffer did NOT change after typing "1"+Enter — pty input dead');
+    console.error('--- buffer (unchanged):\n' + beforeBuf.slice(-500));
+  } else {
+    console.log('PASS invariant 2: xterm buffer advanced after keystroke');
+  }
+
+  await electronApp.close().catch(() => {});
+}
+
+main().then(() => process.exit(exitCode)).catch((err) => {
+  console.error('FAIL:', err?.stack ?? err);
+  process.exit(1);
+});

--- a/tests/terminal/reloadInputContract.test.ts
+++ b/tests/terminal/reloadInputContract.test.ts
@@ -1,0 +1,119 @@
+// Regression test for Task #79b — reload-input wiring contract.
+//
+// Bug report: after `reloadSession`, keystrokes typed into xterm are
+// dropped — claude (in the freshly-spawned PTY) never sees them. The
+// renderer-side reload flow is term.reset() in-place + cold-start suffix;
+// the suffix's `if (!shell.inputWired)` guard skips re-wiring onData.
+//
+// PR #1403 reviewer challenged hypothesis H1 ("term.reset() invalidates
+// the onData subscription") with the xterm.js docs claim that reset does
+// NOT dispose attached event listeners. This test EMPIRICALLY validates
+// that contract end-to-end using a real (non-mocked) xterm Terminal:
+//
+//   1. Construct a real Terminal, term.open() against a real DOM node.
+//   2. Wire term.onData → recorder (mirrors production).
+//   3. Fire a keystroke via coreService.triggerDataEvent — recorder sees it.
+//   4. Simulate the full reload flow: term.reset() (resetShellForReload),
+//      resize, term.reset() again (inside runColdStartSuffix), write a
+//      "snapshot" string, fire another keystroke.
+//   5. Assert the recorder STILL sees the post-reload keystroke.
+//
+// If this test ever fails, the input-wiring assumption in
+// usePtyAttachShell.ts (the `inputWired` guard) is broken and reload
+// will silently drop keystrokes — exactly the user-reported bug. The
+// fix is to drop the guard and re-wire onData on every reload.
+//
+// Why this test lives here: it's the ONLY place we exercise a real xterm
+// instance (the shellRegistry tests vi.mock the Terminal constructor). It
+// runs in jsdom under vitest like the rest of the suite.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+
+// Shims xterm needs in jsdom that vitest's default env doesn't provide.
+beforeAll(() => {
+  if (typeof window !== 'undefined') {
+    const w = window as unknown as Record<string, unknown>;
+    if (!w.matchMedia) {
+      w.matchMedia = () => ({
+        matches: false,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+      });
+    }
+    if (typeof window.requestAnimationFrame !== 'function') {
+      window.requestAnimationFrame = ((cb: FrameRequestCallback) =>
+        setTimeout(() => cb(performance.now()), 16)) as typeof window.requestAnimationFrame;
+      window.cancelAnimationFrame = (id: number) => clearTimeout(id as unknown as NodeJS.Timeout);
+    }
+    if (typeof HTMLCanvasElement !== 'undefined') {
+      // xterm tries to construct a canvas renderer; in jsdom getContext
+      // returns null which xterm handles by falling back to DOM-only
+      // rendering. We just need it to not throw.
+      const proto = HTMLCanvasElement.prototype as unknown as { getContext?: () => null };
+      if (!proto.getContext) proto.getContext = () => null;
+    }
+  }
+});
+
+describe('xterm reload-input contract (Task #79b)', () => {
+  it('term.onData listener survives term.reset() across a full reload-style flow', async () => {
+    const xt = await import('@xterm/xterm');
+    const Terminal = xt.Terminal;
+    const term = new Terminal();
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    term.open(host);
+
+    // Mirror production wiring: onData → recorded list (production: → ccsmPty.input).
+    const recorded: string[] = [];
+    term.onData((data: string) => {
+      recorded.push(data);
+    });
+
+    // Access coreService to fire keystrokes the way xterm's internal
+    // keydown handler does. Real production keystrokes from the helper
+    // textarea route through this same triggerDataEvent path.
+    const core = (term as unknown as {
+      _core: {
+        coreService?: { triggerDataEvent: (data: string, wasUserInput: boolean) => void };
+        _coreService?: { triggerDataEvent: (data: string, wasUserInput: boolean) => void };
+      };
+    })._core;
+    const cs = core.coreService ?? core._coreService;
+    expect(cs).toBeDefined();
+    if (!cs) throw new Error('coreService unreachable');
+
+    // Cold-start keystroke baseline.
+    cs.triggerDataEvent('a', true);
+    expect(recorded).toEqual(['a']);
+
+    // Simulate the full reload flow that usePtyAttachShell drives:
+    // resetShellForReload calls term.reset(); runColdStartSuffix then
+    // calls term.resize + a SECOND term.reset() + writes the snapshot.
+    term.reset();
+    term.resize(80, 24);
+    term.reset();
+    term.write('claude bootstrap snapshot\r\n');
+
+    // Post-reload keystroke must still flow.
+    cs.triggerDataEvent('\r', true); // Enter — the actual key the bug report mentions
+    cs.triggerDataEvent('1', true);  // trust-folder option
+
+    expect(recorded).toEqual(['a', '\r', '1']);
+
+    // Cleanup. xterm queues raf callbacks during reset+resize that resolve
+    // viewport dimensions; jsdom's HTMLCanvasElement.getContext returns
+    // null which makes those late callbacks log a dimensions error. We
+    // drain the rafs while term is still alive, then dispose.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    try {
+      term.dispose();
+    } catch {
+      /* best-effort */
+    }
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    host.remove();
+  });
+});


### PR DESCRIPTION
## Root cause (empirically determined)

After `reloadSession(sid)` on Windows, subsequent keystrokes were silently dropped despite the freshly-spawned claude rendering its trust-folder prompt. The reproduction is in `scripts/dogfood-bug-79b-reload-input.mjs` (real-claude headless probe).

Investigation traced the bug through these layers:

1. **Renderer onData wiring (task H1)** — `usePtyAttachShell.ts` lines 149-163 with the `inputWired` guard. Falsified: `tests/terminal/reloadInputContract.test.ts` exercises a real (non-mocked) xterm Terminal through the full reload-style flow (`reset()` → `resize()` → `reset()` → `write(snapshot)`) and asserts `onData` still fires. xterm source (`CoreService.reset()`, `CoreTerminal._setup`) confirms `reset()` does not dispose `_onData` listeners.

2. **Mask blocking keystrokes (task H2)** — Falsified. Probe runs all assertions AFTER mask is `display: none`.

3. **Main-side sessions Map staleness (task H3)** — **TRUE root cause, but via a path the original hypothesis did not capture.**

   On Windows, `entry.pty.kill('SIGKILL')` in `lifecycle.ts`'s kill-timeout branch (KILL_EXIT_TIMEOUT_MS = 3 s) throws `Signals not supported on windows` (visible in `[main-err]` logs every reload). The lifecycle's existing handling correctly evicts the entry and async-reaps the OS process tree via `killProcessSubtree`.

   But the OLD pty's natural `pty.onExit` then fires LATE — after `reloadSession`'s fresh spawn has already registered a NEW entry under the same sid in `sessions`. The old onExit callback (`lifecycle.spawn` line 77, pre-fix) unconditionally did `sessions.delete(s)` — clobbering the live fresh entry.

   Empirical confirmation (`scripts/dogfood-bug-79b-reload-input.mjs` pre-fix log):
   - `pty.list immediately after mask-off`: fresh entry present, pid 37084.
   - `pty.list after 1500ms`: empty.
   - User keystroke → `ccsmPty.input(sid, data)` → main `sessions.get(sid)` → `undefined` → silent no-op.

4. **Focus state (task H4)** — Falsified. Direct invocation of the production onData closure with sentinel data, plus pre/post listener-count snapshots on `_core._onData._listeners`, showed the closure fires correctly and that `getShell(sessionId)` returns truthy. The IPC call DOES execute; it just lands on an empty sessions map after the late-onExit clobber.

## Fix

`lifecycle.ts` `spawn()`'s onExit deps callback now identity-guards the delete with `sessions.get(s) === entry` (closure capture of the original entry). The OLD pty's late onExit no-ops because the map now holds the FRESH entry, not the original. Mirrors the same guard already present in the kill-timeout branch (`lifecycle.ts` line 254 — `if (sessions.get(sid) === entry) sessions.delete(sid)`).

## Verification

```
$ node scripts/dogfood-bug-79b-reload-input.mjs
PASS invariant 1: fresh pty entry survives in main sessions map
PASS invariant 2: xterm buffer advanced after keystroke
exit=0
```

The probe also captures the still-visible `[ptyHost] kill ... wedged: SIGKILL also failed (Signals not supported on windows.); pid ... may leak` warning — that's the trigger condition; we now tolerate it instead of clobbering the fresh entry.

## Gates

- `npx tsc --noEmit` — PASS
- `npm run lint` — PASS (max-warnings 0)
- `npx vitest run electron/ptyHost/__tests__/lifecycle.test.ts tests/terminal/reloadInputContract.test.ts tests/terminal/shellRegistry.test.ts` — 58/58 pass
- Full `npx vitest run` — 1854/1872 pass. 18 failures are all in `electron/__tests__/db*.test.ts`, native `better-sqlite3` binary mismatch on local Node version; unrelated to this PR (pre-existing infra issue).

## Scope coordination

Sibling worker `fix/reload-spawn-cwd` (#79a) is editing `src/terminal/usePtyAttachShell.ts` near the `pty.spawn` call (line 104, cwd argument). This PR does NOT touch that file; the original task assignment hypothesized the bug was in `usePtyAttachShell.ts` lines 149-163 (the input-wiring block), but empirical investigation falsified that and pointed at `electron/ptyHost/lifecycle.ts` (the spawn-time onExit closure). Per `feedback_reviewer_two_layers.md` Layer 1, the fix follows the actual root cause rather than the hypothesized location.