### PR TITLE
chore(cwd): log empty-cwd fallback at resolver boundary (#83)

### DIFF
--- a/electron/ptyHost/__tests__/cwdResolver.test.ts
+++ b/electron/ptyHost/__tests__/cwdResolver.test.ts
@@ -9,12 +9,15 @@ import { join as pathJoin } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { resolveSpawnCwd } from '../cwdResolver';
+import { log } from '../../shared/log';
 
 let tmp: string;
+let eventSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   tmp = mkdtempSync(pathJoin(tmpdir(), 'ccsm-cwd-resolver-'));
   vi.spyOn(console, 'warn').mockImplementation(() => {});
+  eventSpy = vi.spyOn(log, 'event').mockImplementation(() => {});
 });
 
 afterEach(() => {
@@ -25,15 +28,37 @@ afterEach(() => {
 describe('resolveSpawnCwd', () => {
   it('returns the requested path when it is an existing directory', () => {
     expect(resolveSpawnCwd(tmp)).toBe(tmp);
+    expect(eventSpy).not.toHaveBeenCalled();
   });
 
   it('falls back to homedir when requested path is empty', () => {
     expect(resolveSpawnCwd('')).toBe(homedir());
+    expect(eventSpy).toHaveBeenCalledWith(
+      'cwd.empty_fallback',
+      expect.objectContaining({ reason: 'empty' }),
+    );
   });
 
   it('falls back to homedir when requested path is null/undefined', () => {
     expect(resolveSpawnCwd(null)).toBe(homedir());
+    expect(eventSpy).toHaveBeenCalledWith(
+      'cwd.empty_fallback',
+      expect.objectContaining({ reason: 'null' }),
+    );
+    eventSpy.mockClear();
     expect(resolveSpawnCwd(undefined)).toBe(homedir());
+    expect(eventSpy).toHaveBeenCalledWith(
+      'cwd.empty_fallback',
+      expect.objectContaining({ reason: 'undefined' }),
+    );
+  });
+
+  it('forwards sid into the empty-fallback event payload when provided', () => {
+    expect(resolveSpawnCwd('', 'sid-abc')).toBe(homedir());
+    expect(eventSpy).toHaveBeenCalledWith(
+      'cwd.empty_fallback',
+      expect.objectContaining({ sid: 'sid-abc', reason: 'empty' }),
+    );
   });
 
   it('falls back to homedir when requested path does not exist (and warns)', () => {

--- a/electron/ptyHost/cwdResolver.ts
+++ b/electron/ptyHost/cwdResolver.ts
@@ -7,14 +7,40 @@
 // path is empty, missing, or not a directory, fall back to the user's home
 // directory (always exists by definition for an interactive Electron
 // session) and log a warning so the cause is visible in the console.
+//
+// Empty-cwd hardening (#83, follow-up to PR #1404 reviewer feedback): PR
+// #1404 fixed a renderer-side regression where reload spawns dropped the
+// current cwd. The actual landing spot for that regression was THIS file —
+// the empty-cwd branch silently returned `homedir()` with no log, so the
+// resulting "claude spawned in $HOME → trust folder?" prompt was the only
+// user-visible signal. We now emit a structured `cwd.empty_fallback` event
+// every time empty / null / undefined hits this boundary so future
+// regressions of the same shape surface in main's JSONL log instead of
+// masquerading as a UX bug. Fallback behavior is unchanged — legit callers
+// (e.g. imported JSONLs with no recorded cwd) continue to spawn in homedir.
 
 import { statSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { isSafePath } from '../security/ipcGuards';
+import { log } from '../shared/log';
 
-export function resolveSpawnCwd(requested: string | null | undefined): string {
+export function resolveSpawnCwd(
+  requested: string | null | undefined,
+  sid?: string,
+): string {
   const fallback = homedir();
-  if (!requested || requested.length === 0) return fallback;
+  if (requested === undefined) {
+    log.event('cwd.empty_fallback', { sid, reason: 'undefined' });
+    return fallback;
+  }
+  if (requested === null) {
+    log.event('cwd.empty_fallback', { sid, reason: 'null' });
+    return fallback;
+  }
+  if (requested.length === 0) {
+    log.event('cwd.empty_fallback', { sid, reason: 'empty' });
+    return fallback;
+  }
   // Security gate (#804 risk #1): reject UNC / relative / non-string paths
   // BEFORE the statSync. On Windows `statSync('\\\\evil\\share')` triggers
   // an SMB handshake that leaks the user's NTLM hash. The renderer-supplied

--- a/electron/ptyHost/entryFactory.ts
+++ b/electron/ptyHost/entryFactory.ts
@@ -253,7 +253,7 @@ export function makeEntry(
     args = [flag, claudeSid];
   }
 
-  const spawnCwd = resolveSpawnCwd(cwd);
+  const spawnCwd = resolveSpawnCwd(cwd, sid);
 
   // See `ensureResumeJsonlAtSpawnCwd` for the bug context (#603) — copies
   // the import-source JSONL into the spawn cwd's projectDir so


### PR DESCRIPTION
## Why

PR #1404 reviewer recommended hardening `electron/ptyHost/cwdResolver.ts` after we shipped the renderer-side fix for cwd staleness on reload (#79a). The renderer fix closed the regression path, but the actual landing spot for empty cwd was the resolver's `if (!requested || requested.length === 0) return fallback` — silent, no log, no surface. That silent rewrite is exactly what masked the original bug as a Claude "trust this folder?" prompt (homedir spawn) instead of a real error. The reviewer flagged this for follow-up so the next regression of the same shape becomes traceable from main's JSONL log instead of from user-reported UX weirdness.

## What changed

- `resolveSpawnCwd` now emits `log.event('cwd.empty_fallback', { sid, reason })` whenever `requested` is `undefined`, `null`, or `''`. Fallback behavior is unchanged — it still returns `homedir()` so legit callers (imported JSONLs with no recorded cwd, etc.) keep working. We chose log+fallback over throw because:
  - Throwing would regress the imported-JSONL path where the recorded cwd can legitimately be absent.
  - Existing entryFactory / detachReattach tests treat `(cwd) => cwd ? cwd : '/home/u'` as the normal contract.
  - Reviewer's explicit recommendation in PR #1404 was log+fallback.
- Added optional `sid` arg so the event payload pins the offending session. `entryFactory.ts` forwards its sid at the single call site.

## Tests

Extended `electron/ptyHost/__tests__/cwdResolver.test.ts`:
- Valid-path case now asserts `log.event` is NOT called.
- Empty / null / undefined branches each assert the event fires with the right `reason`.
- New test asserts `sid` is forwarded into the event payload when provided.

Gates: `npm run typecheck` PASS, `npm run lint` PASS, `npx vitest run` for the resolver + entryFactory + detachReattach files PASS (37/37). Full suite has pre-existing `better-sqlite3` ABI mismatches in this local env unrelated to the change; CI's electron-rebuild path doesn't hit them.

## Out of scope (per task #83 brief)

- `src/App.tsx:430 (active.cwd ?? '')` — reviewer flagged for separate minor follow-up.
- `usePtyAttachShell.ts` / `lifecycle.ts` — sibling hot files (#79b / #82 / #1405).