### PR TITLE
fix(terminal): defer scroll-to-bottom past dimension settle (#82)

### DIFF
--- a/scripts/dogfood-bug-82-scrollbar.mjs
+++ b/scripts/dogfood-bug-82-scrollbar.mjs
@@ -1,0 +1,162 @@
+// scripts/dogfood-bug-82-scrollbar.mjs
+//
+// Task #82 dogfood probe — cold-start `.xterm-viewport` scrollbar thumb
+// must be at the bottom (matching the rendered content position), not
+// at the top.
+//
+// Background: on cold-start the renderer writes claude's snapshot, runs
+// `fit.fit()`, then calls `term.scrollToBottom()`. Without the rAF
+// defer (PR for #82), the `.xterm-viewport.scrollTop` write fires
+// before xterm's CanvasAddon / RenderService has reflowed the viewport
+// element to its post-fit dimensions, so the write either no-ops or
+// clamps to 0 — content paints at the bottom (correct, xterm tracks
+// `viewportY` internally) but the native `::-webkit-scrollbar-thumb`
+// sits at the top (desynced from the buffer).
+//
+// Assertion: after a cold start completes, `.xterm-viewport.scrollTop`
+// must equal `scrollHeight - clientHeight` (±2px tolerance — Chromium
+// rounds scroll geometry to integer device-pixel units, so the exact
+// equality can be off by 1 on fractional-DPI configs).
+//
+// Honesty box: the underlying race (xterm dimension settle vs.
+// scrollTop write) is sub-frame (<16ms). Playwright + headless paint
+// timing differs from prod, and the post-attach `sleep(800)` here lets
+// any pending paint settle long before we measure — so this probe
+// reliably passes WITH the fix, but doesn't reliably FAIL without it.
+// It is a non-regression sentinel + a vehicle for the before/after
+// screenshot, NOT a direct race-condition reproducer. The real-time
+// race-condition assertion lives in `tests/terminal/
+// usePtyAttachShell.scrollDefer.test.tsx` which asserts the rAF
+// call-order contract that the fix introduces.
+//
+// Exit code 0 = PASS, 1 = FAIL.
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+  createIsolatedClaudeDir,
+  dismissWelcomeSplash,
+  launchCcsmIsolated,
+  seedSession,
+  waitForTerminalReady,
+  waitForXtermBuffer,
+} from './probe-utils-real-cli.mjs';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function readScrollState(win) {
+  return await win.evaluate(() => {
+    const vp = document.querySelector('.xterm-viewport');
+    const t = window.__ccsmTerm;
+    return {
+      scrollTop: vp instanceof HTMLElement ? vp.scrollTop : null,
+      scrollHeight: vp instanceof HTMLElement ? vp.scrollHeight : null,
+      clientHeight: vp instanceof HTMLElement ? vp.clientHeight : null,
+      viewportY: t?.buffer?.active?.viewportY ?? null,
+      baseY: t?.buffer?.active?.baseY ?? null,
+      bufferType: t?.buffer?.active?.type ?? null,
+    };
+  });
+}
+
+async function captureScreenshot(win, label, outDir) {
+  try {
+    const file = path.join(outDir, `bug-82-${label}.png`);
+    await win.screenshot({ path: file, fullPage: false });
+    console.log(`  screenshot: ${file}`);
+    return file;
+  } catch (e) {
+    console.log(`  screenshot ${label} failed: ${e.message}`);
+    return null;
+  }
+}
+
+async function main() {
+  const { tempDir } = await createIsolatedClaudeDir();
+  const screenshotDir = mkdtempSync(path.join(tmpdir(), 'ccsm-bug82-shots-'));
+  console.log(`screenshot dir: ${screenshotDir}`);
+
+  const { electronApp, win } = await launchCcsmIsolated({ tempDir });
+
+  try {
+    await win.waitForFunction(
+      () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+      null,
+      { timeout: 30000 },
+    );
+
+    // Shrink the window BEFORE creating the session so the very first
+    // cold-start has to populate an overflowing snapshot into a small
+    // viewport. That's the exact race the user hit (small / standard-
+    // sized window, claude banner overflows): cold-start writes the
+    // snapshot, fits, calls scrollToBottom — without the rAF defer the
+    // `.xterm-viewport.scrollTop` write fires before the viewport
+    // reflow lands and gets clamped to 0.
+    await win.setViewportSize({ width: 600, height: 220 }).catch(() => {});
+    await sleep(200);
+
+    // Cold-start a brand new session.
+    const { sid } = await seedSession(win, { name: 'bug82', cwd: tempDir });
+    await win.evaluate((id) => window.__ccsmStore.getState().selectSession(id), sid);
+    await waitForTerminalReady(win, sid, { timeout: 45000 });
+
+    // Wait for claude to render its welcome / prompt — confirms snapshot
+    // write + first paint have landed.
+    await waitForXtermBuffer(win, /claude|welcome|│|╭|\?\sfor\sshortcuts/i, { timeout: 30000 });
+    await dismissWelcomeSplash(win).catch(() => {});
+
+    // Give the cold-start suffix (including the rAF defer + belt-and-
+    // suspenders second rAF) plenty of time to complete.
+    await sleep(800);
+
+    const state = await readScrollState(win);
+    console.log(`scroll state: ${JSON.stringify(state)}`);
+    await captureScreenshot(win, 'cold-start', screenshotDir);
+
+    if (
+      state.scrollTop == null ||
+      state.scrollHeight == null ||
+      state.clientHeight == null
+    ) {
+      console.error('FAIL: .xterm-viewport not found in DOM after cold start');
+      process.exitCode = 1;
+      return;
+    }
+
+    // If the viewport has nothing to scroll (claude entered alt-buffer
+    // immediately and the normal buffer never overflowed), there's no
+    // bug to assert against — the scrollbar is correctly absent. Pass.
+    if (state.scrollHeight <= state.clientHeight) {
+      console.log(
+        'PASS (vacuous): viewport content fits — no scrollbar to desync',
+      );
+      return;
+    }
+
+    const expected = state.scrollHeight - state.clientHeight;
+    const delta = Math.abs(state.scrollTop - expected);
+    if (delta <= 2) {
+      console.log(
+        `PASS: scrollTop=${state.scrollTop} ≈ scrollHeight-clientHeight=${expected} (Δ=${delta})`,
+      );
+      return;
+    }
+    console.error(
+      `FAIL: scrollbar thumb desynced. scrollTop=${state.scrollTop}, ` +
+        `scrollHeight-clientHeight=${expected}, Δ=${delta}px. ` +
+        `xterm viewportY=${state.viewportY}/baseY=${state.baseY} ` +
+        `(${state.bufferType} buffer). ` +
+        `Expected scrollTop at the bottom after cold start — see ` +
+        `src/terminal/usePtyAttachShell.ts runColdStartSuffix's rAF defer.`,
+    );
+    process.exitCode = 1;
+  } finally {
+    await electronApp.close();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exitCode = 1;
+});

--- a/src/terminal/usePtyAttachShell.ts
+++ b/src/terminal/usePtyAttachShell.ts
@@ -184,18 +184,48 @@ async function runColdStartSuffix(
     warn('attach-shell', 'post-attach fit failed', e);
   }
 
-  try {
-    shell.term.scrollToBottom();
-  } catch {
-    /* best-effort */
+  // Task #82 — defer scrollToBottom + focus + setMask(false) past one
+  // animation frame. Issuing them synchronously after `fit.fit()` races
+  // xterm's CanvasAddon / RenderService dimension cache: `.xterm-viewport`
+  // hasn't yet reflowed to its post-fit size, so a `scrollTop` write
+  // either no-ops or clamps to 0 — content paints at the bottom (correct)
+  // but the native `::-webkit-scrollbar-thumb` sits at the top
+  // (desynced). One rAF gives xterm a paint to settle dimensions before
+  // we issue the scroll write and reveal the term.
+  //
+  // Belt-and-suspenders: a second rAF after setMask repeats the scroll
+  // write in case the dimension settle straddled the first frame (e.g.
+  // on a heavy cold start where the first rAF callback fires before the
+  // viewport reflow lands).
+  const w = typeof window !== 'undefined' ? window : null;
+  const raf = w?.requestAnimationFrame?.bind(w);
+  const runReveal = (): void => {
+    try {
+      shell.term.scrollToBottom();
+    } catch {
+      /* best-effort */
+    }
+    try {
+      shell.term.focus();
+    } catch {
+      /* best-effort */
+    }
+    setMask(sessionId, false);
+    if (raf) {
+      raf(() => {
+        try {
+          shell.term.scrollToBottom();
+        } catch {
+          /* best-effort */
+        }
+      });
+    }
+  };
+  if (raf) {
+    raf(runReveal);
+  } else {
+    runReveal();
   }
-  try {
-    shell.term.focus();
-  } catch {
-    /* best-effort */
-  }
-
-  setMask(sessionId, false);
 
   try {
     log.event('attach.cold.complete', {

--- a/tests/terminal/usePtyAttachShell.scrollDefer.test.tsx
+++ b/tests/terminal/usePtyAttachShell.scrollDefer.test.tsx
@@ -1,0 +1,202 @@
+// Task #82: on cold-start, xterm.js's `.xterm-viewport` element needs at
+// least one paint after `fit.fit()` before its `scrollTop` write will
+// land at the bottom — the CanvasAddon / RenderService dimension cache
+// hasn't settled yet, so a synchronous `scrollToBottom()` writes a
+// clamped value (often 0) and the native `::-webkit-scrollbar-thumb`
+// sits at the top while the content correctly paints at the bottom.
+//
+// Fix: defer `scrollToBottom() + focus() + setMask(false)` to a
+// `requestAnimationFrame` callback so xterm has one paint to settle
+// dimensions before we issue the scroll write and reveal the term.
+//
+// This test asserts the call-order contract: those three calls MUST run
+// inside an rAF callback fired after `fit.fit()`, not synchronously.
+// The real visual symptom (scrollbar thumb position in the DOM) is
+// exercised by `scripts/dogfood-bug-82-scrollbar.mjs` — jsdom does not
+// compute `.xterm-viewport` scroll geometry, so a call-order assertion
+// is the faithful unit-level signal.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const { storeState, clearPtyExitSpy, scrollToBottomSpy, focusSpy, fitSpy } = vi.hoisted(() => {
+  const clearPtyExitSpy = vi.fn();
+  const scrollToBottomSpy = vi.fn();
+  const focusSpy = vi.fn();
+  const fitSpy = vi.fn();
+  const storeState: {
+    _clearPtyExit: ReturnType<typeof vi.fn>;
+    pendingForkSource: Record<string, string>;
+    reloadNonce: Record<string, number>;
+    disconnectedSessions: Record<string, unknown>;
+    sessions: Array<{ id: string; cwd: string }>;
+    scrollbackLines: number;
+    terminalFontSizePx: number;
+  } = {
+    _clearPtyExit: clearPtyExitSpy,
+    pendingForkSource: {},
+    reloadNonce: {},
+    disconnectedSessions: {},
+    sessions: [],
+    scrollbackLines: 1000,
+    terminalFontSizePx: 13,
+  };
+  return { storeState, clearPtyExitSpy, scrollToBottomSpy, focusSpy, fitSpy };
+});
+
+vi.mock('../../src/stores/store', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const useStore = ((selector: (s: any) => any) => selector(storeState)) as any;
+  useStore.getState = () => storeState;
+  useStore.setState = (
+    patch:
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      | Record<string, any>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      | ((s: typeof storeState) => Record<string, any>),
+  ) => {
+    const next = typeof patch === 'function' ? patch(storeState) : patch;
+    Object.assign(storeState, next ?? {});
+  };
+  return { useStore };
+});
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: vi.fn(function () {
+    return {
+      open: vi.fn(),
+      loadAddon: vi.fn(),
+      write: vi.fn((_s: string, cb?: () => void) => cb?.()),
+      reset: vi.fn(),
+      focus: focusSpy,
+      scrollToBottom: scrollToBottomSpy,
+      onData: vi.fn(() => ({ dispose: vi.fn() })),
+      resize: vi.fn(),
+      cols: 80,
+      rows: 24,
+      unicode: { activeVersion: '6' },
+      modes: { bracketedPasteMode: false },
+      buffer: {
+        active: { viewportY: 0, baseY: 0, cursorY: 0, length: 0, type: 'normal' as const },
+      },
+      dispose: vi.fn(),
+    };
+  }),
+}));
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: vi.fn(function () {
+    return { fit: fitSpy };
+  }),
+}));
+vi.mock('@xterm/addon-web-links', () => ({ WebLinksAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-clipboard', () => ({ ClipboardAddon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-unicode11', () => ({ Unicode11Addon: vi.fn(function () { return {}; }) }));
+vi.mock('@xterm/addon-canvas', () => ({ CanvasAddon: vi.fn(function () { return {}; }) }));
+
+vi.mock('../../src/shared/log', () => ({
+  log: { event: vi.fn(), info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+
+import { usePtyAttachShell } from '../../src/terminal/usePtyAttachShell';
+import { __resetShellRegistryForTests } from '../../src/terminal/shellRegistry';
+
+function installFakePty(): void {
+  (window as unknown as { ccsmPty: unknown }).ccsmPty = {
+    attach: vi.fn(async () => ({ cols: 80, rows: 24, pid: 1234 })),
+    spawn: vi.fn(async () => ({ ok: true, sid: 'sid-A', pid: 1234, cols: 80, rows: 24 })),
+    detach: vi.fn(async () => undefined),
+    input: vi.fn(async () => undefined),
+    resize: vi.fn(async () => undefined),
+    kill: vi.fn(async () => undefined),
+    getBufferSnapshot: vi.fn(async () => ({ snapshot: '', seq: 0 })),
+    onData: vi.fn(() => () => undefined),
+    onExit: vi.fn(() => () => undefined),
+  };
+}
+
+function uninstallFakePty(): void {
+  delete (window as unknown as { ccsmPty?: unknown }).ccsmPty;
+}
+
+// Manual rAF driver so the test controls when frames fire (rather than
+// relying on jsdom's setTimeout-backed default).
+type RafCb = (t: number) => void;
+let rafQueue: RafCb[] = [];
+function installManualRaf(): void {
+  rafQueue = [];
+  (globalThis as unknown as { requestAnimationFrame: (cb: RafCb) => number })
+    .requestAnimationFrame = (cb: RafCb): number => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    };
+  (globalThis as unknown as { cancelAnimationFrame: (h: number) => void })
+    .cancelAnimationFrame = (): void => {
+      /* tests don't cancel */
+    };
+}
+async function flushRaf(): Promise<void> {
+  await act(async () => {
+    const drain = rafQueue;
+    rafQueue = [];
+    for (const cb of drain) cb(performance.now());
+    await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+async function settleMicrotasks(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 6; i++) await new Promise((r) => setTimeout(r, 0));
+  });
+}
+
+describe('usePtyAttachShell — cold-start scroll defer (#82)', () => {
+  let host: HTMLDivElement;
+  let hostRef: { current: HTMLDivElement | null };
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.appendChild(host);
+    hostRef = { current: host };
+    storeState.pendingForkSource = {};
+    storeState.reloadNonce = {};
+    storeState.disconnectedSessions = {};
+    storeState.sessions = [{ id: 'sid-A', cwd: 'C:/x' }];
+    clearPtyExitSpy.mockClear();
+    scrollToBottomSpy.mockClear();
+    focusSpy.mockClear();
+    fitSpy.mockClear();
+    installManualRaf();
+    installFakePty();
+  });
+
+  afterEach(() => {
+    __resetShellRegistryForTests();
+    document.body.removeChild(host);
+    uninstallFakePty();
+  });
+
+  it('defers scrollToBottom + focus past at least one rAF after fit (cold path)', async () => {
+    renderHook(() => usePtyAttachShell('sid-A', 'C:/x', hostRef));
+    // Drain microtasks — runColdStartSuffix resolves up to (and including)
+    // its fit.fit(), but the scroll/focus/unmask should now sit behind an
+    // rAF that has NOT yet fired.
+    await settleMicrotasks();
+
+    expect(fitSpy).toHaveBeenCalledTimes(1);
+    // Pre-rAF: deferred ops must NOT have run yet.
+    expect(scrollToBottomSpy).not.toHaveBeenCalled();
+    expect(focusSpy).not.toHaveBeenCalled();
+
+    // Fire the rAF — now the deferred ops run.
+    await flushRaf();
+    await settleMicrotasks();
+    // A belt-and-suspenders second rAF is allowed; flush again to be safe.
+    await flushRaf();
+    await settleMicrotasks();
+
+    expect(scrollToBottomSpy).toHaveBeenCalled();
+    expect(focusSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Bug (user dogfood 2026-05-27)

Cold-start a new session. xterm canvas content (claude CLI prompt)
renders at viewport bottom — correct. But the right-side
`.xterm-viewport` scrollbar thumb sits at the TOP — desynced from the
actual content position.

## Investigator diagnosis (agent acabc22c0cf2d9d03)

- No custom scrollbar component. User sees xterm.js's built-in
  `.xterm-viewport` native scrollbar (styled via `::-webkit-scrollbar-thumb`
  at `src/styles/global.css:719-742`).
- Root cause: in `runColdStartSuffix` (`src/terminal/usePtyAttachShell.ts`),
  `scrollToBottom()` is called synchronously after `fit.fit()` — but
  xterm's CanvasAddon / RenderService dimension cache hasn't reflowed
  `.xterm-viewport` to its post-fit size yet. The `scrollTop` write
  either no-ops or clamps to 0. xterm's internal `viewportY` is correct
  (content paints at the bottom), but the DOM scrollbar reflects the
  pre-fit zero state.
- Recommended fix: defer `scrollToBottom + focus + setMask(false)` to
  `requestAnimationFrame` so xterm has one paint to settle dimensions.
- Belt-and-suspenders: second rAF after `setMask` calls `scrollToBottom`
  again, in case the dimension settle straddles the first frame.

## What changed

`src/terminal/usePtyAttachShell.ts` — wrapped the post-fit reveal trio
(scrollToBottom + focus + setMask(false)) in an rAF callback, plus a
second rAF after setMask that re-issues scrollToBottom.

## Tests

- **Unit (new)**: `tests/terminal/usePtyAttachShell.scrollDefer.test.tsx`
  — drives `usePtyAttachShell` with a manual rAF queue and asserts
  scrollToBottom + focus do NOT run before the rAF callback fires.
  RED on main (sync call captured pre-rAF), GREEN with the fix.
- **Dogfood (new)**: `scripts/dogfood-bug-82-scrollbar.mjs` — launches
  a real ccsm + real xterm in a deliberately small viewport, cold-
  starts a session, asserts `.xterm-viewport.scrollTop ==
  scrollHeight - clientHeight`. PASSes with the fix. Honesty note:
  the underlying race is sub-frame (<16ms), and Playwright's headless
  paint timing differs from prod, so this probe doesn't reliably FAIL
  without the fix (the unit test is the load-bearing assertion). The
  probe serves as a non-regression sentinel + before/after screenshot
  vehicle.
- Full unit suite passes (the 36 pre-existing failures are
  `electron-load-smoke` requiring `npm run build` first and
  `db-hardening`, both unrelated to this change).

## Test plan

- [x] `npm run typecheck` — PASS
- [x] `npm run lint` — PASS
- [x] `npx vitest run tests/terminal/` — 48 pass (6 files)
- [x] `node scripts/dogfood-bug-82-scrollbar.mjs` — PASS (scrollTop ==
      scrollHeight - clientHeight, Δ=0)
- [ ] Screenshots: probe captured `bug-82-cold-start.png` in tmpdir
      (Playwright in headless mode — visual diff between with/without
      fix isn't observable because Playwright's paint timing doesn't
      reproduce the sub-frame race; the user-visible bug only
      manifests in production paint timing).

## Hot-spot avoidance

Touched only `src/terminal/usePtyAttachShell.ts` (rebased onto
`e528c8cf` #1405 which landed mid-task — no conflict, that PR is
`electron/`-only). No `electron/` edits per Task #83 hot-spot rule.