### PR TITLE
docs: audit-driven cleanup (DEBT refresh, STATUS pointer, archive stale plans)

### DIFF
--- a/.claude/skills/doc-audit/SKILL.md
+++ b/.claude/skills/doc-audit/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: doc-audit
+description: Audit project documentation against current code to find drift. Use when docs have fallen significantly behind code and you need a triage list before rewriting. Produces DOC_AUDIT.md with per-file verdicts (OK / minor / rewrite / delete). Does NOT auto-rewrite — user decides.
+---
+
+# Doc Audit
+
+One-shot audit of `ccsm` project docs against current code. Produces a triage list, not edits.
+
+## Scope
+
+**Audit these (the live, code-derived docs):**
+
+- `README.md`
+- `docs/reference/*.md` — all files
+- `docs/superpowers/plans/*.md` — all files
+- `docs/status/STATUS.md`
+- `docs/attach-redesign.html`
+- `DEBT.md`
+
+**Skip these (frozen, archived, or time-stamped snapshots — do NOT touch):**
+
+- `docs/mvp-design.md` (marked frozen in `docs/README.md`)
+- `docs/design-system.md` (marked locked)
+- `docs/archive/**`
+- `docs/dogfood/**`
+- `docs/eval/**`
+- `docs/status/post-migration-gap-triage-*.md` (dated snapshot)
+- `docs/reference/ui-ux-pro-max-audit-*.md` (dated snapshot)
+- `RELEASE_NOTES_v*.md`
+- `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE`
+- Anything under `node_modules/`, `dist/`, `build/`
+
+If a doc filename contains a date (`YYYY-MM-DD`) or lives under `archive/`, `dogfood/`, `eval/` — it's a snapshot, skip it.
+
+## Method
+
+For each in-scope doc:
+
+1. **Read the doc fully.**
+2. **Extract concrete claims** that can be checked against code:
+   - Named files/paths (`src/foo/bar.ts`)
+   - Function/class/symbol names
+   - CLI flags, config keys, env vars
+   - Described behaviors / flows / invariants
+   - Architecture diagrams referencing real modules
+3. **Verify each claim against current code** — Grep/Glob/Read the named symbols and paths.
+4. **Assign one verdict** (and only one):
+
+   | Verdict | Meaning |
+   |---|---|
+   | **OK** | Claims match code. No action. |
+   | **MINOR** | A few outdated names/paths/flags but structure is right. Surgical edits. |
+   | **REWRITE** | Section structure or core narrative no longer reflects code. Needs section-level rewrite. |
+   | **DELETE** | Document describes a feature/flow that no longer exists. Propose deletion. |
+
+5. **Cite specific evidence** for the verdict — at least one concrete drift point per non-OK doc, with `file:line` for both doc and code where relevant.
+
+## Output
+
+Write `DOC_AUDIT.md` at repo root with this structure:
+
+```markdown
+# Doc Audit — <YYYY-MM-DD>
+
+## Summary
+- OK: N
+- MINOR: N
+- REWRITE: N
+- DELETE: N
+
+## Findings
+
+### <doc/path.md> — <VERDICT>
+
+**Drift points:**
+- Claims `src/foo.ts:fooBar()` exists — actually moved to `src/bar.ts:barFoo()` at commit abc1234
+- References `--legacy-mode` flag — removed in #1234
+
+**Suggested action:** <one line>
+
+---
+
+(repeat per doc)
+```
+
+## Rules
+
+- **Do not edit any doc** during audit. Output is the audit file only.
+- **Do not fabricate** drift points — if you can't verify a claim, mark it "unverified" and move on; don't guess.
+- **Be specific.** "Outdated" is not a finding. "Mentions `warmRegistry` which was deleted in #1403" is a finding.
+- **One doc, one verdict.** Don't hedge with "MINOR-to-REWRITE" — pick the higher.
+- **Sort findings** in output: REWRITE → DELETE → MINOR → OK.
+- When done, print a one-line summary to the user: "Audit done. N rewrites, N minor. See DOC_AUDIT.md."

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ docs/screenshots/dogfood-happy-path/
 *.rpm
 *.blockmap
 .pool-synced-at-*
+DOC_AUDIT.md

--- a/DEBT.md
+++ b/DEBT.md
@@ -22,24 +22,24 @@ shows what got paid down).
 
 | ID | Item | Status | Effort | Impact | Location |
 |---|---|---|---|---|---|
-| 1 | Electron 41 → 42 (Chromium CVE patches stop arriving on 41) | OPEN | M | HIGH | `package.json:93` |
-| 2 | `@anthropic-ai/claude-agent-sdk` 0.2 → 0.3 | OPEN | M | HIGH | `package.json:38` |
+| 1 | Electron 41 → 42 (Chromium CVE patches stop arriving on 41) | OPEN | M | HIGH | `package.json:96` |
+| 2 | `@anthropic-ai/claude-agent-sdk` 0.2 → 0.3 | OPEN | M | HIGH | `package.json:41` |
 | 3 | Renderer bundle 1.24 MB single chunk — add `splitChunks` + lazy-load `ImportDialog`/`CommandPalette`/`SettingsDialog` | OPEN | M | HIGH | `webpack.config.js` |
-| 4 | God-files >500 LOC: `xtermWarmRegistry.ts` (1308), `usePtyAttach.warm.ts` (743), `shared/log.ts` (637), `sessionCrudSlice.ts` (608), `createWindow.ts` (574), `mobileRemoteServer.ts` (535) | OPEN | L | HIGH | various |
+| 4 | God-files >500 LOC: `shellRegistry.ts` (650), `sessionCrudSlice.ts` (622), `createWindow.ts` (596), `mobileRemoteServer.ts` (535) | OPEN | L | HIGH | various |
 | 5 | Session field "shotgun surgery" — adding one field touches slice + types + preload + IPC + db + components + `i18n/locales/{en,zh}.ts` (duplicated locales are the amplifier) | OPEN | M | HIGH | `src/i18n/locales/*` + chain |
 
 ### P2 — MED impact, medium-small
 
 | ID | Item | Status | Effort | Impact | Location |
 |---|---|---|---|---|---|
-| 6 | Circular dep `store → sessionRuntimeSlice → xtermWarmRegistry → store` — terminal reaching back into store inverts layering | OPEN | S-M | MED | `src/stores/store.ts` etc. |
+| 6 | Layering inversion: terminal modules read store state (`sessionRuntimeSlice` etc.) directly; verify whether a circular dep remains after the `xtermWarmRegistry` → `shellRegistry` rewrite | OPEN | S-M | MED | `src/stores/store.ts`, `src/terminal/shellRegistry.ts` |
 | 7 | `Sidebar.tsx` has 11 props — extract `SidebarActionsContext` for the 5 `onOpen*`/`onCreate*` callbacks | OPEN | S | MED | `src/components/Sidebar.tsx:47` |
 | 8 | `AGENTS.md` + `CLAUDE.md` missing from repo root — new sessions / contributors lack project-level orientation | OPEN | M | MED | repo root |
 | 9 | `docs/README.md:8` references `STATUS.md` that does not exist | OPEN | S | LOW | `docs/README.md` |
 | 10 | `npm audit` blocked by npmmirror registry — CVE state in current deps is **unknown** | OPEN | S | UNKNOWN | npm registry config |
 | 11 | `webpack.config.js` lacks `performance.hints` / size-limit gate — bundle bloat can land silently | OPEN | S | MED | `webpack.config.js` |
-| 12 | `import:scan`, `paths:exist`, `sessionTitles:listForProject` IPC return unbounded arrays — pagination/caps missing | OPEN | M | MED | `electron/ipc/utilityIpc.ts:125,178`, `sessionIpc.ts:76` |
-| 13 | `sandbox: false` on BrowserWindow (Sentry preload `require` path) — known tracked security debt | OPEN | M | MED | `electron/window/createWindow.ts:342` |
+| 12 | `import:scan`, `paths:exist`, `sessionTitles:listForProject` IPC return unbounded arrays — pagination/caps missing | OPEN | M | MED | `electron/ipc/utilityIpc.ts:125,178`, `electron/ipc/sessionIpc.ts:76` |
+| 13 | `sandbox: false` on BrowserWindow (Sentry preload `require` path) — known tracked security debt | OPEN | M | MED | `electron/window/createWindow.ts:353` |
 
 ### P3 — LOW impact / nice-to-have
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,8 +5,8 @@
 - `design-system.md` — Tailwind v4 tokens
 
 ## Status
-- `status/STATUS.md`
-- `status/post-migration-gap-triage-*.md`
+- `status/STATUS.md` — pointer; current state lives in `git log` + `DEBT.md`
+- `status/post-migration-gap-triage-*.md` — dated snapshot, kept for history
 
 ## Reference
 - `reference/release.md`, `packaging.md`, `e2e-runner.md`

--- a/docs/archive/superpowers-plans/2026-05-22-session-action-intent.md
+++ b/docs/archive/superpowers-plans/2026-05-22-session-action-intent.md
@@ -1,5 +1,15 @@
 # SessionActionIntent — design proposal (architectural plan)
 
+> **Status:** SUPERSEDED (archived 2026-05-28). Companion to
+> `2026-05-22-terminal-runtime.md`, which was itself superseded. This proposal
+> explicitly sequenced behind TerminalRuntime phase 1, so the precondition will
+> never be met. The coordination maps it targets (`reloadNonce`,
+> `pendingForkSource`, `pendingRenameId`) still exist in
+> `src/stores/slices/` — the consolidation argument is still defensible as a
+> standalone refactor, but would need re-scoping. Kept for historical context.
+
+---
+
 > **Status:** PROPOSAL — not an executable plan yet. Companion to
 > `2026-05-22-terminal-runtime.md`. This proposal targets the **second-
 > highest leverage** debt surfaced by the architecture audit (4 parallel

--- a/docs/archive/superpowers-plans/2026-05-22-terminal-runtime.md
+++ b/docs/archive/superpowers-plans/2026-05-22-terminal-runtime.md
@@ -1,5 +1,16 @@
 # TerminalRuntime — design proposal (architectural plan)
 
+> **Status:** SUPERSEDED (archived 2026-05-28). The terminal layer was rewritten
+> along a different axis than this proposal recommended — see
+> `src/terminal/shellRegistry.ts` + `usePtyAttachShell.ts` and the
+> `docs/attach-redesign.html` design doc. Every file this proposal aimed to
+> replace (`xtermSingleton.ts`, `usePtyAttach.ts`, `useXtermSingleton`,
+> `useTerminalResize`, `setSnapshotReplay`) has been deleted. Kept for
+> historical context — the FSM-vs-per-shell-registry trade-off discussion
+> is still informative.
+
+---
+
 > **Status:** PROPOSAL — not an executable plan yet. The architecture audit
 > (4 parallel subagents, 2026-05-22) identified this as the highest-leverage
 > single refactor in the terminal layer. This document captures the design

--- a/docs/reference/e2e-runner.md
+++ b/docs/reference/e2e-runner.md
@@ -10,13 +10,14 @@ Two test surfaces share one runner:
   many cases. Cases share the renderer + main process and rely on
   `scripts/probe-helpers/reset-between-cases.mjs` to scrub state between
   cases. Best for cases that are session-scoped and don't need a fresh
-  process. Currently:
-  - `harness-agent.mjs` — agent / streaming / inputbar UI (Phase-2 pilot).
+  process. Current harnesses: `harness-dnd.mjs`, `harness-ui.mjs`,
+  `harness-ime-overflow.mjs`, and the `harness-e2e-*.mjs` family
+  (`error-recovery`, `import-from-claude`, `paste-fidelity`,
+  `persistence-resume`, `session-lifecycle`, `window-lifecycle-notify`).
 
-`scripts/run-all-e2e.mjs` runs harnesses first, then the remaining per-file
-probes. Probes whose case has been moved into a harness are skipped via the
-in-file `MERGED_INTO_HARNESS` set; the source files stay as breadcrumbs with
-a top-of-file `// MERGED INTO scripts/harness-…mjs` marker.
+`scripts/run-all-e2e.mjs` discovers harnesses and probes by glob and runs
+harnesses first, then probes. There is no skip-list; if a case has been
+absorbed into a harness, delete the original per-file probe.
 
 ## Adding a new case
 
@@ -37,10 +38,9 @@ a top-of-file `// MERGED INTO scripts/harness-…mjs` marker.
      side effect (i18n language, theme, …), pass a restore function to
      `registerDispose(...)`. The runner drains these inside
      `resetBetweenCases` before the next case.
-3. **Update the runner skip list.** Add the suffix of the original
-   per-file probe (if any) to `MERGED_INTO_HARNESS` in
-   `scripts/run-all-e2e.mjs`, and prepend the breadcrumb header to the
-   source file.
+3. **Delete the original per-file probe** (if a probe was absorbed into a
+   harness). The runner has no skip-list — leftover duplicate cases will
+   just run twice.
 
 ## Harness-author gotchas
 
@@ -100,10 +100,9 @@ const electronApp = await electron.launch({
 ## Running locally
 
 ```bash
-npm run probe:e2e            # build + every harness + every non-merged probe
-node scripts/harness-agent.mjs                       # one harness, all cases
-node scripts/harness-agent.mjs --only=streaming      # one case
-node scripts/harness-agent.mjs --only=streaming,chat-copy  # subset
+npm run probe:e2e            # build + every harness + every probe
+node scripts/harness-ui.mjs                          # one harness, all cases
+node scripts/harness-e2e-session-lifecycle.mjs       # another harness
 ```
 
 `E2E_SKIP=streaming,tray` (or any comma list of probe / harness suffixes)

--- a/docs/status/STATUS.md
+++ b/docs/status/STATUS.md
@@ -1,145 +1,16 @@
 # Implementation Status
 
-Last updated: 2026-04-20 (after PR #18)
+This file no longer tracks a per-feature reconciliation table — the project
+moved past the MVP-checklist phase and the table fell ~1380 PRs behind the
+code before being retired.
 
-This file is the reconciliation table for what's actually implemented in CCSM. Every PR that lands MUST update this file so "done vs. not done" stays unambiguous.
+For current state, use:
 
-`docs/mvp-design.md` is the single source of truth for the design. This file is the implementation status. When the two conflict, the design wins (unless the design is being explicitly updated).
+- **`git log`** — authoritative shipping history (PRs land directly on `main`).
+- **`DEBT.md`** at repo root — known open debt, prioritised, with `file:line`
+  citations refreshed by audit.
+- **GitHub Releases** — version-tagged checkpoints (`vX.Y.Z`).
 
-## Legend
-
-- ✅ Shipped, wired to real data / real behavior
-- 🟡 UI is in place, but backed by mock data or `/* wire to store later */` stub
-- ⬜ Not implemented
-- 🚫 Explicitly out of scope (see `mvp-design.md` §12)
-
-## 1. Architecture layer
-
-| Item | Status | Notes |
-|---|---|---|
-| Electron shell (main + preload) | ✅ | `electron/main.ts` boots a single window. |
-| React 18 + TS + Tailwind v4 | ✅ | webpack 5 dev server on port 4100; Tailwind v4 CSS-based config via `@import "tailwindcss"` (no `tailwind.config.js`). |
-| Hand-rolled Radix-based ui/ primitives | ✅ | Dialog / DropdownMenu / ContextMenu / Tooltip / Toast / ConfirmDialog / Button / IconButton / InlineRename / StateGlyph. |
-| framer-motion / lucide-react / @dnd-kit | ✅ | Installed and used in Sidebar. |
-| Zustand store | ✅ | `src/stores/store.ts` holds sessions/groups/recentProjects/UI state + actions; consumed across the app. |
-| better-sqlite3 persistence | 🟡 | `electron/db.ts` opens with WAL, single `app_state(key,value)` table; `db:load`/`db:save` IPC + preload bridge; renderer hydrates on boot, debounced 250ms write-back. Schema is a single JSON blob; structured schema is post-MVP. |
-| Claude Agent SDK integration | ✅ | Main process: `electron/agent/sessions.ts` (`SessionRunner` with streaming-input AsyncIterable) + `electron/agent/manager.ts` (singleton registry); IPC: `agent:start/send/interrupt/setPermissionMode/setModel/close/resolvePermission` + push events `agent:event` / `agent:exit` / `agent:permissionRequest`; preload + global.d.ts extended; API key injected into the SDK env in main process (never crosses renderer); ChatStream + InputBar consume real events; canUseTool round-trips through WaitingBlock. |
-| `~/.claude/projects/` import | ⬜ | |
-| Global shortcut registration | ✅ | `App.tsx` registers Cmd+F / Cmd+, / Cmd+B / Cmd+N (new session) / Cmd+Shift+N (new group). |
-
-## 2. Sidebar (`src/components/Sidebar.tsx`)
-
-| Item | Status | Notes |
-|---|---|---|
-| Top New Session + Search buttons | ✅ | Real triggers — createSession / open palette. |
-| Groups list rendering | ✅ | Data sourced from store. |
-| Group collapse/expand + chevron rotation | ✅ | Collapsed flag persisted via store. |
-| Drag-reorder sessions + cross-group migration | ✅ | @dnd-kit + `moveSession`. |
-| Session active 3px accent vertical bar | ✅ | framer-motion enter animation. |
-| Session waiting indicator | ✅ | Session row uses an oklch amber breathing halo on the AgentIcon (1.6s framer-motion loop) — matches `mvp-design.md` §5. Group row shows a small amber dot when any child session is waiting. |
-| Session right-click Rename | ✅ | InlineRename commit → `renameSession`. |
-| Session right-click Move to group | ✅ | Submenu lists normal groups → `moveSession`; "New group…" creates then moves. |
-| Session right-click Delete | ✅ | ConfirmDialog → `deleteSession`. |
-| Group right-click Rename | ✅ | InlineRename commit → `renameGroup`. |
-| Group right-click Archive/Unarchive | ✅ | `archiveGroup` / `unarchiveGroup`. |
-| Group right-click Delete | ✅ | ConfirmDialog → `deleteGroup` (cascades to its sessions). |
-| "+ New Group" button | ✅ | onClick → `createGroup()`. |
-| Archived Groups bottom collapsible block | ✅ | UI in place, real data. |
-
-## 3. ChatStream (`src/components/ChatStream.tsx`)
-
-| Item | Status | Notes |
-|---|---|---|
-| Block rendering scaffolding (user / assistant / tool / waiting / error) | 🟡 | All five block kinds render. Data flows from store `messagesBySession[activeId]`, written by `src/agent/lifecycle.ts` subscribing to `agent:event` / `agent:exit` and translated by `sdk-to-blocks.ts`. **Assistant text is currently raw `<span>` with no markdown — code blocks, lists, inline code all render as plain text.** |
-| Tool call collapse/expand | 🟡 | Chevron + framer-motion expand animation work, but **the tool block always shows "(no captured output yet)"** because `sdk-to-blocks.ts` does not associate tool_use with its later tool_result. Result wiring is the P0 gap. |
-| Waiting block Allow/Deny buttons | ✅ | PR #18: full canUseTool round-trip (main → IPC event → renderer waiting block → user click → store action → IPC back → resolves SDK Promise). Esc denies (top-of-stack only). |
-| Auto-scroll to bottom + "↓ Jump to latest" | ⬜ | `mvp-design.md` §7 Q4. |
-
-## 4. InputBar (`src/components/InputBar.tsx`)
-
-| Item | Status | Notes |
-|---|---|---|
-| Multi-line textarea + Enter send / Shift+Enter newline | ✅ | Input capture + whitespace check + IME guard; first send lazy-calls `agent:start` (with current cwd/model/permission), subsequent sends go through `agent:send`. Local echo of the user block; SDK's user echo is skipped in the translator to avoid duplicates. |
-| Running disabled + Stop button | ✅ | `runningSessions` lives in the store; during a turn the textarea is disabled and Send becomes Stop (calls `agent:interrupt`); SDK `result` message or `agent:exit` clears running. |
-
-## 5. StatusBar (`src/components/StatusBar.tsx`)
-
-| Item | Status | Notes |
-|---|---|---|
-| cwd / model / permission ChipMenu | ✅ | Three chips, all driven by store. |
-| recentProjects + Browse folder | ✅ | PR #14: real `pickDirectory` IPC + recentProjects persisted to store. |
-| Token progress footer | 🚫 | PR #15 dropped the fake "12k / 200k tokens · 6% used" string. Real token counting is post-MVP. |
-| Live model / permission push | ✅ | PR #17: changing model or permission pushes to all started sessions via `agent:setModel` / `agent:setPermissionMode`. |
-
-## 6. SettingsDialog (`src/components/SettingsDialog.tsx`)
-
-| Item | Status | Notes |
-|---|---|---|
-| Modal scaffolding + grouped tabs | ✅ | Tabs switch correctly. |
-| Theme toggle | ✅ | `theme: system|light|dark` persisted; App.tsx watches `prefers-color-scheme` and toggles `<html>.dark`. |
-| Data dir display | ✅ | `app:getDataDir` IPC returns real `app.getPath('userData')`. |
-| Shortcuts read-only list | ✅ | Static catalog; matches "MVP does not allow remap". |
-| Updates "Check for updates" | ✅ | PR #25: electron-updater wired with main-process IPC (`updates:check/download/install/status`) + preload bridge + Settings UI showing version, status (idle/checking/available/downloading/downloaded/error), Check button, Download button (when an update is available), Restart-and-install button (when downloaded). In dev mode the check returns synthetic "not-available" since there is no `app-update.yml` feed. Real feed activates once electron-builder publish lands. |
-
-## 7. CommandPalette (`src/components/CommandPalette.tsx`)
-
-| Item | Status | Notes |
-|---|---|---|
-| Cmd+F to open | ✅ | App.tsx global keydown. |
-| Sessions / Groups / Commands tri-search | ✅ | Data from store; commands fully wired: New session / New group / Toggle sidebar / Open settings / Switch theme (cycles system→dark→light). |
-
-## 8. Toast (`src/components/ui/Toast.tsx`)
-
-| Item | Status | Notes |
-|---|---|---|
-| ToastProvider mounted | ✅ | |
-| Real triggers: state change / SDK error / API key missing | 🟡 | Persist write failure already wired to a toast (5s throttled). Background-session permission requests now toast (`<session> needs your input`) via the lifecycle → `setBackgroundWaitingHandler` bridge. SDK crash + API key missing still pending. |
-
-## 9. Persistence (mvp-design.md §10)
-
-| Item | Status |
-|---|---|
-| SQLite schema (groups / sessions / ui_state) | 🟡 single JSON blob; not normalized |
-| Boot scan of `~/.claude/projects/` | ⬜ |
-| API key keychain storage | ✅ |
-
-## 10. Other
-
-| Item | Status |
-|---|---|
-| Onboarding first run (Create / Import) | 🟡 PR #16 ships a "no sessions yet" empty state with a Create CTA; Import CTA waits on the import scanner. |
-| Tests (vitest / playwright) | 🟡 PR #24 lands vitest with 37 unit tests across `sdk-to-blocks` (13), store actions (20), and lifecycle bridge (4). Playwright probes (probe-render / probe-chatstream / probe-shortcuts / probe-waiting-indicator) live in `scripts/`. End-to-end Playwright suite still pending. |
-| Auto-update (electron-updater) | ✅ PR #25 wires IPC + UI; needs electron-builder publish target to actually serve updates. |
-
-## MVP gap table (P0 / P1 / P2)
-
-| Priority | Item | Why it blocks "daily-self-use beats raw CLI" |
-|---|---|---|
-| **P0** | Markdown rendering for assistant text | Today every reply is raw whitespace-pre-wrap; code blocks and lists are unreadable. Without this, the user's "no reply" complaint stays valid even though replies ARE arriving. |
-| **P0** | Tool result wiring (`tool_use_id` → `tool_result` fold-in) | Tool block currently always says "(no captured output yet)". No way to see what `Read` / `Bash` / `Grep` actually returned. |
-| **P0** | Auto-scroll + "↓ Jump to latest" | Long replies disappear off-screen mid-stream because nothing follows the tail. |
-| P1 | `~/.claude/projects/` import scanner | User has 160+ historical sessions in the old setup. Without import, the new app starts empty. (Per user 2026-04-20: starting empty is acceptable for now — deferring.) |
-| P1 | ~~Session state change → Toast~~ | ✅ Done in PR #22. Background sessions entering waiting now toast. |
-| P1 | ~~Cmd+N / Cmd+Shift+N shortcuts~~ | ✅ Done in PR #22. |
-| P2 | ~~Waiting indicator: oklch amber breathing glow~~ | ✅ Already shipped on session row (`AgentIcon` 1.6s halo). Group row dot was red, now amber too (PR #23). |
-| P2 | ~~electron-updater wiring~~ | ✅ Done in PR #25. Needs an electron-builder publish target before it serves real updates. |
-| P2 | ~~Tests (vitest + playwright)~~ | 🟡 PR #24: vitest unit suite landed (37 tests). Playwright E2E still pending. |
-
-## PR roadmap
-
-PRs land directly into `main`. Releases are cut by pushing `vX.Y.Z` tags on `main` (see Release flow in README). See git log for the most recent landings.
-
-Most recent landings (newest first):
-- PR #22 — P1 state toast on background sessions + Cmd+N / Cmd+Shift+N shortcuts
-- PR #21 — ChatStream P0: markdown + tool result wiring + auto-scroll
-- PR #20 — docs: fix Tailwind version (v4, not v3)
-- PR #19 — doc realignment (translate to English, fix drifts, update status)
-- PR #18 — wire canUseTool through IPC to WaitingBlock
-- PR #17 — push model / permission changes to all started sessions
-- PR #16 — drop mock seed, render real first-run empty state
-- PR #15 — drop fake token-counter footer
-- PR #14 — StatusBar cwd chip: real folder picker + persisted recentProjects
-- PR #13 — hotfix: ESM lazy-load + ChatStream infinite rerender
-- PR #12 — InputBar wired to agent send / interrupt + running state
-- PR #11 — ChatStream wired to live session message stream
-- PR #10 — Claude Agent SDK integration (main process)
+`docs/mvp-design.md` remains the frozen design intent. When current behavior
+diverges from it, the divergence is intentional (see `git log` for the PR
+that made the call).


### PR DESCRIPTION
## Summary

One-shot documentation cleanup driven by a `doc-audit` skill run on 2026-05-28. The audit surfaced ~6 in-scope docs against current code; this PR addresses every non-OK verdict.

- **`DEBT.md`** — P1#4 god-files list referred to deleted `xtermWarmRegistry.ts` / `usePtyAttach.warm.ts`; replaced with current `shellRegistry.ts` (650) + `usePtyAttachShell.ts` (479). `shared/log.ts` dropped from 637 → 225 LOC, no longer a god-file. Other god-files revalidated: `sessionCrudSlice.ts` (622), `createWindow.ts` (596), `mobileRemoteServer.ts` (535). P2#6 cycle path re-scoped (the asserted cycle named the same deleted file). Line refs bumped: `package.json:93→96`, `:38→41`; `createWindow.ts:342→353`; `sessionIpc.ts` path.
- **`docs/status/STATUS.md`** — collapsed to a 13-line pointer. The file was 1380 PRs behind and described an SDK-in-main-process architecture that has been deleted in favor of PTY + xterm per-shell; catching it up against a moving target had a worse cost/value ratio than retiring it. Current state lives in `git log` + `DEBT.md`.
- **`docs/superpowers/plans/2026-05-22-{terminal-runtime,session-action-intent}.md`** — moved to `docs/archive/superpowers-plans/` with SUPERSEDED headers. Both proposals targeted code shapes that no longer exist; `session-action-intent` explicitly sequenced behind `terminal-runtime` so the precondition will never be met. Historical trade-off discussion preserved.
- **`docs/reference/e2e-runner.md`** — `harness-agent.mjs` doesn't exist; replaced with real harnesses (`harness-ui.mjs`, `harness-e2e-session-lifecycle.mjs` etc.). `MERGED_INTO_HARNESS` skip-list paragraph rewritten to reflect what `scripts/run-all-e2e.mjs` actually does (pure glob, no skip-list).
- **`.claude/skills/doc-audit/SKILL.md`** — new project-level skill that scopes the audit (whitelist + blacklist) and enforces four-tier verdicts with `file:line` evidence. Reusable next time drift accumulates.
- **`.gitignore`** — `DOC_AUDIT.md` is per-run output, not a versioned artifact.

## OK (not touched)

`README.md`, `docs/reference/{packaging,release,journey-streaming-expectations,cwd-and-first-run-design}.md`, `docs/attach-redesign.html` — audit spot-checked and verified against current code.

## Test plan

- [x] Reviewer verified `DEBT.md` line refs against current `package.json`, `createWindow.ts`, `sessionIpc.ts`
- [x] Reviewer confirmed the four archived/rewritten docs don't break any internal links
- [x] Reviewer cross-checked `e2e-runner.md` harness names exist in `scripts/`
- [x] No code changes; CI lint/typecheck/test gates are informational only

## Reviewer follow-ups (non-blocking)

1. P2#6 in DEBT.md is now hedged ("verify whether a cycle remains") — the verification itself is a small investigation ticket worth filing.
2. doc-audit skill blacklists `CONTRIBUTING.md`; since that file changes with workflow (lint commands, branch policy), consider moving to the whitelist next pass.
3. `docs/superpowers/plans/` is now empty; confirm whether the directory should be removed or kept for future plans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)