### PR TITLE
build(webpack): add production bundle-size budget (warn at 1.6MiB)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,18 @@ module.exports = (_env, argv = {}) => ({
     ]
   },
   plugins: [new HtmlWebpackPlugin({ template: './src/index.html' })],
+  // Surface renderer bundle bloat without breaking CI. In production we warn
+  // (not error) once an asset/entrypoint exceeds 1.6 MiB; the current bundle is
+  // ~1.24 MB, so today's build stays quiet but future growth gets flagged. In
+  // dev mode hints are disabled to avoid noise during HMR rebuilds.
+  performance:
+    argv.mode === 'production'
+      ? {
+          hints: 'warning',
+          maxAssetSize: 1638400,
+          maxEntrypointSize: 1638400
+        }
+      : { hints: false },
   devServer: {
     port: Number(process.env.CCSM_DEV_PORT) || 4100,
     hot: true,


### PR DESCRIPTION
## Summary
- Addresses DEBT.md item #11: `webpack.config.js` had no `performance` budget, so renderer bundle bloat could land silently.
- Adds a `performance` section to the renderer webpack config:
  - Production mode: `hints: 'warning'` with `maxAssetSize` and `maxEntrypointSize` of 1.6 MiB (1638400 bytes). Warns (does not error) so CI is not broken — just surfaces bloat.
  - Dev mode: `hints: false` to avoid HMR noise.
- Ceiling sits just above the current ~1.21 MiB bundle, so today's build is quiet but future growth is flagged.

## Test plan
- [x] `npm run typecheck` → exit 0
- [x] `npm run lint` (eslint --max-warnings 0) → exit 0
- [x] `npm test` (vitest run) → 36 failures, all pre-existing and unrelated (db/db-hardening/electron-load-smoke); verified identical failures on baseline with the change stashed. No new failures introduced.
- [x] `npm run build` → exit 0, "compiled successfully", `dist/renderer/bundle.js` emitted at 1.21 MiB. No performance warning (under the 1.6 MiB budget, as intended).

Co-Authored-By: Claude Opus 4 <noreply@anthropic.com>