### PR TITLE
refactor(sidebar): extract SidebarActionsContext, drop 5 prop-drilled callbacks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo } from 'react';
 import { TooltipProvider } from './components/ui/Tooltip';
 import { ToastProvider, useToast } from './components/ui/Toast';
 import { Sidebar } from './components/Sidebar';
+import { SidebarActionsProvider } from './components/sidebar/SidebarActionsContext';
 import { AppShell } from './components/AppShell';
 import { AppSkeleton } from './components/AppSkeleton';
 import { TerminalPane } from './components/TerminalPane';
@@ -450,19 +451,24 @@ export default function App() {
         <AppEffectsBridge />
         <AppShell
           sidebar={
-            <Sidebar
-              onCreateSession={newSession}
-              onCreateSessionWithCwd={newSessionWithCwd}
-              onOpenSettings={() => setSettingsOpen(true)}
-              onOpenPalette={() => setPaletteOpen(true)}
-              onOpenImport={() => setImportOpen(true)}
-              activeSessionId={activeId}
-              focusedGroupId={focusedGroupId}
-              onSelectSession={selectSession}
-              onFocusGroup={focusGroup}
-              sessions={sessions}
-              onMoveSession={moveSession}
-            />
+            <SidebarActionsProvider
+              value={{
+                onCreateSession: newSession,
+                onCreateSessionWithCwd: newSessionWithCwd,
+                onOpenSettings: () => setSettingsOpen(true),
+                onOpenPalette: () => setPaletteOpen(true),
+                onOpenImport: () => setImportOpen(true),
+              }}
+            >
+              <Sidebar
+                activeSessionId={activeId}
+                focusedGroupId={focusedGroupId}
+                onSelectSession={selectSession}
+                onFocusGroup={focusGroup}
+                sessions={sessions}
+                onMoveSession={moveSession}
+              />
+            </SidebarActionsProvider>
           }
           main={
             <main className="flex-1 flex flex-col min-w-0 right-pane-frame relative">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -16,26 +16,13 @@ import { GroupRow } from './sidebar/GroupRow';
 import { NewSessionButton } from './sidebar/NewSessionButton';
 import { ArchivedSection } from './sidebar/ArchivedSection';
 import { useSidebarDnd } from './sidebar/useSidebarDnd';
+import { useSidebarActions } from './sidebar/SidebarActionsContext';
 
 // Session order inside a group is user-controlled (drag to reorder) — not
 // derived from state. The array order handed down from the store is the
 // source of truth; don't re-sort it here.
 
 export type SidebarProps = {
-  /** Create a new session in-place. The store seeds `cwd` from the user's
-   *  home directory (the always-true default per the new spec); the user
-   *  repicks via the StatusBar cwd chip. No modal involved — see
-   *  App.tsx::newSession. */
-  onCreateSession?: () => void;
-  /** Create a new session in a user-picked working directory. Routed
-   *  through App.tsx so the same `claudeAvailableRef !== true` gate that
-   *  protects the `+` button (#900 / #852) also covers the cwd-chevron
-   *  path — otherwise clicking the chevron during the boot probe still
-   *  stranded the user on a blank pane (#910 / #911). */
-  onCreateSessionWithCwd?: (cwd: string) => void;
-  onOpenSettings?: () => void;
-  onOpenPalette?: () => void;
-  onOpenImport?: () => void;
   activeSessionId: string;
   focusedGroupId: string | null;
   onSelectSession: (id: string) => void;
@@ -44,7 +31,13 @@ export type SidebarProps = {
   onMoveSession: (sessionId: string, targetGroupId: string, beforeSessionId: string | null) => void;
 };
 
-export function Sidebar({ onCreateSession, onCreateSessionWithCwd, onOpenSettings, onOpenPalette, onOpenImport, activeSessionId, focusedGroupId, onSelectSession, onFocusGroup, sessions, onMoveSession }: SidebarProps) {
+export function Sidebar({ activeSessionId, focusedGroupId, onSelectSession, onFocusGroup, sessions, onMoveSession }: SidebarProps) {
+  // Action callbacks (create session, open settings/palette/import) come from
+  // SidebarActionsContext rather than props — they're stable App-level handlers
+  // (DEBT.md #7). The cwd-chevron path (onCreateSessionWithCwd) is read here and
+  // forwarded into pickCwd below.
+  const { onCreateSession, onCreateSessionWithCwd, onOpenSettings, onOpenPalette, onOpenImport } =
+    useSidebarActions();
   const { t } = useTranslation();
   const groups = useStore((s) => s.groups);
   const createGroup = useStore((s) => s.createGroup);

--- a/src/components/sidebar/SidebarActionsContext.tsx
+++ b/src/components/sidebar/SidebarActionsContext.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext } from 'react';
+
+// The five top-level Sidebar action callbacks used to be prop-drilled from
+// App.tsx through <Sidebar> into its action buttons / child clusters
+// (DEBT.md #7). They're stable App-level handlers that never vary per render
+// branch, so a context fits better than threading them as props: it drops
+// Sidebar's prop surface from 11 to 6 and lets the leaf consumers
+// (e.g. the New Session cluster) read them directly without intermediate
+// pass-through. Mirrors the <ToastProvider> / useToast() shape: a nullable
+// context + a hook that throws when used outside the provider.
+export type SidebarActions = {
+  /** Create a new session in-place (home-dir default cwd). */
+  onCreateSession?: () => void;
+  /** Create a new session in a user-picked working directory. */
+  onCreateSessionWithCwd?: (cwd: string) => void;
+  onOpenSettings?: () => void;
+  onOpenPalette?: () => void;
+  onOpenImport?: () => void;
+};
+
+const Ctx = createContext<SidebarActions | null>(null);
+
+export function SidebarActionsProvider({
+  value,
+  children,
+}: {
+  value: SidebarActions;
+  children: React.ReactNode;
+}) {
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useSidebarActions() {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error('useSidebarActions must be used inside <SidebarActionsProvider>');
+  return ctx;
+}

--- a/tests/sidebar-i18n-aria.test.tsx
+++ b/tests/sidebar-i18n-aria.test.tsx
@@ -16,6 +16,7 @@ import React from 'react';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, cleanup, act } from '@testing-library/react';
 import { Sidebar } from '../src/components/Sidebar';
+import { SidebarActionsProvider } from '../src/components/sidebar/SidebarActionsContext';
 import { useStore } from '../src/stores/store';
 import { usePreferences } from '../src/store/preferences';
 import { initI18n } from '../src/i18n';
@@ -67,18 +68,23 @@ afterEach(() => {
 function renderSidebar() {
   return render(
     <ToastProvider>
-      <Sidebar
-        activeSessionId=""
-        focusedGroupId={null}
-        sessions={[]}
-        onSelectSession={() => {}}
-        onFocusGroup={() => {}}
-        onMoveSession={() => {}}
-        onCreateSession={() => {}}
-        onOpenSettings={() => {}}
-        onOpenPalette={() => {}}
-        onOpenImport={() => {}}
-      />
+      <SidebarActionsProvider
+        value={{
+          onCreateSession: () => {},
+          onOpenSettings: () => {},
+          onOpenPalette: () => {},
+          onOpenImport: () => {},
+        }}
+      >
+        <Sidebar
+          activeSessionId=""
+          focusedGroupId={null}
+          sessions={[]}
+          onSelectSession={() => {}}
+          onFocusGroup={() => {}}
+          onMoveSession={() => {}}
+        />
+      </SidebarActionsProvider>
     </ToastProvider>
   );
 }

--- a/tests/sidebar/SidebarActionsContext.test.tsx
+++ b/tests/sidebar/SidebarActionsContext.test.tsx
@@ -1,0 +1,39 @@
+// Focused coverage for SidebarActionsContext (DEBT.md #7): the 5 sidebar
+// action callbacks moved off props onto a context. Assert the hook throws
+// outside a provider (the guard that surfaces a forgotten provider as a clear
+// error rather than a silent undefined-callback no-op) and returns the exact
+// callbacks inside one.
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import {
+  SidebarActionsProvider,
+  useSidebarActions,
+  type SidebarActions,
+} from '../../src/components/sidebar/SidebarActionsContext';
+
+describe('useSidebarActions', () => {
+  it('throws when used outside a SidebarActionsProvider', () => {
+    expect(() => renderHook(() => useSidebarActions())).toThrow(
+      /must be used inside <SidebarActionsProvider>/
+    );
+  });
+
+  it('returns the provided callbacks inside a provider', () => {
+    const value: SidebarActions = {
+      onCreateSession: () => {},
+      onCreateSessionWithCwd: () => {},
+      onOpenSettings: () => {},
+      onOpenPalette: () => {},
+      onOpenImport: () => {},
+    };
+    const { result } = renderHook(() => useSidebarActions(), {
+      wrapper: ({ children }) => (
+        <SidebarActionsProvider value={value}>{children}</SidebarActionsProvider>
+      ),
+    });
+    expect(result.current).toBe(value);
+    expect(result.current.onCreateSession).toBe(value.onCreateSession);
+    expect(result.current.onOpenSettings).toBe(value.onOpenSettings);
+  });
+});


### PR DESCRIPTION
## Summary
DEBT.md item #7. `Sidebar` carried 11 props, 5 of which were stable App-level action callbacks (`onCreateSession`, `onCreateSessionWithCwd`, `onOpenSettings`, `onOpenPalette`, `onOpenImport`). These are now provided via a new `SidebarActionsContext` and read with `useSidebarActions()` instead of being prop-drilled.

- New `src/components/sidebar/SidebarActionsContext.tsx` — `SidebarActionsProvider` + `useSidebarActions()` hook that throws when used outside a provider (mirrors the existing `ToastProvider`/`useToast()` convention).
- `App.tsx` wraps `<Sidebar/>` in `<SidebarActionsProvider value={{...5 callbacks}}>` and no longer passes them as props.
- `Sidebar.tsx` consumes the 5 callbacks from context; the other 6 props are unchanged.
- **Before: 11 props → After: 6 props.**

## Test plan
- [x] `npm run typecheck` → exit 0
- [x] `npm run lint` → exit 0
- [x] `npm test` → all renderer/sidebar tests pass (incl. updated `sidebar-i18n-aria` and new `SidebarActionsContext` unit test asserting the hook throws outside a provider / returns callbacks inside one). Pre-existing `electron/__tests__/db*.test.ts` failures are an unrelated better-sqlite3 native-ABI mismatch in the local env, present on base.
- [x] `node scripts/harness-ui.mjs` → 14/14 cases green in real Electron (incl. `sidebar-align`, `settings-open`, `import-empty-groups`, `rename`), confirming the provider wiring mounts correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)