### PR TITLE
security(csp): set Content-Security-Policy response header (dev/prod aware)

### DIFF
--- a/electron/window/__tests__/createWindow.test.ts
+++ b/electron/window/__tests__/createWindow.test.ts
@@ -37,6 +37,7 @@ interface FakeWin {
 let latestWin: FakeWin | null = null;
 let appQuitMock: ReturnType<typeof vi.fn>;
 let hasSwitchMock: ReturnType<typeof vi.fn<[string], boolean>>;
+let onHeadersReceivedMock: ReturnType<typeof vi.fn>;
 
 function makeFakeWin(opts: Record<string, unknown>): FakeWin {
   const listeners = new Map<string, (...args: unknown[]) => void>();
@@ -107,7 +108,14 @@ vi.mock('electron', () => {
       getSwitchValue: (_name: string) => '',
     },
   };
-  return { BrowserWindow, Menu, app };
+  const session = {
+    defaultSession: {
+      webRequest: {
+        onHeadersReceived: (...args: unknown[]) => onHeadersReceivedMock(...args),
+      },
+    },
+  };
+  return { BrowserWindow, Menu, app, session };
 });
 
 // Mock the close-action prefs module — both reads + writes are observed.
@@ -135,8 +143,11 @@ import {
   decideCloseAction,
   createWindow,
   CLOSE_ASK_TIMEOUT_MS,
+  buildCsp,
+  sentryIngestOrigin,
   __resetContextMenuSuppressionForTests,
   __resetSuppressIpcForTests,
+  __resetCspForTests,
   type CreateWindowDeps,
 } from '../createWindow';
 
@@ -553,6 +564,8 @@ describe('createWindow factory', () => {
     isQuittingFlag = false;
     appQuitMock = vi.fn();
     hasSwitchMock = vi.fn<[string], boolean>(() => false);
+    onHeadersReceivedMock = vi.fn();
+    __resetCspForTests();
     getCloseActionMock.mockReset().mockReturnValue('tray');
     setCloseActionMock.mockReset();
     ipcHandlers = new Map();
@@ -674,6 +687,29 @@ describe('createWindow factory', () => {
     const evt = { preventDefault: vi.fn() };
     willNav(evt, 'http://localhost:4100/index.html');
     expect(evt.preventDefault).not.toHaveBeenCalled();
+  });
+
+  // ─── CSP response-header injector (DEBT.md #17) ───────────────────────
+  it('registers a CSP onHeadersReceived hook and injects the header', () => {
+    createWindow(deps);
+    expect(onHeadersReceivedMock).toHaveBeenCalledTimes(1);
+    const hook = onHeadersReceivedMock.mock.calls[0][0] as (
+      details: { responseHeaders: Record<string, string[]> },
+      cb: (r: { responseHeaders: Record<string, string[]> }) => void,
+    ) => void;
+    let applied: Record<string, string[]> | null = null;
+    hook({ responseHeaders: { 'x-existing': ['1'] } }, (r) => {
+      applied = r.responseHeaders;
+    });
+    expect(applied!['Content-Security-Policy'][0]).toContain(`default-src 'self'`);
+    // Existing headers are preserved.
+    expect(applied!['x-existing']).toEqual(['1']);
+  });
+
+  it('only installs the CSP hook once across multiple createWindow calls', () => {
+    createWindow(deps);
+    createWindow(deps);
+    expect(onHeadersReceivedMock).toHaveBeenCalledTimes(1);
   });
 
   // ─── window-open handler denies popups (preload-leak hardening) ───────
@@ -902,5 +938,59 @@ describe('createWindow factory', () => {
   it('factory installs the context-menu listener on webContents', () => {
     createWindow(deps);
     expect(latestWin!.webContentsListeners.has('context-menu')).toBe(true);
+  });
+});
+
+describe('sentryIngestOrigin', () => {
+  it('returns the origin of a well-formed DSN', () => {
+    expect(
+      sentryIngestOrigin('https://abc123@o123.ingest.sentry.io/456'),
+    ).toBe('https://o123.ingest.sentry.io');
+  });
+
+  it('returns null for empty / undefined / unparseable input', () => {
+    expect(sentryIngestOrigin(undefined)).toBeNull();
+    expect(sentryIngestOrigin('')).toBeNull();
+    expect(sentryIngestOrigin('   ')).toBeNull();
+    expect(sentryIngestOrigin('not a url')).toBeNull();
+  });
+});
+
+describe('buildCsp', () => {
+  it('prod policy: self-only scripts, no unsafe-eval, inline styles allowed', () => {
+    const csp = buildCsp(false, undefined, undefined);
+    expect(csp).toContain(`default-src 'self'`);
+    expect(csp).toContain(`script-src 'self'`);
+    expect(csp).not.toContain('unsafe-eval');
+    expect(csp).toContain(`style-src 'self' 'unsafe-inline'`);
+    expect(csp).toContain(`img-src 'self' data:`);
+    expect(csp).toContain(`font-src 'self' data:`);
+    expect(csp).toContain(`connect-src 'self'`);
+    expect(csp).toContain(`object-src 'none'`);
+    expect(csp).toContain(`base-uri 'self'`);
+    expect(csp).toContain(`frame-src 'none'`);
+    // No dev-server origins leak into prod.
+    expect(csp).not.toContain('localhost');
+  });
+
+  it('dev policy: adds unsafe-eval + dev-server http/ws connect origins', () => {
+    const csp = buildCsp(true, '4100', undefined);
+    expect(csp).toContain(`script-src 'self' 'unsafe-eval'`);
+    expect(csp).toContain(`http://localhost:4100`);
+    expect(csp).toContain(`ws://localhost:4100`);
+  });
+
+  it('dev policy honors a custom CCSM_DEV_PORT', () => {
+    const csp = buildCsp(true, '5200', undefined);
+    expect(csp).toContain(`http://localhost:5200`);
+    expect(csp).toContain(`ws://localhost:5200`);
+    expect(csp).not.toContain('4100');
+  });
+
+  it('appends the Sentry ingest origin to connect-src when a DSN is set', () => {
+    const csp = buildCsp(false, undefined, 'https://k@o1.ingest.sentry.io/2');
+    expect(csp).toContain(
+      `connect-src 'self' https://o1.ingest.sentry.io`,
+    );
   });
 });

--- a/electron/window/createWindow.ts
+++ b/electron/window/createWindow.ts
@@ -25,6 +25,7 @@ import {
   BrowserWindow,
   Menu,
   app,
+  session,
   type MenuItemConstructorOptions,
   type IpcMain,
 } from 'electron';
@@ -81,6 +82,122 @@ export function isAllowedNavigation(
   } catch {
     return false;
   }
+}
+
+// Content-Security-Policy (DEBT.md #17). The renderer shipped no CSP, so
+// Electron logged an "Insecure Content-Security-Policy" warning and any
+// renderer XSS had a wide blast radius (sandbox:false on the BrowserWindow).
+// We set the policy as a *response header* via `onHeadersReceived` — the
+// authoritative Electron approach — rather than an `http-equiv` meta tag,
+// which can't express every directive (e.g. frame-ancestors / sandbox) and
+// is applied later in the document lifecycle.
+//
+// Two profiles, keyed on the same dev/prod signal the loader uses
+// (`deps.isDev` → webpack-dev-server URL vs packaged file:// bundle):
+//
+//   PROD (file://):
+//     - script-src 'self'      — the `webpack --mode production` bundle is
+//       devtool:false (no `eval`), so we DON'T need 'unsafe-eval'.
+//     - style-src 'self' 'unsafe-inline' — style-loader injects Tailwind +
+//       component CSS as inline <style> tags at runtime; without
+//       'unsafe-inline' every style is refused and the app renders unstyled.
+//     - img/font-src 'self' data: — @fontsource fonts + small inlined images
+//       arrive as data: URIs.
+//     - connect-src 'self' [+ Sentry ingest origin] — Sentry only posts to a
+//       remote DSN when SENTRY_DSN is set (no hardcoded DSN in this repo); we
+//       derive the ingest origin from that env so error reporting isn't
+//       blocked when an operator opts in. Absent a DSN, connect-src stays
+//       'self'.
+//     - object-src/frame-src 'none' — no plugins, no embedded frames (the
+//       ttyd terminal pane is a <webview>, not an <iframe>, and is governed by
+//       webview CSP separately; the app never embeds frame/iframe content).
+//     - base-uri 'self', default-src 'self'.
+//
+//   DEV (http://localhost:<port>):
+//     - script-src adds 'unsafe-eval' — webpack-dev-server's default devtool
+//       (`eval-*`) wraps every module in eval(); without it HMR + the initial
+//       bundle are refused and the renderer never mounts.
+//     - connect-src adds the dev-server origin + its HMR websocket
+//       (ws://localhost:<port>) so live-reload/HMR can poll + push updates.
+
+/** Derive the Sentry ingest origin from a DSN, or null when no DSN / the DSN
+ *  is unparseable. A Sentry DSN looks like
+ *  `https://<key>@<host>/<projectId>`; events POST to that host's origin, so
+ *  that's what `connect-src` must allow. Exported for unit test. */
+export function sentryIngestOrigin(dsn: string | undefined): string | null {
+  if (!dsn || dsn.trim().length === 0) return null;
+  try {
+    return new URL(dsn.trim()).origin;
+  } catch {
+    return null;
+  }
+}
+
+/** Pure CSP-string builder — extracted so the dev/prod policies can be
+ *  unit-tested (and pasted into the PR body) without booting Electron.
+ *  `isDev` mirrors `CreateWindowDeps.isDev`; `devPort` is `CCSM_DEV_PORT`
+ *  (defaults to 4100); `sentryDsn` is `process.env.SENTRY_DSN`. */
+export function buildCsp(
+  isDev: boolean,
+  devPort: string | undefined,
+  sentryDsn: string | undefined,
+): string {
+  const port = devPort && devPort.length > 0 ? devPort : '4100';
+  const sentryOrigin = sentryIngestOrigin(sentryDsn);
+
+  const scriptSrc = ["'self'"];
+  const connectSrc = ["'self'"];
+  if (isDev) {
+    // webpack-dev-server bundles via eval(); HMR uses an http poll + ws push.
+    scriptSrc.push("'unsafe-eval'");
+    connectSrc.push(`http://localhost:${port}`, `ws://localhost:${port}`);
+  }
+  if (sentryOrigin) connectSrc.push(sentryOrigin);
+
+  const directives = [
+    `default-src 'self'`,
+    `script-src ${scriptSrc.join(' ')}`,
+    // style-loader injects inline <style> tags (Tailwind + component CSS).
+    `style-src 'self' 'unsafe-inline'`,
+    `img-src 'self' data:`,
+    `font-src 'self' data:`,
+    `connect-src ${connectSrc.join(' ')}`,
+    `object-src 'none'`,
+    `base-uri 'self'`,
+    `frame-src 'none'`,
+  ];
+  return directives.join('; ');
+}
+
+// Guard so the `onHeadersReceived` hook is registered at most once on the
+// shared `session.defaultSession`. `createWindow` can run more than once
+// (macOS dock-activate re-create), and stacking handlers would append the
+// CSP header N times.
+let cspInstalled = false;
+
+/** Test-only — reset the once-guard so a fresh test can re-install. */
+export function __resetCspForTests(): void {
+  cspInstalled = false;
+}
+
+/** Register the CSP response-header injector on the default session. No-op if
+ *  already installed or if `session.defaultSession` is unavailable (e.g. the
+ *  unit-test electron mock doesn't expose `session`). `isDev` selects the
+ *  dev vs prod policy. */
+export function installCsp(isDev: boolean): void {
+  if (cspInstalled) return;
+  const defaultSession = session?.defaultSession;
+  if (!defaultSession?.webRequest?.onHeadersReceived) return;
+  cspInstalled = true;
+  const csp = buildCsp(isDev, process.env.CCSM_DEV_PORT, process.env.SENTRY_DSN);
+  defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [csp],
+      },
+    });
+  });
 }
 
 // One-shot suppression deadline for the native context menu. The terminal
@@ -228,6 +345,10 @@ export function decideCloseAction(
 export const CLOSE_ASK_TIMEOUT_MS = 10_000;
 
 export function createWindow(deps: CreateWindowDeps): BrowserWindow {
+  // Defense-in-depth: install the Content-Security-Policy response-header
+  // hook on the shared default session before the window loads its URL/file
+  // (DEBT.md #17). Idempotent — safe across macOS dock-activate re-creates.
+  installCsp(deps.isDev);
   // E2E hidden mode: when CCSM_E2E_HIDDEN=1 the window is created
   // at position (-32000, -32000) — far outside any monitor's visible
   // area on every common multi-monitor layout. The window IS shown


### PR DESCRIPTION
## Summary
- DEBT.md #17: the Electron renderer shipped **no CSP**, so Electron logged an "Insecure Content-Security-Policy" warning and any renderer XSS had a wide blast radius (the BrowserWindow runs with `sandbox:false`).
- Adds an **authoritative response-header CSP** via `session.defaultSession.webRequest.onHeadersReceived` in the main process (`electron/window/createWindow.ts`) — not a weaker `http-equiv` meta tag. No change to `src/index.html`.
- Two profiles keyed on the existing `deps.isDev` signal (the same flag that decides dev-server URL vs packaged `file://` load). Hook installed once on the shared default session (idempotent across macOS dock re-creates). `buildCsp` / `sentryIngestOrigin` are pure + unit-tested.

### Exact CSP strings (for review/audit)

**PRODUCTION** (`file://` packaged bundle):
```
default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; frame-src 'none'
```

**PRODUCTION when `SENTRY_DSN` is set** (ingest origin derived from the DSN; no hardcoded DSN ships in this repo):
```
default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' https://o1.ingest.sentry.io; object-src 'none'; base-uri 'self'; frame-src 'none'
```

**DEVELOPMENT** (webpack-dev-server, `CCSM_DEV_PORT` defaults to 4100):
```
default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self' data:; connect-src 'self' http://localhost:4100 ws://localhost:4100; object-src 'none'; base-uri 'self'; frame-src 'none'
```

### Directive rationale
- `script-src 'self'` in prod — `webpack --mode production` defaults to `devtool:false` (no `eval`), so **no `'unsafe-eval'`** is needed. Dev adds `'unsafe-eval'` because webpack-dev-server's default `eval-*` devtool wraps modules in `eval()`.
- `style-src 'self' 'unsafe-inline'` — `style-loader` injects Tailwind + component CSS as inline `<style>` tags at runtime; without `'unsafe-inline'` the app renders unstyled.
- `img-src`/`font-src` allow `data:` — @fontsource fonts + small inlined images.
- `connect-src` adds the Sentry ingest origin only when `SENTRY_DSN` is set, so opt-in crash reporting isn't blocked. Dev also adds the dev-server http origin + HMR websocket.
- `object-src 'none'`, `frame-src 'none'` — no plugins, no embedded iframes (the ttyd terminal pane is a `<webview>`, governed separately).

## Test plan
- [x] `npm run typecheck` → exit 0
- [x] `npm run lint` → exit 0
- [x] `npm test` → 195 files, 1897 passed (incl. new `buildCsp` / `sentryIngestOrigin` / CSP-hook factory tests)
- [x] `npm run build` → exit 0
- [x] `node scripts/harness-ui.mjs` → 14/14 passed, including `terminal-pane-mounted` (xterm.js host mounts). Renderer console captured separately showed **zero CSP violations**; the prod renderer loads via `file://` and styles/scripts/fonts all load under the policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)