### PR TITLE
docs(debt): refresh audit register (2026-05-29)

### DIFF
--- a/DEBT.md
+++ b/DEBT.md
@@ -27,6 +27,8 @@ shows what got paid down).
 | 3 | Renderer bundle 1.24 MB single chunk — add `splitChunks` + lazy-load `ImportDialog`/`CommandPalette`/`SettingsDialog` | OPEN | M | HIGH | `webpack.config.js` |
 | 4 | God-files >500 LOC: `shellRegistry.ts` (650), `sessionCrudSlice.ts` (622), `createWindow.ts` (596), `mobileRemoteServer.ts` (535) | OPEN | L | HIGH | various |
 | 5 | Session field "shotgun surgery" — adding one field touches slice + types + preload + IPC + db + components + `i18n/locales/{en,zh}.ts` (duplicated locales are the amplifier) | OPEN | M | HIGH | `src/i18n/locales/*` + chain |
+| 17 | No Content-Security-Policy — renderer ships no CSP (no `http-equiv` meta in `src/index.html`, no `onHeadersReceived` in main). Electron emits "Insecure CSP" warning. With `sandbox:false` (#13) the blast radius of any renderer XSS is wider | OPEN | M | HIGH | `src/index.html:3`, `electron/window/createWindow.ts` |
+| 18 | `npm audit` (2026-05-29, official registry): 8 prod vulns (1 HIGH, 7 mod). **HIGH** `tmp` <0.2.6 path-traversal ships in product; `@anthropic-ai/sdk` insecure file perms (fixed by SDK 0.3, see #2); `hono`/`ip-address`/`qs`/`fast-uri`/`brace-expansion` mod (mobile-remote web stack). All `npm audit fix`-able. (6 more in dev-only deps: ws/express/webpack-dev-server — not shipped) | OPEN | S | HIGH | `package-lock.json` |
 
 ### P2 — MED impact, medium-small
 
@@ -35,8 +37,8 @@ shows what got paid down).
 | 6 | Layering inversion: terminal modules read store state (`sessionRuntimeSlice` etc.) directly; verify whether a circular dep remains after the `xtermWarmRegistry` → `shellRegistry` rewrite | OPEN | S-M | MED | `src/stores/store.ts`, `src/terminal/shellRegistry.ts` |
 | 7 | `Sidebar.tsx` has 11 props — extract `SidebarActionsContext` for the 5 `onOpen*`/`onCreate*` callbacks | OPEN | S | MED | `src/components/Sidebar.tsx:47` |
 | 8 | `AGENTS.md` + `CLAUDE.md` missing from repo root — new sessions / contributors lack project-level orientation | OPEN | M | MED | repo root |
-| 9 | `docs/README.md:8` references `STATUS.md` that does not exist | OPEN | S | LOW | `docs/README.md` |
-| 10 | `npm audit` blocked by npmmirror registry — CVE state in current deps is **unknown** | OPEN | S | UNKNOWN | npm registry config |
+| 9 | `docs/README.md:8` references `STATUS.md` — resolved: `docs/status/STATUS.md` exists, link is valid | DONE | S | LOW | `docs/README.md` |
+| 10 | `npm audit` blocked by npmmirror registry — workaround: `npm audit --registry=https://registry.npmjs.org/`. Unblocked 2026-05-29; results captured in #18. Permanent fix: added `audit`/`audit:fix` npm scripts that pin the official registry | DONE | S | LOW | `package.json`, `.npmrc` |
 | 11 | `webpack.config.js` lacks `performance.hints` / size-limit gate — bundle bloat can land silently | OPEN | S | MED | `webpack.config.js` |
 | 12 | `import:scan`, `paths:exist`, `sessionTitles:listForProject` IPC return unbounded arrays — pagination/caps missing | OPEN | M | MED | `electron/ipc/utilityIpc.ts:125,178`, `electron/ipc/sessionIpc.ts:76` |
 | 13 | `sandbox: false` on BrowserWindow (Sentry preload `require` path) — known tracked security debt | OPEN | M | MED | `electron/window/createWindow.ts:353` |
@@ -66,6 +68,7 @@ shows what got paid down).
 
 ## Audit history
 
+- **2026-05-29** — refresh via `technical-debt` skill. Still 0 TODO/FIXME/HACK markers. New: #17 missing CSP (HIGH, in flight). #9 resolved (STATUS.md exists). #10 unblocked — `npm audit` via official-registry workaround surfaced #18: 8 prod vulns (1 HIGH `tmp`, 7 mod), all `npm audit fix`-able; added `audit`/`audit:fix` scripts.
 - **2026-05-25** — full audit via `technical-debt` skill (Anthropic Claude harness). 42 rules across 10 categories. 6 items paid down in batch (D1–D6); see commits in week of 2026-05-25.
 
 ## How to update this file


### PR DESCRIPTION
## Summary
- Add #17 (missing Content-Security-Policy, HIGH) and #18 (npm audit prod vulns, HIGH) to the open-debt register.
- Mark #9 DONE — `docs/status/STATUS.md` exists, the `docs/README.md:8` link is valid.
- Mark #10 DONE — `npm audit` unblocked via the official-registry workaround; `audit`/`audit:fix` scripts added (PR #1412).
- Append a 2026-05-29 audit-history line.

Single-file change to `DEBT.md`. Preserves main's current rows #4/#6/#12/#13. Replaces the stale-base PR #1409.

## Test plan
- [x] Docs-only change; no code paths touched.
- [x] Diff is `DEBT.md` only (5 insertions, 2 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)