### PR TITLE
docs(project): add root AGENTS.md + CLAUDE.md orientation (debt #8)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,155 @@
+# AGENTS.md — Project orientation for CCSM
+
+CCSM (Claude Code Session Manager) is an Electron + React + TypeScript desktop
+app for running and managing many Claude Code (`claude` CLI) sessions in
+parallel, grouped by task. It delegates 100% of agent execution to the user's
+local `claude` binary and makes **zero** HTTP calls to Anthropic itself.
+
+This file is the broad map: architecture, module layout, conventions. For the
+condensed "don't break things" checklist see [`CLAUDE.md`](CLAUDE.md). For
+user-facing product framing see [`README.md`](README.md).
+
+## Hard constraints (read first)
+
+- **npm only — never pnpm or yarn.** The build relies on
+  `scripts/postinstall.mjs` (native rebuild via `@electron/rebuild`) and
+  electron-builder, and the package manager decision was deliberate. Using a
+  different manager breaks the native-module rebuild and packaging.
+- **Node >= 22.** `package.json` declares `engines.node: ">=22.0.0"` and
+  `.npmrc` sets `engine-strict=true`, so `npm install` hard-errors on older
+  Node. (`scripts/postinstall.mjs` still carries an older Node-20 warning
+  string; the authoritative gate is `engine-strict`.)
+- **Native modules are rebuilt for Electron's ABI.** `better-sqlite3` (the
+  local DB) and `node-pty` (the terminal backend) are rebuilt against
+  Electron's ABI by the `postinstall` script. A mismatch shows up at runtime
+  as cryptic "renderer window didn't appear" errors, not at install time.
+  better-sqlite3 failure is fatal; node-pty failure is non-fatal because it
+  ships a prebuilt binary fallback (asserted by `scripts/after-pack.cjs`).
+- **Renderer must not import from `electron/`.** Frontend code under `src/`
+  talks to the main process only through `window.ccsm` (typed in
+  `src/global.d.ts`, exposed via `electron/preload/`). This is a convention
+  (documented in `docs/mvp-design.md` §15), not eslint-enforced — keep it
+  intact so a future remote daemon stays possible.
+
+## Process architecture
+
+Three Electron surfaces, TypeScript throughout:
+
+```mermaid
+flowchart LR
+  subgraph Renderer["Renderer (src/) — React 18, sandboxed"]
+    UI[Components + zustand stores + xterm.js]
+  end
+  subgraph Preload["Preload (electron/preload/) — bridge"]
+    Bridge["window.ccsm contextBridge"]
+  end
+  subgraph Main["Main (electron/) — Node + Electron"]
+    IPC[IPC handlers]
+    PTY[PTY host / node-pty]
+    DB[(better-sqlite3)]
+    CLI[[claude CLI]]
+  end
+  UI -->|invoke / on| Bridge
+  Bridge -->|ipcRenderer| IPC
+  IPC --> PTY
+  IPC --> DB
+  PTY --> CLI
+```
+
+- **Main process** (`electron/`) owns the window, the SQLite DB, the PTY host,
+  notifications, the updater, and all IPC handlers. The PTY lives here so
+  sessions stay alive across UI switches (switching is a buffer swap, not a
+  respawn).
+- **Preload** (`electron/preload/`) exposes a single typed `window.ccsm`
+  surface to the renderer via contextBridge. Bridges are split by domain:
+  `ccsmCore`, `ccsmPty`, `ccsmSession`, `ccsmSessionTitles`, `ccsmShell`,
+  `ccsmNotify`.
+- **Renderer** (`src/`) is React 18 bundled by webpack 5. It only knows about
+  `window.ccsm`, never about Node or Electron APIs directly.
+
+## Module map
+
+### `src/` (renderer)
+- `App.tsx`, `index.tsx`, `index.html` — entry + shell mount.
+- `components/` — React UI. Notable: `Sidebar.tsx`, `TerminalPane.tsx`,
+  `CommandPalette.tsx`, `SettingsDialog.tsx`, `ImportDialog.tsx`,
+  `ClaudeMissingGuide.tsx`; plus subfolders `chrome/`, `cwd/`, `settings/`,
+  `sidebar/`, `ui/`.
+- `stores/` — zustand store (`store.ts`) composed from `slices/`
+  (`groupsSlice`, `sessionCrudSlice`, `sessionRuntimeSlice`,
+  `appearanceSlice`, `popoverSlice`, `installerSlice`,
+  `sessionTitleBackfillSlice`), plus `persist.ts` and `drafts.ts`.
+- `store/preferences.ts` — preference accessors (distinct from `stores/`).
+- `terminal/` — xterm.js integration: `shellRegistry.ts` (warm terminal
+  instances), `usePtyAttachShell.ts`, `useAtBottom.ts`, `paste.ts`.
+- `i18n/` — i18next setup (`index.ts`, `useTranslation.ts`) and
+  `locales/` (en + zh; locale strings are duplicated per language — adding a
+  session field touches both, see DEBT #5).
+- `shared/`, `lib/`, `utils/`, `agent/`, `app-effects/`, `styles/`,
+  `types.ts`, and `*.d.ts` ambient declarations (`global.d.ts`, `pty.d.ts`,
+  `session.d.ts`).
+
+### `electron/` (main process)
+- `main.ts` — process entry; `window/createWindow.ts` builds the BrowserWindow
+  (also sets CSP via `onHeadersReceived`).
+- `ipc/` — IPC handlers split by domain: `dbIpc`, `sessionIpc`, `systemIpc`,
+  `utilityIpc`, `windowIpc`.
+- `preload/` — contextBridge entry + `bridges/`.
+- `ptyHost/` — PTY lifecycle (node-pty). `db.ts` / `db-validate.ts` —
+  better-sqlite3 schema + validation.
+- Supporting subsystems: `agent/`, `notify/`, `remote/`, `security/`,
+  `sentry/`, `sessionTitles/`, `sessionWatcher/`, `tray/`, `updater.ts`,
+  `import-scanner.ts`, `commands-loader.ts`, `badgeController.ts`,
+  `memory.ts`, `i18n.ts`, `branding/`, `prefs/`, `lifecycle/`.
+
+### `scripts/`
+- `dev.mjs` — dev orchestrator (run via `npm run dev`).
+- `postinstall.mjs` — native rebuild (see Hard constraints).
+- `after-pack.cjs` — asserts a native PTY binding exists in the packaged app.
+- `run-all-e2e.mjs` + `harness-e2e-*.mjs` — Playwright e2e harnesses
+  (run via `npm run probe:e2e`, which builds first).
+- `harness-ui.mjs` — UI harness for local verification.
+- `dogfood-*.mjs` — bug-specific reproduction harnesses.
+- `setup-aumid.ps1` — registers the Windows AUMID for dev-mode toast
+  notifications.
+
+### `docs/`
+- `mvp-design.md` — frozen MVP scope (the import-boundary rule lives in §15).
+- `design-system.md` — Tailwind v4 tokens.
+- `status/STATUS.md` — pointer; current state lives in `git log` + `DEBT.md`.
+- `reference/` — release, packaging, e2e-runner notes.
+- See `docs/README.md` for the full index.
+
+## Commands
+
+Run from the repo root with npm:
+
+| Command | What it does |
+|---|---|
+| `npm install` | Installs deps and rebuilds native modules for Electron's ABI (`postinstall`). |
+| `npm run dev` | Launches webpack-dev-server + Electron together. |
+| `npm run build` | Cleans `dist/`, compiles main via `tsc`, bundles renderer via webpack (production). |
+| `npm run typecheck` | `tsc --noEmit` for both renderer and `tsconfig.electron.json`. |
+| `npm run lint` | ESLint over `.ts/.tsx` with `--max-warnings 0` (warnings fail). |
+| `npm test` | Vitest run (unit + integration). |
+| `npm run coverage` | Vitest with v8 coverage. |
+| `npm run probe:e2e` | Builds, then runs all Playwright e2e harnesses. |
+| `npm run audit` / `audit:fix` | `npm audit` pinned to the official registry (works around the npmmirror registry). |
+| `npm run make` / `make:win` / `make:mac` / `make:linux` | Build platform installers via electron-builder. |
+
+## Conventions
+
+- **Stack:** Electron (main + renderer), React 18, webpack 5, zustand state,
+  xterm.js + node-pty terminal, better-sqlite3 DB, i18next (en/zh),
+  Tailwind v4, electron-builder packaging, vitest + Playwright tests.
+- **Tests** live in `__tests__/` folders and `tests/`. Prefer adding a test
+  with any behavioural change.
+- **Crash reporting** (Sentry) is off by default — no hardcoded DSN; opt in via
+  the `SENTRY_DSN` env var.
+- **Technical debt** is tracked in [`DEBT.md`](DEBT.md) — a prioritized,
+  file:line-cited register. Read it before large refactors; update the row
+  (don't delete) when you pay an item down.
+- **Ownership:** single maintainer — see [`.github/CODEOWNERS`](.github/CODEOWNERS).
+  `main` is the default branch; releases are cut from tagged commits.
+- **Security policy:** [`SECURITY.md`](SECURITY.md). Contribution basics:
+  [`CONTRIBUTING.md`](CONTRIBUTING.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# CLAUDE.md — Instructions for AI coding agents
+
+CCSM (Claude Code Session Manager) is an Electron + React + TypeScript desktop
+app for managing many Claude Code sessions. This file is the short "don't break
+things" checklist. For the full architecture and module map, read
+[`AGENTS.md`](AGENTS.md).
+
+## Non-negotiable rules
+
+- **npm only — never run pnpm or yarn.** Native rebuild (`scripts/postinstall.mjs`)
+  and electron-builder packaging depend on npm. Switching managers breaks the
+  build.
+- **Node >= 22.** `engines.node` is `">=22.0.0"` and `.npmrc` sets
+  `engine-strict=true`, so install hard-errors on older Node.
+- **Native modules:** `better-sqlite3` and `node-pty` are rebuilt for
+  Electron's ABI by `postinstall`. After dependency or Electron version
+  changes, re-run `npm install` so the rebuild happens.
+- **Renderer (`src/`) must not import from `electron/`.** It talks to the main
+  process only via `window.ccsm` (typed in `src/global.d.ts`, exposed by
+  `electron/preload/`). Convention from `docs/mvp-design.md` §15 — keep it.
+
+## Commands you will use
+
+```bash
+npm install          # deps + native rebuild for Electron ABI
+npm run dev          # webpack-dev-server + Electron (run the app)
+npm run typecheck    # tsc --noEmit (renderer + electron)
+npm run lint         # eslint, --max-warnings 0 (warnings fail)
+npm test             # vitest run
+npm run coverage     # vitest with coverage
+npm run probe:e2e    # build + Playwright e2e harnesses
+```
+
+Before claiming work is done, run `npm run typecheck`, `npm run lint`, and
+`npm test`. Markdown files are not linted by eslint.
+
+## Where things live (quick map)
+
+- `src/` — React renderer: `components/`, zustand `stores/` (slices),
+  `terminal/` (xterm.js), `i18n/` (en + zh locales).
+- `electron/` — main process: `window/` (BrowserWindow + CSP), `ipc/` handlers,
+  `preload/bridges/` (the `window.ccsm` surface), `ptyHost/` (node-pty),
+  `db.ts` (better-sqlite3).
+- `scripts/` — `dev.mjs`, `postinstall.mjs`, e2e/`harness-*`/`dogfood-*` runners.
+- `docs/` — `mvp-design.md` (frozen scope), `design-system.md`,
+  `status/STATUS.md`; index in `docs/README.md`.
+
+## Working norms
+
+- Track and respect technical debt in [`DEBT.md`](DEBT.md). When you fix a
+  listed item, update its row (move to Done, add PR + SHA) rather than deleting.
+- Add or update tests (in `__tests__/` or `tests/`) for behavioural changes.
+- Single maintainer; ownership in [`.github/CODEOWNERS`](.github/CODEOWNERS).
+  `main` is the default branch — use PRs, do not commit straight to it.
+- Sentry crash reporting is off by default (no hardcoded DSN); opt in via the
+  `SENTRY_DSN` env var.

--- a/DEBT.md
+++ b/DEBT.md
@@ -36,7 +36,7 @@ shows what got paid down).
 |---|---|---|---|---|---|
 | 6 | Layering inversion: terminal modules read store state (`sessionRuntimeSlice` etc.) directly; verify whether a circular dep remains after the `xtermWarmRegistry` → `shellRegistry` rewrite | OPEN | S-M | MED | `src/stores/store.ts`, `src/terminal/shellRegistry.ts` |
 | 7 | `Sidebar.tsx` had 11 props — extracted `SidebarActionsContext` for the 5 `onOpen*`/`onCreate*` callbacks (now 6 props). **DONE** ([#1411](https://github.com/Jiahui-Gu/ccsm/pull/1411), `399225d`) | DONE | S | MED | `src/components/Sidebar.tsx` |
-| 8 | `AGENTS.md` + `CLAUDE.md` missing from repo root — new sessions / contributors lack project-level orientation | OPEN | M | MED | repo root |
+| 8 | `AGENTS.md` + `CLAUDE.md` missing from repo root — new sessions / contributors lack project-level orientation. **DONE** ([#1416](https://github.com/Jiahui-Gu/ccsm/pull/1416)): added root `AGENTS.md` (broad map) + `CLAUDE.md` (don't-break checklist) | DONE | M | MED | repo root |
 | 9 | `docs/README.md:8` references `STATUS.md` — resolved: `docs/status/STATUS.md` exists, link is valid | DONE | S | LOW | `docs/README.md` |
 | 10 | `npm audit` blocked by npmmirror registry — workaround: `npm audit --registry=https://registry.npmjs.org/`. Unblocked 2026-05-29; results captured in #18. Permanent fix: added `audit`/`audit:fix` npm scripts that pin the official registry | DONE | S | LOW | `package.json`, `.npmrc` |
 | 11 | `webpack.config.js` lacked `performance.hints` / size-limit gate — bundle bloat could land silently. **DONE** ([#1410](https://github.com/Jiahui-Gu/ccsm/pull/1410), `aa342c0`): prod budget warns at 1.6 MiB asset/entrypoint | DONE | S | MED | `webpack.config.js` |
@@ -74,12 +74,13 @@ shows what got paid down).
 | 7 | `Sidebar.tsx` 11 props → 6 via `SidebarActionsContext` | [#1411](https://github.com/Jiahui-Gu/ccsm/pull/1411) | `399225d` |
 | 18 | 8 prod `npm audit` vulns (1 HIGH `tmp`) — cleared via `npm audit fix`; added `audit`/`audit:fix` scripts | [#1412](https://github.com/Jiahui-Gu/ccsm/pull/1412) | `5c8589a` |
 | 17 | No Content-Security-Policy — set via `onHeadersReceived` response header (dev/prod aware) | [#1413](https://github.com/Jiahui-Gu/ccsm/pull/1413) | `78bd564` |
+| 8 | `AGENTS.md` + `CLAUDE.md` missing from repo root — added both orientation docs | [#1416](https://github.com/Jiahui-Gu/ccsm/pull/1416) | (squash) |
 
 ---
 
 ## Audit history
 
-- **2026-05-29 (paydown)** — debt-paydown batch landed 4 items: #11 webpack bundle budget ([#1410](https://github.com/Jiahui-Gu/ccsm/pull/1410)), #7 SidebarActionsContext ([#1411](https://github.com/Jiahui-Gu/ccsm/pull/1411)), #18 npm audit-fix + audit scripts ([#1412](https://github.com/Jiahui-Gu/ccsm/pull/1412)), #17 CSP response header ([#1413](https://github.com/Jiahui-Gu/ccsm/pull/1413)). Remaining HIGH: #1 Electron 41→42, #2 SDK 0.2→0.3, #3 bundle splitChunks, #4 god-files, #5 shotgun surgery.
+- **2026-05-29 (paydown)** — debt-paydown batch landed 4 items: #11 webpack bundle budget ([#1410](https://github.com/Jiahui-Gu/ccsm/pull/1410)), #7 SidebarActionsContext ([#1411](https://github.com/Jiahui-Gu/ccsm/pull/1411)), #18 npm audit-fix + audit scripts ([#1412](https://github.com/Jiahui-Gu/ccsm/pull/1412)), #17 CSP response header ([#1413](https://github.com/Jiahui-Gu/ccsm/pull/1413)), #8 root AGENTS.md + CLAUDE.md ([#1416](https://github.com/Jiahui-Gu/ccsm/pull/1416)). Remaining HIGH: #1 Electron 41→42, #2 SDK 0.2→0.3, #3 bundle splitChunks (lazy-load half in flight), #4 god-files, #5 shotgun surgery.
 - **2026-05-29** — refresh via `technical-debt` skill. Still 0 TODO/FIXME/HACK markers. New: #17 missing CSP (HIGH, in flight). #9 resolved (STATUS.md exists). #10 unblocked — `npm audit` via official-registry workaround surfaced #18: 8 prod vulns (1 HIGH `tmp`, 7 mod), all `npm audit fix`-able; added `audit`/`audit:fix` scripts.
 - **2026-05-25** — full audit via `technical-debt` skill (Anthropic Claude harness). 42 rules across 10 categories. 6 items paid down in batch (D1–D6); see commits in week of 2026-05-25.
 


### PR DESCRIPTION
## Summary
Pays down DEBT.md #8 — repo root lacked project-level orientation for new sessions/contributors.

- **AGENTS.md** (+155): broad map — hard constraints (npm-only, Node>=22 engine-strict, native ABI rebuild, renderer-must-not-import-electron §15), process-architecture Mermaid diagram, module map (src/electron/scripts/docs), commands table, conventions.
- **CLAUDE.md** (+56): concise AI "don't break things" checklist — non-negotiable rules, commands, where-things-live map, working norms, pointer to AGENTS.md.

Docs-only; zero code paths touched.

## Evidence
Content accuracy (docs have no user-visible runtime behavior): all cited file paths and npm commands verified to exist against the current tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)