### PR TITLE
perf(renderer): lazy-load Settings/Command/Import dialogs (debt #3)

### DIFF
--- a/DEBT.md
+++ b/DEBT.md
@@ -24,7 +24,7 @@ shows what got paid down).
 |---|---|---|---|---|---|
 | 1 | Electron 41 → 42 (Chromium CVE patches stop arriving on 41) | OPEN | M | HIGH | `package.json:96` |
 | 2 | `@anthropic-ai/claude-agent-sdk` 0.2 → 0.3 | OPEN | M | HIGH | `package.json:41` |
-| 3 | Renderer bundle 1.24 MB single chunk — add `splitChunks` + lazy-load `ImportDialog`/`CommandPalette`/`SettingsDialog` | OPEN | M | HIGH | `webpack.config.js` |
+| 3 | Renderer bundle 1.24 MB single chunk — add `splitChunks` + lazy-load `ImportDialog`/`CommandPalette`/`SettingsDialog`. **PARTIAL** ([#1417](https://github.com/Jiahui-Gu/ccsm/pull/1417)): 3 dialogs converted to `React.lazy` + `Suspense` so they code-split out of the initial parse. Remaining: explicit `splitChunks` vendor grouping (webpack 5 already async-splits the lazy chunks). | IN PROGRESS | M | HIGH | `src/App.tsx`, `webpack.config.js` |
 | 4 | God-files >500 LOC: `shellRegistry.ts` (650), `sessionCrudSlice.ts` (622), `createWindow.ts` (596), `mobileRemoteServer.ts` (535) | OPEN | L | HIGH | various |
 | 5 | Session field "shotgun surgery" — adding one field touches slice + types + preload + IPC + db + components + `i18n/locales/{en,zh}.ts` (duplicated locales are the amplifier) | OPEN | M | HIGH | `src/i18n/locales/*` + chain |
 | 17 | No Content-Security-Policy — renderer ships no CSP. **DONE** ([#1413](https://github.com/Jiahui-Gu/ccsm/pull/1413), `78bd564`): CSP set via `onHeadersReceived` response header, dev/prod aware | DONE | M | HIGH | `electron/window/createWindow.ts` |

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,8 +40,8 @@ import { useCwdRedirectedBridge } from './app-effects/useCwdRedirectedBridge';
 import { useHydrateSystemLocale } from './app-effects/useHydrateSystemLocale';
 import { useExitAnimation } from './app-effects/useExitAnimation';
 
-// Lazily-loaded modal dialogs — code-split into separate chunks so the
-// main bundle doesn't pay for them until first open (debt #3).
+// Lazily-loaded modal dialogs — code-split into separate chunks so they
+// drop out of the initial bundle parse (fetched after App mount; debt #3).
 const SettingsDialog = lazy(() =>
   import('./components/SettingsDialog').then((m) => ({ default: m.SettingsDialog }))
 );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useEffect, useMemo, lazy, Suspense } from 'react';
 import { TooltipProvider } from './components/ui/Tooltip';
 import { ToastProvider, useToast } from './components/ui/Toast';
 import { Sidebar } from './components/Sidebar';
@@ -7,9 +7,6 @@ import { AppShell } from './components/AppShell';
 import { AppSkeleton } from './components/AppSkeleton';
 import { TerminalPane } from './components/TerminalPane';
 import { ClaudeMissingGuide } from './components/ClaudeMissingGuide';
-import { SettingsDialog } from './components/SettingsDialog';
-import { CommandPalette } from './components/CommandPalette';
-import { ImportDialog } from './components/ImportDialog';
 import { ShortcutOverlay } from './components/ShortcutOverlay';
 import { DragRegion, WindowControls } from './components/WindowControls';
 import { InstallerCorruptBanner } from './components/InstallerCorruptBanner';
@@ -42,6 +39,18 @@ import { useNotifyFlashBridge } from './app-effects/useNotifyFlashBridge';
 import { useCwdRedirectedBridge } from './app-effects/useCwdRedirectedBridge';
 import { useHydrateSystemLocale } from './app-effects/useHydrateSystemLocale';
 import { useExitAnimation } from './app-effects/useExitAnimation';
+
+// Lazily-loaded modal dialogs — code-split into separate chunks so the
+// main bundle doesn't pay for them until first open (debt #3).
+const SettingsDialog = lazy(() =>
+  import('./components/SettingsDialog').then((m) => ({ default: m.SettingsDialog }))
+);
+const CommandPalette = lazy(() =>
+  import('./components/CommandPalette').then((m) => ({ default: m.CommandPalette }))
+);
+const ImportDialog = lazy(() =>
+  import('./components/ImportDialog').then((m) => ({ default: m.ImportDialog }))
+);
 
 // Initialise i18next once, before any component renders. Subsequent
 // language changes flow through `applyLanguage` (called by the store
@@ -480,16 +489,18 @@ export default function App() {
             </main>
           }
         />
-        <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
-        <ImportDialog open={importOpen} onOpenChange={setImportOpen} />
-        <CommandPalette
-          open={paletteOpen}
-          onOpenChange={setPaletteOpen}
-          onOpenSettings={() => setSettingsOpen(true)}
-          onOpenImport={() => setImportOpen(true)}
-          onSelectSession={selectSession}
-          onFocusGroup={focusGroup}
-        />
+        <Suspense fallback={null}>
+          <SettingsDialog open={settingsOpen} onOpenChange={setSettingsOpen} />
+          <ImportDialog open={importOpen} onOpenChange={setImportOpen} />
+          <CommandPalette
+            open={paletteOpen}
+            onOpenChange={setPaletteOpen}
+            onOpenSettings={() => setSettingsOpen(true)}
+            onOpenImport={() => setImportOpen(true)}
+            onSelectSession={selectSession}
+            onFocusGroup={focusGroup}
+          />
+        </Suspense>
         <ShortcutOverlay open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
         {closeActionDialog}
       </ToastProvider>


### PR DESCRIPTION
## Summary
Pays down DEBT.md #3 (partial — the lazy-load half) — converts the three modal dialogs in `src/App.tsx` from eager static imports to `React.lazy`, wrapped in a single `<Suspense fallback={null}>`.

## Bundle evidence
- `bundle.js` 1,268,911 → 1,245,957 bytes (−22.4 KiB)
- 3 new lazy chunks emitted: 18.5 KiB + 10 KiB + 8.35 KiB
- Main bundle stays under the 1.6 MiB webpack `performance` budget (no warning)

## Verification
- typecheck PASS / lint PASS (max-warnings 0)
- test: 1869 passed, 1 todo; 18 failures are all pre-existing better-sqlite3 ABI mismatch (NODE_MODULE_VERSION 145 vs 137) in `electron/__tests__/db*.test.ts` — none touch renderer/App
- production build: no budget warning

Note: subagent added a 2-line WHY comment above the lazy declarations (chunk-split intent). Reviewer to confirm keep/strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)