### PR TITLE
refactor(terminal): break terminal↔store circular dependency (debt #6)

### DIFF
--- a/DEBT.md
+++ b/DEBT.md
@@ -34,7 +34,7 @@ shows what got paid down).
 
 | ID | Item | Status | Effort | Impact | Location |
 |---|---|---|---|---|---|
-| 6 | Layering inversion: terminal modules read store state (`sessionRuntimeSlice` etc.) directly; verify whether a circular dep remains after the `xtermWarmRegistry` → `shellRegistry` rewrite | OPEN | S-M | MED | `src/stores/store.ts`, `src/terminal/shellRegistry.ts` |
+| 6 | Layering inversion: terminal modules read store state directly — a real cycle existed: `store.ts → sessionCrudSlice → terminal/shellRegistry → store.ts` (shellRegistry statically imported `useStore` for appearance defaults). **DONE** (this PR): broke the `shellRegistry → store` edge via a registered appearance provider (`setShellAppearanceProvider`, store wires it at boot); `madge --circular` now clean. Remaining terminal→store reads are one-directional (permitted). | DONE | S-M | MED | `src/stores/store.ts`, `src/terminal/shellRegistry.ts` |
 | 7 | `Sidebar.tsx` had 11 props — extracted `SidebarActionsContext` for the 5 `onOpen*`/`onCreate*` callbacks (now 6 props). **DONE** ([#1411](https://github.com/Jiahui-Gu/ccsm/pull/1411), `399225d`) | DONE | S | MED | `src/components/Sidebar.tsx` |
 | 8 | `AGENTS.md` + `CLAUDE.md` missing from repo root — new sessions / contributors lack project-level orientation. **DONE** ([#1416](https://github.com/Jiahui-Gu/ccsm/pull/1416)): added root `AGENTS.md` (broad map) + `CLAUDE.md` (don't-break checklist) | DONE | M | MED | repo root |
 | 9 | `docs/README.md:8` references `STATUS.md` — resolved: `docs/status/STATUS.md` exists, link is valid | DONE | S | LOW | `docs/README.md` |
@@ -75,11 +75,13 @@ shows what got paid down).
 | 18 | 8 prod `npm audit` vulns (1 HIGH `tmp`) — cleared via `npm audit fix`; added `audit`/`audit:fix` scripts | [#1412](https://github.com/Jiahui-Gu/ccsm/pull/1412) | `5c8589a` |
 | 17 | No Content-Security-Policy — set via `onHeadersReceived` response header (dev/prod aware) | [#1413](https://github.com/Jiahui-Gu/ccsm/pull/1413) | `78bd564` |
 | 8 | `AGENTS.md` + `CLAUDE.md` missing from repo root — added both orientation docs | [#1416](https://github.com/Jiahui-Gu/ccsm/pull/1416) | (squash) |
+| 6 | Terminal↔store circular dep (`store → sessionCrudSlice → shellRegistry → store`) — broke `shellRegistry → store` edge via registered appearance provider; `madge --circular` clean | [#1418](https://github.com/Jiahui-Gu/ccsm/pull/1418) | — |
 
 ---
 
 ## Audit history
 
+- **2026-05-29 (paydown)** — #6 terminal↔store circular dependency. `madge --circular` confirmed a real cycle: `store.ts → stores/slices/sessionCrudSlice.ts → terminal/shellRegistry.ts → store.ts` (shellRegistry statically imported `useStore` to read `scrollbackLines`/`terminalFontSizePx` for `createShell`). Fixed minimally by inverting that one edge: shellRegistry now exposes `setShellAppearanceProvider`, and `store.ts` registers a lazy provider at boot — so the static graph is one-directional (store → terminal). `madge --circular --extensions ts,tsx src/` now reports "No circular dependency found". The `sessionCrudSlice → shellRegistry` (`disposeShell`) edge and other terminal→store reads are permitted one-way reads.
 - **2026-05-29 (paydown)** — debt-paydown batch landed 4 items: #11 webpack bundle budget ([#1410](https://github.com/Jiahui-Gu/ccsm/pull/1410)), #7 SidebarActionsContext ([#1411](https://github.com/Jiahui-Gu/ccsm/pull/1411)), #18 npm audit-fix + audit scripts ([#1412](https://github.com/Jiahui-Gu/ccsm/pull/1412)), #17 CSP response header ([#1413](https://github.com/Jiahui-Gu/ccsm/pull/1413)), #8 root AGENTS.md + CLAUDE.md ([#1416](https://github.com/Jiahui-Gu/ccsm/pull/1416)). Remaining HIGH: #1 Electron 41→42, #2 SDK 0.2→0.3, #3 bundle splitChunks (lazy-load half in flight), #4 god-files, #5 shotgun surgery.
 - **2026-05-29** — refresh via `technical-debt` skill. Still 0 TODO/FIXME/HACK markers. New: #17 missing CSP (HIGH, in flight). #9 resolved (STATUS.md exists). #10 unblocked — `npm audit` via official-registry workaround surfaced #18: 8 prod vulns (1 HIGH `tmp`, 7 mod), all `npm audit fix`-able; added `audit`/`audit:fix` scripts.
 - **2026-05-25** — full audit via `technical-debt` skill (Anthropic Claude harness). 42 rules across 10 categories. 6 items paid down in batch (D1–D6); see commits in week of 2026-05-25.

--- a/src/stores/store.ts
+++ b/src/stores/store.ts
@@ -15,7 +15,9 @@ import {
 } from './slices/appearanceSlice';
 import { createInstallerSlice } from './slices/installerSlice';
 import { createPopoverSlice } from './slices/popoverSlice';
+import { SCROLLBACK_LINES_DEFAULT, TERMINAL_FONT_SIZE_DEFAULT } from './slices/types';
 import type { State, RootStore } from './slices/types';
+import { setShellAppearanceProvider } from '../terminal/shellRegistry';
 
 export const useStore = create<RootStore>((set, get) => ({
   ...createSessionCrudSlice(set, get),
@@ -29,6 +31,20 @@ export const useStore = create<RootStore>((set, get) => ({
   // (no actions) nor persisted (lifecycle only).
   hydrated: false,
 }));
+
+// Hand the terminal layer a lazy read of the user's current appearance
+// (scrollback cap + terminal font size) WITHOUT shellRegistry importing
+// this module. A static back-import would close the module cycle
+// store → sessionCrudSlice → terminal/shellRegistry → store (DEBT #6);
+// registering a provider here keeps the static graph one-directional
+// (store → terminal) while still giving `createShell` live values.
+setShellAppearanceProvider(() => {
+  const s = useStore.getState();
+  return {
+    scrollbackLines: s.scrollbackLines ?? SCROLLBACK_LINES_DEFAULT,
+    terminalFontSizePx: s.terminalFontSizePx ?? TERMINAL_FONT_SIZE_DEFAULT,
+  };
+});
 
 let hydrated = false;
 

--- a/src/terminal/shellRegistry.ts
+++ b/src/terminal/shellRegistry.ts
@@ -23,10 +23,47 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import { ClipboardAddon } from '@xterm/addon-clipboard';
 import { Unicode11Addon } from '@xterm/addon-unicode11';
 import { CanvasAddon } from '@xterm/addon-canvas';
-import { useStore } from '../stores/store';
 import { SCROLLBACK_LINES_DEFAULT, TERMINAL_FONT_SIZE_DEFAULT } from '../stores/slices/types';
 import { warn, log } from '../shared/log';
 import { pasteIntoActivePty } from './paste';
+
+// Appearance defaults (scrollback cap + terminal font size) are owned by
+// the store, but a static `import { useStore }` here would close a module
+// cycle: store.ts → sessionCrudSlice → terminal/shellRegistry → store.ts
+// (DEBT #6). Instead the store registers a lazy provider at boot via
+// `setShellAppearanceProvider`. Until that runs (tests / non-renderer
+// contexts) we fall back to the compile-time defaults from `slices/types`,
+// which is the same value the store's appearance slice initialises with.
+export type ShellAppearance = {
+  scrollbackLines: number;
+  terminalFontSizePx: number;
+};
+
+let appearanceProvider: (() => ShellAppearance) | null = null;
+
+/**
+ * Register the live appearance source. Called once by `stores/store.ts`
+ * after the store is created so `createShell` can read the user's current
+ * scrollback / font-size without importing the store (which would form a
+ * cycle). Idempotent re-registration is allowed (last writer wins).
+ */
+export function setShellAppearanceProvider(provider: () => ShellAppearance): void {
+  appearanceProvider = provider;
+}
+
+function readAppearance(): ShellAppearance {
+  if (appearanceProvider) {
+    try {
+      return appearanceProvider();
+    } catch (e) {
+      warn('shell', 'appearance provider threw — using defaults', e);
+    }
+  }
+  return {
+    scrollbackLines: SCROLLBACK_LINES_DEFAULT,
+    terminalFontSizePx: TERMINAL_FONT_SIZE_DEFAULT,
+  };
+}
 
 export type Shell = {
   sid: string;
@@ -122,8 +159,7 @@ export function createShell(sid: string, host: HTMLElement): Shell {
     return existing;
   }
 
-  const scrollback = useStore.getState().scrollbackLines ?? SCROLLBACK_LINES_DEFAULT;
-  const fontSize = useStore.getState().terminalFontSizePx ?? TERMINAL_FONT_SIZE_DEFAULT;
+  const { scrollbackLines: scrollback, terminalFontSizePx: fontSize } = readAppearance();
   const term = new Terminal({
     fontFamily: 'Cascadia Mono, Consolas, "Courier New", monospace',
     fontSize,

--- a/tests/components/TerminalPane.test.tsx
+++ b/tests/components/TerminalPane.test.tsx
@@ -31,6 +31,9 @@ vi.mock('../../src/terminal/useAtBottom', () => ({
 }));
 vi.mock('../../src/terminal/shellRegistry', () => ({
   getTopShell: getTopShellSpy,
+  // store.ts registers an appearance provider at module-eval via this
+  // export; the mock must surface it so importing the store doesn't throw.
+  setShellAppearanceProvider: vi.fn(),
 }));
 vi.mock('../../src/terminal/paste', () => ({
   terminalCopy: copySpy,


### PR DESCRIPTION
## Summary
Pays down DEBT.md #6 — **confirmed a real circular dependency** (not verify-only):
`stores/store.ts → stores/slices/sessionCrudSlice.ts → terminal/shellRegistry.ts → stores/store.ts`.

Broken by inverting the closing edge via dependency injection:
- `shellRegistry.ts` — drops the static `import { useStore }`; adds `setShellAppearanceProvider()` + a module-local provider. `createShell` reads `scrollbackLines`/`terminalFontSizePx` through it, falling back to `slices/types` defaults when unregistered (tests / non-renderer).
- `store.ts` — registers the live provider once at boot via `useStore.getState()`. Static graph stays one-directional (store → terminal).
- `tests/components/TerminalPane.test.tsx` — its `vi.mock` of shellRegistry needed the new export.
- `DEBT.md` — #6 → DONE.

Rejected a dynamic-`import()` cut: madge still counts dynamic imports as edges, so the cycle persisted; provider DI is the cleaner architectural break.

## Evidence (madge)
Before: `✖ Found 1 circular dependency!  stores/store.ts > slices/sessionCrudSlice.ts > terminal/shellRegistry.ts`
After:  `✔ No circular dependency found!`

## Verification
- typecheck PASS / lint PASS (`--max-warnings 0`)
- test: 1851 passed; 36 failures all pre-existing & unrelated (18 better-sqlite3 ABI mismatch in `electron/__tests__/db*`; 18 `electron-load-smoke` gated on `dist/electron` absent in fresh worktree). Zero new failures; passing count rose 1847→1851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)