### PR TITLE
fix(ptyHost): guard JSONL watcher teardown behind session-identity check

### DIFF
--- a/electron/ptyHost/__tests__/entryFactory.test.ts
+++ b/electron/ptyHost/__tests__/entryFactory.test.ts
@@ -183,7 +183,7 @@ describe('entryFactory.makeEntry', () => {
     expect(bus().watcherStart).toHaveBeenCalledWith('sid-E', '/tmp/live.jsonl', '/work');
   });
 
-  it('on pty exit: disposes headless, fires deps.onExit(sid), and stops the watcher', () => {
+  it('on pty exit: disposes headless and fires deps.onExit(sid) — does NOT stop the watcher itself', () => {
     const onExit = vi.fn();
     makeEntry('sid-F', '/work', '/bin/claude', 80, 24, { onExit });
     const b = bus();
@@ -191,7 +191,13 @@ describe('entryFactory.makeEntry', () => {
     b.onExit!({ exitCode: 0, signal: null });
     expect(b.headlessDispose).toHaveBeenCalledTimes(1);
     expect(onExit).toHaveBeenCalledWith('sid-F');
-    expect(b.watcherStop).toHaveBeenCalledWith('sid-F');
+    // Watcher teardown is now the caller's concern: it lives INSIDE the
+    // identity-guarded `deps.onExit` body (lifecycle.ts) so a stale pty's
+    // late exit can't tear down a fresh respawned session's watcher under
+    // the same sid. entryFactory's exit pump must therefore NOT call
+    // stopWatching directly. (The `onExit` dep here is a bare spy, so the
+    // real watcher is never touched.)
+    expect(b.watcherStop).not.toHaveBeenCalled();
   });
 
   it('forwards pty data into headless write AND emitPtyData fanout', () => {

--- a/electron/ptyHost/__tests__/lifecycle.test.ts
+++ b/electron/ptyHost/__tests__/lifecycle.test.ts
@@ -229,6 +229,59 @@ describe('lifecycle.spawn', () => {
     expect(sessions.get('sid-X')).toBe(entryB);
   });
 
+  // Regression for the JSONL-watcher half of the same race. Before this fix
+  // `sessionWatcher.stopWatching(sid)` ran UNCONDITIONALLY in entryFactory's
+  // onExit pump (outside the identity guard), so a stale pty's late onExit
+  // killed the FRESH session's JSONL tail-watcher — the renderer then stopped
+  // getting session:state / session:title updates and the notify badge was
+  // wrongly drained. The fix moves stopWatching INSIDE the guarded body so it
+  // only fires when this entry is still the live one for the sid.
+  it('onExit identity-guard also gates stopWatching — stale onExit must NOT stop the fresh session watcher', () => {
+    const sessions = new Map<string, FakeEntry>();
+    const entryA = makeFakeEntry({ pty: makeFakePty({ pid: 100 }) });
+    bus().makeEntry.mockReturnValueOnce(entryA);
+    L.spawn(sessions as any, 'sid-X', '/work', '/bin/claude');
+    const depsA = bus().makeEntry.mock.calls[0][5] as { onExit: (s: string) => void };
+
+    // Reload: entryA evicted, fresh entryB spawned under the same sid.
+    sessions.delete('sid-X');
+    const entryB = makeFakeEntry({ pty: makeFakePty({ pid: 200 }) });
+    bus().makeEntry.mockReturnValueOnce(entryB);
+    L.spawn(sessions as any, 'sid-X', '/work', '/bin/claude');
+    expect(sessions.get('sid-X')).toBe(entryB);
+
+    // OLD pty's late onExit — fresh watcher must survive.
+    depsA.onExit('sid-X');
+    expect(sessions.get('sid-X')).toBe(entryB);
+    expect(bus().watcherStopCalls).toEqual([]);
+  });
+
+  // Normal case: when the LIVE entry's onExit fires, the watcher IS stopped.
+  it('onExit stops the watcher when this entry is still the live one for the sid', () => {
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    bus().makeEntry.mockReturnValue(entry);
+    L.spawn(sessions as any, 'sid-W', '/work', '/bin/claude');
+    const deps = bus().makeEntry.mock.calls[0][5] as { onExit: (s: string) => void };
+
+    deps.onExit('sid-W');
+    expect(sessions.has('sid-W')).toBe(false);
+    expect(bus().watcherStopCalls).toEqual(['sid-W']);
+  });
+
+  // The guarded stopWatching must never propagate a throw out of onExit.
+  it('onExit swallows stopWatching throws (live-entry path)', () => {
+    const sessions = new Map<string, FakeEntry>();
+    const entry = makeFakeEntry();
+    bus().makeEntry.mockReturnValue(entry);
+    L.spawn(sessions as any, 'sid-T', '/work', '/bin/claude');
+    const deps = bus().makeEntry.mock.calls[0][5] as { onExit: (s: string) => void };
+    bus().watcherStopShouldThrow = true;
+    expect(() => deps.onExit('sid-T')).not.toThrow();
+    expect(sessions.has('sid-T')).toBe(false);
+    expect(bus().watcherStopCalls).toEqual(['sid-T']);
+  });
+
   // Sanity: the OLD entry's onExit still self-cleans when no fresh entry
   // has replaced it (the common case — pty exits normally, no reload).
   it('onExit still removes the entry when no replacement has been registered', () => {

--- a/electron/ptyHost/entryFactory.ts
+++ b/electron/ptyHost/entryFactory.ts
@@ -340,10 +340,13 @@ export function makeEntry(
     } catch {
       /* already disposed */
     }
+    // NOTE: stopping the JSONL tail-watcher is deliberately done INSIDE the
+    // identity-guarded `deps.onExit` body (lifecycle.ts), NOT here. A stale
+    // pty's late onExit (Windows wedged-kill reload race) must not tear down
+    // the FRESH session's watcher that a respawn registered under the same
+    // sid — otherwise the renderer stops getting session:state/title updates
+    // and the notify badge is wrongly drained.
     deps.onExit(sid);
-    // Stop the JSONL tail-watcher so we don't keep an fs.watch handle
-    // pinned for a dead session.
-    try { sessionWatcher.stopWatching(sid); } catch { /* never throws */ }
   });
 
   // Start a JSONL tail-watcher for this session. The watcher emits

--- a/electron/ptyHost/lifecycle.ts
+++ b/electron/ptyHost/lifecycle.ts
@@ -85,7 +85,17 @@ export function spawn(
       // dropped — user-visible as "reload made keyboard input dead"
       // (Task #79b empirical repro).
       onExit: (s) => {
-        if (sessions.get(s) === entry) sessions.delete(s);
+        if (sessions.get(s) === entry) {
+          sessions.delete(s);
+          // Stop the JSONL tail-watcher only when THIS entry is still the
+          // live one for that sid. Doing it here (inside the identity guard)
+          // rather than unconditionally in entryFactory's onExit pump means a
+          // stale pty's late exit can't tear down a FRESH session's watcher
+          // that a respawn registered under the same sid (Windows wedged-kill
+          // reload race) — which would otherwise stop session:state/title
+          // updates and wrongly drain the notify badge.
+          try { sessionWatcher.stopWatching(s); } catch { /* never throws */ }
+        }
       },
       onCwdRedirect: opts?.onCwdRedirect,
     },


### PR DESCRIPTION
## Summary
- A stale pty's `onExit` callback could call `sessionWatcher.stopWatching(sid)` and tear down the JSONL tail-watcher belonging to a **fresh** entry for the same sid (Windows ConPTY wedged-kill → reload race).
- The `stopWatching` call is now gated by the entry-identity check already used to guard `sessions.delete(s)`: it only fires when the exiting pty is still the live entry for that sid.
- Removed the unconditional `stopWatching` from the `entryFactory` pty onExit pump; responsibility now lives solely in lifecycle's guarded callback.

## Changes
- `electron/ptyHost/lifecycle.ts` — `stopWatching(s)` moved inside the `sessions.get(s) === entry` guard.
- `electron/ptyHost/entryFactory.ts` — dropped the redundant unconditional `stopWatching`; NOTE comment added.
- Tests: stale onExit must NOT stop a fresh watcher; a live exit DOES; a throwing watcher is swallowed; entryFactory no longer calls stopWatching.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (--max-warnings 0)
- [x] `npm test`
- [x] `node scripts/harness-ui.mjs` (14/14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)