### PR TITLE
fix(drafts): flush pending composer draft on beforeunload

### DIFF
--- a/src/app-effects/useFlushOnBeforeUnload.ts
+++ b/src/app-effects/useFlushOnBeforeUnload.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { flushNow } from '../stores/persist';
+import { flushDraftsNow } from '../stores/drafts';
 
 /**
  * Installs a `'beforeunload'` listener that flushes the debounced persist
@@ -22,6 +23,7 @@ export function useFlushOnBeforeUnload(): void {
   useEffect(() => {
     const onBeforeUnload = () => {
       flushNow();
+      flushDraftsNow();
     };
     window.addEventListener('beforeunload', onBeforeUnload);
     return () => {

--- a/src/stores/drafts.ts
+++ b/src/stores/drafts.ts
@@ -89,6 +89,27 @@ function schedulePersist(): void {
   }, WRITE_DEBOUNCE_MS);
 }
 
+/**
+ * Synchronously dispatch any pending debounced draft write. Call from
+ * `beforeunload` (renderer) so a quick quit doesn't lose the last 250 ms of
+ * composer typing. Mirrors `persist.ts`'s `flushNow`: the saveState IPC is
+ * fire-and-forget — Electron lets the in-flight IPC complete during teardown,
+ * but we don't await it here because beforeunload handlers can't reliably hold
+ * the page open across async work.
+ */
+export function flushDraftsNow(): void {
+  if (!window.ccsm) return;
+  if (writeTimer) {
+    clearTimeout(writeTimer);
+    writeTimer = null;
+  }
+  const drafts: Record<string, string> = {};
+  for (const [k, v] of cache.entries()) drafts[k] = v;
+  void window.ccsm.saveState(STATE_KEY, JSON.stringify({ version: 1, drafts })).catch(() => {
+    /* persist failures are non-fatal; we'll retry on the next edit */
+  });
+}
+
 // Test-only — not exported through any barrel; reach in via the module path.
 export function _resetForTests(): void {
   cache.clear();

--- a/tests/drafts.test.ts
+++ b/tests/drafts.test.ts
@@ -5,6 +5,7 @@ import {
   setDraft,
   clearDraft,
   deleteDrafts,
+  flushDraftsNow,
   _resetForTests,
 } from '../src/stores/drafts';
 
@@ -125,5 +126,28 @@ describe('drafts persistence', () => {
     await flushPersist();
     const blob = JSON.parse(saveState.mock.calls.at(-1)?.[1] as string);
     expect(blob.drafts['s-1']).toBe(tricky);
+  });
+
+  it('flushDraftsNow writes synchronously, bypassing the debounce, and clears the pending timer', async () => {
+    const { saveState } = installCCSM();
+    await hydrateDrafts();
+    setDraft('s-1', 'last-second edit'); // 250ms timer now pending, not yet fired
+    expect(saveState).not.toHaveBeenCalled();
+
+    flushDraftsNow();
+
+    // Written immediately, without advancing any timers.
+    expect(saveState).toHaveBeenCalledTimes(1);
+    const [key, blob] = saveState.mock.calls[0];
+    expect(key).toBe('drafts');
+    expect(JSON.parse(blob as string)).toEqual({
+      version: 1,
+      drafts: { 's-1': 'last-second edit' },
+    });
+
+    // The pending debounce timer was cleared: draining timers must NOT
+    // produce a second redundant write.
+    await flushPersist();
+    expect(saveState).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Composer drafts persist via a 250ms debounced write. On app quit / window close, a draft typed within that window was lost because the debounced timer never fired before the renderer tore down.
- Added `flushDraftsNow()` which clears the pending timer and writes the current draft cache synchronously.
- `useFlushOnBeforeUnload` now calls `flushDraftsNow()` alongside the existing `flushNow()` inside the `beforeunload` handler (listener stays inside the `useEffect`).

## Changes
- `src/stores/drafts.ts` — exported `flushDraftsNow()`.
- `src/app-effects/useFlushOnBeforeUnload.ts` — flush drafts on beforeunload.
- Tests: `flushDraftsNow` writes synchronously without advancing timers, and clears the pending timer.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (--max-warnings 0)
- [x] `npm test`
- [x] `node scripts/harness-ui.mjs` (14/14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)