### PR TITLE
fix(mobile-remote): isolate pty.data per subscribed session + harden token compare

### DIFF
--- a/electron/__tests__/mobileRemoteServer.test.ts
+++ b/electron/__tests__/mobileRemoteServer.test.ts
@@ -7,6 +7,11 @@ import type { Socket } from 'net';
 
 // Mock the ptyHost surface the server consumes. We don't want a real PTY,
 // and pulling in ../ptyHost would drag node-pty + electron transitively.
+//
+// The mock exposes an extra `__emitPtyData(sid, chunk)` that fans out to every
+// listener the server registered via onPtyData, letting a test drive the real
+// broadcast path. (vi.mock factories are hoisted, so the listener array lives
+// inside the factory; we read __emitPtyData back off the mocked module.)
 vi.mock('../ptyHost', () => {
   const listeners: Array<(sid: string, chunk: string) => void> = [];
   return {
@@ -23,8 +28,18 @@ vi.mock('../ptyHost', () => {
         if (i >= 0) listeners.splice(i, 1);
       };
     }),
+    __emitPtyData: (sid: string, chunk: string) => {
+      for (const cb of listeners.slice()) cb(sid, chunk);
+    },
   };
 });
+
+async function emitPtyData(sid: string, chunk: string): Promise<void> {
+  const mod = (await import('../ptyHost')) as unknown as {
+    __emitPtyData: (sid: string, chunk: string) => void;
+  };
+  mod.__emitPtyData(sid, chunk);
+}
 
 type Started = {
   port: number;
@@ -33,7 +48,8 @@ type Started = {
 };
 
 async function startServer(): Promise<Started> {
-  // Capture the random token from the server's startup console.log line.
+  // Token is no longer logged in full (redacted for log hygiene); read it from
+  // the server handle's `url` field instead. Still silence the startup logs.
   const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
   process.env.CCSM_MOBILE_REMOTE = '1';
@@ -50,22 +66,11 @@ async function startServer(): Promise<Started> {
   const { startMobileRemoteServer } = await import('../remote/mobileRemoteServer');
   const handle = startMobileRemoteServer();
   if (!handle) throw new Error('server did not start');
-
-  // Wait for the "listening at" log line that contains the token.
-  let token: string | null = null;
-  for (let i = 0; i < 50 && !token; i += 1) {
-    for (const call of logSpy.mock.calls) {
-      const line = String(call[0] ?? '');
-      const m = line.match(/token=([A-Za-z0-9_-]+)/);
-      if (m) {
-        token = m[1]!;
-        break;
-      }
-    }
-    if (!token) await new Promise((r) => setTimeout(r, 10));
-  }
   logSpy.mockRestore();
-  if (!token) throw new Error('could not capture token from startup log');
+
+  const m = handle.url.match(/token=([A-Za-z0-9_-]+)/);
+  if (!m) throw new Error('could not parse token from handle.url');
+  const token = m[1]!;
 
   return {
     port,
@@ -501,5 +506,97 @@ describe('mobileRemoteServer: server shutdown', () => {
     // 1001 = going-away. A bare destroy() would have surfaced as null
     // (no close frame parsed).
     expect(code).toBe(1001);
+  });
+});
+
+describe('mobileRemoteServer: per-client pty.data isolation', () => {
+  // Helper: connect, drain the initial auth.ok + sessions.list, subscribe to
+  // `sid` via session.snapshot, then drain the snapshot reply so the next
+  // message a test reads is genuinely the first post-subscribe frame.
+  async function connectAndSubscribe(port: number, token: string, sid: string) {
+    const ws = await wsConnect(port, `/ws?token=${token}`);
+    await ws.recvText; // auth.ok + sessions.list
+    ws.socket.write(encodeClientText(JSON.stringify({ type: 'session.snapshot', sid })));
+    const snap = JSON.parse(await ws.nextMessage());
+    expect(snap.type).toBe('session.snapshot');
+    expect(snap.sid).toBe(sid);
+    return ws;
+  }
+
+  it('forwards pty.data only to the client subscribed to that sid', async () => {
+    active = await startServer();
+    const a = await connectAndSubscribe(active.port, active.token, 'A');
+    const b = await connectAndSubscribe(active.port, active.token, 'B');
+
+    // Emit data for session 'A' only.
+    await emitPtyData('A', 'alpha-bytes');
+
+    // Client A (subscribed to 'A') must receive the pty.data frame.
+    const aMsg = JSON.parse(await a.nextMessage());
+    expect(aMsg).toMatchObject({ type: 'pty.data', sid: 'A', chunk: 'alpha-bytes' });
+
+    // Client B (subscribed to 'B') must NOT receive anything for 'A'.
+    await expect(b.nextMessage(200)).rejects.toThrow(/timed out/);
+
+    a.socket.destroy();
+    b.socket.destroy();
+  });
+
+  it('does not forward pty.data to a client that has not subscribed to any sid', async () => {
+    active = await startServer();
+    // Connect but never send session.snapshot — subscribedSid stays null.
+    const ws = await wsConnect(active.port, `/ws?token=${active.token}`);
+    await ws.recvText; // auth.ok + sessions.list
+
+    await emitPtyData('A', 'leak?');
+
+    // No pty.data should arrive for an unsubscribed client.
+    await expect(ws.nextMessage(200)).rejects.toThrow(/timed out/);
+    ws.socket.destroy();
+  });
+
+  it('keeps seq as a per-session global counter, independent of subscribers', async () => {
+    active = await startServer();
+    const a = await connectAndSubscribe(active.port, active.token, 'A');
+
+    // Two chunks for 'A' → seq should be 1 then 2 (incremented once per chunk,
+    // outside the client loop), proving seq is per-session ordering.
+    await emitPtyData('A', 'first');
+    const m1 = JSON.parse(await a.nextMessage());
+    await emitPtyData('A', 'second');
+    const m2 = JSON.parse(await a.nextMessage());
+
+    expect(m1).toMatchObject({ type: 'pty.data', sid: 'A', seq: 1 });
+    expect(m2).toMatchObject({ type: 'pty.data', sid: 'A', seq: 2 });
+
+    a.socket.destroy();
+  });
+});
+
+describe('mobileRemoteServer: constant-time token compare', () => {
+  // tokenMatches is exercised end-to-end through the HTTP auth gate: it must
+  // reject a wrong-length token, reject an equal-length-but-different token,
+  // and accept the exact token.
+  it('rejects a token of a different length (401)', async () => {
+    active = await startServer();
+    const res = await httpGet(active.port, '/?token=short');
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects an equal-length but mismatched token (401)', async () => {
+    active = await startServer();
+    // Same length as the real token, every char flipped to a constant so it
+    // cannot accidentally collide.
+    const wrong = 'A'.repeat(active.token.length);
+    expect(wrong.length).toBe(active.token.length);
+    expect(wrong).not.toBe(active.token);
+    const res = await httpGet(active.port, `/?token=${wrong}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('accepts the exact token (200)', async () => {
+    active = await startServer();
+    const res = await httpGet(active.port, `/?token=${active.token}`);
+    expect(res.status).toBe(200);
   });
 });

--- a/electron/remote/mobileRemoteServer.ts
+++ b/electron/remote/mobileRemoteServer.ts
@@ -11,6 +11,10 @@ import {
 
 type MobileRemoteServer = {
   close: () => void;
+  /** The full local URL (including the bearer token) the desktop UI/user can
+   *  use to connect. Kept off stdout — the token is never logged in full — so
+   *  callers retrieve it from here rather than scraping the console. */
+  url: string;
 };
 
 type WsClient = {
@@ -19,8 +23,25 @@ type WsClient = {
   /** Accumulator for fragmented text messages (FIN=0). Reset on each
    *  complete message; non-empty means we're mid-fragment. */
   fragment: Buffer;
+  /** The single session id this client is currently viewing, set when the
+   *  client sends `session.snapshot` (the "select this session" signal).
+   *  pty.data is only forwarded to clients whose `subscribedSid` matches the
+   *  emitting sid — otherwise every client would receive every session's raw
+   *  terminal bytes (cross-session data leak). `null` = not subscribed yet. */
+  subscribedSid: string | null;
   send: (payload: unknown) => void;
 };
+
+/** Constant-time token comparison to avoid leaking a timing oracle on the
+ *  bearer token. Length is not secret, so an early length-mismatch return is
+ *  fine; the byte comparison itself is constant-time via timingSafeEqual. */
+function tokenMatches(provided: string | null, expected: string): boolean {
+  if (provided === null) return false;
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  return crypto.timingSafeEqual(a, b);
+}
 
 const DEFAULT_PORT = 4177;
 const HOST = '127.0.0.1';
@@ -46,7 +67,7 @@ export function startMobileRemoteServer(): MobileRemoteServer | null {
     }
 
     if (url.pathname === '/') {
-      if (url.searchParams.get('token') !== token) {
+      if (!tokenMatches(url.searchParams.get('token'), token)) {
         sendText(res, 401, 'Unauthorized');
         return;
       }
@@ -59,7 +80,7 @@ export function startMobileRemoteServer(): MobileRemoteServer | null {
 
   server.on('upgrade', (req, socket) => {
     const url = parseRequestUrl(req.url);
-    if (!url || url.pathname !== '/ws' || url.searchParams.get('token') !== token) {
+    if (!url || url.pathname !== '/ws' || !tokenMatches(url.searchParams.get('token'), token)) {
       // socket.end() flushes the HTTP response before sending FIN; a bare
       // destroy() would race the kernel and the peer may miss the 401 body
       // on Windows. Same pattern PR #1341 applied to closeSocket().
@@ -79,6 +100,7 @@ export function startMobileRemoteServer(): MobileRemoteServer | null {
       socket,
       pending: Buffer.alloc(0),
       fragment: Buffer.alloc(0),
+      subscribedSid: null,
       send: (payload) => {
         if (socket.destroyed) return;
         socket.write(encodeFrame(JSON.stringify(payload)));
@@ -112,15 +134,33 @@ export function startMobileRemoteServer(): MobileRemoteServer | null {
   });
 
   const offPtyData = onPtyData((sid, chunk) => {
+    // seq is a per-session global ordering — computed once per chunk, OUTSIDE
+    // the client loop, regardless of how many clients (if any) are watching.
     const seq = (seqBySid.get(sid) ?? 0) + 1;
     seqBySid.set(sid, seq);
     for (const client of clients) {
+      // Only forward this session's bytes to clients viewing it. Without this
+      // gate every client receives every session's raw terminal output over
+      // the wire — a cross-session data leak (the HTML client only filters for
+      // display, not on the network).
+      if (client.subscribedSid !== sid) continue;
       client.send({ type: 'pty.data', sid, chunk, seq });
     }
   });
 
+  const url = `http://${HOST}:${port}/?token=${token}`;
+
   server.listen(port, HOST, () => {
-    console.log(`[mobile-remote] listening at http://${HOST}:${port}/?token=${token}`);
+    // Redact the bearer token in the persistent log line: stdout/stderr get
+    // captured into bug reports and shared, and a full token there is a
+    // credential leak. The host:port/path stay discoverable; the full URL
+    // (with token) is exposed on the returned handle's `url` field for the
+    // desktop UI/user to retrieve without it ever hitting the console.
+    const tokenHint = token.slice(0, 6);
+    console.log(
+      `[mobile-remote] listening at http://${HOST}:${port}/?token=${tokenHint}… ` +
+        `(full URL on the desktop session handle)`,
+    );
     console.log(`[mobile-remote] tailscale: tailscale serve --bg http://${HOST}:${port}`);
   });
 
@@ -129,6 +169,7 @@ export function startMobileRemoteServer(): MobileRemoteServer | null {
   });
 
   return {
+    url,
     close: () => {
       offPtyData();
       // Send a 1001 (going-away) close frame per client and let the FIN
@@ -167,6 +208,10 @@ async function handleClientMessage(client: WsClient, raw: string): Promise<void>
       client.send({ type: 'error', message: 'missing_sid' });
       return;
     }
+    // session.snapshot is the client's "select this session" signal. Record it
+    // so the pty.data broadcast only forwards this session's bytes to this
+    // client (see the onPtyData gate above).
+    client.subscribedSid = message.sid;
     const snapshot = await getBufferSnapshot(message.sid);
     const info = getPtySession(message.sid);
     client.send({


### PR DESCRIPTION
## Summary
Two issues in the mobile remote WebSocket server:
1. **Session bleed** — `onPtyData` broadcast every pty chunk to **all** connected clients regardless of which session they subscribed to. A phone viewing session A would receive session B's terminal output.
2. **Non-constant-time token compare** — auth token checked with `!==`, leaking length/prefix timing.

## Changes
- `electron/remote/mobileRemoteServer.ts`
  - `WsClient` gains `subscribedSid: string | null`; set on `session.snapshot`.
  - `onPtyData` skips clients whose `subscribedSid !== sid` (seq computed once per chunk).
  - `tokenMatches()` uses early length-mismatch return + `crypto.timingSafeEqual`; both HTTP `/` and `upgrade` paths use it.
  - Log line redacts the token to a 6-char prefix; full URL exposed via the handle's new `url` field (backward-compatible).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (--max-warnings 0)
- [x] `npm test` (added isolation + constant-time token tests)
- [x] `node scripts/harness-ui.mjs` (14/14)
- [ ] Real-device verification of cross-session isolation is NOT covered by headless harness — needs a physical phone subscribing to two sessions to fully confirm UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)