### PR TITLE
fix(ipc): expand tilde cwd before persisting in app:userCwds:push

### DIFF
--- a/electron/ipc/__tests__/utilityIpcSecurity.test.ts
+++ b/electron/ipc/__tests__/utilityIpcSecurity.test.ts
@@ -25,6 +25,7 @@ vi.mock('../../prefs/userCwds', () => ({
 }));
 
 import { registerUtilityIpc } from '../utilityIpc';
+import { resolveCwd } from '../../security/ipcGuards';
 
 type Handler = (e: unknown, ...args: unknown[]) => unknown;
 
@@ -100,5 +101,26 @@ describe('app:userCwds:push security gate (#804 risk #4)', () => {
     const safe = process.platform === 'win32' ? 'C:\\safe' : '/safe';
     push(e, safe);
     expect(pushUserCwdMock).not.toHaveBeenCalled();
+  });
+
+  // Regression: a tilde cwd (`~/projects/foo`) was silently rejected because
+  // the handler ran isSafePath on the raw `~`-prefixed string (not absolute →
+  // unsafe) instead of resolving it first like the sibling probePaths handler.
+  // The RESOLVED absolute path must be persisted, never the literal `~/...`.
+  it('expands a tilde path with resolveCwd and pushes the RESOLVED absolute path', () => {
+    const expected = resolveCwd('~/projects/foo');
+    // sanity: resolveCwd actually expanded the tilde to an absolute path
+    expect(expected).not.toBe('~/projects/foo');
+    push(mainFrameEvent(), '~/projects/foo');
+    expect(pushUserCwdMock).toHaveBeenCalledTimes(1);
+    expect(pushUserCwdMock).toHaveBeenCalledWith(expected);
+    // never the literal tilde form
+    expect(pushUserCwdMock).not.toHaveBeenCalledWith('~/projects/foo');
+  });
+
+  it('expands a bare "~" to the home directory before pushing', () => {
+    push(mainFrameEvent(), '~');
+    expect(pushUserCwdMock).toHaveBeenCalledTimes(1);
+    expect(pushUserCwdMock).toHaveBeenCalledWith(os.homedir());
   });
 });

--- a/electron/ipc/utilityIpc.ts
+++ b/electron/ipc/utilityIpc.ts
@@ -136,13 +136,21 @@ export function registerUtilityIpc(deps: UtilityIpcDeps): void {
     // persist a UNC trap path that statSync's later — see resolveSpawnCwd.
     // Drop unsafe entries (UNC / relative / non-absolute) at the boundary
     // so they never reach disk.
-    if (!isSafePath(p)) {
+    //
+    // Mirror `probePaths`: expand `~`/`~/foo` to an absolute home path with
+    // resolveCwd BEFORE isSafePath, then persist the RESOLVED path. Without
+    // this a tilde cwd is silently rejected by isSafePath (a bare `~` is not
+    // an absolute path) and the user's recent-cwd never gets recorded. The
+    // resolveCwd→isSafePath ordering is load-bearing: isSafePath MUST run on
+    // the resolved path before any fs access (UNC/NTLM-leak defense).
+    const resolved = resolveCwd(p);
+    if (!isSafePath(resolved)) {
       console.warn(
         `[main] app:userCwds:push rejected unsafe path ${JSON.stringify(p)}`,
       );
       return getUserCwds();
     }
-    return pushUserCwd(p);
+    return pushUserCwd(resolved);
   });
   ipcMain.handle('app:userHome', () => os.homedir());
 


### PR DESCRIPTION
## Summary
- `app:userCwds:push` persisted the raw user-supplied path. A leading `~` was never expanded, so a tilde path was stored verbatim and later failed to resolve as a real directory.
- Now calls `resolveCwd(p)` (tilde + relative expansion) **before** `isSafePath`, mirroring the existing `probePaths` flow.

## Security note
The `resolveCwd` → `isSafePath` ordering is load-bearing: `isSafePath` must run on the **resolved** path before any fs access (UNC / NTLM-leak defense). The existing UNC / `..` / non-string rejection tests are the regression guard.

## Changes
- `electron/ipc/utilityIpc.ts` — resolve cwd, then safety-check, then persist.
- Tests: real `resolveCwd` import + tilde-expansion assertions; existing UNC/`../`/non-string rejection tests retained.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint` (--max-warnings 0)
- [x] `npm test`
- [x] `node scripts/harness-ui.mjs` (14/14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)