### PR TITLE
fix(db): checkpoint WAL on every saveState to survive OS restart

### DIFF
--- a/electron/__tests__/db-hardening.test.ts
+++ b/electron/__tests__/db-hardening.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
+import { spawn } from 'child_process';
 
 // Mirror db.test.ts: redirect electron's userData to a per-test tmp dir so
 // (a) we never touch the real app data and (b) each test gets a clean slate.
@@ -172,6 +173,113 @@ describe('db hardening: schema versioning', () => {
   it.todo(
     'migrates an older on-disk schema (stored < current) — add when SCHEMA_VERSION ≥ 2'
   );
+});
+
+describe('db hardening: WAL durability across a non-graceful shutdown', () => {
+  // Regression for the OS-restart data-loss bug. CCSM persists its whole
+  // renderer snapshot as ONE tiny ~1 KB `app_state` row. In WAL mode that row
+  // never approaches the default `wal_autocheckpoint` threshold (~4 MB), so
+  // without an explicit checkpoint every write lives ONLY in the `-wal`
+  // sidecar. A graceful quit (`before-quit` → `closeDb`) folds the WAL into the
+  // main DB, but an OS restart / power loss / force-kill skips that path — the
+  // unflushed WAL is discarded and the main DB serves a stale/empty snapshot.
+  // All sessions/groups since the last graceful quit vanish.
+  //
+  // This can ONLY be reproduced across a process boundary: while any process
+  // holds the connection open the WAL is still readable, so an in-process test
+  // is a false green. We spawn `fixtures/wal-writer.cjs` (which mirrors db.ts's
+  // initDb+saveState pragma sequence), SIGKILL it after the write commits,
+  // delete the `-wal`/`-shm` sidecars (the OS dropping the unflushed journal),
+  // then read the main DB from a fresh connection. The `CHECKPOINT` env arm is
+  // the only difference between data loss and survival — pinning that the
+  // `wal_checkpoint(PASSIVE)` added to `saveState` is load-bearing.
+  const writer = path.join(__dirname, 'fixtures', 'wal-writer.cjs');
+
+  async function runForcedShutdown(env: Record<string, string>): Promise<string | null> {
+    const dir = fs.mkdtempSync(path.join(tmpRoot, 'wal-'));
+    const file = path.join(dir, 'ccsm.db');
+    const ready = file + '.ready';
+    const child = spawn(process.execPath, [writer], {
+      env: { ...process.env, DBFILE: file, STATE_VALUE: 'survive-the-restart', ...env },
+      stdio: 'inherit',
+    });
+    try {
+      const start = Date.now();
+      while (!fs.existsSync(ready)) {
+        if (Date.now() - start > 10000) throw new Error('writer never signalled ready');
+        await new Promise((r) => setTimeout(r, 20));
+      }
+      // Forced shutdown: no graceful close, no checkpoint-on-exit.
+      child.kill('SIGKILL');
+      await new Promise((r) => setTimeout(r, 100));
+    } finally {
+      if (!child.killed) child.kill('SIGKILL');
+    }
+    // The OS discards the unflushed WAL on restart.
+    for (const ext of ['-wal', '-shm']) {
+      try {
+        fs.unlinkSync(file + ext);
+      } catch {
+        /* may have been folded in already / never existed */
+      }
+    }
+    // A fresh launch opens the main DB from scratch.
+    const Database = (await import('better-sqlite3')).default;
+    const reader = new Database(file, { readonly: true });
+    try {
+      const row = reader
+        .prepare('SELECT value FROM app_state WHERE key = ?')
+        .get('main') as { value: string } | undefined;
+      return row?.value ?? null;
+    } catch {
+      // Table absent because the main DB was never written — the bug.
+      return null;
+    } finally {
+      reader.close();
+    }
+  }
+
+  it('LOSES data on the current (no-checkpoint) path — documents the bug', async () => {
+    // Neither SYNC_FULL nor CHECKPOINT: byte-for-byte the buggy db.ts path.
+    const value = await runForcedShutdown({});
+    expect(value).not.toBe('survive-the-restart');
+  });
+
+  it('synchronous=FULL alone is NOT enough — data still lost', async () => {
+    // Proves FULL is necessary-but-insufficient: durability of WAL frames
+    // doesn't help when the WAL itself is discarded un-checkpointed.
+    const value = await runForcedShutdown({ SYNC_FULL: '1' });
+    expect(value).not.toBe('survive-the-restart');
+  });
+
+  it('survives when saveState checkpoints the WAL into the main DB', async () => {
+    // The actual fix: fold the WAL into the main file on every write.
+    const value = await runForcedShutdown({ SYNC_FULL: '1', CHECKPOINT: '1' });
+    expect(value).toBe('survive-the-restart');
+  });
+});
+
+describe('db hardening: saveState/initDb wire up WAL durability', () => {
+  // The forced-shutdown suite above proves the MECHANISM (no checkpoint → loss;
+  // checkpoint → survival) across a real process kill, using a fixture that
+  // mirrors db.ts. These two tests pin that db.ts ITSELF actually issues those
+  // pragmas, so the fixture and production can't silently drift apart.
+  it('initDb sets synchronous = FULL', async () => {
+    const { initDb } = await freshDb();
+    const handle = initDb();
+    // synchronous: 0=OFF 1=NORMAL 2=FULL 3=EXTRA
+    expect(handle.pragma('synchronous', { simple: true })).toBe(2);
+  });
+
+  it('saveState issues a passive WAL checkpoint', async () => {
+    const mod = await freshDb();
+    const { getDb, saveState } = mod;
+    const spy = vi.spyOn(getDb(), 'pragma');
+    saveState('main', 'x');
+    const checkpointed = spy.mock.calls.some((c) => String(c[0]).includes('wal_checkpoint'));
+    expect(checkpointed).toBe(true);
+    spy.mockRestore();
+  });
 });
 
 describe('db hardening: prepared statement cache', () => {

--- a/electron/__tests__/fixtures/wal-writer.cjs
+++ b/electron/__tests__/fixtures/wal-writer.cjs
@@ -1,0 +1,52 @@
+// Writer fixture for the WAL-durability regression test
+// (`db-hardening.test.ts` → "db hardening: WAL durability …").
+//
+// This runs in a SEPARATE process so the parent test can SIGKILL it — the
+// only faithful way to reproduce a non-graceful shutdown (OS restart / power
+// loss / force-kill). An in-process test cannot reproduce the bug: as long as
+// the test process is alive, db.ts's connection is alive, and an independent
+// reader still sees the WAL contents. The data is only "lost" once the owning
+// process dies AND the WAL is discarded.
+//
+// It mirrors the EXACT pragma sequence of `electron/db.ts`'s `initDb` +
+// `saveState` for the `app_state` table. The two behaviours under test are
+// gated by env so one fixture drives both the RED and GREEN arms:
+//   SYNC_FULL=1  -> `synchronous = FULL` at open   (db.ts edit #1)
+//   CHECKPOINT=1 -> `wal_checkpoint(PASSIVE)` per write (db.ts edit #2)
+// With neither set, this is byte-for-byte the *current* (buggy) db.ts path.
+//
+// Keep this in sync with electron/db.ts if that pragma sequence ever changes.
+const Database = require('better-sqlite3');
+const fs = require('fs');
+
+const file = process.env.DBFILE;
+const key = process.env.STATE_KEY || 'main';
+const value = process.env.STATE_VALUE || 'written';
+
+const db = new Database(file);
+db.pragma('journal_mode = WAL');
+db.pragma('foreign_keys = ON');
+if (process.env.SYNC_FULL === '1') db.pragma('synchronous = FULL');
+db.exec(
+  'CREATE TABLE IF NOT EXISTS app_state (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at INTEGER NOT NULL)'
+);
+const upsert = db.prepare(
+  'INSERT INTO app_state (key, value, updated_at) VALUES (?, ?, ?) ' +
+    'ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at'
+);
+
+// A handful of writes, like a real session of edits. None of these come close
+// to the default wal_autocheckpoint threshold (~4 MB), so on the buggy path
+// they all live only in the -wal sidecar.
+for (let i = 0; i < 50; i++) {
+  upsert.run(key, 'v' + i, Date.now());
+  if (process.env.CHECKPOINT === '1') db.pragma('wal_checkpoint(PASSIVE)');
+}
+upsert.run(key, value, Date.now());
+if (process.env.CHECKPOINT === '1') db.pragma('wal_checkpoint(PASSIVE)');
+
+// Signal the parent that the write is committed, then hang. We deliberately
+// never call db.close() — the parent SIGKILLs us, which is what a forced
+// shutdown looks like (no `before-quit` → `closeDb` checkpoint).
+fs.writeFileSync(file + '.ready', '1');
+setInterval(() => {}, 1 << 30);

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -129,6 +129,13 @@ export function initDb(): Database.Database {
   handle = ensureHealthyDb(file, handle);
   handle.pragma('journal_mode = WAL');
   handle.pragma('foreign_keys = ON');
+  // WAL's default `synchronous = NORMAL` skips the fsync on each commit, so a
+  // commit that's only reached the WAL can be lost on power loss / OS restart.
+  // FULL fsyncs every commit. Write volume here is tiny (one debounced ~1 KB
+  // app_state row per 250 ms at most), so the cost is negligible. This is the
+  // durability half of the OS-restart fix; `wal_checkpoint` in saveState() is
+  // the other half (see there).
+  handle.pragma('synchronous = FULL');
   handle.exec(SCHEMA_SQL);
 
   // Schema versioning. `user_version` defaults to 0 on a brand-new file.
@@ -203,6 +210,15 @@ export function saveState(key: string, value: string): void {
     );
   }
   stmts.upsertState.run(key, value, Date.now());
+  // Fold the WAL back into the main DB on every write. Our persisted snapshot
+  // is a single tiny row, so it never reaches the default wal_autocheckpoint
+  // threshold (~4 MB) on its own — without this, every session/group change
+  // lives ONLY in the -wal sidecar and is discarded on a non-graceful shutdown
+  // (OS restart, power loss, force-kill), rolling the user back to the last
+  // graceful-quit snapshot. PASSIVE never blocks on readers and is a no-op
+  // under contention, so it's safe on this debounced hot path. See the
+  // `db hardening: WAL durability` suite for the forced-shutdown regression.
+  d.pragma('wal_checkpoint(PASSIVE)');
 }
 
 export function closeDb(): void {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -158,5 +158,28 @@ export default [
         URLSearchParams: 'readonly'
       }
     }
+  },
+  {
+    // CommonJS test fixtures (spawned as standalone Node child processes, e.g.
+    // electron/__tests__/fixtures/wal-writer.cjs). Plain Node scripts — give
+    // them Node globals and CJS module semantics.
+    files: ['**/*.cjs'],
+    languageOptions: {
+      sourceType: 'commonjs',
+      globals: {
+        process: 'readonly',
+        Buffer: 'readonly',
+        __dirname: 'readonly',
+        __filename: 'readonly',
+        require: 'readonly',
+        module: 'readonly',
+        exports: 'readonly',
+        console: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        setInterval: 'readonly',
+        clearInterval: 'readonly'
+      }
+    }
   }
 ];


### PR DESCRIPTION
## Summary

修复安装版 CCSM 在**电脑重启后 sidebar 丢失全部会话和分组**的数据丢失 bug。

根因:CCSM 把整个 renderer 快照存成 `app_state` 里一行 ~1 KB 的 JSON。WAL 模式下这行永远到不了默认 `wal_autocheckpoint` 阈值(~4 MB),所以每次会话/分组改动**只**存在 `ccsm.db-wal` sidecar 里。WAL 只在优雅退出(`before-quit` → `closeDb`)时才合并进主库;OS 重启 / 断电 / 强杀会跳过这条路径——未刷盘的 WAL 被丢弃,主库返回陈旧(通常为空)的快照。

修复(均在 `electron/db.ts`):
- `synchronous = FULL`:每次提交都 fsync 落盘(WAL 默认的 NORMAL 在断电时可能丢最近一次提交)。
- 每次 `saveState` 后 `wal_checkpoint(PASSIVE)`:把已提交帧折回主库,使持久副本就是主文件本身。PASSIVE 不阻塞读者、竞争时是 no-op,适合这条 debounce 热路径。

## Test plan

- [x] 回归测试:子进程(`wal-writer.cjs`)写入 → SIGKILL → 删除 `-wal`/`-shm`(模拟非优雅关机)→ 重开断言值存活。两进程 SIGKILL 是唯一忠实复现方式(进程内 reader 在 writer 存活时仍能看到 WAL)。
- [x] `npm run typecheck`
- [x] `npm run lint`(0 warnings)
- [x] `npm test`(1892 passed,Node ABI 下)
- [x] `npm run probe:e2e`(harness-ui 14/14,Electron ABI 下)
- [x] 端到端 dogfood(与安装版相同的 Electron ABI 145):buggy 路径 → `no such table: app_state`(完整复现空 sidebar);fixed 路径 → `survive-the-restart`(数据存活)

🤖 Generated with [Claude Code](https://claude.com/claude-code)