### PR TITLE
fix(notify): idle-confirmation window — stop notifying on mid-task pauses

### DIFF
--- a/electron/notify/__tests__/notifyDecider.test.ts
+++ b/electron/notify/__tests__/notifyDecider.test.ts
@@ -3,8 +3,6 @@ import {
   decide,
   assertNotifyContext,
   USER_INIT_MUTE_MS,
-  SHORT_TASK_MS,
-  DEDUPE_MS,
   type Ctx,
   type Event,
 } from '../notifyDecider';
@@ -49,7 +47,7 @@ describe('notifyDecider — 7 rules', () => {
     });
   });
 
-  it('rule 2: foreground + active sid + short task → flash only, no toast', () => {
+  it('foreground + active sid → flash only, no toast (regardless of duration)', () => {
     const ctx = makeCtx({
       focused: true,
       activeSid: 's1',
@@ -62,15 +60,15 @@ describe('notifyDecider — 7 rules', () => {
     });
   });
 
-  it('rule 3: foreground + active sid + long task (>= 60s) → toast + flash', () => {
+  it('foreground + active sid + long-running task → still flash only', () => {
     const ctx = makeCtx({
       focused: true,
       activeSid: 's1',
-      runStartTs: new Map([['s1', NOW - (SHORT_TASK_MS + 1_000)]]),
+      runStartTs: new Map([['s1', NOW - 300_000]]),
     });
     expect(decide(waiting('s1'), ctx)).toEqual({
       sid: 's1',
-      toast: true,
+      toast: false,
       flash: true,
     });
   });
@@ -137,41 +135,6 @@ describe('notifyDecider — 7 rules', () => {
   });
 });
 
-describe('notifyDecider — dedupe', () => {
-  it('suppresses fire when last fired within 5s', () => {
-    const ctx = makeCtx({
-      focused: false,
-      lastFiredTs: new Map([['s1', NOW - 3_000]]),
-    });
-    expect(decide(waiting('s1'), ctx)).toBeNull();
-  });
-
-  it('boundary: last fired > 5s ago — fires normally', () => {
-    const ctx = makeCtx({
-      focused: false,
-      lastFiredTs: new Map([['s1', NOW - (DEDUPE_MS + 1_000)]]),
-    });
-    expect(decide(waiting('s1'), ctx)).toEqual({
-      sid: 's1',
-      toast: true,
-      flash: true,
-    });
-  });
-
-  it('dedupe is per-sid — fire on sid-B not blocked by recent sid-A', () => {
-    const ctx = makeCtx({
-      focused: false,
-      lastFiredTs: new Map([['sid-A', NOW - 1_000]]),
-    });
-    expect(decide(waiting('sid-A'), ctx)).toBeNull();
-    expect(decide(waiting('sid-B'), ctx)).toEqual({
-      sid: 'sid-B',
-      toast: true,
-      flash: true,
-    });
-  });
-});
-
 describe('notifyDecider — context-update-only events return null', () => {
   it('window-focus-change returns null', () => {
     const ctx = makeCtx();
@@ -200,14 +163,14 @@ describe('notifyDecider — context-update-only events return null', () => {
     ).toBeNull();
   });
 
-  it('non-waiting OSC title returns null', () => {
-    const ctx = makeCtx();
+  it('an osc-title event is always decided on (no title-content gate)', () => {
+    const ctx = makeCtx({ focused: false });
     expect(
       decide(
-        { type: 'osc-title', sid: 's1', title: '⠂ Claude Code', ts: NOW },
+        { type: 'osc-title', sid: 's1', title: 'anything', ts: NOW },
         ctx,
       ),
-    ).toBeNull();
+    ).toEqual({ sid: 's1', toast: true, flash: true });
   });
 });
 

--- a/electron/notify/__tests__/runStateTracker.test.ts
+++ b/electron/notify/__tests__/runStateTracker.test.ts
@@ -1,311 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { createRunStateTracker, RING_DEBOUNCE_MS } from '../runStateTracker';
-import { decide, DEDUPE_MS, SHORT_TASK_MS } from '../notifyDecider';
+import { createRunStateTracker, IDLE_CONFIRM_MS } from '../runStateTracker';
+import { decide } from '../notifyDecider';
 import type { Decision } from '../notifyDecider';
 
 const NOW = 1_700_000_000_000;
 
-describe('runStateTracker — pure decider', () => {
-  it('running → idle: fires a decision (Rule 5 unfocused branch); toast is deferred', () => {
-    const fires: Decision[] = [];
-    const t = createRunStateTracker(decide, {
-      onDeferredToast: (d) => fires.push(d),
-    });
-    t.setFocused(false); // Rule 5: not focused → toast + flash
-    expect(t.onTitle('s1', 'running', NOW)).toBeNull();
-    expect(t._internals().runStartTs.get('s1')).toBe(NOW);
-    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
-    expect(dec).not.toBeNull();
-    expect(dec?.sid).toBe('s1');
-    // Toast is debounced — immediate decision carries flash only.
-    expect(dec?.toast).toBe(false);
-    expect(dec?.flash).toBe(true);
-    // runStartTs cleared after non-running title
-    expect(t._internals().runStartTs.has('s1')).toBe(false);
-    // lastFiredTs recorded (for the flash)
-    expect(t._internals().lastFiredTs.get('s1')).toBe(NOW + 1_000);
-    // A pending deferred toast is scheduled.
-    expect(t._internals().pendingToastSids).toEqual(['s1']);
-    expect(fires).toEqual([]);
-    t.dispose();
-  });
-
-  it('dedupes back-to-back idle titles within DEDUPE_MS', () => {
-    const t = createRunStateTracker(decide);
-    t.setFocused(false);
-    t.onTitle('s1', 'running', NOW);
-    const first = t.onTitle('s1', 'idle', NOW + 100);
-    expect(first).not.toBeNull();
-    // Second idle within dedupe window — even with a fresh run in between
-    t.onTitle('s1', 'running', NOW + 200);
-    const second = t.onTitle('s1', 'idle', NOW + 100 + DEDUPE_MS - 1);
-    expect(second).toBeNull();
-    t.dispose();
-  });
-
-  it('mute window prevents toast (Rule 7) but flash still fires', () => {
-    const t = createRunStateTracker(decide);
-    t.setFocused(false);
-    t.setMuted('s1', NOW + 60_000); // muted for the next minute
-    t.onTitle('s1', 'running', NOW);
-    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
-    expect(dec).not.toBeNull();
-    expect(dec?.toast).toBe(false);
-    expect(dec?.flash).toBe(true);
-    // Muted sids must not even schedule a deferred toast (the timer would
-    // be re-suppressed at fire-time anyway, so keep the pending-set tidy).
-    expect(t._internals().pendingToastSids).toEqual([]);
-    t.dispose();
-  });
-
-  it('expired mute (untilTs in the past) no longer suppresses toast', () => {
-    const fires: Decision[] = [];
-    const t = createRunStateTracker(decide, {
-      onDeferredToast: (d) => fires.push(d),
-    });
-    t.setFocused(false);
-    t.setMuted('s1', NOW - 1); // already expired
-    t.onTitle('s1', 'running', NOW);
-    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
-    // Immediate is flash-only (toast deferred); pending toast exists.
-    expect(dec?.toast).toBe(false);
-    expect(dec?.flash).toBe(true);
-    expect(t._internals().pendingToastSids).toEqual(['s1']);
-    t.dispose();
-  });
-
-  it('setMuted(null) clears the mute', () => {
-    const t = createRunStateTracker(decide);
-    t.setFocused(false);
-    t.setMuted('s1', Number.POSITIVE_INFINITY); // sticky mute
-    t.setMuted('s1', null);
-    t.onTitle('s1', 'running', NOW);
-    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
-    // Immediate flash fires; toast is deferred.
-    expect(dec?.toast).toBe(false);
-    expect(dec?.flash).toBe(true);
-    expect(t._internals().pendingToastSids).toEqual(['s1']);
-    t.dispose();
-  });
-
-  it('forgetSid clears all per-sid state', () => {
-    const t = createRunStateTracker(decide);
-    t.setFocused(false);
-    // Populate user-input but with timestamp far in the past so Rule 1
-    // doesn't suppress the fire (we still need lastFiredTs populated).
-    t.markUserInput('s1', NOW - 10 * 60 * 1000);
-    t.setMuted('s1', NOW + 100_000);
-    t.onTitle('s1', 'running', NOW);
-    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
-    expect(dec).not.toBeNull(); // ensures lastFiredTs got recorded
-
-    const before = t._internals();
-    expect(before.lastUserInputTs.has('s1')).toBe(true);
-    expect(before.mutedSids.has('s1')).toBe(true);
-    expect(before.lastFiredTs.has('s1')).toBe(true);
-
-    t.forgetSid('s1');
-    const after = t._internals();
-    expect(after.runStartTs.has('s1')).toBe(false);
-    expect(after.mutedSids.has('s1')).toBe(false);
-    expect(after.lastFiredTs.has('s1')).toBe(false);
-    expect(after.lastUserInputTs.has('s1')).toBe(false);
-    expect(after.pendingToastSids).toEqual([]);
-    t.dispose();
-  });
-
-  it('multiple sids tracked independently', () => {
-    const fires: Decision[] = [];
-    const t = createRunStateTracker(decide, {
-      onDeferredToast: (d) => fires.push(d),
-    });
-    t.setFocused(false);
-    t.onTitle('s1', 'running', NOW);
-    t.onTitle('s2', 'running', NOW + 500);
-    expect(t._internals().runStartTs.get('s1')).toBe(NOW);
-    expect(t._internals().runStartTs.get('s2')).toBe(NOW + 500);
-
-    const d1 = t.onTitle('s1', 'idle', NOW + 1_000);
-    expect(d1?.sid).toBe('s1');
-    // s2 should still be running and unaffected
-    expect(t._internals().runStartTs.get('s2')).toBe(NOW + 500);
-
-    const d2 = t.onTitle('s2', 'idle', NOW + 2_000);
-    expect(d2?.sid).toBe('s2');
-
-    // Forgetting s1 doesn't touch s2
-    t.forgetSid('s1');
-    expect(t._internals().lastFiredTs.has('s2')).toBe(true);
-    t.dispose();
-  });
-
-  it('classification "unknown" is a no-op', () => {
-    const t = createRunStateTracker(decide);
-    t.setFocused(false);
-    expect(t.onTitle('s1', 'unknown', NOW)).toBeNull();
-    expect(t._internals().runStartTs.has('s1')).toBe(false);
-    expect(t._internals().lastFiredTs.has('s1')).toBe(false);
-    t.dispose();
-  });
-
-  it('Rule 1: user-input within 60s suppresses fire', () => {
-    const t = createRunStateTracker(decide);
-    t.setFocused(false);
-    t.markUserInput('s1', NOW);
-    t.onTitle('s1', 'running', NOW + 100);
-    // Idle 1s later — Rule 1 mute window still active
-    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
-    expect(dec).toBeNull();
-    t.dispose();
-  });
-
-  it('Rule 2 vs Rule 3: foreground active sid splits on SHORT_TASK_MS', () => {
-    const fires: Decision[] = [];
-    const t = createRunStateTracker(decide, {
-      onDeferredToast: (d) => fires.push(d),
-    });
-    t.setFocused(true);
-    t.setActiveSid('s1');
-
-    // Short task — Rule 2: flash only, no toast → still a non-null Decision
-    t.onTitle('s1', 'running', NOW);
-    const shortDec = t.onTitle('s1', 'idle', NOW + 1_000);
-    expect(shortDec).not.toBeNull();
-    expect(shortDec?.toast).toBe(false);
-    expect(shortDec?.flash).toBe(true);
-    // Rule 2 doesn't toast → no deferred timer scheduled.
-    expect(t._internals().pendingToastSids).toEqual([]);
-
-    // Wait past dedupe, then long task — Rule 3: toast + flash.
-    // Toast is debounced, so the immediate Decision still carries flash only;
-    // the toast surfaces via the deferred callback.
-    const t2 = NOW + DEDUPE_MS + 10_000;
-    t.onTitle('s1', 'running', t2);
-    const longDec = t.onTitle('s1', 'idle', t2 + SHORT_TASK_MS + 1_000);
-    expect(longDec).not.toBeNull();
-    expect(longDec?.toast).toBe(false);
-    expect(longDec?.flash).toBe(true);
-    expect(t._internals().pendingToastSids).toEqual(['s1']);
-    t.dispose();
-  });
-
-  it('Rule 4: foreground but viewing a different sid → toast + flash (toast deferred)', () => {
-    const t = createRunStateTracker(decide);
-    t.setFocused(true);
-    t.setActiveSid('s2'); // viewing s2
-    t.onTitle('s1', 'running', NOW);
-    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
-    // Toast debounced; immediate is flash-only.
-    expect(dec?.toast).toBe(false);
-    expect(dec?.flash).toBe(true);
-    expect(t._internals().pendingToastSids).toEqual(['s1']);
-    t.dispose();
-  });
-
-  it('runStartTs is cleared after every non-running title (even when no decision fires)', () => {
-    const t = createRunStateTracker(decide);
-    t.setFocused(false);
-    t.markUserInput('s1', NOW); // forces Rule 1 → null decision
-    t.onTitle('s1', 'running', NOW);
-    expect(t._internals().runStartTs.has('s1')).toBe(true);
-    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
-    expect(dec).toBeNull();
-    expect(t._internals().runStartTs.has('s1')).toBe(false);
-    t.dispose();
-  });
-
-  // ---------------------------------------------------------------------------
-  // Task #767 regression — `hasObservedRunning` gate
-  //
-  // Before the gate, the very first 'idle' / 'waiting' OSC title for a sid
-  // (which claude.exe emits within ~100-300ms of boot) would call decide()
-  // with no runStartTs entry. notifyDecider Rule 2 then computed
-  //   elapsed = start === undefined ? 0 : now - start  →  0
-  //   0 < SHORT_TASK_MS (60s)                          →  TRUE
-  // so it returned `{toast:false, flash:true}` unconditionally. flashSink
-  // lit `flashStates[sid]=true` for FLASH_DURATION_MS (4s), driving 2.5
-  // AgentIcon framer-motion breath cycles on every fresh / imported /
-  // resumed session — the bug user reported in #767.
-  //
-  // Fix: producer-layer gate — skip decide() until we've seen a 'running'
-  // title for this sid. notifyDecider stays pure / unchanged.
-  // ---------------------------------------------------------------------------
-  it('Task #767: does not fire when first title for a sid is "idle"', () => {
-    const t = createRunStateTracker(decide);
-    // Default focused=true + activeSid set to s1 reproduces the exact
-    // foreground+active context where the unguarded code path tripped
-    // Rule 2 ("foreground-active-short").
-    t.setFocused(true);
-    t.setActiveSid('s1');
-    const dec = t.onTitle('s1', 'idle', NOW);
-    expect(dec).toBeNull();
-    // No mutation: lastFiredTs must stay empty (the bug also poisoned the
-    // 5s dedupe window with a phantom fire).
-    expect(t._internals().lastFiredTs.has('s1')).toBe(false);
-    t.dispose();
-  });
-
-  it('Task #767: does not fire when first title for a sid is "waiting"', () => {
-    const t = createRunStateTracker(decide);
-    t.setFocused(true);
-    t.setActiveSid('s1');
-    const dec = t.onTitle('s1', 'waiting', NOW);
-    expect(dec).toBeNull();
-    expect(t._internals().lastFiredTs.has('s1')).toBe(false);
-    t.dispose();
-  });
-
-  it('Task #767 regression guard: still fires on idle AFTER a running title', () => {
-    // Sanity check that the gate only suppresses the boot-time false
-    // positive — once a real run has started, the existing rules apply
-    // exactly as before. This is the critical regression case: if the
-    // gate were too aggressive, legitimate Rule 2 flashes would silently
-    // disappear.
-    const t = createRunStateTracker(decide);
-    t.setFocused(true);
-    t.setActiveSid('s1');
-    // Real run starts.
-    expect(t.onTitle('s1', 'running', NOW)).toBeNull();
-    // Run finishes 1s later → Rule 2 (foreground+active+short) fires.
-    const dec = t.onTitle('s1', 'idle', NOW + 1_000);
-    expect(dec).not.toBeNull();
-    expect(dec?.toast).toBe(false);
-    expect(dec?.flash).toBe(true);
-    t.dispose();
-  });
-
-  it('Task #767: forgetSid resets the hasObservedRunning gate', () => {
-    // After session teardown, a brand-new lifetime for the same sid (e.g.
-    // re-import with a recycled id) must start gated again.
-    const t = createRunStateTracker(decide);
-    t.setFocused(true);
-    t.setActiveSid('s1');
-    t.onTitle('s1', 'running', NOW);
-    const dec1 = t.onTitle('s1', 'idle', NOW + 1_000);
-    expect(dec1).not.toBeNull(); // gate open after running
-
-    t.forgetSid('s1');
-
-    // Without the forgetSid clearing hasObservedRunning, this fresh idle
-    // would erroneously fire (gate would still be open from the previous
-    // lifetime).
-    const dec2 = t.onTitle('s1', 'idle', NOW + 10_000);
-    expect(dec2).toBeNull();
-    t.dispose();
-  });
-});
-
-// ---------------------------------------------------------------------------
-// "Ring the last waiting" debounce (toast-spam fix).
-//
-// Real-world burst: agent runs a long task with several mid-task permission
-// prompts. Each prompt = a 'waiting' title; user answers in-app, agent
-// resumes (next 'running'), next prompt arrives ~5s later. Pre-debounce
-// the user got 3-5 toasts back-to-back. Post-debounce, each waiting
-// (re)starts a RING_DEBOUNCE_MS timer; only the LAST waiting (i.e. the one
-// where the agent actually gets stuck) fires a toast.
-// ---------------------------------------------------------------------------
-describe('runStateTracker — ring-last debounce', () => {
+describe('runStateTracker — idle confirmation window', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(NOW);
@@ -314,177 +14,208 @@ describe('runStateTracker — ring-last debounce', () => {
     vi.useRealTimers();
   });
 
-  function newTracker(): { tracker: ReturnType<typeof createRunStateTracker>; fires: Decision[] } {
+  function newTracker(): {
+    tracker: ReturnType<typeof createRunStateTracker>;
+    fires: Decision[];
+  } {
     const fires: Decision[] = [];
     const tracker = createRunStateTracker(decide, {
-      onDeferredToast: (d) => fires.push(d),
-      // nowFn defaults to Date.now which vi.useFakeTimers also patches.
+      onConfirmedIdle: (d) => fires.push(d),
     });
     return { tracker, fires };
   }
 
-  it('edge case 1: quick waiting (title flips out before debounce) → no toast', () => {
-    const { tracker, fires } = newTracker();
-    tracker.setFocused(false); // Rule 5 path → would-toast
-    tracker.onTitle('s1', 'running', NOW);
-    tracker.onTitle('s1', 'idle', NOW + 1_000);
-    expect(tracker._internals().pendingToastSids).toEqual(['s1']);
-    // User answers in-app: agent resumes BEFORE the debounce window closes.
-    vi.advanceTimersByTime(2_000);
-    tracker.onTitle('s1', 'running', NOW + 3_000);
-    expect(tracker._internals().pendingToastSids).toEqual([]);
-    // Advance well past the original deadline — no toast fires.
-    vi.advanceTimersByTime(RING_DEBOUNCE_MS + 1_000);
-    expect(fires).toEqual([]);
+  it('onTitle never returns a synchronous decision', () => {
+    const { tracker } = newTracker();
+    tracker.setFocused(false);
+    expect(tracker.onTitle('s1', 'running', NOW)).toBeNull();
+    expect(tracker.onTitle('s1', 'idle', NOW + 1_000)).toBeNull();
     tracker.dispose();
   });
 
-  it('edge case 2: single sustained waiting → exactly one toast at +RING_DEBOUNCE_MS', () => {
+  it('idle → running within the window → no notification (mid-task pause)', () => {
     const { tracker, fires } = newTracker();
     tracker.setFocused(false);
     tracker.onTitle('s1', 'running', NOW);
     tracker.onTitle('s1', 'idle', NOW + 1_000);
-    // Advance past the debounce window — toast fires.
-    vi.advanceTimersByTime(RING_DEBOUNCE_MS + 10);
-    expect(fires.length).toBe(1);
-    expect(fires[0]!.toast).toBe(true);
-    expect(fires[0]!.flash).toBe(false);
-    expect(fires[0]!.sid).toBe('s1');
-    expect(tracker._internals().pendingToastSids).toEqual([]);
+    expect(tracker._internals().pendingIdleSids).toEqual(['s1']);
+    // CLI resumes itself before the window closes.
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS - 100);
+    tracker.onTitle('s1', 'running', NOW + IDLE_CONFIRM_MS - 100);
+    expect(tracker._internals().pendingIdleSids).toEqual([]);
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 1_000);
+    expect(fires).toEqual([]);
     tracker.dispose();
   });
 
-  it('edge case 3: long task with 3 quick prompts then sustained → exactly one toast', () => {
+  it('idle → silence >= window → exactly one notification (real stop)', () => {
     const { tracker, fires } = newTracker();
     tracker.setFocused(false);
-    // Initial run starts at NOW.
     tracker.onTitle('s1', 'running', NOW);
-    // Prompt #1 at +5s; user answers in 2s (running at +7s).
-    vi.advanceTimersByTime(5_000);
-    tracker.onTitle('s1', 'idle', NOW + 5_000);
-    vi.advanceTimersByTime(2_000); // timer not yet exhausted
-    tracker.onTitle('s1', 'running', NOW + 7_000);
-    expect(fires).toEqual([]);
-    // Prompt #2 at +12s; user answers in 3s.
-    vi.advanceTimersByTime(5_000);
-    tracker.onTitle('s1', 'idle', NOW + 12_000);
-    vi.advanceTimersByTime(3_000);
-    tracker.onTitle('s1', 'running', NOW + 15_000);
-    expect(fires).toEqual([]);
-    // Prompt #3 at +20s; this one sticks (user is away).
-    vi.advanceTimersByTime(5_000);
-    tracker.onTitle('s1', 'idle', NOW + 20_000);
-    // Advance the full debounce window.
-    vi.advanceTimersByTime(RING_DEBOUNCE_MS + 10);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 10);
     expect(fires.length).toBe(1);
     expect(fires[0]!.sid).toBe('s1');
+    expect(fires[0]!.toast).toBe(true); // unfocused → Rule 5
+    expect(fires[0]!.flash).toBe(true);
+    expect(tracker._internals().pendingIdleSids).toEqual([]);
     tracker.dispose();
   });
 
-  it('edge case 4a: Rule 1 (user-input) still suppresses at fire-time', () => {
+  it('idle jitter burst → running within window → no notification', () => {
     const { tracker, fires } = newTracker();
     tracker.setFocused(false);
     tracker.onTitle('s1', 'running', NOW);
     tracker.onTitle('s1', 'idle', NOW + 1_000);
-    // 2s into the wait, user touches the sid (e.g. presses Enter from inside
-    // ccsm to take an action). The timer is still pending; at fire-time the
-    // user-init window is active and suppresses the toast.
-    vi.advanceTimersByTime(2_000);
-    tracker.markUserInput('s1', NOW + 3_000);
-    vi.advanceTimersByTime(RING_DEBOUNCE_MS); // fires at NOW + 9_000
+    vi.advanceTimersByTime(200);
+    tracker.onTitle('s1', 'idle', NOW + 1_200); // jitter resets timer
+    vi.advanceTimersByTime(200);
+    tracker.onTitle('s1', 'idle', NOW + 1_400);
+    vi.advanceTimersByTime(200);
+    tracker.onTitle('s1', 'running', NOW + 1_600); // CLI resumes
+    expect(tracker._internals().pendingIdleSids).toEqual([]);
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 1_000);
     expect(fires).toEqual([]);
     tracker.dispose();
   });
 
-  it('edge case 4b: Rule 7 (per-sid mute) still suppresses at fire-time', () => {
+  it('idle → idle → silence >= window → fires exactly once (resets, single fire)', () => {
     const { tracker, fires } = newTracker();
     tracker.setFocused(false);
     tracker.onTitle('s1', 'running', NOW);
     tracker.onTitle('s1', 'idle', NOW + 1_000);
-    expect(tracker._internals().pendingToastSids).toEqual(['s1']);
-    // Mute the sid during the wait — fire-time re-check suppresses.
-    vi.advanceTimersByTime(2_000);
+    vi.advanceTimersByTime(500);
+    tracker.onTitle('s1', 'idle', NOW + 1_500); // resets the window
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 10);
+    expect(fires.length).toBe(1);
+    tracker.dispose();
+  });
+
+  it('boot gate: idle with no prior running → no notification', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(true);
+    tracker.setActiveSid('s1');
+    tracker.onTitle('s1', 'idle', NOW);
+    expect(tracker._internals().pendingIdleSids).toEqual([]);
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 1_000);
+    expect(fires).toEqual([]);
+    tracker.dispose();
+  });
+
+  it('confirmed idle while unfocused → toast + flash', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 10);
+    expect(fires).toEqual([{ sid: 's1', toast: true, flash: true }]);
+    tracker.dispose();
+  });
+
+  it('confirmed idle while focused + active sid → flash only', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(true);
+    tracker.setActiveSid('s1');
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 10);
+    expect(fires).toEqual([{ sid: 's1', toast: false, flash: true }]);
+    tracker.dispose();
+  });
+
+  it('confirmed idle while muted → flash only, no toast', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
     tracker.setMuted('s1', Number.POSITIVE_INFINITY);
-    vi.advanceTimersByTime(RING_DEBOUNCE_MS);
-    expect(fires).toEqual([]);
-    tracker.dispose();
-  });
-
-  it('edge case 5: multiple sids run independent timers', () => {
-    const { tracker, fires } = newTracker();
-    tracker.setFocused(false);
     tracker.onTitle('s1', 'running', NOW);
-    tracker.onTitle('s2', 'running', NOW + 100);
-    // s1 starts waiting at +1s → deadline NOW+9_000.
     tracker.onTitle('s1', 'idle', NOW + 1_000);
-    // s2 starts waiting at +3s → deadline NOW+11_000.
-    vi.advanceTimersByTime(2_000);
-    tracker.onTitle('s2', 'idle', NOW + 3_000);
-    expect(tracker._internals().pendingToastSids.sort()).toEqual(['s1', 's2']);
-    // Advance to NOW+9_010 — only s1 fires.
-    vi.advanceTimersByTime(6_010);
-    expect(fires.length).toBe(1);
-    expect(fires[0]!.sid).toBe('s1');
-    expect(tracker._internals().pendingToastSids).toEqual(['s2']);
-    // Advance to NOW+11_010 — s2 fires too.
-    vi.advanceTimersByTime(2_000);
-    expect(fires.length).toBe(2);
-    expect(fires[1]!.sid).toBe('s2');
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 10);
+    expect(fires).toEqual([{ sid: 's1', toast: false, flash: true }]);
     tracker.dispose();
   });
 
-  it('forgetSid cancels any pending deferred toast', () => {
+  it('forgetSid cancels a pending idle-confirm timer (no fire after teardown)', () => {
     const { tracker, fires } = newTracker();
     tracker.setFocused(false);
     tracker.onTitle('s1', 'running', NOW);
     tracker.onTitle('s1', 'idle', NOW + 1_000);
-    expect(tracker._internals().pendingToastSids).toEqual(['s1']);
+    expect(tracker._internals().pendingIdleSids).toEqual(['s1']);
     tracker.forgetSid('s1');
-    expect(tracker._internals().pendingToastSids).toEqual([]);
-    vi.advanceTimersByTime(RING_DEBOUNCE_MS + 1_000);
+    expect(tracker._internals().pendingIdleSids).toEqual([]);
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 1_000);
     expect(fires).toEqual([]);
     tracker.dispose();
   });
 
-  it('dispose cancels all pending deferred toasts', () => {
+  it('dispose cancels all pending idle-confirm timers', () => {
     const { tracker, fires } = newTracker();
     tracker.setFocused(false);
     tracker.onTitle('s1', 'running', NOW);
     tracker.onTitle('s1', 'idle', NOW + 1_000);
     tracker.onTitle('s2', 'running', NOW + 100);
     tracker.onTitle('s2', 'idle', NOW + 1_100);
-    expect(tracker._internals().pendingToastSids.length).toBe(2);
+    expect(tracker._internals().pendingIdleSids.length).toBe(2);
     tracker.dispose();
-    expect(tracker._internals().pendingToastSids).toEqual([]);
-    vi.advanceTimersByTime(RING_DEBOUNCE_MS + 1_000);
+    expect(tracker._internals().pendingIdleSids).toEqual([]);
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 1_000);
     expect(fires).toEqual([]);
   });
 
-  it('two bursts past dedupe: the LAST waiting wins (timer pushed out by each fresh idle)', () => {
-    // Burst pattern with running flips between idles. Each fresh idle past
-    // the 5s dedupe window pushes the deadline out — only the final waiting
-    // (no follow-up running) actually rings.
+  it('Rule 1: user-input within 60s suppresses the confirmed-idle fire', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.markUserInput('s1', NOW);
+    tracker.onTitle('s1', 'running', NOW + 100);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 10);
+    expect(fires).toEqual([]);
+    tracker.dispose();
+  });
+
+  it('multiple sids run independent windows', () => {
     const { tracker, fires } = newTracker();
     tracker.setFocused(false);
     tracker.onTitle('s1', 'running', NOW);
-    // Idle #1 at +1s.
-    tracker.onTitle('s1', 'idle', NOW + 1_000);
-    // 6s later (past the 5s dedupe), agent resumes briefly.
-    vi.advanceTimersByTime(6_000); // now NOW+7_000
-    tracker.onTitle('s1', 'running', NOW + 7_000);
-    // No fire yet — running cancelled the pending timer.
-    expect(fires).toEqual([]);
-    expect(tracker._internals().pendingToastSids).toEqual([]);
-    // Idle #2 at +8s; this one sticks.
-    vi.advanceTimersByTime(1_000); // now NOW+8_000
-    tracker.onTitle('s1', 'idle', NOW + 8_000);
-    // Deadline now NOW+16_000. Advance to NOW+15_500 — not fired yet.
-    vi.advanceTimersByTime(7_500);
-    expect(fires).toEqual([]);
-    // Past the deadline.
-    vi.advanceTimersByTime(1_000);
+    tracker.onTitle('s2', 'running', NOW + 100);
+    tracker.onTitle('s1', 'idle', NOW + 1_000); // deadline NOW+1000+window
+    vi.advanceTimersByTime(500);
+    tracker.onTitle('s2', 'idle', NOW + 1_500); // deadline NOW+1500+window
+    expect(tracker._internals().pendingIdleSids.sort()).toEqual(['s1', 's2']);
+    // Advance just past s1's deadline.
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS - 500 + 10);
     expect(fires.length).toBe(1);
     expect(fires[0]!.sid).toBe('s1');
+    expect(tracker._internals().pendingIdleSids).toEqual(['s2']);
+    // Advance past s2's deadline.
+    vi.advanceTimersByTime(500);
+    expect(fires.length).toBe(2);
+    expect(fires[1]!.sid).toBe('s2');
+    tracker.dispose();
+  });
+
+  it('classification "unknown" is a no-op (does not start or cancel a window)', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    tracker.onTitle('s1', 'unknown', NOW + 1_500); // must NOT cancel
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 10);
+    expect(fires.length).toBe(1);
+    tracker.dispose();
+  });
+
+  it('Task #767: forgetSid resets the hasObservedRunning gate', () => {
+    const { tracker, fires } = newTracker();
+    tracker.setFocused(false);
+    tracker.onTitle('s1', 'running', NOW);
+    tracker.onTitle('s1', 'idle', NOW + 1_000);
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 10);
+    expect(fires.length).toBe(1); // gate open after running
+    tracker.forgetSid('s1');
+    // Fresh idle with no new running — gate closed again.
+    tracker.onTitle('s1', 'idle', NOW + 20_000);
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 10);
+    expect(fires.length).toBe(1); // no second fire
     tracker.dispose();
   });
 });

--- a/electron/notify/notifyDecider.ts
+++ b/electron/notify/notifyDecider.ts
@@ -1,28 +1,25 @@
 /**
  * Notify decider — pure function mapping (event, ctx) to a notify Decision.
  *
- * 7-rule spec (user-confirmed):
+ * Rule spec (user-confirmed). `decide` is called only on a *confirmed* idle
+ * (the producer-side idle-confirmation window in runStateTracker has already
+ * filtered transient mid-task ✳ titles), so there is no title-content gate,
+ * no task-duration split, and no dedupe here.
  *
  * | # | trigger                                                                       | toast | flash |
  * |---|-------------------------------------------------------------------------------|-------|-------|
- * | 1 | user just acted on this sid (new/import/resume/switch) within 60s, OSC waits  |   x   |   x   |
- * | 2 | ccsm focused + viewing this sid + task duration < 60s                         |   x   |   v   |
- * | 3 | ccsm focused + viewing this sid + task duration >= 60s                        |   v   |   v   |
- * | 4 | ccsm focused + viewing other sid (background sid finishes)                    |   v   |   v   |
- * | 5 | ccsm not focused (window unfocused/minimized)                                 |   v   |   v   |
- * | 6 | multi-sid background concurrent finishes — each sid evaluated independently   |  per  |  per  |
- * | 7 | sid muted — toast suppressed but flash still fires                            |   x   |   v   |
- *
- * Dedupe: same sid within 5s suppressed entirely (returns null).
- * Short-task threshold: 60s (from runStartTs).
+ * | 1 | user just acted on this sid (new/import/resume/switch) within 60s             |   x   |   x   |
+ * | 2 | ccsm focused + viewing this sid                                               |   x   |   v   |
+ * | 3 | ccsm focused + viewing other sid (background sid finishes)                    |   v   |   v   |
+ * | 4 | ccsm not focused (window unfocused/minimized)                                 |   v   |   v   |
+ * | 5 | multi-sid background concurrent finishes — each sid evaluated independently   |  per  |  per  |
+ * | 6 | sid muted — toast suppressed but flash still fires                            |   x   |   v   |
  *
  * `decide` is pure — does NOT mutate ctx. Callers maintain ctx state
  * (this is wired up by the pipeline / sink layer in #689).
  */
 
 export const USER_INIT_MUTE_MS = 60_000;
-export const SHORT_TASK_MS = 60_000;
-export const DEDUPE_MS = 5_000;
 
 export type Event =
   | { type: 'osc-title'; sid: string; title: string; ts: number }
@@ -48,34 +45,20 @@ export type Decision = { toast: boolean; flash: boolean; sid: string };
 
 export type RuleKey =
   | 'user-init-mute'
-  | 'foreground-active-short'
-  | 'foreground-active-long'
+  | 'foreground-active'
   | 'foreground-other-sid'
   | 'unfocused'
   | 'muted';
 
 /**
- * Returns true iff the given OSC title indicates the CLI is waiting for
- * user input (the moment we want to notify on).
- *
- * The producer (#688) emits 'osc-title' events with the raw title string;
- * we treat any title containing "waiting" (case-insensitive) as the
- * waiting signal. This is intentionally permissive — the producer is
- * expected to filter to actual transitions.
- */
-function isWaitingTitle(title: string): boolean {
-  return /waiting/i.test(title);
-}
-
-/**
- * Evaluate the 7 rules for an OSC waiting event.
- * Returns the matched RuleKey + raw (toast, flash) before dedupe.
+ * Evaluate the rules for an OSC waiting event.
+ * Returns the matched RuleKey + (toast, flash).
  */
 function evalRules(
   sid: string,
   ctx: Ctx,
 ): { rule: RuleKey; toast: boolean; flash: boolean } {
-  const { now, focused, activeSid, lastUserInputTs, runStartTs, mutedSids } = ctx;
+  const { now, focused, activeSid, lastUserInputTs, mutedSids } = ctx;
 
   // Rule 1: user-init mute — user touched this sid within 60s
   const lastInput = lastUserInputTs.get(sid);
@@ -106,23 +89,13 @@ function evalRules(
       : { rule: 'foreground-other-sid', ...decision };
   }
 
-  // Foreground + viewing this sid: split by task duration.
-  const start = runStartTs.get(sid);
-  const elapsed = start === undefined ? 0 : now - start;
-
-  if (elapsed < SHORT_TASK_MS) {
-    // Rule 2: short task → flash only, no toast
-    const decision = { toast: false, flash: true };
-    return muted
-      ? { rule: 'muted', toast: false, flash: decision.flash }
-      : { rule: 'foreground-active-short', ...decision };
-  }
-
-  // Rule 3: long task → toast + flash
-  const decision = { toast: true, flash: true };
+  // Foreground + viewing this sid → flash only (you're already looking at
+  // it; the OS toast would be redundant). Duration no longer matters: the
+  // idle-confirmation window already proved this is a real stop.
+  const decision = { toast: false, flash: true };
   return muted
     ? { rule: 'muted', toast: false, flash: decision.flash }
-    : { rule: 'foreground-active-long', ...decision };
+    : { rule: 'foreground-active', ...decision };
 }
 
 /**
@@ -186,25 +159,20 @@ export function assertNotifyContext(ctx: Ctx): void {
  *                          and toggled by setMuted IPC
  *   globalMuted          - app-wide mute (pipeline.isGlobalMutedFn)
  *
- * Plus two additional gates the decider applies last:
+ * Plus one additional gate the decider applies:
  *   userInputRecent      - Rule 1 (lastUserInputTs[sid] within 60s)
- *   dedupe               - 5s per-sid suppression on lastFiredTs
  *
  * | focused | active | hasRun | muted | global | result        | rule        |
  * |---------|--------|--------|-------|--------|---------------|-------------|
  * | *       | *      | *      | *     | T      | null          | global gate |
  * | *       | *      | F      | *     | F      | null          | #767 gate   |
  * | *       | *      | T      | *     | F      | null (R1)     | user-init   |
- * | F       | *      | T      | F     | F      | toast + flash | R5          |
- * | F       | *      | T      | T     | F      | flash only    | R7 (muted)  |
- * | T       | F      | T      | F     | F      | toast + flash | R4          |
- * | T       | F      | T      | T     | F      | flash only    | R7 (muted)  |
- * | T       | T      | T      | F     | F      | flash only    | R2 (<60s)   |
- * | T       | T      | T      | F     | F      | toast + flash | R3 (>=60s)  |
- * | T       | T      | T      | T     | F      | flash only    | R7 (muted)  |
- *
- * After rule eval, a 5s per-sid dedupe (DEDUPE_MS) collapses any
- * still-positive decision back to null if lastFiredTs[sid] is recent.
+ * | F       | *      | T      | F     | F      | toast + flash | R4          |
+ * | F       | *      | T      | T     | F      | flash only    | R6 (muted)  |
+ * | T       | F      | T      | F     | F      | toast + flash | R3          |
+ * | T       | F      | T      | T     | F      | flash only    | R6 (muted)  |
+ * | T       | T      | T      | F     | F      | flash only    | R2          |
+ * | T       | T      | T      | T     | F      | flash only    | R6 (muted)  |
  *
  * Hidden side effect to be aware of:
  *   pipeline.markUserInput() (sinks/pipeline.ts ~line 178) sets a PERMANENT
@@ -227,21 +195,11 @@ export function decide(event: Event, ctx: Ctx): Decision | null {
     return null;
   }
 
-  if (!isWaitingTitle(event.title)) {
-    return null;
-  }
-
   const { sid } = event;
   const result = evalRules(sid, ctx);
 
   // If neither toast nor flash, nothing to fire.
   if (!result.toast && !result.flash) {
-    return null;
-  }
-
-  // 5s dedupe per sid — suppress entirely if last fire was < 5s ago.
-  const lastFired = ctx.lastFiredTs.get(sid);
-  if (lastFired !== undefined && ctx.now - lastFired < DEDUPE_MS) {
     return null;
   }
 

--- a/electron/notify/runStateTracker.ts
+++ b/electron/notify/runStateTracker.ts
@@ -1,93 +1,59 @@
-// Pure run-state decider for the notify pipeline (Task #721 Phase A).
+// Per-sid run-state tracker for the notify pipeline.
 //
-// Extracts the per-sid state-machine that lives inside `sinks/pipeline.ts`
-// today (runStartTs / mutedSids / lastFiredTs and the surrounding context
-// fields the decider reads) into a standalone, Electron-free module so it
-// can be unit-tested in isolation and re-used by Phase B (where pipeline
-// will switch over to delegate here).
+// Owns the idle-confirmation window: an OSC `idle`/`waiting` title does NOT
+// notify immediately. Instead it starts an IDLE_CONFIRM_MS timer. If a
+// `running` title arrives before the timer elapses, the idle was a mid-task
+// pause (the CLI resumes itself) and is dropped. If the timer elapses while
+// still idle, it is a real stop — we run the pure decider once and emit a
+// single confirmed-idle decision through `onConfirmedIdle`.
 //
-// Design notes:
-//   * Pure — no Electron, no I/O. Only depends on the existing
-//     `notifyDecider.decide()` (injected so the test can stub it if it
-//     wants, and so we never hard-link to the module at construction).
-//   * Owns the mutable state that pipeline previously kept inline:
-//       - runStartTs:    Map<sid, ms>     — when the current run began
-//       - mutedSids:     Map<sid, untilTs>— per-sid mute window
-//                                            (untilTs === Infinity = sticky)
-//       - lastFiredTs:   Map<sid, ms>     — for the decider's 5s dedupe
-//       - lastUserInputTs / focused / activeSid — context fields the
-//                                            decider also reads. Exposed
-//                                            via small setters so the
-//                                            wiring layer (Phase B) can
-//                                            push lifecycle events in.
-//   * Single entry point for the title producer: `onTitle(sid, cls, ts)`.
-//       - 'running' → records runStartTs[sid], no decision.
-//       - 'idle' / 'waiting' → calls decide() with a synthesized Ctx.
-//                              On non-null decision, updates lastFiredTs.
-//                              Always clears runStartTs after decide.
-//       - 'unknown' → no-op.
-//   * `forgetSid(sid)` clears every per-sid map entry in one shot
-//                      (mirrors pipeline.forgetSid for the state it owns).
+// This window is the entire mid-task-pause filter. A real stop (Claude asks
+// a question / the task is complete) is NOT followed by `running` until the
+// user acts, so it survives the window; a transient `✳` pause is always
+// followed by `running`, so it never does.
+//
+// Pure-ish: no Electron, no I/O. Depends only on the injected `decide()` and
+// injectable timer/clock fns so tests can drive it deterministically.
 
-import { USER_INIT_MUTE_MS, type Ctx, type Decision, type Event } from './notifyDecider';
+import { type Ctx, type Decision, type Event } from './notifyDecider';
 
 export type TitleClassification = 'idle' | 'running' | 'waiting' | 'unknown';
 
 /**
- * "Ring the last waiting" debounce window.
- *
- * Real-world burst pattern: a long agent task issues several quick
- * permission / question prompts back-to-back (waiting → user answers in-app
- * → running → waiting → …). Pre-debounce, each waiting fired its own toast,
- * giving the user 3-5 OS notifications for a single task. Post-debounce,
- * each waiting (re)starts a 8s timer; if the title flips back to running
- * before 8s elapses (because the user answered in-app, or the CLI moved on
- * on its own), the timer is cancelled and no toast fires. Only the FINAL,
- * still-waiting prompt that has settled for 8s rings.
- *
- * Trade-off: a single long-waiting prompt is now delayed by 8s vs. fire-
- * immediately. We accept the slight latency in exchange for the burst-
- * collapse — toast spam is the louder complaint. Tune via PR if needed.
- *
- * The flash (sidebar halo) still fires IMMEDIATELY on each waiting — only
- * the OS toast is debounced. The user gets instant in-app feedback;
- * the OS-level interrupt is reserved for genuinely stuck waits.
+ * Idle confirmation window. After an `idle` title, wait this long before
+ * treating the stop as real. Each fresh idle resets it; any `running`
+ * cancels it. 1500ms is the starting value (tunable in a follow-up):
+ *   - too short → slow-tool gaps between steps read as a real stop
+ *   - too long  → the user waits this long after a genuine stop
  */
-export const RING_DEBOUNCE_MS = 8_000;
+export const IDLE_CONFIRM_MS = 1_500;
 
 export interface RunStateTrackerOptions {
-  /** Override the debounce window (test only). Defaults to RING_DEBOUNCE_MS. */
-  ringDebounceMs?: number;
-  /** Wall-clock provider for deferred-toast fire-time re-evaluation. Defaults
-   *  to Date.now. Tests inject a mock to advance time deterministically. */
+  /** Override the confirmation window (test only). Defaults to IDLE_CONFIRM_MS. */
+  idleConfirmMs?: number;
+  /** Wall-clock provider. Defaults to Date.now. */
   nowFn?: () => number;
-  /** setTimeout / clearTimeout overrides. Default to globalThis. Tests using
-   *  vi.useFakeTimers() can rely on the defaults, but explicit injection is
-   *  available if a test needs a hand-rolled scheduler. */
+  /** setTimeout / clearTimeout overrides. Default to globalThis. */
   setTimeoutFn?: (cb: () => void, ms: number) => unknown;
   clearTimeoutFn?: (handle: unknown) => void;
-  /** Sink callback for a deferred toast that survived the debounce window.
-   *  Receives a Decision with `toast:true, flash:false` (flash already fired
-   *  on the immediate path when the debounce started). */
-  onDeferredToast?: (decision: Decision) => void;
+  /** Called once when an idle survives the confirmation window. Receives the
+   *  decider's Decision (toast/flash per the focus/active/mute matrix). */
+  onConfirmedIdle?: (decision: Decision) => void;
 }
 
 export interface RunStateTracker {
-  /** Producer entry — feed a classified title for `sid` at `nowTs`.
-   *  Returns the decision the decider produced (if any) so the caller
-   *  can wire sinks. Tracker itself never invokes sinks. */
+  /** Producer entry — feed a classified title for `sid` at `nowTs`. Always
+   *  returns null; decisions are emitted asynchronously via onConfirmedIdle
+   *  when the window closes. */
   onTitle(sid: string, classification: TitleClassification, nowTs: number): Decision | null;
-  /** Drop all per-sid state for `sid` (session teardown). */
+  /** Drop all per-sid state for `sid` (session teardown). Cancels its window. */
   forgetSid(sid: string): void;
-  /** Lifecycle setters — mirror pipeline's surface so Phase B can wire
-   *  them through unchanged. Pure state mutation, no side effects. */
   setFocused(focused: boolean): void;
   setActiveSid(sid: string | null): void;
   markUserInput(sid: string, nowTs: number): void;
-  /** Mute `sid` until `untilTs` (use `Infinity` for sticky). Pass
-   *  `null` to clear. */
+  /** Mute `sid` until `untilTs` (use `Infinity` for sticky). Pass `null` to clear. */
   setMuted(sid: string, untilTs: number | null): void;
-  /** Cancel all pending deferred toasts (test / shutdown cleanup). */
+  /** Cancel all pending idle-confirm timers (test / shutdown cleanup). */
   dispose(): void;
   /** Test-only — read internal maps for assertion. */
   _internals(): {
@@ -97,8 +63,8 @@ export interface RunStateTracker {
     lastUserInputTs: Map<string, number>;
     focused: boolean;
     activeSid: string | null;
-    /** sids with an outstanding deferred-toast timer. */
-    pendingToastSids: string[];
+    /** sids with an outstanding idle-confirm timer. */
+    pendingIdleSids: string[];
   };
 }
 
@@ -106,40 +72,26 @@ export function createRunStateTracker(
   decide: (event: Event, ctx: Ctx) => Decision | null,
   options: RunStateTrackerOptions = {},
 ): RunStateTracker {
-  const ringDebounceMs = options.ringDebounceMs ?? RING_DEBOUNCE_MS;
+  const idleConfirmMs = options.idleConfirmMs ?? IDLE_CONFIRM_MS;
   const nowFn = options.nowFn ?? Date.now;
   const setTimeoutFn =
     options.setTimeoutFn ?? ((cb: () => void, ms: number) => setTimeout(cb, ms));
   const clearTimeoutFn =
     options.clearTimeoutFn ?? ((h: unknown) => clearTimeout(h as ReturnType<typeof setTimeout>));
-  const onDeferredToast = options.onDeferredToast;
+  const onConfirmedIdle = options.onConfirmedIdle;
 
   const runStartTs = new Map<string, number>();
   /** Map<sid, untilTs> — entry present + nowTs < untilTs ⇒ sid is muted. */
   const mutedSids = new Map<string, number>();
   const lastFiredTs = new Map<string, number>();
   const lastUserInputTs = new Map<string, number>();
-  /** Per-sid outstanding deferred-toast timer handle. Cancelled on:
-   *    - 'running' classification (task resumed → no ring)
-   *    - forgetSid (session teardown)
-   *    - dispose (pipeline / process shutdown)
-   *  Reset on each new waiting signal (debounce semantics — ring the LAST). */
-  const pendingToastTimers = new Map<string, unknown>();
-  /**
-   * Per-sid gate (Task #767): true once we have observed a 'running' title
-   * for this sid in the current process lifetime. The decider's Rule 2
-   * ("foreground + active + short task") computes elapsed = now - start;
-   * when no 'running' was ever seen, runStartTs is unset and elapsed
-   * collapses to 0 < SHORT_TASK_MS, unconditionally tripping {flash:true}.
-   *
-   * claude.exe boot reliably emits an 'idle' / 'waiting' OSC title within
-   * a few hundred ms of spawn, so without this gate every fresh / imported /
-   * resumed session lights flashSink for FLASH_DURATION_MS, producing the
-   * 4-second AgentIcon "breath" the user reported in #767.
-   *
-   * Fix at the producer layer: skip decide() entirely until we've seen a
-   * legitimate run start. notifyDecider stays pure / unchanged.
-   */
+  /** Per-sid outstanding idle-confirm timer handle. Cancelled on `running`,
+   *  forgetSid, and dispose. Reset on each fresh idle. */
+  const pendingIdleTimers = new Map<string, unknown>();
+  /** Per-sid gate (#767): true once we've seen a `running` title for this sid
+   *  in the current process. The CLI boot banner emits an `idle` title with
+   *  no prior `running`; without this gate that would start a window and fire
+   *  a phantom notification on every fresh/imported/resumed session. */
   const hasObservedRunning = new Set<string>();
   let focused = true;
   let activeSid: string | null = null;
@@ -152,49 +104,41 @@ export function createRunStateTracker(
     return out;
   }
 
-  function isMutedNow(sid: string, nowTs: number): boolean {
-    const until = mutedSids.get(sid);
-    return until !== undefined && nowTs < until;
-  }
-
-  function cancelPendingToast(sid: string): void {
-    const t = pendingToastTimers.get(sid);
+  function cancelIdleTimer(sid: string): void {
+    const t = pendingIdleTimers.get(sid);
     if (t !== undefined) {
       clearTimeoutFn(t);
-      pendingToastTimers.delete(sid);
+      pendingIdleTimers.delete(sid);
     }
   }
 
-  /**
-   * Schedule (or reset) the deferred-toast timer for `sid`.
-   *
-   * Each fresh waiting signal pushes the fire deadline out to NOW +
-   * ringDebounceMs. Burst-collapse: rapid running ↔ waiting flips never
-   * exhaust the timer; only sustained waiting does.
-   */
-  function schedulePendingToast(sid: string): void {
-    cancelPendingToast(sid);
+  /** Start (or reset) the idle-confirmation window for `sid`. On elapse, run
+   *  the decider once against a snapshot taken AT FIRE TIME and, if it returns
+   *  a decision, emit it through onConfirmedIdle. */
+  function startIdleTimer(sid: string): void {
+    cancelIdleTimer(sid);
     const handle = setTimeoutFn(() => {
-      pendingToastTimers.delete(sid);
-      if (!onDeferredToast) return;
-      // Re-evaluate at fire-time. We deliberately do NOT re-run the full
-      // decider here — runStartTs has been cleared (so Rule 2 would fire
-      // flash-only and Rule 3 would never fire). Instead, re-check the
-      // two dynamic suppressors that may have flipped during the wait:
-      //   1. Rule 1 user-init mute (user touched this sid in last 60s)
-      //   2. Rule 7 per-sid mute
-      // Global mute is enforced one layer up in pipeline.ts (the pipeline
-      // never feeds idle through to the tracker when global mute is on, so
-      // a deferred fire on a globally-muted sid cannot happen unless the
-      // mute toggled on AFTER schedule — acceptable, pipeline owns it).
+      pendingIdleTimers.delete(sid);
       const fireTs = nowFn();
-      const lastInput = lastUserInputTs.get(sid);
-      if (lastInput !== undefined && fireTs - lastInput < USER_INIT_MUTE_MS) return;
-      if (isMutedNow(sid, fireTs)) return;
-      lastFiredTs.set(sid, fireTs);
-      onDeferredToast({ toast: true, flash: false, sid });
-    }, ringDebounceMs);
-    pendingToastTimers.set(sid, handle);
+      const ctx: Ctx = {
+        focused,
+        activeSid,
+        lastUserInputTs,
+        runStartTs,
+        mutedSids: activeMutedSet(fireTs),
+        lastFiredTs,
+        now: fireTs,
+      };
+      const event: Event = { type: 'osc-title', sid, title: 'idle', ts: fireTs };
+      const decision = decide(event, ctx);
+      // The run is over — clear its start clock regardless of outcome.
+      runStartTs.delete(sid);
+      if (decision !== null) {
+        lastFiredTs.set(sid, fireTs);
+        onConfirmedIdle?.(decision);
+      }
+    }, idleConfirmMs);
+    pendingIdleTimers.set(sid, handle);
   }
 
   return {
@@ -204,71 +148,20 @@ export function createRunStateTracker(
       if (classification === 'running') {
         if (!runStartTs.has(sid)) runStartTs.set(sid, nowTs);
         hasObservedRunning.add(sid);
-        // Cancel any pending deferred toast — the task moved on, the user
-        // (or the CLI) already handled the previous waiting signal.
-        cancelPendingToast(sid);
+        // A pending idle was a mid-task pause — the CLI resumed. Drop it.
+        cancelIdleTimer(sid);
         return null;
       }
 
-      // Task #767 gate: if we've never seen this sid go 'running', the
-      // incoming 'idle' / 'waiting' title is the CLI's boot banner (or a
-      // post-import resume settle). There is no real task to notify on, and
-      // the decider would otherwise mis-fire Rule 2 (elapsed = 0 < 60s).
+      // 'idle' or 'waiting'.
+      // Boot gate (#767): no real task to notify on until we've seen running.
       if (!hasObservedRunning.has(sid)) {
-        // Still keep runStartTs clean if anything stray slipped in.
         runStartTs.delete(sid);
         return null;
       }
 
-      // 'idle' or 'waiting' → ask the decider.
-      // The decider matches against the literal word "waiting"; both
-      // classifications represent the same user-attention signal, so we
-      // normalize to that token regardless of which one the producer
-      // emitted.
-      const ctx: Ctx = {
-        focused,
-        activeSid,
-        lastUserInputTs,
-        runStartTs,
-        mutedSids: activeMutedSet(nowTs),
-        lastFiredTs,
-        now: nowTs,
-      };
-      const event: Event = { type: 'osc-title', sid, title: 'waiting', ts: nowTs };
-      const immediate = decide(event, ctx);
-
-      // Mirror pipeline behaviour: always clear runStartTs after a
-      // non-running title so the next run starts a fresh elapsed clock.
-      runStartTs.delete(sid);
-
-      // Debounce-style "ring the LAST waiting": any waiting signal that
-      // would otherwise toast (re)starts the deferred-toast timer.
-      // We trigger the schedule when EITHER:
-      //   - decide() returned toast:true (the original "yes, toast" path), OR
-      //   - decide() returned null AND a deferred toast is already pending
-      //     (a follow-up waiting inside a burst — even if the immediate
-      //     decision was suppressed by 5s dedupe, we still want the timer
-      //     pushed out so the LAST waiting wins).
-      // We do NOT schedule when the sid is currently muted (no point
-      // firing later either — re-eval at fire-time would suppress anyway,
-      // and avoiding the timer keeps the pending-set tidy).
-      const shouldDefer =
-        !isMutedNow(sid, nowTs) &&
-        ((immediate !== null && immediate.toast) || pendingToastTimers.has(sid));
-      if (shouldDefer) {
-        schedulePendingToast(sid);
-      }
-
-      if (immediate !== null) {
-        lastFiredTs.set(sid, nowTs);
-        if (immediate.toast) {
-          // Strip the toast from the immediate fan-out — it will fire (or
-          // not) via the deferred path. Flash still fires immediately so
-          // the in-app halo is instant.
-          return { toast: false, flash: immediate.flash, sid };
-        }
-        return immediate;
-      }
+      // Start/reset the confirmation window. No synchronous decision.
+      startIdleTimer(sid);
       return null;
     },
     forgetSid(sid) {
@@ -277,7 +170,7 @@ export function createRunStateTracker(
       lastFiredTs.delete(sid);
       lastUserInputTs.delete(sid);
       hasObservedRunning.delete(sid);
-      cancelPendingToast(sid);
+      cancelIdleTimer(sid);
     },
     setFocused(next) {
       focused = next;
@@ -293,8 +186,8 @@ export function createRunStateTracker(
       else mutedSids.set(sid, untilTs);
     },
     dispose() {
-      for (const handle of pendingToastTimers.values()) clearTimeoutFn(handle);
-      pendingToastTimers.clear();
+      for (const handle of pendingIdleTimers.values()) clearTimeoutFn(handle);
+      pendingIdleTimers.clear();
     },
     _internals() {
       return {
@@ -304,7 +197,7 @@ export function createRunStateTracker(
         lastUserInputTs,
         focused,
         activeSid,
-        pendingToastSids: Array.from(pendingToastTimers.keys()),
+        pendingIdleSids: Array.from(pendingIdleTimers.keys()),
       };
     },
   };

--- a/electron/notify/sinks/__tests__/dogfood-idle-confirm.evidence.test.ts
+++ b/electron/notify/sinks/__tests__/dogfood-idle-confirm.evidence.test.ts
@@ -1,0 +1,172 @@
+// Dogfood evidence for the notify idle-confirmation window.
+//
+// This is the headless, deterministic proof for the original bug: CCSM used
+// to fire a notification on a MID-TASK PAUSE (a transient `✳` title the CLI
+// emits between tool steps, immediately followed by `running` when it resumes
+// itself). The fix folds an IDLE_CONFIRM_MS window into runStateTracker so a
+// `✳` that is followed by `running` within the window is dropped, and only a
+// `✳` that stays idle past the window (a REAL stop — Claude asked a question
+// or finished the task) fires exactly one notification.
+//
+// Unlike the byte-stream e2e harness, this drives the FULL real pipeline
+// (`installNotifyPipeline` → real OscTitleSniffer → real runStateTracker →
+// real toast sink test-seam) with raw OSC bytes — the same bytes node-pty
+// would deliver — under vitest fake timers so the 1500ms window is exercised
+// to the millisecond.
+//
+// WHAT THIS PROVES (headless):
+//   1. A realistic running→idle→running→idle→…→running pause storm produces
+//      ZERO notifications.
+//   2. A running→idle→(silence > window) real stop produces EXACTLY ONE.
+//   3. The single notification carries the correct sid.
+//
+// WHAT THIS CANNOT PROVE (needs a real device / real CLI):
+//   - That the OS actually renders the toast and the flash is visible.
+//   - That the real Claude CLI emits these exact OSC glyph transitions at
+//     these timings (the e2e seam cannot drive real idle transitions without
+//     a live Anthropic backend — documented in
+//     scripts/harness-e2e-window-lifecycle-notify.mjs). This spec asserts the
+//     pipeline's discrimination logic given the documented OSC contract.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('electron', () => ({
+  Notification: class {
+    static isSupported() {
+      return false;
+    }
+  },
+  BrowserWindow: class {},
+}));
+
+import { installNotifyPipeline } from '../pipeline';
+import { IDLE_CONFIRM_MS } from '../../runStateTracker';
+
+// Real OSC 0 byte sequences, exactly as node-pty delivers them from the CLI.
+function osc(title: string): string {
+  return `\x1b]0;${title}\x07`;
+}
+const RUNNING = osc('⠂ Claude Code'); // braille spinner frame = running
+const IDLE = osc('✳ Claude Code'); // sparkle = idle / waiting for input
+
+interface NotifyEntry {
+  sid: string;
+}
+
+function makeStubWin() {
+  return {
+    isDestroyed: () => false,
+    isVisible: () => true,
+    isMinimized: () => false,
+    show: vi.fn(),
+    restore: vi.fn(),
+    focus: vi.fn(),
+    webContents: {
+      isDestroyed: () => false,
+      send: vi.fn(),
+    },
+  };
+}
+
+function notifyLog(): NotifyEntry[] {
+  return (
+    (globalThis as { __ccsmNotifyLog?: NotifyEntry[] }).__ccsmNotifyLog ?? []
+  );
+}
+
+describe('DOGFOOD: notify idle-confirmation window (real pipeline, real bytes)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    process.env.CCSM_NOTIFY_TEST_HOOK = '1';
+    delete (globalThis as { __ccsmNotifyLog?: unknown }).__ccsmNotifyLog;
+  });
+  afterEach(() => {
+    delete process.env.CCSM_NOTIFY_TEST_HOOK;
+    vi.useRealTimers();
+  });
+
+  it('EVIDENCE 1 — mid-task pause storm fires ZERO notifications', () => {
+    const win = makeStubWin();
+    const pipeline = installNotifyPipeline({
+      getMainWindow: () => win as never,
+      isGlobalMutedFn: () => false,
+      getNameFn: () => 'dogfood',
+    });
+    pipeline.setFocused(false); // unfocused — most aggressive toast path (Rule 5)
+
+    // A realistic multi-step turn: each tool call ends with a brief `✳` pause
+    // that is well under the confirmation window, then the CLI resumes itself
+    // with `running`. This is the exact pattern that used to mis-fire.
+    pipeline.feedChunk('s1', RUNNING);
+    for (let step = 0; step < 6; step++) {
+      vi.advanceTimersByTime(800); // tool runs ~800ms
+      pipeline.feedChunk('s1', IDLE); // brief pause between steps
+      vi.advanceTimersByTime(IDLE_CONFIRM_MS - 400); // pause < window
+      pipeline.feedChunk('s1', RUNNING); // CLI resumes itself → cancels window
+    }
+    // Drain any timers far past the window — nothing should be pending.
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS * 3);
+
+    expect(notifyLog()).toEqual([]);
+    expect(pipeline._internals().tracker._internals().pendingIdleSids).toEqual(
+      [],
+    );
+    pipeline.dispose();
+  });
+
+  it('EVIDENCE 2 — a real stop fires EXACTLY ONE notification with the right sid', () => {
+    const win = makeStubWin();
+    const pipeline = installNotifyPipeline({
+      getMainWindow: () => win as never,
+      isGlobalMutedFn: () => false,
+      getNameFn: () => 'dogfood',
+    });
+    pipeline.setFocused(false);
+
+    // Same turn as EVIDENCE 1, but the final `✳` is a REAL stop: Claude asked
+    // a question / finished. No `running` follows, so the window elapses.
+    pipeline.feedChunk('s1', RUNNING);
+    for (let step = 0; step < 3; step++) {
+      vi.advanceTimersByTime(800);
+      pipeline.feedChunk('s1', IDLE);
+      vi.advanceTimersByTime(IDLE_CONFIRM_MS - 400);
+      pipeline.feedChunk('s1', RUNNING);
+    }
+    vi.advanceTimersByTime(500);
+    pipeline.feedChunk('s1', IDLE); // the real stop
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 50); // silence past the window
+
+    const log = notifyLog();
+    expect(log.length).toBe(1);
+    expect(log[0]!.sid).toBe('s1');
+    pipeline.dispose();
+  });
+
+  it('EVIDENCE 3 — concurrent sessions: one pauses, one really stops', () => {
+    const win = makeStubWin();
+    const pipeline = installNotifyPipeline({
+      getMainWindow: () => win as never,
+      isGlobalMutedFn: () => false,
+      getNameFn: () => 'dogfood',
+    });
+    pipeline.setFocused(false);
+
+    // s1 pauses mid-task; s2 really stops. Only s2 should notify.
+    pipeline.feedChunk('s1', RUNNING);
+    pipeline.feedChunk('s2', RUNNING);
+    vi.advanceTimersByTime(500);
+
+    pipeline.feedChunk('s1', IDLE); // s1 pause begins
+    pipeline.feedChunk('s2', IDLE); // s2 stop begins
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS - 300);
+    pipeline.feedChunk('s1', RUNNING); // s1 resumes → its window cancels
+
+    // s2 never resumes — its window elapses.
+    vi.advanceTimersByTime(IDLE_CONFIRM_MS + 50);
+
+    const log = notifyLog();
+    expect(log.length).toBe(1);
+    expect(log[0]!.sid).toBe('s2');
+    pipeline.dispose();
+  });
+});

--- a/electron/notify/sinks/__tests__/pipeline.test.ts
+++ b/electron/notify/sinks/__tests__/pipeline.test.ts
@@ -74,18 +74,21 @@ describe('installNotifyPipeline (Task #743 orchestrator)', () => {
       pipeline.feedChunk('s1', osc(RUNNING_TITLE));
       pipeline.feedChunk('s1', osc(IDLE_TITLE));
 
-      // Flash sink fired immediately (sidebar halo is instant).
-      const flashSends = sends.filter((s) => s.channel === 'notify:flash');
-      expect(flashSends.length).toBe(1);
-      expect(flashSends[0]!.payload).toEqual({ sid: 's1', on: true });
-
-      // Toast is DEBOUNCED — nothing yet.
+      // Nothing fires synchronously — the idle-confirmation window is open.
+      // A real stop is only confirmed once the window elapses with no running.
+      expect(sends.filter((s) => s.channel === 'notify:flash')).toEqual([]);
       const log0 = (globalThis as { __ccsmNotifyLog?: Array<{ sid: string }> }).__ccsmNotifyLog;
       expect(log0 ?? []).toEqual([]);
       expect(onNotified).not.toHaveBeenCalled();
 
-      // Advance past the ring-debounce window — toast fires.
-      vi.advanceTimersByTime(10_000);
+      // Advance past the idle-confirmation window (1500ms) but under the
+      // flash duration (4000ms) so the flash hasn't auto-cleared yet.
+      vi.advanceTimersByTime(1_600);
+
+      const flashSends = sends.filter((s) => s.channel === 'notify:flash');
+      expect(flashSends.length).toBe(1);
+      expect(flashSends[0]!.payload).toEqual({ sid: 's1', on: true });
+
       const log = (globalThis as { __ccsmNotifyLog?: Array<{ sid: string }> }).__ccsmNotifyLog;
       expect(log).toBeDefined();
       expect(log!.length).toBe(1);
@@ -119,38 +122,54 @@ describe('installNotifyPipeline (Task #743 orchestrator)', () => {
   });
 
   it('markUserInput sticky-mutes the sid (no toast on subsequent run)', () => {
-    const { win, sends } = makeStubWin();
-    const onNotified = vi.fn();
-    const pipeline = installNotifyPipeline({
-      getMainWindow: () => win as never,
-      isGlobalMutedFn: () => false,
-      onNotified,
-    });
-    pipeline.setFocused(false);
-    pipeline.markUserInput('s1');
+    vi.useFakeTimers();
+    try {
+      const { win, sends } = makeStubWin();
+      const onNotified = vi.fn();
+      const pipeline = installNotifyPipeline({
+        getMainWindow: () => win as never,
+        isGlobalMutedFn: () => false,
+        onNotified,
+      });
+      pipeline.setFocused(false);
+      pipeline.markUserInput('s1');
 
-    pipeline.feedChunk('s1', osc(RUNNING_TITLE));
-    pipeline.feedChunk('s1', osc(IDLE_TITLE));
+      pipeline.feedChunk('s1', osc(RUNNING_TITLE));
+      pipeline.feedChunk('s1', osc(IDLE_TITLE));
 
-    expect(onNotified).not.toHaveBeenCalled();
-    // Mute (Rule 7) suppresses toast but still fires flash.
-    expect(sends.some((s) => s.channel === 'notify:flash')).toBe(true);
-    pipeline.dispose();
+      // Confirm the idle window so the decision lands.
+      vi.advanceTimersByTime(10_000);
+
+      expect(onNotified).not.toHaveBeenCalled();
+      // Mute (Rule 7) suppresses toast but still fires flash.
+      expect(sends.some((s) => s.channel === 'notify:flash')).toBe(true);
+      pipeline.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('forgetSid clears sniffer + tracker + flash state', () => {
-    const { win } = makeStubWin();
-    const pipeline = installNotifyPipeline({
-      getMainWindow: () => win as never,
-      isGlobalMutedFn: () => false,
-    });
-    pipeline.setFocused(false);
-    pipeline.feedChunk('s1', osc(RUNNING_TITLE));
-    pipeline.feedChunk('s1', osc(IDLE_TITLE)); // creates flash state
-    expect(pipeline._internals().flash._peek()['s1']).toBe(true);
-    pipeline.forgetSid('s1');
-    expect(pipeline._internals().flash._peek()['s1']).toBeUndefined();
-    pipeline.dispose();
+    vi.useFakeTimers();
+    try {
+      const { win } = makeStubWin();
+      const pipeline = installNotifyPipeline({
+        getMainWindow: () => win as never,
+        isGlobalMutedFn: () => false,
+      });
+      pipeline.setFocused(false);
+      pipeline.feedChunk('s1', osc(RUNNING_TITLE));
+      pipeline.feedChunk('s1', osc(IDLE_TITLE));
+      // Confirm idle (1500ms) but stay under FLASH_DURATION_MS (4000ms) so the
+      // flash auto-off hasn't cleared the peek map yet.
+      vi.advanceTimersByTime(1_600); // confirm idle → creates flash state
+      expect(pipeline._internals().flash._peek()['s1']).toBe(true);
+      pipeline.forgetSid('s1');
+      expect(pipeline._internals().flash._peek()['s1']).toBeUndefined();
+      pipeline.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('setMuted suppresses toast for the sid (Rule 7) but a different sid still fires', () => {
@@ -198,24 +217,30 @@ describe('installNotifyPipeline (Task #743 orchestrator)', () => {
   });
 
   it('diag counters populate only when globalThis.__ccsmDebug is truthy', () => {
-    const { win } = makeStubWin();
-    (globalThis as { __ccsmDebug?: boolean }).__ccsmDebug = true;
-    const pipeline = installNotifyPipeline({
-      getMainWindow: () => win as never,
-      isGlobalMutedFn: () => false,
-    });
-    pipeline.setFocused(false);
-    pipeline.feedChunk('s1', osc(RUNNING_TITLE));
-    pipeline.feedChunk('s1', osc(IDLE_TITLE));
-    const diag = pipeline._internals().diag;
-    expect(diag).not.toBeNull();
-    expect(diag!.chunksFed).toBe(2);
-    expect(diag!.bytesFed).toBeGreaterThan(0);
-    expect(diag!.snifferEvents).toBe(2);
-    expect(diag!.classifications.idle).toBe(1);
-    expect(diag!.classifications.running).toBe(1);
-    expect(diag!.decisions).toBe(1);
-    pipeline.dispose();
+    vi.useFakeTimers();
+    try {
+      const { win } = makeStubWin();
+      (globalThis as { __ccsmDebug?: boolean }).__ccsmDebug = true;
+      const pipeline = installNotifyPipeline({
+        getMainWindow: () => win as never,
+        isGlobalMutedFn: () => false,
+      });
+      pipeline.setFocused(false);
+      pipeline.feedChunk('s1', osc(RUNNING_TITLE));
+      pipeline.feedChunk('s1', osc(IDLE_TITLE));
+      vi.advanceTimersByTime(10_000); // confirm idle → decision counted
+      const diag = pipeline._internals().diag;
+      expect(diag).not.toBeNull();
+      expect(diag!.chunksFed).toBe(2);
+      expect(diag!.bytesFed).toBeGreaterThan(0);
+      expect(diag!.snifferEvents).toBe(2);
+      expect(diag!.classifications.idle).toBe(1);
+      expect(diag!.classifications.running).toBe(1);
+      expect(diag!.decisions).toBe(1);
+      pipeline.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('dispose detaches sniffer listeners (subsequent feeds produce no decisions)', () => {
@@ -251,6 +276,9 @@ describe('installNotifyPipeline (Task #743 orchestrator)', () => {
       pipeline.feedChunk('s1', osc(IDLE_TITLE));
       pipeline.feedChunk('s2', osc(RUNNING_TITLE));
       pipeline.feedChunk('s2', osc(IDLE_TITLE));
+      // Confirm both idle windows (1500ms) but stay under FLASH_DURATION_MS
+      // (4000ms) so the flash sink hasn't auto-cleared yet.
+      vi.advanceTimersByTime(1_600);
       const flash = pipeline._internals().flash;
       expect(Object.keys(flash._peek()).sort()).toEqual(['s1', 's2']);
 

--- a/electron/notify/sinks/pipeline.ts
+++ b/electron/notify/sinks/pipeline.ts
@@ -6,8 +6,8 @@
 //   producer : OscTitleSniffer (#688, dual-mode OSC 0+2 since #713) — feeds
 //              raw titles per sid.
 //   decider  : runStateTracker (#721/#551) — owns per-sid run state, mute
-//              windows, dedupe, and calls notifyDecider.decide() with a
-//              synthesized Ctx. Pure module, no side effects.
+//              windows, the idle-confirmation window, and calls
+//              notifyDecider.decide() with a synthesized Ctx.
 //   sinks    : toastSink (Electron Notification) + flashSink (renderer
 //              flash state). Each is single-responsibility.
 //
@@ -84,17 +84,6 @@ export function installNotifyPipeline(opts: NotifyPipelineOptions): NotifyPipeli
     onNotified: opts.onNotified,
   });
   const flash = createFlashSink({ getMainWindow: opts.getMainWindow });
-  // Deferred-toast wiring (Task: "ring the last waiting"). The tracker
-  // strips toast:true from its synchronous return and instead schedules a
-  // RING_DEBOUNCE_MS timer per sid; on timer fire (no 'running' arrived
-  // in the meantime), it calls back here to ring exactly once. The
-  // `onNotified` badge bump still fires via toastSink.apply, so unread
-  // counts stay consistent regardless of which path the toast took.
-  const tracker = createRunStateTracker(decide, {
-    onDeferredToast: (decision) => {
-      toast.apply(decision);
-    },
-  });
 
   // Diagnostics for e2e probes — counts what each layer sees so we can tell
   // whether failure is "no PTY data", "no OSC titles", "titles seen but
@@ -119,6 +108,18 @@ export function installNotifyPipeline(opts: NotifyPipelineOptions): NotifyPipeli
     if (diag.titlesSeen.length > 10) diag.titlesSeen.shift();
   }
 
+  // The tracker holds the idle-confirmation window. An idle title no longer
+  // produces a synchronous decision; instead the tracker fires onConfirmedIdle
+  // once the window closes (a real stop) and we fan the decision out to both
+  // sinks here. A mid-task pause never reaches this callback.
+  const tracker = createRunStateTracker(decide, {
+    onConfirmedIdle: (decision) => {
+      if (diag) diag.decisions += 1;
+      toast.apply(decision);
+      flash.apply(decision);
+    },
+  });
+
   const onOsc = (evt: OscTitleEvent): void => {
     const now = Date.now();
     if (diag) diag.snifferEvents += 1;
@@ -139,12 +140,9 @@ export function installNotifyPipeline(opts: NotifyPipelineOptions): NotifyPipeli
     }
 
     if (diag && cls === 'idle') diag.decideCalls += 1;
-    const decision = tracker.onTitle(evt.sid, cls, now);
-    if (decision) {
-      if (diag) diag.decisions += 1;
-      toast.apply(decision);
-      flash.apply(decision);
-    }
+    // onTitle never returns a synchronous decision now — a confirmed idle is
+    // emitted asynchronously through onConfirmedIdle when the window closes.
+    tracker.onTitle(evt.sid, cls, now);
   };
 
   sniffer.on('osc-title', onOsc);
@@ -217,9 +215,9 @@ export function installNotifyPipeline(opts: NotifyPipelineOptions): NotifyPipeli
       // pipeline disposal — visible as a slow-growing handle count in
       // long-running tests / HMR reloads.
       flash.dispose();
-      // Cancel any outstanding deferred-toast timers held by the tracker.
+      // Cancel any outstanding idle-confirmation timers held by the tracker.
       // Same leak class as flashSink timers — without this, a still-pending
-      // ring would fire after the pipeline (and its sinks) are torn down,
+      // window would fire after the pipeline (and its sinks) are torn down,
       // attempting to toast against a destroyed BrowserWindow.
       tracker.dispose();
     },


### PR DESCRIPTION
## Problem

CCSM fired a notification on **mid-task pauses** — the transient `✳` (idle)
title the Claude CLI emits between tool steps, which it immediately follows
with a `running` title when it resumes itself. Users only want a notification
at a **real stop**: (B) Claude asks a question / waits for approval, or
(C) the whole task is complete.

## Fix

Keep the OSC-glyph signal source. Fold an **idle-confirmation window**
(`IDLE_CONFIRM_MS = 1500ms`) into `runStateTracker`:

- An `idle` title starts the window instead of notifying synchronously.
- A `running` title arriving within the window cancels it (mid-task pause → dropped).
- The window elapsing while still idle is a real stop → fire **exactly once**
  via `onConfirmedIdle(decision)`.

This let us delete the timer-heuristic band-aids: the `RING_DEBOUNCE_MS`
deferred-toast machinery, the `SHORT_TASK_MS` Rule 2/3 split, `DEDUPE_MS`, and
the dead `isWaitingTitle` + hard-coded `title:'waiting'`. Focus/active-sid
rules, per-sid mute, and the `hasObservedRunning` boot gate are unchanged.

Resolved impl-time question: a confirmed idle while **focused + active sid**
is **flash-only** (no toast), matching the lean choice in the design.

## Commits

- `refactor(notify)`: collapse decider Rule 2/3, drop dedupe + isWaitingTitle
- `feat(notify)`: add idle confirmation window, drop deferred-toast machinery
- `refactor(notify)`: fan out confirmed idle via `onConfirmedIdle` in pipeline
- `test(notify)`: dogfood evidence for the idle-confirmation window

## Evidence (headless, deterministic)

All via vitest fake timers driving the **real** pipeline
(`installNotifyPipeline` → real `OscTitleSniffer` → real `runStateTracker` →
real toast sink test-seam) with raw OSC bytes:

- **`runStateTracker.test.ts`** (15 specs) — window mechanics: pause→running
  drops, silence past window fires once, jitter bursts, boot gate, Rule 1 mute,
  independent per-sid windows.
- **`pipeline.test.ts`** (9 specs) — full wiring: confirmed idle fans out to
  toast + flash; global mute / sticky mute / forgetSid / dispose paths.
- **`dogfood-idle-confirm.evidence.test.ts`** (3 specs) — the bug, end to end:
  1. A 6-step mid-task-pause storm fires **ZERO** notifications.
  2. A real stop fires **EXACTLY ONE** with the correct sid.
  3. Concurrent sessions — one pauses, one really stops — only the stop notifies.

Local gate green: `typecheck` ✓, `lint` (max-warnings 0) ✓,
`npm test` (1894 passed) ✓, `harness-ui` (14/14) ✓.

## What headless CANNOT prove (needs a real device / real CLI)

- That the OS actually **renders** the toast and the flash is visibly drawn.
- That the **real Claude CLI** emits these exact OSC glyph transitions at these
  timings. The e2e notify seam cannot drive real idle transitions without a
  live Anthropic backend (documented in
  `scripts/harness-e2e-window-lifecycle-notify.mjs`). This PR proves the
  pipeline's discrimination logic **given the documented OSC contract**;
  real-CLI timing + OS toast rendering need a manual real-device check before
  merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)