### PR TITLE
feat(ui): reposition scroll-to-bottom and mic buttons

### DIFF
--- a/src/components/ScrollToBottomButton.tsx
+++ b/src/components/ScrollToBottomButton.tsx
@@ -32,7 +32,7 @@ export function ScrollToBottomButton({
       title={t('terminal.scrollToBottom')}
       data-scroll-to-bottom
       className={[
-        'absolute bottom-4 right-4 z-10',
+        'absolute bottom-4 left-1/2 -translate-x-1/2 z-10',
         'inline-grid place-items-center',
         'h-8 w-8 rounded-full',
         'text-fg-secondary',

--- a/src/components/voice/MicButton.tsx
+++ b/src/components/voice/MicButton.tsx
@@ -37,7 +37,7 @@ export function MicButton({ sessionId }: { sessionId: string }) {
       disabled={state.kind === 'transcribing'}
       aria-label={label}
       title={label}
-      className={`absolute top-2 right-2 z-10 rounded p-1.5 bg-black/40 hover:bg-black/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-400 disabled:opacity-60 ${color}`}
+      className={`absolute bottom-2 right-2 z-10 rounded p-1.5 bg-black/40 hover:bg-black/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-400 disabled:opacity-60 ${color}`}
     >
       {state.kind === 'transcribing' ? (
         <Loader2 className="w-4 h-4 animate-spin" />


### PR DESCRIPTION
## Summary
- Scroll-to-bottom button moves from bottom-right (`bottom-4 right-4`) to bottom-center fixed (`bottom-4 left-1/2 -translate-x-1/2`).
- Mic button moves from top-right (`top-2 right-2`) to bottom-right fixed (`bottom-2 right-2`).

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (--max-warnings 0)
- [x] `npm test` vitest 1941 passed
- [x] harness-ui e2e 14/14
- [ ] Maintainer visual confirmation on a real machine

> **Strong-evidence gate:** This is a user-visible CSS layout change. CI green confirms tests pass but cannot confirm the buttons LOOK right. Maintainer must visually confirm on a real machine before merge: scroll-to-bottom button now centered at the bottom; mic button now at the bottom-right corner; no overlap; both still clickable.