### PR TITLE
feat(voice): warm whisper exe/model into page cache on startup

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -90,6 +90,7 @@ import { registerSystemIpc } from './ipc/systemIpc';
 import { registerSessionIpc } from './ipc/sessionIpc';
 import { registerWindowIpc } from './ipc/windowIpc';
 import { registerVoiceIpc } from './ipc/voiceIpc';
+import { warmUpTranscriber } from './voice/warmup';
 import { startMobileRemoteServer } from './remote/mobileRemoteServer';
 import {
   registerUtilityIpc,
@@ -270,6 +271,14 @@ app.whenReady().then(() => {
   registerWindowIpc({ ipcMain });
   registerUtilityIpc({ ipcMain });
   registerVoiceIpc({ ipcMain });
+
+  // Best-effort: warm the whisper exe/DLLs/model into the OS page cache a few
+  // seconds after launch so the user's first voice transcription isn't slowed
+  // by a cold disk read. Delayed so it doesn't compete with window paint / DB /
+  // IPC setup for I/O during the startup-critical window. Fire-and-forget.
+  setTimeout(() => {
+    void warmUpTranscriber();
+  }, 3000);
 
   // Process-wide IPC for the terminal pane's `onContextMenu` handler to
   // ask main to skip the native context menu for one upcoming click.

--- a/electron/voice/__tests__/warmup.test.ts
+++ b/electron/voice/__tests__/warmup.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: { getAppPath: () => '/repo' },
+}));
+
+const MODEL = '/repo/resources/models/ggml-base.bin';
+const BIN = '/repo/resources/whisper-bin/whisper-cli.exe';
+
+function mockTranscriberPaths() {
+  vi.doMock('../transcriber', () => ({
+    resolveModelPath: () => MODEL,
+    resolveBinPath: () => BIN,
+  }));
+}
+
+function mockFs(opts: { modelExists: boolean; binExists: boolean }) {
+  vi.doMock('fs', () => ({
+    existsSync: (p: string) => {
+      const s = String(p).replace(/\\/g, '/');
+      if (s.includes('ggml-base.bin')) return opts.modelExists;
+      if (s.includes('whisper-cli.exe')) return opts.binExists;
+      return false;
+    },
+    writeFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+  }));
+}
+
+describe('warmUpTranscriber', () => {
+  beforeEach(() => vi.resetModules());
+
+  it('runs one whisper-cli pass when model and binary both exist', async () => {
+    mockTranscriberPaths();
+    mockFs({ modelExists: true, binExists: true });
+    const runWhisperCli = vi
+      .fn()
+      .mockResolvedValue({ code: 0, stdout: '', stderr: '' });
+    vi.doMock('../whisperCli', () => ({ runWhisperCli }));
+
+    const { warmUpTranscriber } = await import('../warmup');
+    await warmUpTranscriber();
+
+    expect(runWhisperCli).toHaveBeenCalledTimes(1);
+    const arg = runWhisperCli.mock.calls[0][0];
+    expect(arg.modelPath).toBe(MODEL);
+    expect(arg.binPath).toBe(BIN);
+  });
+
+  it('does not spawn whisper-cli when the model is missing', async () => {
+    mockTranscriberPaths();
+    mockFs({ modelExists: false, binExists: true });
+    const runWhisperCli = vi.fn();
+    vi.doMock('../whisperCli', () => ({ runWhisperCli }));
+
+    const { warmUpTranscriber } = await import('../warmup');
+    await expect(warmUpTranscriber()).resolves.toBeUndefined();
+    expect(runWhisperCli).not.toHaveBeenCalled();
+  });
+
+  it('does not spawn whisper-cli when the binary is missing', async () => {
+    mockTranscriberPaths();
+    mockFs({ modelExists: true, binExists: false });
+    const runWhisperCli = vi.fn();
+    vi.doMock('../whisperCli', () => ({ runWhisperCli }));
+
+    const { warmUpTranscriber } = await import('../warmup');
+    await expect(warmUpTranscriber()).resolves.toBeUndefined();
+    expect(runWhisperCli).not.toHaveBeenCalled();
+  });
+
+  it('resolves without throwing when whisper-cli rejects', async () => {
+    mockTranscriberPaths();
+    const unlinkSync = vi.fn();
+    // Single fs mock that keeps existsSync truthy and captures unlinkSync.
+    vi.doMock('fs', () => ({
+      existsSync: () => true,
+      writeFileSync: vi.fn(),
+      unlinkSync,
+    }));
+    vi.doMock('../whisperCli', () => ({
+      runWhisperCli: vi.fn().mockRejectedValue(new Error('spawn ENOENT')),
+    }));
+
+    const { warmUpTranscriber } = await import('../warmup');
+    await expect(warmUpTranscriber()).resolves.toBeUndefined();
+    expect(unlinkSync).toHaveBeenCalledTimes(1); // temp wav cleaned up in finally
+  });
+});

--- a/electron/voice/warmup.ts
+++ b/electron/voice/warmup.ts
@@ -1,0 +1,37 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import * as os from 'os';
+import { resolveModelPath, resolveBinPath } from './transcriber';
+import { runWhisperCli } from './whisperCli';
+import { encodeWav } from './wavEncoder';
+
+// Best-effort, fire-and-forget warmup. Runs once after app start to fault the
+// whisper exe/DLLs (~52 MB) and model (148 MB) into the OS page cache, so the
+// user's FIRST real transcription is as fast as subsequent ones. The slow part
+// of a cold call is the page-cache miss, not process spawn — a single dummy run
+// pre-reads exactly those pages. Silent: any failure here must never surface to
+// the user or block startup; the real transcribe() path handles its own errors.
+export async function warmUpTranscriber(): Promise<void> {
+  const modelPath = resolveModelPath();
+  const binPath = resolveBinPath();
+  if (!fs.existsSync(modelPath) || !fs.existsSync(binPath)) return;
+
+  const pcm = new Float32Array(1600); // 0.1 s of silence at 16 kHz mono
+  const wavPath = path.join(
+    os.tmpdir(),
+    `ccsm-voice-warmup-${Date.now()}-${Math.random().toString(36).slice(2)}.wav`,
+  );
+  try {
+    fs.writeFileSync(wavPath, encodeWav(pcm, 16000));
+    const threads = Math.max(1, os.cpus().length - 2);
+    await runWhisperCli({ binPath, modelPath, wavPath, threads });
+  } catch {
+    /* best-effort: warmup failure is never user-visible */
+  } finally {
+    try {
+      fs.unlinkSync(wavPath);
+    } catch {
+      /* best-effort temp cleanup */
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The AVX2 whisper-cli backend (#1443) made steady-state transcription sub-second,
but the **first** `voice:transcribe` after launch is visibly slow: a fresh
`spawn(whisper-cli.exe)` must fault the exe + dependency DLLs (~52 MB) and the
model (`ggml-base.bin`, 148 MB) in from disk, page by page, since none are in the
OS page cache yet. Every subsequent call reads them from cache and is fast.

This adds a best-effort, fire-and-forget `warmUpTranscriber()` that runs once,
3 s after `app.whenReady()`, exercising the **same** code path as a real call
(resolve paths -> encode 0.1 s of silence -> spawn whisper-cli -> discard result)
to pre-read exactly those exe/DLL/model pages into the page cache before the user
records anything. It reuses the existing `resolveModelPath`/`resolveBinPath`/
`encodeWav`/`runWhisperCli` building blocks, swallows every error, unlinks its
temp wav in `finally`, and never touches the `transcribe()` interface.

Spec: `docs/superpowers/specs/2026-05-30-voice-coldstart-warmup-design.md`

### Files
- `electron/voice/warmup.ts` (new) — `warmUpTranscriber(): Promise<void>`, single responsibility.
- `electron/voice/__tests__/warmup.test.ts` (new) — 4 unit tests.
- `electron/main.ts` — import + `setTimeout(() => { void warmUpTranscriber(); }, 3000)` right after `registerVoiceIpc({ ipcMain })`.

Note: warmup reuses `resolveModelPath`/`resolveBinPath` from `transcriber.ts`, so
it tracks whatever model filename that module defines (currently `ggml-base.bin`)
with no hardcoding.

## Local checks (host: Windows 11, Node v24.14.0, mode: full)
- typecheck: OK (exit 0) — `tsc --noEmit && tsc --noEmit -p tsconfig.electron.json`
- lint: OK (exit 0) — `eslint . --max-warnings 0`
- unit tests: OK — `npm test` (vitest) -> `Test Files 203 passed (203) | Tests 1945 passed | 1 todo (1946)`, 36.75s. The single `it.todo` is pre-existing in `electron/__tests__/db-hardening.test.ts` (from #1427), unrelated to this change.
- UI e2e: OK — `node scripts/harness-ui.mjs` -> `totals: 14 passed, 0 failed, 0 skipped, 14 total` (21.9s). Confirms the `main.ts` wiring did not break app boot.

The two gates have conflicting native-ABI needs (vitest wants better-sqlite3 for
Node ABI; the Electron harness wants it for Electron ABI). Rebuilt
better-sqlite3 between them via `electron-rebuild -o better-sqlite3`. Parent will
handle final ABI restoration.

## Strong-evidence note (REQUIRED reading before claiming the perf win)

Page-cache warming is an **OS-level effect that headless/CI cannot observe**. The
unit tests only prove the warmup *runs and is safe*:
- both present -> `runWhisperCli` called once; temp wav written then unlinked
- model missing -> no spawn, does not throw
- binary missing -> no spawn, does not throw
- `runWhisperCli` rejects -> still resolves, temp wav still unlinked

They **cannot** prove the first real transcription got faster. The actual latency
win must be confirmed on the maintainer's real Windows machine: launch the build,
wait past the 3 s warmup, then do a first dictation and confirm it is now
sub-second (matching subsequent calls) instead of the previously-observed lag.

**I am not claiming a perf win on green CI alone** — real-machine confirmation is
still pending.

## Not for self-merge
Implementing dev only. Do not merge from here; independent review + merge handled
by the parent/reviewer.