### PR TITLE
fix(terminal): follow wheel scroll in self-drawn scrollbar via onRender

### DIFF
--- a/scripts/dogfood-scrollbar-pinned-bottom.mjs
+++ b/scripts/dogfood-scrollbar-pinned-bottom.mjs
@@ -1,0 +1,203 @@
+// scripts/dogfood-scrollbar-pinned-bottom.mjs
+//
+// Repro probe for the "scrollbar thumb is always pinned to the bottom" bug.
+//
+// User report: 现在任何时候滚动条都在底部 — the self-drawn terminal scrollbar
+// thumb (src/components/TerminalScrollbar.tsx, driven by useTerminalScroll)
+// never leaves the bottom of the track even after the user scrolls up.
+//
+// This probe drives the IDLE (no live claude output) path deterministically
+// via REAL MOUSE WHEEL — which is how users actually scroll, and the path
+// that reproduces the bug:
+//   1. force the terminal into normal buffer
+//   2. write enough lines to create scrollback (baseY > 0)
+//   3. scroll the viewport to the bottom (live tail)
+//   4. real mouse-wheel UP over the terminal host
+//   5. read xterm buffer geometry (viewportY / baseY / rows), the track px
+//      height, AND the rendered self-drawn thumb's style.top.
+//
+// Root cause this guards: xterm's `onScroll` emitter does NOT fire on
+// mouse-wheel scroll (only on programmatic scroll / write-driven scroll).
+// The self-drawn scrollbar originally subscribed only to `onScroll`, so the
+// thumb stayed frozen at its last bottom position while the viewport scrolled
+// up under the wheel — user symptom "任何时候滚动条都在底部". `useTerminalScroll`
+// now also subscribes to `onRender` (fires per wheel tick) to catch this.
+//
+// Expectation after wheel-up: viewportY << baseY, so the thumb must sit WELL
+// ABOVE the bottom — thumbTop ≈ travel*viewportY/baseY << travel. If the thumb
+// is pinned at the bottom (thumbTop ≈ travel) while viewportY << baseY, the bug
+// is present.
+//
+// Exit code 0 = PASS (thumb tracks viewportY), 1 = FAIL (thumb pinned to bottom).
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+  createIsolatedClaudeDir,
+  dismissWelcomeSplash,
+  launchCcsmIsolated,
+  seedSession,
+  waitForTerminalReady,
+  waitForXtermBuffer,
+} from './probe-utils-real-cli.mjs';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const MIN_THUMB = 24; // keep in sync with useTerminalScroll.ts
+
+async function readGeometry(win) {
+  return await win.evaluate(() => {
+    const t = window.__ccsmTerm;
+    const track = document.querySelector('[data-terminal-scrollbar]');
+    const thumb = document.querySelector('[data-terminal-scrollbar-thumb]');
+    const trackRect =
+      track instanceof HTMLElement ? track.getBoundingClientRect() : null;
+    return {
+      viewportY: t?.buffer?.active?.viewportY ?? null,
+      baseY: t?.buffer?.active?.baseY ?? null,
+      rows: t?.rows ?? null,
+      bufferType: t?.buffer?.active?.type ?? null,
+      trackHeight: trackRect ? trackRect.height : null,
+      thumbPresent: thumb instanceof HTMLElement,
+      thumbTop:
+        thumb instanceof HTMLElement ? parseFloat(thumb.style.top) : null,
+      thumbHeight:
+        thumb instanceof HTMLElement ? parseFloat(thumb.style.height) : null,
+    };
+  });
+}
+
+function expectedThumb(g) {
+  const total = g.baseY + g.rows;
+  const rawHeight = (g.trackHeight * g.rows) / total;
+  const thumbHeight = Math.min(g.trackHeight, Math.max(MIN_THUMB, rawHeight));
+  const travel = g.trackHeight - thumbHeight;
+  const clampedViewportY = Math.max(0, Math.min(g.baseY, g.viewportY));
+  const thumbTop = travel > 0 ? (travel * clampedViewportY) / g.baseY : 0;
+  return { thumbTop, thumbHeight, travel };
+}
+
+async function main() {
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'ccsm-scrollbar-pin-'));
+  createIsolatedClaudeDir(tempDir);
+
+  const { electronApp, win } = await launchCcsmIsolated({ tempDir });
+
+  try {
+    await win.waitForFunction(
+      () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+      null,
+      { timeout: 30000 },
+    );
+
+    await win.setViewportSize({ width: 700, height: 400 }).catch(() => {});
+    await sleep(200);
+
+    const { sid } = await seedSession(win, { name: 'pin', cwd: tempDir });
+    await win.evaluate((id) => window.__ccsmStore.getState().selectSession(id), sid);
+    await waitForTerminalReady(win, sid, { timeout: 45000 });
+    await waitForXtermBuffer(win, /claude|welcome|│|╭|\?\sfor\sshortcuts/i, {
+      timeout: 30000,
+    });
+    await dismissWelcomeSplash(win).catch(() => {});
+    await sleep(500);
+
+    // Force normal buffer + create scrollback, then scroll to the bottom
+    // (live tail) so the thumb's resting position is the bottom of the track.
+    await win.evaluate(() => {
+      const t = window.__ccsmTerm;
+      t.write('\x1b[?1049l'); // leave alt buffer (no-op if already normal)
+      for (let i = 0; i < 200; i++) t.write(`scrollbar-pin filler ${i}\r\n`);
+    });
+    await sleep(300);
+    await win.evaluate(() => window.__ccsmTerm.scrollToBottom());
+    await sleep(300);
+
+    const beforeWheel = await readGeometry(win);
+    console.log(`geometry at tail (before wheel): ${JSON.stringify(beforeWheel)}`);
+
+    // Real mouse wheel UP over the terminal host — the path that exposes the
+    // missing-onScroll bug. `term.scrollLines(...)` would NOT reproduce it.
+    const host = await win.$('[data-terminal-host]');
+    const box = await host.boundingBox();
+    await win.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    for (let i = 0; i < 12; i++) {
+      await win.mouse.wheel(0, -120);
+      await sleep(40);
+    }
+    await sleep(400);
+
+    const g = await readGeometry(win);
+    console.log(`geometry after real wheel-up x12: ${JSON.stringify(g)}`);
+
+    if (g.bufferType !== 'normal') {
+      console.error(`SETUP FAIL: expected normal buffer, got ${g.bufferType}`);
+      process.exitCode = 1;
+      return;
+    }
+    if (g.baseY == null || g.baseY <= 0) {
+      console.error(`SETUP FAIL: no scrollback (baseY=${g.baseY})`);
+      process.exitCode = 1;
+      return;
+    }
+    if (!g.thumbPresent || g.trackHeight == null) {
+      console.error(`SETUP FAIL: no self-drawn thumb (baseY=${g.baseY})`);
+      process.exitCode = 1;
+      return;
+    }
+    if (g.viewportY >= g.baseY) {
+      console.error(
+        `SETUP FAIL: scroll-up did not move viewportY off the tail ` +
+          `(viewportY=${g.viewportY} baseY=${g.baseY})`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const exp = expectedThumb(g);
+    const bottomThreshold = exp.travel - 1; // "pinned to bottom" if >= this
+    const dExpected = Math.abs(g.thumbTop - exp.thumbTop);
+
+    console.log(
+      `viewportY=${g.viewportY}/baseY=${g.baseY} travel=${exp.travel.toFixed(2)} ` +
+        `expected thumbTop=${exp.thumbTop.toFixed(2)} actual thumbTop=${g.thumbTop} ` +
+        `(Δ=${dExpected.toFixed(2)})`,
+    );
+
+    // Bug signature: scrolled up (viewportY << baseY) yet thumb sits at the
+    // very bottom of the track.
+    if (g.thumbTop >= bottomThreshold) {
+      console.error(
+        `FAIL (bug confirmed): thumb pinned to bottom. thumbTop=${g.thumbTop} ` +
+          `>= travel-1=${bottomThreshold.toFixed(2)} while viewportY=${g.viewportY} ` +
+          `<< baseY=${g.baseY}. Expected thumbTop≈${exp.thumbTop.toFixed(2)}. ` +
+          `See src/terminal/useTerminalScroll.ts.`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    if (dExpected > 2) {
+      console.error(
+        `FAIL: thumb not pinned but desynced from pure projection ` +
+          `(actual=${g.thumbTop}, expected=${exp.thumbTop.toFixed(2)}).`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log(
+      `PASS: thumb tracks viewportY after idle scroll-up ` +
+        `(thumbTop=${g.thumbTop} ≈ expected ${exp.thumbTop.toFixed(2)}, ` +
+        `well above bottom travel=${exp.travel.toFixed(2)}).`,
+    );
+  } finally {
+    await electronApp.close();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exitCode = 1;
+});

--- a/src/terminal/useTerminalScroll.ts
+++ b/src/terminal/useTerminalScroll.ts
@@ -12,10 +12,20 @@ import { getTopShell } from './shellRegistry';
 //
 // This hook reads xterm's buffer geometry directly and projects a thumb
 // position. There is no reverse sync — the thumb is a *pure function* of
-// the buffer state, so it can never desync. We re-read on the same event
-// set `useAtBottom` uses (`onScroll` + `onLineFeed`) plus `onResize`
-// (track-height / rows change on fit). Drag / track-click translate back
-// to `term.scrollToLine` / `term.scrollLines` against the same buffer.
+// the buffer state, so it can never desync. We re-read on `onScroll` +
+// `onLineFeed` + `onResize` (track-height / rows change on fit) AND on
+// `onRender`. The `onRender` subscription is load-bearing: xterm's
+// `onScroll` emitter does NOT fire for mouse-wheel scrolling (the wheel
+// handler scrolls the `.xterm-viewport` DOM element and repaints, but
+// never emits `onScroll`). Since the wheel is the primary way users
+// scroll, subscribing only to `onScroll` leaves the thumb frozen at its
+// last programmatic position — observed as "the thumb is always pinned to
+// the bottom" (dogfood-scrollbar-pinned-bottom.mjs: onScroll fires 0×,
+// onRender fires per wheel tick). `onRender` fires on every viewport
+// repaint, so it catches wheel scroll; `setGeom` skips no-op updates so
+// the extra firings during live output don't churn React. Drag /
+// track-click translate back to `term.scrollToLine` / `term.scrollLines`
+// against the same buffer.
 //
 // All geometry is in the pure functions below, exported for unit tests.
 
@@ -121,11 +131,19 @@ export function useTerminalScroll(
   useEffect(() => {
     const recompute = (): void => {
       const buf = readBuffer();
-      if (!buf) {
-        setGeom({ visible: false, thumbTop: 0, thumbHeight: 0 });
-        return;
-      }
-      setGeom(computeThumb(buf, trackHeight));
+      const next = buf
+        ? computeThumb(buf, trackHeight)
+        : { visible: false, thumbTop: 0, thumbHeight: 0 };
+      // Skip no-op updates: `onRender` fires on every viewport repaint
+      // (including each frame of live output), but the thumb geometry only
+      // changes when the buffer scroll position or size actually moves.
+      setGeom((prev) =>
+        prev.visible === next.visible &&
+        prev.thumbTop === next.thumbTop &&
+        prev.thumbHeight === next.thumbHeight
+          ? prev
+          : next,
+      );
     };
 
     const term = getTopShell()?.term;
@@ -137,10 +155,13 @@ export function useTerminalScroll(
     const scrollDisposable = term.onScroll(recompute);
     const lineFeedDisposable = term.onLineFeed(recompute);
     const resizeDisposable = term.onResize(recompute);
+    // `onScroll` misses wheel scrolling; `onRender` covers it (see header).
+    const renderDisposable = term.onRender(recompute);
     return () => {
       scrollDisposable.dispose();
       lineFeedDisposable.dispose();
       resizeDisposable.dispose();
+      renderDisposable.dispose();
     };
   }, [sessionId, trackHeight]);
 

--- a/tests/terminal/useTerminalScroll.subscription.test.tsx
+++ b/tests/terminal/useTerminalScroll.subscription.test.tsx
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Hook-level subscription test for `useTerminalScroll`. The pure geometry is
+// pinned in `useTerminalScroll.test.ts`; this file guards the *subscription*
+// regression behind the "scrollbar always pinned to the bottom" bug.
+//
+// Root cause: xterm's `onScroll` emitter does NOT fire on mouse-wheel
+// scrolling — only `onRender` does. The hook must subscribe to `onRender`
+// (in addition to `onScroll` / `onLineFeed` / `onResize`) so the thumb
+// follows wheel scrolling instead of freezing at its last position.
+
+type Listener = () => void;
+const listeners: Record<'scroll' | 'lineFeed' | 'resize' | 'render', Listener | null> = {
+  scroll: null,
+  lineFeed: null,
+  resize: null,
+  render: null,
+};
+
+const fakeBuffer = { active: { viewportY: 0, baseY: 0 } };
+const mk = (key: keyof typeof listeners) =>
+  vi.fn((cb: Listener) => {
+    listeners[key] = cb;
+    return {
+      dispose: vi.fn(() => {
+        listeners[key] = null;
+      }),
+    };
+  });
+
+const fakeTerm = {
+  rows: 24,
+  get buffer() {
+    return fakeBuffer;
+  },
+  onScroll: mk('scroll'),
+  onLineFeed: mk('lineFeed'),
+  onResize: mk('resize'),
+  onRender: mk('render'),
+  scrollToLine: vi.fn(),
+  scrollLines: vi.fn(),
+};
+
+vi.mock('../../src/terminal/shellRegistry', () => ({
+  getTopShell: vi.fn(() => ({ term: fakeTerm })),
+}));
+
+import { useTerminalScroll } from '../../src/terminal/useTerminalScroll';
+
+const H = 200;
+
+describe('useTerminalScroll (subscriptions)', () => {
+  beforeEach(() => {
+    fakeBuffer.active.viewportY = 0;
+    fakeBuffer.active.baseY = 0;
+    listeners.scroll = null;
+    listeners.lineFeed = null;
+    listeners.resize = null;
+    listeners.render = null;
+    fakeTerm.onScroll.mockClear();
+    fakeTerm.onLineFeed.mockClear();
+    fakeTerm.onResize.mockClear();
+    fakeTerm.onRender.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('subscribes to onRender (wheel scroll signal), not just onScroll', () => {
+    renderHook(() => useTerminalScroll('sid-A', H));
+    expect(fakeTerm.onScroll).toHaveBeenCalledTimes(1);
+    expect(fakeTerm.onLineFeed).toHaveBeenCalledTimes(1);
+    expect(fakeTerm.onResize).toHaveBeenCalledTimes(1);
+    expect(fakeTerm.onRender).toHaveBeenCalledTimes(1);
+  });
+
+  it('follows wheel scroll: thumb moves off the bottom when only onRender fires', () => {
+    // Start at the live tail (thumb at bottom).
+    fakeBuffer.active.baseY = 100;
+    fakeBuffer.active.viewportY = 100;
+    const { result } = renderHook(() => useTerminalScroll('sid-A', H));
+    const bottomTop = result.current.thumbTop;
+    expect(bottomTop).toBeCloseTo(H - result.current.thumbHeight, 6);
+
+    // Wheel scroll up: xterm moves viewportY but fires ONLY onRender
+    // (no onScroll). The thumb must follow.
+    act(() => {
+      fakeBuffer.active.viewportY = 0;
+      listeners.render!();
+    });
+    expect(result.current.thumbTop).toBe(0);
+    expect(result.current.thumbTop).not.toBe(bottomTop);
+  });
+
+  it('disposes the onRender listener on unmount', () => {
+    const { unmount } = renderHook(() => useTerminalScroll('sid-A', H));
+    const renderDispose = fakeTerm.onRender.mock.results[0]!.value
+      .dispose as ReturnType<typeof vi.fn>;
+    unmount();
+    expect(renderDispose).toHaveBeenCalled();
+  });
+
+  it('skips redundant state updates when geometry is unchanged across renders', () => {
+    fakeBuffer.active.baseY = 100;
+    fakeBuffer.active.viewportY = 40;
+    const { result } = renderHook(() => useTerminalScroll('sid-A', H));
+    const first = result.current;
+    // onRender fires repeatedly during live output but geometry is identical;
+    // the hook should keep the same geometry object (no-op update).
+    act(() => {
+      listeners.render!();
+      listeners.render!();
+    });
+    expect(result.current.thumbTop).toBe(first.thumbTop);
+    expect(result.current.thumbHeight).toBe(first.thumbHeight);
+    expect(result.current.visible).toBe(first.visible);
+  });
+});


### PR DESCRIPTION
## Root cause
The self-drawn terminal scrollbar thumb was pinned to the bottom of the track on **mouse-wheel scroll** because `useTerminalScroll` recomputed the thumb only on xterm's `onScroll`/`onLineFeed`/`onResize`, and **xterm's `onScroll` emitter does not fire for wheel scrolling** (the wheel handler scrolls the `.xterm-viewport` DOM element + repaints, never emitting `onScroll`). Wheel is the primary way users scroll, so the thumb stayed frozen at its last programmatic position — user symptom "任何时候滚动条都在底部". This is a regression from PR #1442 (the self-drawn scrollbar). It is candidate **(A)** — a subscription gap, not auto-scroll pull-back.

## Signal evidence (real mouse wheel over the terminal host)
Instrumented the live app while wheeling up 10 ticks:
```
onScroll: 0   (never fires on wheel)
domScroll: 10 (.xterm-viewport DOM 'scroll' fires per tick)
onRender: 10  (fires per tick — chosen as the public-API signal)
```

## Fix
Also subscribe to `term.onRender` (public xterm API, fires on every viewport repaint incl. wheel). `setGeom` now skips no-op updates so the extra firings during live output don't churn React. Change is confined to `src/terminal/useTerminalScroll.ts`.

## Before / after (failing dimension: thumbTop vs viewportY)
`scripts/dogfood-scrollbar-pinned-bottom.mjs` — real mouse wheel, idle (no live claude output):
- **before fix**: wheel-up moves `viewportY 191 -> 143` but `thumbTop` stays **326.921** (pinned to bottom, travel=326.92, expected 244.76) → **FAIL**
- **after fix**: `thumbTop` tracks to **244.763** (= expected 244.76) → **PASS**

## What changed
- `src/terminal/useTerminalScroll.ts` — add `onRender` subscription + no-op `setGeom` guard.
- `tests/terminal/useTerminalScroll.subscription.test.tsx` (new) — hook-level test: asserts `onRender` is subscribed and the thumb follows when **only** `onRender` fires (the wheel case).
- `scripts/dogfood-scrollbar-pinned-bottom.mjs` (new) — real-wheel dogfood regression guard, exit 0/1.

## Reverse-verify
Unit (strip `onRender` sub → restore):
- removed → `useTerminalScroll.subscription.test.tsx` 4 tests **FAIL**
- restored → **PASS** (20 scroll tests pass)

Dogfood (strip → restore):
- removed → probe **FAIL** (thumbTop 326.921 pinned while viewportY=143)
- restored → probe **PASS** (thumbTop 244.763 tracks viewportY)

## Local checks (host: Windows 11, mode: full)
- lint: ✓ (exit 0)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0)
- tests: `npm test` — Test Files 204 passed (204), Tests 1949 passed | 1 todo (39.99s)
- dogfood: `scripts/dogfood-scrollbar-pinned-bottom.mjs` — PASS (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)