### PR TITLE
feat(mobile-remote): PR-2 desktop WebRTC peer over werift DataChannel

### DIFF
--- a/electron/remote/__tests__/desktopPeer.loopback.test.ts
+++ b/electron/remote/__tests__/desktopPeer.loopback.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment node
+// werift drives real UDP (ICE) + SCTP over Node's net/dgram stack. The default
+// jsdom environment shims those globals and the DataChannel never opens, so
+// this loopback suite must run in the plain Node environment.
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { RTCPeerConnection } from 'werift';
+
+const inputCalls: Array<[string, string]> = [];
+vi.mock('../../ptyHost', () => ({
+  listPtySessions: () => [{ sid: 's1', cwd: '/tmp', cols: 80, rows: 24, pid: 1 }],
+  getBufferSnapshot: async () => ({ data: '', seq: 0 }),
+  getPtySession: () => ({ cols: 80, rows: 24 }),
+  inputPtySession: (sid: string, data: string) => { inputCalls.push([sid, data]); },
+  resizePtySession: () => {},
+  onPtyData: (cb: (sid: string, chunk: string, seq: number) => void) => {
+    emitPtyData = cb;
+    return () => { emitPtyData = null; };
+  },
+}));
+
+let emitPtyData: ((sid: string, chunk: string, seq: number) => void) | null = null;
+
+import { createDesktopPeer } from '../desktopPeer';
+import type { SignalingClient, SignalDescription, SignalCandidate } from '../signaling';
+
+/** In-memory signaling bus: directly hands the desktop side whatever the phone
+ *  side produces and vice-versa. No network. */
+function makeSignalingPair() {
+  let onOfferCb: ((o: SignalDescription, p: string) => void) | null = null;
+  let onIceCb: ((c: SignalCandidate, p: string) => void) | null = null;
+  const phone = {
+    deliverAnswer: null as null | ((a: SignalDescription) => void),
+    deliverIce: null as null | ((c: SignalCandidate) => void),
+    sendOffer(o: SignalDescription) { onOfferCb?.(o, 'phone1'); },
+    sendIce(c: SignalCandidate) { onIceCb?.(c, 'phone1'); },
+  };
+  const desktopSignaling: SignalingClient = {
+    onOffer: (cb) => { onOfferCb = cb; },
+    onRemoteIce: (cb) => { onIceCb = cb; },
+    sendAnswer: (a) => phone.deliverAnswer?.(a),
+    sendIce: (c) => phone.deliverIce?.(c),
+    close: () => {},
+  };
+  return { phone, desktopSignaling };
+}
+
+describe('createDesktopPeer loopback', () => {
+  beforeEach(() => { inputCalls.length = 0; });
+
+  it('runs session.input over a real DataChannel into ptyHost', async () => {
+    const { phone, desktopSignaling } = makeSignalingPair();
+    const clients = new Set<{ subscribedSid: string | null; send: (p: unknown) => void }>();
+    const peer = createDesktopPeer({ iceServers: [], signaling: desktopSignaling, clients });
+
+    const phonePc = new RTCPeerConnection({ iceServers: [] });
+    const dc = phonePc.createDataChannel('terminal');
+    phonePc.onIceCandidate.subscribe((c) => { if (c) phone.sendIce(c as SignalCandidate); });
+    phone.deliverAnswer = async (a) => { await phonePc.setRemoteDescription(a as never); };
+    phone.deliverIce = async (c) => { await phonePc.addIceCandidate(c as never); };
+
+    const offer = await phonePc.createOffer();
+    await phonePc.setLocalDescription(offer);
+    phone.sendOffer({ type: 'offer', sdp: offer.sdp });
+
+    await new Promise<void>((resolve) => { dc.onopen = () => resolve(); });
+    dc.send(JSON.stringify({ type: 'session.input', sid: 's1', data: 'ls\n' }));
+
+    await vi.waitFor(() => expect(inputCalls).toEqual([['s1', 'ls\n']]), { timeout: 5000 });
+
+    peer.close();
+    await phonePc.close();
+  }, 15000);
+
+  it('forwards pty.data only after subscribe and only for the viewed session', async () => {
+    const { phone, desktopSignaling } = makeSignalingPair();
+    const clients = new Set<{ subscribedSid: string | null; send: (p: unknown) => void }>();
+    const peer = createDesktopPeer({ iceServers: [], signaling: desktopSignaling, clients });
+
+    const phonePc = new RTCPeerConnection({ iceServers: [] });
+    const dc = phonePc.createDataChannel('terminal');
+    phonePc.onIceCandidate.subscribe((c) => { if (c) phone.sendIce(c as SignalCandidate); });
+    phone.deliverAnswer = async (a) => { await phonePc.setRemoteDescription(a as never); };
+    phone.deliverIce = async (c) => { await phonePc.addIceCandidate(c as never); };
+
+    const received: Array<Record<string, unknown>> = [];
+    dc.onmessage = (e) => received.push(JSON.parse(e.data as string));
+
+    const offer = await phonePc.createOffer();
+    await phonePc.setLocalDescription(offer);
+    phone.sendOffer({ type: 'offer', sdp: offer.sdp });
+    await new Promise<void>((resolve) => { dc.onopen = () => resolve(); });
+
+    // Before subscribe: a pty.data for s1 must NOT reach this client.
+    emitPtyData?.('s1', 'early', 1);
+    // Subscribe to s1, then emit again.
+    dc.send(JSON.stringify({ type: 'session.snapshot', sid: 's1' }));
+    await vi.waitFor(() => expect(received.some((m) => m.type === 'session.snapshot')).toBe(true), { timeout: 5000 });
+    emitPtyData?.('s2', 'wrong-session', 2);
+    emitPtyData?.('s1', 'right-session', 3);
+
+    await vi.waitFor(() => {
+      const data = received.filter((m) => m.type === 'pty.data');
+      expect(data).toEqual([{ type: 'pty.data', sid: 's1', chunk: 'right-session', seq: 3 }]);
+    }, { timeout: 5000 });
+
+    peer.close();
+    await phonePc.close();
+  }, 15000);
+});

--- a/electron/remote/__tests__/peerClient.test.ts
+++ b/electron/remote/__tests__/peerClient.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('../../ptyHost', () => ({
+  listPtySessions: vi.fn(() => [{ sid: 's1', cwd: '/tmp', cols: 80, rows: 24, pid: 1 }]),
+  getBufferSnapshot: vi.fn(async () => ({ data: 'hello', seq: 0 })),
+  getPtySession: vi.fn(() => ({ cols: 80, rows: 24 })),
+  inputPtySession: vi.fn(),
+  resizePtySession: vi.fn(),
+  onPtyData: vi.fn(() => () => {}),
+}));
+
+import { handleClientMessage } from '../remoteMessages';
+import type { PeerClient } from '../peerClient';
+import { inputPtySession } from '../../ptyHost';
+
+function makeFakeClient(): PeerClient & { sent: unknown[] } {
+  const sent: unknown[] = [];
+  return { sent, subscribedSid: null, send: (p) => sent.push(p) };
+}
+
+describe('handleClientMessage over PeerClient', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('answers sessions.list', async () => {
+    const c = makeFakeClient();
+    await handleClientMessage(c, JSON.stringify({ type: 'sessions.list' }));
+    expect(c.sent).toEqual([{ type: 'sessions.list', sessions: [{ sid: 's1', cwd: '/tmp', cols: 80, rows: 24 }] }]);
+  });
+
+  it('routes session.input to ptyHost', async () => {
+    const c = makeFakeClient();
+    await handleClientMessage(c, JSON.stringify({ type: 'session.input', sid: 's1', data: 'x' }));
+    expect(inputPtySession).toHaveBeenCalledWith('s1', 'x');
+  });
+
+  it('records subscribedSid on snapshot', async () => {
+    const c = makeFakeClient();
+    await handleClientMessage(c, JSON.stringify({ type: 'session.snapshot', sid: 's1' }));
+    expect(c.subscribedSid).toBe('s1');
+  });
+});

--- a/electron/remote/__tests__/ptyFanout.test.ts
+++ b/electron/remote/__tests__/ptyFanout.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { fanoutPtyData } from '../ptyFanout';
+import type { PeerClient } from '../peerClient';
+
+function client(subscribedSid: string | null): PeerClient & { sent: unknown[] } {
+  const sent: unknown[] = [];
+  return { sent, subscribedSid, send: (p) => sent.push(p) };
+}
+
+describe('fanoutPtyData', () => {
+  it("delivers a session's bytes only to clients viewing that session", () => {
+    const a = client('s1');
+    const b = client('s2');
+    const c = client(null);
+    fanoutPtyData(new Set([a, b, c]), 's1', 'OUT', 7);
+    expect(a.sent).toEqual([{ type: 'pty.data', sid: 's1', chunk: 'OUT', seq: 7 }]);
+    expect(b.sent).toEqual([]);
+    expect(c.sent).toEqual([]);
+  });
+});

--- a/electron/remote/desktopPeer.ts
+++ b/electron/remote/desktopPeer.ts
@@ -1,0 +1,98 @@
+import { RTCPeerConnection, type RTCIceServer } from 'werift';
+import { onPtyData } from '../ptyHost';
+import { handleClientMessage, listEntries } from './remoteMessages';
+import { fanoutPtyData } from './ptyFanout';
+import type { PeerClient } from './peerClient';
+import type { SignalCandidate, SignalingClient } from './signaling';
+
+/** Builds the desktop WebRTC answerer: it accepts a phone's offer via the
+ *  injected signaling transport, opens the `terminal` DataChannel, and runs the
+ *  EXISTING terminal protocol (`handleClientMessage` + pty.data fan-out) over
+ *  that channel. The DataChannel replaces the WebSocket; the protocol core is
+ *  untouched (detail spec §1.2-D, §6). `clients` is the shared peer set the
+ *  pty.data fan-out iterates — owned by the caller so multiple phones can be
+ *  tracked together (detail spec §5.7). */
+export function createDesktopPeer(opts: {
+  iceServers: RTCIceServer[];
+  signaling: SignalingClient;
+  clients: Set<PeerClient>;
+}): { close: () => void } {
+  const { signaling, clients } = opts;
+  const pcs = new Set<RTCPeerConnection>();
+
+  const offPtyData = onPtyData((sid, chunk, seq) => {
+    fanoutPtyData(clients, sid, chunk, seq);
+  });
+
+  signaling.onOffer(async (offer, peerId) => {
+    const pc = new RTCPeerConnection({ iceServers: opts.iceServers });
+    pcs.add(pc);
+
+    pc.onIceCandidate.subscribe((cand) => {
+      // werift hands us its own RTCIceCandidate; forward only the plain wire
+      // fields the SignalCandidate contract carries (candidate/sdpMid/
+      // sdpMLineIndex). The signaling transport must not depend on werift's
+      // class shape.
+      if (!cand) return;
+      const wire: SignalCandidate = {
+        candidate: cand.candidate,
+        sdpMid: cand.sdpMid ?? null,
+        sdpMLineIndex: cand.sdpMLineIndex ?? null,
+      };
+      signaling.sendIce(wire, peerId);
+    });
+
+    pc.onDataChannel.subscribe((channel) => {
+      if (channel.label !== 'terminal') return;
+      const client: PeerClient = {
+        subscribedSid: null,
+        send: (payload) => {
+          if (channel.readyState === 'open') channel.send(JSON.stringify(payload));
+        },
+      };
+      channel.onMessage.subscribe((msg) => {
+        const raw = typeof msg === 'string' ? msg : msg.toString();
+        void handleClientMessage(client, raw);
+      });
+      // The phone learns the session list as soon as the channel opens, same as
+      // the WS server's initial push (mobileRemoteServer.ts). auth.ok is gone —
+      // auth happened at the signaling/GitHub layer (detail spec §6).
+      const pushList = () => client.send({ type: 'sessions.list', sessions: listEntries() });
+      if (channel.readyState === 'open') pushList();
+      else channel.stateChanged.subscribe((s) => { if (s === 'open') pushList(); });
+      clients.add(client);
+
+      const drop = () => clients.delete(client);
+      channel.stateChanged.subscribe((s) => { if (s === 'closed') drop(); });
+    });
+
+    await pc.setRemoteDescription({ type: 'offer', sdp: offer.sdp });
+    const answer = await pc.createAnswer();
+    await pc.setLocalDescription(answer);
+    signaling.sendAnswer({ type: 'answer', sdp: answer.sdp }, peerId);
+  });
+
+  signaling.onRemoteIce(async (cand) => {
+    for (const pc of pcs) {
+      try {
+        await pc.addIceCandidate({
+          candidate: cand.candidate,
+          sdpMid: cand.sdpMid ?? undefined,
+          sdpMLineIndex: cand.sdpMLineIndex ?? undefined,
+        });
+      } catch {
+        /* candidate may target a different pc; ignore mismatches */
+      }
+    }
+  });
+
+  return {
+    close: () => {
+      offPtyData();
+      signaling.close();
+      for (const pc of pcs) void pc.close();
+      pcs.clear();
+      clients.clear();
+    },
+  };
+}

--- a/electron/remote/mobileRemoteServer.ts
+++ b/electron/remote/mobileRemoteServer.ts
@@ -4,6 +4,7 @@ import { onPtyData } from '../ptyHost';
 import { renderMobilePage } from './mobilePage';
 import { displayHost, parseRequestUrl, resolveHost, resolvePort, sendHtml, sendJson, sendText, tokenMatches } from './remoteHttp';
 import { handleClientMessage, listEntries, listSignature } from './remoteMessages';
+import { fanoutPtyData } from './ptyFanout';
 import {
   buildUpgradeResponse,
   closeSocket,
@@ -139,18 +140,10 @@ export function startMobileRemoteServer(options?: {
   const offPtyData = onPtyData((sid, chunk, seq) => {
     // seq is ptyHost's authoritative per-session chunk counter — the SAME one
     // getBufferSnapshot captures. Forward it verbatim so the client can dedupe
-    // live chunks already baked into a snapshot (drop seq <= snapSeq). Earlier
-    // this server kept its own seqBySid counter starting at 0, which diverged
-    // from ptyHost's and made the client drop every live chunk after a
-    // non-empty snapshot — a frozen mobile terminal.
-    for (const client of clients) {
-      // Only forward this session's bytes to clients viewing it. Without this
-      // gate every client receives every session's raw terminal output over
-      // the wire — a cross-session data leak (the HTML client only filters for
-      // display, not on the network).
-      if (client.subscribedSid !== sid) continue;
-      client.send({ type: 'pty.data', sid, chunk, seq });
-    }
+    // live chunks already baked into a snapshot (drop seq <= snapSeq). The
+    // shared fan-out applies the `subscribedSid` cross-session-leak gate so
+    // only clients viewing this session receive its bytes (detail spec §6).
+    fanoutPtyData(clients, sid, chunk, seq);
   });
 
   const shownHost = displayHost(boundHost);

--- a/electron/remote/peerClient.ts
+++ b/electron/remote/peerClient.ts
@@ -1,0 +1,13 @@
+/** The minimal, transport-agnostic surface the terminal protocol needs from a
+ *  connected client. Both the LAN WebSocket server (`WsClient`) and the WebRTC
+ *  DataChannel peer satisfy this — `handleClientMessage` and the pty.data
+ *  fan-out depend ONLY on these two members, so the same protocol core serves
+ *  both pipes (detail spec §6 "swap the pipe, keep the protocol"). */
+export type PeerClient = {
+  /** The single session id this client is viewing, set on `session.snapshot`.
+   *  The pty.data fan-out forwards a session's bytes only to clients whose
+   *  `subscribedSid` matches — without it every client gets every session's raw
+   *  output (cross-session leak). `null` = not subscribed yet. */
+  subscribedSid: string | null;
+  send: (payload: unknown) => void;
+};

--- a/electron/remote/ptyFanout.ts
+++ b/electron/remote/ptyFanout.ts
@@ -1,0 +1,19 @@
+import type { PeerClient } from './peerClient';
+
+/** Forward one session's terminal bytes to every connected client viewing that
+ *  session. The `subscribedSid` gate is the cross-session-leak guard: without
+ *  it every client receives every session's raw output. `seq` is ptyHost's
+ *  authoritative per-session chunk counter, forwarded verbatim so the client
+ *  can dedupe live chunks already baked into a snapshot. Transport-agnostic:
+ *  works for WS and DataChannel clients alike (detail spec §6). */
+export function fanoutPtyData(
+  clients: Iterable<PeerClient>,
+  sid: string,
+  chunk: string,
+  seq: number,
+): void {
+  for (const client of clients) {
+    if (client.subscribedSid !== sid) continue;
+    client.send({ type: 'pty.data', sid, chunk, seq });
+  }
+}

--- a/electron/remote/remoteMessages.ts
+++ b/electron/remote/remoteMessages.ts
@@ -6,7 +6,7 @@ import {
   resizePtySession,
 } from '../ptyHost';
 import { isRecord } from './remoteHttp';
-import type { WsClient } from './wsProtocol';
+import type { PeerClient } from './peerClient';
 
 /** The session-chip payload the mobile client renders: just the identity and
  *  size it needs. We deliberately omit `pid` — it is noise on the wire and the
@@ -30,7 +30,7 @@ export function listSignature(entries: SessionListEntry[]): string {
   return entries.map((e) => `${e.sid}:${e.cwd}`).join('|');
 }
 
-export async function handleClientMessage(client: WsClient, raw: string): Promise<void> {
+export async function handleClientMessage(client: PeerClient, raw: string): Promise<void> {
   let message: unknown;
   try {
     message = JSON.parse(raw);

--- a/electron/remote/signaling.ts
+++ b/electron/remote/signaling.ts
@@ -1,0 +1,16 @@
+/** WebRTC signaling is the out-of-band exchange of SDP offer/answer and ICE
+ *  candidates that lets two peers find each other. In production this rides a
+ *  Cloudflare Durable Object WebSocket (detail spec §3); here we depend only on
+ *  this interface so the desktop peer is testable with an in-memory fake and
+ *  the real transport lands in a later PR without touching peer logic. */
+export type SignalDescription = { type: 'offer' | 'answer'; sdp: string };
+export type SignalCandidate = { candidate: string; sdpMid?: string | null; sdpMLineIndex?: number | null };
+
+export type SignalingClient = {
+  /** Desktop is the answerer: it is handed the phone's offer. */
+  onOffer: (cb: (offer: SignalDescription, peerId: string) => void) => void;
+  onRemoteIce: (cb: (cand: SignalCandidate, peerId: string) => void) => void;
+  sendAnswer: (answer: SignalDescription, peerId: string) => void;
+  sendIce: (cand: SignalCandidate, peerId: string) => void;
+  close: () => void;
+};

--- a/electron/remote/wsProtocol.ts
+++ b/electron/remote/wsProtocol.ts
@@ -1,25 +1,19 @@
 import * as crypto from 'crypto';
 import type { Duplex } from 'stream';
+import type { PeerClient } from './peerClient';
 
-export type WsClient = {
+export type WsClient = PeerClient & {
   socket: Duplex;
   pending: Buffer;
   /** Accumulator for fragmented text messages (FIN=0). Reset on each
    *  complete message; non-empty means we're mid-fragment. */
   fragment: Buffer;
-  /** The single session id this client is currently viewing, set when the
-   *  client sends `session.snapshot` (the "select this session" signal).
-   *  pty.data is only forwarded to clients whose `subscribedSid` matches the
-   *  emitting sid — otherwise every client would receive every session's raw
-   *  terminal bytes (cross-session data leak). `null` = not subscribed yet. */
-  subscribedSid: string | null;
   /** Liveness flag for the heartbeat sweep. Set true on any inbound Pong or
    *  message; the sweep clears it before each Ping and reaps the client on the
    *  next sweep if it's still false — i.e. a full interval passed with no
    *  inbound traffic, meaning the socket is half-open (phone vanished without a
    *  TCP FIN). `socket.on('close')`/'error' can't catch that case. */
   isAlive: boolean;
-  send: (payload: unknown) => void;
 };
 
 /** Hard cap on a single inbound text message. Anything beyond this is a

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "react-i18next": "^17.0.4",
         "smart-whisper": "^0.8.1",
         "tailwind-merge": "^2.5.5",
+        "werift": "^0.23.0",
         "zustand": "^5.0.12"
       },
       "devDependencies": {
@@ -1388,6 +1389,28 @@
         "module-details-from-path": "^1.0.4"
       }
     },
+    "node_modules/@fidm/asn1": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/@fidm/asn1/-/asn1-1.0.4.tgz",
+      "integrity": "sha512-esd1jyNvRb2HVaQGq2Gg8Z0kbQPXzV9Tq5Z14KNIov6KfFD6PTaRIO8UpcsYiTNzOqJpmyzWgVTrUwFV3UF4TQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@fidm/x509": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/@fidm/x509/-/x509-1.2.1.tgz",
+      "integrity": "sha512-nwc2iesjyc9hkuzcrMCBXQRn653XuAUKorfWM8PZyJawiy1QzLj4vahwzaI25+pfpwOLvMzbJ0uKpWLDNmo16w==",
+      "license": "MIT",
+      "dependencies": {
+        "@fidm/asn1": "^1.0.4",
+        "tweetnacl": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -2085,7 +2108,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@malept/cross-spawn-promise": {
@@ -2165,6 +2187,12 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@minhducsun2002/leb128": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/@minhducsun2002/leb128/-/leb128-1.0.0.tgz",
+      "integrity": "sha512-eFrYUPDVHeuwWHluTG1kwNQUEUcFjVKYwPkU8z9DR1JH3AW7JtJsG9cRVGmwz809kKtGfwGJj58juCZxEvnI/g==",
+      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
@@ -2248,6 +2276,33 @@
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmmirror.com/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmmirror.com/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@opentelemetry/api": {
@@ -2777,7 +2832,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-cms/-/asn1-cms-2.6.1.tgz",
       "integrity": "sha512-vdG4fBF6Lkirkcl53q6eOdn3XYKt+kJTG59edgRZORlg/3atWWEReRCx5rYE1ZzTTX6vLK5zDMjHh7vbrcXGtw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.6.0",
@@ -2791,7 +2845,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-csr/-/asn1-csr-2.6.1.tgz",
       "integrity": "sha512-WRWnKfIocHyzFYQTka8O/tXCiBquAPSrRjXbOkHbO4qdmS6loffCEGs+rby6WxxGdJCuunnhS2duHURhjyio6w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.6.0",
@@ -2804,7 +2857,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-ecc/-/asn1-ecc-2.6.1.tgz",
       "integrity": "sha512-+Vqw8WFxrtDIN5ehUdvlN2m73exS2JVG0UAyfVB31gIfor3zWEAQPD+K9ydCxaj3MLen9k0JhKpu9LqviuCE1g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.6.0",
@@ -2817,7 +2869,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-pfx/-/asn1-pfx-2.6.1.tgz",
       "integrity": "sha512-nB5jVQy3MAAWvq0KY0R2JUZG8bO/bTLpnwyOzXyEh/e54ynGTatAR+csOnXkkVD9AFZ2uL8Z7EV918+qB1qDvw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-cms": "^2.6.1",
@@ -2832,7 +2883,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs8/-/asn1-pkcs8-2.6.1.tgz",
       "integrity": "sha512-JB5iQ9Izn5yGMw3ZG4Nw3Xn/hb/G38GYF3lf7WmJb8JZUydhVGEjK/ZlFSWhnlB7K/4oqEs8HnfFIKklhR58Tw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.6.0",
@@ -2845,7 +2895,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-pkcs9/-/asn1-pkcs9-2.6.1.tgz",
       "integrity": "sha512-5EV8nZoMSxeWmcxWmmcolg22ojZRgJg+Y9MX2fnE2bGRo5KQLqV5IL9kdSQDZxlHz95tHvIq9F//bvL1OeNILw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-cms": "^2.6.1",
@@ -2862,7 +2911,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-rsa/-/asn1-rsa-2.6.1.tgz",
       "integrity": "sha512-1nVMEh46SElUt5CB3RUTV4EG/z7iYc7EoaDY5ECwganibQPkZ/Y2eMsTKB/LeyrUJ+W/tKoD9WUqIy8vB+CEdA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.6.0",
@@ -2875,7 +2923,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.6.0.tgz",
       "integrity": "sha512-xNLYLBFTBKkCzEZIw842BxytQQATQv+lDTCEMZ8C196iJcJJMBUZxrhSTxLaohMyKK8QlzRNTRkUmanucnDSqg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "asn1js": "^3.0.6",
@@ -2887,7 +2934,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509/-/asn1-x509-2.6.1.tgz",
       "integrity": "sha512-O9jT5F1A2+t3r7C4VT7LYGXqkGLK7Kj1xFpz7U0isPrubwU5PbDoyYtx6MiGst29yq7pXN5vZbQFKRCP+lLZlA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.6.0",
@@ -2900,7 +2946,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/@peculiar/asn1-x509-attr/-/asn1-x509-attr-2.6.1.tgz",
       "integrity": "sha512-tlW6cxoHwgcQghnJwv3YS+9OO1737zgPogZ+CgWRUK4roEwIPzRH4JEiG770xe5HX2ATfCpmX60gurfWIF9dcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-schema": "^2.6.0",
@@ -2913,7 +2958,6 @@
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/@peculiar/x509/-/x509-1.14.3.tgz",
       "integrity": "sha512-C2Xj8FZ0uHWeCXXqX5B4/gVFQmtSkiuOolzAgutjTfseNOHT3pUjljDZsTSxXFGgio54bCzVFqmEOUrIVk8RDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/asn1-cms": "^2.6.0",
@@ -4247,6 +4291,24 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@shinyoshiaki/binary-data": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmmirror.com/@shinyoshiaki/binary-data/-/binary-data-0.6.1.tgz",
+      "integrity": "sha512-7HDb/fQAop2bCmvDIzU5+69i+UJaFgIVp99h1VzK1mpg1JwSODOkjbqD7ilTYnqlnadF8C4XjpwpepxDsGY6+w==",
+      "license": "MIT",
+      "dependencies": {
+        "generate-function": "^2.3.1",
+        "is-plain-object": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@shinyoshiaki/jspack": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmmirror.com/@shinyoshiaki/jspack/-/jspack-0.0.6.tgz",
+      "integrity": "sha512-SdsNhLjQh4onBlyPrn4ia1Pdx5bXT88G/LIEpOYAjx2u4xeY/m/HB5yHqlkJB1uQR3Zw4R3hBWLj46STRAN0rg=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
@@ -5822,6 +5884,12 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/aes-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/aes-js/-/aes-js-3.1.2.tgz",
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
+      "license": "MIT"
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -6330,7 +6398,6 @@
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.10.tgz",
       "integrity": "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "pvtsutils": "^1.3.6",
@@ -7699,6 +7766,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmmirror.com/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -8045,7 +8128,6 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
       "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@leichtgewicht/ip-codec": "^2.0.1"
@@ -9768,6 +9850,15 @@
         "url": "https://github.com/sponsors/krisk"
       }
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmmirror.com/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/generator-function": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
@@ -10697,6 +10788,12 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/int64-buffer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/int64-buffer/-/int64-buffer-1.1.0.tgz",
+      "integrity": "sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw==",
+      "license": "MIT"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -10721,6 +10818,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/ip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/ip/-/ip-2.0.1.tgz",
+      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
+      "license": "MIT"
     },
     "node_modules/ip-address": {
       "version": "10.2.0",
@@ -11083,7 +11186,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "isobject": "^3.0.1"
@@ -11105,6 +11207,12 @@
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -11297,7 +11405,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11969,7 +12076,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.escaperegexp": {
@@ -12374,6 +12480,12 @@
       "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
       "license": "MIT"
     },
+    "node_modules/mp4box": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmmirror.com/mp4box/-/mp4box-0.5.4.tgz",
+      "integrity": "sha512-GcCH0fySxBurJtvr0dfhz0IxHZjc1RP+F+I8xw+LIwkU1a+7HJx8NCDiww1I5u4Hz6g4eR1JlGADEGJ9r4lSfA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -12384,7 +12496,6 @@
       "version": "7.2.5",
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
       "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dns-packet": "^5.2.2",
@@ -12864,7 +12975,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -13731,7 +13841,6 @@
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.3.6.tgz",
       "integrity": "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"
@@ -13741,7 +13850,6 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
       "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
@@ -14075,7 +14183,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
@@ -14387,6 +14494,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/rx.mini": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/rx.mini/-/rx.mini-1.4.0.tgz",
+      "integrity": "sha512-8w5cSc1mwNja7fl465DXOkVvIOkpvh2GW4jo31nAIvX4WTXCsRnKJGUfiDBzWtYRInEcHAUYIZfzusjIrea8gA=="
     },
     "node_modules/rxjs": {
       "version": "7.8.2",
@@ -15708,7 +15820,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tiny-async-pool": {
@@ -15967,7 +16078,6 @@
       "version": "4.10.0",
       "resolved": "https://registry.npmjs.org/tsyringe/-/tsyringe-4.10.0.tgz",
       "integrity": "sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^1.9.3"
@@ -15980,7 +16090,6 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tunnel-agent": {
@@ -15994,6 +16103,12 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -17181,6 +17296,188 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/werift": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmmirror.com/werift/-/werift-0.23.0.tgz",
+      "integrity": "sha512-/WcIN5DHFG9Ri4anGOmIkp8gxBGFMWSIB/m4sfZ5CWlLfD3iMhiaAUuTBuc+KV3SY9NDmvmLtiN2uaM7k3lVzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@fidm/x509": "^1.2.1",
+        "@minhducsun2002/leb128": "^1.0.0",
+        "@noble/curves": "^1.8.1",
+        "@peculiar/x509": "^1.12.3",
+        "@shinyoshiaki/binary-data": "^0.6.1",
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "aes-js": "^3.1.2",
+        "buffer": "^6.0.3",
+        "debug": "4.4.0",
+        "fast-deep-equal": "^3.1.3",
+        "int64-buffer": "1.1.0",
+        "ip": "^2.0.1",
+        "mp4box": "^0.5.3",
+        "multicast-dns": "^7.2.5",
+        "tweetnacl": "^1.0.3",
+        "werift-common": "*",
+        "werift-dtls": "*",
+        "werift-ice": "*",
+        "werift-rtp": "*",
+        "werift-sctp": "*"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/werift-common": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmmirror.com/werift-common/-/werift-common-0.0.3.tgz",
+      "integrity": "sha512-ma3E4BqKTyZVLhrdfTVs2T1tg9seeUtKMRn5e64LwgrogWa62+3LAUoLBUSl1yPWhgSkXId7GmcHuWDen9IJeQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "debug": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/werift-dtls": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmmirror.com/werift-dtls/-/werift-dtls-0.5.7.tgz",
+      "integrity": "sha512-z2fjbP7fFUFmu/Ky4bCKXzdgPTtmSY1DYi0TUf3GG2zJT4jMQ3TQmGY8y7BSSNGetvL4h3pRZ5un0EcSOWpPog==",
+      "license": "MIT",
+      "dependencies": {
+        "@fidm/x509": "^1.2.1",
+        "@noble/curves": "^1.3.0",
+        "@peculiar/x509": "^1.9.2",
+        "@shinyoshiaki/binary-data": "^0.6.1",
+        "date-fns": "^2.29.3",
+        "lodash": "^4.17.21",
+        "rx.mini": "^1.2.2",
+        "tweetnacl": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/werift-ice": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmmirror.com/werift-ice/-/werift-ice-0.2.2.tgz",
+      "integrity": "sha512-td52pHp+JmFnUn5jfDr/SSNO0dMCbknhuPdN1tFp9cfRj5jaktN63qnAdUuZC20QCC3ETWdsOthcm+RalHpFCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "buffer-crc32": "^1.0.0",
+        "debug": "^4.3.4",
+        "int64-buffer": "^1.0.1",
+        "ip": "^2.0.1",
+        "lodash": "^4.17.21",
+        "multicast-dns": "^7.2.5",
+        "p-cancelable": "^2.1.1",
+        "rx.mini": "^1.2.2"
+      }
+    },
+    "node_modules/werift-ice/node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/werift-rtp": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmmirror.com/werift-rtp/-/werift-rtp-0.8.8.tgz",
+      "integrity": "sha512-GiYMSdvCyScQaw5bnEsraSoHUVZpjfokJAiLV4R1FsiB06t6XiebPYPpkqB9nYNNKiA8Z/cYWsym7wISq1sYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@minhducsun2002/leb128": "^1.0.0",
+        "@shinyoshiaki/jspack": "^0.0.6",
+        "aes-js": "^3.1.2",
+        "buffer": "^6.0.3",
+        "mp4box": "^0.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/werift-rtp/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/werift-sctp": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmmirror.com/werift-sctp/-/werift-sctp-0.0.11.tgz",
+      "integrity": "sha512-7109yuI5U7NTEHjqjn0A8VeynytkgVaxM6lRr1Ziv0D8bPcaB8A7U/P88M7WaCpWDoELHoXiRUjQycMWStIgjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shinyoshiaki/jspack": "^0.0.6"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/werift/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/werift/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1391,7 +1391,7 @@
     },
     "node_modules/@fidm/asn1": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmmirror.com/@fidm/asn1/-/asn1-1.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/@fidm/asn1/-/asn1-1.0.4.tgz",
       "integrity": "sha512-esd1jyNvRb2HVaQGq2Gg8Z0kbQPXzV9Tq5Z14KNIov6KfFD6PTaRIO8UpcsYiTNzOqJpmyzWgVTrUwFV3UF4TQ==",
       "license": "MIT",
       "engines": {
@@ -1400,7 +1400,7 @@
     },
     "node_modules/@fidm/x509": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmmirror.com/@fidm/x509/-/x509-1.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@fidm/x509/-/x509-1.2.1.tgz",
       "integrity": "sha512-nwc2iesjyc9hkuzcrMCBXQRn653XuAUKorfWM8PZyJawiy1QzLj4vahwzaI25+pfpwOLvMzbJ0uKpWLDNmo16w==",
       "license": "MIT",
       "dependencies": {
@@ -2190,7 +2190,7 @@
     },
     "node_modules/@minhducsun2002/leb128": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/@minhducsun2002/leb128/-/leb128-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@minhducsun2002/leb128/-/leb128-1.0.0.tgz",
       "integrity": "sha512-eFrYUPDVHeuwWHluTG1kwNQUEUcFjVKYwPkU8z9DR1JH3AW7JtJsG9cRVGmwz809kKtGfwGJj58juCZxEvnI/g==",
       "license": "MIT"
     },
@@ -2280,7 +2280,7 @@
     },
     "node_modules/@noble/curves": {
       "version": "1.9.7",
-      "resolved": "https://registry.npmmirror.com/@noble/curves/-/curves-1.9.7.tgz",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
       "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
       "license": "MIT",
       "dependencies": {
@@ -2295,7 +2295,7 @@
     },
     "node_modules/@noble/hashes": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmmirror.com/@noble/hashes/-/hashes-1.8.0.tgz",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
@@ -4294,7 +4294,7 @@
     },
     "node_modules/@shinyoshiaki/binary-data": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmmirror.com/@shinyoshiaki/binary-data/-/binary-data-0.6.1.tgz",
+      "resolved": "https://registry.npmjs.org/@shinyoshiaki/binary-data/-/binary-data-0.6.1.tgz",
       "integrity": "sha512-7HDb/fQAop2bCmvDIzU5+69i+UJaFgIVp99h1VzK1mpg1JwSODOkjbqD7ilTYnqlnadF8C4XjpwpepxDsGY6+w==",
       "license": "MIT",
       "dependencies": {
@@ -4307,7 +4307,7 @@
     },
     "node_modules/@shinyoshiaki/jspack": {
       "version": "0.0.6",
-      "resolved": "https://registry.npmmirror.com/@shinyoshiaki/jspack/-/jspack-0.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/@shinyoshiaki/jspack/-/jspack-0.0.6.tgz",
       "integrity": "sha512-SdsNhLjQh4onBlyPrn4ia1Pdx5bXT88G/LIEpOYAjx2u4xeY/m/HB5yHqlkJB1uQR3Zw4R3hBWLj46STRAN0rg=="
     },
     "node_modules/@sindresorhus/is": {
@@ -5886,7 +5886,7 @@
     },
     "node_modules/aes-js": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmmirror.com/aes-js/-/aes-js-3.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
       "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
       "license": "MIT"
     },
@@ -7768,7 +7768,7 @@
     },
     "node_modules/date-fns": {
       "version": "2.30.0",
-      "resolved": "https://registry.npmmirror.com/date-fns/-/date-fns-2.30.0.tgz",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "license": "MIT",
       "dependencies": {
@@ -9852,7 +9852,7 @@
     },
     "node_modules/generate-function": {
       "version": "2.3.1",
-      "resolved": "https://registry.npmmirror.com/generate-function/-/generate-function-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
       "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
       "license": "MIT",
       "dependencies": {
@@ -10790,7 +10790,7 @@
     },
     "node_modules/int64-buffer": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmmirror.com/int64-buffer/-/int64-buffer-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-1.1.0.tgz",
       "integrity": "sha512-94smTCQOvigN4d/2R/YDjz8YVG0Sufvv2aAh8P5m42gwhCsDAJqnbNOrxJsrADuAFAA69Q/ptGzxvNcNuIJcvw==",
       "license": "MIT"
     },
@@ -10821,7 +10821,7 @@
     },
     "node_modules/ip": {
       "version": "2.0.1",
-      "resolved": "https://registry.npmmirror.com/ip/-/ip-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
       "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
       "license": "MIT"
     },
@@ -11210,7 +11210,7 @@
     },
     "node_modules/is-property": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmmirror.com/is-property/-/is-property-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
       "integrity": "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==",
       "license": "MIT"
     },
@@ -12482,7 +12482,7 @@
     },
     "node_modules/mp4box": {
       "version": "0.5.4",
-      "resolved": "https://registry.npmmirror.com/mp4box/-/mp4box-0.5.4.tgz",
+      "resolved": "https://registry.npmjs.org/mp4box/-/mp4box-0.5.4.tgz",
       "integrity": "sha512-GcCH0fySxBurJtvr0dfhz0IxHZjc1RP+F+I8xw+LIwkU1a+7HJx8NCDiww1I5u4Hz6g4eR1JlGADEGJ9r4lSfA==",
       "license": "BSD-3-Clause"
     },
@@ -14497,7 +14497,7 @@
     },
     "node_modules/rx.mini": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmmirror.com/rx.mini/-/rx.mini-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/rx.mini/-/rx.mini-1.4.0.tgz",
       "integrity": "sha512-8w5cSc1mwNja7fl465DXOkVvIOkpvh2GW4jo31nAIvX4WTXCsRnKJGUfiDBzWtYRInEcHAUYIZfzusjIrea8gA=="
     },
     "node_modules/rxjs": {
@@ -16106,7 +16106,7 @@
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmmirror.com/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
       "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
       "license": "Unlicense"
     },
@@ -17300,7 +17300,7 @@
     },
     "node_modules/werift": {
       "version": "0.23.0",
-      "resolved": "https://registry.npmmirror.com/werift/-/werift-0.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/werift/-/werift-0.23.0.tgz",
       "integrity": "sha512-/WcIN5DHFG9Ri4anGOmIkp8gxBGFMWSIB/m4sfZ5CWlLfD3iMhiaAUuTBuc+KV3SY9NDmvmLtiN2uaM7k3lVzw==",
       "license": "MIT",
       "dependencies": {
@@ -17331,7 +17331,7 @@
     },
     "node_modules/werift-common": {
       "version": "0.0.3",
-      "resolved": "https://registry.npmmirror.com/werift-common/-/werift-common-0.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/werift-common/-/werift-common-0.0.3.tgz",
       "integrity": "sha512-ma3E4BqKTyZVLhrdfTVs2T1tg9seeUtKMRn5e64LwgrogWa62+3LAUoLBUSl1yPWhgSkXId7GmcHuWDen9IJeQ==",
       "license": "MIT",
       "dependencies": {
@@ -17344,7 +17344,7 @@
     },
     "node_modules/werift-dtls": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmmirror.com/werift-dtls/-/werift-dtls-0.5.7.tgz",
+      "resolved": "https://registry.npmjs.org/werift-dtls/-/werift-dtls-0.5.7.tgz",
       "integrity": "sha512-z2fjbP7fFUFmu/Ky4bCKXzdgPTtmSY1DYi0TUf3GG2zJT4jMQ3TQmGY8y7BSSNGetvL4h3pRZ5un0EcSOWpPog==",
       "license": "MIT",
       "dependencies": {
@@ -17363,7 +17363,7 @@
     },
     "node_modules/werift-ice": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmmirror.com/werift-ice/-/werift-ice-0.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/werift-ice/-/werift-ice-0.2.2.tgz",
       "integrity": "sha512-td52pHp+JmFnUn5jfDr/SSNO0dMCbknhuPdN1tFp9cfRj5jaktN63qnAdUuZC20QCC3ETWdsOthcm+RalHpFCQ==",
       "license": "MIT",
       "dependencies": {
@@ -17380,7 +17380,7 @@
     },
     "node_modules/werift-ice/node_modules/buffer-crc32": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmmirror.com/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
       "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
       "license": "MIT",
       "engines": {
@@ -17389,7 +17389,7 @@
     },
     "node_modules/werift-rtp": {
       "version": "0.8.8",
-      "resolved": "https://registry.npmmirror.com/werift-rtp/-/werift-rtp-0.8.8.tgz",
+      "resolved": "https://registry.npmjs.org/werift-rtp/-/werift-rtp-0.8.8.tgz",
       "integrity": "sha512-GiYMSdvCyScQaw5bnEsraSoHUVZpjfokJAiLV4R1FsiB06t6XiebPYPpkqB9nYNNKiA8Z/cYWsym7wISq1sYSQ==",
       "license": "MIT",
       "dependencies": {
@@ -17405,7 +17405,7 @@
     },
     "node_modules/werift-rtp/node_modules/buffer": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
@@ -17429,7 +17429,7 @@
     },
     "node_modules/werift-sctp": {
       "version": "0.0.11",
-      "resolved": "https://registry.npmmirror.com/werift-sctp/-/werift-sctp-0.0.11.tgz",
+      "resolved": "https://registry.npmjs.org/werift-sctp/-/werift-sctp-0.0.11.tgz",
       "integrity": "sha512-7109yuI5U7NTEHjqjn0A8VeynytkgVaxM6lRr1Ziv0D8bPcaB8A7U/P88M7WaCpWDoELHoXiRUjQycMWStIgjQ==",
       "license": "MIT",
       "dependencies": {
@@ -17441,7 +17441,7 @@
     },
     "node_modules/werift/node_modules/buffer": {
       "version": "6.0.3",
-      "resolved": "https://registry.npmmirror.com/buffer/-/buffer-6.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
       "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "funding": [
         {
@@ -17465,7 +17465,7 @@
     },
     "node_modules/werift/node_modules/debug": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
       "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "react-i18next": "^17.0.4",
     "smart-whisper": "^0.8.1",
     "tailwind-merge": "^2.5.5",
+    "werift": "^0.23.0",
     "zustand": "^5.0.12"
   },
   "devDependencies": {
@@ -131,7 +132,9 @@
       {
         "from": "resources/models",
         "to": "models",
-        "filter": ["*.bin"]
+        "filter": [
+          "*.bin"
+        ]
       }
     ],
     "afterPack": "scripts/after-pack.cjs",


### PR DESCRIPTION
## Summary

PR-2 of the mobile-remote public-internet track. Builds the **desktop-side WebRTC peer** that runs the existing terminal protocol over a [werift](https://github.com/shinyoshiaki/werift-webrtc) DataChannel instead of a WebSocket — proven by a real werift↔werift local-loopback test. No Cloudflare, no phone, no external accounts.

Implements `docs/superpowers/plans/2026-05-30-mobile-remote-desktop-peer.md` task-by-task (atomic TDD).

- Extract a transport-agnostic `PeerClient = { subscribedSid, send }` seam; `handleClientMessage` + the pty.data fan-out now depend on it, not `WsClient`. `WsClient` is now `PeerClient & {...}` so the LAN WS server still compiles unchanged.
- Share the `subscribedSid`-gated pty.data fan-out (`fanoutPtyData`) across WS and DataChannel transports — the existing WS server is rewired to call it (behavior-preserving).
- `SignalingClient` interface (offer/answer/ICE) — transport-injectable; real Cloudflare wiring deferred to PR-4. Tests inject an in-memory fake.
- `createDesktopPeer`: werift answerer that accepts an offer, opens the `terminal` DataChannel, and runs the unmodified protocol core over it.
- Add werift (pure-TS WebRTC, **no native rebuild** — confirmed `RTCPeerConnection` loads without node-gyp).

## What this PR proves (loopback)

Real werift↔werift DataChannel in `desktopPeer.loopback.test.ts` asserts, with real `expect()`:
- `session.input` over the DataChannel reaches `inputPtySession('s1', 'ls\n')`.
- `pty.data` fan-out honors `subscribedSid` isolation: no delivery before `session.snapshot`, none for a non-viewed session, exactly one for the viewed session.

## What this PR does NOT prove (deferred — real-device / later PRs)

Per project memory, **loopback is not public-internet evidence.** Out of scope here: public-internet reachability, NAT hole-punching, TURN fallback, GitHub auth, the phone PWA client. Those need PR-3+/PR-5 and a real 4G device test by the maintainer. This PR claims **only** the loopback protocol link.

## Scope boundaries honored

- New code lives entirely under `electron/remote/`. Renderer (`src/`) has zero werift import.
- `electron/main.ts` is **untouched vs the PR-1 base** (`git diff origin/feat/mobile-remote-web-exposure -- electron/main.ts` is empty). The old LAN server stays wired until PR-4 — no half-wired main process.
- werift chosen over wrtc deliberately to avoid a native rebuild.

## Implementation note (deviation from plan, for reviewer)

The plan's werift event names were slightly off against the installed `werift@0.23`:
- DataChannel message event is `onMessage.subscribe` (not `message.subscribe`).
- `RTCIceServer.urls` is `string` (not `string | string[]`) — `createDesktopPeer` opts now use werift's exported `RTCIceServer` type.
- ICE candidates are converted to/from the plain `SignalCandidate` wire shape so the signaling contract never depends on werift's class.
- The loopback suite runs under `// @vitest-environment node` — the repo default is jsdom, which shims the UDP/SCTP globals werift needs and the DataChannel never opens there. Verified werift loopback works in plain Node before switching the env.

## Local checks (host: Windows 11, mode: full)

- typecheck: ✓ (exit 0) — `tsc --noEmit` + `tsc --noEmit -p tsconfig.electron.json`
- lint: ✓ (exit 0) — `eslint . --ext .ts,.tsx --max-warnings 0`
- build: ✓ (exit 0) — `npm run build` (webpack compiled successfully; needed so the `electron-load-smoke` test's `dist/electron` precondition is met)
- tests: ✓ `npm test` → `Test Files 204 passed (204) / Tests 1951 passed | 1 todo (1952)` in ~49s
  - new: `electron/remote/__tests__/peerClient.test.ts` (3), `ptyFanout.test.ts` (1), `desktopPeer.loopback.test.ts` (2)
  - existing WS server suite `electron/__tests__/mobileRemoteServer.test.ts` (29) still green after the fan-out rewire

🤖 Generated with [Claude Code](https://claude.com/claude-code)