### PR TITLE
fix(terminal): bind scrollbar thumb to viewportY via rAF sampling (supersedes #1448)

### DIFF
--- a/scripts/dogfood-scrollbar-wheel-tracks-thumb.mjs
+++ b/scripts/dogfood-scrollbar-wheel-tracks-thumb.mjs
@@ -1,0 +1,224 @@
+// scripts/dogfood-scrollbar-wheel-tracks-thumb.mjs
+//
+// Architecture probe for the self-drawn terminal scrollbar (PR #1442 +
+// follow-up). Proves the thumb is bound to xterm's `buffer.active.viewportY`
+// — the single source of truth — so it follows EVERY scroll input, including
+// the one that was broken: real mouse wheel.
+//
+// The bug this guards: xterm's `onScroll` emitter does NOT fire on
+// mouse-wheel (or middle-mouse-button) scrolling — that path goes through
+// DOM scroll + repaint, mutating `viewportY` without an event. The original
+// scrollbar subscribed only to discrete xterm events, so the thumb froze at
+// its last position while the viewport scrolled up under the wheel
+// (user symptom "任何时候滚动条都在底部" / thumb pinned to bottom). PR #1448
+// tried to patch this by adding an `onRender` subscription — still
+// whack-a-mole, middle-mouse stayed broken. This probe verifies the
+// architecture-level fix: `useTerminalScroll` now samples buffer geometry on
+// a requestAnimationFrame loop, so the thumb tracks `viewportY` regardless
+// of which input changed it.
+//
+// Steps:
+//   1. force the terminal into normal buffer
+//   2. write enough lines to create scrollback (baseY > 0)
+//   3. scroll the viewport to the bottom (live tail) — thumb rests at bottom
+//   4. real mouse-wheel UP over the terminal host (win.mouse.wheel)
+//   5. read xterm geometry (viewportY / baseY / rows), the track px height,
+//      AND the rendered self-drawn thumb's style.top
+//   6. assert: viewportY moved off the tail, the thumb MOVED off the bottom,
+//      and thumbTop matches the pure projection f(viewportY,...) within ~1px.
+//
+// NOTE on middle-mouse: Playwright cannot synthesize the OS-level
+// middle-button autoscroll gesture, but middle-mouse scrolling goes through
+// the exact same `viewportY`-without-`onScroll` code path that the mouse
+// wheel exercises here. Driving the wheel proves both are covered by the
+// single rAF binding.
+//
+// Exit code 0 = PASS (thumb tracks viewportY after wheel), 1 = FAIL.
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
+import {
+  createIsolatedClaudeDir,
+  dismissWelcomeSplash,
+  launchCcsmIsolated,
+  seedSession,
+  waitForTerminalReady,
+  waitForXtermBuffer,
+} from './probe-utils-real-cli.mjs';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const MIN_THUMB = 24; // keep in sync with useTerminalScroll.ts
+
+async function readGeometry(win) {
+  return await win.evaluate(() => {
+    const t = window.__ccsmTerm;
+    const track = document.querySelector('[data-terminal-scrollbar]');
+    const thumb = document.querySelector('[data-terminal-scrollbar-thumb]');
+    const trackRect =
+      track instanceof HTMLElement ? track.getBoundingClientRect() : null;
+    return {
+      viewportY: t?.buffer?.active?.viewportY ?? null,
+      baseY: t?.buffer?.active?.baseY ?? null,
+      rows: t?.rows ?? null,
+      bufferType: t?.buffer?.active?.type ?? null,
+      trackHeight: trackRect ? trackRect.height : null,
+      thumbPresent: thumb instanceof HTMLElement,
+      thumbTop:
+        thumb instanceof HTMLElement ? parseFloat(thumb.style.top) : null,
+      thumbHeight:
+        thumb instanceof HTMLElement ? parseFloat(thumb.style.height) : null,
+    };
+  });
+}
+
+// Mirror of computeThumb() in src/terminal/useTerminalScroll.ts — the pure
+// projection the rendered thumb must match.
+function expectedThumb(g) {
+  const total = g.baseY + g.rows;
+  const rawHeight = (g.trackHeight * g.rows) / total;
+  const thumbHeight = Math.min(g.trackHeight, Math.max(MIN_THUMB, rawHeight));
+  const travel = g.trackHeight - thumbHeight;
+  const clampedViewportY = Math.max(0, Math.min(g.baseY, g.viewportY));
+  const thumbTop = travel > 0 ? (travel * clampedViewportY) / g.baseY : 0;
+  return { thumbTop, thumbHeight, travel };
+}
+
+async function main() {
+  const tempDir = mkdtempSync(path.join(tmpdir(), 'ccsm-scrollbar-wheel-'));
+  createIsolatedClaudeDir(tempDir);
+
+  const { electronApp, win } = await launchCcsmIsolated({ tempDir });
+
+  try {
+    await win.waitForFunction(
+      () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+      null,
+      { timeout: 30000 },
+    );
+
+    await win.setViewportSize({ width: 700, height: 400 }).catch(() => {});
+    await sleep(200);
+
+    const { sid } = await seedSession(win, { name: 'wheel', cwd: tempDir });
+    await win.evaluate((id) => window.__ccsmStore.getState().selectSession(id), sid);
+    await waitForTerminalReady(win, sid, { timeout: 45000 });
+    await waitForXtermBuffer(win, /claude|welcome|│|╭|\?\sfor\sshortcuts/i, {
+      timeout: 30000,
+    });
+    await dismissWelcomeSplash(win).catch(() => {});
+    await sleep(500);
+
+    // Force normal buffer + create scrollback, then scroll to the bottom
+    // (live tail) so the thumb's resting position is the bottom of the track.
+    await win.evaluate(() => {
+      const t = window.__ccsmTerm;
+      t.write('\x1b[?1049l'); // leave alt buffer (no-op if already normal)
+      for (let i = 0; i < 200; i++) t.write(`scrollbar-wheel filler ${i}\r\n`);
+    });
+    await sleep(300);
+    await win.evaluate(() => window.__ccsmTerm.scrollToBottom());
+    await sleep(300);
+
+    const beforeWheel = await readGeometry(win);
+    console.log(`geometry at tail (before wheel): ${JSON.stringify(beforeWheel)}`);
+
+    if (beforeWheel.bufferType !== 'normal') {
+      console.error(`SETUP FAIL: expected normal buffer, got ${beforeWheel.bufferType}`);
+      process.exitCode = 1;
+      return;
+    }
+    if (beforeWheel.baseY == null || beforeWheel.baseY <= 0) {
+      console.error(`SETUP FAIL: no scrollback (baseY=${beforeWheel.baseY})`);
+      process.exitCode = 1;
+      return;
+    }
+    if (!beforeWheel.thumbPresent || beforeWheel.trackHeight == null) {
+      console.error(`SETUP FAIL: no self-drawn thumb (baseY=${beforeWheel.baseY})`);
+      process.exitCode = 1;
+      return;
+    }
+    const expBefore = expectedThumb(beforeWheel);
+    // Thumb should be resting at the bottom at the live tail.
+    if (beforeWheel.thumbTop < expBefore.travel - 2) {
+      console.error(
+        `SETUP FAIL: thumb not at bottom before wheel ` +
+          `(thumbTop=${beforeWheel.thumbTop}, expected≈${expBefore.travel.toFixed(2)})`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    // Real mouse wheel UP over the terminal host — the path that mutates
+    // viewportY WITHOUT emitting onScroll. `term.scrollLines(...)` would NOT
+    // reproduce the broken input path.
+    const host = await win.$('[data-terminal-host]');
+    const box = await host.boundingBox();
+    await win.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    for (let i = 0; i < 12; i++) {
+      await win.mouse.wheel(0, -120);
+      await sleep(40);
+    }
+    await sleep(400);
+
+    const g = await readGeometry(win);
+    console.log(`geometry after real wheel-up x12: ${JSON.stringify(g)}`);
+
+    if (g.viewportY >= g.baseY) {
+      console.error(
+        `SETUP FAIL: wheel did not move viewportY off the tail ` +
+          `(viewportY=${g.viewportY} baseY=${g.baseY})`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const exp = expectedThumb(g);
+    const bottomThreshold = exp.travel - 1; // "pinned to bottom" if >= this
+    const dExpected = Math.abs(g.thumbTop - exp.thumbTop);
+    const movedOffBottom = beforeWheel.thumbTop - g.thumbTop;
+
+    console.log(
+      `viewportY=${g.viewportY}/baseY=${g.baseY} travel=${exp.travel.toFixed(2)} ` +
+        `expected thumbTop=${exp.thumbTop.toFixed(2)} actual thumbTop=${g.thumbTop} ` +
+        `(Δproj=${dExpected.toFixed(2)}) moved up by ${movedOffBottom.toFixed(2)}px`,
+    );
+
+    // Bug signature: scrolled up (viewportY << baseY) yet thumb sits at the
+    // very bottom of the track.
+    if (g.thumbTop >= bottomThreshold) {
+      console.error(
+        `FAIL (bug present): thumb pinned to bottom after wheel. ` +
+          `thumbTop=${g.thumbTop} >= travel-1=${bottomThreshold.toFixed(2)} ` +
+          `while viewportY=${g.viewportY} << baseY=${g.baseY}. ` +
+          `Expected thumbTop≈${exp.thumbTop.toFixed(2)}. ` +
+          `See src/terminal/useTerminalScroll.ts (rAF sampling loop).`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    if (dExpected > 1.5) {
+      console.error(
+        `FAIL: thumb moved but desynced from pure projection ` +
+          `(actual=${g.thumbTop}, expected=${exp.thumbTop.toFixed(2)}, Δ=${dExpected.toFixed(2)}).`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    console.log(
+      `PASS: wheel-up moved the thumb off the bottom by ${movedOffBottom.toFixed(2)}px ` +
+        `and thumbTop=${g.thumbTop} ≈ projection ${exp.thumbTop.toFixed(2)} ` +
+        `(Δ=${dExpected.toFixed(2)}px, well above bottom travel=${exp.travel.toFixed(2)}).`,
+    );
+  } finally {
+    await electronApp.close();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exitCode = 1;
+});

--- a/src/terminal/useTerminalScroll.ts
+++ b/src/terminal/useTerminalScroll.ts
@@ -12,10 +12,24 @@ import { getTopShell } from './shellRegistry';
 //
 // This hook reads xterm's buffer geometry directly and projects a thumb
 // position. There is no reverse sync — the thumb is a *pure function* of
-// the buffer state, so it can never desync. We re-read on the same event
-// set `useAtBottom` uses (`onScroll` + `onLineFeed`) plus `onResize`
-// (track-height / rows change on fit). Drag / track-click translate back
-// to `term.scrollToLine` / `term.scrollLines` against the same buffer.
+// the buffer state, so it can never desync.
+//
+// We sample `buffer.active.{viewportY, baseY}` + `term.rows` on a
+// requestAnimationFrame loop instead of subscribing to discrete xterm
+// events (`onScroll` / `onLineFeed` / `onResize` / `onRender`). The thumb
+// is then bound to `viewportY` — xterm's single source of truth — so it
+// follows EVERY input that moves the viewport, not just the ones that
+// happen to emit an event. This matters because mouse-wheel and
+// middle-mouse-button scrolling change `viewportY` but do NOT emit
+// `onScroll` (the wheel path goes through DOM scroll + repaint); chasing
+// those with extra event subscriptions is whack-a-mole. One rAF sampling
+// binding covers wheel, middle-mouse, drag, keyboard, PgUp/PgDn, and CLI
+// output uniformly. Drag / track-click translate back to
+// `term.scrollToLine` / `term.scrollLines` against the same buffer.
+//
+// The loop is cheap when idle: it reads 3 numbers, compares them against
+// the last-pushed geometry, and bails without `setState` when nothing
+// moved — so it does not re-render every frame.
 //
 // All geometry is in the pure functions below, exported for unit tests.
 
@@ -119,29 +133,38 @@ export function useTerminalScroll(
   });
 
   useEffect(() => {
-    const recompute = (): void => {
+    let rafId = 0;
+    // Last geometry we pushed to React state. Seeded to `null` so the very
+    // first sample always commits (even if it's the hidden/empty state),
+    // then used as the no-op guard so idle frames don't call setState.
+    let lastGeom: ScrollGeometry | null = null;
+
+    const sameGeom = (a: ScrollGeometry, b: ScrollGeometry): boolean =>
+      a.visible === b.visible &&
+      a.thumbTop === b.thumbTop &&
+      a.thumbHeight === b.thumbHeight;
+
+    const tick = (): void => {
       const buf = readBuffer();
-      if (!buf) {
-        setGeom({ visible: false, thumbTop: 0, thumbHeight: 0 });
-        return;
+      // `buf` is null until the top shell's xterm Terminal exists (cold
+      // start). Project the hidden state and keep sampling — once the term
+      // mounts, the next frame picks up real geometry. This folds the old
+      // "terminal not ready yet" rAF-retry into the same loop.
+      const next = buf
+        ? computeThumb(buf, trackHeight)
+        : { visible: false, thumbTop: 0, thumbHeight: 0 };
+      // No-op guard: read 3 numbers, compare against the last pushed geom,
+      // and only setState when something actually moved. Idle frames cost
+      // a buffer read + 3 comparisons, no re-render.
+      if (lastGeom === null || !sameGeom(lastGeom, next)) {
+        lastGeom = next;
+        setGeom(next);
       }
-      setGeom(computeThumb(buf, trackHeight));
+      rafId = requestAnimationFrame(tick);
     };
 
-    const term = getTopShell()?.term;
-    if (!term) {
-      const id = requestAnimationFrame(recompute);
-      return () => cancelAnimationFrame(id);
-    }
-    recompute();
-    const scrollDisposable = term.onScroll(recompute);
-    const lineFeedDisposable = term.onLineFeed(recompute);
-    const resizeDisposable = term.onResize(recompute);
-    return () => {
-      scrollDisposable.dispose();
-      lineFeedDisposable.dispose();
-      resizeDisposable.dispose();
-    };
+    rafId = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafId);
   }, [sessionId, trackHeight]);
 
   return {

--- a/tests/terminal/useTerminalScroll.sampling.test.tsx
+++ b/tests/terminal/useTerminalScroll.sampling.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// Behavioural test for `useTerminalScroll`'s rAF-sampling driver.
+//
+// Architecture under test: the hook does NOT subscribe to discrete xterm
+// events (`onScroll` / `onLineFeed` / `onResize` / `onRender`). Instead it
+// samples `buffer.active.{viewportY, baseY}` + `term.rows` on a
+// requestAnimationFrame loop and re-projects the thumb each frame. The
+// point of this design is that mouse-wheel / middle-mouse scrolling moves
+// `viewportY` WITHOUT emitting `onScroll`, so an event-subscription thumb
+// freezes — but a sampling thumb follows `viewportY` regardless of which
+// input changed it.
+//
+// These tests pin that contract:
+//   1. mutating `viewportY` with NO event emitted still updates the geom
+//      after a frame tick (the wheel/middle-mouse case);
+//   2. the loop is a no-op (no extra renders) when nothing moved;
+//   3. the rAF is cancelled on unmount (no leak);
+//   4. it copes with the term not being ready yet, then mounting.
+//
+// The pure geometry itself is pinned separately in useTerminalScroll.test.ts.
+
+const fakeBuffer = { active: { viewportY: 0, baseY: 0, type: 'normal' } };
+let termPresent = true;
+const fakeTerm = {
+  get buffer() {
+    return fakeBuffer;
+  },
+  rows: 24,
+  // Deliberately NO onScroll / onLineFeed / onResize / onRender: the hook
+  // must not depend on them. If the implementation regresses to calling any
+  // of these, `term.onScroll` would be `undefined` and throw — a useful
+  // guard.
+  scrollToLine: vi.fn(),
+  scrollLines: vi.fn(),
+};
+
+vi.mock('../../src/terminal/shellRegistry', () => ({
+  getTopShell: vi.fn(() => (termPresent ? { term: fakeTerm } : null)),
+}));
+
+import { useTerminalScroll, computeThumb } from '../../src/terminal/useTerminalScroll';
+
+const H = 200;
+
+// Drive a single rAF frame under fake timers. jsdom's requestAnimationFrame
+// is backed by a timer, so advancing time flushes the queued callback.
+function tickFrame(): void {
+  act(() => {
+    vi.advanceTimersByTime(16);
+  });
+}
+
+describe('useTerminalScroll (rAF sampling)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fakeBuffer.active.viewportY = 0;
+    fakeBuffer.active.baseY = 0;
+    fakeTerm.rows = 24;
+    termPresent = true;
+    fakeTerm.scrollToLine.mockClear();
+    fakeTerm.scrollLines.mockClear();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('follows viewportY changes with NO event emitted (wheel / middle-mouse path)', () => {
+    fakeBuffer.active.baseY = 100;
+    fakeBuffer.active.viewportY = 100; // at tail
+    const { result } = renderHook(() => useTerminalScroll('sid-A', H));
+
+    // First frame samples the tail position.
+    tickFrame();
+    const atTail = computeThumb({ baseY: 100, viewportY: 100, rows: 24 }, H);
+    expect(result.current.visible).toBe(true);
+    expect(result.current.thumbTop).toBeCloseTo(atTail.thumbTop, 6);
+
+    // Simulate a wheel scroll-up: viewportY moves WITHOUT any xterm event.
+    // An event-subscription thumb would stay frozen here.
+    fakeBuffer.active.viewportY = 20;
+    tickFrame();
+
+    const scrolledUp = computeThumb({ baseY: 100, viewportY: 20, rows: 24 }, H);
+    expect(result.current.thumbTop).toBeCloseTo(scrolledUp.thumbTop, 6);
+    // And it actually moved off the bottom.
+    expect(result.current.thumbTop).toBeLessThan(atTail.thumbTop);
+  });
+
+  it('does not re-render on idle frames when geometry is unchanged', () => {
+    fakeBuffer.active.baseY = 100;
+    fakeBuffer.active.viewportY = 50;
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders++;
+      return useTerminalScroll('sid-A', H);
+    });
+
+    tickFrame(); // first commit
+    const rendersAfterFirstCommit = renders;
+    const top = result.current.thumbTop;
+
+    // Several idle frames with no buffer change — must not bump render count.
+    tickFrame();
+    tickFrame();
+    tickFrame();
+
+    expect(renders).toBe(rendersAfterFirstCommit);
+    expect(result.current.thumbTop).toBe(top);
+  });
+
+  it('cancels the rAF loop on unmount (no leak)', () => {
+    const cancelSpy = vi.spyOn(globalThis, 'cancelAnimationFrame');
+    const { unmount } = renderHook(() => useTerminalScroll('sid-A', H));
+    tickFrame();
+    unmount();
+    expect(cancelSpy).toHaveBeenCalled();
+    cancelSpy.mockRestore();
+  });
+
+  it('handles the term-not-ready case, then projects once it mounts', () => {
+    termPresent = false;
+    fakeBuffer.active.baseY = 100;
+    fakeBuffer.active.viewportY = 30;
+
+    const { result } = renderHook(() => useTerminalScroll('sid-A', H));
+    tickFrame();
+    // No term yet → hidden, no throw.
+    expect(result.current.visible).toBe(false);
+
+    // Term mounts; next sample picks up real geometry.
+    termPresent = true;
+    tickFrame();
+    const expected = computeThumb({ baseY: 100, viewportY: 30, rows: 24 }, H);
+    expect(result.current.visible).toBe(true);
+    expect(result.current.thumbTop).toBeCloseTo(expected.thumbTop, 6);
+  });
+
+  it('re-arms when trackHeight changes (geometry re-projects)', () => {
+    fakeBuffer.active.baseY = 100;
+    fakeBuffer.active.viewportY = 50;
+    const { result, rerender } = renderHook(
+      ({ h }: { h: number }) => useTerminalScroll('sid-A', h),
+      { initialProps: { h: H } },
+    );
+    tickFrame();
+    const tallTrack = computeThumb({ baseY: 100, viewportY: 50, rows: 24 }, H);
+    expect(result.current.thumbHeight).toBeCloseTo(tallTrack.thumbHeight, 6);
+
+    act(() => {
+      rerender({ h: 400 });
+    });
+    tickFrame();
+    const shortTrack = computeThumb({ baseY: 100, viewportY: 50, rows: 24 }, 400);
+    expect(result.current.thumbHeight).toBeCloseTo(shortTrack.thumbHeight, 6);
+  });
+});


### PR DESCRIPTION
## Architectural rationale

The self-drawn terminal scrollbar (PR #1442) is supposed to be a **pure projection of xterm's buffer state** — `thumb = f(viewportY, baseY, rows)`. `buffer.active.viewportY` is xterm's single source of truth.

The bug: `useTerminalScroll.ts` sampled `viewportY` by subscribing to **discrete xterm events** (`onScroll` / `onLineFeed` / `onResize`). But **mouse-wheel and middle-mouse-button scrolling mutate `viewportY` WITHOUT emitting `onScroll`** (the wheel path goes through DOM scroll + repaint). So the thumb froze at the bottom while the viewport scrolled up under the wheel — user symptom: thumb "永远在底部" / pinned to bottom.

PR #1448 tried to patch this by *adding* an `onRender` subscription, but middle-mouse stayed broken. Chasing inputs with a growing list of event subscriptions is whack-a-mole.

**This PR is the architecture-level fix:** replace the event subscriptions with a single **requestAnimationFrame sampling loop**. Each frame reads `buffer.active.{viewportY, baseY}` + `term.rows`, re-projects via the existing pure `computeThumb()`, and calls `setGeom` **only when the geometry changed** (no-op guard). The thumb is bound to `viewportY` — the single source of truth — so it follows **every** scroll input uniformly: wheel, middle-mouse, drag, keyboard, PgUp/PgDn, and CLI output. One binding covers every case.

## What changed
- `src/terminal/useTerminalScroll.ts`: swapped the `onScroll`/`onLineFeed`/`onResize` subscription effect for a rAF sampling loop with a no-op guard (idle frame = 1 buffer read + 3 numeric comparisons, **no re-render**). The cold-start "terminal not ready yet" retry folds into the same loop. rAF is cancelled on cleanup; re-arms on `sessionId` / `trackHeight` change (same dep array). **Pure functions (`computeThumb` / `thumbTopToViewportY` / `MIN_THUMB`) and the public hook API (`{ visible, thumbTop, thumbHeight, dragTo, pageBy }`) are unchanged — `TerminalScrollbar.tsx` needs no edit.**
- `tests/terminal/useTerminalScroll.sampling.test.tsx` (new): pins the rAF-sampling contract — mutating `viewportY` with **no event emitted** still updates the geom after a frame tick (the wheel/middle-mouse path); idle frames don't re-render; rAF is cancelled on unmount; term-not-ready then mounts; re-arms on `trackHeight` change. (The worktree had no `useTerminalScroll.subscription.test.tsx` from #1448 to update — #1448 lives on a separate branch; this new test replaces that obsolete onScroll/onRender-subscription contract with the sampling contract.)
- `scripts/dogfood-scrollbar-wheel-tracks-thumb.mjs` (new): real ccsm + real CLI, creates scrollback (`baseY>0`), scrolls to tail, then drives a **real mouse wheel** (`win.mouse.wheel(0,-120)` ×12) — the exact `viewportY`-without-`onScroll` path — and asserts the rendered thumb's `style.top` tracks `f(viewportY,...)` within ~1px. Middle-mouse-button goes through the **same** code path (Playwright can't synthesize the OS middle-button autoscroll gesture, but the wheel exercises the identical binding).

## Wheel-scroll proof (dogfood probe, real ccsm + real CLI)

**Before fix (old onScroll-only impl — bug reproduced):**
```
before wheel: viewportY=191 baseY=191 thumbTop=326.921 (at bottom, travel=326.92)
after wheel:  viewportY=143 baseY=191 thumbTop=326.921  <-- moved 0px, PINNED
FAIL (bug present): thumb pinned to bottom while viewportY=143 << baseY=191
```

**After fix (rAF sampling — bug gone):**
```
before wheel: viewportY=191 baseY=191 thumbTop=326.921 (at bottom)
after wheel:  viewportY=143 baseY=191 thumbTop=244.763  <-- moved up 82.16px
PASS: thumbTop=244.763 ≈ projection 244.76 (Δ=0.00px)
```

## Reverse-verify (unit test)
- Old onScroll-only impl → `useTerminalScroll.sampling.test.tsx` → **FAIL** (5 failed: wheel-without-event + term-not-ready cases break).
- rAF sampling impl → **PASS** (5/5).

## Local checks (host: Windows 11, mode: full)
- lint: ✓ (exit 0, `--max-warnings 0`)
- typecheck: ✓ (exit 0)
- build: ✓ (exit 0, webpack compiled successfully)
- unit tests (terminal): ✓ `npx vitest run tests/terminal/` → **68 passed (7 files)**
- dogfood wheel probe: ✓ PASS (numbers above) + reverse-verified FAIL on old impl
- harness-ui (`scripts/harness-ui.mjs`): ✓ **14 passed, 0 failed**

### Pre-existing unrelated failures
Full `npm test` shows 41 failures in 3 files only: `electron/__tests__/db.test.ts`, `electron/__tests__/db-hardening.test.ts` (`better-sqlite3` NODE_MODULE_VERSION 145-vs-137 native ABI mismatch in this worktree's shared `node_modules`) and `tests/electron-load-smoke.test.ts` (needs `dist/electron` + native modules). Verified identical on the clean base via `git stash` (3 failed / 41 failed). None touch terminal/scrollbar code. All 1909 non-native tests pass.

## Supersedes #1448
This is the architecture-level fix the user asked for (thumb bound to content, not a growing event-subscription list). **#1448 should be closed in favor of this PR.** I did not touch/merge #1448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)