### PR TITLE
feat(voice): toast feedback, recording timer + a11y for dictation

### DIFF
--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -237,3 +237,11 @@ export function useToast() {
   if (!ctx) throw new Error('useToast must be used inside <ToastProvider>');
   return ctx;
 }
+
+// Non-throwing variant: returns null when no <ToastProvider> is mounted.
+// Used by chrome that can be rendered bare in e2e probes / harnesses (e.g.
+// <TerminalPane> in component tests) where toasts are a nice-to-have, not a
+// hard dependency — the component degrades to no feedback instead of crashing.
+export function useToastOptional() {
+  return useContext(Ctx);
+}

--- a/src/components/voice/MicButton.tsx
+++ b/src/components/voice/MicButton.tsx
@@ -1,27 +1,66 @@
+import { useEffect, useRef, useState } from 'react';
 import { Mic, MicOff, Loader2 } from 'lucide-react';
 import { useTranslation } from '../../i18n/useTranslation';
+import { useToastOptional } from '../ui/Toast';
 import { useVoiceRecorder } from './useVoiceRecorder';
+import { formatElapsed, voiceToastForOutcome } from '../../voice/voiceFeedback';
 
 // Mic toggle in the terminal corner. Targets the active session (sid).
 // Idle → click to record; recording → click to stop; transcribing →
 // disabled spinner; error → red, click resets. Injection (no Enter) is
 // handled by the hook via pasteIntoActivePty.
+//
+// Feedback beyond the icon: no-speech / errors surface as toasts (with a
+// reason + recovery hint), recording shows a live m:ss timer, and the
+// transcribing state shows a visible "Transcribing…" label so the 1–2s
+// cold start doesn't read as a hang. All motion is gated behind
+// motion-reduce: for prefers-reduced-motion users.
 export function MicButton({ sessionId }: { sessionId: string }) {
   const { t } = useTranslation();
-  const { state, toggle } = useVoiceRecorder(sessionId);
+  const toast = useToastOptional();
 
-  const label =
+  const { state, toggle } = useVoiceRecorder(sessionId, (outcome) => {
+    const spec = voiceToastForOutcome(outcome);
+    toast?.push({ kind: spec.kind, title: t(spec.titleKey), body: t(spec.bodyKey) });
+  });
+
+  // Recording duration: ticks once a second while recording, resets on stop.
+  // Kept in component state (not the reducer) since it's pure presentation.
+  const [elapsed, setElapsed] = useState(0);
+  const startedAt = useRef<number | null>(null);
+  useEffect(() => {
+    if (state.kind !== 'recording') {
+      startedAt.current = null;
+      setElapsed(0);
+      return;
+    }
+    startedAt.current = Date.now();
+    setElapsed(0);
+    const id = window.setInterval(() => {
+      if (startedAt.current != null) {
+        setElapsed(Math.floor((Date.now() - startedAt.current) / 1000));
+      }
+    }, 1000);
+    return () => window.clearInterval(id);
+  }, [state.kind]);
+
+  const elapsedLabel = formatElapsed(elapsed);
+
+  // aria-label describes the *current action* the button performs, so a
+  // screen-reader user always knows what a click will do and what state
+  // the recorder is in (color/animation alone is not enough — §1 color).
+  const ariaLabel =
     state.kind === 'recording'
-      ? t('voice.stop')
+      ? t('voice.ariaStop', { time: elapsedLabel })
       : state.kind === 'transcribing'
-        ? t('voice.transcribing')
+        ? t('voice.ariaTranscribing')
         : state.kind === 'error'
           ? state.message === 'mic'
             ? t('voice.errorMic')
             : state.message === 'no-model'
               ? t('voice.errorNoModel')
               : t('voice.errorFailed')
-          : t('voice.start');
+          : t('voice.ariaStart');
 
   const color =
     state.kind === 'recording'
@@ -31,22 +70,47 @@ export function MicButton({ sessionId }: { sessionId: string }) {
         : 'text-neutral-300';
 
   return (
-    <button
-      type="button"
-      onClick={toggle}
-      disabled={state.kind === 'transcribing'}
-      aria-label={label}
-      title={label}
-      className={`absolute bottom-2 right-2 z-10 rounded p-1.5 bg-black/40 hover:bg-black/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-400 disabled:opacity-60 ${color}`}
-    >
-      {state.kind === 'transcribing' ? (
-        <Loader2 className="w-4 h-4 animate-spin" />
-      ) : state.kind === 'error' ? (
-        <MicOff className="w-4 h-4" />
-      ) : (
-        <Mic className={`w-4 h-4 ${state.kind === 'recording' ? 'animate-pulse' : ''}`} />
+    <div className="absolute bottom-2 right-2 z-10 flex items-center gap-1.5">
+      {/* Visible status pill — text + (for recording) a timer. Backs the
+          icon's color/animation cue with a label so state changes aren't
+          conveyed by color alone. */}
+      {state.kind === 'recording' && (
+        <span className="flex items-center gap-1 rounded bg-black/60 px-1.5 py-0.5 text-[11px] font-medium text-red-300 tabular-nums">
+          <span
+            aria-hidden="true"
+            className="inline-block h-1.5 w-1.5 rounded-full bg-red-500 animate-pulse motion-reduce:animate-none"
+          />
+          {t('voice.recording')} {elapsedLabel}
+        </span>
       )}
-    </button>
+      {state.kind === 'transcribing' && (
+        <span className="rounded bg-black/60 px-1.5 py-0.5 text-[11px] font-medium text-neutral-200">
+          {t('voice.transcribing')}
+        </span>
+      )}
+
+      <button
+        type="button"
+        onClick={toggle}
+        disabled={state.kind === 'transcribing'}
+        aria-label={ariaLabel}
+        aria-busy={state.kind === 'transcribing'}
+        title={ariaLabel}
+        className={`rounded p-1.5 bg-black/40 hover:bg-black/70 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-neutral-400 disabled:opacity-60 ${color}`}
+      >
+        {state.kind === 'transcribing' ? (
+          <Loader2 className="w-4 h-4 animate-spin motion-reduce:animate-none" />
+        ) : state.kind === 'error' ? (
+          <MicOff className="w-4 h-4" />
+        ) : (
+          <Mic
+            className={`w-4 h-4 ${
+              state.kind === 'recording' ? 'animate-pulse motion-reduce:animate-none' : ''
+            }`}
+          />
+        )}
+      </button>
+    </div>
   );
 }
 

--- a/src/components/voice/useVoiceRecorder.ts
+++ b/src/components/voice/useVoiceRecorder.ts
@@ -1,5 +1,6 @@
 import { useCallback, useReducer, useRef } from 'react';
 import { voiceReducer, type VoiceState } from '../../voice/recorderMachine';
+import type { VoiceOutcome } from '../../voice/voiceFeedback';
 import { resampleTo16k } from '../../voice/resample';
 import { getTopShell } from '../../terminal/shellRegistry';
 import { pasteIntoActivePty } from '../../terminal/paste';
@@ -9,7 +10,13 @@ const MIN_SAMPLES_16K = 16000 * 0.3; // ~300ms; shorter clips are treated as sil
 // Owns Web Audio capture + the transcription/injection flow. The button
 // targets the active session (sid passed in by the hosting TerminalPane),
 // matching how paste resolves its target via getTopShell().
-export function useVoiceRecorder(sid: string): {
+//
+// `onFeedback` surfaces user-visible outcomes (no speech / errors) without
+// coupling this hook to the toast runtime — the host wires it to useToast().
+export function useVoiceRecorder(
+  sid: string,
+  onFeedback?: (outcome: VoiceOutcome) => void
+): {
   state: VoiceState;
   toggle: () => void;
 } {
@@ -18,6 +25,10 @@ export function useVoiceRecorder(sid: string): {
   const ctxRef = useRef<AudioContext | null>(null);
   const chunksRef = useRef<Float32Array[]>([]);
   const processorRef = useRef<ScriptProcessorNode | null>(null);
+  // Keep the latest callback in a ref so the memoized stop()/start() don't
+  // need to re-create when the host passes a fresh closure each render.
+  const feedbackRef = useRef(onFeedback);
+  feedbackRef.current = onFeedback;
 
   const cleanup = useCallback(() => {
     processorRef.current?.disconnect();
@@ -45,7 +56,8 @@ export function useVoiceRecorder(sid: string): {
 
     const pcm = resampleTo16k(merged, inputRate);
     if (pcm.length < MIN_SAMPLES_16K) {
-      dispatch({ type: 'DONE' }); // silent / too short — back to idle quietly
+      dispatch({ type: 'DONE' }); // silent / too short — back to idle…
+      feedbackRef.current?.({ kind: 'no-speech' }); // …but tell the user why
       return;
     }
     try {
@@ -53,15 +65,19 @@ export function useVoiceRecorder(sid: string): {
       if (!res || !res.ok) {
         if (res && res.error === 'empty') {
           dispatch({ type: 'DONE' });
+          feedbackRef.current?.({ kind: 'no-speech' });
           return;
         }
-        dispatch({ type: 'FAIL', message: res ? res.error : 'transcribe-failed' });
+        const message = res ? res.error : 'transcribe-failed';
+        dispatch({ type: 'FAIL', message });
+        feedbackRef.current?.({ kind: 'error', message });
         return;
       }
       await pasteIntoActivePty(() => getTopShell()?.term, sid, res.text);
       dispatch({ type: 'DONE' });
     } catch {
       dispatch({ type: 'FAIL', message: 'transcribe-failed' });
+      feedbackRef.current?.({ kind: 'error', message: 'transcribe-failed' });
     }
   }, [cleanup, sid]);
 
@@ -85,6 +101,7 @@ export function useVoiceRecorder(sid: string): {
     } catch {
       cleanup();
       dispatch({ type: 'FAIL', message: 'mic' });
+      feedbackRef.current?.({ kind: 'error', message: 'mic' });
     }
   }, [cleanup]);
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -250,10 +250,21 @@ const en = {
   voice: {
     start: 'Start dictation',
     stop: 'Stop dictation',
+    recording: 'Recording',
     transcribing: 'Transcribing…',
+    // a11y: spoken by screen readers, must describe the current action.
+    ariaStart: 'Start dictation',
+    ariaStop: 'Stop dictation, {{time}} elapsed',
+    ariaTranscribing: 'Transcribing your speech, please wait',
+    // No usable audio captured — clip too short or no speech detected.
+    noSpeechTitle: "Didn't catch that",
+    noSpeechBody: 'Please try speaking again, a little longer.',
     errorMic: 'Microphone access denied',
+    errorMicBody: 'Allow microphone access for this app in your system settings, then try again.',
     errorNoModel: 'Voice model not installed',
+    errorNoModelBody: 'The speech-to-text model is missing. Install the voice model to use dictation.',
     errorFailed: 'Transcription failed',
+    errorFailedBody: 'Something went wrong while transcribing. Click the mic to try again.',
   },
   chat: {
     cwdChipNoneLabel: '(none)',

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -239,10 +239,21 @@ const zh: EnCatalog = {
   voice: {
     start: '开始语音输入',
     stop: '停止语音输入',
+    recording: '录音中',
     transcribing: '识别中…',
+    // a11y: 屏幕阅读器朗读,需描述当前动作。
+    ariaStart: '开始语音输入',
+    ariaStop: '停止语音输入,已录制 {{time}}',
+    ariaTranscribing: '正在识别你的语音,请稍候',
+    // 没采到可用音频——太短或没检测到说话。
+    noSpeechTitle: '没听清',
+    noSpeechBody: '请再说一次,稍微说长一点。',
     errorMic: '麦克风访问被拒绝',
+    errorMicBody: '请在系统设置里允许本应用访问麦克风,然后重试。',
     errorNoModel: '语音模型未安装',
+    errorNoModelBody: '缺少语音转文字模型。请先安装语音模型再使用语音输入。',
     errorFailed: '识别失败',
+    errorFailedBody: '识别时出错了。点麦克风图标重试。',
   },
   chat: {
     cwdChipNoneLabel: '（无）',

--- a/src/voice/voiceFeedback.ts
+++ b/src/voice/voiceFeedback.ts
@@ -1,0 +1,54 @@
+// Pure mapping from a voice-capture outcome to a toast spec. Kept separate
+// from useVoiceRecorder so the "what to show the user" decision is a plain
+// function we can unit-test without Web Audio, React, or the toast runtime.
+//
+// The hook owns the side effects (capture, transcribe, paste, dispatch); this
+// module owns only the decision of which feedback (if any) to surface.
+
+export type VoiceOutcome =
+  | { kind: 'no-speech' } // clip too short or transcriber returned empty
+  | { kind: 'error'; message: string }; // mic denied / no-model / transcribe-failed
+
+export type VoiceToastSpec = {
+  // Maps to ToastKind in components/ui/Toast.tsx. 'info' rides the polite
+  // aria-live region; 'error' rides the assertive (role="alert") region.
+  kind: 'info' | 'error';
+  // i18n keys (namespace-qualified) — resolved by the caller via t().
+  titleKey: string;
+  bodyKey: string;
+};
+
+// Normalize the transcriber's error string into the three known buckets.
+// Unknown messages fall back to the generic "transcription failed" copy so a
+// user never gets a silent failure.
+function errorKeys(message: string): { titleKey: string; bodyKey: string } {
+  switch (message) {
+    case 'mic':
+      return { titleKey: 'voice.errorMic', bodyKey: 'voice.errorMicBody' };
+    case 'no-model':
+      return { titleKey: 'voice.errorNoModel', bodyKey: 'voice.errorNoModelBody' };
+    default:
+      return { titleKey: 'voice.errorFailed', bodyKey: 'voice.errorFailedBody' };
+  }
+}
+
+export function voiceToastForOutcome(outcome: VoiceOutcome): VoiceToastSpec {
+  if (outcome.kind === 'no-speech') {
+    return {
+      kind: 'info',
+      titleKey: 'voice.noSpeechTitle',
+      bodyKey: 'voice.noSpeechBody',
+    };
+  }
+  const { titleKey, bodyKey } = errorKeys(outcome.message);
+  return { kind: 'error', titleKey, bodyKey };
+}
+
+// Format an elapsed-seconds count as m:ss (e.g. 0:03, 1:07). Used for the
+// recording-duration indicator and its aria-label.
+export function formatElapsed(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  const m = Math.floor(s / 60);
+  const rem = s % 60;
+  return `${m}:${String(rem).padStart(2, '0')}`;
+}

--- a/tests/voice/MicButton.test.tsx
+++ b/tests/voice/MicButton.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, cleanup } from '@testing-library/react';
+import type { VoiceState } from '../../src/voice/recorderMachine';
+import type { VoiceOutcome } from '../../src/voice/voiceFeedback';
+import { ToastProvider } from '../../src/components/ui/Toast';
+import { initI18n } from '../../src/i18n';
+
+// We mock the recorder hook so the test drives MicButton's *presentation*
+// (timer / labels / aria) from an arbitrary VoiceState, and can invoke the
+// onFeedback callback to assert the toast wiring — without Web Audio. The
+// capture/transcribe flow is covered separately (recorderMachine +
+// voiceFeedback unit tests).
+let mockState: VoiceState = { kind: 'idle' };
+let lastFeedback: ((o: VoiceOutcome) => void) | undefined;
+const toggle = vi.fn();
+
+vi.mock('../../src/components/voice/useVoiceRecorder', () => ({
+  useVoiceRecorder: (_sid: string, onFeedback?: (o: VoiceOutcome) => void) => {
+    lastFeedback = onFeedback;
+    return { state: mockState, toggle };
+  },
+}));
+
+import { MicButton } from '../../src/components/voice/MicButton';
+
+function renderButton() {
+  return render(
+    <ToastProvider>
+      <MicButton sessionId="s1" />
+    </ToastProvider>
+  );
+}
+
+beforeEach(() => {
+  initI18n('en');
+  mockState = { kind: 'idle' };
+  lastFeedback = undefined;
+  toggle.mockClear();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  cleanup();
+});
+
+describe('<MicButton /> feedback + a11y', () => {
+  it('idle: descriptive start aria-label, not busy', () => {
+    mockState = { kind: 'idle' };
+    renderButton();
+    const btn = screen.getByRole('button', { name: 'Start dictation' });
+    expect(btn).toHaveAttribute('aria-busy', 'false');
+  });
+
+  it('recording: shows a live timer that ticks each second + reduced-motion-safe pulse', () => {
+    mockState = { kind: 'recording' };
+    renderButton();
+    // Initial render shows 0:00.
+    expect(screen.getByText(/Recording 0:00/)).toBeInTheDocument();
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+    expect(screen.getByText(/Recording 0:03/)).toBeInTheDocument();
+    // aria-label carries the elapsed time for screen readers.
+    expect(
+      screen.getByRole('button', { name: /Stop dictation, 0:03 elapsed/ })
+    ).toBeInTheDocument();
+    // Pulsing red dot is gated for prefers-reduced-motion.
+    const dot = document.querySelector('.animate-pulse.motion-reduce\\:animate-none');
+    expect(dot).not.toBeNull();
+  });
+
+  it('transcribing: visible label, aria-busy, disabled, motion-reduce spinner', () => {
+    mockState = { kind: 'transcribing' };
+    renderButton();
+    expect(screen.getByText('Transcribing…')).toBeInTheDocument();
+    const btn = screen.getByRole('button', { name: 'Transcribing your speech, please wait' });
+    expect(btn).toHaveAttribute('aria-busy', 'true');
+    expect(btn).toBeDisabled();
+    const spinner = document.querySelector('.animate-spin.motion-reduce\\:animate-none');
+    expect(spinner).not.toBeNull();
+  });
+
+  it('no-speech outcome pushes a polite info toast with reason + recovery', () => {
+    mockState = { kind: 'idle' };
+    renderButton();
+    act(() => {
+      lastFeedback?.({ kind: 'no-speech' });
+    });
+    const region = document.querySelector('[role="status"][aria-live="polite"]');
+    expect(region?.textContent).toContain("Didn't catch that");
+    expect(region?.textContent).toContain('Please try speaking again');
+  });
+
+  it('mic error outcome pushes an assertive error toast with recovery guidance', () => {
+    mockState = { kind: 'error', message: 'mic' };
+    renderButton();
+    act(() => {
+      lastFeedback?.({ kind: 'error', message: 'mic' });
+    });
+    const region = document.querySelector('[role="alert"][aria-live="assertive"]');
+    expect(region?.textContent).toContain('Microphone access denied');
+    expect(region?.textContent).toContain('system settings');
+  });
+
+  it('no-model error outcome explains the missing model', () => {
+    mockState = { kind: 'error', message: 'no-model' };
+    renderButton();
+    act(() => {
+      lastFeedback?.({ kind: 'error', message: 'no-model' });
+    });
+    const region = document.querySelector('[role="alert"][aria-live="assertive"]');
+    expect(region?.textContent).toContain('Voice model not installed');
+  });
+});

--- a/tests/voice/voiceFeedback.test.ts
+++ b/tests/voice/voiceFeedback.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  voiceToastForOutcome,
+  formatElapsed,
+  type VoiceOutcome,
+} from '../../src/voice/voiceFeedback';
+
+describe('voiceToastForOutcome', () => {
+  it('no-speech → info toast with the "didn\'t catch that" copy', () => {
+    expect(voiceToastForOutcome({ kind: 'no-speech' })).toEqual({
+      kind: 'info',
+      titleKey: 'voice.noSpeechTitle',
+      bodyKey: 'voice.noSpeechBody',
+    });
+  });
+
+  it('mic error → assertive error toast with recovery body', () => {
+    expect(voiceToastForOutcome({ kind: 'error', message: 'mic' })).toEqual({
+      kind: 'error',
+      titleKey: 'voice.errorMic',
+      bodyKey: 'voice.errorMicBody',
+    });
+  });
+
+  it('no-model error → error toast pointing at the missing model', () => {
+    expect(voiceToastForOutcome({ kind: 'error', message: 'no-model' })).toEqual({
+      kind: 'error',
+      titleKey: 'voice.errorNoModel',
+      bodyKey: 'voice.errorNoModelBody',
+    });
+  });
+
+  it('transcribe-failed → generic failure error toast', () => {
+    expect(voiceToastForOutcome({ kind: 'error', message: 'transcribe-failed' })).toEqual({
+      kind: 'error',
+      titleKey: 'voice.errorFailed',
+      bodyKey: 'voice.errorFailedBody',
+    });
+  });
+
+  it('unknown error message falls back to the generic failure copy (never silent)', () => {
+    const outcome: VoiceOutcome = { kind: 'error', message: 'some-future-code' };
+    expect(voiceToastForOutcome(outcome)).toEqual({
+      kind: 'error',
+      titleKey: 'voice.errorFailed',
+      bodyKey: 'voice.errorFailedBody',
+    });
+  });
+});
+
+describe('formatElapsed', () => {
+  it('formats sub-minute durations as 0:ss', () => {
+    expect(formatElapsed(0)).toBe('0:00');
+    expect(formatElapsed(3)).toBe('0:03');
+    expect(formatElapsed(59)).toBe('0:59');
+  });
+
+  it('rolls over into minutes', () => {
+    expect(formatElapsed(60)).toBe('1:00');
+    expect(formatElapsed(67)).toBe('1:07');
+    expect(formatElapsed(125)).toBe('2:05');
+  });
+
+  it('floors fractional seconds and clamps negatives to 0:00', () => {
+    expect(formatElapsed(3.9)).toBe('0:03');
+    expect(formatElapsed(-5)).toBe('0:00');
+  });
+});


### PR DESCRIPTION
Closes part of #27 (CCSM voice input UX improvements). Pure feedback/a11y layer — no change to recording, resampling, the `voice:transcribe` IPC contract, or `transcriber.ts`. No new keyboard shortcuts, no waveform/level meter (out of scope).

## What changed (4 items + a11y)

**1. Silent / too-short / empty feedback** — `useVoiceRecorder.ts` previously dropped to idle silently when a clip was < ~300ms (`MIN_SAMPLES_16K`) or the transcriber returned `empty`. Now both raise a polite "Didn't catch that / try again, a little longer" info toast (reuses `Toast.tsx`, rides its `aria-live="polite"` / `role="status"` region).

**2. Errors as toasts with reason + recovery** — mic-denied / no-model / transcribe-failed used to only flip the icon to a red `MicOff` with no text. Now each pushes an assertive error toast (`role="alert"` / `aria-live="assertive"` region already in `Toast.tsx`) with a cause + how-to-fix body: open system settings / install the voice model / click to retry.

**3. Stronger transcribing feedback** — `MicButton.tsx` adds a visible "Transcribing…" pill next to the spinner and sets `aria-busy={true}`, so the 1-2s cold start no longer reads as a hang.

**4. Recording duration indicator** — recording shows a red dot + "Recording m:ss" pill, timer ticking once a second via component-local state + interval, cleared on stop.

**A11y (ui-ux-pro-max §1)** — mic `aria-label` now describes the current action incl. elapsed time (`Stop dictation, 0:03 elapsed`); every animation (`animate-pulse`/`animate-spin`/dot) is wrapped in `motion-reduce:animate-none`; state changes are conveyed by aria-live text, not color alone.

## Files
- `src/voice/voiceFeedback.ts` (new) — pure outcome→toast-spec mapping + `formatElapsed`; SRP, no React/Web Audio, fully unit-tested.
- `src/components/voice/useVoiceRecorder.ts` — fires an injected `onFeedback(outcome)` on no-speech / errors (kept decoupled from the toast runtime via a ref).
- `src/components/voice/MicButton.tsx` — timer, recording/transcribing pills, dynamic aria-label, aria-busy, motion-reduce, wires `onFeedback` to toasts.
- `src/components/ui/Toast.tsx` — adds non-throwing `useToastOptional()` so bare `<TerminalPane>` renders (e2e probes / component tests) degrade to no-toast instead of crashing.
- `src/i18n/locales/{en,zh}.ts` — new voice keys (recording, aria*, noSpeech*, error*Body), en + zh in lockstep (verified by `i18n-key-parity` test).
- `tests/voice/voiceFeedback.test.ts`, `tests/voice/MicButton.test.tsx` (new).

## Tests
- `voiceFeedback.test.ts` — outcome→toast mapping for all branches incl. unknown-error fallback; `formatElapsed` m:ss / rollover / clamp.
- `MicButton.test.tsx` — drives presentation from each `VoiceState` (mocks the recorder hook): live timer ticks 0:00→0:03, transcribing label + `aria-busy` + disabled, motion-reduce classes present, and the no-speech/mic/no-model toasts land in the correct aria-live region with reason + recovery text.
- No `.skip`/`xit`/`it.todo` added; no tests deleted.

## Visual evidence (real packaged app, electron+playwright)
Drove the four states in the live app via a throwaway (uncommitted) dogfood script reusing the `harness-e2e-voice-input.mjs` mic/transcribe seams. App locale happened to be zh, which doubles as i18n proof:
- Recording: top-right pill `● 录音中 0:03` (red dot + Recording + timer).
- Transcribing: pill `识别中…` next to the spinner.
- No-speech: bottom-right info toast `没听清 / 请再说一次,稍微说长一点。`
- Error: error toast `麦克风访问被拒绝 / 请在系统设置里允许本应用访问麦克风,然后重试。`

(Screenshots not committed per repo convention — captured locally, all four states rendered as designed.) The existing `harness-e2e-voice-input` happy-path also still passes (1/1, transcript injected, no auto-submit).

## Local checks (host: Windows 11, mode: fast)
- lint: ✓ (exit 0, eslint --max-warnings 0)
- typecheck: ✓ (exit 0, tsc renderer + electron)
- build: ✓ (exit 0, webpack)
- tests: ✓ `vitest run tests/voice/ tests/toast-a11y tests/components/TerminalPane tests/i18n-key-parity` → 34 passed. Full suite: all pass except pre-existing env-only failures (`db*.test.ts` native `ERR_DLOPEN_FAILED` — better-sqlite3 not rebuilt for this Electron ABI; `electron-load-smoke` needs `dist/electron`) — both reproduce identically on the clean baseline before this change (verified via `git stash`), unrelated to this PR. CI runs in a properly-built env.