### PR TITLE
fix(mobile-remote): flatten Worker ICE urls[] to werift urls:string (PR-6)

### DIFF
--- a/docs/superpowers/plans/2026-05-31-mobile-remote-pr6-ice-flatten.md
+++ b/docs/superpowers/plans/2026-05-31-mobile-remote-pr6-ice-flatten.md
@@ -1,0 +1,228 @@
+# Mobile Remote PR-6: Flatten Worker ICE `urls[]` → werift `urls:string` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `electron/remote/turnCred.ts` flatten the Worker's `{urls: string[]}` ICE entries into werift's `{urls: string}` shape, so the desktop answerer actually finds STUN/TURN when fed the real Worker payload.
+
+**Architecture:** One pure helper `flattenIceServers` added to `turnCred.ts`; `fetchIceServers` calls it after parsing the body. Controller and main.ts unchanged. Worker unchanged. All coverage at the `turnCred` seam via injected `fetchImpl`.
+
+**Tech Stack:** TypeScript, werift (`RTCIceServer`), vitest (Node ABI).
+
+**Base branch:** branch from `feat/mobile-remote-web-exposure` at tip `9d09737`. PR targets `feat/mobile-remote-web-exposure`, NOT `main`.
+
+---
+
+### Task 1: Flatten array `urls` into singular werift entries
+
+**Files:**
+- Modify: `electron/remote/turnCred.ts`
+- Test: `electron/remote/__tests__/turnCred.test.ts`
+
+- [ ] **Step 1: Add the failing tests**
+
+Append these cases to `electron/remote/__tests__/turnCred.test.ts` (keep existing tests). They assume the existing helper that builds a fake `fetchImpl` returning a given JSON body with `ok:true`; if the existing file names it differently, reuse that. Pattern for a 200 response with a JSON body:
+
+```ts
+function ok(body: unknown): typeof fetch {
+  return (async () =>
+    ({ ok: true, json: async () => body }) as unknown as Response) as unknown as typeof fetch;
+}
+
+it('flattens an array of STUN urls into singular entries', async () => {
+  const res = await fetchIceServers({
+    workerOrigin: 'https://w.example',
+    token: 't',
+    fetchImpl: ok({ iceServers: [{ urls: ['stun:a:3478', 'stun:b:3478'] }] }),
+  });
+  expect(res).toEqual([{ urls: 'stun:a:3478' }, { urls: 'stun:b:3478' }]);
+  for (const s of res ?? []) expect(typeof s.urls).toBe('string');
+});
+
+it('carries username/credential onto every TURN url', async () => {
+  const res = await fetchIceServers({
+    workerOrigin: 'https://w.example',
+    token: 't',
+    fetchImpl: ok({
+      iceServers: [{ urls: ['turn:t:3478', 'turns:t:5349'], username: 'u', credential: 'c' }],
+    }),
+  });
+  expect(res).toEqual([
+    { urls: 'turn:t:3478', username: 'u', credential: 'c' },
+    { urls: 'turns:t:5349', username: 'u', credential: 'c' },
+  ]);
+});
+
+it('handles the real mixed STUN+TURN Worker shape', async () => {
+  const res = await fetchIceServers({
+    workerOrigin: 'https://w.example',
+    token: 't',
+    fetchImpl: ok({
+      iceServers: [
+        { urls: ['stun:s:3478'] },
+        { urls: ['turn:t:3478'], username: 'u', credential: 'c' },
+      ],
+    }),
+  });
+  expect(res).toEqual([
+    { urls: 'stun:s:3478' },
+    { urls: 'turn:t:3478', username: 'u', credential: 'c' },
+  ]);
+});
+
+it('passes through already-singular urls unchanged (idempotent)', async () => {
+  const res = await fetchIceServers({
+    workerOrigin: 'https://w.example',
+    token: 't',
+    fetchImpl: ok({ iceServers: [{ urls: 'stun:x:3478' }] }),
+  });
+  expect(res).toEqual([{ urls: 'stun:x:3478' }]);
+});
+
+it('returns null when flattening yields no usable urls', async () => {
+  const res = await fetchIceServers({
+    workerOrigin: 'https://w.example',
+    token: 't',
+    fetchImpl: ok({ iceServers: [{ urls: [] }, { urls: '' }] }),
+  });
+  expect(res).toBeNull();
+});
+```
+
+Also update the existing "200 → returns the array" test to assert each `urls` is a string (it already passes a singular shape, so add):
+```ts
+for (const s of res ?? []) expect(typeof s.urls).toBe('string');
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm test -- turnCred`
+Expected: the new array/flatten tests FAIL (current code returns `body.iceServers` verbatim, so `urls` stays an array and `toEqual` mismatches); existing tests still pass.
+
+- [ ] **Step 3: Implement `flattenIceServers` and wire it in**
+
+Replace the body of `electron/remote/turnCred.ts` with:
+
+```ts
+// electron/remote/turnCred.ts
+import { type RTCIceServer } from 'werift';
+
+type WireIceServer = {
+  urls: string | string[];
+  username?: string;
+  credential?: string;
+};
+
+/** werift's RTCIceServer.urls is a single string and werift consumes it as
+ *  one (`urls.includes("stun:")`, `urls.slice(5)`). The Worker sends `urls`
+ *  as a string[] (comma-split STUN_URLS/TURN_URLS). Flatten each wire entry
+ *  into one werift entry per url, carrying username/credential onto each so
+ *  TURN auth survives. */
+function flattenIceServers(wire: WireIceServer[]): RTCIceServer[] {
+  const out: RTCIceServer[] = [];
+  for (const entry of wire) {
+    const urls = Array.isArray(entry.urls) ? entry.urls : [entry.urls];
+    for (const url of urls) {
+      if (typeof url !== 'string' || url.length === 0) continue;
+      const server: RTCIceServer = { urls: url };
+      if (entry.username !== undefined) server.username = entry.username;
+      if (entry.credential !== undefined) server.credential = entry.credential;
+      out.push(server);
+    }
+  }
+  return out;
+}
+
+/** Fetch ICE servers (STUN + optional TURN) from the Worker's
+ *  `POST /turn/credentials`. Returns null — never throws — on any non-OK
+ *  response (501 "turn not configured" is the expected default), network
+ *  error, malformed body, or a payload that flattens to nothing, so the
+ *  controller degrades to STUN-only instead of crashing mobile-remote
+ *  startup. `fetchImpl` is injectable for tests. */
+export async function fetchIceServers(deps: {
+  workerOrigin: string;
+  token: string;
+  fetchImpl?: typeof fetch;
+}): Promise<RTCIceServer[] | null> {
+  const f = deps.fetchImpl ?? fetch;
+  try {
+    const res = await f(new URL('/turn/credentials', deps.workerOrigin).toString(), {
+      method: 'POST',
+      headers: { authorization: `Bearer ${deps.token}` },
+    });
+    if (!res.ok) return null;
+    const body = (await res.json()) as { iceServers?: WireIceServer[] };
+    if (!Array.isArray(body.iceServers)) return null;
+    const flat = flattenIceServers(body.iceServers);
+    return flat.length > 0 ? flat : null;
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npm test -- turnCred`
+Expected: all tests PASS (new flatten cases + existing 200/501/throw/malformed).
+
+- [ ] **Step 5: Local gate**
+
+Run: `npm run typecheck && npm run lint && npm test`
+Expected: all green. (`WireIceServer` is local; no new globals; no eslint config change needed.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add electron/remote/turnCred.ts electron/remote/__tests__/turnCred.test.ts
+git commit -m "fix(mobile-remote): flatten Worker ICE urls[] to werift urls:string (PR-6)"
+```
+
+---
+
+### Task 2: Include the design docs in the PR branch
+
+**Files:**
+- Add: `docs/superpowers/specs/2026-05-31-mobile-remote-pr6-ice-flatten-design.md` (already written in the planning worktree — copy its contents)
+- Add: `docs/superpowers/plans/2026-05-31-mobile-remote-pr6-ice-flatten.md` (this file)
+
+- [ ] **Step 1: Ensure both docs exist on the branch**
+
+The spec and plan were authored in the `mobile-remote` planning worktree. Copy both files into this branch at the same paths so they ride along in the PR. If they are already present (because you branched from a worktree that has them uncommitted), `git add` them.
+
+- [ ] **Step 2: Commit the docs**
+
+```bash
+git add docs/superpowers/specs/2026-05-31-mobile-remote-pr6-ice-flatten-design.md \
+        docs/superpowers/plans/2026-05-31-mobile-remote-pr6-ice-flatten.md
+git commit -m "docs(mobile-remote): PR-6 ICE flatten spec + plan"
+```
+
+---
+
+### Task 3: Open the PR (do NOT merge)
+
+- [ ] **Step 1: Push and open PR against the integration branch**
+
+```bash
+git push -u origin <your-branch>
+gh pr create --base feat/mobile-remote-web-exposure \
+  --title "fix(mobile-remote): flatten Worker ICE urls[] to werift urls:string (PR-6)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Worker returns ICE entries with `urls: string[]` (comma-split STUN_URLS/TURN_URLS), but werift's `RTCIceServer.urls` is a single string and werift consumes it as one (`urls.includes("stun:")`, `urls.slice(5)`). Fed the real Worker payload, werift found no STUN/TURN and gathered only host candidates.
+- This PR flattens each wire entry into one werift entry per url (carrying username/credential onto TURN entries) inside `fetchIceServers`. No Worker change, no controller change, no main.ts change.
+
+## Evidence boundary
+Automated tests prove the desktop now produces werift-shaped ICE from the real Worker array payload. They do NOT prove public-internet reachability, TURN relay, or the real OAuth round-trip — those remain user-only real-device steps and are additionally blocked until the user deploys our Worker (the live origin currently serves a static SPA; `POST /auth/session` → 405).
+
+## Test plan
+- [ ] `npm run typecheck` green
+- [ ] `npm run lint` green
+- [ ] `npm test` green (turnCred flatten cases: array STUN, TURN auth carry, mixed shape, singular idempotent, empty→null)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 2: STOP.** Report the PR number + the green local gate to the parent (manager). Do **NOT** self-review and do **NOT** `gh pr merge`. An independent reviewer merges.

--- a/docs/superpowers/specs/2026-05-31-mobile-remote-pr6-ice-flatten-design.md
+++ b/docs/superpowers/specs/2026-05-31-mobile-remote-pr6-ice-flatten-design.md
@@ -1,0 +1,111 @@
+# Mobile Remote PR-6: Flatten Worker ICE `urls[]` → werift `urls:string` — Design
+
+**Status:** design. Authored 2026-05-31.
+
+**Base:** `feat/mobile-remote-web-exposure` at integration tip `9d09737` (after PR-5).
+
+## 1. Goal
+
+Make the desktop WebRTC answerer actually use the ICE servers the Cloudflare Worker returns. Today it cannot: the Worker sends each entry's `urls` as a **string array**, but werift's `RTCIceServer.urls` is a **single string** and werift consumes it as a string (`urls.includes("stun:")`, `urls.slice(5)`). Fed the real Worker payload, werift finds **no** STUN/TURN server and gathers only host candidates — public-internet hole-punching fails. This PR flattens the Worker shape into werift's shape on the desktop side. **Zero Worker changes.**
+
+## 2. The bug (evidence)
+
+- werift type — `node_modules/werift/lib/webrtc/src/peerConnection.d.ts:157`:
+  ```ts
+  export type RTCIceServer = { urls: string; username?: string; credential?: string };
+  ```
+- werift runtime — `node_modules/werift/lib/webrtc/src/utils.js:97-98`:
+  ```js
+  const stunServer = url2Address(iceServers.find(({ urls }) => urls.includes("stun:"))?.urls.slice(5));
+  const turnServer = url2Address(iceServers.find(({ urls }) => urls.includes("turn:"))?.urls.slice(5));
+  ```
+  `urls` is treated as a string. An **array** `["stun:stun.cloudflare.com:3478"]` fails: `.includes("stun:")` is element-equality (false), and `.slice(5)` on an array returns a sub-array that `url2Address` cannot parse.
+- Worker payload — `cloudflare/src/routes/turnCred.ts:38-43` returns `{ urls: cfg.stunUrls }` and `{ urls: cfg.turnUrls, username, credential }` where `stunUrls`/`turnUrls` are `string[]` (`cloudflare/src/lib/config.ts:53-54` comma-splits `STUN_URLS`/`TURN_URLS`). `cloudflare/src/routes/session.ts:22` likewise returns `[{ urls: cfg.stunUrls }]`.
+
+**Asymmetry:** the array form is valid for standard browser `RTCIceServer` (the phone offerer accepts it). Only the desktop (werift) side breaks. So we fix on the **desktop**, never the Worker.
+
+## 3. Why PR-5's tests passed
+
+`turnCred.test.ts` and `mobileRemoteController.test.ts` inject hand-built **singular-string** fakes (`[{ urls: 'stun:stun.l.google.com:19302' }]`) that already match werift's shape, so they never exercise the array form the real Worker sends. The `GOOGLE_STUN` fallback constant is also singular, so the fallback path works while the Worker path is dead. PR-6 adds the missing array-shape coverage.
+
+## 4. Design
+
+### 4.1 Single fix point: `electron/remote/turnCred.ts`
+
+`fetchIceServers` is the only place a Worker ICE payload enters the desktop (the `/auth/session` STUN list is already discarded — `MobileRemoteLogin` carries only `token`/`doUrl`). So flatten there, right after parsing the body, before returning.
+
+The Worker entry shape is wider than werift's type, so parse it as the wire shape and normalize:
+
+```ts
+import { type RTCIceServer } from 'werift';
+
+type WireIceServer = {
+  urls: string | string[];
+  username?: string;
+  credential?: string;
+};
+
+/** werift's RTCIceServer.urls is a single string and werift consumes it as
+ *  one (`urls.includes("stun:")`, `urls.slice(5)`). The Worker sends `urls`
+ *  as a string[] (comma-split STUN_URLS/TURN_URLS). Flatten each wire entry
+ *  into one werift entry per url, carrying username/credential onto each so
+ *  TURN auth survives. */
+function flattenIceServers(wire: WireIceServer[]): RTCIceServer[] {
+  const out: RTCIceServer[] = [];
+  for (const entry of wire) {
+    const urls = Array.isArray(entry.urls) ? entry.urls : [entry.urls];
+    for (const url of urls) {
+      if (typeof url !== 'string' || url.length === 0) continue;
+      const server: RTCIceServer = { urls: url };
+      if (entry.username !== undefined) server.username = entry.username;
+      if (entry.credential !== undefined) server.credential = entry.credential;
+      out.push(server);
+    }
+  }
+  return out;
+}
+```
+
+`fetchIceServers` body change:
+
+```ts
+if (!res.ok) return null;
+const body = (await res.json()) as { iceServers?: WireIceServer[] };
+if (!Array.isArray(body.iceServers)) return null;
+const flat = flattenIceServers(body.iceServers);
+return flat.length > 0 ? flat : null;
+```
+
+Returning `null` when flattening yields nothing (e.g. all-empty `urls`) keeps the existing contract: the controller falls back to `GOOGLE_STUN` rather than handing werift an empty list. No throw path is added.
+
+### 4.2 Controller — no change
+
+`resolveIceServers` already does `injected > worker-fetched (if non-empty) > GOOGLE_STUN`. `fetchIceServers` now returns already-flattened werift entries, so the controller is correct as-is. `GOOGLE_STUN` is already singular. No edit.
+
+### 4.3 No Worker change, no main.ts change
+
+The Worker's array shape is intentional and valid for browsers (phone side). `main.ts` wiring is unchanged.
+
+## 5. Testing strategy
+
+Extend `electron/remote/__tests__/turnCred.test.ts` (Node ABI, vitest, inject `fetchImpl`):
+
+- **array STUN → flattened singular:** body `{ iceServers: [{ urls: ['stun:a:3478', 'stun:b:3478'] }] }` → returns `[{urls:'stun:a:3478'},{urls:'stun:b:3478'}]` (two singular entries, each `urls` a string).
+- **array TURN carries auth onto every url:** `{ iceServers: [{ urls: ['turn:t:3478','turns:t:5349'], username:'u', credential:'c' }] }` → two entries, each with `urls` string + `username:'u'` + `credential:'c'`.
+- **mixed STUN+TURN (real Worker shape):** `{ iceServers: [{urls:['stun:s:3478']},{urls:['turn:t:3478'],username:'u',credential:'c'}] }` → 2 entries; the stun entry has no username/credential, the turn entry does. Each entry's `urls` satisfies werift's `urls.includes("stun:"|"turn:")` + `.slice(5)` (i.e. is a string, not an array).
+- **already-singular still works:** `{ iceServers: [{ urls: 'stun:x:3478' }] }` → `[{urls:'stun:x:3478'}]` (idempotent — back-compat with injected/singular sources).
+- **empty/garbage urls dropped:** `{ iceServers: [{ urls: [] }, { urls: '' }] }` → flatten empty → returns `null` (controller falls back to Google STUN).
+- Existing 4 tests (200→array, 501→null, throw→null, malformed→null) stay green; the "200→array" assertion is updated to also assert each returned `urls` is a `string`, not an array.
+
+No new controller tests needed (its logic is unchanged); the flattening is fully covered at the `turnCred` seam.
+
+## 6. Evidence boundary (the /goal gate — unchanged from PR-5)
+
+These tests prove the desktop now produces werift-shaped ICE entries from the real Worker payload. They do **NOT** prove public-internet reachability, TURN relay, or the real OAuth round-trip. Those still require **user-only real-device verification over 4G**, and that verification is **also blocked by a deployment precondition**: the live `ccsm-worker.jiahuigu.workers.dev` currently serves a static SPA, not our Worker (`POST /auth/session` → 405). The user must `wrangler deploy` our Worker before any real-device acceptance — agent never deploys (only `--dry-run`). PR-6 is the last *code* blocker on the desktop ICE path; the deploy is the last *infra* blocker.
+
+## 7. Out of scope
+
+- Worker changes (none — array shape is valid for browsers).
+- Worker deployment (user-only).
+- Periodic TURN cred refresh (still a documented follow-up from PR-5).
+- main.ts / controller changes (none).

--- a/electron/remote/__tests__/turnCred.test.ts
+++ b/electron/remote/__tests__/turnCred.test.ts
@@ -33,12 +33,86 @@ describe('fetchIceServers', () => {
       { urls: 'stun:stun.cloudflare.com:3478' },
       { urls: 'turn:turn.example:3478', username: 'u', credential: 'c' },
     ]);
+    for (const s of result ?? []) expect(typeof s.urls).toBe('string');
     expect(calls).toHaveLength(1);
     expect(calls[0].url).toBe('https://w.example.dev/turn/credentials');
     expect(calls[0].init?.method).toBe('POST');
     expect(
       (calls[0].init?.headers as Record<string, string>).authorization,
     ).toBe('Bearer JWT');
+  });
+
+  it('flattens an array of STUN urls into singular entries', async () => {
+    const fetchImpl = (async () =>
+      jsonResponse({
+        iceServers: [{ urls: ['stun:a:3478', 'stun:b:3478'] }],
+      })) as unknown as typeof fetch;
+    const result = await fetchIceServers({
+      workerOrigin: 'https://w.example.dev',
+      token: 'JWT',
+      fetchImpl,
+    });
+    expect(result).toEqual([{ urls: 'stun:a:3478' }, { urls: 'stun:b:3478' }]);
+    for (const s of result ?? []) expect(typeof s.urls).toBe('string');
+  });
+
+  it('carries username/credential onto every TURN url', async () => {
+    const fetchImpl = (async () =>
+      jsonResponse({
+        iceServers: [
+          { urls: ['turn:t:3478', 'turns:t:5349'], username: 'u', credential: 'c' },
+        ],
+      })) as unknown as typeof fetch;
+    const result = await fetchIceServers({
+      workerOrigin: 'https://w.example.dev',
+      token: 'JWT',
+      fetchImpl,
+    });
+    expect(result).toEqual([
+      { urls: 'turn:t:3478', username: 'u', credential: 'c' },
+      { urls: 'turns:t:5349', username: 'u', credential: 'c' },
+    ]);
+  });
+
+  it('handles the real mixed STUN+TURN Worker shape', async () => {
+    const fetchImpl = (async () =>
+      jsonResponse({
+        iceServers: [
+          { urls: ['stun:s:3478'] },
+          { urls: ['turn:t:3478'], username: 'u', credential: 'c' },
+        ],
+      })) as unknown as typeof fetch;
+    const result = await fetchIceServers({
+      workerOrigin: 'https://w.example.dev',
+      token: 'JWT',
+      fetchImpl,
+    });
+    expect(result).toEqual([
+      { urls: 'stun:s:3478' },
+      { urls: 'turn:t:3478', username: 'u', credential: 'c' },
+    ]);
+  });
+
+  it('passes through already-singular urls unchanged (idempotent)', async () => {
+    const fetchImpl = (async () =>
+      jsonResponse({ iceServers: [{ urls: 'stun:x:3478' }] })) as unknown as typeof fetch;
+    const result = await fetchIceServers({
+      workerOrigin: 'https://w.example.dev',
+      token: 'JWT',
+      fetchImpl,
+    });
+    expect(result).toEqual([{ urls: 'stun:x:3478' }]);
+  });
+
+  it('returns null when flattening yields no usable urls', async () => {
+    const fetchImpl = (async () =>
+      jsonResponse({ iceServers: [{ urls: [] }, { urls: '' }] })) as unknown as typeof fetch;
+    const result = await fetchIceServers({
+      workerOrigin: 'https://w.example.dev',
+      token: 'JWT',
+      fetchImpl,
+    });
+    expect(result).toBeNull();
   });
 
   it('returns null on a 501 (TURN not configured)', async () => {

--- a/electron/remote/turnCred.ts
+++ b/electron/remote/turnCred.ts
@@ -1,11 +1,38 @@
 // electron/remote/turnCred.ts
 import { type RTCIceServer } from 'werift';
 
+type WireIceServer = {
+  urls: string | string[];
+  username?: string;
+  credential?: string;
+};
+
+/** werift's RTCIceServer.urls is a single string and werift consumes it as
+ *  one (`urls.includes("stun:")`, `urls.slice(5)`). The Worker sends `urls`
+ *  as a string[] (comma-split STUN_URLS/TURN_URLS). Flatten each wire entry
+ *  into one werift entry per url, carrying username/credential onto each so
+ *  TURN auth survives. */
+function flattenIceServers(wire: WireIceServer[]): RTCIceServer[] {
+  const out: RTCIceServer[] = [];
+  for (const entry of wire) {
+    const urls = Array.isArray(entry.urls) ? entry.urls : [entry.urls];
+    for (const url of urls) {
+      if (typeof url !== 'string' || url.length === 0) continue;
+      const server: RTCIceServer = { urls: url };
+      if (entry.username !== undefined) server.username = entry.username;
+      if (entry.credential !== undefined) server.credential = entry.credential;
+      out.push(server);
+    }
+  }
+  return out;
+}
+
 /** Fetch ICE servers (STUN + optional TURN) from the Worker's
  *  `POST /turn/credentials`. Returns null — never throws — on any non-OK
  *  response (501 "turn not configured" is the expected default), network
- *  error, or malformed body, so the controller degrades to STUN-only instead
- *  of crashing mobile-remote startup. `fetchImpl` is injectable for tests. */
+ *  error, malformed body, or a payload that flattens to nothing, so the
+ *  controller degrades to STUN-only instead of crashing mobile-remote
+ *  startup. `fetchImpl` is injectable for tests. */
 export async function fetchIceServers(deps: {
   workerOrigin: string;
   token: string;
@@ -18,8 +45,10 @@ export async function fetchIceServers(deps: {
       headers: { authorization: `Bearer ${deps.token}` },
     });
     if (!res.ok) return null;
-    const body = (await res.json()) as { iceServers?: RTCIceServer[] };
-    return Array.isArray(body.iceServers) ? body.iceServers : null;
+    const body = (await res.json()) as { iceServers?: WireIceServer[] };
+    if (!Array.isArray(body.iceServers)) return null;
+    const flat = flattenIceServers(body.iceServers);
+    return flat.length > 0 ? flat : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- Worker returns ICE entries with `urls: string[]` (comma-split STUN_URLS/TURN_URLS), but werift's `RTCIceServer.urls` is a single string and werift consumes it as one (`urls.includes("stun:")`, `urls.slice(5)`). Fed the real Worker payload, werift found no STUN/TURN and gathered only host candidates.
- This PR flattens each wire entry into one werift entry per url (carrying username/credential onto TURN entries) inside `fetchIceServers`. No Worker change, no controller change, no main.ts change.

## Evidence boundary
Automated tests prove the desktop now produces werift-shaped ICE from the real Worker array payload. They do NOT prove public-internet reachability, TURN relay, or the real OAuth round-trip — those remain real-device acceptance steps, and are additionally blocked until the stale SPA at the live origin is overwrite-deployed with our Worker.

## Test plan
- [x] `npm run typecheck` green
- [x] `npm run lint` green (--max-warnings 0)
- [x] `npm test` green (turnCred 9/9: array STUN, TURN auth carry, mixed shape, singular idempotent, empty->null; TDD red verified before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)