### PR TITLE
fix(oauth): desktop GitHub login via system browser + 127.0.0.1 loopback

### DIFF
--- a/cloudflare/src/routes/oauthCallback.ts
+++ b/cloudflare/src/routes/oauthCallback.ts
@@ -3,6 +3,7 @@ import { readCookie } from "../lib/cors";
 import { exchangeCode, fetchGithubUserId } from "../lib/github";
 import { hmacUserHash } from "../lib/userHash";
 import { signJwt, nowSec } from "../lib/jwt";
+import { parsePort } from "./oauthDesktopStart";
 
 function renderCallbackHtml(authCode: string): string {
   const payload = JSON.stringify({ authCode });
@@ -50,6 +51,26 @@ export async function handleOauthCallback(req: Request, cfg: Config): Promise<Re
       headers: {
         Location: `${PHONE_ORIGIN}/phone#${frag.toString()}`,
         "Set-Cookie": "oauth_state=; Path=/; Max-Age=0, oauth_flow=; Path=/; Max-Age=0",
+      },
+    });
+  }
+
+  if (readCookie(req, "oauth_flow") === "desktop") {
+    const port = parsePort(readCookie(req, "oauth_port"));
+    if (port == null) return new Response("invalid port", { status: 400 });
+    const authCode = await signJwt(cfg.serverSecret, {
+      typ: "auth_code",
+      userHash,
+      exp: nowSec() + 60,
+    });
+    const loopback = new URL(`http://127.0.0.1:${port}/`);
+    loopback.searchParams.set("authCode", authCode);
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: loopback.toString(),
+        "Set-Cookie":
+          "oauth_state=; Path=/; Max-Age=0, oauth_flow=; Path=/; Max-Age=0, oauth_port=; Path=/; Max-Age=0",
       },
     });
   }

--- a/cloudflare/src/routes/oauthDesktopStart.ts
+++ b/cloudflare/src/routes/oauthDesktopStart.ts
@@ -1,0 +1,35 @@
+import type { Config } from "../lib/config";
+import { b64url } from "../lib/base64";
+
+export function parsePort(raw: string | null): number | null {
+  if (raw == null || !/^\d+$/.test(raw)) return null;
+  const n = Number(raw);
+  if (n < 1024 || n > 65535) return null;
+  return n;
+}
+
+export async function handleOauthDesktopStart(req: Request, cfg: Config): Promise<Response> {
+  const url = new URL(req.url);
+  const port = parsePort(url.searchParams.get("port"));
+  if (port == null) return new Response("invalid port", { status: 400 });
+
+  const state = b64url(crypto.getRandomValues(new Uint8Array(16)));
+  const auth = new URL("https://github.com/login/oauth/authorize");
+  auth.searchParams.set("client_id", cfg.githubClientId);
+  auth.searchParams.set("redirect_uri", cfg.oauthRedirectUri);
+  auth.searchParams.set("scope", "read:user");
+  auth.searchParams.set("state", state);
+
+  const attrs = "Path=/; Max-Age=300; HttpOnly; Secure; SameSite=Lax";
+  return new Response(null, {
+    status: 302,
+    headers: {
+      Location: auth.toString(),
+      "Set-Cookie": [
+        `oauth_state=${state}; ${attrs}`,
+        `oauth_flow=desktop; ${attrs}`,
+        `oauth_port=${port}; ${attrs}`,
+      ].join(", "),
+    },
+  });
+}

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -1,6 +1,7 @@
 import { loadConfig, type Env } from "./lib/config";
 import { handleOauthStart } from "./routes/oauthStart";
 import { handleOauthLogin } from "./routes/oauthLogin";
+import { handleOauthDesktopStart } from "./routes/oauthDesktopStart";
 import { handleOauthCallback } from "./routes/oauthCallback";
 import { handleSession } from "./routes/session";
 import { handleTurnCred } from "./routes/turnCred";
@@ -24,6 +25,8 @@ export default {
         res = await handleOauthStart(req, cfg);
       } else if (req.method === "GET" && pathname === "/auth/github/login") {
         res = await handleOauthLogin(req, cfg);
+      } else if (req.method === "GET" && pathname === "/auth/github/desktop-start") {
+        res = await handleOauthDesktopStart(req, cfg);
       } else if (req.method === "GET" && pathname === "/auth/github/callback") {
         res = await handleOauthCallback(req, cfg);
       } else if (req.method === "POST" && pathname === "/auth/session") {

--- a/cloudflare/test/oauthCallback.test.ts
+++ b/cloudflare/test/oauthCallback.test.ts
@@ -54,6 +54,35 @@ describe("oauthCallback", () => {
     expect(claims?.userHash).toBe(await hmacUserHash(secret, 777));
   });
 
+  it("desktop flow: 302s to the loopback with a one-time auth_code, clearing all 3 cookies", async () => {
+    mockGithub(777);
+    const req = new Request("https://x/auth/github/callback?code=c&state=S", {
+      headers: { Cookie: "oauth_state=S; oauth_flow=desktop; oauth_port=49231" },
+    });
+    const res = await handleOauthCallback(req, cfg);
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("Location")!);
+    expect(loc.origin).toBe("http://127.0.0.1:49231");
+    const authCode = loc.searchParams.get("authCode")!;
+    expect(authCode.length).toBeGreaterThan(0);
+    const claims = await verifyJwt(secret, authCode);
+    expect(claims?.typ).toBe("auth_code");
+    expect(claims?.userHash).toBe(await hmacUserHash(secret, 777));
+    const cookie = res.headers.get("Set-Cookie")!;
+    expect(cookie).toContain("oauth_state=; Path=/; Max-Age=0");
+    expect(cookie).toContain("oauth_flow=; Path=/; Max-Age=0");
+    expect(cookie).toContain("oauth_port=; Path=/; Max-Age=0");
+  });
+
+  it("desktop flow: rejects a bad port cookie with 400", async () => {
+    mockGithub(777);
+    const req = new Request("https://x/auth/github/callback?code=c&state=S", {
+      headers: { Cookie: "oauth_state=S; oauth_flow=desktop; oauth_port=80" },
+    });
+    const res = await handleOauthCallback(req, cfg);
+    expect(res.status).toBe(400);
+  });
+
   it("phone flow: 302s to /phone with token+doUrl in the fragment, not the query", async () => {
     mockGithub(777);
     const phoneCfg = {

--- a/cloudflare/test/oauthDesktopStart.test.ts
+++ b/cloudflare/test/oauthDesktopStart.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { handleOauthDesktopStart, parsePort } from "../src/routes/oauthDesktopStart";
+import type { Config } from "../src/lib/config";
+
+const cfg = {
+  githubClientId: "cid",
+  oauthRedirectUri: "https://x/cb",
+} as Config;
+
+function req(port?: string): Request {
+  const u = new URL("https://x/auth/github/desktop-start");
+  if (port !== undefined) u.searchParams.set("port", port);
+  return new Request(u.toString());
+}
+
+describe("parsePort", () => {
+  it("accepts an in-range integer", () => {
+    expect(parsePort("1024")).toBe(1024);
+    expect(parsePort("65535")).toBe(65535);
+    expect(parsePort("49152")).toBe(49152);
+  });
+  it("rejects null, non-numeric, and out-of-range", () => {
+    expect(parsePort(null)).toBeNull();
+    expect(parsePort("")).toBeNull();
+    expect(parsePort("abc")).toBeNull();
+    expect(parsePort("80")).toBeNull();
+    expect(parsePort("1023")).toBeNull();
+    expect(parsePort("65536")).toBeNull();
+    expect(parsePort("12.5")).toBeNull();
+    expect(parsePort("-1")).toBeNull();
+  });
+});
+
+describe("oauthDesktopStart", () => {
+  it("302s to github authorize and sets state, flow, and port cookies", async () => {
+    const res = await handleOauthDesktopStart(req("49231"), cfg);
+    expect(res.status).toBe(302);
+    const loc = new URL(res.headers.get("Location")!);
+    expect(loc.origin + loc.pathname).toBe("https://github.com/login/oauth/authorize");
+    expect(loc.searchParams.get("client_id")).toBe("cid");
+    expect(loc.searchParams.get("redirect_uri")).toBe("https://x/cb");
+    expect(loc.searchParams.get("scope")).toBe("read:user");
+    const state = loc.searchParams.get("state")!;
+    expect(state.length).toBeGreaterThan(0);
+    const cookie = res.headers.get("Set-Cookie")!;
+    expect(cookie).toContain(`oauth_state=${state}`);
+    expect(cookie).toContain("oauth_flow=desktop");
+    expect(cookie).toContain("oauth_port=49231");
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("Secure");
+    expect(cookie).toContain("SameSite=Lax");
+  });
+
+  it("rejects a missing port with 400", async () => {
+    const res = await handleOauthDesktopStart(req(), cfg);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-numeric port with 400", async () => {
+    const res = await handleOauthDesktopStart(req("abc"), cfg);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an out-of-range port with 400", async () => {
+    const res = await handleOauthDesktopStart(req("80"), cfg);
+    expect(res.status).toBe(400);
+  });
+});

--- a/docs/superpowers/plans/2026-05-31-desktop-oauth-loopback.md
+++ b/docs/superpowers/plans/2026-05-31-desktop-oauth-loopback.md
@@ -1,0 +1,53 @@
+# Desktop OAuth Loopback Implementation Plan
+
+> **For agentic workers:** Implement task-by-task, TDD, commit per task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Fix the broken desktop GitHub login by replacing the in-app popup + `postMessage` authCode delivery with a system-browser + `127.0.0.1` loopback flow (gh CLI / VS Code pattern).
+
+**Architecture:** Mirror the existing `oauth_flow=phone` design on the Worker. A new `GET /auth/github/desktop-start?port=<port>` sets `oauth_flow=desktop` + `oauth_port` cookies and 302s to GitHub. The shared callback, on `oauth_flow=desktop`, 302s the one-time `auth_code` JWT to `http://127.0.0.1:<port>/?authCode=...`. Desktop main process runs a temp loopback HTTP server, opens the system browser via `shell.openExternal`, and resolves the authCode from the loopback request. GitHub `redirect_uri` stays the Worker callback (single registered host).
+
+**Tech Stack:** Cloudflare Worker (TS, vitest-pool-workers), Electron main (node:http, electron shell), vitest.
+
+---
+
+### Task 1: Worker `desktop-start` route
+
+**Files:**
+- Create: `cloudflare/src/routes/oauthDesktopStart.ts`
+- Test: `cloudflare/test/oauthDesktopStart.test.ts`
+
+`parsePort(raw)`: accept integer 1024–65535, else null. `handleOauthDesktopStart`: 400 on bad port; else 302 to github authorize with `oauth_state`, `oauth_flow=desktop`, `oauth_port=<port>` cookies (HttpOnly; Secure; SameSite=Lax; Max-Age=300).
+
+### Task 2: Worker callback desktop branch
+
+**Files:**
+- Modify: `cloudflare/src/routes/oauthCallback.ts`
+- Test: `cloudflare/test/oauthCallback.test.ts`
+
+After computing `userHash`, before the legacy desktop postMessage path: if `oauth_flow === "desktop"`, parse `oauth_port` (400 if bad), sign `auth_code` JWT (exp +60s), 302 to `http://127.0.0.1:<port>/?authCode=...`, clear `oauth_state`/`oauth_flow`/`oauth_port` cookies. Leave the `oauth_flow=phone` branch and the legacy popup HTML untouched (popup path becomes dead once desktop migrates; cleanup is follow-up).
+
+### Task 3: Worker route wiring
+
+**Files:**
+- Modify: `cloudflare/src/worker.ts`
+
+Add `GET /auth/github/desktop-start → handleOauthDesktopStart`.
+
+### Task 4: Desktop `runOauthLoopback`
+
+**Files:**
+- Create: `electron/remote/oauthLoopback.ts`
+- Test: `electron/remote/__tests__/oauthLoopback.test.ts`
+
+`runOauthLoopback({ workerOrigin, openExternal?, timeoutMs? })`: start `http.createServer` on `127.0.0.1:0`; read assigned port; `openExternal(`${workerOrigin}/auth/github/desktop-start?port=<port>`)`; on GET `/?authCode=...` resolve `{authCode}`, respond a minimal "You can close this window." HTML, close server; timeout → reject; ignore favicon/other paths. Inject `openExternal` and an `http`-server factory for testability so the test never opens a real browser.
+
+### Task 5: Swap injection in main.ts
+
+**Files:**
+- Modify: `electron/main.ts` (import + the `runPopup:` seam ~L368)
+
+Replace `runOauthPopup({...})` with `runOauthLoopback({ workerOrigin: WORKER_ORIGIN })`. Keep `loginWithGithub` shape unchanged.
+
+### Task 6: Deploy + verify
+
+`cd cloudflare && npm run typecheck && npx vitest run`; root `npm run typecheck && npm run lint && npm test`; `wrangler deploy`; dogfood desktop login end-to-end with the user's diagnostic logs; capture evidence.

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -96,7 +96,7 @@ import { createSessionStore } from './remote/sessionStore';
 import { createOauthTokenProvider } from './remote/oauthTokenProvider';
 import { registerMobileRemoteIpc } from './ipc/mobileRemoteIpc';
 import { loginWithGithub, fetchSession } from './remote/oauthLogin';
-import { runOauthPopup } from './remote/oauthWindow';
+import { runOauthLoopback } from './remote/oauthLoopback';
 import { MOBILE_REMOTE_CHANNELS } from './shared/ipcChannels';
 import nodePath from 'node:path';
 import {
@@ -366,9 +366,8 @@ app.whenReady().then(async () => {
       loginWithGithub({
         workerOrigin: WORKER_ORIGIN,
         runPopup: () =>
-          runOauthPopup({
+          runOauthLoopback({
             workerOrigin: WORKER_ORIGIN,
-            parent: BrowserWindow.getAllWindows()[0] ?? undefined,
           }),
         fetchSession,
         store: mobileRemoteSessionStore,

--- a/electron/remote/__tests__/oauthLoopback.test.ts
+++ b/electron/remote/__tests__/oauthLoopback.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import http from 'node:http';
+import { runOauthLoopback } from '../oauthLoopback';
+
+const ORIGIN = 'https://ccsm-worker.example.workers.dev';
+
+function get(url: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    http
+      .get(url, (res) => {
+        let body = '';
+        res.on('data', (c) => (body += c));
+        res.on('end', () => resolve({ status: res.statusCode ?? 0, body }));
+      })
+      .on('error', reject);
+  });
+}
+
+function portFromStartUrl(startUrl: string): number {
+  return Number(new URL(startUrl).searchParams.get('port'));
+}
+
+describe('runOauthLoopback', () => {
+  it('opens the desktop-start url with the assigned port and resolves the authCode', async () => {
+    let startUrl = '';
+    const openExternal = vi.fn(async (url: string) => {
+      startUrl = url;
+      const port = portFromStartUrl(url);
+      // simulate the Worker 302 landing on the loopback
+      await get(`http://127.0.0.1:${port}/?authCode=AC123`);
+    });
+
+    const result = await runOauthLoopback({ workerOrigin: ORIGIN, openExternal, timeoutMs: 2000 });
+
+    expect(result).toEqual({ authCode: 'AC123' });
+    expect(startUrl.startsWith(`${ORIGIN}/auth/github/desktop-start?port=`)).toBe(true);
+    expect(portFromStartUrl(startUrl)).toBeGreaterThanOrEqual(1024);
+  });
+
+  it('serves a close-the-window page on the loopback', async () => {
+    let pagePromise: Promise<{ status: number; body: string }> | null = null;
+    const openExternal = async (url: string) => {
+      pagePromise = get(`http://127.0.0.1:${portFromStartUrl(url)}/?authCode=X`);
+      await pagePromise;
+    };
+    await runOauthLoopback({ workerOrigin: ORIGIN, openExternal, timeoutMs: 2000 });
+    const page = await pagePromise!;
+    expect(page.status).toBe(200);
+    expect(page.body).toMatch(/close this window/i);
+  });
+
+  it('ignores non-root paths (e.g. favicon) without resolving', async () => {
+    const openExternal = async (url: string) => {
+      const port = portFromStartUrl(url);
+      const fav = await get(`http://127.0.0.1:${port}/favicon.ico`);
+      expect(fav.status).toBe(404);
+      await get(`http://127.0.0.1:${port}/?authCode=REAL`);
+    };
+    const result = await runOauthLoopback({ workerOrigin: ORIGIN, openExternal, timeoutMs: 2000 });
+    expect(result).toEqual({ authCode: 'REAL' });
+  });
+
+  it('rejects on timeout when no authCode arrives', async () => {
+    const openExternal = vi.fn(async () => {
+      /* never hits the loopback */
+    });
+    await expect(
+      runOauthLoopback({ workerOrigin: ORIGIN, openExternal, timeoutMs: 60 }),
+    ).rejects.toThrow(/timeout/i);
+  });
+
+  it('rejects when openExternal throws', async () => {
+    const openExternal = vi.fn(async () => {
+      throw new Error('no browser');
+    });
+    await expect(
+      runOauthLoopback({ workerOrigin: ORIGIN, openExternal, timeoutMs: 2000 }),
+    ).rejects.toThrow(/no browser/i);
+  });
+});

--- a/electron/remote/oauthLoopback.ts
+++ b/electron/remote/oauthLoopback.ts
@@ -1,0 +1,65 @@
+// electron/remote/oauthLoopback.ts
+import http from 'node:http';
+import { AddressInfo } from 'node:net';
+
+type Server = http.Server;
+
+export function runOauthLoopback(opts: {
+  workerOrigin: string;
+  openExternal?: (url: string) => void | Promise<void>;
+  createServer?: (handler: http.RequestListener) => Server;
+  timeoutMs?: number;
+}): Promise<{ authCode: string }> {
+  const open =
+    opts.openExternal ??
+    ((url: string) => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { shell } = require('electron') as typeof import('electron');
+      return shell.openExternal(url);
+    });
+  const makeServer = opts.createServer ?? ((h) => http.createServer(h));
+  const timeoutMs = opts.timeoutMs ?? 120_000;
+
+  return new Promise<{ authCode: string }>((resolve, reject) => {
+    let done = false;
+
+    const server = makeServer((req, res) => {
+      const url = new URL(req.url ?? '/', 'http://127.0.0.1');
+      if (url.pathname !== '/') {
+        res.writeHead(404).end();
+        return;
+      }
+      const authCode = url.searchParams.get('authCode');
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end('<!doctype html><meta charset="utf-8"><title>Signed in</title><body>You can close this window.');
+      if (typeof authCode === 'string' && authCode) {
+        finish(() => resolve({ authCode }));
+      }
+    });
+
+    const timer = setTimeout(() => finish(() => reject(new Error('oauth timeout'))), timeoutMs);
+
+    function finish(fn: () => void): void {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      try {
+        server.close();
+      } catch {
+        /* ignore */
+      }
+      fn();
+    }
+
+    server.on('error', (err) => finish(() => reject(err)));
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as AddressInfo | null;
+      if (!addr) {
+        finish(() => reject(new Error('loopback: no address')));
+        return;
+      }
+      const startUrl = `${opts.workerOrigin}/auth/github/desktop-start?port=${addr.port}`;
+      Promise.resolve(open(startUrl)).catch((err) => finish(() => reject(err)));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes broken desktop GitHub login. The in-app `BrowserWindow` popup delivered the authCode via `window.opener.postMessage("*")` → a fake-opener preload → IPC, a chain that silently dropped the code. This replaces it with the **system-browser + `127.0.0.1` loopback** pattern used by the `gh` CLI and VS Code.

- **Worker** `GET /auth/github/desktop-start?port=<port>`: validates port (1024–65535), sets `oauth_state` / `oauth_flow=desktop` / `oauth_port` cookies (HttpOnly; Secure; SameSite=Lax; Max-Age=300), 302s to GitHub authorize. `redirect_uri` stays the Worker callback (single registered OAuth host).
- **Worker callback** desktop branch: on `oauth_flow=desktop`, signs a one-time `auth_code` JWT (exp +60s) and 302s to `http://127.0.0.1:<port>/?authCode=...`, clearing all three cookies. Mirrors the existing phone-flow redirect.
- **Desktop** `runOauthLoopback`: spins a temp `http` server on `127.0.0.1:0`, opens the desktop-start URL via `shell.openExternal`, resolves the authCode from the Worker's redirect back to the loopback. `openExternal` and the server factory are injected so tests never open a real browser.
- `main.ts` swaps `runOauthPopup` → `runOauthLoopback` at the existing DI seam; `loginWithGithub` shape unchanged. `oauthWindow.ts` (legacy popup) is now unused by production code; left with its test for a follow-up cleanup.

Worker deployed (version `260cd59e`) and the route verified live: valid port → 302 to GitHub with the 3 cookies; bad/missing port → 400.

## Test plan

- [x] Cloudflare: `npm run typecheck` + `npx vitest run` (52 passed)
- [x] Electron oauth tests: `oauthLoopback` (5), `oauthLogin`, `oauthWindow` (10 total)
- [x] Root `npm run typecheck` + `npm run lint` clean
- [x] `harness-ui` 15/15 (incl. `settings-mobile-remote-pane`)
- [x] Live Worker route verified via curl (302 + cookies / 400)
- [ ] **Desktop dogfood (acceptance):** boot app → "Login with GitHub" → system browser opens → consent → authCode returns to loopback → session established. Requires real GitHub consent (reviewer/user performs).

Note: pre-existing `better-sqlite3` ABI mismatch makes `electron/__tests__/db*.test.ts` fail under vitest-on-Node locally (NODE_MODULE_VERSION 145 vs 137); unrelated to this change, which touches no db code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)