### PR TITLE
fix(cloudflare): bind signaling peer identity, reject same-user peerId squatting

### DIFF
--- a/cloudflare/src/pairingDo.ts
+++ b/cloudflare/src/pairingDo.ts
@@ -7,6 +7,9 @@ interface Member {
   ws: WebSocket;
   role: "desktop" | "phone";
   peerId: string;
+  // The doProxy-verified userHash this socket authenticated as, when known.
+  // Null only when the DO is driven directly (tests) without the header.
+  userHash: string | null;
 }
 
 type ErrCode = "bad-message" | "not-registered" | "peer-not-found" | "room-full";
@@ -15,6 +18,10 @@ export class PairingDurableObject {
   private members = new Map<string, Member>();
   private state: DurableObjectState;
   private cfg: Config;
+  // Trusted identity anchor injected by doProxy (X-CCSM-User-Hash). Absent when
+  // the DO is driven directly in tests; belt-and-suspenders only — the
+  // load-bearing defense is the duplicate-peerId rejection below.
+  private userHash: string | null = null;
 
   constructor(state: DurableObjectState, env: Env) {
     this.state = state;
@@ -25,6 +32,7 @@ export class PairingDurableObject {
     if (req.headers.get("Upgrade") !== "websocket") {
       return new Response("expected websocket", { status: 426 });
     }
+    this.userHash = req.headers.get("X-CCSM-User-Hash") ?? null;
     const pair = new WebSocketPair();
     const client = pair[0];
     const server = pair[1];
@@ -66,7 +74,13 @@ export class PairingDurableObject {
         if (this.members.size >= MAX_MEMBERS) {
           return this.sendErr(ws, "room-full", "too many peers");
         }
-        self = { ws, role: msg.role, peerId: msg.peerId };
+        // Reject peerId squatting: a second device/tab of the same user (the
+        // room is already userHash-scoped by doProxy) must not overwrite an
+        // existing member's routing entry. Reuse "bad-message" — no new code.
+        if (this.members.has(msg.peerId)) {
+          return this.sendErr(ws, "bad-message", "peer-id-taken");
+        }
+        self = { ws, role: msg.role, peerId: msg.peerId, userHash: this.userHash };
         this.members.set(self.peerId, self);
         ws.send(
           JSON.stringify({

--- a/cloudflare/src/routes/doProxy.ts
+++ b/cloudflare/src/routes/doProxy.ts
@@ -22,5 +22,11 @@ export async function handleDoProxy(
   }
   const id = env.PAIRING.idFromName(claims.userHash);
   const stub = env.PAIRING.get(id);
-  return stub.fetch(req);
+  // Inject the JWT-verified userHash as a trusted identity anchor. A DO
+  // internal stub.fetch CAN carry custom headers (unlike a browser WebSocket),
+  // so we clone the request preserving method/URL/Upgrade and add the header.
+  const headers = new Headers(req.headers);
+  headers.set("X-CCSM-User-Hash", claims.userHash);
+  const forwarded = new Request(req, { headers });
+  return stub.fetch(forwarded);
 }

--- a/cloudflare/test/doProxy.test.ts
+++ b/cloudflare/test/doProxy.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { handleDoProxy } from "../src/routes/doProxy";
+import { signJwt, nowSec } from "../src/lib/jwt";
+import type { Config, Env } from "../src/lib/config";
+
+const secret = new TextEncoder().encode("signing-key");
+const cfg = { serverSecret: secret } as Config;
+
+// Captures the Request the DO stub.fetch() receives so we can assert on the
+// identity header doProxy injects.
+function makeEnv(): { env: Env; captured: () => Request | null } {
+  let captured: Request | null = null;
+  const stub = {
+    fetch: (req: Request) => {
+      captured = req;
+      return Promise.resolve(new Response("ok", { status: 200 }));
+    },
+  };
+  const env = {
+    PAIRING: {
+      idFromName: (_name: string) => ({ name: _name }),
+      get: (_id: unknown) => stub,
+    },
+  } as unknown as Env;
+  return { env, captured: () => captured };
+}
+
+function wsReq(token: string): Request {
+  return new Request(`https://x/do/deadbeef?token=${token}`, {
+    headers: { Upgrade: "websocket" },
+  });
+}
+
+describe("handleDoProxy", () => {
+  it("426 when not a websocket upgrade", async () => {
+    const { env } = makeEnv();
+    const res = await handleDoProxy(
+      new Request("https://x/do/deadbeef"),
+      env,
+      cfg,
+      "deadbeef",
+    );
+    expect(res.status).toBe(426);
+  });
+
+  it("401 when the token is invalid", async () => {
+    const { env } = makeEnv();
+    const res = await handleDoProxy(wsReq("garbage"), env, cfg, "deadbeef");
+    expect(res.status).toBe(401);
+  });
+
+  it("403 when the token userHash does not match the path", async () => {
+    const { env } = makeEnv();
+    const token = await signJwt(secret, {
+      typ: "session",
+      userHash: "other",
+      exp: nowSec() + 60,
+    });
+    const res = await handleDoProxy(wsReq(token), env, cfg, "deadbeef");
+    expect(res.status).toBe(403);
+  });
+
+  it("injects X-CCSM-User-Hash with the verified userHash and preserves upgrade", async () => {
+    const { env, captured } = makeEnv();
+    const token = await signJwt(secret, {
+      typ: "session",
+      userHash: "deadbeef",
+      exp: nowSec() + 60,
+    });
+    const res = await handleDoProxy(wsReq(token), env, cfg, "deadbeef");
+    expect(res.status).toBe(200);
+    const fwd = captured();
+    expect(fwd).not.toBeNull();
+    expect(fwd!.headers.get("X-CCSM-User-Hash")).toBe("deadbeef");
+    expect(fwd!.headers.get("Upgrade")).toBe("websocket");
+    expect(new URL(fwd!.url).pathname).toBe("/do/deadbeef");
+  });
+});

--- a/cloudflare/test/pairingDo.test.ts
+++ b/cloudflare/test/pairingDo.test.ts
@@ -110,6 +110,37 @@ describe("PairingDurableObject", () => {
     expect(await err).toMatchObject({ type: "error", code: "room-full" });
   });
 
+  it("rejects a second register with an already-taken peerId without evicting the victim", async () => {
+    const victim = await connect("squat");
+    victim.send(JSON.stringify({ type: "register", role: "desktop", peerId: "A" }));
+    await next(victim);
+
+    // Attacker (same userHash room) tries to squat peerId "A".
+    const attacker = await connect("squat");
+    const attackerErr = next(attacker);
+    attacker.send(JSON.stringify({ type: "register", role: "phone", peerId: "A" }));
+    expect(await attackerErr).toMatchObject({
+      type: "error",
+      code: "bad-message",
+      message: "peer-id-taken",
+    });
+
+    // The original victim is still in the routing table: a third distinct peer
+    // can still reach "A" by its peerId.
+    const third = await connect("squat");
+    third.send(JSON.stringify({ type: "register", role: "phone", peerId: "C" }));
+    await next(third);
+    await next(victim); // consume peer-present for C
+
+    const victimGetsOffer = next(victim);
+    third.send(JSON.stringify({ type: "offer", to: "A", sdp: "SDP" }));
+    expect(await victimGetsOffer).toMatchObject({
+      type: "offer",
+      from: "C",
+      sdp: "SDP",
+    });
+  });
+
   it("different userHash lands on a different DO instance (isolation)", async () => {
     const a = await connect("iso-A");
     const b = await connect("iso-B");


### PR DESCRIPTION
## Summary
- Closes the residual same-user peer-spoofing gap in the signaling DurableObject (audit finding #68, severity HIGH). The room is already userHash-scoped by `doProxy`, but the DO trusted client-asserted `peerId` at register time with no uniqueness check — so a second device/tab of the **same** GitHub user could re-register an existing peerId and overwrite the victim's `members` entry, kicking them out of the routing table.
- Forging `from` on offer/answer/ice was already blocked (the relay rewrites `from: self.peerId`); the only missing piece was register-time squatting.

## Changes
- **`pairingDo.ts`**: reject `register` when the peerId is already taken (reuse `"bad-message"` code, message `"peer-id-taken"` — no new ErrCode, no protocol change, no client change). Also reads the `X-CCSM-User-Hash` anchor (below) and stamps it on each member.
- **`doProxy.ts`**: injects the JWT-verified `userHash` as `X-CCSM-User-Hash` into the upgrade request forwarded to the stub (a DO internal `stub.fetch` can carry custom headers, unlike a browser WebSocket). Belt-and-suspenders identity anchor; the load-bearing defense is the duplicate-peerId rejection.

Deliberately NOT server-minting a *different* peerId: both clients (`doSignalingClient.ts`, `phoneSignaling.ts`) use their own `opts.peerId` as the routing key and ignore the `registered.peerId` echo, so minting a new id would break routing. Uniqueness rejection closes the hole with zero client/protocol churn.

## Test plan
- [x] DO: attacker re-registering an existing peerId gets `{type:"error",message:"peer-id-taken"}` **and** the victim is not evicted (proven by relaying a third peer's offer to the victim afterwards).
- [x] doProxy: forwarded Request carries `X-CCSM-User-Hash` = verified userHash, with `Upgrade` + `/do/<hash>` path preserved; plus 426/401/403 paths.
- [x] `cd cloudflare && npm test` — 14 files / 49 tests pass.
- [x] `cd cloudflare && npm run typecheck` — clean (run separately; vitest skips tsc).
- n/a real-device: pure Worker/DO logic, no user-visible behavior to dogfood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)