### PR TITLE
fix(remote): route ICE by peerId + cap session.input to harden desktop peer

### DIFF
--- a/electron/remote/__tests__/desktopPeerIceRouting.test.ts
+++ b/electron/remote/__tests__/desktopPeerIceRouting.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Lightweight fake RTCPeerConnection: records addIceCandidate calls per instance
+// and exposes only the surface createDesktopPeer touches. No real ICE/SCTP, so
+// this routing test is deterministic and runs in any environment. The class is
+// declared inside the (hoisted) vi.mock factory to satisfy hoisting rules; the
+// constructor pushes each instance onto a shared registry we read back below.
+const pcInstances = vi.hoisted(() => [] as FakePeerConnectionShape[]);
+type FakePeerConnectionShape = {
+  iceCandidates: unknown[];
+  onIceCandidate: { subscribe: (cb: (c: unknown) => void) => void };
+  onDataChannel: { subscribe: (cb: (c: unknown) => void) => void };
+  addIceCandidate: (cand: unknown) => Promise<void>;
+};
+
+vi.mock('werift', () => {
+  class FakePeerConnection {
+    iceCandidates: unknown[] = [];
+    onIceCandidate = { subscribe: (_cb: (c: unknown) => void) => {} };
+    onDataChannel = { subscribe: (_cb: (c: unknown) => void) => {} };
+    constructor() { pcInstances.push(this as unknown as FakePeerConnectionShape); }
+    async setRemoteDescription() {}
+    async createAnswer() { return { sdp: 'answer-sdp' }; }
+    async setLocalDescription() {}
+    async addIceCandidate(cand: unknown) { this.iceCandidates.push(cand); }
+    close() {}
+  }
+  return { RTCPeerConnection: FakePeerConnection };
+});
+vi.mock('../../ptyHost', () => ({
+  listPtySessions: () => [],
+  getBufferSnapshot: async () => ({ data: '', seq: 0 }),
+  getPtySession: () => null,
+  inputPtySession: () => {},
+  resizePtySession: () => {},
+  onPtyData: () => () => {},
+}));
+
+import { createDesktopPeer } from '../desktopPeer';
+import type { SignalingClient, SignalDescription, SignalCandidate } from '../signaling';
+
+describe('createDesktopPeer ICE routing by peerId', () => {
+  let onOfferCb: ((o: SignalDescription, p: string) => void) | null;
+  let onIceCb: ((c: SignalCandidate, p: string) => void) | null;
+
+  beforeEach(() => {
+    pcInstances.length = 0;
+    onOfferCb = null;
+    onIceCb = null;
+  });
+
+  function makeSignaling(): SignalingClient {
+    return {
+      onOffer: (cb) => { onOfferCb = cb; },
+      onRemoteIce: (cb) => { onIceCb = cb; },
+      sendAnswer: () => {},
+      sendIce: () => {},
+      close: () => {},
+    };
+  }
+
+  it('routes a candidate only to the addressed peer and drops unknown peers', async () => {
+    const signaling = makeSignaling();
+    createDesktopPeer({ iceServers: [], signaling, clients: new Set() });
+
+    await onOfferCb?.({ type: 'offer', sdp: 'a' }, 'phoneA');
+    await onOfferCb?.({ type: 'offer', sdp: 'b' }, 'phoneB');
+    expect(pcInstances).toHaveLength(2);
+    const [pcA, pcB] = pcInstances;
+
+    const candX: SignalCandidate = { candidate: 'cand-x', sdpMid: '0', sdpMLineIndex: 0 };
+    await onIceCb?.(candX, 'phoneB');
+
+    expect(pcB.iceCandidates).toHaveLength(1);
+    expect(pcA.iceCandidates).toHaveLength(0);
+
+    // A candidate addressed to an unknown peer is silently dropped (no throw).
+    const candY: SignalCandidate = { candidate: 'cand-y', sdpMid: '0', sdpMLineIndex: 0 };
+    await expect(onIceCb?.(candY, 'unknown-peer')).resolves.toBeUndefined();
+    expect(pcA.iceCandidates).toHaveLength(0);
+    expect(pcB.iceCandidates).toHaveLength(1);
+  });
+});

--- a/electron/remote/__tests__/remoteMessages.test.ts
+++ b/electron/remote/__tests__/remoteMessages.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const inputCalls: Array<[string, string]> = [];
+vi.mock('../../ptyHost', () => ({
+  listPtySessions: () => [{ sid: 's1', cwd: '/tmp', cols: 80, rows: 24, pid: 1 }],
+  getBufferSnapshot: async () => ({ data: '', seq: 0 }),
+  getPtySession: () => ({ cols: 80, rows: 24 }),
+  inputPtySession: (sid: string, data: string) => { inputCalls.push([sid, data]); },
+  resizePtySession: () => {},
+}));
+
+import { handleClientMessage } from '../remoteMessages';
+import type { PeerClient } from '../peerClient';
+
+const MAX_INPUT_BYTES = 64 * 1024;
+
+function makeClient() {
+  return { subscribedSid: null, send: vi.fn() } as unknown as PeerClient & { send: ReturnType<typeof vi.fn> };
+}
+
+describe('handleClientMessage session.input cap', () => {
+  beforeEach(() => { inputCalls.length = 0; });
+
+  it('forwards input under the cap', async () => {
+    const client = makeClient();
+    await handleClientMessage(client, JSON.stringify({ type: 'session.input', sid: 's1', data: 'ls\n' }));
+    expect(inputCalls).toEqual([['s1', 'ls\n']]);
+    expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it('rejects input over the cap with input_too_large and does not forward', async () => {
+    const client = makeClient();
+    const huge = 'x'.repeat(MAX_INPUT_BYTES + 1);
+    await handleClientMessage(client, JSON.stringify({ type: 'session.input', sid: 's1', data: huge }));
+    expect(inputCalls).toEqual([]);
+    expect(client.send).toHaveBeenCalledWith({ type: 'error', message: 'input_too_large' });
+  });
+
+  it('accepts input at exactly the cap boundary', async () => {
+    const client = makeClient();
+    const atCap = 'x'.repeat(MAX_INPUT_BYTES);
+    await handleClientMessage(client, JSON.stringify({ type: 'session.input', sid: 's1', data: atCap }));
+    expect(inputCalls).toEqual([['s1', atCap]]);
+    expect(client.send).not.toHaveBeenCalled();
+  });
+});

--- a/electron/remote/desktopPeer.ts
+++ b/electron/remote/desktopPeer.ts
@@ -18,7 +18,7 @@ export function createDesktopPeer(opts: {
   clients: Set<PeerClient>;
 }): { close: () => void } {
   const { signaling, clients } = opts;
-  const pcs = new Set<RTCPeerConnection>();
+  const pcs = new Map<string, RTCPeerConnection>();
 
   const offPtyData = onPtyData((sid, chunk, seq) => {
     fanoutPtyData(clients, sid, chunk, seq);
@@ -26,7 +26,7 @@ export function createDesktopPeer(opts: {
 
   signaling.onOffer(async (offer, peerId) => {
     const pc = new RTCPeerConnection({ iceServers: opts.iceServers });
-    pcs.add(pc);
+    pcs.set(peerId, pc);
 
     pc.onIceCandidate.subscribe((cand) => {
       // werift hands us its own RTCIceCandidate; forward only the plain wire
@@ -72,17 +72,21 @@ export function createDesktopPeer(opts: {
     signaling.sendAnswer({ type: 'answer', sdp: answer.sdp }, peerId);
   });
 
-  signaling.onRemoteIce(async (cand) => {
-    for (const pc of pcs) {
-      try {
-        await pc.addIceCandidate({
-          candidate: cand.candidate,
-          sdpMid: cand.sdpMid ?? undefined,
-          sdpMLineIndex: cand.sdpMLineIndex ?? undefined,
-        });
-      } catch {
-        /* candidate may target a different pc; ignore mismatches */
-      }
+  signaling.onRemoteIce(async (cand, peerId) => {
+    // Route each candidate to ONLY the pc that owns its peerId. Fanning every
+    // candidate to all pcs leaks one phone's candidates into another's
+    // connection (cross-peer isolation bug) once more than one phone connects.
+    // A candidate for an unknown peer is silently dropped.
+    const pc = pcs.get(peerId);
+    if (!pc) return;
+    try {
+      await pc.addIceCandidate({
+        candidate: cand.candidate,
+        sdpMid: cand.sdpMid ?? undefined,
+        sdpMLineIndex: cand.sdpMLineIndex ?? undefined,
+      });
+    } catch {
+      /* candidate may still be invalid; ignore */
     }
   });
 
@@ -90,7 +94,7 @@ export function createDesktopPeer(opts: {
     close: () => {
       offPtyData();
       signaling.close();
-      for (const pc of pcs) void pc.close();
+      for (const pc of pcs.values()) void pc.close();
       pcs.clear();
       clients.clear();
     },

--- a/electron/remote/remoteMessages.ts
+++ b/electron/remote/remoteMessages.ts
@@ -8,6 +8,11 @@ import {
 import { isRecord } from './remoteHttp';
 import type { PeerClient } from './peerClient';
 
+/** Upper bound on a single session.input payload. An authenticated same-user
+ *  peer could otherwise flood the pty with an unbounded write (DoS / pty
+ *  flood); 64 KiB comfortably covers real keystrokes and pastes. */
+const MAX_INPUT_BYTES = 64 * 1024;
+
 /** The session-chip payload the mobile client renders: just the identity and
  *  size it needs. We deliberately omit `pid` — it is noise on the wire and the
  *  client never uses it. */
@@ -73,6 +78,10 @@ export async function handleClientMessage(client: PeerClient, raw: string): Prom
   if (message.type === 'session.input') {
     if (typeof message.sid !== 'string' || typeof message.data !== 'string') {
       client.send({ type: 'error', message: 'invalid_input' });
+      return;
+    }
+    if (Buffer.byteLength(message.data, 'utf8') > MAX_INPUT_BYTES) {
+      client.send({ type: 'error', message: 'input_too_large' });
       return;
     }
     inputPtySession(message.sid, message.data);


### PR DESCRIPTION
## Summary
Two independent desktop-peer hardening fixes (audit findings #69), both in `electron/remote/`:

- **Route ICE candidates by peerId** (`desktopPeer.ts`). `createDesktopPeer` kept peer connections in a `Set` and fanned every incoming ICE candidate to ALL pcs. The `SignalingClient.onRemoteIce` callback already provides the `peerId`, so this leaked one phone's candidates into another phone's connection once more than one device connected. Now pcs are keyed in a `Map<peerId, RTCPeerConnection>` and each candidate is routed only to its addressed peer; candidates for an unknown peer are silently dropped.
- **Cap `session.input` at 64 KiB** (`remoteMessages.ts`). The `session.input` branch forwarded an unbounded `message.data` straight into the pty, letting an authenticated same-user peer flood it (DoS / pty flood). Input is now bounded by UTF-8 byte length (`<= 64 KiB` accepted), oversize payloads get an `input_too_large` error and are not forwarded.

No protocol or client change: the cap only rejects abusive payloads, and ICE routing uses the peerId the signaling layer already carried.

## Tests
- `electron/remote/__tests__/desktopPeerIceRouting.test.ts` (new): proves a candidate addressed to phoneB lands only on phoneB's pc (never phoneA) and an unknown-peer candidate is dropped without throwing. werift mocked for determinism.
- `electron/remote/__tests__/remoteMessages.test.ts` (new): under-cap forwarded, over-cap rejected with `input_too_large` + not forwarded, exactly-at-cap accepted (boundary pinned).
- Both written TDD: watched each fail for the right reason against the old code before implementing.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (`--max-warnings 0`)
- [x] `npx vitest run electron/remote/` — 14 files / 50 tests pass (incl. new tests + existing werift loopback)
- [ ] Full `npm test`: 23 pre-existing `better-sqlite3` ABI failures (`NODE_MODULE_VERSION` mismatch in `db.test.ts`/`db-hardening.test.ts`) are environmental (native module needs an `npm install` rebuild), unrelated to this change — no `electron/remote/` test fails.

Note: changes are signaling/message logic with no renderer/UI surface, so harness-ui cannot observe them; the remote unit suite is the applicable evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)