### PR TITLE
refactor(cloudflare): de-hardcode the Worker's own origin

### DIFF
--- a/cloudflare/src/lib/config.ts
+++ b/cloudflare/src/lib/config.ts
@@ -7,6 +7,9 @@ export interface Env {
   ROOM_TTL_SECONDS: string;
   TURN_URLS: string;
   STUN_URLS: string;
+  // optional: comma-separated CORS allowlist; absence falls back to the
+  // current deploy's public origin (back-compat with the existing deploy).
+  PUBLIC_ORIGIN?: string;
   // secrets (already put on ccsm-worker)
   GITHUB_OAUTH_CLIENT_ID: string;
   GITHUB_OAUTH_CLIENT_SECRET: string;
@@ -28,6 +31,19 @@ export interface Config {
   stunUrls: string[];
   turnKeyId?: string;
   turnKeyApiToken?: string;
+  allowedOrigins: string[];
+}
+
+// Back-compat fallback for the existing ccsm-worker deploy when PUBLIC_ORIGIN
+// is not set. Keep in sync with the live worker's public origin.
+export const DEFAULT_ALLOWED_ORIGIN = "https://ccsm-worker.jiahuigu.workers.dev";
+
+// Resolve the CORS allowlist from env without requiring secrets to be present
+// (used by the OPTIONS preflight path, which runs before loadConfig).
+export function resolveAllowedOrigins(env: Env): string[] {
+  const raw = typeof env.PUBLIC_ORIGIN === "string" ? env.PUBLIC_ORIGIN : "";
+  const list = raw.split(",").map((s) => s.trim()).filter(Boolean);
+  return list.length > 0 ? list : [DEFAULT_ALLOWED_ORIGIN];
 }
 
 export function loadConfig(env: Env): Config {
@@ -43,6 +59,7 @@ export function loadConfig(env: Env): Config {
     return typeof v === "string" && v.length > 0 ? v : undefined;
   };
   const enc = new TextEncoder();
+  const allowedOrigins = resolveAllowedOrigins(env);
   return {
     githubClientId: need("GITHUB_OAUTH_CLIENT_ID"),
     githubClientSecret: need("GITHUB_OAUTH_CLIENT_SECRET"),
@@ -55,5 +72,6 @@ export function loadConfig(env: Env): Config {
     stunUrls: need("STUN_URLS").split(",").map((s) => s.trim()).filter(Boolean),
     turnKeyId: opt("TURN_KEY_ID"),
     turnKeyApiToken: opt("TURN_KEY_API_TOKEN"),
+    allowedOrigins,
   };
 }

--- a/cloudflare/src/lib/cors.ts
+++ b/cloudflare/src/lib/cors.ts
@@ -1,8 +1,6 @@
-const ALLOWED_ORIGINS = ["https://ccsm-worker.jiahuigu.workers.dev"]; // add PWA origin if hosted separately
-
-export function corsPreflight(req: Request): Response {
+export function corsPreflight(req: Request, allowedOrigins: string[]): Response {
   const origin = req.headers.get("Origin") ?? "";
-  const allow = ALLOWED_ORIGINS.includes(origin) ? origin : "";
+  const allow = allowedOrigins.includes(origin) ? origin : "";
   return new Response(null, {
     status: 204,
     headers: {
@@ -14,10 +12,10 @@ export function corsPreflight(req: Request): Response {
   });
 }
 
-export function withSecurityHeaders(res: Response, req: Request): Response {
+export function withSecurityHeaders(res: Response, req: Request, allowedOrigins: string[]): Response {
   const h = new Headers(res.headers);
   const origin = req.headers.get("Origin") ?? "";
-  if (ALLOWED_ORIGINS.includes(origin)) h.set("Access-Control-Allow-Origin", origin);
+  if (allowedOrigins.includes(origin)) h.set("Access-Control-Allow-Origin", origin);
   h.set("X-Content-Type-Options", "nosniff");
   h.set("Referrer-Policy", "no-referrer");
   return new Response(res.body, { status: res.status, headers: h });

--- a/cloudflare/src/routes/session.ts
+++ b/cloudflare/src/routes/session.ts
@@ -15,10 +15,14 @@ export async function handleSession(req: Request, cfg: Config): Promise<Response
     userHash: claims.userHash,
     exp: nowSec() + ttlSec,
   });
+  // Derive the DO WebSocket host from the inbound request: the DO lives on the
+  // same Worker the client just reached, so this is self-configuring across
+  // any subdomain/zone the Worker is deployed to.
+  const host = new URL(req.url).host;
   return json({
     token,
     userHash: claims.userHash,
-    doUrl: `wss://ccsm-worker.jiahuigu.workers.dev/do/${claims.userHash}`,
+    doUrl: `wss://${host}/do/${claims.userHash}`,
     iceServers: [{ urls: cfg.stunUrls }],
     expiresInSeconds: ttlSec,
   });

--- a/cloudflare/src/worker.ts
+++ b/cloudflare/src/worker.ts
@@ -1,4 +1,4 @@
-import { loadConfig, type Env } from "./lib/config";
+import { loadConfig, resolveAllowedOrigins, type Env } from "./lib/config";
 import { handleOauthStart } from "./routes/oauthStart";
 import { handleOauthLogin } from "./routes/oauthLogin";
 import { handleOauthCallback } from "./routes/oauthCallback";
@@ -14,7 +14,8 @@ export default {
     const url = new URL(req.url);
     const { pathname } = url;
 
-    if (req.method === "OPTIONS") return corsPreflight(req);
+    const allowedOrigins = resolveAllowedOrigins(env);
+    if (req.method === "OPTIONS") return corsPreflight(req, allowedOrigins);
     if (pathname === "/healthz") return new Response("ok");
 
     const cfg = loadConfig(env);
@@ -40,6 +41,6 @@ export default {
     } catch (err) {
       res = new Response(`internal error: ${(err as Error).message}`, { status: 500 });
     }
-    return withSecurityHeaders(res, req);
+    return withSecurityHeaders(res, req, allowedOrigins);
   },
 };

--- a/cloudflare/test/config.test.ts
+++ b/cloudflare/test/config.test.ts
@@ -47,4 +47,21 @@ describe("loadConfig", () => {
     expect(cfg.turnKeyId).toBe("kid");
     expect(cfg.turnKeyApiToken).toBe("ktok");
   });
+
+  it("falls back to the default allowed origin when PUBLIC_ORIGIN is unset", () => {
+    const cfg = loadConfig(baseEnv());
+    expect(cfg.allowedOrigins).toEqual([
+      "https://ccsm-worker.jiahuigu.workers.dev",
+    ]);
+  });
+
+  it("reads allowed origins from PUBLIC_ORIGIN (comma-separated) when set", () => {
+    const env = baseEnv();
+    env.PUBLIC_ORIGIN = "https://ccsm.example.com, https://pwa.example.com";
+    const cfg = loadConfig(env);
+    expect(cfg.allowedOrigins).toEqual([
+      "https://ccsm.example.com",
+      "https://pwa.example.com",
+    ]);
+  });
 });

--- a/cloudflare/test/cors.test.ts
+++ b/cloudflare/test/cors.test.ts
@@ -2,21 +2,30 @@ import { describe, it, expect } from "vitest";
 import { corsPreflight, withSecurityHeaders, json, readCookie } from "../src/lib/cors";
 
 const ALLOWED = "https://ccsm-worker.jiahuigu.workers.dev";
+const allowlist = [ALLOWED];
 
 describe("cors", () => {
   it("preflight echoes an allowed origin", () => {
-    const res = corsPreflight(new Request("https://x", { headers: { Origin: ALLOWED } }));
+    const res = corsPreflight(new Request("https://x", { headers: { Origin: ALLOWED } }), allowlist);
     expect(res.status).toBe(204);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe(ALLOWED);
   });
 
   it("preflight blanks a disallowed origin", () => {
-    const res = corsPreflight(new Request("https://x", { headers: { Origin: "https://evil" } }));
+    const res = corsPreflight(new Request("https://x", { headers: { Origin: "https://evil" } }), allowlist);
     expect(res.headers.get("Access-Control-Allow-Origin")).toBe("");
   });
 
+  it("preflight allows a configured custom origin", () => {
+    const res = corsPreflight(
+      new Request("https://x", { headers: { Origin: "https://ccsm.example.com" } }),
+      ["https://ccsm.example.com"],
+    );
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://ccsm.example.com");
+  });
+
   it("withSecurityHeaders sets nosniff + referrer-policy", () => {
-    const res = withSecurityHeaders(new Response("hi"), new Request("https://x"));
+    const res = withSecurityHeaders(new Response("hi"), new Request("https://x"), allowlist);
     expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
     expect(res.headers.get("Referrer-Policy")).toBe("no-referrer");
   });

--- a/cloudflare/test/session.test.ts
+++ b/cloudflare/test/session.test.ts
@@ -10,8 +10,8 @@ const cfg = {
   stunUrls: ["stun:stun.cloudflare.com:3478"],
 } as Config;
 
-function post(body: unknown): Request {
-  return new Request("https://x/auth/session", {
+function post(body: unknown, host = "ccsm-worker.jiahuigu.workers.dev"): Request {
+  return new Request(`https://${host}/auth/session`, {
     method: "POST",
     body: JSON.stringify(body),
   });
@@ -50,5 +50,17 @@ describe("session", () => {
     expect(body.iceServers[0].urls).toEqual(["stun:stun.cloudflare.com:3478"]);
     const claims = await verifyJwt(secret, body.token);
     expect(claims).toMatchObject({ typ: "session", userHash: "deadbeef" });
+  });
+
+  it("derives doUrl from the inbound request host (self-configuring)", async () => {
+    const authCode = await signJwt(secret, {
+      typ: "auth_code",
+      userHash: "deadbeef",
+      exp: nowSec() + 60,
+    });
+    const res = await handleSession(post({ authCode }, "ccsm.example.com"), cfg);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { doUrl: string };
+    expect(body.doUrl).toBe("wss://ccsm.example.com/do/deadbeef");
   });
 });

--- a/cloudflare/wrangler.toml
+++ b/cloudflare/wrangler.toml
@@ -30,6 +30,13 @@ TURN_TTL_SECONDS = "600"           # 10 min
 ROOM_TTL_SECONDS = "60"            # DO survives this long after both sides drop
 TURN_URLS = "turn:turn.cloudflare.com:3478?transport=udp,turns:turn.cloudflare.com:5349?transport=tcp"
 STUN_URLS = "stun:stun.cloudflare.com:3478"
+# PUBLIC_ORIGIN: optional comma-separated CORS allowlist. When unset, the worker
+# falls back to its current public origin (DEFAULT_ALLOWED_ORIGIN in config.ts),
+# so the existing deploy keeps working. Set this when serving the PWA from a
+# different subdomain/zone, e.g.:
+# PUBLIC_ORIGIN = "https://ccsm-worker.jiahuigu.workers.dev,https://pwa.example.com"
+# (The DO WebSocket doUrl is always derived from the inbound request host, so it
+#  needs no config.)
 
 # Secrets (NEVER in repo; already put on ccsm-worker, user re-puts nothing):
 #   GITHUB_OAUTH_CLIENT_ID      GitHub OAuth app client id (public value, stored as secret)


### PR DESCRIPTION
## Summary
Removes two hardcoded `ccsm-worker.jiahuigu.workers.dev` literals that would silently break CORS and the DO WebSocket URL on any redeploy to a different subdomain/zone (audit finding #71):
- `cloudflare/src/lib/cors.ts` — the `ALLOWED_ORIGINS` literal
- `cloudflare/src/routes/session.ts` — the `doUrl` `wss://` host literal

## Approach (hybrid)
- **`doUrl` → derived from the inbound request.** The DO lives on the *same* Worker the client just reached, so `new URL(req.url).host` is correct by construction and self-configuring across any subdomain/zone. Zero new config.
- **CORS allowlist → configured, not echoed.** CORS is a security boundary; echoing the caller's `Origin` would defeat the allowlist. `corsPreflight` / `withSecurityHeaders` now take an injected `allowedOrigins: string[]`, sourced from a new optional `PUBLIC_ORIGIN` env var via a secret-free `resolveAllowedOrigins(env)` (usable on the OPTIONS preflight path, which runs before `loadConfig`).
- **Back-compat.** When `PUBLIC_ORIGIN` is unset, the allowlist falls back to `DEFAULT_ALLOWED_ORIGIN` (the current origin), so the existing live deploy keeps working unchanged. No secret values touched — origins are public.

## Tests (TDD)
4 new assertions, written failing first then driven to green:
- `doUrl` follows the request host (`wss://ccsm.example.com/do/...`)
- CORS allows a configured custom origin
- `PUBLIC_ORIGIN` absence falls back to the default
- `PUBLIC_ORIGIN` comma-list parsed when set

## Test plan
- [x] `cd cloudflare && npm run typecheck` — clean (re-run by parent)
- [x] `cd cloudflare && npx vitest run` — 13 files / 48 tests pass (re-run by parent)
- [ ] independent review + merge (not by the implementing agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)