### PR TITLE
fix(security): add fromMainFrame guards to 4 privileged IPC handlers

### DIFF
--- a/electron/ipc/__tests__/mobileRemoteIpc.test.ts
+++ b/electron/ipc/__tests__/mobileRemoteIpc.test.ts
@@ -28,6 +28,13 @@ function memStore(loggedIn: boolean): SessionStore {
   };
 }
 
+// Event shaped so the fromMainFrame guard (senderFrame === sender.mainFrame)
+// passes — login/logout are guarded; these tests exercise the flow itself.
+function mainFrameEvent(): unknown {
+  const mainFrame = { id: 1 };
+  return { sender: { mainFrame }, senderFrame: mainFrame };
+}
+
 describe('registerMobileRemoteIpc', () => {
   it('login runs the flow and restarts the peer', async () => {
     const { ipcMain, invoke } = fakeIpc();
@@ -40,7 +47,7 @@ describe('registerMobileRemoteIpc', () => {
       broadcast: () => {},
       doLogin: async () => ({ loggedIn: true, userHash: 'h', expiresAtMs: 123, persisted: true }),
     });
-    const state = await invoke(MOBILE_REMOTE_CHANNELS.login);
+    const state = await invoke(MOBILE_REMOTE_CHANNELS.login, mainFrameEvent());
     expect(state).toMatchObject({ loggedIn: true, userHash: 'h' });
     expect(restart).toHaveBeenCalled();
   });
@@ -61,7 +68,7 @@ describe('registerMobileRemoteIpc', () => {
         persisted: true,
       }),
     });
-    const state = await invoke(MOBILE_REMOTE_CHANNELS.logout);
+    const state = await invoke(MOBILE_REMOTE_CHANNELS.logout, mainFrameEvent());
     expect(store.load()).toBeNull();
     expect(state).toMatchObject({ loggedIn: false });
     expect(restart).toHaveBeenCalled();

--- a/electron/ipc/__tests__/mobileRemoteIpcSecurity.test.ts
+++ b/electron/ipc/__tests__/mobileRemoteIpcSecurity.test.ts
@@ -1,0 +1,115 @@
+// Security gate around the mobile-remote login / logout IPC handlers.
+//
+// `login` triggers an OAuth flow and restarts the remote server; `logout`
+// clears the persisted session and restarts the server. Both are privileged
+// and state-mutating, so they must confirm the message came from our
+// top-level renderer frame before acting. `authState` is read-only and
+// intentionally stays unguarded.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MOBILE_REMOTE_CHANNELS } from '../../shared/ipcChannels';
+import type { SessionStore } from '../../remote/sessionStore';
+import type { MobileRemoteAuthState } from '../../remote/oauthLogin';
+
+vi.mock('electron', () => ({}));
+
+// Mock the security guard. Default: accept; tests can flip to reject.
+let allowGuard = true;
+vi.mock('../../security/ipcGuards', () => ({
+  fromMainFrame: (_e: unknown) => allowGuard,
+}));
+
+import { registerMobileRemoteIpc } from '../mobileRemoteIpc';
+
+type Handler = (e: unknown, ...args: unknown[]) => Promise<MobileRemoteAuthState>;
+
+function fakeIpcMain() {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle: (ch: string, fn: Handler) => handlers.set(ch, fn),
+    on: (ch: string, fn: Handler) => handlers.set(ch, fn),
+  } as unknown as Electron.IpcMain;
+  return { ipcMain, handlers };
+}
+
+const loggedOutState: MobileRemoteAuthState = {
+  loggedIn: false,
+  userHash: null,
+  expiresAtMs: null,
+  persisted: false,
+};
+const loggedInState: MobileRemoteAuthState = {
+  loggedIn: true,
+  userHash: 'abc',
+  expiresAtMs: Date.now() + 60_000,
+  persisted: false,
+};
+
+const fakeEvent = {} as Electron.IpcMainInvokeEvent;
+
+describe('mobile-remote login/logout security gate', () => {
+  let handlers: Map<string, Handler>;
+  let store: SessionStore;
+  let restartMobileRemote: ReturnType<typeof vi.fn>;
+  let broadcast: ReturnType<typeof vi.fn>;
+  let doLogin: ReturnType<typeof vi.fn>;
+  let clearMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    allowGuard = true;
+    clearMock = vi.fn();
+    // `stateFromStore` reads store.load(); an expired/empty session yields
+    // loggedOut(). Return null so the rejected return is a stable loggedOut.
+    store = {
+      load: () => null,
+      clear: () => clearMock(),
+      isPersistAvailable: () => false,
+    } as unknown as SessionStore;
+    restartMobileRemote = vi.fn();
+    broadcast = vi.fn();
+    doLogin = vi.fn(async () => loggedInState);
+    const fake = fakeIpcMain();
+    handlers = fake.handlers;
+    registerMobileRemoteIpc({
+      ipcMain: fake.ipcMain,
+      store,
+      restartMobileRemote,
+      broadcast,
+      doLogin,
+    });
+  });
+
+  it('login runs OAuth + restarts when the sender is the main frame', async () => {
+    const result = await handlers.get(MOBILE_REMOTE_CHANNELS.login)!(fakeEvent);
+    expect(doLogin).toHaveBeenCalled();
+    expect(restartMobileRemote).toHaveBeenCalled();
+    expect(broadcast).toHaveBeenCalledWith(loggedInState);
+    expect(result).toEqual(loggedInState);
+  });
+
+  it('login does nothing when the sender is not the main frame', async () => {
+    allowGuard = false;
+    const result = await handlers.get(MOBILE_REMOTE_CHANNELS.login)!(fakeEvent);
+    expect(doLogin).not.toHaveBeenCalled();
+    expect(restartMobileRemote).not.toHaveBeenCalled();
+    expect(broadcast).not.toHaveBeenCalled();
+    expect(result).toEqual(loggedOutState);
+  });
+
+  it('logout clears + restarts when the sender is the main frame', async () => {
+    const result = await handlers.get(MOBILE_REMOTE_CHANNELS.logout)!(fakeEvent);
+    expect(clearMock).toHaveBeenCalled();
+    expect(restartMobileRemote).toHaveBeenCalled();
+    expect(broadcast).toHaveBeenCalledWith(loggedOutState);
+    expect(result).toEqual(loggedOutState);
+  });
+
+  it('logout does nothing when the sender is not the main frame', async () => {
+    allowGuard = false;
+    const result = await handlers.get(MOBILE_REMOTE_CHANNELS.logout)!(fakeEvent);
+    expect(clearMock).not.toHaveBeenCalled();
+    expect(restartMobileRemote).not.toHaveBeenCalled();
+    expect(broadcast).not.toHaveBeenCalled();
+    expect(result).toEqual(loggedOutState);
+  });
+});

--- a/electron/ipc/__tests__/systemIpcSecurity.test.ts
+++ b/electron/ipc/__tests__/systemIpcSecurity.test.ts
@@ -1,0 +1,98 @@
+// Security gate around the `ccsm:set-language` IPC handler.
+//
+// `set-language` mutates main-process app language and rebuilds the tray /
+// app accelerator menus. It is state-mutating and privileged, so it must
+// confirm the message came from our top-level renderer frame before acting.
+
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
+
+vi.mock('electron', () => ({}));
+vi.mock('../../agent/read-default-model', () => ({
+  readDefaultModelFromSettings: async () => null,
+}));
+
+// Mock the security guard. Default: accept; tests can flip to reject.
+let allowGuard = true;
+vi.mock('../../security/ipcGuards', () => ({
+  fromMainFrame: (_e: unknown) => allowGuard,
+}));
+
+// systemIpc.ts loads i18n through a dynamic `require('../i18n')`; under vitest
+// node can't resolve the bare `.ts`, so patch Module.prototype.require to hand
+// back a stub (same approach as electron/shared/__tests__/log.test.ts).
+const setMainLanguageMock = vi.fn();
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const Module = require('node:module') as typeof import('node:module');
+const ModuleProto = (Module as unknown as { prototype: { require: (id: string) => unknown } })
+  .prototype;
+const originalRequire = ModuleProto.require;
+ModuleProto.require = function patchedRequire(this: NodeJS.Module, id: string) {
+  if (id === '../i18n') {
+    return {
+      setMainLanguage: (l: string) => setMainLanguageMock(l),
+      resolveSystemLanguage: (_l: string) => 'en',
+    };
+  }
+  return originalRequire.call(this, id);
+};
+
+afterAll(() => {
+  ModuleProto.require = originalRequire;
+});
+
+import { registerSystemIpc } from '../systemIpc';
+
+type Handler = (e: unknown, ...args: unknown[]) => unknown;
+
+function fakeIpcMain() {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle: (ch: string, fn: Handler) => handlers.set(ch, fn),
+    on: (ch: string, fn: Handler) => handlers.set(ch, fn),
+  } as unknown as Electron.IpcMain;
+  return { ipcMain, handlers };
+}
+
+const fakeEvent = {} as Electron.IpcMainEvent;
+
+describe('ccsm:set-language security gate', () => {
+  let setLanguage: Handler;
+  let applyAppMenuLocale: ReturnType<typeof vi.fn>;
+  let applyTrayLocale: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    allowGuard = true;
+    setMainLanguageMock.mockClear();
+    applyAppMenuLocale = vi.fn();
+    applyTrayLocale = vi.fn();
+    const { ipcMain, handlers } = fakeIpcMain();
+    registerSystemIpc({
+      ipcMain,
+      app: { getLocale: () => 'en-US', getVersion: () => '0.0.0' } as unknown as Electron.App,
+      applyAppMenuLocale,
+      applyTrayLocale,
+    });
+    // registerSystemIpc seeds the language once at boot — clear so the test
+    // only observes calls triggered by the handler.
+    setMainLanguageMock.mockClear();
+    applyAppMenuLocale.mockClear();
+    applyTrayLocale.mockClear();
+    setLanguage = handlers.get('ccsm:set-language')!;
+    expect(setLanguage).toBeDefined();
+  });
+
+  it('applies the language when the sender is the main frame', () => {
+    setLanguage(fakeEvent, 'zh');
+    expect(setMainLanguageMock).toHaveBeenCalledWith('zh');
+    expect(applyTrayLocale).toHaveBeenCalled();
+    expect(applyAppMenuLocale).toHaveBeenCalled();
+  });
+
+  it('does nothing when the sender is not the main frame', () => {
+    allowGuard = false;
+    setLanguage(fakeEvent, 'zh');
+    expect(setMainLanguageMock).not.toHaveBeenCalled();
+    expect(applyTrayLocale).not.toHaveBeenCalled();
+    expect(applyAppMenuLocale).not.toHaveBeenCalled();
+  });
+});

--- a/electron/ipc/__tests__/utilityIpc.test.ts
+++ b/electron/ipc/__tests__/utilityIpc.test.ts
@@ -172,6 +172,13 @@ describe('ccsm:openExternal IPC handler', () => {
   type Handler = (e: unknown, ...args: unknown[]) => unknown;
   let handler: Handler;
 
+  // Event shaped so the fromMainFrame guard (senderFrame === sender.mainFrame)
+  // passes — these tests exercise scheme validation, not the frame guard.
+  const e = (() => {
+    const mainFrame = { id: 1 };
+    return { sender: { mainFrame }, senderFrame: mainFrame } as unknown;
+  })();
+
   beforeEach(() => {
     openExternalMock.mockClear();
     const handlers = new Map<string, Handler>();
@@ -185,8 +192,8 @@ describe('ccsm:openExternal IPC handler', () => {
   });
 
   it('forwards http(s) URLs to shell.openExternal and returns true', async () => {
-    const r1 = await handler({}, 'https://example.com');
-    const r2 = await handler({}, 'http://localhost:8080/x');
+    const r1 = await handler(e, 'https://example.com');
+    const r2 = await handler(e, 'http://localhost:8080/x');
     expect(r1).toBe(true);
     expect(r2).toBe(true);
     expect(openExternalMock).toHaveBeenCalledTimes(2);
@@ -195,35 +202,35 @@ describe('ccsm:openExternal IPC handler', () => {
   });
 
   it('rejects file:// without calling shell.openExternal', async () => {
-    const r = await handler({}, 'file:///etc/passwd');
+    const r = await handler(e, 'file:///etc/passwd');
     expect(r).toBe(false);
     expect(openExternalMock).not.toHaveBeenCalled();
   });
 
   it('rejects javascript: without calling shell.openExternal', async () => {
-    const r = await handler({}, 'javascript:alert(1)');
+    const r = await handler(e, 'javascript:alert(1)');
     expect(r).toBe(false);
     expect(openExternalMock).not.toHaveBeenCalled();
   });
 
   it('rejects data: without calling shell.openExternal', async () => {
-    const r = await handler({}, 'data:text/html,x');
+    const r = await handler(e, 'data:text/html,x');
     expect(r).toBe(false);
     expect(openExternalMock).not.toHaveBeenCalled();
   });
 
   it('rejects non-string inputs without calling shell.openExternal', async () => {
-    expect(await handler({}, 42)).toBe(false);
-    expect(await handler({}, null)).toBe(false);
-    expect(await handler({}, undefined)).toBe(false);
-    expect(await handler({}, { url: 'https://x' })).toBe(false);
+    expect(await handler(e, 42)).toBe(false);
+    expect(await handler(e, null)).toBe(false);
+    expect(await handler(e, undefined)).toBe(false);
+    expect(await handler(e, { url: 'https://x' })).toBe(false);
     expect(openExternalMock).not.toHaveBeenCalled();
   });
 
   it('returns false (does not throw) when shell.openExternal rejects', async () => {
     openExternalMock.mockRejectedValueOnce(new Error('boom'));
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const r = await handler({}, 'https://example.com');
+    const r = await handler(e, 'https://example.com');
     expect(r).toBe(false);
     expect(warnSpy).toHaveBeenCalled();
     warnSpy.mockRestore();

--- a/electron/ipc/__tests__/utilityIpcSecurity.test.ts
+++ b/electron/ipc/__tests__/utilityIpcSecurity.test.ts
@@ -12,9 +12,12 @@ import * as os from 'os';
 const pushUserCwdMock = vi.fn((p: string) => [p, os.homedir()]);
 const getUserCwdsMock = vi.fn(() => [os.homedir()]);
 
+const openExternalMock = vi.fn(async (_url: string) => {});
+
 vi.mock('electron', () => ({
   BrowserWindow: { fromWebContents: () => null },
   dialog: { showOpenDialog: async () => ({ canceled: true, filePaths: [] }) },
+  shell: { openExternal: (url: string) => openExternalMock(url) },
 }));
 vi.mock('../../import-scanner', () => ({
   scanImportableSessions: async () => [],
@@ -122,5 +125,37 @@ describe('app:userCwds:push security gate (#804 risk #4)', () => {
     push(mainFrameEvent(), '~');
     expect(pushUserCwdMock).toHaveBeenCalledTimes(1);
     expect(pushUserCwdMock).toHaveBeenCalledWith(os.homedir());
+  });
+});
+
+// `ccsm:openExternal` opens an arbitrary URL in the OS browser — a privileged
+// action. Beyond the http(s) scheme whitelist it must also confirm the IPC
+// came from our top-level renderer frame (defense-in-depth).
+describe('ccsm:openExternal security gate', () => {
+  let openExternal: Handler;
+
+  beforeEach(() => {
+    openExternalMock.mockClear();
+    const { ipcMain, handlers } = fakeIpcMain();
+    registerUtilityIpc({ ipcMain });
+    openExternal = handlers.get('ccsm:openExternal')!;
+    expect(openExternal).toBeDefined();
+  });
+
+  it('opens an https URL when the sender is the main frame', async () => {
+    const result = await openExternal(mainFrameEvent(), 'https://example.com');
+    expect(openExternalMock).toHaveBeenCalledWith('https://example.com');
+    expect(result).toBe(true);
+  });
+
+  it('does not open when the sender is a sub-frame (fromMainFrame guard)', async () => {
+    const subFrame = { id: 2 };
+    const e = {
+      sender: { mainFrame: { id: 1 } },
+      senderFrame: subFrame,
+    } as unknown as Electron.IpcMainInvokeEvent;
+    const result = await openExternal(e, 'https://example.com');
+    expect(openExternalMock).not.toHaveBeenCalled();
+    expect(result).toBeFalsy();
   });
 });

--- a/electron/ipc/__tests__/voiceIpc.test.ts
+++ b/electron/ipc/__tests__/voiceIpc.test.ts
@@ -34,12 +34,19 @@ describe('registerVoiceIpc', () => {
   };
   beforeEach(() => vi.resetModules());
 
+  // Event shaped so the fromMainFrame guard (senderFrame === sender.mainFrame)
+  // passes — this test exercises payload validation, not the frame guard.
+  function mainFrameEvent(): unknown {
+    const mainFrame = { id: 1 };
+    return { sender: { mainFrame }, senderFrame: mainFrame };
+  }
+
   it('short-circuits invalid payloads with empty error and never calls transcribe', async () => {
     const transcribe = vi.fn();
     vi.doMock('../../voice/transcriber', () => ({ transcribe }));
     const { registerVoiceIpc } = await import('../voiceIpc');
     registerVoiceIpc({ ipcMain: ipcMain as never });
-    const res = await handler({}, new Float32Array(0));
+    const res = await handler(mainFrameEvent(), new Float32Array(0));
     expect(res).toEqual({ ok: false, error: 'empty' });
     expect(transcribe).not.toHaveBeenCalled();
   });

--- a/electron/ipc/__tests__/voiceIpcSecurity.test.ts
+++ b/electron/ipc/__tests__/voiceIpcSecurity.test.ts
@@ -1,0 +1,61 @@
+// Security gate around the `voice:transcribe` IPC handler.
+//
+// `transcribe` hands renderer-supplied PCM to an external transcription path.
+// It is privileged, so it must confirm the message came from our top-level
+// renderer frame before invoking the transcriber.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const transcribeMock = vi.fn(async () => ({ ok: true, text: 'hello' }));
+vi.mock('../../voice/transcriber', () => ({
+  transcribe: (pcm: Float32Array) => transcribeMock(pcm),
+}));
+
+// Mock the security guard. Default: accept; tests can flip to reject.
+let allowGuard = true;
+vi.mock('../../security/ipcGuards', () => ({
+  fromMainFrame: (_e: unknown) => allowGuard,
+}));
+
+import { registerVoiceIpc } from '../voiceIpc';
+
+type Handler = (e: unknown, ...args: unknown[]) => Promise<unknown>;
+
+function fakeIpcMain() {
+  const handlers = new Map<string, Handler>();
+  const ipcMain = {
+    handle: (ch: string, fn: Handler) => handlers.set(ch, fn),
+    on: (ch: string, fn: Handler) => handlers.set(ch, fn),
+  } as unknown as Electron.IpcMain;
+  return { ipcMain, handlers };
+}
+
+const fakeEvent = {} as Electron.IpcMainInvokeEvent;
+
+describe('voice:transcribe security gate', () => {
+  let transcribeHandler: Handler;
+
+  beforeEach(() => {
+    transcribeMock.mockClear();
+    allowGuard = true;
+    const { ipcMain, handlers } = fakeIpcMain();
+    registerVoiceIpc({ ipcMain });
+    transcribeHandler = handlers.get('voice:transcribe')!;
+    expect(transcribeHandler).toBeDefined();
+  });
+
+  it('transcribes when the sender is the main frame', async () => {
+    const pcm = new Float32Array([0.1, 0.2, 0.3]);
+    const result = await transcribeHandler(fakeEvent, pcm);
+    expect(transcribeMock).toHaveBeenCalledWith(pcm);
+    expect(result).toEqual({ ok: true, text: 'hello' });
+  });
+
+  it('rejects without transcribing when the sender is not the main frame', async () => {
+    allowGuard = false;
+    const pcm = new Float32Array([0.1, 0.2, 0.3]);
+    const result = await transcribeHandler(fakeEvent, pcm);
+    expect(transcribeMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ ok: false, error: 'rejected' });
+  });
+});

--- a/electron/ipc/mobileRemoteIpc.ts
+++ b/electron/ipc/mobileRemoteIpc.ts
@@ -3,6 +3,7 @@ import type { IpcMain } from 'electron';
 import { MOBILE_REMOTE_CHANNELS } from '../shared/ipcChannels';
 import type { SessionStore } from '../remote/sessionStore';
 import { loggedOut, type MobileRemoteAuthState } from '../remote/oauthLogin';
+import { fromMainFrame } from '../security/ipcGuards';
 
 function stateFromStore(store: SessionStore): MobileRemoteAuthState {
   const s = store.load();
@@ -24,14 +25,16 @@ export function registerMobileRemoteIpc(deps: {
 }): void {
   const { ipcMain, store, restartMobileRemote, broadcast, doLogin } = deps;
 
-  ipcMain.handle(MOBILE_REMOTE_CHANNELS.login, async () => {
+  ipcMain.handle(MOBILE_REMOTE_CHANNELS.login, async (e) => {
+    if (!fromMainFrame(e)) return stateFromStore(store);
     const state = await doLogin();
     restartMobileRemote();
     broadcast(state);
     return state;
   });
 
-  ipcMain.handle(MOBILE_REMOTE_CHANNELS.logout, async () => {
+  ipcMain.handle(MOBILE_REMOTE_CHANNELS.logout, async (e) => {
+    if (!fromMainFrame(e)) return stateFromStore(store);
     store.clear();
     restartMobileRemote();
     const state = stateFromStore(store);

--- a/electron/ipc/systemIpc.ts
+++ b/electron/ipc/systemIpc.ts
@@ -6,6 +6,7 @@
 
 import type { IpcMain, App } from 'electron';
 import { readDefaultModelFromSettings } from '../agent/read-default-model';
+import { fromMainFrame } from '../security/ipcGuards';
 
 export interface SystemIpcDeps {
   ipcMain: IpcMain;
@@ -35,7 +36,8 @@ export function registerSystemIpc(deps: SystemIpcDeps): void {
       return undefined;
     }
   });
-  ipcMain.on('ccsm:set-language', (_e, lang: unknown) => {
+  ipcMain.on('ccsm:set-language', (e, lang: unknown) => {
+    if (!fromMainFrame(e)) return;
     if (lang === 'en' || lang === 'zh') {
       i18n.setMainLanguage(lang);
       // Tray menu / tooltip + app accelerator menu are built once on app

--- a/electron/ipc/utilityIpc.ts
+++ b/electron/ipc/utilityIpc.ts
@@ -241,7 +241,8 @@ export function registerUtilityIpc(deps: UtilityIpcDeps): void {
   // untrusted by definition. Anything outside http(s) (file://, javascript:,
   // data:, vbscript:, custom protocol handlers, ...) is rejected before
   // touching `shell.openExternal`.
-  ipcMain.handle('ccsm:openExternal', async (_e, url: unknown) => {
+  ipcMain.handle('ccsm:openExternal', async (e, url: unknown) => {
+    if (!fromMainFrame(e)) return false;
     if (!isAllowedExternalUrl(url)) return false;
     try {
       await shell.openExternal(url);

--- a/electron/ipc/voiceIpc.ts
+++ b/electron/ipc/voiceIpc.ts
@@ -1,6 +1,7 @@
 import type { IpcMain } from 'electron';
 import { transcribe } from '../voice/transcriber';
 import type { VoiceResult } from '../voice/voiceTypes';
+import { fromMainFrame } from '../security/ipcGuards';
 
 // 10 minutes of 16 kHz mono audio. IPC payloads are untrusted by
 // convention; cap the buffer so a hostile/buggy renderer can't OOM main
@@ -17,7 +18,8 @@ export interface VoiceIpcDeps {
 
 export function registerVoiceIpc(deps: VoiceIpcDeps): void {
   const { ipcMain } = deps;
-  ipcMain.handle('voice:transcribe', async (_e, pcm: unknown): Promise<VoiceResult> => {
+  ipcMain.handle('voice:transcribe', async (e, pcm: unknown): Promise<VoiceResult> => {
+    if (!fromMainFrame(e)) return { ok: false, error: 'rejected' };
     if (!validateVoicePayload(pcm)) return { ok: false, error: 'empty' };
     return transcribe(pcm);
   });

--- a/electron/voice/voiceTypes.ts
+++ b/electron/voice/voiceTypes.ts
@@ -3,4 +3,4 @@
 // can't import from electron/ — same convention as `UpdateStatus`).
 export type VoiceResult =
   | { ok: true; text: string }
-  | { ok: false; error: 'no-model' | 'transcribe-failed' | 'empty' };
+  | { ok: false; error: 'no-model' | 'transcribe-failed' | 'empty' | 'rejected' };

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -16,7 +16,7 @@ export type UpdateStatus =
 // UpdateStatus). Keep these two in sync.
 export type VoiceResult =
   | { ok: true; text: string }
-  | { ok: false; error: 'no-model' | 'transcribe-failed' | 'empty' };
+  | { ok: false; error: 'no-model' | 'transcribe-failed' | 'empty' | 'rejected' };
 
 // Desktop GitHub OAuth login state for the public-internet mobile-remote path
 // (PR-4b). Structurally mirrors electron/remote/oauthLogin.ts's


### PR DESCRIPTION
## What

Adds the `fromMainFrame` defense-in-depth guard to the four privileged,
state-mutating IPC handlers that were missing it (audit finding #71):

- `ccsm:openExternal` (utilityIpc) — opens an arbitrary URL in the OS browser
- `ccsm:set-language` (systemIpc) — mutates app language, rebuilds tray/menu
- `voice:transcribe` (voiceIpc) — hands renderer PCM to the transcriber
- mobile-remote `login` / `logout` (mobileRemoteIpc) — OAuth flow + server restart

Each guard rejects messages that did not originate from our top-level renderer
frame, returning a benign value instead of acting:
- `openExternal` → `false`
- `set-language` → early `return` (no-op)
- `voice:transcribe` → `{ ok: false, error: 'rejected' }`
- `login` / `logout` → current `stateFromStore(store)` (no state change)

`authState` is intentionally left unguarded — it is read-only.

## Why this matters

A compromised iframe (future webview, misconfigured CSP) shares the same
`e.sender` as the top-level frame and could otherwise drive these privileged
actions. Pairs with the existing `setWindowOpenHandler({ action: 'deny' })`
and `will-navigate` blocks. Same pattern already used by the `#804` cwd/dialog
handlers.

## Required type change

`voice:transcribe`'s rejection needs a new error variant, so `'rejected'` is
added to the `VoiceResult` union in both `electron/voice/voiceTypes.ts` and its
renderer mirror `src/global.d.ts` (the two are kept in sync by their own
file comments; the renderer cannot import from `electron/`).

## Tests

- 3 new security suites (`systemIpcSecurity`, `voiceIpcSecurity`,
  `mobileRemoteIpcSecurity`) — each asserts the allow-path acts and the
  reject-path is a no-op returning the benign value.
- `utilityIpcSecurity` extended with a real sub-frame mismatch case for
  `openExternal`.
- 4 pre-existing tests updated to pass a main-frame-shaped event so they keep
  exercising their original validation logic through the new guard.

## Verification (run in the worktree)

- `npm run typecheck` — clean
- `npm run lint` (`--max-warnings 0`) — exit 0
- `npx vitest run electron/ipc/` — 9 files / 69 tests pass