### PR TITLE
fix(terminal): re-sync self-drawn thumb + jump button on wheel scroll (#82)

### DIFF
--- a/src/terminal/useAtBottom.ts
+++ b/src/terminal/useAtBottom.ts
@@ -16,12 +16,15 @@ import { getTopShell } from './shellRegistry';
 // every burst of output even though the user is effectively at bottom).
 //
 // We re-read on `onScroll` (xterm fires this for both user scroll and
-// programmatic scroll caused by new output) and on `onLineFeed` (covers
+// programmatic scroll caused by new output), on `onLineFeed` (covers
 // the case where output advances `baseY` without changing `viewportY` —
 // e.g. user scrolled up, new lines keep streaming; xterm bumps baseY but
-// no scroll event fires). The hook reads the registry's top shell
-// (z-stack path — see `shellRegistry.ts` / `usePtyAttachShell.ts`) so
-// the listeners attach to whichever Terminal is currently in the foreground.
+// no scroll event fires), and on `onRender` (covers wheel scroll, which
+// moves `viewportY` but fires no `onScroll` — xterm passes
+// `suppressScrollEvent=true` on its wheel path). The hook reads the
+// registry's top shell (z-stack path — see `shellRegistry.ts` /
+// `usePtyAttachShell.ts`) so the listeners attach to whichever Terminal
+// is currently in the foreground.
 //
 // Returns a stable `atBottom` boolean and a `scrollToBottom` function
 // that delegates to xterm's public API.
@@ -50,9 +53,14 @@ export function useAtBottom(sessionId: string | null): AtBottomState {
     recompute();
     const scrollDisposable = term.onScroll(recompute);
     const lineFeedDisposable = term.onLineFeed(recompute);
+    // Wheel scroll moves viewportY without firing onScroll (xterm passes
+    // suppressScrollEvent=true on the wheel path), so the button would miss
+    // a wheel-up off the bottom. onRender fires on that repaint (#82).
+    const renderDisposable = term.onRender(recompute);
     return () => {
       scrollDisposable.dispose();
       lineFeedDisposable.dispose();
+      renderDisposable.dispose();
     };
   }, [sessionId]);
 

--- a/src/terminal/useTerminalScroll.ts
+++ b/src/terminal/useTerminalScroll.ts
@@ -12,10 +12,11 @@ import { getTopShell } from './shellRegistry';
 //
 // This hook reads xterm's buffer geometry directly and projects a thumb
 // position. There is no reverse sync — the thumb is a *pure function* of
-// the buffer state, so it can never desync. We re-read on the same event
-// set `useAtBottom` uses (`onScroll` + `onLineFeed`) plus `onResize`
-// (track-height / rows change on fit). Drag / track-click translate back
-// to `term.scrollToLine` / `term.scrollLines` against the same buffer.
+// the buffer state, so it can never desync. We re-read on `onScroll` +
+// `onLineFeed` + `onResize` (fit) and `onRender` — the last catches wheel
+// scroll, which moves `viewportY` but fires no `onScroll` (xterm passes
+// `suppressScrollEvent=true` on its wheel path). Drag / track-click
+// translate back to `term.scrollToLine` / `term.scrollLines`.
 //
 // All geometry is in the pure functions below, exported for unit tests.
 
@@ -137,10 +138,16 @@ export function useTerminalScroll(
     const scrollDisposable = term.onScroll(recompute);
     const lineFeedDisposable = term.onLineFeed(recompute);
     const resizeDisposable = term.onResize(recompute);
+    // Wheel scroll moves viewportY but xterm suppresses onScroll for it
+    // (Viewport.handleWheel → scrollLines(amount, suppressScrollEvent=true)),
+    // so onScroll/onLineFeed/onResize all miss it and the thumb freezes (#82).
+    // onRender fires on the wheel-driven repaint, re-syncing the thumb.
+    const renderDisposable = term.onRender(recompute);
     return () => {
       scrollDisposable.dispose();
       lineFeedDisposable.dispose();
       resizeDisposable.dispose();
+      renderDisposable.dispose();
     };
   }, [sessionId, trackHeight]);
 

--- a/tests/terminal/useAtBottom.test.tsx
+++ b/tests/terminal/useAtBottom.test.tsx
@@ -4,6 +4,7 @@ import { renderHook, act } from '@testing-library/react';
 // Capture the listener xterm registered so the test can fire it synthetically.
 let scrollListener: (() => void) | null = null;
 let lineFeedListener: (() => void) | null = null;
+let renderListener: (() => void) | null = null;
 
 const fakeBuffer = { active: { viewportY: 0, baseY: 0 } };
 const scrollToBottomSpy = vi.fn(() => {
@@ -22,6 +23,10 @@ const fakeTerm = {
     lineFeedListener = cb;
     return { dispose: vi.fn(() => { lineFeedListener = null; }) };
   }),
+  onRender: vi.fn((cb: () => void) => {
+    renderListener = cb;
+    return { dispose: vi.fn(() => { renderListener = null; }) };
+  }),
   scrollToBottom: scrollToBottomSpy,
 };
 
@@ -37,9 +42,11 @@ describe('useAtBottom (warm registry)', () => {
     fakeBuffer.active.baseY = 0;
     scrollListener = null;
     lineFeedListener = null;
+    renderListener = null;
     scrollToBottomSpy.mockClear();
     fakeTerm.onScroll.mockClear();
     fakeTerm.onLineFeed.mockClear();
+    fakeTerm.onRender.mockClear();
   });
 
   afterEach(() => {
@@ -94,6 +101,22 @@ describe('useAtBottom (warm registry)', () => {
     expect(result.current.atBottom).toBe(false);
   });
 
+  it('flips atBottom on wheel scroll (onRender only — xterm suppresses onScroll)', () => {
+    fakeBuffer.active.baseY = 100;
+    fakeBuffer.active.viewportY = 100;
+    const { result } = renderHook(() => useAtBottom('sid-A'));
+    expect(result.current.atBottom).toBe(true);
+
+    // Wheel-up moves viewportY but fires NO onScroll/onLineFeed — only a
+    // repaint (onRender). The button must still reveal. Red if the onRender
+    // subscription is dropped.
+    act(() => {
+      fakeBuffer.active.viewportY = 20;
+      renderListener!();
+    });
+    expect(result.current.atBottom).toBe(false);
+  });
+
   it('scrollToBottom delegates to term.scrollToBottom and restores atBottom', () => {
     fakeBuffer.active.baseY = 100;
     fakeBuffer.active.viewportY = 20;
@@ -107,13 +130,15 @@ describe('useAtBottom (warm registry)', () => {
     expect(result.current.atBottom).toBe(true);
   });
 
-  it('disposes the scroll + lineFeed listeners on unmount', () => {
+  it('disposes the scroll + lineFeed + render listeners on unmount', () => {
     const { unmount } = renderHook(() => useAtBottom('sid-A'));
     const scrollDispose = fakeTerm.onScroll.mock.results[0]!.value.dispose as ReturnType<typeof vi.fn>;
     const lineFeedDispose = fakeTerm.onLineFeed.mock.results[0]!.value.dispose as ReturnType<typeof vi.fn>;
+    const renderDispose = fakeTerm.onRender.mock.results[0]!.value.dispose as ReturnType<typeof vi.fn>;
     unmount();
     expect(scrollDispose).toHaveBeenCalled();
     expect(lineFeedDispose).toHaveBeenCalled();
+    expect(renderDispose).toHaveBeenCalled();
   });
 
   it('recomputes on session change (effect re-runs on sessionId change)', () => {

--- a/tests/terminal/useTerminalScroll.hook.test.tsx
+++ b/tests/terminal/useTerminalScroll.hook.test.tsx
@@ -1,0 +1,122 @@
+// Hook-level tests for `useTerminalScroll`'s xterm subscription — distinct
+// from `useTerminalScroll.test.ts`, which pins the pure geometry. These
+// prove the thumb re-projects on the events that actually move `viewportY`,
+// most importantly `onRender` (the wheel-scroll path, #82): wheel moves
+// `viewportY` but xterm suppresses `onScroll` for it, so without the
+// `onRender` subscription the thumb would freeze while content scrolls.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+let scrollListener: (() => void) | null = null;
+let lineFeedListener: (() => void) | null = null;
+let resizeListener: (() => void) | null = null;
+let renderListener: (() => void) | null = null;
+
+const fakeBuffer = { active: { viewportY: 0, baseY: 0 } };
+const fakeTerm = {
+  rows: 24,
+  get buffer() {
+    return fakeBuffer;
+  },
+  onScroll: vi.fn((cb: () => void) => {
+    scrollListener = cb;
+    return { dispose: vi.fn(() => { scrollListener = null; }) };
+  }),
+  onLineFeed: vi.fn((cb: () => void) => {
+    lineFeedListener = cb;
+    return { dispose: vi.fn(() => { lineFeedListener = null; }) };
+  }),
+  onResize: vi.fn((cb: () => void) => {
+    resizeListener = cb;
+    return { dispose: vi.fn(() => { resizeListener = null; }) };
+  }),
+  onRender: vi.fn((cb: () => void) => {
+    renderListener = cb;
+    return { dispose: vi.fn(() => { renderListener = null; }) };
+  }),
+};
+
+vi.mock('../../src/terminal/shellRegistry', () => ({
+  getTopShell: vi.fn(() => ({ term: fakeTerm })),
+}));
+
+import { useTerminalScroll, computeThumb } from '../../src/terminal/useTerminalScroll';
+
+const H = 200;
+
+describe('useTerminalScroll (xterm subscription)', () => {
+  beforeEach(() => {
+    fakeBuffer.active.viewportY = 0;
+    fakeBuffer.active.baseY = 0;
+    scrollListener = null;
+    lineFeedListener = null;
+    resizeListener = null;
+    renderListener = null;
+    fakeTerm.onScroll.mockClear();
+    fakeTerm.onLineFeed.mockClear();
+    fakeTerm.onResize.mockClear();
+    fakeTerm.onRender.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('projects the initial thumb from buffer state on mount', () => {
+    fakeBuffer.active.baseY = 100;
+    fakeBuffer.active.viewportY = 100; // at bottom
+    const { result } = renderHook(() => useTerminalScroll('sid-A', H));
+    const expected = computeThumb({ baseY: 100, viewportY: 100, rows: 24 }, H);
+    expect(result.current.visible).toBe(true);
+    expect(result.current.thumbTop).toBeCloseTo(expected.thumbTop, 6);
+  });
+
+  it('subscribes to onRender (the wheel-scroll repaint event)', () => {
+    renderHook(() => useTerminalScroll('sid-A', H));
+    expect(fakeTerm.onRender).toHaveBeenCalledTimes(1);
+    expect(renderListener).toBeInstanceOf(Function);
+  });
+
+  // THE #82 regression lock: a wheel scroll moves viewportY but xterm fires
+  // NO onScroll / onLineFeed / onResize for it — only a repaint (onRender).
+  // The thumb must still re-project. If the onRender subscription is removed,
+  // this test goes red (thumbTop stays at the bottom while content moved up).
+  it('re-projects the thumb on onRender alone when wheel moves viewportY', () => {
+    fakeBuffer.active.baseY = 100;
+    fakeBuffer.active.viewportY = 100; // start at bottom
+    const { result } = renderHook(() => useTerminalScroll('sid-A', H));
+    const bottomThumbTop = result.current.thumbTop;
+    expect(bottomThumbTop).toBeGreaterThan(0);
+
+    // Simulate wheel-up: viewportY drops, but ONLY onRender fires.
+    act(() => {
+      fakeBuffer.active.viewportY = 0;
+      renderListener!();
+    });
+
+    expect(result.current.thumbTop).toBe(0); // thumb followed content to top
+    expect(result.current.thumbTop).toBeLessThan(bottomThumbTop);
+  });
+
+  it('still re-projects on onScroll (drag / programmatic path)', () => {
+    fakeBuffer.active.baseY = 100;
+    fakeBuffer.active.viewportY = 100;
+    const { result } = renderHook(() => useTerminalScroll('sid-A', H));
+    act(() => {
+      fakeBuffer.active.viewportY = 50;
+      scrollListener!();
+    });
+    const mid = computeThumb({ baseY: 100, viewportY: 50, rows: 24 }, H);
+    expect(result.current.thumbTop).toBeCloseTo(mid.thumbTop, 6);
+  });
+
+  it('disposes the onRender listener (with the others) on unmount', () => {
+    const { unmount } = renderHook(() => useTerminalScroll('sid-A', H));
+    const renderDispose = fakeTerm.onRender.mock.results[0]!.value
+      .dispose as ReturnType<typeof vi.fn>;
+    unmount();
+    expect(renderDispose).toHaveBeenCalled();
+    expect(renderListener).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Wheel-up moved the CLI content but the visible scrollbar thumb stayed frozen (and the jump-to-bottom button missed the off-bottom state). Root cause: xterm passes `suppressScrollEvent=true` on its wheel path (`Viewport.handleWheel → scrollLines(amount, true)`), so `onScroll` / `onLineFeed` / `onResize` **never fire on a wheel scroll**. Both the self-drawn scrollbar (`useTerminalScroll`) and the jump button (`useAtBottom`) subscribed only to those events, so neither recomputed.

Fix: subscribe both hooks to `term.onRender`, which **does** fire on the wheel-driven repaint, re-projecting the thumb and recomputing `atBottom`.

## Why this, not #1464

PR #1464's `reconcileView` forces `term._core.viewport.syncScrollArea(true)` to rewrite `.xterm-viewport.scrollTop`. But #1442 (already on `main`) removed the native scrollbar — that DOM element is CSS-hidden and non-load-bearing. The visible thumb is now a pure projection of `buffer.active.viewportY`/`baseY` (`computeThumb`), so #1464 writes to a dead element and cannot fix this symptom. **#1464 should be closed.**

## Changes
- `src/terminal/useTerminalScroll.ts` — add `term.onRender(recompute)` subscription + disposal
- `src/terminal/useAtBottom.ts` — same
- `tests/terminal/useTerminalScroll.hook.test.tsx` (new) — regression lock: fires `onRender` alone after a wheel-style `viewportY` move, asserts the thumb re-projects; goes red if the subscription is removed
- `tests/terminal/useAtBottom.test.tsx` — equivalent wheel-only case + render-listener disposal

## Test plan
- [x] `npm run typecheck` — green
- [x] `npm run lint` — green
- [x] `npx vitest run tests/terminal/` — 7 files / 69 tests green
- [ ] **Real-device merge gate:** unit tests prove the `onRender` subscription fires and the thumb re-projects under a mocked term, but jsdom has no real scroll physics — they cannot prove the visible thumb actually repaints on a physical wheel-up. **User must wheel-scroll up in the real app and confirm the thumb tracks the content** before merge.

Note: the full `npm test` run shows 41 failures isolated to `electron/__tests__/db*.test.ts` and `electron-load-smoke.test.ts` — all from the `better-sqlite3` native-ABI mismatch / missing `dist/` in this local env; they fail identically on `main` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)