### PR TITLE
fix(build): unpack @shinyoshiaki/binary-data so 0.2.17 startup crash is fixed (v0.2.18)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccsm",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "description": "CCSM (Claude Code Session Manager) — group-first manager for many Claude Code sessions",
   "productName": "CCSM",
   "license": "MIT",
@@ -124,7 +124,8 @@
     "asar": true,
     "asarUnpack": [
       "**/node_modules/better-sqlite3/**",
-      "**/node_modules/node-pty/**"
+      "**/node_modules/node-pty/**",
+      "**/node_modules/@shinyoshiaki/binary-data/**"
     ],
     "extraResources": [
       {


### PR DESCRIPTION
## Summary
- 0.2.17 installer crashes on launch — background process spawns but no window appears.
- Root cause (from `$APPDATA/CCSM/logs/main.log`): `uncaughtException: Cannot find module 'lib/binary-stream'` thrown from `@shinyoshiaki/binary-data/src/index.js`, reached via `werift -> dtls -> desktopPeer -> mobileRemoteController -> main`.
- `@shinyoshiaki/binary-data` resolves its internals through nested `src/node_modules/{lib,types}`. electron-builder packs these into the `app.asar` archive, where Node's directory-walk `require('lib/binary-stream')` can't find them. The uncaught exception kills the main process before any window opens.
- Fix: add the package to `asarUnpack` so its nested `node_modules` stay on disk, where resolution works. Bumps version to `0.2.18` so it supersedes the broken 0.2.17.

## Why CI verification matters here
Local Windows packaging is blocked by a symlink-privilege failure during winCodeSign extraction (non-admin, no Developer Mode). The `windows-latest` CI runner has the privilege and produces the real installer. The fix itself is config-only (2 lines).

## Test plan
- [ ] CI `verify` job green (lint + typecheck + build + test — native modules rebuilt for Node, unlike the local env)
- [ ] After merge + `v0.2.18` tag: `release.yml` builds the Windows installer
- [ ] Install `CCSM-Setup-0.2.18-x64.exe`, confirm the app window launches (no `lib/binary-stream` crash in `main.log`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)