### PR TITLE
feat(voice): runtime on-demand whisper model download with 6 selectable tiers

### DIFF
--- a/electron/ipc/__tests__/voiceIpc.test.ts
+++ b/electron/ipc/__tests__/voiceIpc.test.ts
@@ -26,21 +26,98 @@ describe('validateVoicePayload', () => {
 });
 
 describe('registerVoiceIpc', () => {
-  let handler: (e: unknown, pcm: unknown) => Promise<unknown>;
+  const handlers = new Map<string, (e: unknown, pcm: unknown) => Promise<unknown>>();
   const ipcMain = {
-    handle: vi.fn((_ch: string, h: typeof handler) => {
-      handler = h;
+    handle: vi.fn((ch: string, h: (e: unknown, pcm: unknown) => Promise<unknown>) => {
+      handlers.set(ch, h);
     }),
   };
-  beforeEach(() => vi.resetModules());
+  beforeEach(() => {
+    vi.resetModules();
+    handlers.clear();
+  });
 
   it('short-circuits invalid payloads with empty error and never calls transcribe', async () => {
     const transcribe = vi.fn();
     vi.doMock('../../voice/transcriber', () => ({ transcribe }));
+    vi.doMock('../../voice/modelDownloader', () => ({
+      isTierDownloaded: vi.fn(),
+      downloadTier: vi.fn(),
+      cancelDownload: vi.fn(),
+    }));
     const { registerVoiceIpc } = await import('../voiceIpc');
+    const { VOICE_CHANNELS } = await import('../../shared/ipcChannels');
     registerVoiceIpc({ ipcMain: ipcMain as never });
+    const handler = handlers.get(VOICE_CHANNELS.transcribe)!;
     const res = await handler({}, new Float32Array(0));
     expect(res).toEqual({ ok: false, error: 'empty' });
     expect(transcribe).not.toHaveBeenCalled();
+  });
+});
+
+describe('registerVoiceIpc — model-download handlers', () => {
+  const handlers = new Map<string, (e: unknown, arg: unknown) => Promise<unknown>>();
+  const ipcMain = {
+    handle: vi.fn((ch: string, h: (e: unknown, arg: unknown) => Promise<unknown>) => {
+      handlers.set(ch, h);
+    }),
+  };
+
+  const isTierDownloaded = vi.fn();
+  const downloadTier = vi.fn();
+  const cancelDownload = vi.fn();
+
+  beforeEach(async () => {
+    vi.resetModules();
+    handlers.clear();
+    isTierDownloaded.mockReset();
+    downloadTier.mockReset();
+    cancelDownload.mockReset();
+    vi.doMock('../../voice/transcriber', () => ({ transcribe: vi.fn() }));
+    vi.doMock('../../voice/modelDownloader', () => ({
+      isTierDownloaded,
+      downloadTier,
+      cancelDownload,
+    }));
+    const { registerVoiceIpc } = await import('../voiceIpc');
+    registerVoiceIpc({ ipcMain: ipcMain as never });
+  });
+
+  it('registers transcribe, isDownloaded, download, and cancel channels', async () => {
+    const { VOICE_CHANNELS } = await import('../../shared/ipcChannels');
+    expect(handlers.has(VOICE_CHANNELS.transcribe)).toBe(true);
+    expect(handlers.has(VOICE_CHANNELS.isDownloaded)).toBe(true);
+    expect(handlers.has(VOICE_CHANNELS.download)).toBe(true);
+    expect(handlers.has(VOICE_CHANNELS.cancel)).toBe(true);
+  });
+
+  it('isDownloaded delegates valid tiers and rejects unknown ones without delegating', async () => {
+    const { VOICE_CHANNELS } = await import('../../shared/ipcChannels');
+    const h = handlers.get(VOICE_CHANNELS.isDownloaded)!;
+    isTierDownloaded.mockReturnValue(true);
+    expect(await h({}, 'base')).toBe(true);
+    expect(isTierDownloaded).toHaveBeenCalledWith('base');
+    expect(await h({}, 'bogus')).toBe(false);
+    expect(isTierDownloaded).toHaveBeenCalledTimes(1);
+  });
+
+  it('download delegates valid tiers and returns null for unknown ones', async () => {
+    const { VOICE_CHANNELS } = await import('../../shared/ipcChannels');
+    const h = handlers.get(VOICE_CHANNELS.download)!;
+    const ready = { kind: 'ready', tier: 'tiny' };
+    downloadTier.mockResolvedValue(ready);
+    expect(await h({}, 'tiny')).toBe(ready);
+    expect(downloadTier).toHaveBeenCalledWith('tiny');
+    expect(await h({}, 42)).toBeNull();
+    expect(downloadTier).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancel delegates valid tiers and ignores unknown ones', async () => {
+    const { VOICE_CHANNELS } = await import('../../shared/ipcChannels');
+    const h = handlers.get(VOICE_CHANNELS.cancel)!;
+    await h({}, 'small');
+    expect(cancelDownload).toHaveBeenCalledWith('small');
+    await h({}, null);
+    expect(cancelDownload).toHaveBeenCalledTimes(1);
   });
 });

--- a/electron/ipc/voiceIpc.ts
+++ b/electron/ipc/voiceIpc.ts
@@ -1,6 +1,14 @@
 import type { IpcMain } from 'electron';
 import { transcribe } from '../voice/transcriber';
 import type { VoiceResult } from '../voice/voiceTypes';
+import { VOICE_CHANNELS } from '../shared/ipcChannels';
+import { isVoiceTier } from '../voice/modelTiers';
+import {
+  isTierDownloaded,
+  downloadTier,
+  cancelDownload,
+  type VoiceModelStatus,
+} from '../voice/modelDownloader';
 
 // 10 minutes of 16 kHz mono audio. IPC payloads are untrusted by
 // convention; cap the buffer so a hostile/buggy renderer can't OOM main
@@ -17,8 +25,23 @@ export interface VoiceIpcDeps {
 
 export function registerVoiceIpc(deps: VoiceIpcDeps): void {
   const { ipcMain } = deps;
-  ipcMain.handle('voice:transcribe', async (_e, pcm: unknown): Promise<VoiceResult> => {
+
+  ipcMain.handle(VOICE_CHANNELS.transcribe, async (_e, pcm: unknown): Promise<VoiceResult> => {
     if (!validateVoicePayload(pcm)) return { ok: false, error: 'empty' };
     return transcribe(pcm);
+  });
+
+  ipcMain.handle(VOICE_CHANNELS.isDownloaded, async (_e, tier: unknown): Promise<boolean> => {
+    if (!isVoiceTier(tier)) return false;
+    return isTierDownloaded(tier);
+  });
+
+  ipcMain.handle(VOICE_CHANNELS.download, async (_e, tier: unknown): Promise<VoiceModelStatus | null> => {
+    if (!isVoiceTier(tier)) return null;
+    return downloadTier(tier);
+  });
+
+  ipcMain.handle(VOICE_CHANNELS.cancel, async (_e, tier: unknown): Promise<void> => {
+    if (isVoiceTier(tier)) cancelDownload(tier);
   });
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -84,6 +84,7 @@ import {
 import { loadNotifyEnabled, subscribeNotifyEnabledInvalidation } from './prefs/notifyEnabled';
 import { subscribeCrashReportingInvalidation } from './prefs/crashReporting';
 import { subscribeScrollbackInvalidation } from './prefs/scrollback';
+import { subscribeVoiceTierInvalidation } from './prefs/voiceTier';
 import { BadgeController } from './badgeController';
 import { registerDbIpc } from './ipc/dbIpc';
 import { registerSystemIpc } from './ipc/systemIpc';
@@ -237,6 +238,7 @@ app.whenReady().then(() => {
   subscribeCrashReportingInvalidation();
   subscribeNotifyEnabledInvalidation();
   subscribeScrollbackInvalidation();
+  subscribeVoiceTierInvalidation();
   // Order is significant for systemIpc: it seeds the active i18n language
   // from the OS locale, so any subsequent producer that calls i18n.t()
   // sees the correct active language.

--- a/electron/prefs/__tests__/voiceTier.test.ts
+++ b/electron/prefs/__tests__/voiceTier.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// voiceTier reads app_state via ../db and subscribes to the stateSavedBus.
+// Mock both so the test stays in-memory and deterministic.
+const loadState = vi.fn();
+let savedBusHandler: ((key: string) => void) | undefined;
+const onStateSaved = vi.fn((h: (key: string) => void) => {
+  savedBusHandler = h;
+  return () => {
+    savedBusHandler = undefined;
+  };
+});
+
+vi.mock('../../db', () => ({ loadState: (...a: unknown[]) => loadState(...a) }));
+vi.mock('../../shared/stateSavedBus', () => ({
+  onStateSaved: (h: (key: string) => void) => onStateSaved(h),
+}));
+
+describe('voiceTier prefs', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    loadState.mockReset();
+    onStateSaved.mockReset();
+    savedBusHandler = undefined;
+  });
+
+  it('returns a stored valid tier', async () => {
+    loadState.mockReturnValue('small');
+    const { loadVoiceTier } = await import('../voiceTier');
+    expect(loadVoiceTier()).toBe('small');
+  });
+
+  it('falls back to base for an unknown stored value', async () => {
+    loadState.mockReturnValue('bogus');
+    const { loadVoiceTier } = await import('../voiceTier');
+    expect(loadVoiceTier()).toBe('base');
+  });
+
+  it('falls back to base when loadState throws', async () => {
+    loadState.mockImplementation(() => {
+      throw new Error('db down');
+    });
+    const { loadVoiceTier } = await import('../voiceTier');
+    expect(loadVoiceTier()).toBe('base');
+  });
+
+  it('caches the first read (db hit once across calls)', async () => {
+    loadState.mockReturnValue('medium');
+    const { loadVoiceTier } = await import('../voiceTier');
+    expect(loadVoiceTier()).toBe('medium');
+    expect(loadVoiceTier()).toBe('medium');
+    expect(loadState).toHaveBeenCalledTimes(1);
+  });
+
+  it('invalidateVoiceTierCache forces a re-read', async () => {
+    loadState.mockReturnValueOnce('tiny').mockReturnValueOnce('large-v3');
+    const { loadVoiceTier, invalidateVoiceTierCache } = await import('../voiceTier');
+    expect(loadVoiceTier()).toBe('tiny');
+    invalidateVoiceTierCache();
+    expect(loadVoiceTier()).toBe('large-v3');
+    expect(loadState).toHaveBeenCalledTimes(2);
+  });
+
+  it('subscription invalidates cache only on the voiceTier key', async () => {
+    loadState.mockReturnValueOnce('tiny').mockReturnValueOnce('base');
+    const { loadVoiceTier, subscribeVoiceTierInvalidation, VOICE_TIER_KEY } =
+      await import('../voiceTier');
+    subscribeVoiceTierInvalidation();
+    expect(loadVoiceTier()).toBe('tiny');
+
+    savedBusHandler?.('somethingElse');
+    expect(loadVoiceTier()).toBe('tiny'); // still cached
+    expect(loadState).toHaveBeenCalledTimes(1);
+
+    savedBusHandler?.(VOICE_TIER_KEY);
+    expect(loadVoiceTier()).toBe('base'); // re-read
+    expect(loadState).toHaveBeenCalledTimes(2);
+  });
+});

--- a/electron/prefs/voiceTier.ts
+++ b/electron/prefs/voiceTier.ts
@@ -1,0 +1,39 @@
+// Selected whisper model tier preference. Mirrors the notifyEnabled.ts
+// pattern (Task #730 Phase A1): persisted in app_state under `voiceTier`,
+// cached in main-process memory, invalidated via the stateSavedBus when the
+// renderer's Settings pane writes a new value (db:save) — no restart needed.
+//
+// Default `base`. An unknown/corrupt stored value falls back to the default
+// via isVoiceTier validation.
+
+import { loadState } from '../db';
+import { onStateSaved } from '../shared/stateSavedBus';
+import { DEFAULT_TIER, isVoiceTier, type VoiceTier } from '../voice/modelTiers';
+
+export const VOICE_TIER_KEY = 'voiceTier';
+
+let _voiceTierCached: VoiceTier | undefined;
+
+export function loadVoiceTier(): VoiceTier {
+  if (_voiceTierCached !== undefined) return _voiceTierCached;
+  try {
+    const raw = loadState(VOICE_TIER_KEY);
+    const value = isVoiceTier(raw) ? raw : DEFAULT_TIER;
+    _voiceTierCached = value;
+    return value;
+  } catch {
+    return DEFAULT_TIER;
+  }
+}
+
+export function invalidateVoiceTierCache(): void {
+  _voiceTierCached = undefined;
+}
+
+/** Wire cache invalidation to the stateSavedBus. Call once during boot
+ *  (before `registerDbIpc`). Returns the unsubscribe handle. */
+export function subscribeVoiceTierInvalidation(): () => void {
+  return onStateSaved((key) => {
+    if (key === VOICE_TIER_KEY) invalidateVoiceTierCache();
+  });
+}

--- a/electron/preload/bridges/ccsmVoice.ts
+++ b/electron/preload/bridges/ccsmVoice.ts
@@ -1,16 +1,40 @@
 // `window.ccsmVoice` — speech-to-text bridge. The renderer captures mic
 // audio (Web Audio), resamples to 16 kHz mono Float32 PCM, and hands it
-// here; main runs smart-whisper and returns the transcript. One IPC hop
-// each way. Mirrors the single-concern bridge pattern from #769.
+// here; main runs whisper-cli and returns the transcript. Also exposes
+// runtime model-download controls (models are not bundled; downloaded on
+// demand into userData/models/). Mirrors the single-concern bridge pattern
+// from #769.
 import { contextBridge, ipcRenderer } from 'electron';
+import { VOICE_CHANNELS } from '../../shared/ipcChannels';
 
 type VoiceResult =
   | { ok: true; text: string }
-  | { ok: false; error: 'no-model' | 'transcribe-failed' | 'empty' };
+  | { ok: false; error: 'model-missing' | 'bin-missing' | 'transcribe-failed' | 'empty' };
+
+// Mirrors electron/voice/modelTiers.ts + modelDownloader.ts (renderer can't
+// import from electron/). Keep in sync with src/global.d.ts.
+type VoiceTier = 'tiny' | 'base' | 'small' | 'medium' | 'large-v3' | 'large-v3-turbo';
+
+type VoiceModelStatus =
+  | { kind: 'idle'; tier: VoiceTier }
+  | { kind: 'downloading'; tier: VoiceTier; transferred: number; total: number | null }
+  | { kind: 'ready'; tier: VoiceTier }
+  | { kind: 'error'; tier: VoiceTier; message: string };
 
 const api = {
   transcribe: (pcm: Float32Array): Promise<VoiceResult> =>
-    ipcRenderer.invoke('voice:transcribe', pcm),
+    ipcRenderer.invoke(VOICE_CHANNELS.transcribe, pcm),
+  isModelDownloaded: (tier: VoiceTier): Promise<boolean> =>
+    ipcRenderer.invoke(VOICE_CHANNELS.isDownloaded, tier),
+  downloadModel: (tier: VoiceTier): Promise<VoiceModelStatus | null> =>
+    ipcRenderer.invoke(VOICE_CHANNELS.download, tier),
+  cancelDownload: (tier: VoiceTier): Promise<void> =>
+    ipcRenderer.invoke(VOICE_CHANNELS.cancel, tier),
+  onModelStatus: (handler: (status: VoiceModelStatus) => void): (() => void) => {
+    const listener = (_e: unknown, status: VoiceModelStatus) => handler(status);
+    ipcRenderer.on(VOICE_CHANNELS.status, listener);
+    return () => ipcRenderer.removeListener(VOICE_CHANNELS.status, listener);
+  },
 };
 
 export type CCSMVoiceAPI = typeof api;

--- a/electron/shared/ipcChannels.ts
+++ b/electron/shared/ipcChannels.ts
@@ -88,3 +88,13 @@ export const DB_CHANNELS = {
   load: 'db:load',
   save: 'db:save',
 } as const;
+
+export const VOICE_CHANNELS = {
+  // renderer → main (invoke)
+  transcribe: 'voice:transcribe',
+  isDownloaded: 'voice:isModelDownloaded',
+  download: 'voice:downloadModel',
+  cancel: 'voice:cancelDownload',
+  // main → renderer (fan-out: per-tier download progress / ready / error)
+  status: 'voice:modelStatus',
+} as const;

--- a/electron/voice/__tests__/modelDownloader.test.ts
+++ b/electron/voice/__tests__/modelDownloader.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// modelDownloader pulls app/BrowserWindow from electron, writes to fs, and
+// streams via stream/promises pipeline. Mock all three plus global fetch so
+// the test stays in-memory and deterministic.
+
+const sentMessages: Array<{ channel: string; payload: unknown }> = [];
+const webContents = {
+  send: (channel: string, payload: unknown) => sentMessages.push({ channel, payload }),
+};
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/userData' },
+  BrowserWindow: { getAllWindows: () => [{ webContents }] },
+}));
+
+// In-memory fs: track files by normalized path with their byte size.
+const files = new Map<string, number>();
+function norm(p: string): string {
+  return String(p).replace(/\\/g, '/');
+}
+
+const fsMock = {
+  mkdirSync: vi.fn(),
+  createWriteStream: vi.fn(() => ({
+    write: (_chunk: Buffer, cb: (err?: Error | null) => void) => cb(null),
+    end: (cb: () => void) => cb(),
+  })),
+  statSync: vi.fn((p: string) => {
+    const size = files.get(norm(p));
+    if (size === undefined) throw new Error('ENOENT');
+    return { size };
+  }),
+  renameSync: vi.fn((from: string, to: string) => {
+    const size = files.get(norm(from));
+    if (size === undefined) throw new Error('ENOENT');
+    files.delete(norm(from));
+    files.set(norm(to), size);
+  }),
+  unlinkSync: vi.fn((p: string) => {
+    files.delete(norm(p));
+  }),
+};
+vi.mock('fs', () => ({ ...fsMock, default: fsMock }));
+
+// pipeline(source, meter) — drive the meter's write() with the source's chunks
+// (so the downloader's transferred-byte accounting + tmp-file size run), then
+// final(). The meter writes into our fake fs createWriteStream, so we record
+// the landed size onto the tmp path the meter is targeting.
+const pipelineImpl = vi.fn();
+vi.mock('stream/promises', () => ({
+  pipeline: (...args: unknown[]) => pipelineImpl(...args),
+  default: { pipeline: (...args: unknown[]) => pipelineImpl(...args) },
+}));
+
+// Build a Response-like with a body whose chunks we control.
+function makeResponse(opts: {
+  ok: boolean;
+  status?: number;
+  contentLength?: string | null;
+  chunks?: Buffer[];
+}) {
+  return {
+    ok: opts.ok,
+    status: opts.status ?? (opts.ok ? 200 : 500),
+    body: opts.ok ? { __chunks: opts.chunks ?? [] } : null,
+    headers: { get: (k: string) => (k === 'content-length' ? opts.contentLength ?? null : null) },
+  };
+}
+
+// Default pipeline behavior: pump body chunks through the meter, sizing the
+// tmp file by total bytes written. The tmp path is closed over via a module
+// variable set in run(); we recover it from the meter by tracking writes.
+beforeEach(() => {
+  vi.resetModules();
+  files.clear();
+  sentMessages.length = 0;
+  pipelineImpl.mockReset();
+  vi.unstubAllGlobals();
+});
+
+// A pipeline that feeds the response chunks into the meter and records the
+// resulting tmp-file size. We infer the tmp path from the most recent
+// downloading status broadcast is not reliable, so instead the meter's write
+// callback path is what matters: we mirror the byte count into a holder and
+// the test's fetch closure stamps the tmp path size directly.
+function installPumpingPipeline(tmpHolder: { path: string | null }, total: number) {
+  pipelineImpl.mockImplementation(async (source: { __chunks: Buffer[] }, meter: NodeJS.WritableStream) => {
+    let written = 0;
+    for (const chunk of source.__chunks) {
+      await new Promise<void>((resolve, reject) =>
+        meter.write(chunk, (err?: Error | null) => (err ? reject(err) : resolve())),
+      );
+      written += chunk.length;
+    }
+    await new Promise<void>((resolve) => meter.end(resolve));
+    if (tmpHolder.path) files.set(norm(tmpHolder.path), total > 0 ? total : written);
+  });
+}
+
+describe('modelDownloader.isTierDownloaded', () => {
+  it('true only when the model file exists with non-zero size', async () => {
+    const { isTierDownloaded } = await import('../modelDownloader');
+    expect(isTierDownloaded('base')).toBe(false);
+    files.set('/userData/models/ggml-base.bin', 0);
+    expect(isTierDownloaded('base')).toBe(false);
+    files.set('/userData/models/ggml-base.bin', 147951465);
+    expect(isTierDownloaded('base')).toBe(true);
+  });
+});
+
+describe('modelDownloader.downloadTier', () => {
+  it('downloads from the primary, lands atomically, and broadcasts ready', async () => {
+    const tmp = { path: null as string | null };
+    installPumpingPipeline(tmp, 6);
+    const fetchMock = vi.fn(async (url: string) => {
+      // Capture the tmp path the downloader will write to by deriving it: the
+      // downloader writes ggml-tiny.bin.download-<rand>; we don't know rand,
+      // so stamp via renameSync source instead. Simpler: set tmp.path on first
+      // statSync miss. Here we mark success by returning chunks.
+      expect(url).toContain('huggingface.co');
+      return makeResponse({ ok: true, contentLength: '6', chunks: [Buffer.from('abcdef')] });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { downloadTier } = await import('../modelDownloader');
+    // The downloader picks a random tmp path; intercept renameSync to learn it.
+    const fs = await import('fs');
+    (fs.renameSync as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      (from: string, to: string) => {
+        files.set(norm(to), 6);
+        files.delete(norm(from));
+      },
+    );
+    // statSync must report the tmp size; pre-seed when createWriteStream runs.
+    (fs.createWriteStream as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      (p: string) => {
+        tmp.path = p;
+        return {
+          write: (_c: Buffer, cb: (e?: Error | null) => void) => cb(null),
+          end: (cb: () => void) => cb(),
+        };
+      },
+    );
+
+    const status = await downloadTier('tiny');
+    expect(status).toEqual({ kind: 'ready', tier: 'tiny' });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const ready = sentMessages.filter((m) => (m.payload as { kind: string }).kind === 'ready');
+    expect(ready).toHaveLength(1);
+  });
+
+  it('falls back to the mirror when the primary fails', async () => {
+    const tmp = { path: null as string | null };
+    installPumpingPipeline(tmp, 6);
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.includes('huggingface.co')) return makeResponse({ ok: false, status: 503 });
+      return makeResponse({ ok: true, contentLength: '6', chunks: [Buffer.from('abcdef')] });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { downloadTier } = await import('../modelDownloader');
+    const fs = await import('fs');
+    (fs.createWriteStream as unknown as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      tmp.path = p;
+      return {
+        write: (_c: Buffer, cb: (e?: Error | null) => void) => cb(null),
+        end: (cb: () => void) => cb(),
+      };
+    });
+
+    const status = await downloadTier('tiny');
+    expect(status.kind).toBe('ready');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0][0]).toContain('huggingface.co');
+    expect(fetchMock.mock.calls[1][0]).toContain('hf-mirror.com');
+  });
+
+  it('rejects a truncated download (landed size != Content-Length) and tries the mirror', async () => {
+    const tmp = { path: null as string | null };
+    // Primary writes only 3 bytes but declares 6 → size mismatch.
+    pipelineImpl.mockImplementationOnce(async (_s: unknown, meter: NodeJS.WritableStream) => {
+      await new Promise<void>((r) => meter.write(Buffer.from('abc'), () => r()));
+      await new Promise<void>((r) => meter.end(r));
+      if (tmp.path) files.set(norm(tmp.path), 3);
+    });
+    installPumpingPipeline(tmp, 6); // mirror writes full 6
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, contentLength: '6', chunks: [Buffer.from('abcdef')] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { downloadTier } = await import('../modelDownloader');
+    const fs = await import('fs');
+    (fs.createWriteStream as unknown as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      tmp.path = p;
+      return {
+        write: (_c: Buffer, cb: (e?: Error | null) => void) => cb(null),
+        end: (cb: () => void) => cb(),
+      };
+    });
+
+    const status = await downloadTier('tiny');
+    expect(status.kind).toBe('ready');
+    // Both sources attempted; the partial was unlinked before the retry.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fs.unlinkSync).toHaveBeenCalled();
+  });
+
+  it('returns an error status when all sources fail', async () => {
+    const fetchMock = vi.fn(async () => makeResponse({ ok: false, status: 500 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { downloadTier } = await import('../modelDownloader');
+    const status = await downloadTier('tiny');
+    expect(status.kind).toBe('error');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const errors = sentMessages.filter((m) => (m.payload as { kind: string }).kind === 'error');
+    expect(errors.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('dedups concurrent requests for the same tier (single fetch round)', async () => {
+    const tmp = { path: null as string | null };
+    installPumpingPipeline(tmp, 6);
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, contentLength: '6', chunks: [Buffer.from('abcdef')] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { downloadTier } = await import('../modelDownloader');
+    const fs = await import('fs');
+    (fs.createWriteStream as unknown as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      tmp.path = p;
+      return {
+        write: (_c: Buffer, cb: (e?: Error | null) => void) => cb(null),
+        end: (cb: () => void) => cb(),
+      };
+    });
+
+    const [a, b] = await Promise.all([downloadTier('tiny'), downloadTier('tiny')]);
+    expect(a).toBe(b); // same Promise resolution
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/electron/voice/__tests__/modelDownloader.test.ts
+++ b/electron/voice/__tests__/modelDownloader.test.ts
@@ -43,10 +43,11 @@ const fsMock = {
 };
 vi.mock('fs', () => ({ ...fsMock, default: fsMock }));
 
-// pipeline(source, meter) — drive the meter's write() with the source's chunks
-// (so the downloader's transferred-byte accounting + tmp-file size run), then
-// final(). The meter writes into our fake fs createWriteStream, so we record
-// the landed size onto the tmp path the meter is targeting.
+// pipeline(source, meter, writeStream, opts) — drive the meter's transform()
+// with the source's chunks (so the downloader's transferred-byte accounting
+// runs), then finish. The meter is a pass-through Transform; pipeline owns the
+// destination WriteStream. We record the landed size onto the tmp path the
+// downloader is writing to (captured via the createWriteStream mock).
 const pipelineImpl = vi.fn();
 vi.mock('stream/promises', () => ({
   pipeline: (...args: unknown[]) => pipelineImpl(...args),
@@ -79,23 +80,22 @@ beforeEach(() => {
   vi.unstubAllGlobals();
 });
 
-// A pipeline that feeds the response chunks into the meter and records the
-// resulting tmp-file size. We infer the tmp path from the most recent
-// downloading status broadcast is not reliable, so instead the meter's write
-// callback path is what matters: we mirror the byte count into a holder and
-// the test's fetch closure stamps the tmp path size directly.
+// A pipeline that feeds the response chunks into the meter (a pass-through
+// Transform) so the downloader's byte accounting + progress broadcasts run,
+// then records the resulting tmp-file size. The tmp path is captured by the
+// createWriteStream mock into tmpHolder.
 function installPumpingPipeline(tmpHolder: { path: string | null }, total: number) {
-  pipelineImpl.mockImplementation(async (source: { __chunks: Buffer[] }, meter: NodeJS.WritableStream) => {
-    let written = 0;
-    for (const chunk of source.__chunks) {
-      await new Promise<void>((resolve, reject) =>
-        meter.write(chunk, (err?: Error | null) => (err ? reject(err) : resolve())),
-      );
-      written += chunk.length;
-    }
-    await new Promise<void>((resolve) => meter.end(resolve));
-    if (tmpHolder.path) files.set(norm(tmpHolder.path), total > 0 ? total : written);
-  });
+  pipelineImpl.mockImplementation(
+    async (source: { __chunks: Buffer[] }, meter: NodeJS.ReadWriteStream) => {
+      let written = 0;
+      for (const chunk of source.__chunks) {
+        meter.write(chunk);
+        written += chunk.length;
+      }
+      meter.end();
+      if (tmpHolder.path) files.set(norm(tmpHolder.path), total > 0 ? total : written);
+    },
+  );
 }
 
 describe('modelDownloader.isTierDownloaded', () => {
@@ -179,9 +179,9 @@ describe('modelDownloader.downloadTier', () => {
   it('rejects a truncated download (landed size != Content-Length) and tries the mirror', async () => {
     const tmp = { path: null as string | null };
     // Primary writes only 3 bytes but declares 6 → size mismatch.
-    pipelineImpl.mockImplementationOnce(async (_s: unknown, meter: NodeJS.WritableStream) => {
-      await new Promise<void>((r) => meter.write(Buffer.from('abc'), () => r()));
-      await new Promise<void>((r) => meter.end(r));
+    pipelineImpl.mockImplementationOnce(async (_s: unknown, meter: NodeJS.ReadWriteStream) => {
+      meter.write(Buffer.from('abc'));
+      meter.end();
       if (tmp.path) files.set(norm(tmp.path), 3);
     });
     installPumpingPipeline(tmp, 6); // mirror writes full 6
@@ -238,5 +238,68 @@ describe('modelDownloader.downloadTier', () => {
     const [a, b] = await Promise.all([downloadTier('tiny'), downloadTier('tiny')]);
     expect(a).toBe(b); // same Promise resolution
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels mid-stream: error "cancelled", tmp unlinked, no mirror fetch', async () => {
+    const tmp = { path: null as string | null };
+    // pipeline rejects with an AbortError once the signal is aborted, mirroring
+    // node's stream/promises behavior on AbortController.abort().
+    pipelineImpl.mockImplementation(
+      (
+        _source: unknown,
+        _meter: unknown,
+        _dest: unknown,
+        opts: { signal: AbortSignal },
+      ) =>
+        new Promise((_resolve, reject) => {
+          opts.signal.addEventListener('abort', () => {
+            const err = new Error('The operation was aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }),
+    );
+    const fetchMock = vi.fn(async () =>
+      makeResponse({ ok: true, contentLength: '6', chunks: [Buffer.from('abcdef')] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { downloadTier, cancelDownload } = await import('../modelDownloader');
+    const fs = await import('fs');
+    (fs.createWriteStream as unknown as ReturnType<typeof vi.fn>).mockImplementation((p: string) => {
+      tmp.path = p;
+      files.set(norm(p), 3); // a partial is on disk when we abort
+      return {
+        write: (_c: Buffer, cb: (e?: Error | null) => void) => cb(null),
+        end: (cb: () => void) => cb(),
+      };
+    });
+    (fs.unlinkSync as unknown as ReturnType<typeof vi.fn>).mockClear();
+
+    const promise = downloadTier('tiny');
+    // Let the fetch + pipeline wiring settle, then cancel.
+    await Promise.resolve();
+    await Promise.resolve();
+    cancelDownload('tiny');
+
+    const status = await promise;
+    expect(status).toEqual({ kind: 'error', tier: 'tiny', message: 'cancelled' });
+    // Mirror must NOT be fetched after cancel (break path), only the primary.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // The partial tmp file was cleaned up.
+    expect(fs.unlinkSync).toHaveBeenCalled();
+  });
+
+  it('short-circuits to ready when the tier is already downloaded', async () => {
+    files.set('/userData/models/ggml-tiny.bin', 12345);
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { downloadTier } = await import('../modelDownloader');
+    const status = await downloadTier('tiny');
+    expect(status).toEqual({ kind: 'ready', tier: 'tiny' });
+    expect(fetchMock).not.toHaveBeenCalled();
+    const ready = sentMessages.filter((m) => (m.payload as { kind: string }).kind === 'ready');
+    expect(ready).toHaveLength(1);
   });
 });

--- a/electron/voice/__tests__/modelTiers.test.ts
+++ b/electron/voice/__tests__/modelTiers.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  VOICE_TIERS,
+  DEFAULT_TIER,
+  HEAVY_TIERS,
+  tierFilename,
+  isVoiceTier,
+  buildDownloadUrls,
+  TIER_SIZE_BYTES,
+  type VoiceTier,
+} from '../modelTiers';
+
+describe('VOICE_TIERS', () => {
+  it('enumerates the six main tiers in order, no .en / quantized variants', () => {
+    expect([...VOICE_TIERS]).toEqual([
+      'tiny',
+      'base',
+      'small',
+      'medium',
+      'large-v3',
+      'large-v3-turbo',
+    ]);
+  });
+
+  it('defaults to base', () => {
+    expect(DEFAULT_TIER).toBe('base');
+    expect(VOICE_TIERS).toContain(DEFAULT_TIER);
+  });
+
+  it('marks only the GB-scale tiers as heavy', () => {
+    expect([...HEAVY_TIERS]).toEqual(['medium', 'large-v3', 'large-v3-turbo']);
+    for (const t of HEAVY_TIERS) expect(VOICE_TIERS).toContain(t);
+  });
+
+  it('has a display size for every tier', () => {
+    for (const t of VOICE_TIERS) {
+      expect(TIER_SIZE_BYTES[t]).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('tierFilename', () => {
+  it('produces the ggml-<tier>.bin name', () => {
+    expect(tierFilename('base')).toBe('ggml-base.bin');
+    expect(tierFilename('large-v3-turbo')).toBe('ggml-large-v3-turbo.bin');
+  });
+});
+
+describe('isVoiceTier', () => {
+  it('accepts every known tier', () => {
+    for (const t of VOICE_TIERS) expect(isVoiceTier(t)).toBe(true);
+  });
+
+  it('rejects unknown strings and non-strings', () => {
+    expect(isVoiceTier('large')).toBe(false);
+    expect(isVoiceTier('base.en')).toBe(false);
+    expect(isVoiceTier('')).toBe(false);
+    expect(isVoiceTier(null)).toBe(false);
+    expect(isVoiceTier(42)).toBe(false);
+    expect(isVoiceTier(undefined)).toBe(false);
+  });
+});
+
+describe('buildDownloadUrls', () => {
+  it('returns HuggingFace primary then hf-mirror fallback for the tier file', () => {
+    const urls = buildDownloadUrls('base');
+    expect(urls).toEqual([
+      'https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.bin',
+      'https://hf-mirror.com/ggerganov/whisper.cpp/resolve/main/ggml-base.bin',
+    ]);
+  });
+
+  it('embeds the per-tier filename for every tier', () => {
+    for (const t of VOICE_TIERS as readonly VoiceTier[]) {
+      const urls = buildDownloadUrls(t);
+      expect(urls).toHaveLength(2);
+      for (const u of urls) expect(u.endsWith(`/${tierFilename(t)}`)).toBe(true);
+    }
+  });
+});

--- a/electron/voice/__tests__/transcriber.test.ts
+++ b/electron/voice/__tests__/transcriber.test.ts
@@ -1,20 +1,36 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('electron', () => ({
-  app: { getAppPath: () => '/repo' },
+  app: { getAppPath: () => '/repo', getPath: () => '/userData' },
+}));
+
+// transcribe() reads the current tier from prefs; pin it to 'base' so the
+// model filename is deterministic.
+vi.mock('../../prefs/voiceTier', () => ({
+  loadVoiceTier: () => 'base',
 }));
 
 describe('resolveModelPath / resolveBinPath', () => {
   beforeEach(() => vi.resetModules());
 
-  it('resolves repo-local base model path in dev', async () => {
+  it('prefers the userData models dir for the requested tier', async () => {
+    vi.doMock('fs', () => ({ existsSync: () => true }));
     const { resolveModelPath } = await import('../transcriber');
-    expect(resolveModelPath().replace(/\\/g, '/')).toContain(
+    expect(resolveModelPath('small').replace(/\\/g, '/')).toBe(
+      '/userData/models/ggml-small.bin',
+    );
+  });
+
+  it('falls back to the dev resources tree when userData/packaged are absent', async () => {
+    vi.doMock('fs', () => ({ existsSync: () => false }));
+    const { resolveModelPath } = await import('../transcriber');
+    expect(resolveModelPath('base').replace(/\\/g, '/')).toContain(
       'resources/models/ggml-base.bin',
     );
   });
 
   it('resolves repo-local whisper-cli path in dev', async () => {
+    vi.doMock('fs', () => ({ existsSync: () => false }));
     const { resolveBinPath } = await import('../transcriber');
     expect(resolveBinPath().replace(/\\/g, '/')).toContain(
       'resources/whisper-bin/whisper-cli.exe',
@@ -38,21 +54,21 @@ describe('transcribe', () => {
     }));
   }
 
-  it('returns no-model when the model file is missing', async () => {
+  it('returns model-missing when the model file is absent', async () => {
     mockFs({ modelExists: false, binExists: true });
     const { transcribe } = await import('../transcriber');
     expect(await transcribe(new Float32Array(16000))).toEqual({
       ok: false,
-      error: 'no-model',
+      error: 'model-missing',
     });
   });
 
-  it('returns no-model when the binary is missing', async () => {
+  it('returns bin-missing when the engine binary is absent', async () => {
     mockFs({ modelExists: true, binExists: false });
     const { transcribe } = await import('../transcriber');
     expect(await transcribe(new Float32Array(16000))).toEqual({
       ok: false,
-      error: 'no-model',
+      error: 'bin-missing',
     });
   });
 

--- a/electron/voice/modelDownloader.ts
+++ b/electron/voice/modelDownloader.ts
@@ -16,7 +16,7 @@
 import { app, BrowserWindow } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
-import { Writable } from 'stream';
+import { Transform } from 'stream';
 import { pipeline } from 'stream/promises';
 import { VOICE_CHANNELS } from '../shared/ipcChannels';
 import { buildDownloadUrls, tierFilename, type VoiceTier } from './modelTiers';
@@ -85,24 +85,30 @@ async function downloadFromUrl(
 
   let transferred = 0;
   let lastEmit = 0;
-  const sink = fs.createWriteStream(tmpPath);
-  const meter = new Writable({
-    write(chunk: Buffer, _enc, cb) {
+  // Pure pass-through: count bytes and throttle progress broadcasts, but let
+  // pipeline own the destination WriteStream. The stream is the LAST stage so
+  // pipeline destroys it (closing the fd) on abort/error/success alike —
+  // otherwise the fd leaks on cancel and Windows can EBUSY the tmp unlink.
+  const meter = new Transform({
+    transform(chunk: Buffer, _enc, cb) {
       transferred += chunk.length;
       const now = Date.now();
       if (now - lastEmit >= PROGRESS_THROTTLE_MS) {
         lastEmit = now;
         broadcastStatus({ kind: 'downloading', tier, transferred, total });
       }
-      sink.write(chunk, (err) => cb(err ?? null));
-    },
-    final(cb) {
-      sink.end(() => cb());
+      cb(null, chunk); // pass through unchanged
     },
   });
 
-  // pipeline rejects (and aborts) on signal abort, propagating cleanup.
-  await pipeline(res.body as unknown as NodeJS.ReadableStream, meter, { signal });
+  // pipeline rejects (and aborts) on signal abort, propagating cleanup and
+  // destroying every stage including the WriteStream.
+  await pipeline(
+    res.body as unknown as NodeJS.ReadableStream,
+    meter,
+    fs.createWriteStream(tmpPath),
+    { signal },
+  );
 
   // Integrity: landed size must match the response's declared length.
   const landed = fs.statSync(tmpPath).size;
@@ -162,6 +168,14 @@ async function run(tier: VoiceTier, controller: AbortController): Promise<VoiceM
 export function downloadTier(tier: VoiceTier): Promise<VoiceModelStatus> {
   const existing = inFlight.get(tier);
   if (existing) return existing.promise;
+
+  // Already on disk: short-circuit. Cheap defensive guard since this is a
+  // public IPC entry point and re-fetching a present model is wasteful.
+  if (isTierDownloaded(tier)) {
+    const ready: VoiceModelStatus = { kind: 'ready', tier };
+    broadcastStatus(ready);
+    return Promise.resolve(ready);
+  }
 
   const controller = new AbortController();
   const promise = run(tier, controller).finally(() => {

--- a/electron/voice/modelDownloader.ts
+++ b/electron/voice/modelDownloader.ts
@@ -1,0 +1,172 @@
+// Runtime whisper-model downloader. Models are NOT in the installer; this
+// fetches the selected tier into the writable userData/models/ dir on demand.
+//
+// Integrity: the landed file size is checked against THIS response's
+// Content-Length (catches truncated/dropped connections). We deliberately do
+// NOT compare against a hardcoded size — HuggingFace re-uploads models on
+// `main` and mirrors lag, so a fixed-byte gate would false-flag a good file.
+// Corrupt-but-right-size content is caught later by whisper-cli failing to
+// load (→ transcribe-failed). If a source omits Content-Length (some mirrors
+// do), we accept any non-empty file.
+//
+// Sources: HuggingFace primary → hf-mirror.com fallback (HF is often
+// unreachable from mainland China). No proxy is hardcoded — Node's fetch
+// honors the user's HTTP(S)_PROXY env.
+
+import { app, BrowserWindow } from 'electron';
+import * as path from 'path';
+import * as fs from 'fs';
+import { Writable } from 'stream';
+import { pipeline } from 'stream/promises';
+import { VOICE_CHANNELS } from '../shared/ipcChannels';
+import { buildDownloadUrls, tierFilename, type VoiceTier } from './modelTiers';
+
+export type VoiceModelStatus =
+  | { kind: 'idle'; tier: VoiceTier }
+  | { kind: 'downloading'; tier: VoiceTier; transferred: number; total: number | null }
+  | { kind: 'ready'; tier: VoiceTier }
+  | { kind: 'error'; tier: VoiceTier; message: string };
+
+const PROGRESS_THROTTLE_MS = 200;
+
+// One in-flight download per tier; concurrent requests for the same tier
+// share the Promise. Also used to drive cancellation.
+const inFlight = new Map<VoiceTier, { promise: Promise<VoiceModelStatus>; controller: AbortController }>();
+
+let lastStatus: VoiceModelStatus | null = null;
+
+function modelsDir(): string {
+  return path.join(app.getPath('userData'), 'models');
+}
+
+function modelPath(tier: VoiceTier): string {
+  return path.join(modelsDir(), tierFilename(tier));
+}
+
+export function isTierDownloaded(tier: VoiceTier): boolean {
+  try {
+    return fs.statSync(modelPath(tier)).size > 0;
+  } catch {
+    return false;
+  }
+}
+
+function sendAll(channel: string, payload: VoiceModelStatus): void {
+  lastStatus = payload;
+  for (const win of BrowserWindow.getAllWindows()) {
+    win.webContents.send(channel, payload);
+  }
+}
+
+function broadcastStatus(payload: VoiceModelStatus): void {
+  sendAll(VOICE_CHANNELS.status, payload);
+}
+
+export function getLastStatus(): VoiceModelStatus | null {
+  return lastStatus;
+}
+
+export function cancelDownload(tier: VoiceTier): void {
+  inFlight.get(tier)?.controller.abort();
+}
+
+async function downloadFromUrl(
+  url: string,
+  tier: VoiceTier,
+  tmpPath: string,
+  signal: AbortSignal,
+): Promise<void> {
+  const res = await fetch(url, { signal });
+  if (!res.ok || !res.body) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  const lenHeader = res.headers.get('content-length');
+  const total = lenHeader ? Number(lenHeader) : null;
+
+  let transferred = 0;
+  let lastEmit = 0;
+  const sink = fs.createWriteStream(tmpPath);
+  const meter = new Writable({
+    write(chunk: Buffer, _enc, cb) {
+      transferred += chunk.length;
+      const now = Date.now();
+      if (now - lastEmit >= PROGRESS_THROTTLE_MS) {
+        lastEmit = now;
+        broadcastStatus({ kind: 'downloading', tier, transferred, total });
+      }
+      sink.write(chunk, (err) => cb(err ?? null));
+    },
+    final(cb) {
+      sink.end(() => cb());
+    },
+  });
+
+  // pipeline rejects (and aborts) on signal abort, propagating cleanup.
+  await pipeline(res.body as unknown as NodeJS.ReadableStream, meter, { signal });
+
+  // Integrity: landed size must match the response's declared length.
+  const landed = fs.statSync(tmpPath).size;
+  if (total != null && landed !== total) {
+    throw new Error(`size mismatch: got ${landed}, expected ${total}`);
+  }
+  if (landed === 0) {
+    throw new Error('empty download');
+  }
+}
+
+async function run(tier: VoiceTier, controller: AbortController): Promise<VoiceModelStatus> {
+  fs.mkdirSync(modelsDir(), { recursive: true });
+  const dest = modelPath(tier);
+  const tmpPath = `${dest}.download-${Math.random().toString(36).slice(2)}`;
+  const urls = buildDownloadUrls(tier);
+
+  broadcastStatus({ kind: 'downloading', tier, transferred: 0, total: null });
+
+  let lastErr: unknown;
+  try {
+    for (const url of urls) {
+      try {
+        await downloadFromUrl(url, tier, tmpPath, controller.signal);
+        fs.renameSync(tmpPath, dest); // atomic landing
+        const ready: VoiceModelStatus = { kind: 'ready', tier };
+        broadcastStatus(ready);
+        return ready;
+      } catch (err) {
+        lastErr = err;
+        // Clean the partial before trying the next source.
+        try {
+          fs.unlinkSync(tmpPath);
+        } catch {
+          /* best-effort */
+        }
+        if (controller.signal.aborted) break; // don't fall through to mirror on cancel
+      }
+    }
+    const message = controller.signal.aborted
+      ? 'cancelled'
+      : lastErr instanceof Error
+        ? lastErr.message
+        : 'download failed';
+    const errStatus: VoiceModelStatus = { kind: 'error', tier, message };
+    broadcastStatus(errStatus);
+    return errStatus;
+  } finally {
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {
+      /* best-effort: gone after rename or already cleaned */
+    }
+  }
+}
+
+export function downloadTier(tier: VoiceTier): Promise<VoiceModelStatus> {
+  const existing = inFlight.get(tier);
+  if (existing) return existing.promise;
+
+  const controller = new AbortController();
+  const promise = run(tier, controller).finally(() => {
+    inFlight.delete(tier);
+  });
+  inFlight.set(tier, { promise, controller });
+  return promise;
+}

--- a/electron/voice/modelTiers.ts
+++ b/electron/voice/modelTiers.ts
@@ -1,0 +1,66 @@
+// Whisper model tier catalog. Models are NOT bundled in the installer
+// (they were ignored by .gitignore + the fetch script was never wired into
+// packaging, which shipped an empty models/ dir → "model not installed").
+// They are downloaded on demand at runtime into userData/models/ instead.
+//
+// Six main tiers, no .en / quantized variants. The renderer mirrors
+// `VoiceTier` / `VOICE_TIERS` structurally in src/global.d.ts (renderer can't
+// import from electron/ — same convention as VoiceResult / UpdateStatus).
+
+export type VoiceTier =
+  | 'tiny'
+  | 'base'
+  | 'small'
+  | 'medium'
+  | 'large-v3'
+  | 'large-v3-turbo';
+
+export const VOICE_TIERS: readonly VoiceTier[] = [
+  'tiny',
+  'base',
+  'small',
+  'medium',
+  'large-v3',
+  'large-v3-turbo',
+] as const;
+
+export const DEFAULT_TIER: VoiceTier = 'base';
+
+// Tiers whose pure-CPU transcription is slow and whose download is large
+// (GB-scale). The settings UI warns before picking one of these.
+export const HEAVY_TIERS: readonly VoiceTier[] = ['medium', 'large-v3', 'large-v3-turbo'] as const;
+
+export function tierFilename(tier: VoiceTier): string {
+  return `ggml-${tier}.bin`;
+}
+
+export function isVoiceTier(x: unknown): x is VoiceTier {
+  return typeof x === 'string' && (VOICE_TIERS as readonly string[]).includes(x);
+}
+
+// Display-only sizes (measured via HEAD Content-Length, 2026-06-03). Used to
+// show "~141 MB" before download and to render progress when the live
+// Content-Length is missing. NOT a validation gate: HuggingFace re-uploads
+// models on `main` (large-v3 changed format historically) and mirrors lag, so
+// an exact byte match would false-flag a correctly downloaded file. Download
+// integrity is checked against THIS response's Content-Length in the
+// downloader; corrupt-but-right-size content is caught by whisper-cli failing
+// to load (→ transcribe-failed).
+export const TIER_SIZE_BYTES: Record<VoiceTier, number> = {
+  tiny: 77691713,
+  base: 147951465,
+  small: 487601967,
+  medium: 1533763059,
+  'large-v3': 3095033483,
+  'large-v3-turbo': 1624555275,
+};
+
+const HF_PRIMARY = 'https://huggingface.co/ggerganov/whisper.cpp/resolve/main';
+const HF_MIRROR = 'https://hf-mirror.com/ggerganov/whisper.cpp/resolve/main';
+
+// Primary (HuggingFace) first, mirror (hf-mirror.com, same path layout) as
+// fallback — HF is frequently unreachable from mainland China.
+export function buildDownloadUrls(tier: VoiceTier): string[] {
+  const f = tierFilename(tier);
+  return [`${HF_PRIMARY}/${f}`, `${HF_MIRROR}/${f}`];
+}

--- a/electron/voice/transcriber.ts
+++ b/electron/voice/transcriber.ts
@@ -5,14 +5,21 @@ import * as os from 'os';
 import type { VoiceResult } from './voiceTypes';
 import { runWhisperCli } from './whisperCli';
 import { encodeWav } from './wavEncoder';
+import { tierFilename, type VoiceTier } from './modelTiers';
+import { loadVoiceTier } from '../prefs/voiceTier';
 
-const MODEL_FILENAME = 'ggml-base.bin';
 const BIN_FILENAME = 'whisper-cli.exe';
 
-export function resolveModelPath(): string {
-  const packaged = path.join(process.resourcesPath ?? '', 'models', MODEL_FILENAME);
+// Models live in the writable userData dir (downloaded at runtime). Fall back
+// to the old packaged locations so installs that shipped a bundled model still
+// work, then to the dev resources/ tree.
+export function resolveModelPath(tier: VoiceTier): string {
+  const filename = tierFilename(tier);
+  const userData = path.join(app.getPath('userData'), 'models', filename);
+  if (fs.existsSync(userData)) return userData;
+  const packaged = path.join(process.resourcesPath ?? '', 'models', filename);
   if (process.resourcesPath && fs.existsSync(packaged)) return packaged;
-  return path.join(app.getAppPath(), 'resources', 'models', MODEL_FILENAME);
+  return path.join(app.getAppPath(), 'resources', 'models', filename);
 }
 
 export function resolveBinPath(): string {
@@ -22,10 +29,10 @@ export function resolveBinPath(): string {
 }
 
 export async function transcribe(pcm: Float32Array): Promise<VoiceResult> {
-  const modelPath = resolveModelPath();
-  if (!fs.existsSync(modelPath)) return { ok: false, error: 'no-model' };
+  const modelPath = resolveModelPath(loadVoiceTier());
+  if (!fs.existsSync(modelPath)) return { ok: false, error: 'model-missing' };
   const binPath = resolveBinPath();
-  if (!fs.existsSync(binPath)) return { ok: false, error: 'no-model' };
+  if (!fs.existsSync(binPath)) return { ok: false, error: 'bin-missing' };
 
   const wavPath = path.join(
     os.tmpdir(),

--- a/electron/voice/voiceTypes.ts
+++ b/electron/voice/voiceTypes.ts
@@ -1,6 +1,14 @@
 // Result of a voice transcription, returned over the `voice:transcribe`
 // IPC channel. Mirrored structurally in `src/global.d.ts` (the renderer
 // can't import from electron/ — same convention as `UpdateStatus`).
+//
+// Error split (was a single ambiguous `no-model`):
+//   model-missing     — selected tier not downloaded yet → guide to Settings
+//   bin-missing       — whisper-cli.exe absent → broken install (not fixable
+//                       by the user; ships with the package)
+//   transcribe-failed — whisper-cli ran but errored (incl. corrupt model)
+//   empty             — ran fine, produced no text
 export type VoiceResult =
   | { ok: true; text: string }
-  | { ok: false; error: 'no-model' | 'transcribe-failed' | 'empty' };
+  | { ok: false; error: 'model-missing' | 'bin-missing' | 'transcribe-failed' | 'empty' };
+

--- a/electron/voice/warmup.ts
+++ b/electron/voice/warmup.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import { resolveModelPath, resolveBinPath } from './transcriber';
 import { runWhisperCli } from './whisperCli';
 import { encodeWav } from './wavEncoder';
+import { loadVoiceTier } from '../prefs/voiceTier';
 
 // Best-effort, fire-and-forget warmup. Runs once after app start to fault the
 // whisper exe/DLLs (~52 MB) and model (148 MB) into the OS page cache, so the
@@ -12,7 +13,7 @@ import { encodeWav } from './wavEncoder';
 // pre-reads exactly those pages. Silent: any failure here must never surface to
 // the user or block startup; the real transcribe() path handles its own errors.
 export async function warmUpTranscriber(): Promise<void> {
-  const modelPath = resolveModelPath();
+  const modelPath = resolveModelPath(loadVoiceTier());
   const binPath = resolveBinPath();
   if (!fs.existsSync(modelPath) || !fs.existsSync(binPath)) return;
 

--- a/package.json
+++ b/package.json
@@ -127,13 +127,6 @@
     ],
     "extraResources": [
       {
-        "from": "resources/models",
-        "to": "models",
-        "filter": [
-          "*.bin"
-        ]
-      },
-      {
         "from": "resources/whisper-bin",
         "to": "whisper-bin"
       }

--- a/scripts/after-pack.cjs
+++ b/scripts/after-pack.cjs
@@ -88,4 +88,30 @@ exports.default = async function afterPack(context) {
   console.log(
     `[after-pack] OK ${platformKey}: node-pty ${flavor} binding present (${sizeKB} KB) at ${which}`,
   );
+
+  // Verify the whisper-cli engine landed. Models are downloaded at runtime
+  // (NOT bundled — that empty-dir bug is what motivated the runtime
+  // downloader), but the engine binary IS shipped via extraResources
+  // whisper-bin. A missing exe means every transcribe returns bin-missing
+  // with no recovery, so turn it into a hard build failure here. win32 only:
+  // the prebuilt whisper-cli we ship is a Windows binary.
+  if (electronPlatformName === 'win32') {
+    const whisperCli = path.join(resourcesDir, 'whisper-bin', 'whisper-cli.exe');
+    if (!fs.existsSync(whisperCli)) {
+      let listing = '<missing>';
+      try {
+        listing = fs.readdirSync(path.join(resourcesDir, 'whisper-bin')).join(', ') || '<empty>';
+      } catch {
+        // whisper-bin dir may not exist at all (extraResources typo etc.)
+      }
+      throw new Error(
+        `[after-pack] whisper-cli.exe missing for ${platformKey}.\n` +
+          `  Looked for: ${whisperCli}\n` +
+          `  whisper-bin contents: ${listing}\n` +
+          `Hint: confirm build.extraResources ships resources/whisper-bin → whisper-bin.`,
+      );
+    }
+    const cliKB = (fs.statSync(whisperCli).size / 1024).toFixed(0);
+    console.log(`[after-pack] OK ${platformKey}: whisper-cli.exe present (${cliKB} KB)`);
+  }
 };

--- a/scripts/harness-e2e-voice-download.mjs
+++ b/scripts/harness-e2e-voice-download.mjs
@@ -1,0 +1,367 @@
+// Workflow group ⑤ — voice MODEL-DOWNLOAD happy-path e2e harness.
+//
+// Proves the runtime whisper-model download flow end-to-end through the REAL
+// prod bundle: the new Settings "Voice" tab (src/components/settings/
+// VoicePane.tsx) → window.ccsmVoice.downloadModel(tier) → IPC
+// voice:downloadModel → downloadTier() in electron/voice/modelDownloader.ts →
+// real fetch/Transform/pipeline/WriteStream/rename/isTierDownloaded →
+// voice:modelStatus broadcasts → VoicePane UI flips to "Installed".
+//
+// The ONLY thing stubbed is the network. We replace the main-process global
+// `fetch` (via electronApp.evaluate, BEFORE triggering the download) with a
+// fake that returns a Response-like carrying a tiny Node Readable body and a
+// matching content-length header. Everything downstream of fetch is the REAL
+// production downloader: the Transform meter, stream/promises.pipeline into
+// fs.createWriteStream, the size-vs-content-length integrity check, the atomic
+// tmp→dest rename, and isTierDownloaded(). The real `downloading`→`ready`
+// status broadcasts drive the real VoicePane subscription.
+//
+// We do NOT need a terminal session or the fake Anthropic API — Settings is a
+// pure renderer surface. We seed minimal onboarding so the app mounts cleanly.
+//
+// Run: `node scripts/harness-e2e-voice-download.mjs`
+
+import { existsSync, mkdirSync, statSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import {
+  createIsolatedClaudeDir,
+  launchCcsmIsolated,
+} from './probe-utils-real-cli.mjs';
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const VOICE_TIERS = ['tiny', 'base', 'small', 'medium', 'large-v3', 'large-v3-turbo'];
+const TARGET_TIER = 'tiny';
+const FAKE_BODY = 'FAKE_GGML_MODEL_BYTES_'.repeat(64); // small, non-empty, multi-chunk
+
+const SCREENSHOT_PATH = path.resolve('scripts/.artifacts/voice-download-evidence.png');
+
+// Minimal onboarding seed so App mounts without first-run gates.
+function seedOnboarding(tempDir) {
+  writeFileSync(
+    path.join(tempDir, '.claude.json'),
+    JSON.stringify(
+      {
+        hasCompletedOnboarding: true,
+        bypassPermissionsModeAccepted: true,
+        customApiKeyResponses: { approved: ['fake-ci-key'] },
+        projects: {},
+      },
+      null,
+      2,
+    ),
+  );
+  writeFileSync(path.join(tempDir, 'settings.json'), '{}');
+  writeFileSync(path.join(tempDir, 'settings.local.json'), '{}');
+}
+
+// ============================================================================
+// Test seam: replace main-process global fetch with a tiny fake payload.
+// ============================================================================
+//
+// modelDownloader.downloadFromUrl does:
+//   const res = await fetch(url, { signal });
+//   if (!res.ok || !res.body) throw ...
+//   const total = Number(res.headers.get('content-length'));
+//   await pipeline(res.body, meter, fs.createWriteStream(tmp), { signal });
+//
+// So our fake must return: { ok:true, status:200, headers.get('content-length')
+// = byteLength, body = a REAL Node Readable } so the real pipeline consumes it.
+async function installFetchStub(electronApp, bodyText) {
+  const err = await electronApp.evaluate(async ({}, text) => {
+    try {
+      // `require` is not injected into Playwright's main-process evaluate
+      // scope, but the main module's require IS reachable (verified at runtime).
+      const nodeRequire = process.mainModule.require.bind(process.mainModule);
+      const { Readable } = nodeRequire('node:stream');
+      const buf = Buffer.from(text, 'utf8');
+      const total = buf.length;
+      if (globalThis.__realFetch) return null; // idempotent
+      globalThis.__realFetch = globalThis.fetch;
+      globalThis.__fetchStubCalls = [];
+      globalThis.fetch = async (url, _opts) => {
+        globalThis.__fetchStubCalls.push(String(url));
+        // Emit the body as several small chunks with a tiny delay between
+        // them so the real Transform meter crosses its 200ms progress-throttle
+        // and broadcasts at least one real `downloading` status — letting the
+        // harness observe the progress UI before `ready`.
+        const CHUNKS = 6;
+        const per = Math.ceil(buf.length / CHUNKS);
+        async function* gen() {
+          for (let i = 0; i < buf.length; i += per) {
+            await new Promise((r) => setTimeout(r, 90));
+            yield buf.subarray(i, Math.min(buf.length, i + per));
+          }
+        }
+        return {
+          ok: true,
+          status: 200,
+          body: Readable.from(gen()),
+          headers: {
+            get: (name) =>
+              String(name).toLowerCase() === 'content-length'
+                ? String(total)
+                : null,
+          },
+        };
+      };
+      return null;
+    } catch (e) {
+      return String(e && e.stack ? e.stack : e);
+    }
+  }, bodyText);
+  if (err) throw new Error(`installFetchStub: ${err}`);
+}
+
+async function readFetchStubCalls(electronApp) {
+  return await electronApp.evaluate(() => globalThis.__fetchStubCalls || []);
+}
+
+// Resolve the isolated userData dir so we can confirm the real file landed.
+async function getModelsDir(electronApp) {
+  return await electronApp.evaluate(({ app }) => {
+    const p = process.mainModule.require('node:path');
+    return p.join(app.getPath('userData'), 'models');
+  });
+}
+
+// ============================================================================
+// Case: voice-model-download
+// ============================================================================
+
+async function caseVoiceModelDownload({ electronApp, win }) {
+  // 0. Wait for the app to settle past any availability probe.
+  await win
+    .waitForFunction(
+      () => !document.querySelector('[data-testid="claude-availability-probing"]'),
+      null,
+      { timeout: 30_000 },
+    )
+    .catch(() => {});
+
+  // 1. Stub network BEFORE any download is triggered.
+  await installFetchStub(electronApp, FAKE_BODY);
+
+  // 2. Open Settings via the Ctrl+, global shortcut (App.useShortcutHandlers).
+  await win.keyboard.press('Control+Comma');
+
+  // Settings dialog tab list is role="tablist" aria-label = settings title.
+  const voiceTab = win.locator('#settings-tab-voice');
+  await voiceTab.waitFor({ state: 'visible', timeout: 15_000 });
+
+  // 3. Click the Voice tab.
+  await voiceTab.click();
+
+  // The Voice pane root carries `data-voice-pane`; the tier list is a
+  // role="radiogroup" aria-label="Model" with one role="radio" per tier whose
+  // <span class="font-mono"> holds the tier id.
+  const pane = win.locator('[data-voice-pane]');
+  await pane.waitFor({ state: 'visible', timeout: 10_000 });
+
+  const radiogroup = win.locator('[data-voice-pane] [role="radiogroup"]');
+  await radiogroup.waitFor({ state: 'visible', timeout: 10_000 });
+
+  // Assert all 6 tiers render (matched by the mono tier-name span text).
+  const renderedTiers = [];
+  for (const tier of VOICE_TIERS) {
+    const cell = radiogroup.locator('span.font-mono', { hasText: new RegExp(`^${escapeRe(tier)}$`) });
+    const count = await cell.count();
+    if (count > 0) renderedTiers.push(tier);
+  }
+  if (renderedTiers.length !== VOICE_TIERS.length) {
+    throw new Error(
+      `expected all 6 tiers to render; got ${renderedTiers.length}: [${renderedTiers.join(', ')}]`,
+    );
+  }
+  console.log(`[case=voice-model-download] all 6 tiers rendered: [${renderedTiers.join(', ')}]`);
+
+  // Locate the TARGET_TIER row (the role="radio" ancestor of its mono span).
+  const targetRow = radiogroup
+    .locator('[role="radio"]')
+    .filter({ has: win.locator('span.font-mono', { hasText: new RegExp(`^${escapeRe(TARGET_TIER)}$`) }) })
+    .first();
+  await targetRow.waitFor({ state: 'visible', timeout: 10_000 });
+
+  // 4. Click the Download button inside the target tier's row. The pane is
+  // locale-driven (EN "Download" / ZH "下载"); in a not-downloaded,
+  // not-downloading row the Download button is the row's only button, so match
+  // structurally rather than by text.
+  const downloadBtn = targetRow.locator('button').first();
+  if ((await downloadBtn.count()) === 0) {
+    const btnTexts = await targetRow.locator('button').allInnerTexts();
+    throw new Error(
+      `Download button not found in ${TARGET_TIER} row; buttons present: ${JSON.stringify(btnTexts)}`,
+    );
+  }
+  await downloadBtn.click();
+
+  // 5a. Assert a `downloading` status reached the UI: progress bar OR the
+  // "Downloading…" text appears. The bar is a div with width style under the
+  // row; the text matches the en `voice.downloading` template prefix.
+  let sawDownloading = false;
+  {
+    const deadline = Date.now() + 10_000;
+    while (Date.now() < deadline) {
+      // Locale-agnostic: the "Downloading…" line and the cancel button both
+      // carry a mono progress label; the progress bar is the accent-filled div.
+      const downloadingText = await targetRow
+        .locator('span.font-mono')
+        .filter({ hasText: /(Downloading|下载中)/ })
+        .count();
+      const bar = await targetRow.locator('div.bg-accent').count();
+      if (downloadingText > 0 || bar > 0) {
+        sawDownloading = true;
+        break;
+      }
+      await sleep(80);
+    }
+  }
+  // The chunked+delayed fake stream guarantees the real meter crosses its
+  // 200ms throttle, so a `downloading` frame MUST reach the UI.
+  if (!sawDownloading) {
+    throw new Error('no downloading status / progress bar reached the VoicePane UI');
+  }
+  console.log(`[case=voice-model-download] saw a downloading frame: ${sawDownloading}`);
+
+  // 5b. Assert the UI flips to installed: the "Installed" badge appears for
+  // the target tier (rendered when downloaded && !selected). Poll with a
+  // deadline like the input harness.
+  // 5b. Assert the UI flips to installed. Once downloaded, the row no longer
+  // offers a Download button — it shows the "Installed" badge (EN "Installed"
+  // / ZH "已下载") with a "Use" button, or "In use" if auto-selected. The
+  // most robust locale-agnostic signal is: the Download button disappears AND
+  // the installed/in-use badge text is present. Poll with a deadline.
+  let installed = false;
+  const INSTALLED_RE = /(Installed|In use|已下载|使用中)/;
+  {
+    const deadline = Date.now() + 15_000;
+    while (Date.now() < deadline) {
+      const badge = await targetRow
+        .locator('span')
+        .filter({ hasText: INSTALLED_RE })
+        .count();
+      const downloadedDisk = await isTierOnDisk(electronApp, TARGET_TIER);
+      if (badge > 0 || downloadedDisk) {
+        // The download-affordance is gone once the model has landed: in a
+        // downloaded row the only button is "Use" (EN/ZH), and a downloading
+        // row shows a Cancel button + progress bar. We assert the installed
+        // badge text directly — that's the PR's installed-state UI.
+        if (badge > 0) {
+          installed = true;
+          break;
+        }
+      }
+      await sleep(150);
+    }
+  }
+
+  // Confirm the REAL downloader actually wrote the model file to disk.
+  const onDisk = await isTierOnDisk(electronApp, TARGET_TIER);
+  const calls = await readFetchStubCalls(electronApp);
+
+  if (!onDisk) {
+    throw new Error(
+      `model file for ${TARGET_TIER} not on disk after download.\n` +
+        `  fetch stub calls: ${JSON.stringify(calls)}`,
+    );
+  }
+  if (calls.length === 0) {
+    throw new Error('fetch stub was never called — real downloader did not run');
+  }
+  console.log(
+    `[case=voice-model-download] real downloader wrote model to disk; fetch hit: ${calls[0]}`,
+  );
+
+  if (!installed) {
+    // UI never reflected installed even though the file landed → still a fail
+    // for the UI-flow claim, surface diagnostics.
+    const rowHtml = await targetRow.evaluate((el) => el.outerHTML).catch(() => '<unavailable>');
+    throw new Error(
+      `model landed on disk but VoicePane never showed the installed state for ${TARGET_TIER}.\n` +
+        `  row html: ${rowHtml.slice(0, 600)}`,
+    );
+  }
+  console.log(`[case=voice-model-download] VoicePane shows ${TARGET_TIER} installed ✓`);
+
+  // 6. Screenshot the post-download (installed) Voice pane.
+  mkdirSync(path.dirname(SCREENSHOT_PATH), { recursive: true });
+  await win.screenshot({ path: SCREENSHOT_PATH });
+  const sz = statSync(SCREENSHOT_PATH).size;
+  if (sz <= 0) throw new Error(`screenshot written but empty: ${SCREENSHOT_PATH}`);
+  console.log(`[case=voice-model-download] screenshot: ${SCREENSHOT_PATH} (${sz} bytes)`);
+}
+
+async function isTierOnDisk(electronApp, tier) {
+  const dir = await getModelsDir(electronApp);
+  const file = path.join(dir, `ggml-${tier}.bin`);
+  try {
+    return statSync(file).size > 0;
+  } catch {
+    return false;
+  }
+}
+
+function escapeRe(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ============================================================================
+// Runner
+// ============================================================================
+
+async function main() {
+  if (!existsSync(path.resolve('dist/renderer/index.html'))) {
+    console.error('dist/renderer/index.html missing — run `npm run build` first');
+    process.exit(2);
+  }
+
+  const results = [];
+  const harnessStart = Date.now();
+
+  let isolated = null;
+  let launched = null;
+  try {
+    isolated = await createIsolatedClaudeDir();
+    seedOnboarding(isolated.tempDir);
+    launched = await launchCcsmIsolated({ tempDir: isolated.tempDir });
+    const ctx = { electronApp: launched.electronApp, win: launched.win, tempDir: isolated.tempDir };
+    console.log(`\n[HARNESS=voice-download] launch ready (tempDir=${isolated.tempDir})`);
+
+    const t0 = Date.now();
+    console.log(`\n[HARNESS=voice-download] >>> case: voice-model-download`);
+    try {
+      await caseVoiceModelDownload(ctx);
+      const ms = Date.now() - t0;
+      results.push({ name: 'voice-model-download', ok: true, ms });
+      console.log(`[HARNESS=voice-download] <<< PASS voice-model-download (${ms}ms)`);
+    } catch (err) {
+      const ms = Date.now() - t0;
+      results.push({ name: 'voice-model-download', ok: false, ms, error: String(err?.stack || err) });
+      console.error(`[HARNESS=voice-download] <<< FAIL voice-model-download (${ms}ms): ${err?.message || err}`);
+    }
+  } finally {
+    if (launched?.electronApp) try { await launched.electronApp.close(); } catch (_) { /* ignore */ }
+    launched?.cleanup?.();
+    isolated?.cleanup?.();
+  }
+
+  const totalMs = Date.now() - harnessStart;
+  const passed = results.filter((r) => r.ok).length;
+  const failed = results.length - passed;
+  console.log('\n===== SUMMARY =====');
+  for (const r of results) {
+    console.log(`  ${r.ok ? 'PASS' : 'FAIL'}  ${r.name.padEnd(24)} ${r.ms}ms`);
+    if (!r.ok && r.error) console.log(`        ${r.error.split('\n')[0]}`);
+  }
+  console.log(`  total: ${passed}/${results.length} passed, ${(totalMs / 1000).toFixed(1)}s wall`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+const _entryUrlMain =
+  process.argv[1] && new URL(`file://${process.argv[1].replace(/\\/g, '/')}`).href;
+if (_entryUrlMain && import.meta.url === _entryUrlMain) {
+  main().catch((err) => {
+    console.error('[HARNESS=voice-download] unhandled top-level error:', err?.stack || err);
+    process.exit(1);
+  });
+}

--- a/src/components/SettingsDialog.tsx
+++ b/src/components/SettingsDialog.tsx
@@ -9,14 +9,16 @@ import { DURATION_RAW, EASING } from '../lib/motion';
 import { AppearancePane } from './settings/AppearancePane';
 import { NotificationsPane } from './settings/NotificationsPane';
 import { UpdatesPane } from './settings/UpdatesPane';
+import { VoicePane } from './settings/VoicePane';
 
-type Tab = 'appearance' | 'notifications' | 'updates';
+type Tab = 'appearance' | 'notifications' | 'voice' | 'updates';
 
 // Tab catalog. Labels are i18n keys under `settings:tabs.*` rather than
 // literal strings, so the nav re-renders when the user flips language.
 const TABS: { id: Tab; tabKey: string }[] = [
   { id: 'appearance', tabKey: 'appearance' },
   { id: 'notifications', tabKey: 'notifications' },
+  { id: 'voice', tabKey: 'voice' },
   { id: 'updates', tabKey: 'updates' }
 ];
 
@@ -70,16 +72,19 @@ export function SettingsDialog({
   const tabRefs = useRef<Record<Tab, HTMLButtonElement | null>>({
     appearance: null,
     notifications: null,
+    voice: null,
     updates: null
   });
   const tabIds: Record<Tab, string> = {
     appearance: 'settings-tab-appearance',
     notifications: 'settings-tab-notifications',
+    voice: 'settings-tab-voice',
     updates: 'settings-tab-updates'
   };
   const panelIds: Record<Tab, string> = {
     appearance: 'settings-panel-appearance',
     notifications: 'settings-panel-notifications',
+    voice: 'settings-panel-voice',
     updates: 'settings-panel-updates'
   };
 
@@ -169,6 +174,7 @@ export function SettingsDialog({
           >
             {tab === 'appearance' && <AppearancePane />}
             {tab === 'notifications' && <NotificationsPane />}
+            {tab === 'voice' && <VoicePane />}
             {tab === 'updates' && <UpdatesPane />}
           </div>
         </div>

--- a/src/components/settings/VoicePane.tsx
+++ b/src/components/settings/VoicePane.tsx
@@ -167,7 +167,7 @@ export function VoicePane() {
                     className="h-full bg-accent transition-[width] duration-200"
                     style={{
                       width:
-                        status.total != null
+                        status.total != null && status.total > 0
                           ? `${Math.min(100, (status.transferred / status.total) * 100)}%`
                           : '100%'
                     }}

--- a/src/components/settings/VoicePane.tsx
+++ b/src/components/settings/VoicePane.tsx
@@ -1,0 +1,183 @@
+import React, { useEffect, useState } from 'react';
+import { Check } from 'lucide-react';
+import { cn } from '../../lib/cn';
+import { Button } from '../ui/Button';
+import { useTranslation } from '../../i18n/useTranslation';
+import type { VoiceTier, VoiceModelStatus } from '../../global';
+
+// Mirrors electron/voice/modelTiers.ts (renderer can't import from electron/).
+const VOICE_TIERS: readonly VoiceTier[] = [
+  'tiny',
+  'base',
+  'small',
+  'medium',
+  'large-v3',
+  'large-v3-turbo'
+];
+
+const HEAVY_TIERS: ReadonlySet<VoiceTier> = new Set(['medium', 'large-v3', 'large-v3-turbo']);
+
+// Display-only sizes (HEAD-measured 2026-06-03). See modelTiers.ts — these
+// are for the "~X MB" hint, never a validation gate.
+const TIER_SIZE_BYTES: Record<VoiceTier, number> = {
+  tiny: 77691713,
+  base: 147951465,
+  small: 487601967,
+  medium: 1533763059,
+  'large-v3': 3095033483,
+  'large-v3-turbo': 1624555275
+};
+
+const ACCURACY_KEY: Record<VoiceTier, string> = {
+  tiny: 'voice.accuracyTiny',
+  base: 'voice.accuracyBase',
+  small: 'voice.accuracySmall',
+  medium: 'voice.accuracyMedium',
+  'large-v3': 'voice.accuracyLargeV3',
+  'large-v3-turbo': 'voice.accuracyLargeV3Turbo'
+};
+
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / 1024 / 1024).toFixed(0)} MB`;
+  return `${(n / 1024 / 1024 / 1024).toFixed(2)} GB`;
+}
+
+export function VoicePane() {
+  const { t } = useTranslation('settings');
+  const [selected, setSelected] = useState<VoiceTier | null>(null);
+  const [downloaded, setDownloaded] = useState<Record<VoiceTier, boolean>>(
+    () => Object.fromEntries(VOICE_TIERS.map((tier) => [tier, false])) as Record<VoiceTier, boolean>
+  );
+  const [statuses, setStatuses] = useState<Partial<Record<VoiceTier, VoiceModelStatus>>>({});
+
+  useEffect(() => {
+    void window.ccsm?.loadState('voiceTier').then((raw) => {
+      setSelected((raw as VoiceTier | null) ?? 'base');
+    });
+    for (const tier of VOICE_TIERS) {
+      void window.ccsmVoice?.isModelDownloaded(tier).then((ok) => {
+        setDownloaded((prev) => ({ ...prev, [tier]: ok }));
+      });
+    }
+    const off = window.ccsmVoice?.onModelStatus((status) => {
+      setStatuses((prev) => ({ ...prev, [status.tier]: status }));
+      if (status.kind === 'ready') {
+        setDownloaded((prev) => ({ ...prev, [status.tier]: true }));
+      }
+    });
+    return () => off?.();
+  }, []);
+
+  function onUse(tier: VoiceTier) {
+    setSelected(tier);
+    void window.ccsm?.saveState('voiceTier', tier);
+  }
+
+  function onDownload(tier: VoiceTier) {
+    void window.ccsmVoice?.downloadModel(tier);
+  }
+
+  function onCancel(tier: VoiceTier) {
+    void window.ccsmVoice?.cancelDownload(tier);
+  }
+
+  return (
+    <div data-voice-pane>
+      <div className="text-meta text-fg-tertiary mb-4 max-w-[520px]">{t('voice.intro')}</div>
+      <div role="radiogroup" aria-label={t('voice.tierLabel')} className="flex flex-col gap-2">
+        {VOICE_TIERS.map((tier) => {
+          const status = statuses[tier];
+          const isDownloading = status?.kind === 'downloading';
+          const isError = status?.kind === 'error';
+          const isDownloaded = downloaded[tier];
+          const isSelected = selected === tier;
+          const isHeavy = HEAVY_TIERS.has(tier);
+
+          return (
+            <div
+              key={tier}
+              role="radio"
+              aria-checked={isSelected}
+              tabIndex={0}
+              onClick={() => isDownloaded && onUse(tier)}
+              onKeyDown={(e) => {
+                if ((e.key === ' ' || e.key === 'Enter') && isDownloaded) {
+                  e.preventDefault();
+                  onUse(tier);
+                }
+              }}
+              className={cn(
+                'rounded-md border p-3 outline-none focus-ring transition-colors',
+                isSelected ? 'border-accent bg-bg-hover' : 'border-border-default',
+                isDownloaded ? 'cursor-pointer hover:bg-bg-hover' : 'cursor-default'
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-chrome font-medium text-fg-primary font-mono">{tier}</span>
+                <span className="text-meta text-fg-tertiary">{formatBytes(TIER_SIZE_BYTES[tier])}</span>
+                {isSelected && (
+                  <span className="inline-flex items-center gap-1 text-meta text-accent">
+                    <Check size={11} strokeWidth={3} />
+                    {t('voice.selected')}
+                  </span>
+                )}
+                {!isSelected && isDownloaded && (
+                  <span className="text-meta text-fg-secondary">{t('voice.installed')}</span>
+                )}
+                <span className="ml-auto flex items-center gap-2">
+                  {isDownloading ? (
+                    <>
+                      <span className="text-meta text-fg-secondary font-mono">
+                        {t('voice.downloading', {
+                          transferred: formatBytes(status.transferred),
+                          total: status.total != null ? ` / ${formatBytes(status.total)}` : ''
+                        })}
+                      </span>
+                      <Button variant="ghost" size="sm" onClick={() => onCancel(tier)}>
+                        {t('voice.cancelButton')}
+                      </Button>
+                    </>
+                  ) : isDownloaded ? (
+                    !isSelected && (
+                      <Button variant="secondary" size="sm" onClick={() => onUse(tier)}>
+                        {t('voice.useButton')}
+                      </Button>
+                    )
+                  ) : (
+                    <Button variant="secondary" size="sm" onClick={() => onDownload(tier)}>
+                      {t('voice.downloadButton')}
+                    </Button>
+                  )}
+                </span>
+              </div>
+              <div className="text-meta text-fg-tertiary mt-1">{t(ACCURACY_KEY[tier])}</div>
+              {isHeavy && (
+                <div className="text-meta text-state-warning-fg mt-1">{t('voice.heavyWarning')}</div>
+              )}
+              {isError && (
+                <div className="text-meta text-state-error-fg mt-1">
+                  {t('voice.downloadError', { message: status.message })}
+                </div>
+              )}
+              {isDownloading && (
+                <div className="mt-2 h-1 rounded-full bg-bg-elevated overflow-hidden">
+                  <div
+                    className="h-full bg-accent transition-[width] duration-200"
+                    style={{
+                      width:
+                        status.total != null
+                          ? `${Math.min(100, (status.transferred / status.total) * 100)}%`
+                          : '100%'
+                    }}
+                  />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/voice/MicButton.tsx
+++ b/src/components/voice/MicButton.tsx
@@ -57,9 +57,11 @@ export function MicButton({ sessionId }: { sessionId: string }) {
         : state.kind === 'error'
           ? state.message === 'mic'
             ? t('voice.errorMic')
-            : state.message === 'no-model'
-              ? t('voice.errorNoModel')
-              : t('voice.errorFailed')
+            : state.message === 'model-missing'
+              ? t('voice.errorModelMissing')
+              : state.message === 'bin-missing'
+                ? t('voice.errorBinMissing')
+                : t('voice.errorFailed')
           : t('voice.ariaStart');
 
   const color =

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -16,7 +16,17 @@ export type UpdateStatus =
 // UpdateStatus). Keep these two in sync.
 export type VoiceResult =
   | { ok: true; text: string }
-  | { ok: false; error: 'no-model' | 'transcribe-failed' | 'empty' };
+  | { ok: false; error: 'model-missing' | 'bin-missing' | 'transcribe-failed' | 'empty' };
+
+// Mirrors electron/voice/modelTiers.ts + modelDownloader.ts. Renderer can't
+// import from electron/; keep in sync with electron/preload/bridges/ccsmVoice.ts.
+export type VoiceTier = 'tiny' | 'base' | 'small' | 'medium' | 'large-v3' | 'large-v3-turbo';
+
+export type VoiceModelStatus =
+  | { kind: 'idle'; tier: VoiceTier }
+  | { kind: 'downloading'; tier: VoiceTier; transferred: number; total: number | null }
+  | { kind: 'ready'; tier: VoiceTier }
+  | { kind: 'error'; tier: VoiceTier; message: string };
 
 declare global {
   interface Window {
@@ -134,6 +144,10 @@ declare global {
     };
     ccsmVoice?: {
       transcribe: (pcm: Float32Array) => Promise<VoiceResult>;
+      isModelDownloaded: (tier: VoiceTier) => Promise<boolean>;
+      downloadModel: (tier: VoiceTier) => Promise<VoiceModelStatus | null>;
+      cancelDownload: (tier: VoiceTier) => Promise<void>;
+      onModelStatus: (handler: (status: VoiceModelStatus) => void) => () => void;
     };
   }
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -96,6 +96,7 @@ const en = {
       general: 'General',
       appearance: 'Appearance',
       notifications: 'Notifications',
+      voice: 'Voice',
       updates: 'Updates'
     },
     theme: 'Theme',
@@ -173,6 +174,25 @@ const en = {
       downloadedToastTitle: 'Update downloaded — restart to apply',
       downloadedToastBody: 'Version {{version}} is ready.',
       downloadedToastAction: 'Restart'
+    },
+    voice: {
+      intro:
+        'Pick a speech-to-text model. Models are downloaded on demand into your user data folder — larger models are more accurate but slower on CPU and take longer to download. Each tier is kept separately, so switching back to one you already downloaded is instant.',
+      tierLabel: 'Model',
+      accuracyTiny: 'Fastest, lowest accuracy',
+      accuracyBase: 'Fast, good for short phrases',
+      accuracySmall: 'Balanced speed and accuracy',
+      accuracyMedium: 'High accuracy',
+      accuracyLargeV3: 'Highest accuracy',
+      accuracyLargeV3Turbo: 'Near-highest accuracy, faster than large-v3',
+      heavyWarning: 'Large download; transcription can be slow on CPU-only machines.',
+      installed: 'Installed',
+      selected: 'In use',
+      downloadButton: 'Download',
+      cancelButton: 'Cancel',
+      useButton: 'Use',
+      downloading: 'Downloading… {{transferred}}{{total}}',
+      downloadError: 'Download failed: {{message}}'
     }
   },
   notifications: {
@@ -261,8 +281,10 @@ const en = {
     noSpeechBody: 'Please try speaking again, a little longer.',
     errorMic: 'Microphone access denied',
     errorMicBody: 'Allow microphone access for this app in your system settings, then try again.',
-    errorNoModel: 'Voice model not installed',
-    errorNoModelBody: 'The speech-to-text model is missing. Install the voice model to use dictation.',
+    errorModelMissing: 'Voice model not downloaded',
+    errorModelMissingBody: 'Open Settings → Voice to download a speech-to-text model, then try again.',
+    errorBinMissing: 'Voice engine missing from this install',
+    errorBinMissingBody: 'The whisper engine is missing from this install. Please reinstall CCSM to repair it.',
     errorFailed: 'Transcription failed',
     errorFailedBody: 'Something went wrong while transcribing. Click the mic to try again.',
   },

--- a/src/i18n/locales/zh.ts
+++ b/src/i18n/locales/zh.ts
@@ -91,6 +91,7 @@ const zh: EnCatalog = {
       general: '通用',
       appearance: '外观',
       notifications: '通知',
+      voice: '语音',
       updates: '更新'
     },
     theme: '主题',
@@ -162,6 +163,25 @@ const zh: EnCatalog = {
       downloadedToastTitle: '更新已下载 — 重启以应用',
       downloadedToastBody: '版本 {{version}} 已就绪。',
       downloadedToastAction: '重启'
+    },
+    voice: {
+      intro:
+        '选择语音转文字模型。模型按需下载到用户数据目录——模型越大越准,但纯 CPU 上更慢、下载也更久。各档位独立保存,切回已下载过的档位是即时的。',
+      tierLabel: '模型',
+      accuracyTiny: '最快,精度最低',
+      accuracyBase: '快,适合短句',
+      accuracySmall: '速度与精度均衡',
+      accuracyMedium: '高精度',
+      accuracyLargeV3: '最高精度',
+      accuracyLargeV3Turbo: '接近最高精度,比 large-v3 快',
+      heavyWarning: '下载体积大;纯 CPU 机器上转写可能很慢。',
+      installed: '已下载',
+      selected: '使用中',
+      downloadButton: '下载',
+      cancelButton: '取消',
+      useButton: '使用',
+      downloading: '下载中… {{transferred}}{{total}}',
+      downloadError: '下载失败:{{message}}'
     }
   },
   notifications: {
@@ -250,8 +270,10 @@ const zh: EnCatalog = {
     noSpeechBody: '请再说一次,稍微说长一点。',
     errorMic: '麦克风访问被拒绝',
     errorMicBody: '请在系统设置里允许本应用访问麦克风,然后重试。',
-    errorNoModel: '语音模型未安装',
-    errorNoModelBody: '缺少语音转文字模型。请先安装语音模型再使用语音输入。',
+    errorModelMissing: '语音模型未下载',
+    errorModelMissingBody: '打开"设置 → 语音"下载一个语音转文字模型,然后重试。',
+    errorBinMissing: '安装包缺少语音引擎',
+    errorBinMissingBody: '此安装缺少 whisper 引擎。请重新安装 CCSM 以修复。',
     errorFailed: '识别失败',
     errorFailedBody: '识别时出错了。点麦克风图标重试。',
   },

--- a/src/voice/voiceFeedback.ts
+++ b/src/voice/voiceFeedback.ts
@@ -7,7 +7,7 @@
 
 export type VoiceOutcome =
   | { kind: 'no-speech' } // clip too short or transcriber returned empty
-  | { kind: 'error'; message: string }; // mic denied / no-model / transcribe-failed
+  | { kind: 'error'; message: string }; // mic denied / model-missing / bin-missing / transcribe-failed
 
 export type VoiceToastSpec = {
   // Maps to ToastKind in components/ui/Toast.tsx. 'info' rides the polite
@@ -25,8 +25,10 @@ function errorKeys(message: string): { titleKey: string; bodyKey: string } {
   switch (message) {
     case 'mic':
       return { titleKey: 'voice.errorMic', bodyKey: 'voice.errorMicBody' };
-    case 'no-model':
-      return { titleKey: 'voice.errorNoModel', bodyKey: 'voice.errorNoModelBody' };
+    case 'model-missing':
+      return { titleKey: 'voice.errorModelMissing', bodyKey: 'voice.errorModelMissingBody' };
+    case 'bin-missing':
+      return { titleKey: 'voice.errorBinMissing', bodyKey: 'voice.errorBinMissingBody' };
     default:
       return { titleKey: 'voice.errorFailed', bodyKey: 'voice.errorFailedBody' };
   }

--- a/tests/settings/VoicePane.test.tsx
+++ b/tests/settings/VoicePane.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, screen, waitFor, act, fireEvent, cleanup } from '@testing-library/react';
+import React from 'react';
+import { VoicePane } from '../../src/components/settings/VoicePane';
+import type { VoiceTier, VoiceModelStatus } from '../../src/global';
+
+// In-memory renderer bridges VoicePane reads: window.ccsm (loadState/saveState
+// for the selected tier) and window.ccsmVoice (per-tier downloaded check +
+// download/cancel + status push hook).
+function makeBridges(opts?: {
+  selectedTier?: VoiceTier;
+  downloaded?: Partial<Record<VoiceTier, boolean>>;
+}) {
+  const saveState = vi.fn(async () => {});
+  const downloadModel = vi.fn(async () => null);
+  const cancelDownload = vi.fn(async () => {});
+  let pushCb: ((s: VoiceModelStatus) => void) | null = null;
+
+  const ccsm = {
+    loadState: vi.fn(async (key: string) =>
+      key === 'voiceTier' ? opts?.selectedTier ?? 'base' : undefined,
+    ),
+    saveState,
+  } as unknown as Window['ccsm'];
+
+  const ccsmVoice = {
+    transcribe: vi.fn(),
+    isModelDownloaded: vi.fn(async (tier: VoiceTier) => opts?.downloaded?.[tier] ?? false),
+    downloadModel,
+    cancelDownload,
+    onModelStatus: (cb: (s: VoiceModelStatus) => void) => {
+      pushCb = cb;
+      return () => {
+        pushCb = null;
+      };
+    },
+  } as unknown as Window['ccsmVoice'];
+
+  return {
+    ccsm,
+    ccsmVoice,
+    spies: { saveState, downloadModel, cancelDownload },
+    push: (s: VoiceModelStatus) => pushCb?.(s),
+  };
+}
+
+let current: ReturnType<typeof makeBridges>;
+
+beforeEach(() => {
+  current = makeBridges();
+  (window as { ccsm?: unknown }).ccsm = current.ccsm;
+  (window as { ccsmVoice?: unknown }).ccsmVoice = current.ccsmVoice;
+});
+
+afterEach(() => {
+  cleanup();
+  delete (window as { ccsm?: unknown }).ccsm;
+  delete (window as { ccsmVoice?: unknown }).ccsmVoice;
+});
+
+async function renderPane() {
+  await act(async () => {
+    render(<VoicePane />);
+  });
+}
+
+describe('VoicePane', () => {
+  it('renders all six tiers as radios', async () => {
+    await renderPane();
+    await waitFor(() => {
+      expect(screen.getAllByRole('radio')).toHaveLength(6);
+    });
+    for (const tier of ['tiny', 'base', 'small', 'medium', 'large-v3', 'large-v3-turbo']) {
+      expect(screen.getByText(tier)).toBeInTheDocument();
+    }
+  });
+
+  it('marks the stored tier as selected (aria-checked)', async () => {
+    current = makeBridges({ selectedTier: 'small', downloaded: { small: true } });
+    (window as { ccsm?: unknown }).ccsm = current.ccsm;
+    (window as { ccsmVoice?: unknown }).ccsmVoice = current.ccsmVoice;
+    await renderPane();
+    await waitFor(() => {
+      const small = screen.getByText('small').closest('[role="radio"]');
+      expect(small?.getAttribute('aria-checked')).toBe('true');
+    });
+  });
+
+  it('shows a Download button for an un-downloaded tier and calls downloadModel', async () => {
+    await renderPane();
+    const buttons = await screen.findAllByRole('button', { name: 'Download' });
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
+    await act(async () => {
+      fireEvent.click(buttons[0]);
+    });
+    expect(current.spies.downloadModel).toHaveBeenCalledTimes(1);
+  });
+
+  it('selecting a downloaded tier persists voiceTier', async () => {
+    current = makeBridges({ selectedTier: 'base', downloaded: { tiny: true } });
+    (window as { ccsm?: unknown }).ccsm = current.ccsm;
+    (window as { ccsmVoice?: unknown }).ccsmVoice = current.ccsmVoice;
+    await renderPane();
+
+    const useBtn = await screen.findByRole('button', { name: 'Use' });
+    await act(async () => {
+      fireEvent.click(useBtn);
+    });
+    expect(current.spies.saveState).toHaveBeenCalledWith('voiceTier', 'tiny');
+  });
+
+  it('renders a progress bar + Cancel when a download status arrives', async () => {
+    await renderPane();
+    await waitFor(() => expect(screen.getAllByRole('radio')).toHaveLength(6));
+
+    act(() => {
+      current.push({ kind: 'downloading', tier: 'tiny', transferred: 1000, total: 4000 });
+    });
+
+    const cancelBtn = await screen.findByRole('button', { name: 'Cancel' });
+    await act(async () => {
+      fireEvent.click(cancelBtn);
+    });
+    expect(current.spies.cancelDownload).toHaveBeenCalledWith('tiny');
+  });
+
+  it('a ready status flips the tier to installed (Use button appears)', async () => {
+    await renderPane();
+    await waitFor(() => expect(screen.getAllByRole('radio')).toHaveLength(6));
+
+    act(() => {
+      current.push({ kind: 'ready', tier: 'tiny' });
+    });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Use' })).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/settings/VoicePane.test.tsx
+++ b/tests/settings/VoicePane.test.tsx
@@ -124,6 +124,21 @@ describe('VoicePane', () => {
     expect(current.spies.cancelDownload).toHaveBeenCalledWith('tiny');
   });
 
+  it('treats a zero Content-Length total as indeterminate (full-bar, no Infinity)', async () => {
+    const { container } = await act(async () => render(<VoicePane />));
+    await waitFor(() => expect(screen.getAllByRole('radio')).toHaveLength(6));
+
+    act(() => {
+      // Content-Length: 0 → total === 0. transferred/0 would be Infinity; the
+      // bar must fall back to the indeterminate full-bar branch instead.
+      current.push({ kind: 'downloading', tier: 'tiny', transferred: 0, total: 0 });
+    });
+
+    const bar = container.querySelector('.bg-accent') as HTMLElement | null;
+    expect(bar).not.toBeNull();
+    expect(bar?.style.width).toBe('100%');
+  });
+
   it('a ready status flips the tier to installed (Use button appears)', async () => {
     await renderPane();
     await waitFor(() => expect(screen.getAllByRole('radio')).toHaveLength(6));

--- a/tests/voice/MicButton.test.tsx
+++ b/tests/voice/MicButton.test.tsx
@@ -105,13 +105,23 @@ describe('<MicButton /> feedback + a11y', () => {
     expect(region?.textContent).toContain('system settings');
   });
 
-  it('no-model error outcome explains the missing model', () => {
-    mockState = { kind: 'error', message: 'no-model' };
+  it('model-missing error outcome points the user at the settings download', () => {
+    mockState = { kind: 'error', message: 'model-missing' };
     renderButton();
     act(() => {
-      lastFeedback?.({ kind: 'error', message: 'no-model' });
+      lastFeedback?.({ kind: 'error', message: 'model-missing' });
     });
     const region = document.querySelector('[role="alert"][aria-live="assertive"]');
-    expect(region?.textContent).toContain('Voice model not installed');
+    expect(region?.textContent).toContain('Voice model not downloaded');
+  });
+
+  it('bin-missing error outcome explains the broken install', () => {
+    mockState = { kind: 'error', message: 'bin-missing' };
+    renderButton();
+    act(() => {
+      lastFeedback?.({ kind: 'error', message: 'bin-missing' });
+    });
+    const region = document.querySelector('[role="alert"][aria-live="assertive"]');
+    expect(region?.textContent).toContain('Voice engine missing from this install');
   });
 });

--- a/tests/voice/voiceFeedback.test.ts
+++ b/tests/voice/voiceFeedback.test.ts
@@ -22,11 +22,19 @@ describe('voiceToastForOutcome', () => {
     });
   });
 
-  it('no-model error → error toast pointing at the missing model', () => {
-    expect(voiceToastForOutcome({ kind: 'error', message: 'no-model' })).toEqual({
+  it('model-missing error → error toast pointing at the settings download', () => {
+    expect(voiceToastForOutcome({ kind: 'error', message: 'model-missing' })).toEqual({
       kind: 'error',
-      titleKey: 'voice.errorNoModel',
-      bodyKey: 'voice.errorNoModelBody',
+      titleKey: 'voice.errorModelMissing',
+      bodyKey: 'voice.errorModelMissingBody',
+    });
+  });
+
+  it('bin-missing error → error toast pointing at a broken install', () => {
+    expect(voiceToastForOutcome({ kind: 'error', message: 'bin-missing' })).toEqual({
+      kind: 'error',
+      titleKey: 'voice.errorBinMissing',
+      bodyKey: 'voice.errorBinMissingBody',
     });
   });
 


### PR DESCRIPTION
## What

Whisper STT models are no longer bundled in the installer. The settings page now lets users pick a tier and download it on demand into `userData/models/`.

**Root cause of the original installed-app "语音模型未安装" (no-model) bug:** `.gitignore` ignored `resources/models/*.bin` and `scripts/fetch-whisper-model.mjs` was never wired into any packaging command, so the packaged installer shipped an empty `models/` dir. Dev worked only because models were fetched manually locally.

## Changes

- **6 selectable tiers** — tiny / base / small / medium / large-v3 / large-v3-turbo (`electron/voice/modelTiers.ts`).
- **Runtime downloader** (`electron/voice/modelDownloader.ts`): streams to a temp file, atomic rename on success, integrity via the response Content-Length (no hardcoded sizes — HF re-uploads), HuggingFace primary → hf-mirror.com fallback (HF often unreachable from mainland China), AbortController cancel, per-tier in-flight dedup, throttled progress broadcast.
- **Tier persistence** (`electron/prefs/voiceTier.ts`) following the notifyEnabled prefs pattern.
- **IPC + bridge**: `VOICE_CHANNELS` block, 4 handlers (transcribe/isDownloaded/download/cancel) + status push, `window.ccsmVoice` surface.
- **Settings UI** — new Voice tab + `VoicePane` (per-tier download/cancel/progress, large-model "slow on CPU" warning), i18n en+zh.
- **Error split** — old ambiguous `no-model` → `model-missing` (self-serve download) vs `bin-missing` (corrupt install); MicButton + voiceFeedback toast guidance.
- **Packaging** — drop the empty `resources/models` extraResource; `after-pack.cjs` hard-fails if `whisper-cli.exe` is missing.

## Tests

New: modelTiers, modelDownloader (mirror fallback / size-mismatch / abort / dedup / progress), voiceTier, VoicePane. Updated: transcriber, voiceIpc, voiceFeedback, MicButton, ipc-channel-parity.

Local gate: `typecheck` green, `lint` green (`--max-warnings 0`), `npm test` 1978 passed / 2 failed — the 2 failures are the pre-existing `db-hardening.test.ts` better-sqlite3 ABI/environment baseline (NODE_MODULE_VERSION 145 vs 137 — better-sqlite3 built for Electron ABI, vitest runs under Node), unrelated to this change. Zero voice/IPC/parity failures.

## Evidence status — NOT YET PROVEN ON REAL DEVICE

The end-to-end user-visible flow (settings → select tier → download tiny → progress bar → installed → mic transcribes, plus mirror fallback) has **not** been verified in a running app yet — the test harness can't run the Electron GUI against the real HuggingFace network. **Do not merge on CI-green alone.** Real-device verification (screenshots of the download flow + a successful transcription) is required before merge.
