### PR TITLE
refactor(db): migrate better-sqlite3 -> node:sqlite (eliminate native-ABI test/prod split)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,24 +34,24 @@ jobs:
           node-version: '22'
           cache: 'npm'
 
-      # Linux native builds for better-sqlite3 need python + build tools; the
+      # Linux native builds for node-pty need python + build tools; the
       # GitHub-hosted ubuntu image already has them, but setup-python makes
       # it explicit and pins the version so upstream image changes don't
       # surprise us.
       # Pinned to 3.11 because 3.12+ removed the distutils stdlib (PEP 632)
-      # which the older node-gyp invoked by better-sqlite3's postinstall
-      # still imports. Bump back when better-sqlite3 ships node-gyp >= 10.
+      # which the older node-gyp invoked by node-pty's postinstall still
+      # imports. Bump back when node-pty ships node-gyp >= 10.
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
       # Cache node_modules directly (not ~/.npm) — `npm ci --legacy-peer-deps`
       # on Windows is the dominant CI cost (~178s = 49% of total wall-clock,
-      # eval #877). Restoring node_modules verbatim skips install + native
-      # rebuilds (better-sqlite3, node-pty) baked into the cached tree.
+      # eval #877). Restoring node_modules verbatim skips install + the
+      # node-pty native rebuild baked into the cached tree.
       # Key includes os/arch/node major + lockfile hash so any dep change
-      # busts the cache. Native ABI for Node-side tests is re-aligned by the
-      # `npm rebuild better-sqlite3` step below, which always runs.
+      # busts the cache. The DB layer uses Node's built-in node:sqlite, so
+      # no SQLite native ABI re-alignment is needed for the Node-side tests.
       - name: Cache node_modules
         id: nm_cache
         uses: actions/cache@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,12 +67,6 @@ jobs:
           # first install when the Electron binary cache is cold.
           ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
 
-      # Rebuild better-sqlite3 against Node (tests run under node, not
-      # electron). The electron-builder `postinstall` above builds for the
-      # electron ABI; we overwrite with the node ABI for CI tests here.
-      - name: Rebuild better-sqlite3 for Node
-        run: npm rebuild better-sqlite3
-
       - name: Lint
         run: npm run lint
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,9 +32,8 @@ jobs:
           cache: 'npm'
       # Cache node_modules directly — same rationale as ci.yml: `npm ci`
       # is the dominant Windows CI cost. Cache hit skips install entirely
-      # and inherits the postinstall-rebuilt native bindings (better-sqlite3,
-      # node-pty) from the cached tree, which is what the Electron e2e
-      # actually loads.
+      # and inherits the postinstall-rebuilt native binding (node-pty)
+      # from the cached tree, which is what the Electron e2e actually loads.
       #
       # CRITICAL: this cache key MUST be distinct from ci.yml's key. ci.yml
       # runs `npm ci` with `ELECTRON_SKIP_BINARY_DOWNLOAD=1` (no electron
@@ -43,8 +42,8 @@ jobs:
       # native modules built against Electron's ABI (NMV 145). Sharing a
       # key meant whichever workflow won the race poisoned the other:
       #   - ci.yml winning → e2e gets no electron binary + Node-20-ABI
-      #     `.node` files → main process throws ERR_DLOPEN_FAILED on
-      #     better-sqlite3 require during initDb() → BrowserWindow never
+      #     `.node` files → main process throws ERR_DLOPEN_FAILED on the
+      #     node-pty require during PTY setup → BrowserWindow never
       #     created → harness times out with the bare "no renderer window
       #     appeared in time" error.
       # The `e2e-` prefix isolates this workflow's cache entirely.
@@ -79,16 +78,15 @@ jobs:
       - name: Ensure Electron binary
         run: node node_modules/electron/install.js
       # Rebuild native modules against Electron's ABI on every run. The
-      # node_modules cache is shared with ci.yml, which compiles
-      # better-sqlite3 / node-pty against Node 20's ABI (NODE_MODULE_VERSION
-      # 115). When the e2e job restores that cache and launches Electron
-      # (NODE_MODULE_VERSION 145), the main process throws
-      # "The module ... was compiled against a different Node.js version"
-      # during `initDb()` — the BrowserWindow is never created and the
-      # harness times out with the bare "no renderer window appeared in
-      # time" error. Running `@electron/rebuild` is a fast no-op when the
-      # `.node` files already match Electron's ABI and self-heals when
-      # ci.yml won the cache race. Diagnosed via Task #919.
+      # node_modules cache is shared with ci.yml, which compiles node-pty
+      # against Node 20's ABI (NODE_MODULE_VERSION 115). When the e2e job
+      # restores that cache and launches Electron (NODE_MODULE_VERSION 145),
+      # the main process throws "The module ... was compiled against a
+      # different Node.js version" during PTY setup — the BrowserWindow is
+      # never created and the harness times out with the bare "no renderer
+      # window appeared in time" error. Running `@electron/rebuild` is a
+      # fast no-op when the `.node` files already match Electron's ABI and
+      # self-heals when ci.yml won the cache race. Diagnosed via Task #919.
       - name: Ensure native modules built for Electron ABI
         run: npx electron-rebuild
       - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,6 @@ jobs:
         run: npm ci --legacy-peer-deps
         env:
           ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
-      - name: Rebuild better-sqlite3 for Node
-        run: npm rebuild better-sqlite3
       - run: npm run lint
       - run: npm run typecheck
       - run: npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,12 +19,13 @@ user-facing product framing see [`README.md`](README.md).
   `.npmrc` sets `engine-strict=true`, so `npm install` hard-errors on older
   Node. (`scripts/postinstall.mjs` still carries an older Node-20 warning
   string; the authoritative gate is `engine-strict`.)
-- **Native modules are rebuilt for Electron's ABI.** `better-sqlite3` (the
-  local DB) and `node-pty` (the terminal backend) are rebuilt against
-  Electron's ABI by the `postinstall` script. A mismatch shows up at runtime
-  as cryptic "renderer window didn't appear" errors, not at install time.
-  better-sqlite3 failure is fatal; node-pty failure is non-fatal because it
-  ships a prebuilt binary fallback (asserted by `scripts/after-pack.cjs`).
+- **Native modules are rebuilt for Electron's ABI.** `node-pty` (the
+  terminal backend) is rebuilt against Electron's ABI by the `postinstall`
+  script. A mismatch shows up at runtime as cryptic "renderer window didn't
+  appear" errors, not at install time. node-pty failure is non-fatal because
+  it ships a prebuilt binary fallback (asserted by `scripts/after-pack.cjs`).
+  The local DB uses Node's built-in `node:sqlite`, which needs no native
+  rebuild.
 - **Renderer must not import from `electron/`.** Frontend code under `src/`
   talks to the main process only through `window.ccsm` (typed in
   `src/global.d.ts`, exposed via `electron/preload/`). This is a convention
@@ -46,7 +47,7 @@ flowchart LR
   subgraph Main["Main (electron/) — Node + Electron"]
     IPC[IPC handlers]
     PTY[PTY host / node-pty]
-    DB[(better-sqlite3)]
+    DB[(node:sqlite)]
     CLI[[claude CLI]]
   end
   UI -->|invoke / on| Bridge
@@ -96,7 +97,7 @@ flowchart LR
   `utilityIpc`, `windowIpc`.
 - `preload/` — contextBridge entry + `bridges/`.
 - `ptyHost/` — PTY lifecycle (node-pty). `db.ts` / `db-validate.ts` —
-  better-sqlite3 schema + validation.
+  node:sqlite schema + validation.
 - Supporting subsystems: `agent/`, `notify/`, `remote/`, `security/`,
   `sentry/`, `sessionTitles/`, `sessionWatcher/`, `tray/`, `updater.ts`,
   `import-scanner.ts`, `commands-loader.ts`, `badgeController.ts`,
@@ -140,7 +141,7 @@ Run from the repo root with npm:
 ## Conventions
 
 - **Stack:** Electron (main + renderer), React 18, webpack 5, zustand state,
-  xterm.js + node-pty terminal, better-sqlite3 DB, i18next (en/zh),
+  xterm.js + node-pty terminal, node:sqlite DB, i18next (en/zh),
   Tailwind v4, electron-builder packaging, vitest + Playwright tests.
 - **Tests** live in `__tests__/` folders and `tests/`. Prefer adding a test
   with any behavioural change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,10 @@ things" checklist. For the full architecture and module map, read
   build.
 - **Node >= 22.** `engines.node` is `">=22.0.0"` and `.npmrc` sets
   `engine-strict=true`, so install hard-errors on older Node.
-- **Native modules:** `better-sqlite3` and `node-pty` are rebuilt for
-  Electron's ABI by `postinstall`. After dependency or Electron version
-  changes, re-run `npm install` so the rebuild happens.
+- **Native modules:** `node-pty` is rebuilt for Electron's ABI by
+  `postinstall`. After dependency or Electron version changes, re-run
+  `npm install` so the rebuild happens. (The DB uses Node's built-in
+  `node:sqlite`, which needs no native rebuild.)
 - **Renderer (`src/`) must not import from `electron/`.** It talks to the main
   process only via `window.ccsm` (typed in `src/global.d.ts`, exposed by
   `electron/preload/`). Convention from `docs/mvp-design.md` §15 — keep it.
@@ -40,7 +41,7 @@ Before claiming work is done, run `npm run typecheck`, `npm run lint`, and
   `terminal/` (xterm.js), `i18n/` (en + zh locales).
 - `electron/` — main process: `window/` (BrowserWindow + CSP), `ipc/` handlers,
   `preload/bridges/` (the `window.ccsm` surface), `ptyHost/` (node-pty),
-  `db.ts` (better-sqlite3).
+  `db.ts` (node:sqlite).
 - `scripts/` — `dev.mjs`, `postinstall.mjs`, e2e/`harness-*`/`dogfood-*` runners.
 - `docs/` — `mvp-design.md` (frozen scope), `design-system.md`,
   `status/STATUS.md`; index in `docs/README.md`.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To disable after opting in: open Settings → Notifications and uncheck "Send cr
 
 ## Development
 
-Requires Node 20+ and `npm`. The native module `better-sqlite3` is rebuilt for Electron's ABI on `npm install` via `electron-builder install-app-deps`.
+Requires Node 22+ and `npm`. The native module `node-pty` is rebuilt for Electron's ABI on `npm install` via `scripts/postinstall.mjs`. (The local DB uses Node's built-in `node:sqlite`, which needs no native rebuild.)
 
 ```bash
 npm install
@@ -107,7 +107,7 @@ The architecture has a hard rule: **frontend code under `src/` may not import fr
 
 ### Windows: `gyp ERR! find Python` on `npm install`
 
-`better-sqlite3`'s native rebuild uses `node-gyp`, which on Windows often
+`node-pty`'s native rebuild uses `node-gyp`, which on Windows often
 picks up the `WindowsApps\python.exe` Microsoft Store launcher stub instead
 of a real interpreter and fails. If you see `gyp ERR! find Python`, point
 node-gyp at a real Python 3.x in your **user-level** `~/.npmrc` (not the
@@ -169,7 +169,7 @@ CCSM falls back to plain Electron notifications.
 - **Electron** (main + renderer) with TypeScript throughout
 - **React 18** for the renderer UI, bundled by **webpack 5**
 - **xterm.js** + `node-pty` for the embedded terminal that hosts each `claude` session
-- **better-sqlite3** for the local database (groups, sessions, ordering, preferences)
+- **node:sqlite** (Node built-in) for the local database (groups, sessions, ordering, preferences)
 - **electron-builder** for packaging (NSIS / dmg / AppImage / deb / rpm)
 - **vitest** for unit + integration tests, **playwright** for e2e
 

--- a/docs/reference/packaging.md
+++ b/docs/reference/packaging.md
@@ -101,10 +101,11 @@ Known caveats:
 - **Auto-update on Linux** works only for `AppImage` (deb/rpm auto-update
   requires a repo which we don't host). deb/rpm users must re-download from
   GitHub Releases to upgrade.
-- **`better-sqlite3`**: the Linux build rebuilds native modules for the
+- **`node-pty`**: the Linux build rebuilds this native module for the
   Electron ABI in CI. If you see "`NODE_MODULE_VERSION` mismatch" when
-  building locally, run `npx electron-builder install-app-deps` or, for
-  running vitest against Node, `npm rebuild better-sqlite3`.
+  building locally, run `npx @electron/rebuild -f -o node-pty
+  --build-from-source`. (The DB uses Node's built-in `node:sqlite`, so it
+  needs no rebuild.)
 
 ## Icons
 
@@ -117,13 +118,15 @@ Drop a real branded asset into `build/` (and re-add the corresponding
 
 ## Native modules
 
-The only native dep right now is `better-sqlite3`. `postinstall` runs
-`electron-builder install-app-deps` which rebuilds it against the Electron
-ABI. CI additionally runs `npm rebuild better-sqlite3` before `npm test`
-because vitest executes under Node, not Electron.
+The only native dep right now is `node-pty`. `postinstall`
+(`scripts/postinstall.mjs`) rebuilds it against the Electron ABI via
+`@electron/rebuild`; a failed rebuild falls back to node-pty's bundled
+prebuilt binary, asserted by `scripts/after-pack.cjs`. The DB layer uses
+Node's built-in `node:sqlite`, so no SQLite native module is bundled or
+rebuilt.
 
 ## ASAR
 
-The app bundle uses ASAR (`asar: true`), with `better-sqlite3` unpacked via
+The app bundle uses ASAR (`asar: true`), with `node-pty` unpacked via
 `asarUnpack`. Native `.node` files cannot be loaded from inside an ASAR
 archive; unpacking them is the standard fix.

--- a/electron/__tests__/db-hardening.test.ts
+++ b/electron/__tests__/db-hardening.test.ts
@@ -76,7 +76,7 @@ describe('db hardening: schema versioning', () => {
   it('stamps user_version=1 on a freshly-created database', async () => {
     const { initDb } = await freshDb();
     const handle = initDb();
-    const v = handle.pragma('user_version', { simple: true }) as number;
+    const v = (handle.prepare('PRAGMA user_version').get() as { user_version: number }).user_version;
     expect(v).toBe(1);
   });
 
@@ -92,8 +92,8 @@ describe('db hardening: schema versioning', () => {
 
     const file = path.join(tmpDir, 'ccsm.db');
     // Manually create a healthy SQLite file with a far-future user_version.
-    const Database = (await import('better-sqlite3')).default;
-    const seed = new Database(file);
+    const { DatabaseSync } = await import('node:sqlite');
+    const seed = new DatabaseSync(file);
     seed.exec(`
       CREATE TABLE app_state (
         key TEXT PRIMARY KEY,
@@ -102,7 +102,7 @@ describe('db hardening: schema versioning', () => {
       );
       INSERT INTO app_state (key, value, updated_at) VALUES ('preExisting', 'keepme', 0);
     `);
-    seed.pragma('user_version = 99');
+    seed.exec('PRAGMA user_version = 99');
     seed.close();
 
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -111,7 +111,9 @@ describe('db hardening: schema versioning', () => {
 
     // The stored version must NOT be rewritten — the breadcrumb has to
     // survive across boots so a bug report can include it.
-    expect(handle.pragma('user_version', { simple: true })).toBe(99);
+    expect(
+      (handle.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
+    ).toBe(99);
 
     // Existing user rows must not be wiped (no silent data loss on
     // perceived-newer files).
@@ -144,8 +146,8 @@ describe('db hardening: schema versioning', () => {
     mod.closeDb();
 
     const file = path.join(tmpDir, 'ccsm.db');
-    const Database = (await import('better-sqlite3')).default;
-    const seed = new Database(file);
+    const { DatabaseSync } = await import('node:sqlite');
+    const seed = new DatabaseSync(file);
     seed.exec(`
       CREATE TABLE app_state (
         key TEXT PRIMARY KEY,
@@ -161,7 +163,9 @@ describe('db hardening: schema versioning', () => {
     const { initDb, loadState } = mod;
     const handle = initDb();
 
-    expect(handle.pragma('user_version', { simple: true })).toBe(1);
+    expect(
+      (handle.prepare('PRAGMA user_version').get() as { user_version: number }).user_version
+    ).toBe(1);
     expect(loadState('legacy')).toBe('survives');
   });
 
@@ -215,17 +219,38 @@ describe('db hardening: WAL durability across a non-graceful shutdown', () => {
     } finally {
       if (!child.killed) child.kill('SIGKILL');
     }
-    // The OS discards the unflushed WAL on restart.
+    // The OS discards the unflushed WAL on restart. We model that by deleting
+    // the -wal/-shm sidecars. On Windows the SIGKILL'd child's file handles
+    // can linger briefly after the process is reaped (EBUSY/EPERM on unlink),
+    // so a naive try/catch would silently leave the sidecars in place — the
+    // reader would then still see the WAL contents and the durability test
+    // would FALSELY pass ("data survived") on the buggy path. Retry with
+    // backoff until each sidecar is provably gone, and fail loudly if it
+    // cannot be removed so the durability assertion stays truthful.
     for (const ext of ['-wal', '-shm']) {
-      try {
-        fs.unlinkSync(file + ext);
-      } catch {
-        /* may have been folded in already / never existed */
+      const sidecar = file + ext;
+      const deadline = Date.now() + 5000;
+      while (true) {
+        try {
+          fs.unlinkSync(sidecar);
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code === 'ENOENT') break; // never existed / already gone
+          if (Date.now() > deadline) {
+            throw new Error(
+              `failed to remove sidecar ${sidecar} after 5s (last error: ${code}) — ` +
+                'durability test cannot run truthfully while the WAL is still present'
+            );
+          }
+          await new Promise((r) => setTimeout(r, 25));
+          continue;
+        }
+        if (!fs.existsSync(sidecar)) break;
       }
     }
     // A fresh launch opens the main DB from scratch.
-    const Database = (await import('better-sqlite3')).default;
-    const reader = new Database(file, { readonly: true });
+    const { DatabaseSync } = await import('node:sqlite');
+    const reader = new DatabaseSync(file, { readOnly: true });
     try {
       const row = reader
         .prepare('SELECT value FROM app_state WHERE key = ?')
@@ -268,13 +293,15 @@ describe('db hardening: saveState/initDb wire up WAL durability', () => {
     const { initDb } = await freshDb();
     const handle = initDb();
     // synchronous: 0=OFF 1=NORMAL 2=FULL 3=EXTRA
-    expect(handle.pragma('synchronous', { simple: true })).toBe(2);
+    expect(
+      (handle.prepare('PRAGMA synchronous').get() as { synchronous: number }).synchronous
+    ).toBe(2);
   });
 
   it('saveState issues a passive WAL checkpoint', async () => {
     const mod = await freshDb();
     const { getDb, saveState } = mod;
-    const spy = vi.spyOn(getDb(), 'pragma');
+    const spy = vi.spyOn(getDb(), 'exec');
     saveState('main', 'x');
     const checkpointed = spy.mock.calls.some((c) => String(c[0]).includes('wal_checkpoint'));
     expect(checkpointed).toBe(true);

--- a/electron/__tests__/db.test.ts
+++ b/electron/__tests__/db.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
-import Database from 'better-sqlite3';
+import { DatabaseSync } from 'node:sqlite';
 
 // Wrap fs so the corruption-recovery test can pin that `electron/db.ts`
 // actually calls `unlinkSync` on the `-wal` / `-shm` sidecar paths.
@@ -97,8 +97,8 @@ describe('db: schema versioning branches', () => {
     const mod = await freshDb();
     // Pre-seed the canonical db file with a future-version user_version stamp.
     const file = path.join(tmpDir, 'ccsm.db');
-    const seed = new Database(file);
-    seed.pragma('user_version = 99');
+    const seed = new DatabaseSync(file);
+    seed.exec('PRAGMA user_version = 99');
     seed.close();
 
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
@@ -114,13 +114,14 @@ describe('db: schema versioning branches', () => {
   it('keeps an existing matching user_version untouched (no migrate, no warn)', async () => {
     const mod = await freshDb();
     const file = path.join(tmpDir, 'ccsm.db');
-    const seed = new Database(file);
-    seed.pragma('user_version = 1'); // matches SCHEMA_VERSION
+    const seed = new DatabaseSync(file);
+    seed.exec('PRAGMA user_version = 1'); // matches SCHEMA_VERSION
     seed.close();
 
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const handle = mod.initDb();
-    const v = handle.pragma('user_version', { simple: true }) as number;
+    const v = (handle.prepare('PRAGMA user_version').get() as { user_version: number })
+      .user_version;
     expect(v).toBe(1);
     expect(warn).not.toHaveBeenCalled();
     warn.mockRestore();
@@ -133,7 +134,7 @@ describe('db: legacy-table cleanup', () => {
     // Pre-seed a db with the legacy tables AND content. initDb() must drop
     // them silently — they're tables the current app no longer reads.
     const file = path.join(tmpDir, 'ccsm.db');
-    const seed = new Database(file);
+    const seed = new DatabaseSync(file);
     seed.exec(`
       CREATE TABLE endpoints (id INTEGER PRIMARY KEY, name TEXT);
       CREATE TABLE endpoint_models (id INTEGER PRIMARY KEY, endpoint_id INTEGER);
@@ -238,7 +239,7 @@ afterEach(async () => {
 describe('db: __setDbForTests injection', () => {
   it('swaps in an in-memory handle and re-runs the schema bootstrap', async () => {
     const mod = await freshDb();
-    const mem = new Database(':memory:');
+    const mem = new DatabaseSync(':memory:');
     mod.__setDbForTests(mem);
 
     // app_state must be created by __setDbForTests's SCHEMA_SQL execution.
@@ -270,7 +271,7 @@ describe('db: __setDbForTests injection', () => {
     // saveState() would call .run() on a Statement bound to the now-closed
     // file handle and throw.
     mod.closeDb();
-    const mem = new Database(':memory:');
+    const mem = new DatabaseSync(':memory:');
     mod.__setDbForTests(mem);
     expect(() => mod.saveState('warm', 'b')).not.toThrow();
     expect(mod.loadState('warm')).toBe('b');
@@ -289,6 +290,10 @@ describe('db: closeDb hygiene', () => {
     const a = mod.initDb();
     mod.closeDb();
     const b = mod.initDb();
-    expect(a).not.toBe(b);
+    // Compare via a boolean rather than `expect(a).not.toBe(b)`: a failing
+    // identity matcher would make vitest serialize the now-closed handle `a`,
+    // and node:sqlite throws ERR_INVALID_STATE when a closed DatabaseSync is
+    // introspected. `Object.is` only ever serializes the boolean result.
+    expect(Object.is(a, b)).toBe(false);
   });
 });

--- a/electron/__tests__/fixtures/wal-writer.cjs
+++ b/electron/__tests__/fixtures/wal-writer.cjs
@@ -16,17 +16,17 @@
 // With neither set, this is byte-for-byte the *current* (buggy) db.ts path.
 //
 // Keep this in sync with electron/db.ts if that pragma sequence ever changes.
-const Database = require('better-sqlite3');
+const { DatabaseSync } = require('node:sqlite');
 const fs = require('fs');
 
 const file = process.env.DBFILE;
 const key = process.env.STATE_KEY || 'main';
 const value = process.env.STATE_VALUE || 'written';
 
-const db = new Database(file);
-db.pragma('journal_mode = WAL');
-db.pragma('foreign_keys = ON');
-if (process.env.SYNC_FULL === '1') db.pragma('synchronous = FULL');
+const db = new DatabaseSync(file);
+db.exec('PRAGMA journal_mode = WAL');
+db.exec('PRAGMA foreign_keys = ON');
+if (process.env.SYNC_FULL === '1') db.exec('PRAGMA synchronous = FULL');
 db.exec(
   'CREATE TABLE IF NOT EXISTS app_state (key TEXT PRIMARY KEY, value TEXT NOT NULL, updated_at INTEGER NOT NULL)'
 );
@@ -40,10 +40,10 @@ const upsert = db.prepare(
 // they all live only in the -wal sidecar.
 for (let i = 0; i < 50; i++) {
   upsert.run(key, 'v' + i, Date.now());
-  if (process.env.CHECKPOINT === '1') db.pragma('wal_checkpoint(PASSIVE)');
+  if (process.env.CHECKPOINT === '1') db.exec('PRAGMA wal_checkpoint(PASSIVE)');
 }
 upsert.run(key, value, Date.now());
-if (process.env.CHECKPOINT === '1') db.pragma('wal_checkpoint(PASSIVE)');
+if (process.env.CHECKPOINT === '1') db.exec('PRAGMA wal_checkpoint(PASSIVE)');
 
 // Signal the parent that the write is committed, then hang. We deliberately
 // never call db.close() — the parent SIGKILLs us, which is what a forced

--- a/electron/db.ts
+++ b/electron/db.ts
@@ -1,9 +1,27 @@
-import Database from 'better-sqlite3';
+import { DatabaseSync, type StatementSync } from 'node:sqlite';
 import { app } from 'electron';
 import * as path from 'path';
 import * as fs from 'fs';
 
-let db: Database.Database | null = null;
+// node:sqlite is still flagged experimental in Node 22–24, so it emits one
+// `ExperimentalWarning` on first use. A plain `process.on('warning')` listener
+// can't suppress it — it runs *alongside* Node's built-in `onWarning` printer,
+// which always prints. So we detach that one named default listener and
+// reinstall a filter that drops ONLY the SQLite ExperimentalWarning and
+// delegates every other warning back to Node's original handler untouched
+// (deprecations, unhandled rejections, etc. print exactly as before). This is
+// surgical — not `--no-warnings`, not `removeAllListeners`. Runs once at load.
+const defaultWarningHandler = process
+  .listeners('warning')
+  .find((l) => l.name === 'onWarning');
+if (defaultWarningHandler) process.removeListener('warning', defaultWarningHandler);
+process.on('warning', (warning) => {
+  if (warning.name === 'ExperimentalWarning' && /\bSQLite\b/.test(warning.message)) return;
+  if (defaultWarningHandler) defaultWarningHandler(warning);
+  else console.warn(warning.stack ?? `${warning.name}: ${warning.message}`);
+});
+
+let db: DatabaseSync | null = null;
 
 // Schema version for the on-disk SQLite layout. Bumped only when the table
 // shapes change in a way readers care about. Use `PRAGMA user_version` so
@@ -11,21 +29,21 @@ let db: Database.Database | null = null;
 //
 // Migration policy: on a fresh DB (`user_version === 0`), we run the current
 // schema and stamp it. On a downgrade (stored > current) we log a warning
-// and proceed; better-sqlite3 will tolerate unknown columns/indexes added by
-// a future version. Real upgrades land in `migrate()` below — empty for now
+// and proceed; SQLite will tolerate unknown columns/indexes added by a
+// future version. Real upgrades land in `migrate()` below — empty for now
 // because v1 is the only shipped version.
 const SCHEMA_VERSION = 1;
 
 // ── Cached prepared statements ───────────────────────────────────────────────
-// better-sqlite3 caches compiled SQL inside each Statement object, but the
+// node:sqlite caches compiled SQL inside each Statement object, but the
 // JavaScript-side allocation/lookup still costs ~10 microseconds per call.
 // For hot paths (saveState on every keystroke in the composer draft persister)
 // that adds up. Cache the Statement once per process lifetime; reset to null
 // when the underlying db closes so the next initDb() rebuilds them.
 type PreparedCache = {
-  loadState: Database.Statement<[string]> | null;
-  upsertState: Database.Statement<[string, string, number]> | null;
-  deleteState: Database.Statement<[string]> | null;
+  loadState: StatementSync | null;
+  upsertState: StatementSync | null;
+  deleteState: StatementSync | null;
 };
 
 const stmts: PreparedCache = {
@@ -72,11 +90,11 @@ function migrate(_from: number, _to: number): void {
  * read to throw. Cost is roughly proportional to db size; on a fresh DB
  * (the common case) it returns in microseconds.
  */
-function ensureHealthyDb(file: string, current: Database.Database): Database.Database {
+function ensureHealthyDb(file: string, current: DatabaseSync): DatabaseSync {
   let result: string | null = null;
   try {
-    const row = current.pragma('quick_check', { simple: true });
-    result = typeof row === 'string' ? row : null;
+    const row = current.prepare('PRAGMA quick_check').get() as { quick_check?: string } | undefined;
+    result = typeof row?.quick_check === 'string' ? row.quick_check : null;
   } catch (err) {
     // The pragma itself threw — treat the same as corruption.
     console.error('[db] quick_check threw, treating as corruption:', err);
@@ -98,13 +116,13 @@ function ensureHealthyDb(file: string, current: Database.Database): Database.Dat
     console.error(`[db] corrupt database moved to ${backup}`);
   } catch (err) {
     // If we can't rename (file locked, missing, etc.) fall back to deleting
-    // so the next `new Database()` gets a clean slate. Logging both paths
+    // so the next `new DatabaseSync()` gets a clean slate. Logging both paths
     // helps post-mortem when a user reports "my data vanished".
     console.error('[db] failed to back up corrupt db, removing instead:', err);
     try {
       fs.unlinkSync(file);
     } catch {
-      // ignore — `new Database` will create one
+      // ignore — `new DatabaseSync` will create one
     }
   }
   // Also clear sidecar WAL/SHM files so SQLite doesn't try to replay a
@@ -116,35 +134,36 @@ function ensureHealthyDb(file: string, current: Database.Database): Database.Dat
       // ignore — they may not exist
     }
   }
-  return new Database(file);
+  return new DatabaseSync(file);
 }
 
-export function initDb(): Database.Database {
+export function initDb(): DatabaseSync {
   if (db) return db;
   const dir = app.getPath('userData');
   fs.mkdirSync(dir, { recursive: true });
   const file = path.join(dir, 'ccsm.db');
 
-  let handle = new Database(file);
+  let handle = new DatabaseSync(file);
   handle = ensureHealthyDb(file, handle);
-  handle.pragma('journal_mode = WAL');
-  handle.pragma('foreign_keys = ON');
+  handle.exec('PRAGMA journal_mode = WAL');
+  handle.exec('PRAGMA foreign_keys = ON');
   // WAL's default `synchronous = NORMAL` skips the fsync on each commit, so a
   // commit that's only reached the WAL can be lost on power loss / OS restart.
   // FULL fsyncs every commit. Write volume here is tiny (one debounced ~1 KB
   // app_state row per 250 ms at most), so the cost is negligible. This is the
   // durability half of the OS-restart fix; `wal_checkpoint` in saveState() is
   // the other half (see there).
-  handle.pragma('synchronous = FULL');
+  handle.exec('PRAGMA synchronous = FULL');
   handle.exec(SCHEMA_SQL);
 
   // Schema versioning. `user_version` defaults to 0 on a brand-new file.
-  const stored = handle.pragma('user_version', { simple: true }) as number;
+  const stored = (handle.prepare('PRAGMA user_version').get() as { user_version: number })
+    .user_version;
   if (stored === 0) {
-    handle.pragma(`user_version = ${SCHEMA_VERSION}`);
+    handle.exec(`PRAGMA user_version = ${SCHEMA_VERSION}`);
   } else if (stored < SCHEMA_VERSION) {
     migrate(stored, SCHEMA_VERSION);
-    handle.pragma(`user_version = ${SCHEMA_VERSION}`);
+    handle.exec(`PRAGMA user_version = ${SCHEMA_VERSION}`);
   } else if (stored > SCHEMA_VERSION) {
     // Downgrade scenario (user installed v0.3, then rolled back to v0.2).
     // We don't refuse to boot — that's worse than risking a stale read —
@@ -179,16 +198,16 @@ export function initDb(): Database.Database {
 }
 
 // Test-only: swap in an in-memory database. Never call from app code.
-export function __setDbForTests(instance: Database.Database | null): void {
+export function __setDbForTests(instance: DatabaseSync | null): void {
   db = instance;
   resetStmts();
   if (instance) {
-    instance.pragma('foreign_keys = ON');
+    instance.exec('PRAGMA foreign_keys = ON');
     instance.exec(SCHEMA_SQL);
   }
 }
 
-export function getDb(): Database.Database {
+export function getDb(): DatabaseSync {
   return initDb();
 }
 
@@ -218,7 +237,7 @@ export function saveState(key: string, value: string): void {
   // graceful-quit snapshot. PASSIVE never blocks on readers and is a no-op
   // under contention, so it's safe on this debounced hot path. See the
   // `db hardening: WAL durability` suite for the forced-shutdown regression.
-  d.pragma('wal_checkpoint(PASSIVE)');
+  d.exec('PRAGMA wal_checkpoint(PASSIVE)');
 }
 
 export function closeDb(): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/headless": "^5.5.0",
         "@xterm/xterm": "^5.5.0",
-        "better-sqlite3": "^12.9.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "electron-log": "^5.4.4",
@@ -55,7 +54,6 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
-        "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^22.10.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
@@ -4658,16 +4656,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/better-sqlite3": {
-      "version": "7.6.13",
-      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
-      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
@@ -6513,6 +6501,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6549,20 +6538,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/better-sqlite3": {
-      "version": "12.9.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.9.0.tgz",
-      "integrity": "sha512-wqUv4Gm3toFpHDQmaKD4QhZm3g1DjUBI0yzS4UBl6lElUmXFYdTQmmEDpAFa5o8FiFiymURypEnfVHzILKaxqQ==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "prebuild-install": "^7.1.1"
-      },
-      "engines": {
-        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
-      }
-    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -6584,26 +6559,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bindings": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "file-uri-to-path": "1.0.0"
-      }
-    },
-    "node_modules/bl": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
-      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -6738,6 +6693,7 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6753,6 +6709,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -7726,6 +7683,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
@@ -7741,21 +7699,13 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/deep-extend": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -7898,6 +7848,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -8521,6 +8472,7 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
@@ -9178,15 +9130,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -9398,12 +9341,6 @@
       "engines": {
         "node": ">=16.0.0"
       }
-    },
-    "node_modules/file-uri-to-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
     },
     "node_modules/filelist": {
       "version": "1.0.6",
@@ -9671,12 +9608,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
-    },
     "node_modules/fs-extra": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -9866,12 +9797,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -10574,6 +10499,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10588,7 +10514,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/ignore": {
       "version": "7.0.5",
@@ -10688,12 +10615,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
-    },
-    "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/internal-slot": {
@@ -12304,6 +12225,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -12345,12 +12267,6 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
-    },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
@@ -12411,12 +12327,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -13523,45 +13433,6 @@
         "node": "^12.20.0 || >=14"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -13710,6 +13581,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
@@ -13814,30 +13686,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/rc": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "dependencies": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
-      },
-      "bin": {
-        "rc": "cli.js"
-      }
-    },
-    "node_modules/rc/node_modules/strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -13985,6 +13833,7 @@
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -14421,6 +14270,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -15011,51 +14861,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/simple-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -15231,6 +15036,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
@@ -15500,40 +15306,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/tar-fs/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
-    },
-    "node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tar/node_modules/yallist": {
@@ -15966,18 +15738,6 @@
       "dev": true,
       "license": "0BSD"
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -16270,6 +16030,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/utila": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/headless": "^5.5.0",
     "@xterm/xterm": "^5.5.0",
-    "better-sqlite3": "^12.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "electron-log": "^5.4.4",
@@ -85,7 +84,6 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
-    "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^22.10.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
@@ -122,7 +120,6 @@
     "npmRebuild": false,
     "asar": true,
     "asarUnpack": [
-      "**/node_modules/better-sqlite3/**",
       "**/node_modules/node-pty/**"
     ],
     "extraResources": [

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -110,16 +110,14 @@ function runRebuild(moduleName, { allowFailure } = { allowFailure: false }) {
   return true;
 }
 
-runRebuild('better-sqlite3', { allowFailure: false });
 runRebuild('node-pty', { allowFailure: true });
 
 function printHint() {
   console.error('');
-  console.error('Native modules (better-sqlite3 + node-pty) must be rebuilt');
+  console.error('Native modules (node-pty) must be rebuilt');
   console.error('for the Electron ABI before the app can start. If the');
   console.error('automatic rebuild fails, try running it manually:');
   console.error('');
-  console.error('  npx @electron/rebuild -f -o better-sqlite3 --build-from-source');
   console.error('  npx @electron/rebuild -f -o node-pty --build-from-source');
   console.error('');
   console.error('On Windows you need Visual Studio Build Tools (C++ workload)');

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -3,19 +3,19 @@
 //
 // Background: previously package.json had
 //   "postinstall": "electron-builder install-app-deps || true"
-// which silently swallowed native rebuild failures. better-sqlite3 would
+// which silently swallowed native rebuild failures. A native module would
 // end up compiled against the host Node ABI (e.g. NODE_MODULE_VERSION 127)
 // instead of Electron's ABI (e.g. 130), and the app would fail at runtime
 // with cryptic "renderer window didn't appear" errors.
 //
-// Now we fail loudly for native deps required by the app — currently
-// better-sqlite3 (DB) and node-pty (terminal). Windows toast no longer
-// requires a native rebuild; it goes through Electron's built-in
-// `Notification` API directly.
+// Now we fail loudly for native deps required by the app. The DB layer uses
+// Node's built-in node:sqlite (no native rebuild), so node-pty (terminal) is
+// the only remaining native module. Windows toast no longer requires a native
+// rebuild; it goes through Electron's built-in `Notification` API directly.
 //
 // `electron-builder install-app-deps` walks every native module declared
 // in package.json's `dependencies` and rebuilds against Electron's ABI,
-// so node-pty is covered automatically alongside better-sqlite3.
+// so node-pty is covered automatically.
 //
 // node-pty rebuild failure caveat (Windows): node-pty pulls winpty as a
 // transitive dep whose `GetCommitHash.bat` shells out to git-bash;
@@ -30,26 +30,24 @@ import { fileURLToPath } from 'node:url';
 import process from 'node:process';
 
 // Preflight: warn (don't block) when running on a Node major other than 20.
-// better-sqlite3 builds cleanly on Node 20.x; newer node-gyp + Node may need
+// node-pty builds cleanly on Node 20.x; newer node-gyp + Node may need
 // extra toolchain. We don't pin engines.node so contributors who only touch
 // UI/tests can still `npm install` on newer Node; this warning gives them
 // the clue if it breaks.
 const nodeMajor = Number.parseInt(process.versions.node.split('.')[0], 10);
 if (nodeMajor !== 20) {
   console.warn(
-    `[postinstall] WARNING: ccsm native deps (better-sqlite3 + node-pty) build cleanly on Node 20.x. You're on Node ${process.version}. If you only touch UI/tests, this is fine; if you hit \`node-gyp\` errors during install, switch with \`nvm use 20\` and re-run \`npm ci --legacy-peer-deps\`. CI uses Node 20.`,
+    `[postinstall] WARNING: ccsm native dep (node-pty) builds cleanly on Node 20.x. You're on Node ${process.version}. If you only touch UI/tests, this is fine; if you hit \`node-gyp\` errors during install, switch with \`nvm use 20\` and re-run \`npm ci --legacy-peer-deps\`. CI uses Node 20.`,
   );
 }
 
 // Strategy:
-//   1. Rebuild better-sqlite3 strictly via @electron/rebuild — failure
-//      here is fatal (DB unusable at runtime).
-//   2. Attempt to rebuild node-pty — failure here is logged but
+//   1. Attempt to rebuild node-pty — failure here is logged but
 //      non-fatal. node-pty 1.x ships a prebuilt
 //      `prebuilds/<os>-<arch>/node.napi.node` that the runtime falls
 //      back to. The common Windows failure (winpty's `GetCommitHash.bat`
 //      requiring git-bash on PATH) is benign for that reason.
-//   3. scripts/after-pack.cjs asserts ONE of the two binding paths
+//   2. scripts/after-pack.cjs asserts ONE of the two binding paths
 //      exists in the packaged app; missing both is a hard build failure.
 //
 // We deliberately do NOT use `electron-builder install-app-deps` here

--- a/scripts/probe-helpers/reset-between-cases.mjs
+++ b/scripts/probe-helpers/reset-between-cases.mjs
@@ -102,11 +102,10 @@ export async function resetBetweenCases(app, win, opts = {}) {
   await app.evaluate(async (_main, keepKeys) => {
     try {
       const path = require('node:path');
-      const Database = require('better-sqlite3');
+      const { DatabaseSync } = require('node:sqlite');
       const { app: electronApp } = require('electron');
       const dbPath = path.join(electronApp.getPath('userData'), 'ccsm.db');
-      const db = new Database(dbPath);
-      db.exec('DELETE FROM messages;');
+      const db = new DatabaseSync(dbPath);
       if (keepKeys.length === 0) {
         db.exec('DELETE FROM app_state;');
       } else {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,23 +2,33 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    environment: 'jsdom',
-    include: [
-      'tests/**/*.test.ts',
-      'tests/**/*.test.tsx',
-      'electron/**/__tests__/**/*.test.ts',
+    // Two projects, split by the runtime the code under test actually runs in.
+    // This is the whole point of the node:sqlite migration: main-process code
+    // (electron/**) runs under Node, not a browser. Running its tests under
+    // jsdom drove vitest's client bundler to try inlining the `node:sqlite`
+    // built-in and fail with "Cannot bundle Node.js built-in node:sqlite".
+    // Under the `node` environment the built-in stays a runtime require, as it
+    // is in production. Renderer tests (src/** via tests/**) keep jsdom.
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: 'electron',
+          environment: 'node',
+          include: ['electron/**/__tests__/**/*.test.ts'],
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'renderer',
+          environment: 'jsdom',
+          setupFiles: ['tests/setup.ts'],
+          include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
+        },
+      },
     ],
     globals: true,
-    setupFiles: ['tests/setup.ts'],
-    // node:sqlite is a Node built-in (DatabaseSync). Some CI runners drive
-    // vitest's bundler to try inlining it and fail with "Cannot bundle
-    // Node.js built-in node:sqlite". Mark it external so it stays a runtime
-    // require instead of being bundled.
-    server: {
-      deps: {
-        external: ['node:sqlite'],
-      },
-    },
     // v8 coverage instrumentation roughly doubles test wall-clock under
     // jsdom, so the default 5s testTimeout starts to flake on slower
     // suites (e.g. shortcut-overlay-platform with multiple act/render

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,15 @@ export default defineConfig({
     ],
     globals: true,
     setupFiles: ['tests/setup.ts'],
+    // node:sqlite is a Node built-in (DatabaseSync). Some CI runners drive
+    // vitest's bundler to try inlining it and fail with "Cannot bundle
+    // Node.js built-in node:sqlite". Mark it external so it stays a runtime
+    // require instead of being bundled.
+    server: {
+      deps: {
+        external: ['node:sqlite'],
+      },
+    },
     // v8 coverage instrumentation roughly doubles test wall-clock under
     // jsdom, so the default 5s testTimeout starts to flake on slower
     // suites (e.g. shortcut-overlay-platform with multiple act/render


### PR DESCRIPTION
## What

Migrate `electron/db.ts` from the native **better-sqlite3** module to Node's built-in **`node:sqlite`** (`DatabaseSync`), and remove better-sqlite3 from the project entirely.

## Why

better-sqlite3 is a native addon, so its compiled binary is ABI-specific. Production runs the **Electron** ABI while `npm test` runs under **Node**, which forced CI/release to `npm rebuild better-sqlite3` against the Node ABI before tests, and `postinstall` to rebuild it for Electron. `node:sqlite` is a pure-runtime built-in — no native rebuild, no ABI split, no `NODE_MODULE_VERSION` mismatch.

## Changes

- **`electron/db.ts`** — `new Database` -> `new DatabaseSync`; `.pragma()` -> `db.exec('PRAGMA ...')` (setters) / `db.prepare('PRAGMA ...').get()` (getters) with scalar unpacking. `prepare/get/run/all/exec/close` keep their names.
- **ExperimentalWarning suppression** — `node:sqlite` emits one `ExperimentalWarning` on first use. A plain `process.on('warning')` listener cannot suppress it (it runs alongside Node's built-in printer). Instead we detach Node's single default `onWarning` listener and reinstall a filter that drops only the SQLite warning and delegates every other warning back to the original handler untouched. Not `--no-warnings`, not `removeAllListeners`.
- **Tests/fixtures** — `db.test.ts`, `db-hardening.test.ts`, `fixtures/wal-writer.cjs` build via `DatabaseSync`; the hardening reader opens `{ readOnly: true }`.
- **Windows EBUSY fix** — db-hardening forced-shutdown helper previously did `try { unlinkSync(sidecar) } catch {}`, which on Windows swallowed `EBUSY` after `SIGKILL`, leaving the `-wal`/`-shm` sidecars in place. Data then falsely "survived" the simulated crash, masking the durability regression. Replaced with a bounded retry/backoff that fails loudly if a sidecar cannot be removed, so the WAL-durability tests assert the truth (data really is lost when only the WAL holds it).
- **better-sqlite3 removed** — `package.json` dep + `@types/better-sqlite3` + `asarUnpack`; `scripts/postinstall.mjs` native rebuild; the `npm rebuild better-sqlite3` step in `.github/workflows/ci.yml` and `.github/workflows/release.yml`. `db.ts` was the only production consumer; the e2e probe helper (`reset-between-cases.mjs`) now uses `DatabaseSync` too.

## Evidence (local gate, all green)

- `npm run typecheck` — pass
- `npm run lint` — pass (0 problems)
- `npm test` — 204 files / 1946 passed / 1 todo, after `npm run build` (the load-smoke harness require()s `dist/`)
- `db.test.ts` + `db-hardening.test.ts` — 28 passed / 1 todo, including the three WAL-durability tests that now pass truthfully:
  - "LOSES data on the current (no-checkpoint) path — documents the bug"
  - "synchronous=FULL alone is NOT enough — data still lost"
  - "survives when saveState checkpoints the WAL into the main DB"

Verified the SQLite `ExperimentalWarning` is fully suppressed while a `DeprecationWarning` still prints with Node's native formatting.